### PR TITLE
feat: IAM method support in new join service

### DIFF
--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -27,9 +27,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/digitorus/pkcs7"
@@ -64,6 +67,7 @@ import (
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/kube/token"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
@@ -689,9 +693,9 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 	remoteAddr := "42.42.42.42:42"
 
 	t.Run("IAM method", func(t *testing.T) {
-		a.SetHTTPClientForAWSSTS(&mockClient{
+		a.SetHTTPClientForAWSSTS(&mockSTSClient{
 			respStatusCode: http.StatusOK,
-			respBody: responseFromAWSIdentity(auth.AWSIdentity{
+			respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 				Account: "1234",
 				Arn:     "arn:aws::1111",
 			}),
@@ -822,6 +826,54 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 	})
 }
 
+func responseFromAWSIdentity(id iamjoin.AWSIdentity) string {
+	return fmt.Sprintf(`{
+		"GetCallerIdentityResponse": {
+			"GetCallerIdentityResult": {
+				"Account": "%s",
+				"Arn": "%s"
+			}}}`, id.Account, id.Arn)
+}
+
+type mockSTSClient struct {
+	respStatusCode int
+	respBody       string
+}
+
+func (c *mockSTSClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: c.respStatusCode,
+		Body:       io.NopCloser(strings.NewReader(c.respBody)),
+	}, nil
+}
+
+var identityRequestTemplate = template.Must(template.New("sts-request").Parse(`POST / HTTP/1.1
+Host: {{.Host}}
+User-Agent: aws-sdk-go/1.37.17 (go1.17.1; darwin; amd64)
+Content-Length: 43
+Accept: application/json
+Authorization: AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20211102/us-east-1/sts/aws4_request, SignedHeaders=accept;content-length;content-type;host;x-amz-date;x-amz-security-token;{{.SignedHeader}}, Signature=111
+Content-Type: application/x-www-form-urlencoded; charset=utf-8
+X-Amz-Date: 20211102T204300Z
+X-Amz-Security-Token: aaa
+X-Teleport-Challenge: {{.Challenge}}
+
+Action=GetCallerIdentity&Version=2011-06-15`))
+
+type identityRequestTemplateInput struct {
+	Host         string
+	SignedHeader string
+	Challenge    string
+}
+
+func defaultIdentityRequestTemplateInput(challenge string) identityRequestTemplateInput {
+	return identityRequestTemplateInput{
+		Host:         "sts.amazonaws.com",
+		SignedHeader: "x-teleport-challenge;",
+		Challenge:    challenge,
+	}
+}
+
 // authClientForRegisterResult is a test helper that creats an auth client for
 // the given [*joinclient.JoinResult].
 func authClientForRegisterResult(t *testing.T, ctx context.Context, addr *utils.NetAddr, result *joinclient.JoinResult) *authclient.Client {
@@ -948,9 +1000,9 @@ func TestRegisterBot_BotInstanceRejoin(t *testing.T) {
 		return nil, errMockInvalidToken
 	})
 
-	a.SetHTTPClientForAWSSTS(&mockClient{
+	a.SetHTTPClientForAWSSTS(&mockSTSClient{
 		respStatusCode: http.StatusOK,
-		respBody: responseFromAWSIdentity(auth.AWSIdentity{
+		respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 			Account: "1234",
 			Arn:     "arn:aws::1111",
 		}),

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 	"google.golang.org/grpc/credentials"
@@ -195,10 +194,6 @@ func (a *Server) CheckPasswordWOToken(ctx context.Context, user string, password
 
 func (a *Server) ResetPassword(ctx context.Context, username string) error {
 	return a.resetPassword(ctx, username)
-}
-
-func (a *Server) SetHTTPClientForAWSSTS(clt utils.HTTPDoClient) {
-	a.httpClientForAWSSTS = clt
 }
 
 func (a *Server) SetJWKSValidator(clt JWKSValidator) {
@@ -410,7 +405,6 @@ func CheckOracleAllowRules(claims oracle.Claims, token string, allowRules []*typ
 }
 
 type GitHubManager = githubManager
-type AWSIdentity = awsIdentity
 type AttestedData = attestedData
 type SignedAttestedData = signedAttestedData
 type JWKSValidator = k8sJWKSValidator
@@ -421,7 +415,6 @@ type AzureVerifyTokenFunc = azureVerifyTokenFunc
 type AccessTokenClaims = accessTokenClaims
 type EC2Client = ec2Client
 type EC2ClientKey = ec2ClientKey
-type IAMRegisterOption = iamRegisterOption
 
 func WithAzureCerts(certs []*x509.Certificate) AzureRegisterOption {
 	return func(cfg *AzureRegisterConfig) {
@@ -439,14 +432,6 @@ func WithAzureVMClientGetter(getVMClient vmClientGetter) AzureRegisterOption {
 	return func(cfg *AzureRegisterConfig) {
 		cfg.getVMClient = getVMClient
 	}
-}
-
-func WithFIPS(b bool) iamRegisterOption {
-	return withFips(b)
-}
-
-func WithAuthVersion(v *semver.Version) iamRegisterOption {
-	return withAuthVersion(v)
 }
 
 func (s *TLSServer) GRPCServer() *GRPCServer {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5852,6 +5852,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Authorizer:  cfg.Authorizer,
 		AuthService: cfg.AuthServer,
 		Clock:       cfg.AuthServer.clock,
+		FIPS:        cfg.AuthServer.fips,
 	}))
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{

--- a/lib/auth/join/iam/iam.go
+++ b/lib/auth/join/iam/iam.go
@@ -48,18 +48,18 @@ type stsIdentityRequestOptions struct {
 	imdsClient imdsClient
 }
 
-type stsIdentityRequestOption func(cfg *stsIdentityRequestOptions)
+type STSIdentityRequestOption func(cfg *stsIdentityRequestOptions)
 
 // WithFIPSEndpoint is a functional option to use a FIPS STS endpoint. In non-US
 // regions, this will use the us-east-1 FIPS endpoint.
-func WithFIPSEndpoint(useFIPS bool) stsIdentityRequestOption {
+func WithFIPSEndpoint(useFIPS bool) STSIdentityRequestOption {
 	return func(opts *stsIdentityRequestOptions) {
 		opts.useFIPS = useFIPS
 	}
 }
 
 // WithIMDSClient is a functional option to use a custom IMDS client.
-func WithIMDSClient(clt imdsClient) stsIdentityRequestOption {
+func WithIMDSClient(clt imdsClient) STSIdentityRequestOption {
 	return func(opts *stsIdentityRequestOptions) {
 		opts.imdsClient = clt
 	}
@@ -75,7 +75,7 @@ type imdsClient interface {
 
 // CreateSignedSTSIdentityRequest is called on the client side and returns an
 // sts:GetCallerIdentity request signed with the local AWS credentials
-func CreateSignedSTSIdentityRequest(ctx context.Context, challenge string, opts ...stsIdentityRequestOption) ([]byte, error) {
+func CreateSignedSTSIdentityRequest(ctx context.Context, challenge string, opts ...STSIdentityRequestOption) ([]byte, error) {
 	var options stsIdentityRequestOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -190,6 +190,9 @@ type RegisterParams struct {
 	GitlabParams GitlabParams
 	// BoundKeypairParams contains parameters specific to bound keypair joining.
 	BoundKeypairParams *BoundKeypairParams
+	// CreateSignedSTSIdentityRequestFunc overrides the function used to
+	// generate a signed AWs sts:GetCallerIdentity request.
+	CreateSignedSTSIdentityRequestFunc func(ctx context.Context, challenge string, opts ...iam.STSIdentityRequestOption) ([]byte, error)
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {
@@ -203,6 +206,10 @@ func (r *RegisterParams) CheckAndSetDefaults() error {
 
 	if err := r.verifyAuthOrProxyAddress(); err != nil {
 		return trace.BadParameter("no auth or proxy servers set")
+	}
+
+	if r.CreateSignedSTSIdentityRequestFunc == nil {
+		r.CreateSignedSTSIdentityRequestFunc = iam.CreateSignedSTSIdentityRequest
 	}
 
 	return nil
@@ -797,7 +804,7 @@ func registerUsingIAMMethod(
 	// Call RegisterUsingIAMMethod and pass a callback to respond to the challenge with a signed join request.
 	certs, err := joinServiceClient.RegisterUsingIAMMethod(ctx, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 		// create the signed sts:GetCallerIdentity request and include the challenge
-		signedRequest, err := iam.CreateSignedSTSIdentityRequest(ctx, challenge,
+		signedRequest, err := params.CreateSignedSTSIdentityRequestFunc(ctx, challenge,
 			iam.WithFIPSEndpoint(params.FIPS),
 		)
 		if err != nil {

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -44,6 +44,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -430,7 +431,7 @@ func (a *Server) checkAzureRequest(
 }
 
 func generateAzureChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.RawURLEncoding, 24)
+	challenge, err := joinutils.GenerateChallenge(base64.RawURLEncoding, 24)
 	return challenge, trace.Wrap(err)
 }
 

--- a/lib/auth/join_gitlab.go
+++ b/lib/auth/join_gitlab.go
@@ -20,13 +20,12 @@ package auth
 
 import (
 	"context"
-	"regexp"
-	"strings"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/gitlab"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 type gitlabIDTokenValidator interface {
@@ -87,20 +86,7 @@ func joinRuleGlobMatch(want string, got string) (bool, error) {
 	if want == "" {
 		return true, nil
 	}
-	return globMatch(want, got)
-}
-
-// globMatch performs simple a simple glob-style match test on a string.
-// - '*' matches zero or more characters.
-// - '?' matches any single character.
-// It returns true if a match is detected.
-func globMatch(pattern, str string) (bool, error) {
-	pattern = regexp.QuoteMeta(pattern)
-	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
-	pattern = strings.ReplaceAll(pattern, `\?`, ".")
-	pattern = "^" + pattern + "$"
-	matched, err := regexp.MatchString(pattern, str)
-	return matched, trace.Wrap(err)
+	return joinutils.GlobMatch(want, got)
 }
 
 func checkGitLabAllowRules(token *types.ProvisionTokenV2, claims *gitlab.IDTokenClaims) error {

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -19,345 +19,41 @@
 package auth
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"net/http"
-	"net/url"
-	"slices"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/aws"
 )
 
-const (
-	// Hardcoding the sts API version here may be more strict than necessary,
-	// but this is set by the Teleport node and can only be changed when we
-	// update our AWS SDK dependency. Since Auth should always be upgraded
-	// before nodes, we will have a chance to update the check on Auth if we
-	// ever have a need to allow a newer API version.
-	expectedSTSIdentityRequestBody = "Action=GetCallerIdentity&Version=2011-06-15"
-
-	// AWS SignedHeaders will always be lowercase
-	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html#sigv4-auth-header-overview
-	challengeHeaderKey = "x-teleport-challenge"
-)
-
-// validateSTSHost returns an error if the given stsHost is not a valid regional
-// endpoint for the AWS STS service, or nil if it is valid. If fips is true, the
-// endpoint must be a valid FIPS endpoint.
-//
-// This is a security-critical check: we are allowing the client to tell us
-// which URL we should use to validate their identity. If the client could pass
-// off an attacker-controlled URL as the STS endpoint, the entire security
-// mechanism of the IAM join method would be compromised.
-//
-// To keep this validation simple and secure, we check the given endpoint
-// against a static list of known valid endpoints. We will need to update this
-// list as AWS adds new regions.
-func validateSTSHost(stsHost string, cfg *iamRegisterConfig) error {
-	valid := slices.Contains(iam.ValidSTSEndpoints(), stsHost)
-	if !valid {
-		return trace.AccessDenied("IAM join request uses unknown STS host %q. "+
-			"This could mean that the Teleport Node attempting to join the cluster is "+
-			"running in a new AWS region which is unknown to this Teleport auth server. "+
-			"Alternatively, if this URL looks suspicious, an attacker may be attempting to "+
-			"join your Teleport cluster. "+
-			"Following is the list of valid STS endpoints known to this auth server. "+
-			"If a legitimate STS endpoint is not included, please file an issue at "+
-			"https://github.com/gravitational/teleport. %v",
-			stsHost, iam.ValidSTSEndpoints())
-	}
-
-	if cfg.fips && !slices.Contains(iam.FIPSSTSEndpoints(), stsHost) {
-		return trace.AccessDenied("node selected non-FIPS STS endpoint (%s) for the IAM join method", stsHost)
-	}
-
-	return nil
+// SetHTTPClientForAWSSTS sets an HTTP client that will be used for sending
+// client-signed sts:GetCallerIdentity requests to AWS, for tests.
+func (a *Server) SetHTTPClientForAWSSTS(clt utils.HTTPDoClient) {
+	a.httpClientForAWSSTS = clt
 }
 
-// validateSTSIdentityRequest checks that a received sts:GetCallerIdentity
-// request is valid and includes the challenge as a signed header. An example
-// valid request looks like:
-// ```
-// POST / HTTP/1.1
-// Host: sts.amazonaws.com
-// Accept: application/json
-// Authorization: AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20211108/us-east-1/sts/aws4_request, SignedHeaders=accept;content-length;content-type;host;x-amz-date;x-amz-security-token;x-teleport-challenge, Signature=999...
-// Content-Length: 43
-// Content-Type: application/x-www-form-urlencoded; charset=utf-8
-// User-Agent: aws-sdk-go/1.37.17 (go1.17.1; darwin; amd64)
-// X-Amz-Date: 20211108T190420Z
-// X-Amz-Security-Token: aaa...
-// X-Teleport-Challenge: 0ezlc3usTAkXeZTcfOazUq0BGrRaKmb4EwODk8U7J5A
-//
-// Action=GetCallerIdentity&Version=2011-06-15
-// ```
-func validateSTSIdentityRequest(req *http.Request, challenge string, cfg *iamRegisterConfig) (err error) {
-	defer func() {
-		// Always log a warning on the Auth server if the function detects an
-		// invalid sts:GetCallerIdentity request, it's either going to be caused
-		// by a node in a unknown region or an attacker.
-		if err != nil {
-			logger.WarnContext(req.Context(), "Detected an invalid sts:GetCallerIdentity used by a client attempting to use the IAM join method", "error", err)
-		}
-	}()
-
-	if err := validateSTSHost(req.Host, cfg); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if req.Method != http.MethodPost {
-		return trace.AccessDenied("sts identity request method %q does not match expected method %q", req.RequestURI, http.MethodPost)
-	}
-
-	if req.Header.Get(challengeHeaderKey) != challenge {
-		return trace.AccessDenied("sts identity request does not include challenge header or it does not match")
-	}
-
-	authHeader := req.Header.Get(aws.AuthorizationHeader)
-
-	sigV4, err := aws.ParseSigV4(authHeader)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !slices.Contains(sigV4.SignedHeaders, challengeHeaderKey) {
-		return trace.AccessDenied("sts identity request auth header %q does not include "+
-			challengeHeaderKey+" as a signed header", authHeader)
-	}
-
-	body, err := utils.GetAndReplaceRequestBody(req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !bytes.Equal([]byte(expectedSTSIdentityRequestBody), body) {
-		return trace.BadParameter("sts request body %q does not equal expected %q", string(body), expectedSTSIdentityRequestBody)
-	}
-
-	return nil
+// GetHTTPClientForAWSSTS returns an HTTP client that should be used for sending
+// client-signed sts:GetCallerIdentity requests to AWS.
+func (a *Server) GetHTTPClientForAWSSTS() utils.HTTPDoClient {
+	return a.httpClientForAWSSTS
 }
 
-func parseSTSRequest(req []byte) (*http.Request, error) {
-	httpReq, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(req)))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Unset RequestURI and set req.URL instead (necessary quirk of sending a
-	// request parsed by http.ReadRequest). Also, force https here.
-	if httpReq.RequestURI != "/" {
-		return nil, trace.AccessDenied("unexpected sts identity request URI: %q", httpReq.RequestURI)
-	}
-	httpReq.RequestURI = ""
-	httpReq.URL = &url.URL{
-		Scheme: "https",
-		Host:   httpReq.Host,
-	}
-	return httpReq, nil
-}
-
-// awsIdentity holds aws Account and Arn, used for JSON parsing
-type awsIdentity struct {
-	Account string `json:"Account"`
-	Arn     string `json:"Arn"`
-}
-
-// JoinAttrs returns the protobuf representation of the attested identity.
-// This is used for auditing and for evaluation of WorkloadIdentity rules and
-// templating.
-func (c *awsIdentity) JoinAttrs() *workloadidentityv1pb.JoinAttrsAWSIAM {
-	attrs := &workloadidentityv1pb.JoinAttrsAWSIAM{
-		Account: c.Account,
-		Arn:     c.Arn,
-	}
-
-	return attrs
-}
-
-// getCallerIdentityReponse is used for JSON parsing
-type getCallerIdentityResponse struct {
-	GetCallerIdentityResult awsIdentity `json:"GetCallerIdentityResult"`
-}
-
-// stsIdentityResponse is used for JSON parsing
-type stsIdentityResponse struct {
-	GetCallerIdentityResponse getCallerIdentityResponse `json:"GetCallerIdentityResponse"`
-}
-
-// executeSTSIdentityRequest sends the sts:GetCallerIdentity HTTP request to the
-// AWS API, parses the response, and returns the awsIdentity
-func executeSTSIdentityRequest(ctx context.Context, client utils.HTTPDoClient, req *http.Request) (*awsIdentity, error) {
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	// set the http request context so it can be canceled
-	req = req.WithContext(ctx)
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer resp.Body.Close()
-
-	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, trace.AccessDenied("aws sts api returned status: %q body: %q",
-			resp.Status, body)
-	}
-
-	var identityResponse stsIdentityResponse
-	if err := json.Unmarshal(body, &identityResponse); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	id := &identityResponse.GetCallerIdentityResponse.GetCallerIdentityResult
-	if id.Account == "" {
-		return nil, trace.BadParameter("received empty AWS account ID from sts API")
-	}
-	if id.Arn == "" {
-		return nil, trace.BadParameter("received empty AWS identity ARN from sts API")
-	}
-	return id, nil
-}
-
-// arnMatches returns true if arn matches the pattern.
-// Pattern should be an AWS ARN which may include "*" to match any combination
-// of zero or more characters and "?" to match any single character.
-// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
-func arnMatches(pattern, arn string) (bool, error) {
-	return globMatch(pattern, arn)
-}
-
-// checkIAMAllowRules checks if the given identity matches any of the given
-// allowRules.
-func checkIAMAllowRules(identity *awsIdentity, token string, allowRules []*types.TokenRule) error {
-	for _, rule := range allowRules {
-		// if this rule specifies an AWS account, the identity must match
-		if len(rule.AWSAccount) > 0 {
-			if rule.AWSAccount != identity.Account {
-				// account doesn't match, continue to check the next rule
-				continue
-			}
-		}
-		// if this rule specifies an AWS ARN, the identity must match
-		if len(rule.AWSARN) > 0 {
-			matches, err := arnMatches(rule.AWSARN, identity.Arn)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			if !matches {
-				// arn doesn't match, continue to check the next rule
-				continue
-			}
-		}
-		// node identity matches this allow rule
-		return nil
-	}
-	return trace.AccessDenied("instance %v did not match any allow rules in token %v", identity.Arn, token)
-}
-
-// checkIAMRequest checks if the given request satisfies the token rules and
-// included the required challenge.
-//
-// If the joining entity presents a valid IAM identity, this will be returned,
-// even if the identity does not match the token's allow rules. This is to
-// support inclusion in audit logs.
-func (a *Server) checkIAMRequest(ctx context.Context, challenge string, req *proto.RegisterUsingIAMMethodRequest, cfg *iamRegisterConfig) (*awsIdentity, error) {
-	tokenName := req.RegisterUsingTokenRequest.Token
-	provisionToken, err := a.GetToken(ctx, tokenName)
-	if err != nil {
-		return nil, trace.Wrap(err, "getting token")
-	}
-	if provisionToken.GetJoinMethod() != types.JoinMethodIAM {
-		return nil, trace.AccessDenied("this token does not support the IAM join method")
-	}
-
-	// parse the incoming http request to the sts:GetCallerIdentity endpoint
-	identityRequest, err := parseSTSRequest(req.StsIdentityRequest)
-	if err != nil {
-		return nil, trace.Wrap(err, "parsing STS request")
-	}
-
-	// validate that the host, method, and headers are correct and the expected
-	// challenge is included in the signed portion of the request
-	if err := validateSTSIdentityRequest(identityRequest, challenge, cfg); err != nil {
-		return nil, trace.Wrap(err, "validating STS request")
-	}
-
-	// send the signed request to the public AWS API and get the node identity
-	// from the response
-	identity, err := executeSTSIdentityRequest(ctx, a.httpClientForAWSSTS, identityRequest)
-	if err != nil {
-		return nil, trace.Wrap(err, "executing STS request")
-	}
-
-	// check that the node identity matches an allow rule for this token
-	if err := checkIAMAllowRules(identity, provisionToken.GetName(), provisionToken.GetAllowRules()); err != nil {
-		// We return the identity since it's "validated" but does not match the
-		// rules. This allows us to include it in a failed join audit event
-		// as additional context to help the user understand why the join failed.
-		return identity, trace.Wrap(err, "checking allow rules")
-	}
-
-	return identity, nil
-}
-
-func generateIAMChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.RawStdEncoding, 32)
-	return challenge, trace.Wrap(err)
-}
-
-type iamRegisterConfig struct {
-	authVersion *semver.Version
-	fips        bool
-}
-
-func defaultIAMRegisterConfig(fips bool) *iamRegisterConfig {
-	return &iamRegisterConfig{
-		authVersion: teleport.SemVer(),
-		fips:        fips,
-	}
-}
-
-type iamRegisterOption func(cfg *iamRegisterConfig)
-
-func withAuthVersion(v *semver.Version) iamRegisterOption {
-	return func(cfg *iamRegisterConfig) {
-		cfg.authVersion = v
-	}
-}
-
-func withFips(fips bool) iamRegisterOption {
-	return func(cfg *iamRegisterConfig) {
-		cfg.fips = fips
-	}
-}
-
-// RegisterUsingIAMMethodWithOpts registers the caller using the IAM join method and
+// RegisterUsingIAMMethod registers the caller using the IAM join method and
 // returns signed certs to join the cluster.
 //
 // The caller must provide a ChallengeResponseFunc which returns a
 // *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
 // including the challenge as a signed header.
-func (a *Server) RegisterUsingIAMMethodWithOpts(
+//
+// TODO(nklaassen): DELETE IN 20 when removing the legacy join service.
+func (a *Server) RegisterUsingIAMMethod(
 	ctx context.Context,
 	challengeResponse client.RegisterIAMChallengeResponseFunc,
-	opts ...iamRegisterOption,
 ) (certs *proto.Certs, err error) {
 	var provisionToken types.ProvisionToken
 	var joinRequest *types.RegisterUsingTokenRequest
@@ -371,12 +67,7 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 		}
 	}()
 
-	cfg := defaultIAMRegisterConfig(a.fips)
-	for _, opt := range opts {
-		opt(cfg)
-	}
-
-	challenge, err := generateIAMChallenge()
+	challenge, err := iamjoin.GenerateIAMChallenge()
 	if err != nil {
 		return nil, trace.Wrap(err, "generating IAM challenge")
 	}
@@ -398,7 +89,13 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 	}
 
 	// check that the GetCallerIdentity request is valid and matches the token
-	verifiedIdentity, err := a.checkIAMRequest(ctx, challenge, req, cfg)
+	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
+		Challenge:          challenge,
+		ProvisionToken:     provisionToken,
+		STSIdentityRequest: req.StsIdentityRequest,
+		HTTPClient:         a.GetHTTPClientForAWSSTS(),
+		FIPS:               a.fips,
+	})
 	if verifiedIdentity != nil {
 		joinFailureMetadata = verifiedIdentity
 	}
@@ -416,17 +113,4 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 	params := makeHostCertsParams(req.RegisterUsingTokenRequest, verifiedIdentity)
 	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
 	return certs, trace.Wrap(err, "generating certs")
-}
-
-// RegisterUsingIAMMethod registers the caller using the IAM join method and
-// returns signed certs to join the cluster.
-//
-// The caller must provide a ChallengeResponseFunc which returns a
-// *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
-// including the challenge as a signed header.
-func (a *Server) RegisterUsingIAMMethod(
-	ctx context.Context,
-	challengeResponse client.RegisterIAMChallengeResponseFunc,
-) (certs *proto.Certs, err error) {
-	return a.RegisterUsingIAMMethodWithOpts(ctx, challengeResponse)
 }

--- a/lib/auth/join_oracle.go
+++ b/lib/auth/join_oracle.go
@@ -32,6 +32,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 // RegisterUsingOracleMethod registers the caller using the Oracle join method and
@@ -95,7 +96,7 @@ func (a *Server) registerUsingOracleMethod(
 }
 
 func generateOracleChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.StdEncoding, 32)
+	challenge, err := joinutils.GenerateChallenge(base64.StdEncoding, 32)
 	return challenge, trace.Wrap(err)
 }
 

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -1,0 +1,325 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package iamjoin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws"
+)
+
+const (
+	// Hardcoding the sts API version here may be more strict than necessary,
+	// but this is set by the Teleport node and can only be changed when we
+	// update our AWS SDK dependency. Since Auth should always be upgraded
+	// before nodes, we will have a chance to update the check on Auth if we
+	// ever have a need to allow a newer API version.
+	expectedSTSIdentityRequestBody = "Action=GetCallerIdentity&Version=2011-06-15"
+
+	// AWS SignedHeaders will always be lowercase
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html#sigv4-auth-header-overview
+	challengeHeaderKey = "x-teleport-challenge"
+)
+
+// validateSTSHost returns an error if the given stsHost is not a valid regional
+// endpoint for the AWS STS service, or nil if it is valid. If fips is true, the
+// endpoint must be a valid FIPS endpoint.
+//
+// This is a security-critical check: we are allowing the client to tell us
+// which URL we should use to validate their identity. If the client could pass
+// off an attacker-controlled URL as the STS endpoint, the entire security
+// mechanism of the IAM join method would be compromised.
+//
+// To keep this validation simple and secure, we check the given endpoint
+// against a static list of known valid endpoints. We will need to update this
+// list as AWS adds new regions.
+func validateSTSHost(stsHost string, fips bool) error {
+	valid := slices.Contains(iam.ValidSTSEndpoints(), stsHost)
+	if !valid {
+		return trace.AccessDenied("IAM join request uses unknown STS host %q. "+
+			"This could mean that the Teleport Node attempting to join the cluster is "+
+			"running in a new AWS region which is unknown to this Teleport auth server. "+
+			"Alternatively, if this URL looks suspicious, an attacker may be attempting to "+
+			"join your Teleport cluster. "+
+			"Following is the list of valid STS endpoints known to this auth server. "+
+			"If a legitimate STS endpoint is not included, please file an issue at "+
+			"https://github.com/gravitational/teleport. %v",
+			stsHost, iam.ValidSTSEndpoints())
+	}
+
+	if fips && !slices.Contains(iam.FIPSSTSEndpoints(), stsHost) {
+		return trace.AccessDenied("node selected non-FIPS STS endpoint (%s) for the IAM join method", stsHost)
+	}
+
+	return nil
+}
+
+// validateSTSIdentityRequest checks that a received sts:GetCallerIdentity
+// request is valid and includes the challenge as a signed header. An example
+// valid request looks like:
+// ```
+// POST / HTTP/1.1
+// Host: sts.amazonaws.com
+// Accept: application/json
+// Authorization: AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20211108/us-east-1/sts/aws4_request, SignedHeaders=accept;content-length;content-type;host;x-amz-date;x-amz-security-token;x-teleport-challenge, Signature=999...
+// Content-Length: 43
+// Content-Type: application/x-www-form-urlencoded; charset=utf-8
+// User-Agent: aws-sdk-go/1.37.17 (go1.17.1; darwin; amd64)
+// X-Amz-Date: 20211108T190420Z
+// X-Amz-Security-Token: aaa...
+// X-Teleport-Challenge: 0ezlc3usTAkXeZTcfOazUq0BGrRaKmb4EwODk8U7J5A
+//
+// Action=GetCallerIdentity&Version=2011-06-15
+// ```
+func validateSTSIdentityRequest(req *http.Request, challenge string, fips bool) (err error) {
+	if err := validateSTSHost(req.Host, fips); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if req.Method != http.MethodPost {
+		return trace.AccessDenied("sts identity request method %q does not match expected method %q", req.RequestURI, http.MethodPost)
+	}
+
+	if req.Header.Get(challengeHeaderKey) != challenge {
+		return trace.AccessDenied("sts identity request does not include challenge header or it does not match")
+	}
+
+	authHeader := req.Header.Get(aws.AuthorizationHeader)
+
+	sigV4, err := aws.ParseSigV4(authHeader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !slices.Contains(sigV4.SignedHeaders, challengeHeaderKey) {
+		return trace.AccessDenied("sts identity request auth header %q does not include "+
+			challengeHeaderKey+" as a signed header", authHeader)
+	}
+
+	body, err := utils.GetAndReplaceRequestBody(req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !bytes.Equal([]byte(expectedSTSIdentityRequestBody), body) {
+		return trace.BadParameter("sts request body %q does not equal expected %q", string(body), expectedSTSIdentityRequestBody)
+	}
+
+	return nil
+}
+
+func parseSTSRequest(req []byte) (*http.Request, error) {
+	httpReq, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(req)))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Unset RequestURI and set req.URL instead (necessary quirk of sending a
+	// request parsed by http.ReadRequest). Also, force https here.
+	if httpReq.RequestURI != "/" {
+		return nil, trace.AccessDenied("unexpected sts identity request URI: %q", httpReq.RequestURI)
+	}
+	httpReq.RequestURI = ""
+	httpReq.URL = &url.URL{
+		Scheme: "https",
+		Host:   httpReq.Host,
+	}
+	return httpReq, nil
+}
+
+// AWSIdentity holds aws Account and Arn, used for JSON parsing
+type AWSIdentity struct {
+	Account string `json:"Account"`
+	Arn     string `json:"Arn"`
+}
+
+// JoinAttrs returns the protobuf representation of the attested identity.
+// This is used for auditing and for evaluation of WorkloadIdentity rules and
+// templating.
+func (c *AWSIdentity) JoinAttrs() *workloadidentityv1pb.JoinAttrsAWSIAM {
+	attrs := &workloadidentityv1pb.JoinAttrsAWSIAM{
+		Account: c.Account,
+		Arn:     c.Arn,
+	}
+
+	return attrs
+}
+
+// getCallerIdentityReponse is used for JSON parsing
+type getCallerIdentityResponse struct {
+	GetCallerIdentityResult AWSIdentity `json:"GetCallerIdentityResult"`
+}
+
+// stsIdentityResponse is used for JSON parsing
+type stsIdentityResponse struct {
+	GetCallerIdentityResponse getCallerIdentityResponse `json:"GetCallerIdentityResponse"`
+}
+
+// executeSTSIdentityRequest sends the sts:GetCallerIdentity HTTP request to the
+// AWS API, parses the response, and returns the awsIdentity
+func executeSTSIdentityRequest(ctx context.Context, client utils.HTTPDoClient, req *http.Request) (*AWSIdentity, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// set the http request context so it can be canceled
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, trace.AccessDenied("aws sts api returned status: %q body: %q",
+			resp.Status, body)
+	}
+
+	var identityResponse stsIdentityResponse
+	if err := json.Unmarshal(body, &identityResponse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	id := &identityResponse.GetCallerIdentityResponse.GetCallerIdentityResult
+	if id.Account == "" {
+		return nil, trace.BadParameter("received empty AWS account ID from sts API")
+	}
+	if id.Arn == "" {
+		return nil, trace.BadParameter("received empty AWS identity ARN from sts API")
+	}
+	return id, nil
+}
+
+// arnMatches returns true if arn matches the pattern.
+// Pattern should be an AWS ARN which may include "*" to match any combination
+// of zero or more characters and "?" to match any single character.
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
+func arnMatches(pattern, arn string) (bool, error) {
+	return joinutils.GlobMatch(pattern, arn)
+}
+
+// checkIAMAllowRules checks if the given identity matches any of the given
+// allowRules.
+func checkIAMAllowRules(identity *AWSIdentity, allowRules []*types.TokenRule) error {
+	for _, rule := range allowRules {
+		// if this rule specifies an AWS account, the identity must match
+		if len(rule.AWSAccount) > 0 {
+			if rule.AWSAccount != identity.Account {
+				// account doesn't match, continue to check the next rule
+				continue
+			}
+		}
+		// if this rule specifies an AWS ARN, the identity must match
+		if len(rule.AWSARN) > 0 {
+			matches, err := arnMatches(rule.AWSARN, identity.Arn)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if !matches {
+				// arn doesn't match, continue to check the next rule
+				continue
+			}
+		}
+		// node identity matches this allow rule
+		return nil
+	}
+	return trace.AccessDenied("instance %v did not match any allow rules", identity.Arn)
+}
+
+// CheckIAMRequestParams holds parameters for checking an IAM-method join request.
+type CheckIAMRequestParams struct {
+	// Challenge is the challenge that was sent to the client.
+	Challenge string
+	// ProvisionToken is the provision token being used.
+	ProvisionToken types.ProvisionToken
+	// STSIdentityRequest is the signed sts:GetCallerIdentity request sent by
+	// the client in response to the challenge.
+	STSIdentityRequest []byte
+	// HTTPClient is an optional HTTP client to use for sending
+	// STSIdentityRequest to AWS, if nil a default client will be used.
+	HTTPClient utils.HTTPDoClient
+	// FIPS must be true if the server is in FIPS mode.
+	FIPS bool
+}
+
+// CheckIAMRequest checks if the given request satisfies the token rules and
+// included the required challenge.
+//
+// If the joining entity presents a valid IAM identity, this will be returned,
+// even if the identity does not match the token's allow rules. This is to
+// support inclusion in audit logs.
+func CheckIAMRequest(ctx context.Context, params *CheckIAMRequestParams) (*AWSIdentity, error) {
+	if params.ProvisionToken.GetJoinMethod() != types.JoinMethodIAM {
+		return nil, trace.AccessDenied("this token does not support the IAM join method")
+
+	}
+
+	// parse the incoming http request to the sts:GetCallerIdentity endpoint
+	identityRequest, err := parseSTSRequest(params.STSIdentityRequest)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing STS request")
+	}
+
+	// validate that the host, method, and headers are correct and the expected
+	// challenge is included in the signed portion of the request
+	if err := validateSTSIdentityRequest(identityRequest, params.Challenge, params.FIPS); err != nil {
+		return nil, trace.Wrap(err, "validating STS request")
+	}
+
+	// send the signed request to the public AWS API and get the node identity
+	// from the response
+	identity, err := executeSTSIdentityRequest(ctx, params.HTTPClient, identityRequest)
+	if err != nil {
+		return nil, trace.Wrap(err, "executing STS request")
+	}
+
+	// check that the node identity matches an allow rule for this token
+	if err := checkIAMAllowRules(identity, params.ProvisionToken.GetAllowRules()); err != nil {
+		// We return the identity since it's "validated" but does not match the
+		// rules. This allows us to include it in a failed join audit event
+		// as additional context to help the user understand why the join failed.
+		return identity, trace.Wrap(err, "checking allow rules")
+	}
+
+	return identity, nil
+}
+
+// GenerateIAMChallenge generates a random challenge string for the IAM join method.
+func GenerateIAMChallenge() (string, error) {
+	challenge, err := joinutils.GenerateChallenge(base64.RawStdEncoding, 32)
+	return challenge, trace.Wrap(err)
+}

--- a/lib/join/internal/diagnostic/diagnostic.go
+++ b/lib/join/internal/diagnostic/diagnostic.go
@@ -47,6 +47,7 @@ type Info struct {
 	BotGeneration       uint64
 	BotInstanceID       string
 	Error               error
+	RawJoinAttrs        any
 }
 
 // New returns an empty diagnostic ready to use.
@@ -72,8 +73,7 @@ func (d *Diagnostic) Set(f func(*Info)) {
 // SlogAttrs returns the current collected info as a slice of [slog.Attr]
 // suitable for logging. Unset fields will be included as an empty [slog.Attr]
 // which are conventionally ignored by log handlers.
-func (d *Diagnostic) SlogAttrs() []slog.Attr {
-	info := d.Get()
+func (info *Info) SlogAttrs() []slog.Attr {
 	return []slog.Attr{
 		stringAttr("error", info.Error.Error()),
 		stringAttr("remote_addr", info.RemoteAddr),

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth_test
+package join_test
 
 import (
 	"bytes"
@@ -29,19 +29,20 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
-	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func responseFromAWSIdentity(id auth.AWSIdentity) string {
+func responseFromAWSIdentity(id iamjoin.AWSIdentity) string {
 	return fmt.Sprintf(`{
 		"GetCallerIdentityResponse": {
 			"GetCallerIdentityResult": {
@@ -109,21 +110,38 @@ func withChallenge(challenge string) challengeResponseOption {
 	}
 }
 
-func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
+type iamJoinTestCase struct {
+	desc                     string
+	authServer               *authtest.Server
+	tokenName                string
+	requestTokenName         string
+	tokenSpec                types.ProvisionTokenSpecV2
+	stsClient                utils.HTTPDoClient
+	challengeResponseOptions []challengeResponseOption
+	challengeResponseErr     error
+	assertError              require.ErrorAssertionFunc
+}
+
+func TestJoinIAM(t *testing.T) {
 	t.Parallel()
+	ctx := t.Context()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p, err := newTestPack(ctx, t.TempDir())
+	regularServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir: t.TempDir(),
+		},
+	})
 	require.NoError(t, err)
-	a := p.a
+	t.Cleanup(func() { assert.NoError(t, regularServer.Shutdown(ctx)) })
 
-	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
+	fipsServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir:  t.TempDir(),
+			FIPS: true,
+		},
+	})
 	require.NoError(t, err)
-
-	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
-	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, regularServer.Shutdown(ctx)) })
 
 	isAccessDenied := func(t require.TestingT, err error, _ ...any) {
 		require.True(t, trace.IsAccessDenied(err), "expected Access Denied error, actual error: %v", err)
@@ -132,19 +150,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		require.True(t, trace.IsBadParameter(err), "expected Bad Parameter error, actual error: %v", err)
 	}
 
-	testCases := []struct {
-		desc                     string
-		tokenName                string
-		requestTokenName         string
-		tokenSpec                types.ProvisionTokenSpecV2
-		stsClient                utils.HTTPDoClient
-		iamRegisterOptions       []auth.IAMRegisterOption
-		challengeResponseOptions []challengeResponseOption
-		challengeResponseErr     error
-		assertError              require.ErrorAssertionFunc
-	}{
+	testCases := []iamJoinTestCase{
 		{
 			desc:             "basic passing case",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -159,7 +168,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -168,6 +177,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn 1",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -182,7 +192,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-test",
 				}),
@@ -191,6 +201,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn 2",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -205,7 +216,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-123",
 				}),
@@ -214,6 +225,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -228,7 +240,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -237,6 +249,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -251,7 +264,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -260,6 +273,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard 2 arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -274,7 +288,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -283,6 +297,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong wildcard arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -297,7 +312,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name",
 				}),
@@ -306,6 +321,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong wildcard 2 arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -320,7 +336,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name2",
 				}),
@@ -329,6 +345,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong token",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "wrong-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -343,7 +360,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -352,6 +369,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "challenge response error",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -366,7 +384,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -376,6 +394,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong arn",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -390,7 +409,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-1234",
 				}),
@@ -399,6 +418,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong challenge",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -413,7 +433,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -425,6 +445,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong account",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -439,7 +460,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "5678",
 					Arn:     "arn:aws::1111",
 				}),
@@ -448,6 +469,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "sts api error",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -468,6 +490,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong sts host",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -482,7 +505,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -494,6 +517,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "regional sts endpoint",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -508,7 +532,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -520,6 +544,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "unsigned challenge header",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -534,7 +559,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -546,6 +571,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "fips pass",
+			authServer:       fipsServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -560,14 +586,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
-			},
-			iamRegisterOptions: []auth.IAMRegisterOption{
-				auth.WithFIPS(true),
-				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts-fips.us-east-1.amazonaws.com"),
@@ -575,7 +597,8 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
-			desc:             "non-fips client fail v12",
+			desc:             "non-fips client fail",
+			authServer:       fipsServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -590,14 +613,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
-			},
-			iamRegisterOptions: []auth.IAMRegisterOption{
-				auth.WithFIPS(true),
-				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts.us-east-1.amazonaws.com"),
@@ -608,41 +627,76 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			// Set mock client.
-			a.SetHTTPClientForAWSSTS(tc.stsClient)
-
-			// add token to auth server
-			token, err := types.NewProvisionTokenFromSpec(
-				tc.tokenName,
-				time.Now().Add(time.Minute),
-				tc.tokenSpec)
-			require.NoError(t, err)
-			require.NoError(t, a.UpsertToken(ctx, token))
-			defer func() {
-				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
-			}()
-
-			_, err = a.RegisterUsingIAMMethodWithOpts(context.Background(), func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
-				templateInput := defaultIdentityRequestTemplateInput(challenge)
-				for _, opt := range tc.challengeResponseOptions {
-					opt(&templateInput)
-				}
-				var identityRequest bytes.Buffer
-				require.NoError(t, identityRequestTemplate.Execute(&identityRequest, templateInput))
-
-				req := &proto.RegisterUsingIAMMethodRequest{
-					RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
-						Token:        tc.requestTokenName,
-						HostID:       "test-node",
-						Role:         types.RoleNode,
-						PublicSSHKey: sshPublicKey,
-						PublicTLSKey: tlsPublicKey,
-					},
-					StsIdentityRequest: identityRequest.Bytes(),
-				}
-				return req, tc.challengeResponseErr
-			}, tc.iamRegisterOptions...)
-			tc.assertError(t, err)
+			testIAMJoin(t, &tc)
 		})
 	}
+}
+
+func testIAMJoin(t *testing.T, tc *iamJoinTestCase) {
+	ctx := t.Context()
+	// Set mock client.
+	tc.authServer.Auth().SetHTTPClientForAWSSTS(tc.stsClient)
+
+	// Add token to auth server.
+	token, err := types.NewProvisionTokenFromSpec(
+		tc.tokenName,
+		time.Now().Add(time.Minute),
+		tc.tokenSpec)
+	require.NoError(t, err)
+	require.NoError(t, tc.authServer.Auth().UpsertToken(ctx, token))
+	t.Cleanup(func() {
+		assert.NoError(t, tc.authServer.Auth().DeleteToken(ctx, token.GetName()))
+	})
+
+	// Make an unauthenticated auth client that will be used for the join.
+	nopClient, err := tc.authServer.NewClient(authtest.TestNop())
+	require.NoError(t, err)
+	defer nopClient.Close()
+
+	createSignedSTSIdentityRequest := func(ctx context.Context, challenge string, opts ...iam.STSIdentityRequestOption) ([]byte, error) {
+		if tc.challengeResponseErr != nil {
+			return nil, trace.Wrap(tc.challengeResponseErr)
+		}
+		templateInput := defaultIdentityRequestTemplateInput(challenge)
+		for _, opt := range tc.challengeResponseOptions {
+			opt(&templateInput)
+		}
+		var identityRequest bytes.Buffer
+		if err := identityRequestTemplate.Execute(&identityRequest, templateInput); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return identityRequest.Bytes(), nil
+	}
+
+	// Test joining via the legacy join service.
+	//
+	// TODO(nklaassen): DELETE IN 20 when removing the legacy join service.
+	t.Run("legacy", func(t *testing.T) {
+		_, err := joinclient.LegacyJoin(ctx, joinclient.JoinParams{
+			Token:      tc.requestTokenName,
+			JoinMethod: types.JoinMethodIAM,
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				HostUUID: "test-uuid",
+				NodeName: "test-node",
+			},
+			CreateSignedSTSIdentityRequestFunc: createSignedSTSIdentityRequest,
+			AuthClient:                         nopClient,
+		})
+		tc.assertError(t, err)
+	})
+
+	// Tests joining via the new join service with auth-assigned host UUIDs.
+	t.Run("new", func(t *testing.T) {
+		_, err := joinclient.Join(ctx, joinclient.JoinParams{
+			Token: tc.requestTokenName,
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				NodeName: "test-node",
+			},
+			CreateSignedSTSIdentityRequestFunc: createSignedSTSIdentityRequest,
+			AuthClient:                         nopClient,
+		})
+		tc.assertError(t, err)
+	})
 }

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -154,12 +154,12 @@ func joinViaAuthClient(ctx context.Context, params JoinParams, authClient authjo
 
 func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Client) (*JoinResult, error) {
 	// Clients may specify the join method or not, to let the server choose the
-	// method based on the provsion token.
+	// method based on the provision token.
 	var joinMethodPtr *string
 	switch params.JoinMethod {
 	case types.JoinMethodUnspecified:
 		// leave joinMethodPtr nil to let the server pick based on the token
-	case types.JoinMethodToken, types.JoinMethodBoundKeypair:
+	case types.JoinMethodToken, types.JoinMethodBoundKeypair, types.JoinMethodIAM:
 		joinMethod := string(params.JoinMethod)
 		joinMethodPtr = &joinMethod
 	default:
@@ -196,7 +196,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	}
 
 	// Generate keys based on the signature algorithm suite from the ServerInit message.
-	signer, publicKeys, err := generateKeys(ctx, serverInit.SignatureAlgorithmSuite)
+	signer, publicKeys, err := GenerateKeys(ctx, serverInit.SignatureAlgorithmSuite)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -242,6 +242,8 @@ func joinWithMethod(
 		return tokenJoin(stream, clientParams)
 	case types.JoinMethodBoundKeypair:
 		return boundKeypairJoin(ctx, stream, joinParams, clientParams)
+	case types.JoinMethodIAM:
+		return iamJoin(ctx, stream, joinParams, clientParams)
 	default:
 		// TODO(nklaassen): implement remaining join methods.
 		return nil, trace.NotImplemented("server selected join method %v which is not supported by this client", method)
@@ -348,7 +350,9 @@ func pemEncodeTLSCert(rawCert []byte) []byte {
 	})
 }
 
-func generateKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (crypto.Signer, *messages.PublicKeys, error) {
+// GenerateKeys generates host keys appropriate for a cluster join request
+// according to the cluster's configured signature algorithm suite.
+func GenerateKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (crypto.Signer, *messages.PublicKeys, error) {
 	signer, err := cryptosuites.GenerateKey(
 		ctx,
 		cryptosuites.StaticAlgorithmSuite(suite),

--- a/lib/join/joinclient/join_iam.go
+++ b/lib/join/joinclient/join_iam.go
@@ -1,0 +1,72 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinclient
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+func iamJoin(
+	ctx context.Context,
+	stream messages.ClientStream,
+	joinParams JoinParams,
+	clientParams messages.ClientParams,
+) (messages.Response, error) {
+	// The IAM join method involves the following messages:
+	//
+	// client->server ClientInit
+	// client<-server ServerInit
+	// client->server IAMInit
+	// client<-server IAMChallenge
+	// client->server IAMChallengeSolution
+	// client<-server Result
+	//
+	// At this point the ServerInit messages has already been received, what's
+	// left is to send the IAMInit message, handle the challenge-response, and
+	// receive and return the final result.
+	if err := stream.Send(&messages.IAMInit{
+		ClientParams: clientParams,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending IAMInit")
+	}
+
+	challenge, err := messages.RecvResponse[*messages.IAMChallenge](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving IAMChallenge")
+	}
+
+	signedRequest, err := joinParams.CreateSignedSTSIdentityRequestFunc(ctx, challenge.Challenge,
+		iam.WithFIPSEndpoint(joinParams.FIPS),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating signed sts:GetCallerIdentity request")
+	}
+
+	if err := stream.Send(&messages.IAMChallengeSolution{
+		STSIdentityRequest: signedRequest,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending IAMChallengeSolution")
+	}
+
+	result, err := stream.Recv()
+	return result, trace.Wrap(err, "receiving join result")
+}

--- a/lib/join/joinutils/utils.go
+++ b/lib/join/joinutils/utils.go
@@ -1,0 +1,72 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinutils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+)
+
+// GlobMatch performs simple a simple glob-style match test on a string.
+// - '*' matches zero or more characters.
+// - '?' matches any single character.
+// It returns true if a match is detected.
+func GlobMatch(pattern, str string) (bool, error) {
+	pattern = regexp.QuoteMeta(pattern)
+	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	pattern = strings.ReplaceAll(pattern, `\?`, ".")
+	pattern = "^" + pattern + "$"
+	matched, err := regexp.MatchString(pattern, str)
+	return matched, trace.Wrap(err)
+}
+
+// GenerateChallenge generates a crypto-random challenge with length random
+// bytes and encodes it to base64.
+func GenerateChallenge(encoding *base64.Encoding, length int) (string, error) {
+	// read crypto-random bytes to generate the challenge
+	challengeRawBytes := make([]byte, length)
+	if _, err := rand.Read(challengeRawBytes); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// encode the challenge to base64 so it can be sent over HTTP
+	return encoding.EncodeToString(challengeRawBytes), nil
+}
+
+// RawJoinAttrsToStruct converts raw join attributes into a struct suitable for
+// logging or audit events.
+func RawJoinAttrsToStruct(in any) (*apievents.Struct, error) {
+	if in == nil {
+		return nil, nil
+	}
+	attrBytes, err := json.Marshal(in)
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling join attributes")
+	}
+	out := &apievents.Struct{}
+	if err := out.UnmarshalJSON(attrBytes); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling join attributes")
+	}
+	return out, nil
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -46,7 +47,9 @@ import (
 	joinauthz "github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -69,6 +72,7 @@ type AuthService interface {
 	UpsertLock(context.Context, types.Lock) error
 	CheckLockInForce(constants.LockingMode, []types.LockTarget) error
 	GetClock() clockwork.Clock
+	GetHTTPClientForAWSSTS() utils.HTTPDoClient
 }
 
 // ServerConfig holds configuration parameters for [Server].
@@ -76,6 +80,7 @@ type ServerConfig struct {
 	AuthService AuthService
 	Authorizer  authz.Authorizer
 	Clock       clockwork.Clock
+	FIPS        bool
 }
 
 // Server implements cluster joining for nodes and bots.
@@ -201,6 +206,8 @@ func (s *Server) handleJoinMethod(
 		return s.handleTokenJoin(stream, authCtx, clientInit, provisionToken)
 	case types.JoinMethodBoundKeypair:
 		return s.handleBoundKeypairJoin(stream, authCtx, clientInit, provisionToken)
+	case types.JoinMethodIAM:
+		return s.handleIAMJoin(stream, authCtx, clientInit, provisionToken)
 	default:
 		// TODO(nklaassen): implement checks for all join methods.
 		return nil, trace.NotImplemented("join method %s is not yet implemented by the new join service", joinMethod)
@@ -326,14 +333,15 @@ func (s *Server) makeResult(
 	authCtx *joinauthz.Context,
 	clientInit *messages.ClientInit,
 	clientParams *messages.ClientParams,
-	rawClaims any,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (messages.Response, error) {
 	switch types.SystemRole(clientInit.SystemRole) {
 	case types.RoleInstance:
-		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, provisionToken)
+		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, provisionToken, rawClaims)
 	case types.RoleBot:
-		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, rawClaims, provisionToken)
+		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, provisionToken, rawClaims, attrs)
 		return result, trace.Wrap(err)
 	default:
 		return nil, trace.NotImplemented("new join service only supports Instance and Bot system roles, client requested %s", clientInit.SystemRole)
@@ -346,8 +354,9 @@ func (s *Server) makeHostResult(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
 ) (*messages.HostResult, error) {
-	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(provisionToken))
+	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(provisionToken), rawClaims)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -373,11 +382,12 @@ func makeHostCertsParams(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	joinMethod types.JoinMethod,
+	rawClaims any,
 ) (*HostCertsParams, error) {
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(hostParams.PublicKeys.PublicTLSKey)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("failed to parse TLS public key")
 	}
 	tlsPubPEM, err := keys.MarshalPublicKey(crypto.PublicKey(tlsPub))
 	if err != nil {
@@ -387,7 +397,7 @@ func makeHostCertsParams(
 	// GenerateHostCertsForJoin requires the SSH key to be in authorized keys format.
 	sshPub, err := ssh.ParsePublicKey(hostParams.PublicKeys.PublicSSHKey)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("failed to parse SSH public key")
 	}
 	sshAuthorizedKey := ssh.MarshalAuthorizedKey(sshPub)
 
@@ -399,6 +409,7 @@ func makeHostCertsParams(
 		AdditionalPrincipals: hostParams.AdditionalPrincipals,
 		DNSNames:             hostParams.DNSNames,
 		RemoteAddr:           diag.Get().RemoteAddr,
+		RawJoinClaims:        rawClaims,
 	}
 
 	if authCtx.IsInstance {
@@ -424,10 +435,11 @@ func (s *Server) makeBotResult(
 	diag *diagnostic.Diagnostic,
 	authCtx *joinauthz.Context,
 	botParams *messages.BotParams,
-	rawClaims any,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*messages.BotResult, string, error) {
-	certsParams, err := makeBotCertsParams(diag, authCtx, botParams, rawClaims)
+	certsParams, err := makeBotCertsParams(diag, authCtx, botParams, rawClaims, attrs)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -451,6 +463,7 @@ func makeBotCertsParams(
 	authCtx *joinauthz.Context,
 	botParams *messages.BotParams,
 	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*BotCertsParams, error) {
 	// GenerateBotCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(botParams.PublicKeys.PublicTLSKey)
@@ -477,6 +490,7 @@ func makeBotCertsParams(
 		Expires:       botParams.Expires,
 		RemoteAddr:    diag.Get().RemoteAddr,
 		RawJoinClaims: rawClaims,
+		Attrs:         attrs,
 	}, nil
 }
 
@@ -551,14 +565,25 @@ func setDiagnosticClientParams(diag *diagnostic.Diagnostic, clientParams *messag
 }
 
 func handleJoinFailure(ctx context.Context, emitter apievents.Emitter, diag *diagnostic.Diagnostic) {
-	log.LogAttrs(ctx, slog.LevelWarn, "Failure to join cluster occurred", diag.SlogAttrs()...)
-	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diag)); err != nil {
+	diagInfo := diag.Get()
+	slogAttrs := diagInfo.SlogAttrs()
+
+	// Fetch and encode RawJoinAttrs if they are available.
+	attributesStruct, err := joinutils.RawJoinAttrsToStruct(diagInfo.RawJoinAttrs)
+	if err != nil {
+		log.WarnContext(ctx, "Unable to fetch join attributes from join method", "error", err)
+	}
+	if attributesStruct != nil {
+		slogAttrs = append(slogAttrs, slog.Any("attributes", attributesStruct))
+	}
+
+	log.LogAttrs(ctx, slog.LevelWarn, "Failure to join cluster occurred", slogAttrs...)
+	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diagInfo, attributesStruct)); err != nil {
 		log.WarnContext(ctx, "Failed to emit failed join event", "error", err)
 	}
 }
 
-func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
-	info := d.Get()
+func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) apievents.AuditEvent {
 	errorMessage := info.Error.Error()
 	if errors.Is(info.Error, context.Canceled) || status.Code(info.Error) == codes.Canceled {
 		errorMessage = "join attempt timed out or was aborted"
@@ -582,6 +607,7 @@ func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
 			TokenName:     info.SafeTokenName,
 			BotName:       info.BotName,
 			BotInstanceID: info.BotInstanceID,
+			Attributes:    attributesStruct,
 		}
 	}
 	return &apievents.InstanceJoin{
@@ -599,6 +625,7 @@ func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
 		TokenExpires: info.TokenExpires,
 		Role:         info.Role,
 		NodeName:     info.NodeName,
+		Attributes:   attributesStruct,
 	}
 }
 

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -84,7 +84,13 @@ func (s *Server) handleBoundKeypairJoin(
 		return rotationResp, trace.Wrap(err)
 	}
 	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
-		botCertsParams, err := makeBotCertsParams(diag, authCtx, boundKeypairInit.ClientParams.BotParams, claims)
+		botCertsParams, err := makeBotCertsParams(
+			diag,
+			authCtx,
+			boundKeypairInit.ClientParams.BotParams,
+			claims,
+			nil, // TODO(timothyb89): workload id claims
+		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -188,7 +194,13 @@ func AdaptRegisterUsingBoundKeypairMethod(
 	}
 
 	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
-		botCertsParams, err := makeBotCertsParams(diag, authCtx, clientParams.BotParams, claims)
+		botCertsParams, err := makeBotCertsParams(
+			diag,
+			authCtx,
+			clientParams.BotParams,
+			claims,
+			nil, // TODO(timothyb89): workload id claims
+		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -1,0 +1,108 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join
+
+import (
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/join/internal/authz"
+	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+// handleIAMJoin handles join attempts for the IAM join method.
+//
+// The IAM join method involves the following messages:
+//
+// client->server ClientInit
+// client<-server ServerInit
+// client->server IAMInit
+// client<-server IAMChallenge
+// client->server IAMChallengeSolution
+// client<-server Result
+//
+// At this point the ServerInit message has already been sent, what's left is
+// to receive the IAMInit message, handle the challenge-response, and send the
+// final result if everything checks out.
+func (s *Server) handleIAMJoin(
+	stream messages.ServerStream,
+	authCtx *authz.Context,
+	clientInit *messages.ClientInit,
+	provisionToken types.ProvisionToken,
+) (messages.Response, error) {
+	// Receive the IAMInit message from the client.
+	iamInit, err := messages.RecvRequest[*messages.IAMInit](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving IAMInit message")
+	}
+	// Set any diagnostic info from the ClientParams.
+	setDiagnosticClientParams(stream.Diagnostic(), &iamInit.ClientParams)
+
+	// Generate and send the challenge.
+	challenge, err := iamjoin.GenerateIAMChallenge()
+	if err != nil {
+		return nil, trace.Wrap(err, "generating challenge")
+	}
+	if err := stream.Send(&messages.IAMChallenge{
+		Challenge: challenge,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending challenge")
+	}
+
+	// Receive the solution from the client.
+	solution, err := messages.RecvRequest[*messages.IAMChallengeSolution](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving challenge solution")
+	}
+
+	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
+	// the verified identity matches allow rules in the provision token.
+	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
+		Challenge:          challenge,
+		ProvisionToken:     provisionToken,
+		STSIdentityRequest: solution.STSIdentityRequest,
+		HTTPClient:         s.cfg.AuthService.GetHTTPClientForAWSSTS(),
+		FIPS:               s.cfg.FIPS,
+	})
+	// An identity will be returned even on error if the sts:GetCallerIdentity
+	// request was completed but no allow rules were matched, include it in the
+	// diagnostic for debugging.
+	stream.Diagnostic().Set(func(info *diagnostic.Info) {
+		info.RawJoinAttrs = verifiedIdentity
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "verifying challenge response")
+	}
+
+	// Make and return the final result message.
+	result, err := s.makeResult(
+		stream.Context(),
+		stream.Diagnostic(),
+		authCtx,
+		clientInit,
+		&iamInit.ClientParams,
+		provisionToken,
+		verifiedIdentity,
+		&workloadidentityv1pb.JoinAttrs{
+			Iam: verifiedIdentity.JoinAttrs(),
+		},
+	)
+	return result, trace.Wrap(err)
+}

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -47,8 +47,9 @@ func (s *Server) handleTokenJoin(
 		authCtx,
 		clientInit,
 		&tokenInit.ClientParams,
-		nil, /*rawClaims*/
 		provisionToken,
+		nil, /*rawClaims*/
+		nil, /*attrs*/
 	)
 	return result, trace.Wrap(err)
 }


### PR DESCRIPTION
Part of [RFD 27e](https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md)

This PR adds support for the IAM join method to the new join service and client. Both the new and legacy gRPC servers are updated to use common logic that verifies the request.