### PR TITLE
Fix inherited AccessList ownership permissions

### DIFF
--- a/lib/accesslists/hierarchy_user_test.go
+++ b/lib/accesslists/hierarchy_user_test.go
@@ -232,6 +232,43 @@ func TestGetHierarchyForUser(t *testing.T) {
 			want:  nil,
 		},
 		{
+			name: "owner/owner via direct nested ownerships requirements are met",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("level1"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice", mkTrait("need")),
+			start: "level1",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"root"},
+		},
+		{
+			name: "owner/owner via direct nested ownerships requirements not met",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1"), withOwnerTraitReq("need")): {},
+				mustMakeAccessList("level1"): {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "level1",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  nil,
+		},
+		{
+			name: "owner/owner many levels up the ownership chain",
+			state: state{
+				mustMakeAccessList("root", withOwnerList("level1")): {},
+				mustMakeAccessList("level1"):                        {mustCreateMember("level2", withACLMemKind())},
+				mustMakeAccessList("level2"):                        {mustCreateMember("level3", withACLMemKind())},
+				mustMakeAccessList("level3"):                        {mustCreateMember("level4", withACLMemKind())},
+				mustMakeAccessList("level4"):                        {mustCreateMember("levelTail", withACLMemKind())},
+				mustMakeAccessList("levelTail"):                     {mustCreateMember("alice")},
+			},
+			user:  makeUser("alice"),
+			start: "levelTail",
+			kind:  accesslists.RelationshipKindOwner,
+			want:  []string{"root"},
+		},
+		{
 			name: "member/multiple parents included",
 			state: state{
 				mustMakeAccessList("rootA"):  {mustCreateMember("level2", withACLMemKind())},

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -532,6 +532,34 @@ func TestAccessLists(t *testing.T) {
 			expectedInheritedTraitCount: 1,
 		},
 		{
+			name:  "one level nested ownership inheritance chain",
+			cloud: true,
+			user:  userNoRolesOrTraits,
+			// user is member of acl child that is configured as owner of acl root
+			accessLists: []*accesslist.AccessList{
+				newAccessList(t, clock, "child", emptyGrants, accesslist.Grants{}),
+				newAccessListWithOwners(t, clock, "root", emptyGrants, grants([]string{"roleRoot"}, nil), []accesslist.Owner{{
+					Name:           "child",
+					MembershipKind: accesslist.MembershipKindList},
+				}),
+			},
+
+			members: newAccessListMembers(t, clock, "child", "user"),
+			roles:   []string{"roleRoot"},
+			wantErr: require.NoError,
+			expected: newUserLoginState(t, "user",
+				nil,
+				nil,
+				nil,
+				[]string{"roleRoot"},
+				nil,
+			),
+			expectedRoleCount:           1,
+			expectedTraitCount:          0,
+			expectedInheritedRoleCount:  1,
+			expectedInheritedTraitCount: 0,
+		},
+		{
 			name:  "an access list that references a non-existent role should be skipped entirely",
 			user:  user,
 			cloud: true,


### PR DESCRIPTION
### What

Fix a ownership permission inheritance case when a user is a member of access list B and access list B is configured as Owners of access list A. 


changelog: Fix Access List owners inheritance permsison when a inheritance deep is equal one. (Nested access list members configured as Owner of another Access list)

