### PR TITLE
[chore] make testFuncs method naming consistent

### DIFF
--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -57,9 +57,9 @@ func TestAccessList(t *testing.T) {
 			_, err := p.accessLists.UpsertAccessList(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.accessLists.ListAccessLists,
-		cacheGet:  p.cache.GetAccessList,
-		cacheList: p.cache.ListAccessLists,
+		upstreamList: p.accessLists.ListAccessLists,
+		cacheGet:     p.cache.GetAccessList,
+		cacheList:    p.cache.ListAccessLists,
 		update: func(ctx context.Context, item *accesslist.AccessList) error {
 			_, err := p.accessLists.UpsertAccessList(ctx, item)
 			return trace.Wrap(err)
@@ -91,7 +91,7 @@ func TestAccessListMembers(t *testing.T) {
 			_, err := p.accessLists.UpsertAccessListMember(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: p.accessLists.ListAllAccessListMembers,
+		upstreamList: p.accessLists.ListAllAccessListMembers,
 		cacheGet: func(ctx context.Context, name string) (*accesslist.AccessListMember, error) {
 			return p.cache.GetAccessListMember(ctx, al.GetName(), name)
 		},
@@ -176,7 +176,7 @@ func TestAccessListReviews(t *testing.T) {
 			reviews[oldName].SetName(review.GetName())
 			return trace.Wrap(err)
 		},
-		list: p.accessLists.ListAllAccessListReviews,
+		upstreamList: p.accessLists.ListAllAccessListReviews,
 		cacheList: func(ctx context.Context, pageSize int, startKey string) ([]*accesslist.Review, string, error) {
 			return p.cache.ListAccessListReviews(ctx, al.GetName(), pageSize, startKey)
 		},

--- a/lib/cache/access_monitoring_rule_test.go
+++ b/lib/cache/access_monitoring_rule_test.go
@@ -45,9 +45,9 @@ func TestAccessMonitoringRules(t *testing.T) {
 			_, err := p.accessMonitoringRules.CreateAccessMonitoringRule(ctx, i)
 			return err
 		},
-		list:      p.accessMonitoringRules.ListAccessMonitoringRules,
-		cacheGet:  p.cache.GetAccessMonitoringRule,
-		cacheList: p.cache.ListAccessMonitoringRules,
+		upstreamList: p.accessMonitoringRules.ListAccessMonitoringRules,
+		cacheGet:     p.cache.GetAccessMonitoringRule,
+		cacheList:    p.cache.ListAccessMonitoringRules,
 		update: func(ctx context.Context, i *accessmonitoringrulesv1.AccessMonitoringRule) error {
 			_, err := p.accessMonitoringRules.UpdateAccessMonitoringRule(ctx, i)
 			return err

--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -46,14 +46,14 @@ func TestApps(t *testing.T) {
 				URI: "localhost",
 			})
 		},
-		create:     p.apps.CreateApp,
-		list:       p.apps.ListApps,
-		Range:      p.apps.Apps,
-		cacheGet:   p.cache.GetApp,
-		cacheList:  p.cache.ListApps,
-		cacheRange: p.cache.Apps,
-		update:     p.apps.UpdateApp,
-		deleteAll:  p.apps.DeleteAllApps,
+		create:        p.apps.CreateApp,
+		upstreamList:  p.apps.ListApps,
+		upstreamRange: p.apps.Apps,
+		cacheGet:      p.cache.GetApp,
+		cacheList:     p.cache.ListApps,
+		cacheRange:    p.cache.Apps,
+		update:        p.apps.UpdateApp,
+		deleteAll:     p.apps.DeleteAllApps,
 	})
 }
 
@@ -73,7 +73,7 @@ func TestApplicationServers(t *testing.T) {
 				return types.NewAppServerV3FromApp(app, "host", uuid.New().String())
 			},
 			create: withKeepalive(p.presenceS.UpsertApplicationServer),
-			list: getAllAdapter(func(ctx context.Context) ([]types.AppServer, error) {
+			upstreamList: getAllAdapter(func(ctx context.Context) ([]types.AppServer, error) {
 				return p.presenceS.GetApplicationServers(ctx, apidefaults.Namespace)
 			}),
 			cacheList: getAllAdapter(func(ctx context.Context) ([]types.AppServer, error) {
@@ -94,7 +94,7 @@ func TestApplicationServers(t *testing.T) {
 				return types.NewAppServerV3FromApp(app, "host", uuid.New().String())
 			},
 			create: withKeepalive(p.presenceS.UpsertApplicationServer),
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.AppServer, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.AppServer, string, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindAppServer,
 					StartKey:     pageToken,

--- a/lib/cache/auth_server_test.go
+++ b/lib/cache/auth_server_test.go
@@ -42,10 +42,10 @@ func TestAuthServers(t *testing.T) {
 				},
 			}, nil
 		},
-		create:    p.presenceS.UpsertAuthServer,
-		list:      getAllAdapter(func(context.Context) ([]types.Server, error) { return p.presenceS.GetAuthServers() }),
-		cacheList: getAllAdapter(func(context.Context) ([]types.Server, error) { return p.cache.GetAuthServers() }),
-		update:    p.presenceS.UpsertAuthServer,
+		create:       p.presenceS.UpsertAuthServer,
+		upstreamList: getAllAdapter(func(context.Context) ([]types.Server, error) { return p.presenceS.GetAuthServers() }),
+		cacheList:    getAllAdapter(func(context.Context) ([]types.Server, error) { return p.cache.GetAuthServers() }),
+		update:       p.presenceS.UpsertAuthServer,
 		deleteAll: func(_ context.Context) error {
 			return p.presenceS.DeleteAllAuthServers()
 		},

--- a/lib/cache/auto_update_test.go
+++ b/lib/cache/auto_update_test.go
@@ -41,7 +41,7 @@ func TestAutoUpdateConfig(t *testing.T) {
 			_, err := p.autoUpdateService.UpsertAutoUpdateConfig(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateConfig, error) {
+		upstreamList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateConfig, error) {
 			item, err := p.autoUpdateService.GetAutoUpdateConfig(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateConfig{}, nil
@@ -77,7 +77,7 @@ func TestAutoUpdateVersion(t *testing.T) {
 			_, err := p.autoUpdateService.UpsertAutoUpdateVersion(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateVersion, error) {
+		upstreamList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateVersion, error) {
 			item, err := p.autoUpdateService.GetAutoUpdateVersion(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateVersion{}, nil
@@ -111,7 +111,7 @@ func TestAutoUpdateAgentRollout(t *testing.T) {
 			_, err := p.autoUpdateService.UpsertAutoUpdateAgentRollout(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
+		upstreamList: getAllAdapter(func(ctx context.Context) ([]*autoupdatev1.AutoUpdateAgentRollout, error) {
 			item, err := p.autoUpdateService.GetAutoUpdateAgentRollout(ctx)
 			if trace.IsNotFound(err) {
 				return []*autoupdatev1.AutoUpdateAgentRollout{}, nil

--- a/lib/cache/bot_instance_test.go
+++ b/lib/cache/bot_instance_test.go
@@ -64,7 +64,7 @@ func TestBotInstanceCache(t *testing.T) {
 			_, err := p.botInstanceService.CreateBotInstance(ctx, resource)
 			return err
 		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*machineidv1.BotInstance, string, error) {
 			return p.botInstanceService.ListBotInstances(ctx, pageSize, pageToken, nil)
 		},
 		update: func(ctx context.Context, bi *machineidv1.BotInstance) error {

--- a/lib/cache/cluster_config_test.go
+++ b/lib/cache/cluster_config_test.go
@@ -188,8 +188,8 @@ func TestAccessGraphSettings(t *testing.T) {
 			_, err := p.clusterConfigS.UpsertAccessGraphSettings(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      singletonListAdapter(p.clusterConfigS.GetAccessGraphSettings),
-		cacheList: singletonListAdapter(p.cache.GetAccessGraphSettings),
-		deleteAll: p.clusterConfigS.DeleteAccessGraphSettings,
+		upstreamList: singletonListAdapter(p.clusterConfigS.GetAccessGraphSettings),
+		cacheList:    singletonListAdapter(p.cache.GetAccessGraphSettings),
+		deleteAll:    p.clusterConfigS.DeleteAccessGraphSettings,
 	}, withSkipPaginationTest())
 }

--- a/lib/cache/crown_jewel_test.go
+++ b/lib/cache/crown_jewel_test.go
@@ -41,7 +41,7 @@ func TestCrownJewel(t *testing.T) {
 			_, err := p.crownJewels.CreateCrownJewel(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*crownjewelv1.CrownJewel, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*crownjewelv1.CrownJewel, string, error) {
 			return p.crownJewels.ListCrownJewels(ctx, int64(pageSize), pageToken)
 		},
 		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*crownjewelv1.CrownJewel, string, error) {

--- a/lib/cache/database_test.go
+++ b/lib/cache/database_test.go
@@ -48,7 +48,7 @@ func TestDatabaseServices(t *testing.T) {
 			})
 		},
 		create: withKeepalive(p.databaseServices.UpsertDatabaseService),
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]types.DatabaseService, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.DatabaseService, string, error) {
 			resources, next, err := listResource(ctx, p.presenceS, types.KindDatabaseService, pageSize, pageToken)
 			if err != nil {
 				return nil, "", trace.Wrap(err)
@@ -92,14 +92,14 @@ func TestDatabases(t *testing.T) {
 				URI:      "localhost:5432",
 			})
 		},
-		create:     p.databases.CreateDatabase,
-		list:       p.databases.ListDatabases,
-		Range:      p.databases.RangeDatabases,
-		cacheGet:   p.cache.GetDatabase,
-		cacheList:  p.cache.ListDatabases,
-		cacheRange: p.cache.RangeDatabases,
-		update:     p.databases.UpdateDatabase,
-		deleteAll:  p.databases.DeleteAllDatabases,
+		create:        p.databases.CreateDatabase,
+		upstreamList:  p.databases.ListDatabases,
+		upstreamRange: p.databases.RangeDatabases,
+		cacheGet:      p.cache.GetDatabase,
+		cacheList:     p.cache.ListDatabases,
+		cacheRange:    p.cache.RangeDatabases,
+		update:        p.databases.UpdateDatabase,
+		deleteAll:     p.databases.DeleteAllDatabases,
 	})
 }
 
@@ -123,7 +123,7 @@ func TestDatabaseServers(t *testing.T) {
 				})
 			},
 			create: withKeepalive(p.presenceS.UpsertDatabaseServer),
-			list: getAllAdapter(func(ctx context.Context) ([]types.DatabaseServer, error) {
+			upstreamList: getAllAdapter(func(ctx context.Context) ([]types.DatabaseServer, error) {
 				return p.presenceS.GetDatabaseServers(ctx, apidefaults.Namespace)
 			}),
 			cacheList: getAllAdapter(func(ctx context.Context) ([]types.DatabaseServer, error) {
@@ -148,7 +148,7 @@ func TestDatabaseServers(t *testing.T) {
 				})
 			},
 			create: withKeepalive(p.presenceS.UpsertDatabaseServer),
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.DatabaseServer, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.DatabaseServer, string, error) {
 				resources, next, err := listResource(ctx, p.presenceS, types.KindDatabaseServer, pageSize, pageToken)
 				if err != nil {
 					return nil, "", trace.Wrap(err)
@@ -192,8 +192,8 @@ func TestDatabaseObjects(t *testing.T) {
 			_, err := p.databaseObjects.CreateDatabaseObject(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.databaseObjects.ListDatabaseObjects,
-		cacheList: p.databaseObjects.ListDatabaseObjects,
+		upstreamList: p.databaseObjects.ListDatabaseObjects,
+		cacheList:    p.databaseObjects.ListDatabaseObjects,
 		deleteAll: func(ctx context.Context) error {
 			token := ""
 			var objects []*dbobjectv1.DatabaseObject

--- a/lib/cache/discovery_config_test.go
+++ b/lib/cache/discovery_config_test.go
@@ -49,9 +49,9 @@ func TestDiscoveryConfig(t *testing.T) {
 			_, err := p.discoveryConfigs.CreateDiscoveryConfig(ctx, discoveryConfig)
 			return trace.Wrap(err)
 		},
-		list:      p.discoveryConfigs.ListDiscoveryConfigs,
-		cacheGet:  p.cache.GetDiscoveryConfig,
-		cacheList: p.cache.ListDiscoveryConfigs,
+		upstreamList: p.discoveryConfigs.ListDiscoveryConfigs,
+		cacheGet:     p.cache.GetDiscoveryConfig,
+		cacheList:    p.cache.ListDiscoveryConfigs,
 		update: func(ctx context.Context, discoveryConfig *discoveryconfig.DiscoveryConfig) error {
 			_, err := p.discoveryConfigs.UpdateDiscoveryConfig(ctx, discoveryConfig)
 			return trace.Wrap(err)

--- a/lib/cache/git_server_test.go
+++ b/lib/cache/git_server_test.go
@@ -47,7 +47,7 @@ func TestGitServers(t *testing.T) {
 			_, err := p.gitServers.CreateGitServer(ctx, server)
 			return trace.Wrap(err)
 		},
-		list: p.gitServers.ListGitServers,
+		upstreamList: p.gitServers.ListGitServers,
 		update: func(ctx context.Context, server types.Server) error {
 			_, err := p.gitServers.UpdateGitServer(ctx, server)
 			return trace.Wrap(err)

--- a/lib/cache/health_check_config_test.go
+++ b/lib/cache/health_check_config_test.go
@@ -57,7 +57,7 @@ func TestHealthCheckConfig(t *testing.T) {
 			_, err := p.healthCheckConfig.CreateHealthCheckConfig(ctx, cfg)
 			return trace.Wrap(err)
 		},
-		list: p.healthCheckConfig.ListHealthCheckConfigs,
+		upstreamList: p.healthCheckConfig.ListHealthCheckConfigs,
 		update: func(ctx context.Context, cfg *healthcheckconfigv1.HealthCheckConfig) error {
 			_, err := p.healthCheckConfig.UpdateHealthCheckConfig(ctx, cfg)
 			return trace.Wrap(err)

--- a/lib/cache/identitycenter_test.go
+++ b/lib/cache/identitycenter_test.go
@@ -63,7 +63,7 @@ func TestIdentityCenterAccount(t *testing.T) {
 			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccount(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.identityCenter.ListIdentityCenterAccounts,
+		upstreamList: fixturePack.identityCenter.ListIdentityCenterAccounts,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteIdentityCenterAccount(
 				ctx, services.IdentityCenterAccountID(id)))
@@ -111,7 +111,7 @@ func TestIdentityCenterPrincipalAssignment(t *testing.T) {
 			_, err := fixturePack.identityCenter.UpdatePrincipalAssignment(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.identityCenter.ListPrincipalAssignments,
+		upstreamList: fixturePack.identityCenter.ListPrincipalAssignments,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeletePrincipalAssignment(ctx, services.PrincipalAssignmentID(id)))
 		},
@@ -162,7 +162,7 @@ func TestIdentityCenterAccountAssignment(t *testing.T) {
 			_, err := fixturePack.identityCenter.UpdateIdentityCenterAccountAssignment(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.identityCenter.ListIdentityCenterAccountAssignments,
+		upstreamList: fixturePack.identityCenter.ListIdentityCenterAccountAssignments,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.identityCenter.DeleteAccountAssignment(ctx, services.IdentityCenterAccountAssignmentID(id)))
 		},

--- a/lib/cache/installer_test.go
+++ b/lib/cache/installer_test.go
@@ -33,9 +33,9 @@ func TestInstallers(t *testing.T) {
 		newResource: func(name string) (types.Installer, error) {
 			return types.NewInstallerV1(name, "test.sh")
 		},
-		create:    p.clusterConfigS.SetInstaller,
-		list:      getAllAdapter(p.clusterConfigS.GetInstallers),
-		cacheList: getAllAdapter(p.cache.GetInstallers),
+		create:       p.clusterConfigS.SetInstaller,
+		upstreamList: getAllAdapter(p.clusterConfigS.GetInstallers),
+		cacheList:    getAllAdapter(p.cache.GetInstallers),
 		deleteAll: func(ctx context.Context) error {
 			return p.clusterConfigS.DeleteAllInstallers(ctx)
 		},

--- a/lib/cache/integrations_test.go
+++ b/lib/cache/integrations_test.go
@@ -44,9 +44,9 @@ func TestIntegrations(t *testing.T) {
 			_, err := p.integrations.CreateIntegration(ctx, i)
 			return err
 		},
-		list:      p.integrations.ListIntegrations,
-		cacheGet:  p.cache.GetIntegration,
-		cacheList: p.cache.ListIntegrations,
+		upstreamList: p.integrations.ListIntegrations,
+		cacheGet:     p.cache.GetIntegration,
+		cacheList:    p.cache.ListIntegrations,
 		update: func(ctx context.Context, i types.Integration) error {
 			_, err := p.integrations.UpdateIntegration(ctx, i)
 			return err

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -41,12 +41,12 @@ func TestKubernetes(t *testing.T) {
 				Name: name,
 			}, types.KubernetesClusterSpecV3{})
 		},
-		create:    p.kubernetes.CreateKubernetesCluster,
-		list:      getAllAdapter(p.kubernetes.GetKubernetesClusters),
-		cacheGet:  p.cache.GetKubernetesCluster,
-		cacheList: getAllAdapter(p.cache.GetKubernetesClusters),
-		update:    p.kubernetes.UpdateKubernetesCluster,
-		deleteAll: p.kubernetes.DeleteAllKubernetesClusters,
+		create:       p.kubernetes.CreateKubernetesCluster,
+		upstreamList: getAllAdapter(p.kubernetes.GetKubernetesClusters),
+		cacheGet:     p.cache.GetKubernetesCluster,
+		cacheList:    getAllAdapter(p.cache.GetKubernetesClusters),
+		update:       p.kubernetes.UpdateKubernetesCluster,
+		deleteAll:    p.kubernetes.DeleteAllKubernetesClusters,
 	}, withSkipPaginationTest())
 }
 
@@ -65,10 +65,10 @@ func TestKubernetesServers(t *testing.T) {
 				require.NoError(t, err)
 				return types.NewKubernetesServerV3FromCluster(app, "host", uuid.New().String())
 			},
-			create:    withKeepalive(p.presenceS.UpsertKubernetesServer),
-			list:      getAllAdapter(p.presenceS.GetKubernetesServers),
-			cacheList: getAllAdapter(p.cache.GetKubernetesServers),
-			update:    withKeepalive(p.presenceS.UpsertKubernetesServer),
+			create:       withKeepalive(p.presenceS.UpsertKubernetesServer),
+			upstreamList: getAllAdapter(p.presenceS.GetKubernetesServers),
+			cacheList:    getAllAdapter(p.cache.GetKubernetesServers),
+			update:       withKeepalive(p.presenceS.UpsertKubernetesServer),
 			deleteAll: func(ctx context.Context) error {
 				return p.presenceS.DeleteAllKubernetesServers(ctx)
 			},
@@ -83,7 +83,7 @@ func TestKubernetesServers(t *testing.T) {
 				return types.NewKubernetesServerV3FromCluster(app, "host", uuid.New().String())
 			},
 			create: withKeepalive(p.presenceS.UpsertKubernetesServer),
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeServer, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.KubeServer, string, error) {
 				resources, next, err := listResource(ctx, p.presenceS, types.KindKubeServer, pageSize, pageToken)
 				if err != nil {
 					return nil, "", trace.Wrap(err)

--- a/lib/cache/lock_test.go
+++ b/lib/cache/lock_test.go
@@ -42,11 +42,11 @@ func TestLocks(t *testing.T) {
 				},
 			)
 		},
-		create:    p.accessS.UpsertLock,
-		list:      getAllAdapter(func(ctx context.Context) ([]types.Lock, error) { return p.accessS.GetLocks(ctx, false) }),
-		cacheList: getAllAdapter(func(ctx context.Context) ([]types.Lock, error) { return p.cache.GetLocks(ctx, false) }),
-		cacheGet:  p.cache.GetLock,
-		update:    p.accessS.UpsertLock,
-		deleteAll: p.accessS.DeleteAllLocks,
+		create:       p.accessS.UpsertLock,
+		upstreamList: getAllAdapter(func(ctx context.Context) ([]types.Lock, error) { return p.accessS.GetLocks(ctx, false) }),
+		cacheList:    getAllAdapter(func(ctx context.Context) ([]types.Lock, error) { return p.cache.GetLocks(ctx, false) }),
+		cacheGet:     p.cache.GetLock,
+		update:       p.accessS.UpsertLock,
+		deleteAll:    p.accessS.DeleteAllLocks,
 	}, withSkipPaginationTest())
 }

--- a/lib/cache/networking_restrictions_test.go
+++ b/lib/cache/networking_restrictions_test.go
@@ -32,9 +32,9 @@ func TestNetworkRestrictions(t *testing.T) {
 		newResource: func(name string) (types.NetworkRestrictions, error) {
 			return types.NewNetworkRestrictions(), nil
 		},
-		create:    p.restrictions.SetNetworkRestrictions,
-		list:      singletonListAdapter(p.restrictions.GetNetworkRestrictions),
-		cacheList: singletonListAdapter(p.cache.GetNetworkRestrictions),
-		deleteAll: p.restrictions.DeleteNetworkRestrictions,
+		create:       p.restrictions.SetNetworkRestrictions,
+		upstreamList: singletonListAdapter(p.restrictions.GetNetworkRestrictions),
+		cacheList:    singletonListAdapter(p.cache.GetNetworkRestrictions),
+		deleteAll:    p.restrictions.DeleteNetworkRestrictions,
 	}, withSkipPaginationTest()) // skip pagination test because NetworkRestrictions is a singleton resource
 }

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -45,7 +45,7 @@ func TestNodes(t *testing.T) {
 				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
 			},
 			create: withKeepalive(p.presenceS.UpsertNode),
-			list: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
+			upstreamList: getAllAdapter(func(ctx context.Context) ([]types.Server, error) {
 				return p.presenceS.GetNodes(ctx, apidefaults.Namespace)
 			}),
 			cacheGet: func(ctx context.Context, name string) (types.Server, error) {
@@ -70,7 +70,7 @@ func TestNodes(t *testing.T) {
 				return NewServer(types.KindNode, name, "127.0.0.1:2022", apidefaults.Namespace), nil
 			},
 			create: withKeepalive(p.presenceS.UpsertNode),
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindNode,
 					Limit:        int32(pageSize),

--- a/lib/cache/notification_test.go
+++ b/lib/cache/notification_test.go
@@ -41,9 +41,9 @@ func TestUserNotifications(t *testing.T) {
 			_, err := p.notifications.CreateUserNotification(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.notifications.ListUserNotifications,
-		cacheList: p.cache.ListUserNotifications,
-		deleteAll: p.notifications.DeleteAllUserNotifications,
+		upstreamList: p.notifications.ListUserNotifications,
+		cacheList:    p.cache.ListUserNotifications,
+		deleteAll:    p.notifications.DeleteAllUserNotifications,
 	})
 }
 
@@ -63,8 +63,8 @@ func TestGlobalNotifications(t *testing.T) {
 			_, err := p.notifications.CreateGlobalNotification(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.notifications.ListGlobalNotifications,
-		cacheList: p.cache.ListGlobalNotifications,
-		deleteAll: p.notifications.DeleteAllGlobalNotifications,
+		upstreamList: p.notifications.ListGlobalNotifications,
+		cacheList:    p.cache.ListGlobalNotifications,
+		deleteAll:    p.notifications.DeleteAllGlobalNotifications,
 	})
 }

--- a/lib/cache/okta_test.go
+++ b/lib/cache/okta_test.go
@@ -69,9 +69,9 @@ func TestOktaImportRules(t *testing.T) {
 			_, err := p.okta.CreateOktaImportRule(ctx, resource)
 			return trace.Wrap(err)
 		},
-		list:      p.okta.ListOktaImportRules,
-		cacheGet:  p.cache.GetOktaImportRule,
-		cacheList: p.cache.ListOktaImportRules,
+		upstreamList: p.okta.ListOktaImportRules,
+		cacheGet:     p.cache.GetOktaImportRule,
+		cacheList:    p.cache.ListOktaImportRules,
 		update: func(ctx context.Context, resource types.OktaImportRule) error {
 			_, err := p.okta.UpdateOktaImportRule(ctx, resource)
 			return trace.Wrap(err)
@@ -113,9 +113,9 @@ func TestOktaAssignments(t *testing.T) {
 			_, err := p.okta.CreateOktaAssignment(ctx, resource)
 			return trace.Wrap(err)
 		},
-		list:      p.okta.ListOktaAssignments,
-		cacheGet:  p.cache.GetOktaAssignment,
-		cacheList: p.cache.ListOktaAssignments,
+		upstreamList: p.okta.ListOktaAssignments,
+		cacheGet:     p.cache.GetOktaAssignment,
+		cacheList:    p.cache.ListOktaAssignments,
 		update: func(ctx context.Context, resource types.OktaAssignment) error {
 			_, err := p.okta.UpdateOktaAssignment(ctx, resource)
 			return trace.Wrap(err)

--- a/lib/cache/plugin_static_credentials_test.go
+++ b/lib/cache/plugin_static_credentials_test.go
@@ -85,8 +85,8 @@ func TestPluginStaticCredentials(t *testing.T) {
 							},
 						})
 				},
-				create: p.pluginStaticCredentials.CreatePluginStaticCredentials,
-				list:   getAllAdapter(p.pluginStaticCredentials.GetAllPluginStaticCredentials),
+				create:       p.pluginStaticCredentials.CreatePluginStaticCredentials,
+				upstreamList: getAllAdapter(p.pluginStaticCredentials.GetAllPluginStaticCredentials),
 				update: func(ctx context.Context, cred types.PluginStaticCredentials) error {
 					_, err := p.pluginStaticCredentials.UpdatePluginStaticCredentials(ctx, cred)
 					return err

--- a/lib/cache/plugins_test.go
+++ b/lib/cache/plugins_test.go
@@ -72,7 +72,7 @@ func TestPlugin(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
 				return p.cache.GetPlugin(ctx, name, false)
 			},
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.Plugin, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Plugin, string, error) {
 				return p.plugin.ListPlugins(ctx, pageSize, pageToken, false)
 			},
 			cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Plugin, string, error) {
@@ -96,7 +96,7 @@ func TestPlugin(t *testing.T) {
 			create: func(ctx context.Context, item types.Plugin) error {
 				return trace.Wrap(p.plugin.CreatePlugin(ctx, item))
 			},
-			list: func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
 				return p.plugin.ListPlugins(ctx, pageSize, token, false)
 			},
 			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
@@ -126,7 +126,7 @@ func TestPlugin(t *testing.T) {
 			cacheGet: func(ctx context.Context, name string) (types.Plugin, error) {
 				return p.cache.GetPlugin(ctx, name, true)
 			},
-			list: func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {
 				return p.plugin.ListPlugins(ctx, pageSize, token, true)
 			},
 			cacheList: func(ctx context.Context, pageSize int, token string) ([]types.Plugin, string, error) {

--- a/lib/cache/provisioning_test.go
+++ b/lib/cache/provisioning_test.go
@@ -68,7 +68,7 @@ func TestProvisioningPrincipalState(t *testing.T) {
 			_, err := fixturePack.provisioningStates.UpdateProvisioningState(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams,
+		upstreamList: fixturePack.provisioningStates.ListProvisioningStatesForAllDownstreams,
 		delete: func(ctx context.Context, id string) error {
 			return trace.Wrap(fixturePack.provisioningStates.DeleteProvisioningState(
 				ctx, testDownstreamID, services.ProvisioningStateID(id)))

--- a/lib/cache/proxy_server_test.go
+++ b/lib/cache/proxy_server_test.go
@@ -43,10 +43,10 @@ func TestProxies(t *testing.T) {
 				},
 			}, nil
 		},
-		create:    p.presenceS.UpsertProxy,
-		list:      getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.presenceS.GetProxies() }),
-		cacheList: getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.cache.GetProxies() }),
-		update:    p.presenceS.UpsertProxy,
+		create:       p.presenceS.UpsertProxy,
+		upstreamList: getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.presenceS.GetProxies() }),
+		cacheList:    getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.cache.GetProxies() }),
+		update:       p.presenceS.UpsertProxy,
 		deleteAll: func(_ context.Context) error {
 			return p.presenceS.DeleteAllProxies()
 		},

--- a/lib/cache/recording_encryption_test.go
+++ b/lib/cache/recording_encryption_test.go
@@ -60,8 +60,8 @@ func TestRecordingEncryption(t *testing.T) {
 			_, err := p.recordingEncryption.UpdateRecordingEncryption(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      singletonListAdapter(p.recordingEncryption.GetRecordingEncryption),
-		cacheList: singletonListAdapter(p.cache.GetRecordingEncryption),
-		deleteAll: p.recordingEncryption.DeleteRecordingEncryption,
+		upstreamList: singletonListAdapter(p.recordingEncryption.GetRecordingEncryption),
+		cacheList:    singletonListAdapter(p.cache.GetRecordingEncryption),
+		deleteAll:    p.recordingEncryption.DeleteRecordingEncryption,
 	}, withSkipPaginationTest())
 }

--- a/lib/cache/remote_cluster_test.go
+++ b/lib/cache/remote_cluster_test.go
@@ -46,9 +46,9 @@ func TestRemoteClusters(t *testing.T) {
 				_, err := p.trustS.CreateRemoteCluster(ctx, rc)
 				return err
 			},
-			list:      getAllAdapter(p.trustS.GetRemoteClusters),
-			cacheGet:  p.cache.GetRemoteCluster,
-			cacheList: getAllAdapter(p.cache.GetRemoteClusters),
+			upstreamList: getAllAdapter(p.trustS.GetRemoteClusters),
+			cacheGet:     p.cache.GetRemoteCluster,
+			cacheList:    getAllAdapter(p.cache.GetRemoteClusters),
 			update: func(ctx context.Context, rc types.RemoteCluster) error {
 				_, err := p.trustS.UpdateRemoteCluster(ctx, rc)
 				return err
@@ -71,9 +71,9 @@ func TestRemoteClusters(t *testing.T) {
 				_, err := p.trustS.CreateRemoteCluster(ctx, rc)
 				return err
 			},
-			list:      getAllAdapter(p.trustS.GetRemoteClusters),
-			cacheGet:  p.cache.GetRemoteCluster,
-			cacheList: getAllAdapter(p.cache.GetRemoteClusters),
+			upstreamList: getAllAdapter(p.trustS.GetRemoteClusters),
+			cacheGet:     p.cache.GetRemoteCluster,
+			cacheList:    getAllAdapter(p.cache.GetRemoteClusters),
 			update: func(ctx context.Context, rc types.RemoteCluster) error {
 				_, err := p.trustS.UpdateRemoteCluster(ctx, rc)
 				return err
@@ -99,10 +99,10 @@ func TestTunnelConnections(t *testing.T) {
 				LastHeartbeat: time.Now().UTC(),
 			})
 		},
-		create:    modifyNoContext(p.trustS.UpsertTunnelConnection),
-		list:      getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.trustS.GetAllTunnelConnections() }),
-		cacheList: getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.cache.GetAllTunnelConnections() }),
-		update:    modifyNoContext(p.trustS.UpsertTunnelConnection),
+		create:       modifyNoContext(p.trustS.UpsertTunnelConnection),
+		upstreamList: getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.trustS.GetAllTunnelConnections() }),
+		cacheList:    getAllAdapter(func(ctx context.Context) ([]types.TunnelConnection, error) { return p.cache.GetAllTunnelConnections() }),
+		update:       modifyNoContext(p.trustS.UpsertTunnelConnection),
 		deleteAll: func(ctx context.Context) error {
 			return p.trustS.DeleteAllTunnelConnections()
 		},

--- a/lib/cache/reverse_tunnel_test.go
+++ b/lib/cache/reverse_tunnel_test.go
@@ -41,7 +41,7 @@ func TestReverseTunnels(t *testing.T) {
 			_, err := p.presenceS.UpsertReverseTunnel(ctx, tunnel)
 			return err
 		},
-		list: p.presenceS.ListReverseTunnels,
+		upstreamList: p.presenceS.ListReverseTunnels,
 		update: func(ctx context.Context, tunnel types.ReverseTunnel) error {
 			_, err := p.presenceS.UpsertReverseTunnel(ctx, tunnel)
 			return err

--- a/lib/cache/role_test.go
+++ b/lib/cache/role_test.go
@@ -64,9 +64,9 @@ func TestRoles(t *testing.T) {
 				_, err := p.accessS.UpsertRole(ctx, role)
 				return err
 			},
-			list:      getAllAdapter(p.accessS.GetRoles),
-			cacheGet:  p.cache.GetRole,
-			cacheList: getAllAdapter(p.cache.GetRoles),
+			upstreamList: getAllAdapter(p.accessS.GetRoles),
+			cacheGet:     p.cache.GetRole,
+			cacheList:    getAllAdapter(p.cache.GetRoles),
 			update: func(ctx context.Context, role types.Role) error {
 				_, err := p.accessS.UpsertRole(ctx, role)
 				return err
@@ -93,7 +93,7 @@ func TestRoles(t *testing.T) {
 				_, err := p.accessS.UpsertRole(ctx, role)
 				return err
 			},
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.Role, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.Role, string, error) {
 				var out []types.Role
 				req := &proto.ListRolesRequest{
 					Limit:    int32(pageSize),

--- a/lib/cache/saml_idp_test.go
+++ b/lib/cache/saml_idp_test.go
@@ -42,11 +42,11 @@ func TestSAMLIdPServiceProviders(t *testing.T) {
 					EntityID:         "IAMShowcase" + name,
 				})
 		},
-		create:    p.samlIDPServiceProviders.CreateSAMLIdPServiceProvider,
-		list:      p.samlIDPServiceProviders.ListSAMLIdPServiceProviders,
-		cacheGet:  p.cache.GetSAMLIdPServiceProvider,
-		cacheList: p.cache.ListSAMLIdPServiceProviders,
-		update:    p.samlIDPServiceProviders.UpdateSAMLIdPServiceProvider,
-		deleteAll: p.samlIDPServiceProviders.DeleteAllSAMLIdPServiceProviders,
+		create:       p.samlIDPServiceProviders.CreateSAMLIdPServiceProvider,
+		upstreamList: p.samlIDPServiceProviders.ListSAMLIdPServiceProviders,
+		cacheGet:     p.cache.GetSAMLIdPServiceProvider,
+		cacheList:    p.cache.ListSAMLIdPServiceProviders,
+		update:       p.samlIDPServiceProviders.UpdateSAMLIdPServiceProvider,
+		deleteAll:    p.samlIDPServiceProviders.DeleteAllSAMLIdPServiceProviders,
 	})
 }

--- a/lib/cache/sercurity_report_test.go
+++ b/lib/cache/sercurity_report_test.go
@@ -42,9 +42,9 @@ func TestAuditQuery(t *testing.T) {
 				err := p.secReports.UpsertSecurityAuditQuery(ctx, item)
 				return trace.Wrap(err)
 			},
-			list:      getAllAdapter(p.secReports.GetSecurityAuditQueries),
-			cacheGet:  p.cache.GetSecurityAuditQuery,
-			cacheList: getAllAdapter(p.cache.GetSecurityAuditQueries),
+			upstreamList: getAllAdapter(p.secReports.GetSecurityAuditQueries),
+			cacheGet:     p.cache.GetSecurityAuditQuery,
+			cacheList:    getAllAdapter(p.cache.GetSecurityAuditQueries),
 			update: func(ctx context.Context, item *secreports.AuditQuery) error {
 				err := p.secReports.UpsertSecurityAuditQuery(ctx, item)
 				return trace.Wrap(err)
@@ -62,9 +62,9 @@ func TestAuditQuery(t *testing.T) {
 				err := p.secReports.UpsertSecurityAuditQuery(ctx, item)
 				return trace.Wrap(err)
 			},
-			list:      getAllAdapter(p.secReports.GetSecurityAuditQueries),
-			cacheGet:  p.cache.GetSecurityAuditQuery,
-			cacheList: p.cache.ListSecurityAuditQueries,
+			upstreamList: getAllAdapter(p.secReports.GetSecurityAuditQueries),
+			cacheGet:     p.cache.GetSecurityAuditQuery,
+			cacheList:    p.cache.ListSecurityAuditQueries,
 			update: func(ctx context.Context, item *secreports.AuditQuery) error {
 				err := p.secReports.UpsertSecurityAuditQuery(ctx, item)
 				return trace.Wrap(err)
@@ -92,9 +92,9 @@ func TestSecurityReports(t *testing.T) {
 				err := p.secReports.UpsertSecurityReport(ctx, item)
 				return trace.Wrap(err)
 			},
-			list:      getAllAdapter(p.secReports.GetSecurityReports),
-			cacheGet:  p.cache.GetSecurityReport,
-			cacheList: getAllAdapter(p.cache.GetSecurityReports),
+			upstreamList: getAllAdapter(p.secReports.GetSecurityReports),
+			cacheGet:     p.cache.GetSecurityReport,
+			cacheList:    getAllAdapter(p.cache.GetSecurityReports),
 			update: func(ctx context.Context, item *secreports.Report) error {
 				err := p.secReports.UpsertSecurityReport(ctx, item)
 				return trace.Wrap(err)
@@ -111,9 +111,9 @@ func TestSecurityReports(t *testing.T) {
 				err := p.secReports.UpsertSecurityReport(ctx, item)
 				return trace.Wrap(err)
 			},
-			list:      p.secReports.ListSecurityReports,
-			cacheGet:  p.cache.GetSecurityReport,
-			cacheList: p.cache.ListSecurityReports,
+			upstreamList: p.secReports.ListSecurityReports,
+			cacheGet:     p.cache.GetSecurityReport,
+			cacheList:    p.cache.ListSecurityReports,
 			update: func(ctx context.Context, item *secreports.Report) error {
 				err := p.secReports.UpsertSecurityReport(ctx, item)
 				return trace.Wrap(err)
@@ -140,9 +140,9 @@ func TestSecurityReportState(t *testing.T) {
 			err := p.secReports.UpsertSecurityReportsState(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.secReports.ListSecurityReportsStates,
-		cacheGet:  p.cache.GetSecurityReportState,
-		cacheList: p.cache.ListSecurityReportsStates,
+		upstreamList: p.secReports.ListSecurityReportsStates,
+		cacheGet:     p.cache.GetSecurityReportState,
+		cacheList:    p.cache.ListSecurityReportsStates,
 		update: func(ctx context.Context, item *secreports.ReportState) error {
 			err := p.secReports.UpsertSecurityReportsState(ctx, item)
 			return trace.Wrap(err)

--- a/lib/cache/spiffe_federation_test.go
+++ b/lib/cache/spiffe_federation_test.go
@@ -58,9 +58,9 @@ func TestSPIFFEFederations(t *testing.T) {
 			_, err := p.spiffeFederations.CreateSPIFFEFederation(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.spiffeFederations.ListSPIFFEFederations,
-		deleteAll: p.spiffeFederations.DeleteAllSPIFFEFederations,
-		cacheList: p.cache.ListSPIFFEFederations,
-		cacheGet:  p.cache.GetSPIFFEFederation,
+		upstreamList: p.spiffeFederations.ListSPIFFEFederations,
+		deleteAll:    p.spiffeFederations.DeleteAllSPIFFEFederations,
+		cacheList:    p.cache.ListSPIFFEFederations,
+		cacheGet:     p.cache.GetSPIFFEFederation,
 	})
 }

--- a/lib/cache/static_host_user_test.go
+++ b/lib/cache/static_host_user_test.go
@@ -41,9 +41,9 @@ func TestStaticHostUsers(t *testing.T) {
 			_, err := p.staticHostUsers.CreateStaticHostUser(ctx, item)
 			return trace.Wrap(err)
 		},
-		list:      p.staticHostUsers.ListStaticHostUsers,
-		cacheList: p.cache.ListStaticHostUsers,
-		cacheGet:  p.cache.GetStaticHostUser,
-		deleteAll: p.staticHostUsers.DeleteAllStaticHostUsers,
+		upstreamList: p.staticHostUsers.ListStaticHostUsers,
+		cacheList:    p.cache.ListStaticHostUsers,
+		cacheGet:     p.cache.GetStaticHostUser,
+		deleteAll:    p.staticHostUsers.DeleteAllStaticHostUsers,
 	})
 }

--- a/lib/cache/tokens_test.go
+++ b/lib/cache/tokens_test.go
@@ -142,7 +142,7 @@ func TestTokensCache(t *testing.T) {
 			err := p.provisionerS.CreateToken(ctx, resource)
 			return err
 		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]types.ProvisionToken, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.ProvisionToken, string, error) {
 			return p.provisionerS.ListProvisionTokens(ctx, pageSize, pageToken, nil, "")
 		},
 		update: func(ctx context.Context, t types.ProvisionToken) error {

--- a/lib/cache/user_group_test.go
+++ b/lib/cache/user_group_test.go
@@ -45,12 +45,12 @@ func TestUserGroups(t *testing.T) {
 				}, types.UserGroupSpecV1{},
 			)
 		},
-		create:    p.userGroups.CreateUserGroup,
-		list:      p.userGroups.ListUserGroups,
-		cacheGet:  p.cache.GetUserGroup,
-		cacheList: p.cache.ListUserGroups,
-		update:    p.userGroups.UpdateUserGroup,
-		deleteAll: p.userGroups.DeleteAllUserGroups,
+		create:       p.userGroups.CreateUserGroup,
+		upstreamList: p.userGroups.ListUserGroups,
+		cacheGet:     p.cache.GetUserGroup,
+		cacheList:    p.cache.ListUserGroups,
+		update:       p.userGroups.UpdateUserGroup,
+		deleteAll:    p.userGroups.DeleteAllUserGroups,
 	})
 
 	require.NoError(t, p.userGroups.DeleteAllUserGroups(t.Context()))

--- a/lib/cache/user_login_state_test.go
+++ b/lib/cache/user_login_state_test.go
@@ -41,9 +41,9 @@ func TestUserLoginStates(t *testing.T) {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)
 		},
-		list:      getAllAdapter(p.userLoginStates.GetUserLoginStates),
-		cacheGet:  p.cache.GetUserLoginState,
-		cacheList: getAllAdapter(p.cache.GetUserLoginStates),
+		upstreamList: getAllAdapter(p.userLoginStates.GetUserLoginStates),
+		cacheGet:     p.cache.GetUserLoginState,
+		cacheList:    getAllAdapter(p.cache.GetUserLoginStates),
 		update: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)
@@ -59,9 +59,9 @@ func TestUserLoginStates(t *testing.T) {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)
 		},
-		list:      p.userLoginStates.ListUserLoginStates,
-		cacheGet:  p.cache.GetUserLoginState,
-		cacheList: p.cache.ListUserLoginStates,
+		upstreamList: p.userLoginStates.ListUserLoginStates,
+		cacheGet:     p.cache.GetUserLoginState,
+		cacheList:    p.cache.ListUserLoginStates,
 		update: func(ctx context.Context, uls *userloginstate.UserLoginState) error {
 			_, err := p.userLoginStates.UpsertUserLoginState(ctx, uls)
 			return trace.Wrap(err)

--- a/lib/cache/user_task_test.go
+++ b/lib/cache/user_task_test.go
@@ -41,7 +41,7 @@ func TestUserTasks(t *testing.T) {
 			_, err := p.userTasks.CreateUserTask(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context, pageLimit int, pageToken string) ([]*usertasksv1.UserTask, string, error) {
+		upstreamList: func(ctx context.Context, pageLimit int, pageToken string) ([]*usertasksv1.UserTask, string, error) {
 			return p.userTasks.ListUserTasks(ctx, int64(pageLimit), pageToken, &usertasksv1.ListUserTasksFilters{})
 		},
 		cacheList: func(ctx context.Context, pageLimit int, pageToken string) ([]*usertasksv1.UserTask, string, error) {

--- a/lib/cache/users_test.go
+++ b/lib/cache/users_test.go
@@ -45,8 +45,8 @@ func TestUsers(t *testing.T) {
 				_, err := p.usersS.UpsertUser(ctx, user)
 				return err
 			},
-			list:      getAllAdapter(func(ctx context.Context) ([]types.User, error) { return p.usersS.GetUsers(ctx, false) }),
-			cacheList: getAllAdapter(func(ctx context.Context) ([]types.User, error) { return p.cache.GetUsers(ctx, false) }),
+			upstreamList: getAllAdapter(func(ctx context.Context) ([]types.User, error) { return p.usersS.GetUsers(ctx, false) }),
+			cacheList:    getAllAdapter(func(ctx context.Context) ([]types.User, error) { return p.cache.GetUsers(ctx, false) }),
 			update: func(ctx context.Context, user types.User) error {
 				_, err := p.usersS.UpdateUser(ctx, user)
 				return err
@@ -64,7 +64,7 @@ func TestUsers(t *testing.T) {
 				_, err := p.usersS.UpsertUser(ctx, user)
 				return err
 			},
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.User, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.User, string, error) {
 				var out []types.User
 				req := &userspb.ListUsersRequest{
 					PageSize:  int32(pageSize),

--- a/lib/cache/web_tokens_test.go
+++ b/lib/cache/web_tokens_test.go
@@ -45,9 +45,9 @@ func TestWebTokens(t *testing.T) {
 				User:  "llama",
 			})
 		},
-		list:      getAllAdapter(p.webTokenS.GetWebTokens),
-		cacheList: getAllAdapter(p.cache.GetWebTokens),
-		deleteAll: p.webTokenS.DeleteAllWebTokens,
+		upstreamList: getAllAdapter(p.webTokenS.GetWebTokens),
+		cacheList:    getAllAdapter(p.cache.GetWebTokens),
+		deleteAll:    p.webTokenS.DeleteAllWebTokens,
 		delete: func(ctx context.Context, token string) error {
 			return p.webTokenS.DeleteWebToken(ctx, types.DeleteWebTokenRequest{
 				Token: token,

--- a/lib/cache/web_ui_config_test.go
+++ b/lib/cache/web_ui_config_test.go
@@ -39,9 +39,9 @@ func TestWebUIConfig(t *testing.T) {
 				},
 			}, nil
 		},
-		create:    p.clusterConfigS.SetUIConfig,
-		list:      singletonListAdapter(p.clusterConfigS.GetUIConfig),
-		cacheList: singletonListAdapter(p.cache.GetUIConfig),
-		deleteAll: p.clusterConfigS.DeleteUIConfig,
+		create:       p.clusterConfigS.SetUIConfig,
+		upstreamList: singletonListAdapter(p.clusterConfigS.GetUIConfig),
+		cacheList:    singletonListAdapter(p.cache.GetUIConfig),
+		deleteAll:    p.clusterConfigS.DeleteUIConfig,
 	}, withSkipPaginationTest()) // UIConfig is a singleton resource, so pagination is not applicable.
 }

--- a/lib/cache/windows_desktop_test.go
+++ b/lib/cache/windows_desktop_test.go
@@ -49,7 +49,7 @@ func TestWindowsDesktop(t *testing.T) {
 			)
 		},
 		create: p.windowsDesktops.CreateWindowsDesktop,
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktop, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktop, string, error) {
 			var desktops []types.WindowsDesktop
 			req := types.ListWindowsDesktopsRequest{
 				StartKey: pageToken,
@@ -180,12 +180,12 @@ func TestWindowsDesktopService(t *testing.T) {
 					},
 				)
 			},
-			create:    withKeepalive(p.presenceS.UpsertWindowsDesktopService),
-			list:      getAllAdapter(p.presenceS.GetWindowsDesktopServices),
-			cacheGet:  p.cache.GetWindowsDesktopService,
-			cacheList: getAllAdapter(p.cache.GetWindowsDesktopServices),
-			update:    withKeepalive(p.presenceS.UpsertWindowsDesktopService),
-			deleteAll: p.presenceS.DeleteAllWindowsDesktopServices,
+			create:       withKeepalive(p.presenceS.UpsertWindowsDesktopService),
+			upstreamList: getAllAdapter(p.presenceS.GetWindowsDesktopServices),
+			cacheGet:     p.cache.GetWindowsDesktopService,
+			cacheList:    getAllAdapter(p.cache.GetWindowsDesktopServices),
+			update:       withKeepalive(p.presenceS.UpsertWindowsDesktopService),
+			deleteAll:    p.presenceS.DeleteAllWindowsDesktopServices,
 		}, withSkipPaginationTest())
 	})
 
@@ -203,7 +203,7 @@ func TestWindowsDesktopService(t *testing.T) {
 				)
 			},
 			create: withKeepalive(p.presenceS.UpsertWindowsDesktopService),
-			list: func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktopService, string, error) {
+			upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktopService, string, error) {
 				req := proto.ListResourcesRequest{
 					ResourceType: types.KindWindowsDesktopService,
 					StartKey:     pageToken,
@@ -267,9 +267,9 @@ func TestDynamicWindowsDesktop(t *testing.T) {
 			_, err := p.dynamicWindowsDesktops.CreateDynamicWindowsDesktop(ctx, dwd)
 			return err
 		},
-		list:      p.dynamicWindowsDesktops.ListDynamicWindowsDesktops,
-		cacheGet:  p.cache.GetDynamicWindowsDesktop,
-		cacheList: p.cache.ListDynamicWindowsDesktops,
+		upstreamList: p.dynamicWindowsDesktops.ListDynamicWindowsDesktops,
+		cacheGet:     p.cache.GetDynamicWindowsDesktop,
+		cacheList:    p.cache.ListDynamicWindowsDesktops,
 		update: func(ctx context.Context, dwd types.DynamicWindowsDesktop) error {
 			_, err := p.dynamicWindowsDesktops.UpdateDynamicWindowsDesktop(ctx, dwd)
 			return err

--- a/lib/cache/workload_identity_test.go
+++ b/lib/cache/workload_identity_test.go
@@ -61,7 +61,7 @@ func TestWorkloadIdentity(t *testing.T) {
 			_, err := p.workloadIdentity.CreateWorkloadIdentity(ctx, item)
 			return trace.Wrap(err)
 		},
-		list: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadidentityv1pb.WorkloadIdentity, string, error) {
 			return p.workloadIdentity.ListWorkloadIdentities(ctx, pageSize, pageToken, nil)
 		},
 		deleteAll: func(ctx context.Context) error {


### PR DESCRIPTION
To avoid confusion in tests this change renames the upstream methods to be consistent with their cache counterparts.

No functional changes have been made.