### PR TITLE
Fix `tsh app login` when setting up access for AWS using Roles Anywhere integration

### DIFF
--- a/lib/aws/awsconfigfile/awsconfigfile.go
+++ b/lib/aws/awsconfigfile/awsconfigfile.go
@@ -25,6 +25,10 @@ import (
 	ini "gopkg.in/ini.v1"
 )
 
+const (
+	ownershipComment = "Do not edit. Section managed by Teleport."
+)
+
 // AWSConfigFilePath returns the path to the AWS configuration file.
 func AWSConfigFilePath() (string, error) {
 	// See https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
@@ -42,19 +46,19 @@ func AWSConfigFilePath() (string, error) {
 
 // SetDefaultProfileCredentialProcess sets the credential_process for the default profile.
 // File is created if it does not exist.
-func SetDefaultProfileCredentialProcess(configFilePath, sectionComment, credentialProcess string) error {
+func SetDefaultProfileCredentialProcess(configFilePath, credentialProcess string) error {
 	const sectionName = "default"
-	return trace.Wrap(addCredentialProcessToSection(configFilePath, sectionName, sectionComment, credentialProcess))
+	return trace.Wrap(addCredentialProcessToSection(configFilePath, sectionName, credentialProcess))
 }
 
 // UpsertProfileCredentialProcess sets the credential_process for the profile with name profileName.
 // File is created if it does not exist.
-func UpsertProfileCredentialProcess(configFilePath, profileName, sectionComment, credentialProcess string) error {
+func UpsertProfileCredentialProcess(configFilePath, profileName, credentialProcess string) error {
 	sectionName := "profile " + profileName
-	return trace.Wrap(addCredentialProcessToSection(configFilePath, sectionName, sectionComment, credentialProcess))
+	return trace.Wrap(addCredentialProcessToSection(configFilePath, sectionName, credentialProcess))
 }
 
-func addCredentialProcessToSection(configFilePath, sectionName, sectionComment, credentialProcessCommand string) error {
+func addCredentialProcessToSection(configFilePath, sectionName, credentialProcessCommand string) error {
 	iniFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNestedValues: true, // Allow AWS-like nested values. Docs: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values
 		Loose:             true, // Allow non-existing files. ini.SaveTo will create the file if it does not exist.
@@ -69,12 +73,8 @@ func addCredentialProcessToSection(configFilePath, sectionName, sectionComment, 
 	case iniFile.HasSection(sectionName):
 		section = iniFile.Section(sectionName)
 
-		if !strings.HasPrefix(sectionComment, "; ") {
-			sectionComment = "; " + sectionComment
-		}
-		// Check ownership of the section by comparing comments.
-		if section.Comment != sectionComment {
-			return trace.BadParameter("%s: section %q is not managed by teleport, remove the section and try again", configFilePath, sectionName)
+		if !strings.Contains(section.Comment, ownershipComment) {
+			return trace.BadParameter("%s: section %q is not managed by Teleport, remove the section and try again", configFilePath, sectionName)
 		}
 
 	default:
@@ -84,7 +84,7 @@ func addCredentialProcessToSection(configFilePath, sectionName, sectionComment, 
 		}
 	}
 
-	section.Comment = sectionComment
+	section.Comment = ownershipComment
 	_, err = section.NewKey("credential_process", credentialProcessCommand)
 	if err != nil {
 		return trace.Wrap(err)
@@ -102,33 +102,46 @@ func addCredentialProcessToSection(configFilePath, sectionName, sectionComment, 
 	return trace.Wrap(iniFile.SaveTo(configFilePath))
 }
 
-// RemoveCredentialProcessByComment removes the credential_process key on sections that have a specific section comment.
-func RemoveCredentialProcessByComment(configFilePath, sectionComment string) error {
-	if !strings.HasPrefix(sectionComment, "; ") {
-		sectionComment = "; " + sectionComment
+// RemoveTeleportManagedProfile removes the credential_process key on sections that have a specific section comment.
+func RemoveTeleportManagedProfile(configFilePath, profile string) error {
+	sectionName := "profile " + profile
+
+	iniFile, err := ini.LoadSources(ini.LoadOptions{
+		AllowNestedValues: true,  // Allow AWS-like nested values. Docs: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values
+		Loose:             false, // If file does not exist, then there's nothing to be removed.
+	}, configFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// Ignore non-existing file.
+			return nil
+		}
+
+		return trace.Wrap(err)
 	}
 
-	compareExactlyFn := func(comment string) bool {
-		return sectionComment == comment
+	configFileChanged := false
+	if iniFile.HasSection(sectionName) {
+		section := iniFile.Section(sectionName)
+
+		if !strings.Contains(section.Comment, ownershipComment) {
+			return trace.BadParameter("%s: section %q is not managed by Teleport, remove the section manually and try again", configFilePath, sectionName)
+		}
+
+		if strings.Contains(section.Comment, ownershipComment) {
+			iniFile.DeleteSection(section.Name())
+			configFileChanged = true
+		}
+	}
+	// No need to save the file if no sections were changed.
+	if !configFileChanged {
+		return nil
 	}
 
-	return removeCredentialProcess(configFilePath, compareExactlyFn)
+	return trace.Wrap(iniFile.SaveTo(configFilePath))
 }
 
-// RemoveCredentialProcessByCommentPrefix removes the credential_process key on sections that have a specific section comment prefix.
-func RemoveCredentialProcessByCommentPrefix(configFilePath, sectionComment string) error {
-	if !strings.HasPrefix(sectionComment, "; ") {
-		sectionComment = "; " + sectionComment
-	}
-
-	comparePrefixFn := func(comment string) bool {
-		return strings.HasPrefix(comment, sectionComment)
-	}
-	return removeCredentialProcess(configFilePath, comparePrefixFn)
-}
-
-// RemoveCredentialProcessByComment removes the credential_process key on sections that have a specific section comment.
-func removeCredentialProcess(configFilePath string, matchCommentFn func(string) bool) error {
+// RemoveAllTeleportManagedProfiles removes all the profiles managed by Teleport.
+func RemoveAllTeleportManagedProfiles(configFilePath string) error {
 	iniFile, err := ini.LoadSources(ini.LoadOptions{
 		AllowNestedValues: true,  // Allow AWS-like nested values. Docs: http://docs.aws.amazon.com/cli/latest/topic/config-vars.html#nested-values
 		Loose:             false, // If file does not exist, then there's nothing to be removed.
@@ -144,21 +157,10 @@ func removeCredentialProcess(configFilePath string, matchCommentFn func(string) 
 
 	sectionChanged := false
 	for _, section := range iniFile.Sections() {
-		if !matchCommentFn(section.Comment) {
-			continue
+		if strings.Contains(section.Comment, ownershipComment) {
+			iniFile.DeleteSection(section.Name())
+			sectionChanged = true
 		}
-
-		if !section.HasKey("credential_process") {
-			continue
-		}
-
-		section.DeleteKey("credential_process")
-		if len(section.Keys()) > 0 {
-			return trace.BadParameter("%s: section %q contains other keys, remove the section and try again", configFilePath, section.Name())
-		}
-		iniFile.DeleteSection(section.Name())
-
-		sectionChanged = true
 	}
 
 	// No need to save the file if no sections were changed.

--- a/lib/aws/awsconfigfile/awsconfigfile.go
+++ b/lib/aws/awsconfigfile/awsconfigfile.go
@@ -68,6 +68,10 @@ func addCredentialProcessToSection(configFilePath, sectionName, sectionComment, 
 		iniFile.NewSection(sectionName)
 	}
 
+	if !strings.HasPrefix(sectionComment, "; ") {
+		sectionComment = "; " + sectionComment
+	}
+
 	section := iniFile.Section(sectionName)
 	if cmp.Or(section.Comment, sectionComment) != sectionComment {
 		return trace.BadParameter("%s: section %q is not managed by teleport, remove the section and try again", configFilePath, sectionName)

--- a/lib/aws/awsconfigfile/awsconfigfile_test.go
+++ b/lib/aws/awsconfigfile/awsconfigfile_test.go
@@ -107,7 +107,8 @@ credential_process = credential_process
 			name:           "replaces default credential process",
 			sectionName:    "default",
 			sectionComment: "This section is managed by Teleport. Do not edit.",
-			existingContents: strPtr(`[default]
+			existingContents: strPtr(`; This section is managed by Teleport. Do not edit.
+[default]
 credential_process = another process`),
 			errCheck: require.NoError,
 			expected: `; This section is managed by Teleport. Do not edit.
@@ -119,7 +120,8 @@ credential_process = credential_process
 			name:           "comments are kept",
 			sectionName:    "default",
 			sectionComment: "This section is managed by Teleport. Do not edit.",
-			existingContents: strPtr(`[default]
+			existingContents: strPtr(`; This section is managed by Teleport. Do not edit.
+[default]
 ; this is a comment
 # yet another comment
 credential_process = another process`),
@@ -175,6 +177,18 @@ some_setting = value
 [profile Upper-and-lower-CASE]
 credential_process = credential_process
 `,
+		},
+		{
+			name:           "refuses to change the profile when a profile with the same name already exists but has no comment",
+			sectionName:    "profile My-Profile",
+			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing My-Profile",
+			existingContents: strPtr(`[sectionA]
+some_setting = value
+
+[profile My-Profile]
+credential_process=credential_process
+`),
+			errCheck: require.Error,
 		},
 		{
 			// This is not exactly a test but serves documentation purposes on the limitation of the library we use.

--- a/lib/aws/awsconfigfile/awsconfigfile_test.go
+++ b/lib/aws/awsconfigfile/awsconfigfile_test.go
@@ -156,6 +156,48 @@ credential_process = another process
 another_field = another_value`),
 			errCheck: require.Error,
 		},
+		{
+			name:           "re-apply the login, should not add another section",
+			sectionName:    "profile Upper-and-lower-CASE",
+			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE",
+			existingContents: strPtr(`[sectionA]
+some_setting = value
+
+; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+[profile Upper-and-lower-CASE]
+credential_process=credential_process
+`),
+			errCheck: require.NoError,
+			expected: `[sectionA]
+some_setting = value
+
+; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+[profile Upper-and-lower-CASE]
+credential_process = credential_process
+`,
+		},
+		{
+			// This is not exactly a test but serves documentation purposes on the limitation of the library we use.
+			// It's not possible to keep the exact formatting of the existing file because it doesn't support it.
+			// Instead, it will reformat the file before saving it.
+			// The library supports turning off pretty printing but that would just reformat the entire file using no spaces, and no alignment,
+			// even if the original file had it.
+			name:           "document reformatting behavior",
+			sectionName:    "profile Upper-and-lower-CASE",
+			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE",
+			existingContents: strPtr(`[sectionA]
+with_spaces = value
+without_spaces=value`),
+			errCheck: require.NoError,
+			expected: `[sectionA]
+with_spaces    = value
+without_spaces = value
+
+; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+[profile Upper-and-lower-CASE]
+credential_process = credential_process
+`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			configFilePath := filepath.Join(t.TempDir(), "config")

--- a/lib/aws/awsconfigfile/awsconfigfile_test.go
+++ b/lib/aws/awsconfigfile/awsconfigfile_test.go
@@ -52,7 +52,6 @@ func TestAddCredentialProcessToSection(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
 		sectionName      string
-		sectionComment   string
 		existingContents *string
 		errCheck         require.ErrorAssertionFunc
 		expected         string
@@ -60,10 +59,9 @@ func TestAddCredentialProcessToSection(t *testing.T) {
 		{
 			name:             "adds section",
 			sectionName:      "profile my-aws-iam-ra-profile",
-			sectionComment:   "This section is managed by Teleport. Do not edit.",
 			existingContents: nil, // no config file
 			errCheck:         require.NoError,
-			expected: `; This section is managed by Teleport. Do not edit.
+			expected: `; Do not edit. Section managed by Teleport.
 [profile my-aws-iam-ra-profile]
 credential_process = credential_process
 `,
@@ -71,10 +69,9 @@ credential_process = credential_process
 		{
 			name:             "no config file",
 			sectionName:      "default",
-			sectionComment:   "This section is managed by Teleport. Do not edit.",
 			existingContents: nil, // no config file
 			errCheck:         require.NoError,
-			expected: `; This section is managed by Teleport. Do not edit.
+			expected: `; Do not edit. Section managed by Teleport.
 [default]
 credential_process = credential_process
 `,
@@ -82,10 +79,9 @@ credential_process = credential_process
 		{
 			name:             "empty config file",
 			sectionName:      "default",
-			sectionComment:   "This section is managed by Teleport. Do not edit.",
 			existingContents: strPtr(""),
 			errCheck:         require.NoError,
-			expected: `; This section is managed by Teleport. Do not edit.
+			expected: `; Do not edit. Section managed by Teleport.
 [default]
 credential_process = credential_process
 `,
@@ -93,40 +89,37 @@ credential_process = credential_process
 		{
 			name:             "no default profile",
 			sectionName:      "default",
-			sectionComment:   "This section is managed by Teleport. Do not edit.",
 			existingContents: strPtr("[profile foo]"),
 			errCheck:         require.NoError,
 			expected: `[profile foo]
 
-; This section is managed by Teleport. Do not edit.
+; Do not edit. Section managed by Teleport.
 [default]
 credential_process = credential_process
 `,
 		},
 		{
-			name:           "replaces default credential process",
-			sectionName:    "default",
-			sectionComment: "This section is managed by Teleport. Do not edit.",
-			existingContents: strPtr(`; This section is managed by Teleport. Do not edit.
+			name:        "replaces default credential process",
+			sectionName: "default",
+			existingContents: strPtr(`; Do not edit. Section managed by Teleport.
 [default]
 credential_process = another process`),
 			errCheck: require.NoError,
-			expected: `; This section is managed by Teleport. Do not edit.
+			expected: `; Do not edit. Section managed by Teleport.
 [default]
 credential_process = credential_process
 `,
 		},
 		{
-			name:           "comments are kept",
-			sectionName:    "default",
-			sectionComment: "This section is managed by Teleport. Do not edit.",
-			existingContents: strPtr(`; This section is managed by Teleport. Do not edit.
+			name:        "comments are kept",
+			sectionName: "default",
+			existingContents: strPtr(`; Do not edit. Section managed by Teleport.
 [default]
 ; this is a comment
 # yet another comment
 credential_process = another process`),
 			errCheck: require.NoError,
-			expected: `; This section is managed by Teleport. Do not edit.
+			expected: `; Do not edit. Section managed by Teleport.
 [default]
 ; this is a comment
 # yet another comment
@@ -134,9 +127,8 @@ credential_process = credential_process
 `,
 		},
 		{
-			name:           "error when default profile exists and has other fields",
-			sectionName:    "default",
-			sectionComment: "This section is managed by Teleport. Do not edit.",
+			name:        "error when default profile exists and has other fields",
+			sectionName: "default",
 			existingContents: strPtr(`[default]
 credential_process = another process
 another_field = another_value`),
@@ -149,9 +141,8 @@ another_field = another_value`),
 			errCheck:         require.Error,
 		},
 		{
-			name:           "error when profile does not have the expected comment",
-			sectionName:    "default",
-			sectionComment: "This section is managed by Teleport. Do not edit.",
+			name:        "error when profile does not have the expected comment",
+			sectionName: "default",
 			existingContents: strPtr(`; Another Comment
 [default]
 credential_process = another process
@@ -159,13 +150,12 @@ another_field = another_value`),
 			errCheck: require.Error,
 		},
 		{
-			name:           "re-apply the login, should not add another section",
-			sectionName:    "profile Upper-and-lower-CASE",
-			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE",
+			name:        "re-apply the login, should not add another section",
+			sectionName: "profile Upper-and-lower-CASE",
 			existingContents: strPtr(`[sectionA]
 some_setting = value
 
-; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+; Do not edit. Section managed by Teleport.
 [profile Upper-and-lower-CASE]
 credential_process=credential_process
 `),
@@ -173,15 +163,14 @@ credential_process=credential_process
 			expected: `[sectionA]
 some_setting = value
 
-; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+; Do not edit. Section managed by Teleport.
 [profile Upper-and-lower-CASE]
 credential_process = credential_process
 `,
 		},
 		{
-			name:           "refuses to change the profile when a profile with the same name already exists but has no comment",
-			sectionName:    "profile My-Profile",
-			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing My-Profile",
+			name:        "refuses to change the profile when a profile with the same name already exists but has no comment",
+			sectionName: "profile My-Profile",
 			existingContents: strPtr(`[sectionA]
 some_setting = value
 
@@ -196,9 +185,8 @@ credential_process=credential_process
 			// Instead, it will reformat the file before saving it.
 			// The library supports turning off pretty printing but that would just reformat the entire file using no spaces, and no alignment,
 			// even if the original file had it.
-			name:           "document reformatting behavior",
-			sectionName:    "profile Upper-and-lower-CASE",
-			sectionComment: "Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE",
+			name:        "document reformatting behavior",
+			sectionName: "profile Upper-and-lower-CASE",
 			existingContents: strPtr(`[sectionA]
 with_spaces = value
 without_spaces=value`),
@@ -207,7 +195,26 @@ without_spaces=value`),
 with_spaces    = value
 without_spaces = value
 
+; Do not edit. Section managed by Teleport.
+[profile Upper-and-lower-CASE]
+credential_process = credential_process
+`,
+		},
+		{
+			name:        "upserting an existing profile which used the previous version of the comment",
+			sectionName: "profile Upper-and-lower-CASE",
+			existingContents: strPtr(`[sectionA]
+some_setting = value
+
 ; Do not edit. Section managed by Teleport. Generated for accessing Upper-and-lower-CASE
+[profile Upper-and-lower-CASE]
+credential_process=credential_process
+`),
+			errCheck: require.NoError,
+			expected: `[sectionA]
+some_setting = value
+
+; Do not edit. Section managed by Teleport.
 [profile Upper-and-lower-CASE]
 credential_process = credential_process
 `,
@@ -220,7 +227,7 @@ credential_process = credential_process
 				require.NoError(t, err)
 			}
 
-			err := addCredentialProcessToSection(configFilePath, tc.sectionName, tc.sectionComment, "credential_process")
+			err := addCredentialProcessToSection(configFilePath, tc.sectionName, "credential_process")
 			tc.errCheck(t, err)
 
 			if tc.expected != "" {
@@ -234,14 +241,13 @@ credential_process = credential_process
 	t.Run("creates directory if it does not exist", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configFilePath := filepath.Join(tmpDir, "dir", "config")
-		sectionComment := "This section is managed by Teleport. Do not edit. Profile for app: my-app"
-		err := SetDefaultProfileCredentialProcess(configFilePath, sectionComment, "credential_process")
+		err := SetDefaultProfileCredentialProcess(configFilePath, "credential_process")
 		require.NoError(t, err)
 
 		require.DirExists(t, filepath.Join(tmpDir, "dir"))
 		bs, err := os.ReadFile(configFilePath)
 		require.NoError(t, err)
-		require.Equal(t, `; This section is managed by Teleport. Do not edit. Profile for app: my-app
+		require.Equal(t, `; Do not edit. Section managed by Teleport.
 [default]
 credential_process = credential_process
 `, string(bs))
@@ -250,69 +256,91 @@ credential_process = credential_process
 	t.Run("sets a named profile", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		configFilePath := filepath.Join(tmpDir, "dir", "config")
-		sectionComment := "This section is managed by Teleport. Do not edit. Profile for app: my-app"
-		err := UpsertProfileCredentialProcess(configFilePath, "my-profile", sectionComment, "credential_process")
+		err := UpsertProfileCredentialProcess(configFilePath, "my-profile", "credential_process")
 		require.NoError(t, err)
 
 		require.DirExists(t, filepath.Join(tmpDir, "dir"))
 		bs, err := os.ReadFile(configFilePath)
 		require.NoError(t, err)
-		require.Equal(t, `; This section is managed by Teleport. Do not edit. Profile for app: my-app
+		require.Equal(t, `; Do not edit. Section managed by Teleport.
 [profile my-profile]
 credential_process = credential_process
 `, string(bs))
 	})
 }
 
-func TestRemoveCredentialProcessByComment(t *testing.T) {
+func TestRemoveTeleportManagedProfile(t *testing.T) {
 	for _, tc := range []struct {
 		name             string
-		commentSection   string
 		existingContents *string
+		profile          string
 		errCheck         require.ErrorAssertionFunc
 		expected         string
 	}{
 		{
 			name:             "no config file",
-			commentSection:   "a comment",
 			existingContents: nil, // no config file
 			errCheck:         require.NoError,
 			expected:         "",
 		},
 		{
 			name:             "empty config file",
-			commentSection:   "a comment",
 			existingContents: strPtr(""),
 			errCheck:         require.NoError,
 			expected:         "",
 		},
 		{
 			name:             "no section with expected comment",
-			commentSection:   "a comment",
 			existingContents: strPtr("; another comment\n[profile foo]\ncredential_process = process"),
 			errCheck:         require.NoError,
 			expected:         "; another comment\n[profile foo]\ncredential_process = process",
 		},
 		{
 			name:             "matching comment but no profile using credential_process",
-			commentSection:   "; a comment",
 			existingContents: strPtr("; a comment\n[profile foo]\nanother_key = value"),
 			errCheck:         require.NoError,
 			expected:         "; a comment\n[profile foo]\nanother_key = value",
 		},
 		{
 			name:             "removes the entire profile when the only key is the credential process",
-			commentSection:   "a comment",
 			existingContents: strPtr("; a comment\n[profile foo]\ncredential_process = process"),
 			errCheck:         require.NoError,
 			expected:         "",
 		},
 		{
-			name:             "an error is returned if more keys exist",
-			commentSection:   "a comment",
-			existingContents: strPtr("; a comment\n[profile foo]\ncredential_process = process\nanother_key = value"),
-			errCheck:         require.Error,
-			expected:         "; a comment\n[profile foo]\ncredential_process = process\nanother_key = value",
+			name:    "an error is returned if comment doesn't match",
+			profile: "foo",
+			existingContents: strPtr(`; a comment
+[profile foo]
+credential_process = process
+`),
+			errCheck: require.Error,
+			expected: `; a comment
+[profile foo]
+credential_process = process
+`,
+		},
+		{
+			name:    "no error even if it has more keys",
+			profile: "foo",
+			existingContents: strPtr(`; Do not edit. Section managed by Teleport.
+[profile foo]
+credential_process = process
+another_key = value
+`),
+			errCheck: require.NoError,
+			expected: ``,
+		},
+		{
+			name:    "no error even if it is using the previous comment version",
+			profile: "foo",
+			existingContents: strPtr(`; Do not edit. Section managed by Teleport. Generated for accessing MyApp
+[profile foo]
+credential_process = process
+another_key = value
+`),
+			errCheck: require.NoError,
+			expected: ``,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -321,7 +349,7 @@ func TestRemoveCredentialProcessByComment(t *testing.T) {
 				err := os.WriteFile(configFilePath, []byte(*tc.existingContents), 0600)
 				require.NoError(t, err)
 			}
-			err := RemoveCredentialProcessByComment(configFilePath, tc.commentSection)
+			err := RemoveTeleportManagedProfile(configFilePath, tc.profile)
 			tc.errCheck(t, err)
 
 			if tc.expected != "" {
@@ -333,17 +361,16 @@ func TestRemoveCredentialProcessByComment(t *testing.T) {
 	}
 }
 
-func TestRemoveCredentialProcessByCommentPrefix(t *testing.T) {
+func TestRemoveAllTeleportManagedProfiles(t *testing.T) {
 	for _, tc := range []struct {
-		name                 string
-		commentSectionPrefix string
-		existingContents     *string
-		errCheck             require.ErrorAssertionFunc
-		expected             string
+		name             string
+		profile          string
+		existingContents *string
+		errCheck         require.ErrorAssertionFunc
+		expected         string
 	}{
 		{
-			name:                 "multiple sections are removed",
-			commentSectionPrefix: "Do not remove. Generated by Teleport for app",
+			name: "multiple sections are removed",
 			existingContents: strPtr(`; Do not remove. Generated by ACME Tool
 [profile foo1]
 credential_process = process
@@ -351,11 +378,11 @@ credential_process = process
 [default]
 aws_region = us-east-1
 
-; Do not remove. Generated by Teleport for app XYZ
+; Do not edit. Section managed by Teleport.
 [profile foo2]
 credential_process = process
 
-; Do not remove. Generated by Teleport for app ABC
+; Do not edit. Section managed by Teleport.
 [profile foo3]
 credential_process = process
 `),
@@ -369,8 +396,7 @@ aws_region = us-east-1
 `,
 		},
 		{
-			name:                 "does not remove any section when comments are missing",
-			commentSectionPrefix: "Do not remove. Generated by Teleport for app",
+			name: "does not remove any section when comments are missing",
 			existingContents: strPtr(`[profile foo1]
 credential_process = process
 
@@ -398,7 +424,7 @@ credential_process = process
 				err := os.WriteFile(configFilePath, []byte(*tc.existingContents), 0600)
 				require.NoError(t, err)
 			}
-			err := RemoveCredentialProcessByCommentPrefix(configFilePath, tc.commentSectionPrefix)
+			err := RemoveAllTeleportManagedProfiles(configFilePath)
 			tc.errCheck(t, err)
 
 			if tc.expected != "" {
@@ -416,21 +442,19 @@ func TestUpdateRemoveCycle(t *testing.T) {
 	err := os.WriteFile(configFilePath, []byte(initialContents), 0600)
 	require.NoError(t, err)
 
-	sectionComment := "This section is managed by Teleport. Do not edit."
-
-	err = UpsertProfileCredentialProcess(configFilePath, "my-profile", sectionComment, "my-process")
+	err = UpsertProfileCredentialProcess(configFilePath, "my-profile", "my-process")
 	require.NoError(t, err)
 
-	err = UpsertProfileCredentialProcess(configFilePath, "my-profile2", sectionComment+" xyz", "my-process")
+	err = UpsertProfileCredentialProcess(configFilePath, "my-profile2", "my-process")
 	require.NoError(t, err)
 
-	err = UpsertProfileCredentialProcess(configFilePath, "my-profile3", sectionComment+" xyz", "my-process")
+	err = UpsertProfileCredentialProcess(configFilePath, "my-profile3", "my-process")
 	require.NoError(t, err)
 
-	err = RemoveCredentialProcessByComment(configFilePath, sectionComment)
+	err = RemoveTeleportManagedProfile(configFilePath, "my-profile")
 	require.NoError(t, err)
 
-	err = RemoveCredentialProcessByCommentPrefix(configFilePath, sectionComment)
+	err = RemoveAllTeleportManagedProfiles(configFilePath)
 	require.NoError(t, err)
 
 	bs, err := os.ReadFile(configFilePath)

--- a/tool/tsh/common/app_aws_test.go
+++ b/tool/tsh/common/app_aws_test.go
@@ -254,7 +254,7 @@ func TestAWSRolesAnywhereBasedAccess(t *testing.T) {
 	awsConfigContents, err := os.ReadFile(awsConfigFile)
 	require.NoError(t, err)
 
-	expectedProfileConfig := `; Do not edit. Section managed by Teleport. Generated for accessing aws-profile
+	expectedProfileConfig := `; Do not edit. Section managed by Teleport.
 [profile aws-profile]
 credential_process=tsh apps config --format aws-credential-process aws-profile
 `


### PR DESCRIPTION
When a user logs in to an AWS app which relies on AWS IAM Roles Anywhere integration for credentials, `tsh` will write a new entry to `~/.aws/config` file.

If the user logs out, the entry is removed.
However, if the user logs in again it will complain that:
```bash
$ tsh app login My-App --aws-role MyRole
ERROR: failed to add AWS profile to config
    /Users/user/.aws/config: section "profile My-App" is not managed by teleport, remove the section and try again
```

`tsh` uses the profile's comment section to check whether the profile already exists.
However, the comment was not properly escaped by the `; ` symbol, and so it was not being marked as managed by Teleport.

This PR fixes that, and escapes the comment (only if not already escaped).


Changelog: Fixes AWS CLI access when using the AWS Roles Anywhere integration.

Fixes: https://github.com/gravitational/teleport/issues/59969
Fixes: https://github.com/gravitational/teleport/issues/59867