### PR TITLE
[v18] EC2 Auto Discovery: retry matchers

### DIFF
--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -201,27 +201,29 @@ type EC2ClientGetter func(ctx context.Context, region string, opts ...awsconfig.
 
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
 func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client EC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
-	return matchersToEC2InstanceFetchers(ctx, matchers, func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
-		if assumeRole != nil {
-			opts = append(opts, awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID))
+	return matchersToEC2InstanceFetchers(ctx, matchers, func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+		if matcher.AssumeRole != nil {
+			opts = append(opts, awsconfig.WithAssumeRole(matcher.AssumeRole.RoleARN, matcher.AssumeRole.ExternalID))
+
 		}
+
+		opts = append(opts, awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: matcher.Integration}))
+
 		return getEC2Client(ctx, region, opts...)
 	}, discoveryConfigName)
 }
 
-// innerEC2ClientGetter is an EC2 client getter that exposes assumeRole for tests.
-type innerEC2ClientGetter func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
+// matcherEC2ClientGetter is an EC2 client getter that builds an EC2 client for the given matcher.
+// It includes the source of credentials (integration or ambient) and the assume role if any.
+// Region is not considered part of the identity because each matcher can have multiple regions.
+type matcherEC2ClientGetter func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
 
-func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client innerEC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
+func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client matcherEC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
 	ret := []Fetcher{}
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
-			opts := []awsconfig.OptionsFn{
-				awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: matcher.Integration}),
-			}
-			ec2Client, err := getEC2Client(ctx, region, matcher.AssumeRole, opts...)
-			if err != nil {
-				return nil, trace.Wrap(err)
+			ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+				return getEC2Client(ctx, region, matcher, opts...)
 			}
 
 			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
@@ -230,7 +232,7 @@ func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 				Document:            matcher.SSM.DocumentName,
 				InstallSuffix:       matcher.Params.Suffix,
 				UpdateGroup:         matcher.Params.UpdateGroup,
-				EC2Client:           ec2Client,
+				EC2ClientGetter:     ec2ClientGetter,
 				Labels:              matcher.Tags,
 				Integration:         matcher.Integration,
 				DiscoveryConfigName: discoveryConfigName,
@@ -248,7 +250,7 @@ type ec2FetcherConfig struct {
 	Document            string
 	InstallSuffix       string
 	UpdateGroup         string
-	EC2Client           ec2.DescribeInstancesAPIClient
+	EC2ClientGetter     EC2ClientGetter
 	Labels              types.Labels
 	Integration         string
 	DiscoveryConfigName string
@@ -257,7 +259,7 @@ type ec2FetcherConfig struct {
 
 type ec2InstanceFetcher struct {
 	Filters             []ec2types.Filter
-	EC2                 ec2.DescribeInstancesAPIClient
+	EC2ClientGetter     EC2ClientGetter
 	Region              string
 	DocumentName        string
 	Parameters          map[string]string
@@ -369,7 +371,7 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 	}
 
 	fetcher := ec2InstanceFetcher{
-		EC2:                 cfg.EC2Client,
+		EC2ClientGetter:     cfg.EC2ClientGetter,
 		Filters:             tagFilters,
 		Region:              cfg.Region,
 		DocumentName:        cfg.Document,
@@ -460,9 +462,14 @@ func chunkInstances(insts EC2Instances) []Instances {
 
 // GetInstances fetches all EC2 instances matching configured filters.
 func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([]Instances, error) {
+	ec2Client, err := f.EC2ClientGetter(ctx, f.Region)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var instances []Instances
 	f.cachedInstances.clear()
-	paginator := ec2.NewDescribeInstancesPaginator(f.EC2, &ec2.DescribeInstancesInput{
+	paginator := ec2.NewDescribeInstancesPaginator(ec2Client, &ec2.DescribeInstancesInput{
 		Filters: f.Filters,
 	})
 

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -54,11 +55,11 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 	return &output, nil
 }
 
-func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) innerEC2ClientGetter {
-	return func(ctx context.Context, region string, assumeRole *types.AssumeRole, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) matcherEC2ClientGetter {
+	return func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		var roleARN string
-		if assumeRole != nil {
-			roleARN = assumeRole.RoleARN
+		if matcher.AssumeRole != nil {
+			roleARN = matcher.AssumeRole.RoleARN
 		}
 		return &mockEC2Client{
 			output: m[roleARN],
@@ -327,6 +328,26 @@ func TestEC2Watcher(t *testing.T) {
 		require.Fail(t, "unexpected instance: %v", inst)
 	default:
 	}
+}
+
+func TestMatchersToEC2InstanceFetchers(t *testing.T) {
+	ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+		return nil, errors.New("ec2 client getter invocation must not fail when creating fetchers")
+	}
+
+	matchers := []types.AWSMatcher{{
+		Params: &types.InstallerParams{
+			InstallTeleport: true,
+		},
+		Types:   []string{"EC2"},
+		Regions: []string{"us-west-2"},
+		Tags:    map[string]utils.Strings{"*": {"*"}},
+		SSM:     &types.AWSSSM{},
+	}}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), matchers, ec2ClientGetter, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, fetchers)
 }
 
 func TestConvertEC2InstancesToServerInfos(t *testing.T) {

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -56,7 +56,7 @@ func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.Descri
 }
 
 func makeMockClients(m map[string]*ec2.DescribeInstancesOutput) matcherEC2ClientGetter {
-	return func(ctx context.Context, region string, matcher types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+	return func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		var roleARN string
 		if matcher.AssumeRole != nil {
 			roleARN = matcher.AssumeRole.RoleARN


### PR DESCRIPTION
Backport #59973 to branch/v18

changelog: Fixed crash of EC2 auto discovery when AWS credentials provided in to the Discovery Service are not valid.
