### PR TITLE
deflake TestTrackingSession/node_with_proxy_recording_mode

### DIFF
--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -124,8 +124,10 @@ func newMockServer(t *testing.T) *mockServer {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
+	bkpath := t.TempDir()
+	datadir := t.TempDir()
 	bk, err := lite.NewWithConfig(ctx, lite.Config{
-		Path:  t.TempDir(),
+		Path:  bkpath,
 		Clock: clock,
 	})
 	require.NoError(t, err)
@@ -141,6 +143,9 @@ func newMockServer(t *testing.T) *mockServer {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, bk.Close())
+		// TempDir does not delete contents on exit cleanup.
+		os.RemoveAll(bkpath)
+		os.RemoveAll(datadir)
 	})
 
 	authCfg := &auth.InitConfig{
@@ -157,7 +162,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 	return &mockServer{
 		auth:                authServer,
-		datadir:             t.TempDir(),
+		datadir:             datadir,
 		MockRecorderEmitter: &eventstest.MockRecorderEmitter{},
 		clock:               clock,
 	}


### PR DESCRIPTION
To reproduce:
```
go test -timeout=5m -count=1000 -shuffle=on -run ^TestTrackingSession$ github.com/gravitational/teleport/lib/srv 
```

`TempDir` does not delete directory contents on cleanup, this commit adds manual cleanup to deflake the test.