### PR TITLE
Fix settings default Access List eligibility

### DIFF
--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1504,6 +1504,15 @@ func TestAccessListMemberOwnerEligibility(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, m2.Spec.IneligibleStatus)
 
+	require.NoError(t, service.DeleteAllAccessLists(ctx))
+	member := newAccessListMember(t, acl.GetName(), "member1", withExpire(time.Time{}))
+	member.Spec.IneligibleStatus = accesslistv1.IneligibleStatus_INELIGIBLE_STATUS_USER_NOT_EXIST.String()
+	_, _, err = service.UpsertAccessListWithMembers(ctx, acl, []*accesslist.AccessListMember{member})
+	require.NoError(t, err)
+
+	m3, err := service.GetAccessListMember(ctx, acl.GetName(), "member1")
+	require.NoError(t, err)
+	require.Equal(t, accesslistv1.IneligibleStatus_INELIGIBLE_STATUS_USER_NOT_EXIST.String(), m3.Spec.IneligibleStatus)
 }
 
 type newAccessListOptions struct {


### PR DESCRIPTION
### What

Fix the issue illegibility reconciliation infinity loop when the eligibility status is set to NOT_EXISTING 

After applying https://github.com/gravitational/teleport.e/pull/7296#discussion_r2363091256 (merge only to master)  where the eligibility status is set to  `NOT_EXISTING`  the `setMemberEligibility` setOwnersEligibility should handle the case where the eligibility was set explicitly and only the case when `Eligibility`is `""`, or Undefined should cause setting the default value.   