### PR TITLE
Deflake TestTrackingSession

### DIFF
--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/user"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -141,6 +142,9 @@ func newMockServer(t *testing.T) *mockServer {
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, bk.Close())
+		// This will race the TempDir cleanup, for a high test count give a
+		// chance for the locks to be released.
+		time.Sleep(10 * time.Millisecond)
 	})
 
 	authCfg := &auth.InitConfig{


### PR DESCRIPTION
When running the test at high count (1000) and
the CPU is heavily loaded the resource release
can be delayed enough to race with TempDir cleanup leading to unlinkat errors in tests.

This change adds a short delay to give time for
remaing file locks to be released after closing
the db.