### PR TITLE
Try fixing flaky `TestTrackingSession`

### DIFF
--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -130,7 +130,7 @@ func newMockServer(t *testing.T) *mockServer {
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, bk.Close())
+		_ = bk.Close()
 	})
 
 	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -129,6 +129,9 @@ func newMockServer(t *testing.T) *mockServer {
 		Clock: clock,
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, bk.Close())
+	})
 
 	clusterName, err := services.NewClusterNameWithRandomID(types.ClusterNameSpecV2{
 		ClusterName: "localhost",
@@ -139,9 +142,6 @@ func newMockServer(t *testing.T) *mockServer {
 		StaticTokens: []types.ProvisionTokenV1{},
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, bk.Close())
-	})
 
 	authCfg := &auth.InitConfig{
 		Backend:        bk,
@@ -154,6 +154,9 @@ func newMockServer(t *testing.T) *mockServer {
 
 	authServer, err := auth.NewServer(authCfg, authtest.WithClock(clock))
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, authServer.Close())
+	})
 
 	return &mockServer{
 		auth:                authServer,


### PR DESCRIPTION
The test fails because something is not stopped during shutdown and continues to write to the temp directory.
A quick look at the test indicates that the routine is somewhere in the authServer and the change of behaviour is likely a side effect of the introduction of `cfg.HostUUID` in #59738.

I was not able to find the exact routine that was still writing (I did not look more 5 minutes though 😬) and hope that calling `authServer.Close()` will be enough to fix the test.

If the flakiness persists, we will need to fix `authServer.Close()`

Fixes: https://github.com/gravitational/teleport/issues/60054