### PR TITLE
MWI: Add `AllServicesReported` method to `readyz.Registry`

### DIFF
--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -146,3 +146,32 @@ func TestReadyz(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, rsp.StatusCode)
 	})
 }
+
+func TestAllServicesReported(t *testing.T) {
+	reg := readyz.NewRegistry()
+
+	a := reg.AddService("a")
+	b := reg.AddService("b")
+
+	select {
+	case <-reg.AllServicesReported():
+		t.Fatal("AllServicesReported should be blocked")
+	default:
+	}
+
+	a.Report(readyz.Healthy)
+
+	select {
+	case <-reg.AllServicesReported():
+		t.Fatal("AllServicesReported should be blocked")
+	default:
+	}
+
+	b.Report(readyz.Unhealthy)
+
+	select {
+	case <-reg.AllServicesReported():
+	default:
+		t.Fatal("AllServicesReported should not be blocked")
+	}
+}

--- a/lib/tbot/readyz/reporter.go
+++ b/lib/tbot/readyz/reporter.go
@@ -32,6 +32,7 @@ type Reporter interface {
 type reporter struct {
 	mu     *sync.Mutex
 	status *ServiceStatus
+	notify func()
 }
 
 func (r *reporter) Report(status Status) {
@@ -44,6 +45,7 @@ func (r *reporter) ReportReason(status Status, reason string) {
 
 	r.status.Status = status
 	r.status.Reason = reason
+	r.notify()
 }
 
 // NoopReporter returns a no-op Reporter that can be used when no real reporter


### PR DESCRIPTION
This method will be used by the heartbeat service to wait until services have reported their initial status (with a timeout) before submitting the initial heartbeat. Otherwise, we'd potentially report all services as "initializing" for 30 minutes in daemon mode, or forever in long-shot mode.
