### PR TITLE
Disable golangci-lint schema validation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -120,36 +120,54 @@ jobs:
       - name: golangci-lint (api)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: api
           skip-cache: true
       - name: golangci-lint (teleport)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           args: --build-tags libfido2,piv
           skip-cache: true
       - name: golangci-lint (assets/backport)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: assets/backport
           skip-cache: true
       - name: golangci-lint (build.assets/tooling)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: build.assets/tooling
           skip-cache: true
       - name: golangci-lint (integrations/terraform)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: integrations/terraform
           skip-cache: true
       - name: golangci-lint (integrations/event-handler)
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
+          # Disable verify as it downloads a json schema from an external CDN.
+          # If the config is not valid, golangci-lint will fail.
+          verify: false
           version: ${{ env.GOLANGCI_LINT_VERSION }}
           working-directory: integrations/event-handler
           skip-cache: true


### PR DESCRIPTION
This PR disables golangci-lint schema validation.

Why:
- golangci-lint is installed from the github CDN
- but the schema used from validation is downloaded from some other 3rd party CDN [with less availability](https://github.com/gravitational/teleport/actions/runs/18353624301/job/52279881887)
- if the config is invalid, golangci-lint will complain anyway

Slack thread: https://gravitational.slack.com/archives/C0DF0TPMY/p1759947275892289?thread_ts=1759947192.397149&cid=C0DF0TPMY