### PR TITLE
Deflake `TestSSHServerBasics`

### DIFF
--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -322,6 +322,10 @@ func TestSSHServerBasics(t *testing.T) {
 	oldExpiry, expiry := expiry, auth.getLastServerExpiry()
 	require.Greater(t, expiry, oldExpiry)
 
+	auth.mu.Lock()
+	auth.failUpserts = 1
+	auth.mu.Unlock()
+
 	err = downstream.Send(ctx, &proto.InventoryHeartbeat{
 		SSHServer: &types.ServerV2{
 			Metadata: types.Metadata{
@@ -336,10 +340,6 @@ func TestSSHServerBasics(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-
-	auth.mu.Lock()
-	auth.failUpserts = 1
-	auth.mu.Unlock()
 
 	// we should now see an upsert failure, but no additional
 	// keepalive failures, and the upsert should succeed on retry.

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -200,15 +200,15 @@ func (a *fakeAuth) UpsertInstance(ctx context.Context, instance types.Instance) 
 // TestSSHServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // an ssh service.
 func TestSSHServerBasics(t *testing.T) {
+	synctestOrParallel(t, testSSHServerBasics)
+}
+func testSSHServerBasics(t *testing.T) {
 	const serverID = "test-server"
 	const zeroAddr = "0.0.0.0:123"
 	const peerAddr = "1.2.3.4:456"
 	const wantAddr = "1.2.3.4:123"
 
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	events := make(chan testEvent, 1024)
 
@@ -415,13 +415,13 @@ func TestSSHServerBasics(t *testing.T) {
 // TestAppServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // an app service.
 func TestAppServerBasics(t *testing.T) {
+	synctestOrParallel(t, testAppServerBasics)
+}
+func testAppServerBasics(t *testing.T) {
 	const serverID = "test-server"
 	const appCount = 3
 
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	events := make(chan testEvent, 1024)
 
@@ -648,13 +648,13 @@ func TestAppServerBasics(t *testing.T) {
 // TestDatabaseServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // a database server.
 func TestDatabaseServerBasics(t *testing.T) {
+	synctestOrParallel(t, testDatabaseServerBasics)
+}
+func testDatabaseServerBasics(t *testing.T) {
 	const serverID = "test-server"
 	const dbCount = 3
 
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	events := make(chan testEvent, 1024)
 
@@ -914,6 +914,9 @@ func TestDatabaseServerBasics(t *testing.T) {
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat_Disabled(t *testing.T) {
+	synctestOrParallel(t, testInstanceHeartbeat_Disabled)
+}
+func testInstanceHeartbeat_Disabled(t *testing.T) {
 	const serverID = "test-instance"
 	const peerAddr = "1.2.3.4:456"
 
@@ -962,6 +965,9 @@ func TestInstanceHeartbeatDisabledEnv(t *testing.T) {
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat(t *testing.T) {
+	synctestOrParallel(t, testInstanceHeartbeat)
+}
+func testInstanceHeartbeat(t *testing.T) {
 	const serverID = "test-instance"
 	const peerAddr = "1.2.3.4:456"
 
@@ -1078,7 +1084,9 @@ func TestInstanceHeartbeat(t *testing.T) {
 // TestUpdateLabels verifies that an instance's labels can be updated over an
 // inventory control stream.
 func TestUpdateLabels(t *testing.T) {
-	t.Parallel()
+	synctestOrParallel(t, testUpdateLabels)
+}
+func testUpdateLabels(t *testing.T) {
 	const serverID = "test-instance"
 	const peerAddr = "1.2.3.4:456"
 
@@ -1106,11 +1114,19 @@ func TestUpdateLabels(t *testing.T) {
 		ServerID: "auth",
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
-	downstreamHandle, err := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
-		return downstream, nil
-	}, func(_ context.Context) (*proto.UpstreamInventoryHello, error) { return upstreamHello, nil })
+	downstreamHandle, err := NewDownstreamHandle(
+		func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+			return downstream, nil
+		},
+		func(_ context.Context) (*proto.UpstreamInventoryHello, error) {
+			return upstreamHello, nil
+		},
+		withMetadataGetter(func(ctx context.Context) (*metadata.Metadata, error) {
+			return nil, context.Canceled
+		}),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, downstreamHandle.Close()) })
 
@@ -1140,8 +1156,9 @@ func TestUpdateLabels(t *testing.T) {
 // TestAgentMetadata verifies that an instance's agent metadata is received in
 // inventory control stream.
 func TestAgentMetadata(t *testing.T) {
-	t.Parallel()
-
+	synctestOrParallel(t, testAgentMetadata)
+}
+func testAgentMetadata(t *testing.T) {
 	const serverID = "test-instance"
 	const peerAddr = "1.2.3.4:456"
 
@@ -1169,13 +1186,15 @@ func TestAgentMetadata(t *testing.T) {
 		ServerID: "auth",
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	inventoryHandle, err := NewDownstreamHandle(
 		func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 			return downstream, nil
 		},
-		func(ctx context.Context) (*proto.UpstreamInventoryHello, error) { return upstreamHello, nil },
+		func(ctx context.Context) (*proto.UpstreamInventoryHello, error) {
+			return upstreamHello, nil
+		},
 		withMetadataGetter(func(ctx context.Context) (*metadata.Metadata, error) {
 			return &metadata.Metadata{
 				OS:                    "llamaOS",
@@ -1216,8 +1235,6 @@ func TestAgentMetadata(t *testing.T) {
 }
 
 func TestGoodbye(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name            string
 		supportsGoodbye bool
@@ -1246,7 +1263,7 @@ func TestGoodbye(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		inner := func(t *testing.T) {
 			// Test Setup: crafting a controller and an upstream/downstream stream pipe
 			controller := NewController(
 				&fakeAuth{},
@@ -1272,16 +1289,22 @@ func TestGoodbye(t *testing.T) {
 			handle, err := NewDownstreamHandle(
 				func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
 					return currentDownstream, nil
-				}, func(ctx context.Context) (*proto.UpstreamInventoryHello, error) {
+				},
+				func(ctx context.Context) (*proto.UpstreamInventoryHello, error) {
 					return upstreamHello, nil
-				}, WithDownstreamClock(clock))
+				},
+				WithDownstreamClock(clock),
+				withMetadataGetter(func(ctx context.Context) (*metadata.Metadata, error) {
+					return nil, context.Canceled
+				}),
+			)
 			require.NoError(t, err)
 			t.Cleanup(func() {
 				require.NoError(t, handle.Close())
 			})
 
 			// Test setup: wait for the downstream handler to finish its startup and respond to its hello
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 			select {
 			case msg := <-upstream.Recv():
@@ -1298,7 +1321,7 @@ func TestGoodbye(t *testing.T) {
 			// Then send a Pong message to indicate the test is done.
 			nonce := rand.Int()
 			go func() {
-				ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+				ctx, cancel = context.WithTimeout(t.Context(), 10*time.Second)
 				defer cancel()
 				handle.SetAndSendGoodbye(ctx, test.deleteResources, test.softReload)
 
@@ -1365,7 +1388,7 @@ func TestGoodbye(t *testing.T) {
 			// Simulating a failure on the old control stream, asking for a reconnection
 			require.NoError(t, downstream.CloseWithError(io.EOF))
 
-			ctx, cancel = context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel = context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 			// Wait to hit the handle linear retry, then jump into the future
 			require.NoError(t, clock.BlockUntilContext(ctx, 1))
@@ -1407,18 +1430,21 @@ func TestGoodbye(t *testing.T) {
 				}
 			}
 
+		}
+		t.Run(test.name, func(t *testing.T) {
+			synctestOrParallel(t, inner)
 		})
 	}
 }
 
 func TestKubernetesServerBasics(t *testing.T) {
+	synctestOrParallel(t, testKubernetesServerBasics)
+}
+func testKubernetesServerBasics(t *testing.T) {
 	const serverID = "test-server"
 	const kubeCount = 3
 
-	t.Parallel()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	events := make(chan testEvent, 1024)
 
@@ -1642,6 +1668,9 @@ func TestKubernetesServerBasics(t *testing.T) {
 }
 
 func TestGetSender(t *testing.T) {
+	synctestOrParallel(t, testGetSender)
+}
+func testGetSender(t *testing.T) {
 	controller := NewController(
 		&fakeAuth{},
 		usagereporter.DiscardUsageReporter{},
@@ -1668,9 +1697,17 @@ func TestGetSender(t *testing.T) {
 		Services: types.SystemRoles{types.RoleNode, types.RoleApp}.StringSlice(),
 	}
 
-	handle, err := NewDownstreamHandle(func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
-		return downstream, nil
-	}, func(ctx context.Context) (*proto.UpstreamInventoryHello, error) { return upstreamHello, nil })
+	handle, err := NewDownstreamHandle(
+		func(ctx context.Context) (client.DownstreamInventoryControlStream, error) {
+			return downstream, nil
+		},
+		func(ctx context.Context) (*proto.UpstreamInventoryHello, error) {
+			return upstreamHello, nil
+		},
+		withMetadataGetter(func(ctx context.Context) (*metadata.Metadata, error) {
+			return nil, context.Canceled
+		}),
+	)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, handle.Close()) })
 
@@ -1689,7 +1726,7 @@ func TestGetSender(t *testing.T) {
 	}
 	// Send the downstream hello so that the
 	// sender becomes available.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	require.NoError(t, upstream.Send(ctx, downstreamHello))
 
@@ -1703,11 +1740,14 @@ func TestGetSender(t *testing.T) {
 
 // TestTimeReconciliation verifies basic behavior of the time reconciliation check.
 func TestTimeReconciliation(t *testing.T) {
+	synctestOrParallel(t, testTimeReconciliation)
+}
+func testTimeReconciliation(t *testing.T) {
 	const serverID = "test-server"
 	const peerAddr = "1.2.3.4:456"
 	const wantAddr = "1.2.3.4:123"
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx := t.Context()
 	events := make(chan testEvent, 1024)
 	auth := &fakeAuth{
 		expectAddr: wantAddr,
@@ -1729,7 +1769,6 @@ func TestTimeReconciliation(t *testing.T) {
 		require.NoError(t, downstream.Close())
 		require.NoError(t, upstream.Close())
 		require.NoError(t, controller.Close())
-		cancel()
 	})
 
 	// Launch goroutine to respond to clock request.

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -200,7 +200,8 @@ func (a *fakeAuth) UpsertInstance(ctx context.Context, instance types.Instance) 
 // TestSSHServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // an ssh service.
 func TestSSHServerBasics(t *testing.T) {
-	synctestOrParallel(t, testSSHServerBasics)
+	t.Parallel()
+	maybeSynctest(t, testSSHServerBasics)
 }
 func testSSHServerBasics(t *testing.T) {
 	const serverID = "test-server"
@@ -415,7 +416,8 @@ func testSSHServerBasics(t *testing.T) {
 // TestAppServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // an app service.
 func TestAppServerBasics(t *testing.T) {
-	synctestOrParallel(t, testAppServerBasics)
+	t.Parallel()
+	maybeSynctest(t, testAppServerBasics)
 }
 func testAppServerBasics(t *testing.T) {
 	const serverID = "test-server"
@@ -648,7 +650,8 @@ func testAppServerBasics(t *testing.T) {
 // TestDatabaseServerBasics verifies basic expected behaviors for a single control stream heartbeating
 // a database server.
 func TestDatabaseServerBasics(t *testing.T) {
-	synctestOrParallel(t, testDatabaseServerBasics)
+	t.Parallel()
+	maybeSynctest(t, testDatabaseServerBasics)
 }
 func testDatabaseServerBasics(t *testing.T) {
 	const serverID = "test-server"
@@ -914,7 +917,8 @@ func testDatabaseServerBasics(t *testing.T) {
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat_Disabled(t *testing.T) {
-	synctestOrParallel(t, testInstanceHeartbeat_Disabled)
+	t.Parallel()
+	maybeSynctest(t, testInstanceHeartbeat_Disabled)
 }
 func testInstanceHeartbeat_Disabled(t *testing.T) {
 	const serverID = "test-instance"
@@ -965,7 +969,8 @@ func TestInstanceHeartbeatDisabledEnv(t *testing.T) {
 
 // TestInstanceHeartbeat verifies basic expected behaviors for instance heartbeat.
 func TestInstanceHeartbeat(t *testing.T) {
-	synctestOrParallel(t, testInstanceHeartbeat)
+	t.Parallel()
+	maybeSynctest(t, testInstanceHeartbeat)
 }
 func testInstanceHeartbeat(t *testing.T) {
 	const serverID = "test-instance"
@@ -1084,7 +1089,8 @@ func testInstanceHeartbeat(t *testing.T) {
 // TestUpdateLabels verifies that an instance's labels can be updated over an
 // inventory control stream.
 func TestUpdateLabels(t *testing.T) {
-	synctestOrParallel(t, testUpdateLabels)
+	t.Parallel()
+	maybeSynctest(t, testUpdateLabels)
 }
 func testUpdateLabels(t *testing.T) {
 	const serverID = "test-instance"
@@ -1156,7 +1162,8 @@ func testUpdateLabels(t *testing.T) {
 // TestAgentMetadata verifies that an instance's agent metadata is received in
 // inventory control stream.
 func TestAgentMetadata(t *testing.T) {
-	synctestOrParallel(t, testAgentMetadata)
+	t.Parallel()
+	maybeSynctest(t, testAgentMetadata)
 }
 func testAgentMetadata(t *testing.T) {
 	const serverID = "test-instance"
@@ -1432,13 +1439,15 @@ func TestGoodbye(t *testing.T) {
 
 		}
 		t.Run(test.name, func(t *testing.T) {
-			synctestOrParallel(t, inner)
+			t.Parallel()
+			maybeSynctest(t, inner)
 		})
 	}
 }
 
 func TestKubernetesServerBasics(t *testing.T) {
-	synctestOrParallel(t, testKubernetesServerBasics)
+	t.Parallel()
+	maybeSynctest(t, testKubernetesServerBasics)
 }
 func testKubernetesServerBasics(t *testing.T) {
 	const serverID = "test-server"
@@ -1668,7 +1677,8 @@ func testKubernetesServerBasics(t *testing.T) {
 }
 
 func TestGetSender(t *testing.T) {
-	synctestOrParallel(t, testGetSender)
+	t.Parallel()
+	maybeSynctest(t, testGetSender)
 }
 func testGetSender(t *testing.T) {
 	controller := NewController(
@@ -1740,7 +1750,8 @@ func testGetSender(t *testing.T) {
 
 // TestTimeReconciliation verifies basic behavior of the time reconciliation check.
 func TestTimeReconciliation(t *testing.T) {
-	synctestOrParallel(t, testTimeReconciliation)
+	t.Parallel()
+	maybeSynctest(t, testTimeReconciliation)
 }
 func testTimeReconciliation(t *testing.T) {
 	const serverID = "test-server"

--- a/lib/inventory/inventory_nosynctest_test.go
+++ b/lib/inventory/inventory_nosynctest_test.go
@@ -1,0 +1,29 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build !go1.25
+
+package inventory
+
+import "testing"
+
+// TODO(espadolini): DELETE IN v21 or after the oldest supported Teleport
+// version is on go 1.25
+
+func synctestOrParallel(t *testing.T, fn func(*testing.T)) {
+	t.Parallel()
+	fn(t)
+}

--- a/lib/inventory/inventory_nosynctest_test.go
+++ b/lib/inventory/inventory_nosynctest_test.go
@@ -23,7 +23,6 @@ import "testing"
 // TODO(espadolini): DELETE IN v21 or after the oldest supported Teleport
 // version is on go 1.25
 
-func synctestOrParallel(t *testing.T, fn func(*testing.T)) {
-	t.Parallel()
+func maybeSynctest(t *testing.T, fn func(*testing.T)) {
 	fn(t)
 }

--- a/lib/inventory/inventory_synctest_exp_test.go
+++ b/lib/inventory/inventory_synctest_exp_test.go
@@ -14,15 +14,22 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !go1.25 && !goexperiment.synctest
+//go:build !go1.25 && goexperiment.synctest
 
 package inventory
 
-import "testing"
+import (
+	"testing"
+	"testing/synctest"
+)
 
 // TODO(espadolini): DELETE IN v21 or after the oldest supported Teleport
 // version is on go 1.25
 
 func maybeSynctest(t *testing.T, fn func(*testing.T)) {
-	fn(t)
+	// in go 1.24 with the synctest experiment there's no integrated support for
+	// t.Cleanup callbacks to run before exiting the bubble, but if we run
+	// things in a subtest we get the same behavior, albeit with everything in a
+	// subtest, which is ugly but functional
+	synctest.Run(func() { t.Run("goexperiment.synctest", fn) })
 }

--- a/lib/inventory/inventory_synctest_test.go
+++ b/lib/inventory/inventory_synctest_test.go
@@ -23,6 +23,6 @@ import (
 	"testing/synctest"
 )
 
-func synctestOrParallel(t *testing.T, fn func(*testing.T)) {
+func maybeSynctest(t *testing.T, fn func(*testing.T)) {
 	synctest.Test(t, fn)
 }

--- a/lib/inventory/inventory_synctest_test.go
+++ b/lib/inventory/inventory_synctest_test.go
@@ -1,0 +1,28 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build go1.25
+
+package inventory
+
+import (
+	"testing"
+	"testing/synctest"
+)
+
+func synctestOrParallel(t *testing.T, fn func(*testing.T)) {
+	synctest.Test(t, fn)
+}

--- a/lib/inventory/store_test.go
+++ b/lib/inventory/store_test.go
@@ -99,6 +99,12 @@ func BenchmarkStore(b *testing.B) {
 // 1. Handles are loadable by ID.
 // 2. When multiple handles have the same ID, loads are distributed across them.
 func TestStoreAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("TestStoreAccess is heavy")
+	}
+
+	t.Parallel()
+
 	store := NewStore()
 
 	// we keep a record of all handles inserted into the store
@@ -152,6 +158,12 @@ func TestStoreAccess(t *testing.T) {
 // every handle in the store, even when multiple handles are registered with
 // the same server ID.
 func TestAllHandles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("TestAllHandles is heavy")
+	}
+
+	t.Parallel()
+
 	store := NewStore()
 
 	// we keep a record of all handles inserted into the store


### PR DESCRIPTION
This PR fixes a (logical) race condition that could happen in `lib/inventory.TestSSHServerBasics` where the inventory controller was instructed to fail the following node heartbeat upsert after queuing up the node heartbeat that was intended to fail, making it possible for it to succeed depending on timing. Other tests in the package already correctly set the flag before sending the heartbeat, so this PR aligns the behavior of the flaky test to the other tests.

In addition, this PR also puts the `lib/inventory` tests into synctest bubbles (in go 1.25) for a 4000-fold reduction in execution time. 

Fixes #54711