### PR TITLE
scoped access resource verbs

### DIFF
--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -134,8 +134,10 @@ type ScopedRoleSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// AssignableScopes is a list of scopes to which this role can be assigned.
 	AssignableScopes []string `protobuf:"bytes,1,rep,name=assignable_scopes,json=assignableScopes,proto3" json:"assignable_scopes,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// Allow specifies the permissions granted by this role.
+	Allow         *ScopedRoleConditions `protobuf:"bytes,2,opt,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedRoleSpec) Reset() {
@@ -175,6 +177,115 @@ func (x *ScopedRoleSpec) GetAssignableScopes() []string {
 	return nil
 }
 
+func (x *ScopedRoleSpec) GetAllow() *ScopedRoleConditions {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// ScopedRoleConditions describes a role's allow block.
+type ScopedRoleConditions struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Rules describe basic resource:verb permissions.
+	Rules         []*ScopedRule `protobuf:"bytes,1,rep,name=rules,proto3" json:"rules,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRoleConditions) Reset() {
+	*x = ScopedRoleConditions{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRoleConditions) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRoleConditions) ProtoMessage() {}
+
+func (x *ScopedRoleConditions) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRoleConditions.ProtoReflect.Descriptor instead.
+func (*ScopedRoleConditions) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ScopedRoleConditions) GetRules() []*ScopedRule {
+	if x != nil {
+		return x.Rules
+	}
+	return nil
+}
+
+// Rule maps resources to verbs. This is the underlying type used to describe
+// permissions like 'node:read' or 'role:create'.
+type ScopedRule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Resources is a list of resource kinds (e.g. 'scoped_token') that the below verbs apply to.
+	Resources []string `protobuf:"bytes,1,rep,name=resources,proto3" json:"resources,omitempty"`
+	// Verbs is the list of action verbs (e.g. 'read') that apply to the above resources.
+	Verbs         []string `protobuf:"bytes,2,rep,name=verbs,proto3" json:"verbs,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedRule) Reset() {
+	*x = ScopedRule{}
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedRule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedRule) ProtoMessage() {}
+
+func (x *ScopedRule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_access_v1_role_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedRule.ProtoReflect.Descriptor instead.
+func (*ScopedRule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_access_v1_role_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ScopedRule) GetResources() []string {
+	if x != nil {
+		return x.Resources
+	}
+	return nil
+}
+
+func (x *ScopedRule) GetVerbs() []string {
+	if x != nil {
+		return x.Verbs
+	}
+	return nil
+}
+
 var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
@@ -187,9 +298,16 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12=\n" +
-	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"=\n" +
+	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\x84\x01\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
-	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopesBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
+	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12E\n" +
+	"\x05allow\x18\x02 \x01(\v2/.teleport.scopes.access.v1.ScopedRoleConditionsR\x05allow\"S\n" +
+	"\x14ScopedRoleConditions\x12;\n" +
+	"\x05rules\x18\x01 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\"@\n" +
+	"\n" +
+	"ScopedRule\x12\x1c\n" +
+	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
+	"\x05verbs\x18\x02 \x03(\tR\x05verbsBWZUgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1b\x06proto3"
 
 var (
 	file_teleport_scopes_access_v1_role_proto_rawDescOnce sync.Once
@@ -203,20 +321,24 @@ func file_teleport_scopes_access_v1_role_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_access_v1_role_proto_rawDescData
 }
 
-var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_scopes_access_v1_role_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
-	(*ScopedRole)(nil),     // 0: teleport.scopes.access.v1.ScopedRole
-	(*ScopedRoleSpec)(nil), // 1: teleport.scopes.access.v1.ScopedRoleSpec
-	(*v1.Metadata)(nil),    // 2: teleport.header.v1.Metadata
+	(*ScopedRole)(nil),           // 0: teleport.scopes.access.v1.ScopedRole
+	(*ScopedRoleSpec)(nil),       // 1: teleport.scopes.access.v1.ScopedRoleSpec
+	(*ScopedRoleConditions)(nil), // 2: teleport.scopes.access.v1.ScopedRoleConditions
+	(*ScopedRule)(nil),           // 3: teleport.scopes.access.v1.ScopedRule
+	(*v1.Metadata)(nil),          // 4: teleport.header.v1.Metadata
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
-	2, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
+	4, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.allow:type_name -> teleport.scopes.access.v1.ScopedRoleConditions
+	3, // 3: teleport.scopes.access.v1.ScopedRoleConditions.rules:type_name -> teleport.scopes.access.v1.ScopedRule
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }
@@ -230,7 +352,7 @@ func file_teleport_scopes_access_v1_role_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_access_v1_role_proto_rawDesc), len(file_teleport_scopes_access_v1_role_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/access/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/service_grpc.pb.go
@@ -58,7 +58,9 @@ type ScopedAccessServiceClient interface {
 	CreateScopedRole(ctx context.Context, in *CreateScopedRoleRequest, opts ...grpc.CallOption) (*CreateScopedRoleResponse, error)
 	// UpdateScopedRole updates a scoped role.
 	UpdateScopedRole(ctx context.Context, in *UpdateScopedRoleRequest, opts ...grpc.CallOption) (*UpdateScopedRoleResponse, error)
-	// DeleteScopedRole deletes a scoped role.
+	// DeleteScopedRole deletes a scoped role. Note that scoped role deletion is always
+	// conditional. Scoped roles cannot be deleted if referenced by any existing assignment
+	// and deletes may fail due to concurrent modification.
 	DeleteScopedRole(ctx context.Context, in *DeleteScopedRoleRequest, opts ...grpc.CallOption) (*DeleteScopedRoleResponse, error)
 	// GetScopedRoleAssignment gets a scoped role assignment by name.
 	GetScopedRoleAssignment(ctx context.Context, in *GetScopedRoleAssignmentRequest, opts ...grpc.CallOption) (*GetScopedRoleAssignmentResponse, error)
@@ -182,7 +184,9 @@ type ScopedAccessServiceServer interface {
 	CreateScopedRole(context.Context, *CreateScopedRoleRequest) (*CreateScopedRoleResponse, error)
 	// UpdateScopedRole updates a scoped role.
 	UpdateScopedRole(context.Context, *UpdateScopedRoleRequest) (*UpdateScopedRoleResponse, error)
-	// DeleteScopedRole deletes a scoped role.
+	// DeleteScopedRole deletes a scoped role. Note that scoped role deletion is always
+	// conditional. Scoped roles cannot be deleted if referenced by any existing assignment
+	// and deletes may fail due to concurrent modification.
 	DeleteScopedRole(context.Context, *DeleteScopedRoleRequest) (*DeleteScopedRoleResponse, error)
 	// GetScopedRoleAssignment gets a scoped role assignment by name.
 	GetScopedRoleAssignment(context.Context, *GetScopedRoleAssignmentRequest) (*GetScopedRoleAssignmentResponse, error)

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -48,5 +48,21 @@ message ScopedRoleSpec {
   // AssignableScopes is a list of scopes to which this role can be assigned.
   repeated string assignable_scopes = 1;
 
-  // TODO(fspmarshall): port relevant role features to scoped roles.
+  // Allow specifies the permissions granted by this role.
+  ScopedRoleConditions allow = 2;
+}
+
+// ScopedRoleConditions describes a role's allow block.
+message ScopedRoleConditions {
+  // Rules describe basic resource:verb permissions.
+  repeated ScopedRule rules = 1;
+}
+
+// Rule maps resources to verbs. This is the underlying type used to describe
+// permissions like 'node:read' or 'role:create'.
+message ScopedRule {
+  // Resources is a list of resource kinds (e.g. 'scoped_token') that the below verbs apply to.
+  repeated string resources = 1;
+  // Verbs is the list of action verbs (e.g. 'read') that apply to the above resources.
+  repeated string verbs = 2;
 }

--- a/api/proto/teleport/scopes/access/v1/service.proto
+++ b/api/proto/teleport/scopes/access/v1/service.proto
@@ -36,7 +36,9 @@ service ScopedAccessService {
   // UpdateScopedRole updates a scoped role.
   rpc UpdateScopedRole(UpdateScopedRoleRequest) returns (UpdateScopedRoleResponse);
 
-  // DeleteScopedRole deletes a scoped role.
+  // DeleteScopedRole deletes a scoped role. Note that scoped role deletion is always
+  // conditional. Scoped roles cannot be deleted if referenced by any existing assignment
+  // and deletes may fail due to concurrent modification.
   rpc DeleteScopedRole(DeleteScopedRoleRequest) returns (DeleteScopedRoleResponse);
 
   // GetScopedRoleAssignment gets a scoped role assignment by name.

--- a/integrations/lib/testing/integration/authhelper.go
+++ b/integrations/lib/testing/integration/authhelper.go
@@ -80,11 +80,12 @@ func (a *MinimalAuthHelper) StartServer(t *testing.T) *client.Client {
 
 	server, err := authtest.NewTestTLSServer(authtest.TLSServerConfig{
 		APIConfig: &auth.APIConfig{
-			AuthServer:     authServer.AuthServer,
-			Authorizer:     authServer.Authorizer,
-			AuditLog:       authServer.AuditLog,
-			Emitter:        authServer.AuditLog,
-			PluginRegistry: a.PluginRegistry,
+			AuthServer:       authServer.AuthServer,
+			Authorizer:       authServer.Authorizer,
+			ScopedAuthorizer: authServer.ScopedAuthorizer,
+			AuditLog:         authServer.AuditLog,
+			Emitter:          authServer.AuditLog,
+			PluginRegistry:   a.PluginRegistry,
 		},
 		AuthServer:    authServer,
 		AcceptedUsage: authServer.AcceptedUsage,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -82,6 +82,12 @@ type ServerWithRoles struct {
 	alog       events.AuditLogSessionStreamer
 	// context holds authorization context
 	context authz.Context
+
+	// scopedContext is an authz context that may or may not be scoped, some methods which have been
+	// converted to support scoped identities will be supplied with this context instead of the standard
+	// context field above. Only one of the two is non-nil at a time, so care must be taken to ensure
+	// that the correct one is used for a given method.
+	scopedContext *authz.ScopedContext
 }
 
 // CloseContext is closed when the auth server shuts down

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -174,6 +174,9 @@ func NewTestServer(cfg ServerConfig) (*Server, error) {
 	if tlsCfg.APIConfig.Authorizer == nil {
 		tlsCfg.APIConfig.Authorizer = authServer.Authorizer
 	}
+	if tlsCfg.APIConfig.ScopedAuthorizer == nil {
+		tlsCfg.APIConfig.ScopedAuthorizer = authServer.ScopedAuthorizer
+	}
 	if tlsCfg.APIConfig.AuditLog == nil {
 		tlsCfg.APIConfig.AuditLog = authServer.AuditLog
 	}
@@ -245,6 +248,8 @@ type AuthServer struct {
 	Backend backend.Backend
 	// Authorizer is an authorizer used in tests
 	Authorizer authz.Authorizer
+	// ScopedAuthorizer is a scoped authorizer used in tests.
+	ScopedAuthorizer authz.ScopedAuthorizer
 	// LockWatcher is a lock watcher used in tests.
 	LockWatcher *services.LockWatcher
 }
@@ -473,17 +478,24 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	}
 	srv.AuthServer.SetHeadlessAuthenticationWatcher(headlessAuthenticationWatcher)
 
-	srv.Authorizer, err = authz.NewAuthorizer(authz.AuthorizerOpts{
+	authorizerOpts := authz.AuthorizerOpts{
 		ClusterName:         srv.ClusterName,
 		AccessPoint:         srv.AuthServer,
 		ReadOnlyAccessPoint: srv.AuthServer.ReadOnlyCache,
+		ScopedRoleReader:    srv.AuthServer.ScopedAccessCache,
 		LockWatcher:         srv.LockWatcher,
 		// AuthServer does explicit device authorization checks.
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			DisableGlobalMode: true,
 			DisableRoleMode:   true,
 		},
-	})
+	}
+	srv.Authorizer, err = authz.NewAuthorizer(authorizerOpts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	srv.ScopedAuthorizer, err = authz.NewScopedAuthorizer(authorizerOpts)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -789,10 +801,11 @@ func (a *AuthServer) Trust(ctx context.Context, remote *AuthServer, roleMap type
 // NewTestTLSServer returns new test TLS server
 func (a *AuthServer) NewTestTLSServer(opts ...TestTLSServerOption) (*TLSServer, error) {
 	apiConfig := &auth.APIConfig{
-		AuthServer: a.AuthServer,
-		Authorizer: a.Authorizer,
-		AuditLog:   a.AuditLog,
-		Emitter:    a.AuthServer,
+		AuthServer:       a.AuthServer,
+		Authorizer:       a.Authorizer,
+		ScopedAuthorizer: a.ScopedAuthorizer,
+		AuditLog:         a.AuditLog,
+		Emitter:          a.AuthServer,
 	}
 	cfg := TLSServerConfig{
 		APIConfig:     apiConfig,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -898,6 +898,14 @@ func (g *GRPCServer) GetInstances(filter *types.InstanceFilter, stream authpb.Au
 func (g *GRPCServer) GetClusterAlerts(ctx context.Context, query *types.GetClusterAlertsRequest) (*authpb.GetClusterAlertsResponse, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
+		if errors.Is(err, authz.ErrScopedIdentity) {
+			// NOTE: scoped alerts do not currently exist. a lot of client logic wants to incidentally load cluster alerts
+			// as part of other operations. ordinarily we just return an access denied when a scoped identity is used to
+			// call an API that doesn't support scoping yet, but doing so here would complicate client logic a lot. it is
+			// therefore preferable to instead consider a scoped invocation a valid call that just happens to not match
+			// any alerts.
+			return &authpb.GetClusterAlertsResponse{}, nil
+		}
 		return nil, trail.ToGRPC(err)
 	}
 
@@ -1279,7 +1287,7 @@ func (g *GRPCServer) UpdatePluginData(ctx context.Context, params *types.PluginD
 }
 
 func (g *GRPCServer) Ping(ctx context.Context, req *authpb.PingRequest) (*authpb.PingResponse, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -4597,10 +4605,43 @@ func (g *GRPCServer) GetAccountRecoveryCodes(ctx context.Context, req *authpb.Ge
 	return rc, nil
 }
 
+// isScopePinnedLocalUserCredential returns true if the credentials associated with a given context
+// are specifically for a local user with a scope pin. this is used to help determine if it is safe to
+// perform a fallback operation when an API that isn't ported to scopes gets called with a scoped identity.
+// In theory, this check is redundant as this is the only condition where Authorizer.Authorize currently
+// returns ErrScopedIdentity, but having this extra check here helps us better describe the *security model*
+// of the fallback, which may not be sane in potential future scenarios where scoped identity errors are produced
+// for system roles or non-local users.
+func isScopePinnedLocalUserCredential(ctx context.Context) bool {
+	userI, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return false
+	}
+
+	if user, ok := userI.(authz.LocalUser); ok && user.Identity.ScopePin != nil {
+		return true
+	}
+
+	return false
+}
+
 // CreateAuthenticateChallenge is implemented by AuthService.CreateAuthenticateChallenge.
 func (g *GRPCServer) CreateAuthenticateChallenge(ctx context.Context, req *authpb.CreateAuthenticateChallengeRequest) (*authpb.MFAAuthenticateChallenge, error) {
 	actx, err := g.authenticate(ctx)
 	if err != nil {
+		if errors.Is(err, authz.ErrScopedIdentity) && isScopePinnedLocalUserCredential(ctx) && req.MFARequiredCheck != nil {
+			if _, ok := req.MFARequiredCheck.Target.(*authpb.IsMFARequiredRequest_AdminAction); ok {
+				// NOTE: scopes don't currently have a concept of admin action MFA. a lot of client logic wants to do a preemtive
+				// check to see if MFA is required. ordinarily we just return an access denied when a scoped identity is used to
+				// call an API that doesn't support scoping yet, but doing so here would complicate client logic a lot. it is
+				// therefore preferable to instead consider a scoped invocation a valid call that just happens to result in a
+				// no mfa required result.
+				return &authpb.MFAAuthenticateChallenge{
+					MFARequired: authpb.MFARequired_MFA_REQUIRED_NO,
+				}, nil
+			}
+		}
+
 		return nil, trace.Wrap(err)
 	}
 
@@ -5926,10 +5967,10 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	)
 
 	scopedAccessControl, err := scopedaccess.New(scopedaccess.Config{
-		Authorizer: cfg.Authorizer,
-		Reader:     cfg.AuthServer.ScopedAccessCache,
-		Writer:     cfg.AuthServer.scopedAccessBackend,
-		Logger:     logger,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Reader:           cfg.AuthServer.ScopedAccessCache,
+		Writer:           cfg.AuthServer.scopedAccessBackend,
+		Logger:           logger,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating scoped access control service")
@@ -6288,6 +6329,29 @@ func (g *GRPCServer) authenticate(ctx context.Context) (*grpcContext, error) {
 			authServer: g.AuthServer,
 			context:    *authContext,
 			alog:       g.AuthServer,
+		},
+	}, nil
+}
+
+// scopedGRPCContext servers the same role as [grpcContext] but for scoped identities. It is currently
+// a thin wrapper around [ServerWithRoles] since we don't have any need to embed an [authz.Context] yet,
+// but we may embed one in the future.
+type scopedGRPCContext struct {
+	*ServerWithRoles
+}
+
+// scopedAuthenticate functions similarly to authenticate but supports scoped identities. It returns an initialized auth server
+// that has been set up with a scoped access checker, which may be based off of either a scoped or unscoped identity.
+func (g *GRPCServer) scopedAuthenticate(ctx context.Context) (*scopedGRPCContext, error) {
+	authContext, err := g.ScopedAuthorizer.AuthorizeScoped(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &scopedGRPCContext{
+		ServerWithRoles: &ServerWithRoles{
+			authServer:    g.AuthServer,
+			scopedContext: authContext,
+			alog:          g.AuthServer,
 		},
 	}, nil
 }

--- a/lib/auth/scopes/access/service.go
+++ b/lib/auth/scopes/access/service.go
@@ -35,16 +35,16 @@ import (
 
 // Config contains the parameters for [New].
 type Config struct {
-	Authorizer authz.Authorizer
-	Reader     services.ScopedAccessReader
-	Writer     services.ScopedAccessWriter
-	Logger     *slog.Logger
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Reader           services.CachedScopedAccessReader
+	Writer           services.ScopedAccessWriter
+	Logger           *slog.Logger
 }
 
 // CheckAndSetDefaults checks the config for missing parameters and sets default values.
 func (c *Config) CheckAndSetDefaults() error {
-	if c.Authorizer == nil {
-		return trace.BadParameter("missing Authorizer in scoped access grpc service config")
+	if c.ScopedAuthorizer == nil {
+		return trace.BadParameter("missing ScopedAuthorizer in scoped access grpc service config")
 	}
 
 	if c.Reader == nil {
@@ -86,14 +86,22 @@ func (s *Server) CreateScopedRole(ctx context.Context, req *scopedaccessv1.Creat
 		return nil, trace.Wrap(err)
 	}
 
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to create scoped roles", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	if err := authzContext.CheckerContext.Decision(ctx, req.GetRole().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbCreate)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped roles in the requested scope",
+			"user", authzContext.User.GetName(),
+			"scope", req.GetRole().GetScope())
+		return nil, trace.Wrap(err)
 	}
 
 	return s.cfg.Writer.CreateScopedRole(ctx, req)
@@ -105,14 +113,18 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		return nil, trace.Wrap(err)
 	}
 
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to create scoped role assignments", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	if req.GetAssignment() == nil {
@@ -135,6 +147,15 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 		req.RoleRevisions = make(map[string]string)
 	}
 
+	if err := authzContext.CheckerContext.Decision(ctx, req.GetAssignment().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbCreate)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to create scoped role assignments in the requested scope",
+			"user", authzContext.User.GetName(),
+			"scope", req.GetAssignment().GetScope())
+		return nil, trace.Wrap(err)
+	}
+
 	for _, subAssignment := range req.GetAssignment().GetSpec().GetAssignments() {
 		rsp, err := s.cfg.Reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
 			Name: subAssignment.GetRole(),
@@ -153,7 +174,15 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 			req.RoleRevisions[subAssignment.GetRole()] = rsp.GetRole().GetMetadata().GetRevision()
 		}
 
-		// TODO(fspmarshall): implement validation of role assignment access-controls at this step.
+		// XXX: we're kind of side-stepping the question of what, if any, per-role policies should be enforced
+		// by currently requiring that all assignments only assign roles from the same scope as part of the
+		// backend validation logic. if/when we lift that restriction, we'll need to revisit this logic and
+		// decide what, if any, additional access-control checks may be required when an assignment references
+		// a role from a different scope. the current thinking is that we will allow assignments to reference
+		// roles in parent scopes *but* said assignments will not be able to introduce conflicts in modification
+		// of said parent roles. this is consistent with the scopes security model but has the downside of requiring
+		// us to change/relax role modification restrictions and possibly introduce a means of automated cleanup of
+		// dangling/malformed assignments.
 	}
 
 	return s.cfg.Writer.CreateScopedRoleAssignment(ctx, req)
@@ -161,92 +190,262 @@ func (s *Server) CreateScopedRoleAssignment(ctx context.Context, req *scopedacce
 
 // DeleteScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete a scoped roles", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped roles", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// perform an early check for root scope delete permission to allow us to short-circuit
+	// and perform an unconditional delete. this is not strictly necessary, but allows us to
+	// have an escape hatch for deleting roles that are so malformed that they cannot be read.
+	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
+	}); err == nil {
+		return s.cfg.Writer.DeleteScopedRole(ctx, req)
 	}
+
+	// load the role so we can determine the resource scope
+	grsp, err := s.cfg.Reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: req.GetName(),
+	})
+	if err != nil {
+		if trace.IsNotFound(err) {
+			// this API deliberately does not distinguish between kinds of concurrent modification
+			// in its error kinds.
+			return nil, trace.CompareFailed("scoped role %q has been concurrently modified and/or deleted", req.GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	// if a revision has been asserted, it must match the revision of the resource we are going to use for
+	// access-control checks.
+	if rev := req.GetRevision(); rev != "" && rev != grsp.GetRole().GetMetadata().GetRevision() {
+		return nil, trace.CompareFailed("scoped role %q has been concurrently modified", req.GetName())
+	}
+
+	// evaluate the access to the role based on its scope
+	if err := authzContext.CheckerContext.Decision(ctx, grsp.GetRole().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped roles in the requested scope",
+			"user", authzContext.User.GetName(),
+			"scope", grsp.GetRole().GetScope(),
+			"role", req.GetName(),
+			"error", err,
+		)
+		return nil, trace.Wrap(err)
+	}
+
+	// set the revision to the current revision to prevent deletion in the event of concurrent modification
+	// that might invalidate the access-control checks we just performed.
+	req.Revision = grsp.GetRole().GetMetadata().GetRevision()
 
 	return s.cfg.Writer.DeleteScopedRole(ctx, req)
 }
 
 // DeleteScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete a scoped role assignment", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to delete a scoped role assignment", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// perform an early check for root scope delete permission to allow us to short-circuit
+	// and perform an unconditional delete. this is not strictly necessary, but allows us to
+	// have an escape hatch for deleting assignments that are so malformed that they cannot be read.
+	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
+	}); err == nil {
+		return s.cfg.Writer.DeleteScopedRoleAssignment(ctx, req)
 	}
+
+	// load the assignment so we can determine the resource scope
+	grsp, err := s.cfg.Reader.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: req.GetName(),
+	})
+	if err != nil {
+		if trace.IsNotFound(err) {
+			// this API deliberately does not distinguish between kinds of concurrent modification
+			// in its error kinds.
+			return nil, trace.CompareFailed("scoped role assignment %q has been concurrently modified and/or deleted", req.GetName())
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	// if a revision has been asserted, it must match the revision of the resource we are going to use for
+	// access-control checks.
+	if rev := req.GetRevision(); rev != "" && rev != grsp.GetAssignment().GetMetadata().GetRevision() {
+		return nil, trace.CompareFailed("scoped role assignment %q has been concurrently modified", req.GetName())
+	}
+
+	// evaluate the access to the assignment based on its scope
+	if err := authzContext.CheckerContext.Decision(ctx, grsp.GetAssignment().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbDelete)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to delete scoped role assignments in the requested scope",
+			"user", authzContext.User.GetName(),
+			"scope", grsp.GetAssignment().GetScope(),
+			"assignment", req.GetName(),
+			"error", err,
+		)
+		return nil, trace.Wrap(err)
+	}
+
+	// set the revision to the current revision to prevent deletion in the event of concurrent modification
+	// that might invalidate the access-control checks we just performed.
+	req.Revision = grsp.GetAssignment().GetMetadata().GetRevision()
 
 	return s.cfg.Writer.DeleteScopedRoleAssignment(ctx, req)
 }
 
 // GetScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to get scoped roles", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to get scoped roles", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return s.cfg.Reader.GetScopedRole(ctx, req)
+	// load the role so we can determine the resource scope
+	preAuthzRsp, err := s.cfg.Reader.GetScopedRole(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// evaluate the access to the role based on its scope
+	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetRole().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role",
+			"user", authzContext.User.GetName(),
+			"scope", preAuthzRsp.GetRole().GetScope(),
+			"role", req.GetName(),
+			"error", err,
+		)
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(fspmarshall/scopes): we likely want to add an exception here to allow users to view the roles that they
+	// are assigned. though we may want to have such an exception be an opt-in mode to avoid complicating local administration.
+
+	// return of the pre-authz response is safe because we have now confirmed the user has access to its contents.
+	return preAuthzRsp, nil
 }
 
 // GetScopedRoleAssignment implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to get scoped role assignments", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to get scoped role assignments", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return s.cfg.Reader.GetScopedRoleAssignment(ctx, req)
+	// load the assignment so we can determine the resource scope
+	preAuthzRsp, err := s.cfg.Reader.GetScopedRoleAssignment(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// evaluate the access to the assignment based on its scope
+	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRsp.GetAssignment().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to read scoped role assignment",
+			"user", authzContext.User.GetName(),
+			"scope", preAuthzRsp.GetAssignment().GetScope(),
+			"assignment", req.GetName(),
+			"error", err,
+		)
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(fspmarshall/scopes): we must add an exception here to allow users to view the assignments that they
+	// are assigned. we also need to explicitly support "escaping" the scope pin while doing this in order for users
+	// to be able to discover privileges in their scopes. we will want to have such an exception be an opt-in mode.
+
+	// return of the pre-authz response is safe because we have now confirmed the user has access to its contents.
+	return preAuthzRsp, nil
 }
 
 // ListScopedRoleAssignments implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to list scoped role assignments", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to list scoped role assignments", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once before iteration. a resource-dependent
+	// rule context would need to be built once for each invocation of the filter function used during
+	// iteration, but we don't currently support resource attributes in scoped role where clauses, so
+	// can be pre-built once at the beginning of the call.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return s.cfg.Reader.ListScopedRoleAssignments(ctx, req)
+	// list scoped role assignments with a filter that only passes assignments the user has access to.
+	rsp, err := s.cfg.Reader.ListScopedRoleAssignmentsWithFilter(ctx, req, func(assignment *scopedaccessv1.ScopedRoleAssignment) bool {
+		err := authzContext.CheckerContext.Decision(ctx, assignment.GetScope(), func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRoleAssignment, types.VerbReadNoSecrets, types.VerbList)
+		})
+		return err == nil
+	})
+	return rsp, trace.Wrap(err)
 }
 
 // ListScopedRoles implements [scopedaccessv1.ScopedRoleServiceServer].
 func (s *Server) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission to list scoped roles", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to list scoped roles", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once before iteration. a resource-dependent
+	// rule context would need to be built once for each invocation of the filter function, but
+	// we don't currently support resource attributes in scoped role where clauses, so can be pre-built
+	// once at the beginning of the call.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	return s.cfg.Reader.ListScopedRoles(ctx, req)
+	// list scoped roles with a filter that only passes roles the user has access to.
+	rsp, err := s.cfg.Reader.ListScopedRolesWithFilter(ctx, req, func(role *scopedaccessv1.ScopedRole) bool {
+		err := authzContext.CheckerContext.Decision(ctx, role.GetScope(), func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbReadNoSecrets, types.VerbList)
+		})
+		return err == nil
+	})
+
+	return rsp, trace.Wrap(err)
 }
 
 // UpdateScopedRole implements [scopedaccessv1.ScopedRoleServiceServer].
@@ -255,14 +454,50 @@ func (s *Server) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.Updat
 		return nil, trace.Wrap(err)
 	}
 
-	authzContext, err := s.cfg.Authorizer.Authorize(ctx)
+	authzContext, err := s.cfg.ScopedAuthorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.cfg.Logger.WarnContext(ctx, "user does not have permission update scoped roles", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission update scoped roles", authzContext.User.GetName())
+	// build rule context for where-clause evaluation once to avoid re-creation
+	// on each decision invocation.
+	ruleCtx := authzContext.RuleContext()
+
+	// do a pre-check to weed out requests that definitely won't be authorized.
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbUpdate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// load the existing role to determine its scope
+	extant, err := s.cfg.Reader.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: req.GetRole().GetMetadata().GetName(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// ensure that if a revision has been asserted, it matches the current revision of the role
+	if rev := req.GetRole().GetMetadata().GetRevision(); rev != "" && rev != extant.GetRole().GetMetadata().GetRevision() {
+		return nil, trace.CompareFailed("scoped role %q has been concurrently modified", req.GetRole().GetMetadata().GetName())
+	}
+	req.Role.Metadata.Revision = extant.GetRole().GetMetadata().GetRevision()
+
+	// disallow change of resource scope via update. use of scopes.Compare directly is generally discouraged,
+	// but that is due to ease of misuse, which isn't really a concern for a simple equivalence check.
+	if scopes.Compare(req.GetRole().GetScope(), extant.GetRole().GetScope()) != scopes.Equivalent {
+		return nil, trace.BadParameter("cannot modify the resource scope of scoped role %q (%q -> %q)", req.GetRole().GetMetadata().GetName(), extant.GetRole().GetScope(), req.GetRole().GetScope())
+	}
+
+	// the sanity of this check is hard-dependent on the above requirement that updates not modify the resource scope.
+	// we do not currently have a model for what a scope update would look like, and likely this would require significant
+	// rework to be able to support such a thing.
+	if err := authzContext.CheckerContext.Decision(ctx, req.GetRole().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbUpdate)
+	}); err != nil {
+		s.cfg.Logger.WarnContext(ctx, "user does not have permission to update scoped roles in the requested scope",
+			"user", authzContext.User.GetName(),
+			"scope", req.GetRole().GetScope())
+		return nil, trace.Wrap(err)
 	}
 
 	return s.cfg.Writer.UpdateScopedRole(ctx, req)

--- a/lib/auth/scopes/access/service_test.go
+++ b/lib/auth/scopes/access/service_test.go
@@ -1,0 +1,957 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package accesscontrol
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedaccesscache "github.com/gravitational/teleport/lib/scopes/cache/access"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+const testClusterName = "test-cluster"
+
+// fakeSplitAuthorizer is a mock implementation of ScopedAuthorizer that provides a hard-coded context.
+type fakeSplitAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (a *fakeSplitAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	return a.ctx, nil
+}
+
+// newFakeScopedAuthorizer builds a fake split authorizer with a hard-coded context based on the provided scoped access info and reader.
+// this means that while the identity/assignments can be fake, the underlying reader must contain the expected scoped
+// roles in order for the context to be built successfully.
+func newFakeScopedAuthorizer(t *testing.T, accessInfo *services.AccessInfo, reader services.ScopedRoleReader) *fakeSplitAuthorizer {
+	t.Helper()
+
+	scopedCtx, err := services.NewScopedAccessCheckerContext(t.Context(), accessInfo, testClusterName, reader)
+	require.NoError(t, err)
+
+	return &fakeSplitAuthorizer{
+		ctx: &authz.ScopedContext{
+			User: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: accessInfo.Username,
+				},
+			},
+			CheckerContext: services.NewScopedSplitAccessCheckerContext(scopedCtx),
+		},
+	}
+}
+
+// newFakeUnscopedAuthorizer builds a fake split authorizer with a hard-coded context based on the provided unscoped access info and reader.
+// this means that while the identity can be fake, the underlying reader must contain the expected classic roles in order for the context to
+// be built successfully.
+func newFakeUnscopedAuthorizer(t *testing.T, accessInfo *services.AccessInfo, reader services.RoleGetter) *fakeSplitAuthorizer {
+	t.Helper()
+
+	checker, err := services.NewAccessChecker(accessInfo, testClusterName, reader)
+	require.NoError(t, err)
+
+	return &fakeSplitAuthorizer{
+		ctx: &authz.ScopedContext{
+			User: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: accessInfo.Username,
+				},
+			},
+			CheckerContext: services.NewUnscopedSplitAccessCheckerContext(checker),
+		},
+	}
+}
+
+// newServerForIdentity builds a server with an access checker that is hard-coded to the provided access info. The backend pack
+// much be pre-seeded with the relevant scoped/unscoped roles, but assignments are drawn from the access info (as they would be
+// if the access info was being taken from a certificate).
+func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.AccessInfo) *Server {
+	t.Helper()
+
+	var authz authz.ScopedAuthorizer
+	if accessInfo.ScopePin != nil {
+		authz = newFakeScopedAuthorizer(t, accessInfo, bk.cache)
+	} else {
+		authz = newFakeUnscopedAuthorizer(t, accessInfo, bk.classicService)
+	}
+
+	srv, err := New(Config{
+		ScopedAuthorizer: authz,
+		Reader:           bk.cache,
+		Writer:           bk.service,
+	})
+	require.NoError(t, err)
+
+	return srv
+}
+
+type backendPack struct {
+	backend        backend.Backend
+	service        *local.ScopedAccessService
+	classicService *local.AccessService
+	cache          *scopedaccesscache.Cache
+}
+
+func (p *backendPack) Close() {
+	p.cache.Close()
+	p.backend.Close()
+}
+
+// newBackendPack creates a scoped access service and populates it with the provided scoped roles.
+func newBackendPack(t *testing.T) *backendPack {
+	t.Helper()
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	service := local.NewScopedAccessService(backend)
+	classicService := local.NewAccessService(backend)
+	events := local.NewEventsService(backend)
+
+	cache, err := scopedaccesscache.NewCache(scopedaccesscache.CacheConfig{
+		Events: events,
+		Reader: service,
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-cache.Init():
+	case <-time.After(30 * time.Second):
+		require.FailNow(t, "timed out waiting for scoped access cache to initialize")
+	}
+
+	return &backendPack{
+		backend:        backend,
+		service:        service,
+		classicService: classicService,
+		cache:          cache,
+	}
+}
+
+// TestRoleBasics verifies that basic CRUD operations on scoped roles work as expected, with a focus on ensuring that
+// pinned scopes and role permissions are being properly enforced.
+func TestRoleBasics(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newBackendPack(t)
+	defer bk.Close()
+
+	initialRoles := []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-admin",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "prod-admin",
+			},
+			Scope: "/prod",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/prod"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	for _, role := range initialRoles {
+		// bootstrap in an initial role so that we can start using scoped permissions for our tests
+		_, err := bk.service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+	}
+
+	// wait for roles to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 2
+	})
+
+	// set up server pinned to a staging admin identity
+	srv := newServerForIdentity(t, bk, &services.AccessInfo{
+		ScopePin: &scopesv1.Pin{
+			Scope: "/staging",
+			Assignments: map[string]*scopesv1.PinnedAssignments{
+				"/staging": {
+					Roles: []string{"staging-admin"},
+				},
+			},
+		},
+		Username: "alice",
+	})
+
+	// verify expected successful read
+	rrsp, err := srv.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "staging-admin",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "staging-admin", rrsp.GetRole().GetMetadata().GetName())
+	require.Equal(t, "/staging", rrsp.GetRole().GetScope())
+
+	// verify expected denied read
+	_, err = srv.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "prod-admin",
+	})
+	require.Error(t, err)
+	// within the scopes model, getting a disallowed resource by its name is always considered an access denied,
+	// this is a divergence from our traditional RBAC model where a not found might be returned instead. scopes don't
+	// "hide" primary keys in the same manner if the caller has scoped read permissions.
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify expected successful list request includes only allowed roles
+	lrsp, err := srv.ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lrsp.GetNextPageToken())
+	require.Len(t, lrsp.GetRoles(), 1)
+	require.Equal(t, "staging-admin", lrsp.GetRoles()[0].GetMetadata().GetName())
+
+	// verify expected successful create
+	crsp, err := srv.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-user",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "staging-user", crsp.GetRole().GetMetadata().GetName())
+
+	// wait for roles to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 3
+	})
+
+	// verify expected denied create (out of scope)
+	_, err = srv.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "prod-user",
+			},
+			Scope: "/prod",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/prod"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that denied create really didn't create the role (requires using backend service
+	// directly to avoid false positive due to cache replication)
+	rrsp, err = bk.service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "prod-user",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected not found error, got: %v", err)
+	require.Nil(t, rrsp)
+
+	// verify expected successful update
+
+	// start by getting the existing role
+	rrsp, err = srv.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "staging-user",
+	})
+	require.NoError(t, err)
+
+	// modify the role
+	rrsp.Role.Metadata.Labels = map[string]string{
+		"key": "val",
+	}
+
+	// update the role
+	ursp, err := srv.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: rrsp.GetRole(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "staging-user", ursp.GetRole().GetMetadata().GetName())
+	require.NotEqual(t, rrsp.GetRole().GetMetadata().GetRevision(), ursp.GetRole().GetMetadata().GetRevision())
+
+	// observe change in cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		for _, role := range roles {
+			if role.GetMetadata().GetName() == "staging-user" {
+				if val, ok := role.GetMetadata().GetLabels()["key"]; ok && val == "val" {
+					return true
+				}
+			}
+		}
+		return false
+	})
+
+	// verify expected denied update (out of scope)
+
+	// start by getting the existing role (requires using backend service
+	// directly since our server is using a scoped identity)
+	rrsp, err = bk.service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "prod-admin",
+	})
+	require.NoError(t, err)
+
+	// modify the role
+	rrsp.Role.Metadata.Labels = map[string]string{
+		"key": "val",
+	}
+
+	// attempt to update the role
+	ursp, err = srv.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: rrsp.GetRole(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+	require.Nil(t, ursp)
+
+	// verify that denied update really didn't update the role (requires using backend service
+	// directly to avoid false positive due to cache replication)
+	rrsp, err = bk.service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "prod-admin",
+	})
+	require.NoError(t, err)
+	require.Nil(t, rrsp.GetRole().GetMetadata().GetLabels())
+
+	// verify expected successful delete
+	_, err = srv.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name: "staging-user",
+	})
+	require.NoError(t, err)
+
+	// wait for deletion to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		for _, role := range roles {
+			if role.GetMetadata().GetName() == "staging-user" {
+				return false
+			}
+		}
+		return true
+	})
+
+	// verify expected denied delete (out of scope)
+	_, err = srv.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name: "prod-admin",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that denied delete really didn't delete the role (requires using backend service
+	// directly to avoid false positive due to cache replication)
+	rrsp, err = bk.service.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "prod-admin",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "prod-admin", rrsp.GetRole().GetMetadata().GetName())
+}
+
+// TestAssignmentBasics verifies that basic CRUD operations on scoped role assignments work as expected, with a focus on ensuring that
+// pinned scopes and role permissions are being properly enforced.
+func TestAssignmentBasics(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newBackendPack(t)
+	defer bk.Close()
+
+	initialRoles := []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-admin",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "prod-admin",
+			},
+			Scope: "/prod",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/prod"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	}
+
+	roleRevisions := make(map[string]string)
+	for _, role := range initialRoles {
+		// bootstrap in an initial role so that we can start using scoped permissions for our tests
+		crsp, err := bk.service.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+			Role: role,
+		})
+		require.NoError(t, err)
+		roleRevisions[role.GetMetadata().GetName()] = crsp.GetRole().GetMetadata().GetRevision()
+	}
+
+	// wait for roles to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 2
+	})
+
+	// set up some initial assignments
+	initialAssignments := []*scopedaccessv1.ScopedRoleAssignment{
+		newScopedRoleAssignmentAtScope("staging-admin", "/staging"),
+		newScopedRoleAssignmentAtScope("prod-admin", "/prod"),
+	}
+
+	for _, assignment := range initialAssignments {
+		_, err := bk.service.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+			Assignment:    assignment,
+			RoleRevisions: roleRevisions, // when bypassing rbac layer, revisions must be explicit
+		})
+		require.NoError(t, err)
+	}
+
+	// wait for assignments to be populated into cache
+	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		return len(assignments) == 2
+	})
+
+	// set up server pinned to a staging admin identity
+	srv := newServerForIdentity(t, bk, &services.AccessInfo{
+		ScopePin: &scopesv1.Pin{
+			Scope: "/staging",
+			Assignments: map[string]*scopesv1.PinnedAssignments{
+				"/staging": {
+					Roles: []string{"staging-admin"},
+				},
+			},
+		},
+		Username: "alice",
+	})
+
+	// verify expected successful read
+	rasp, err := srv.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: initialAssignments[0].GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, initialAssignments[0].GetMetadata().GetName(), rasp.GetAssignment().GetMetadata().GetName())
+	require.Equal(t, "/staging", rasp.GetAssignment().GetScope())
+
+	// verify expected denied read
+	rasp, err = srv.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: initialAssignments[1].GetMetadata().GetName(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+	require.Nil(t, rasp)
+
+	// verify expected successful list request includes only allowed assignments
+	lasp, err := srv.ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lasp.GetNextPageToken())
+	require.Len(t, lasp.GetAssignments(), 1)
+	require.Equal(t, initialAssignments[0].GetMetadata().GetName(), lasp.GetAssignments()[0].GetMetadata().GetName())
+
+	// verify expected successful create
+	a1 := newScopedRoleAssignmentAtScope("staging-admin", "/staging")
+	carsp, err := srv.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: a1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, a1.GetMetadata().GetName(), carsp.GetAssignment().GetMetadata().GetName())
+
+	// wait for assignments to be populated into cache
+	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		return len(assignments) == 3
+	})
+
+	// verify expected denied create (out of scope)
+	a2 := newScopedRoleAssignmentAtScope("prod-admin", "/prod")
+	carsp, err = srv.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: a2,
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+	require.Nil(t, carsp)
+
+	// verify that denied create really didn't create the assignment (requires using backend service
+	// directly to avoid false positive due to cache replication)
+	garsp, err := bk.service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: a2.GetMetadata().GetName(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsNotFound(err), "expected not found error, got: %v", err)
+	require.Nil(t, garsp)
+
+	// verify expected successful delete
+	_, err = srv.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: a1.GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+
+	// wait for deletion to be populated into cache
+	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		for _, assignment := range assignments {
+			if assignment.GetMetadata().GetName() == a1.GetMetadata().GetName() {
+				return false
+			}
+		}
+		return true
+	})
+
+	// verify expected denied delete (out of scope)
+	_, err = srv.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: initialAssignments[1].GetMetadata().GetName(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that denied delete really didn't delete the assignment (requires using backend service
+	// directly to avoid false positive due to cache replication)
+	rasp, err = bk.service.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: initialAssignments[1].GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, initialAssignments[1].GetMetadata().GetName(), rasp.GetAssignment().GetMetadata().GetName())
+}
+
+func newScopedRoleAssignmentAtScope(roleName string, scope string) *scopedaccessv1.ScopedRoleAssignment {
+	return &scopedaccessv1.ScopedRoleAssignment{
+		Kind: scopedaccess.KindScopedRoleAssignment,
+		Metadata: &headerv1.Metadata{
+			Name: uuid.New().String(),
+		},
+		Scope: scope,
+		Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+			User: "bob",
+			Assignments: []*scopedaccessv1.Assignment{
+				{
+					Role:  roleName,
+					Scope: scope,
+				},
+			},
+		},
+		Version: types.V1,
+	}
+}
+
+// TestUnscopedBasics verifies that unscoped access control works as expected.
+func TestUnscopedBasics(t *testing.T) {
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bk := newBackendPack(t)
+	defer bk.Close()
+
+	classicRoles := []*types.RoleV6{
+		{
+			Metadata: types.Metadata{
+				Name: "unscoped-auditor",
+			},
+			Spec: types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Rules: []types.Rule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList},
+						},
+					},
+				},
+			},
+			Version: types.V8,
+		},
+		{
+			Metadata: types.Metadata{
+				Name: "unscoped-admin",
+			},
+			Spec: types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Rules: []types.Rule{
+						{
+							Resources: []string{scopedaccess.KindScopedRole, scopedaccess.KindScopedRoleAssignment},
+							Verbs:     []string{types.VerbReadNoSecrets, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V8,
+		},
+	}
+
+	for _, role := range classicRoles {
+		_, err := bk.classicService.CreateRole(ctx, role)
+		require.NoError(t, err)
+	}
+
+	// set up server pinned to unscoped admin identity
+	srvAlice := newServerForIdentity(t, bk, &services.AccessInfo{
+		Username: "alice",
+		Roles:    []string{"unscoped-admin"},
+	})
+
+	// set up server pinned to unscoped auditor identity
+	srvBob := newServerForIdentity(t, bk, &services.AccessInfo{
+		Username: "bob",
+		Roles:    []string{"unscoped-auditor"},
+	})
+
+	// verify that admin can create a role
+	crsp, err := srvAlice.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "some-role",
+			},
+			Scope: "/some-scope",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/some-scope"},
+			},
+			Version: types.V1,
+		},
+	})
+	require.NoError(t, err)
+
+	// wait for roles to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		return len(roles) == 1
+	})
+
+	// verify that admin can read the role
+	rrsp, err := srvAlice.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "some-role",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "some-role", rrsp.GetRole().GetMetadata().GetName())
+
+	// verify that admin can list the role
+	lrsp, err := srvAlice.ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lrsp.GetNextPageToken())
+	require.Len(t, lrsp.GetRoles(), 1)
+	require.Equal(t, "some-role", lrsp.GetRoles()[0].GetMetadata().GetName())
+
+	// verify that auditor cannot create a role
+	_, err = srvBob.CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: &scopedaccessv1.ScopedRole{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "some-other-role",
+			},
+			Scope: "/some-scope",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/some-scope"},
+			},
+			Version: types.V1,
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that auditor can read the admin-created role
+	rrsp, err = srvBob.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "some-role",
+	})
+	require.NoError(t, err)
+	require.Equal(t, crsp.GetRole().GetMetadata().GetName(), rrsp.GetRole().GetMetadata().GetName())
+
+	// verify that auditor can list the admin-created role
+	lrsp, err = srvBob.ListScopedRoles(ctx, &scopedaccessv1.ListScopedRolesRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lrsp.GetNextPageToken())
+	require.Len(t, lrsp.GetRoles(), 1)
+	require.Equal(t, crsp.GetRole().GetMetadata().GetName(), lrsp.GetRoles()[0].GetMetadata().GetName())
+
+	// verify that admin can create an assignment
+	acrsp, err := srvAlice.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Scope: "/some-scope",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "bob",
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "some-role",
+						Scope: "/some-scope",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "/some-scope", acrsp.GetAssignment().GetScope())
+
+	// wait for assignments to be populated into cache
+	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		return len(assignments) == 1
+	})
+
+	// verify that admin can read the assignment
+	rasp, err := srvAlice.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: acrsp.GetAssignment().GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, acrsp.GetAssignment().GetMetadata().GetName(), rasp.GetAssignment().GetMetadata().GetName())
+
+	// verify that admin can list the assignment
+	lasp, err := srvAlice.ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lasp.GetNextPageToken())
+	require.Len(t, lasp.GetAssignments(), 1)
+	require.Equal(t, acrsp.GetAssignment().GetMetadata().GetName(), lasp.GetAssignments()[0].GetMetadata().GetName())
+
+	// verify that auditor cannot create an assignment
+	_, err = srvBob.CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: &scopedaccessv1.ScopedRoleAssignment{
+			Kind: scopedaccess.KindScopedRoleAssignment,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Scope: "/some-scope",
+			Spec: &scopedaccessv1.ScopedRoleAssignmentSpec{
+				User: "alice",
+				Assignments: []*scopedaccessv1.Assignment{
+					{
+						Role:  "some-role",
+						Scope: "/some-scope",
+					},
+				},
+			},
+			Version: types.V1,
+		},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that auditor can read the admin-created assignment
+	rasp, err = srvBob.GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+		Name: acrsp.GetAssignment().GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, acrsp.GetAssignment().GetMetadata().GetName(), rasp.GetAssignment().GetMetadata().GetName())
+
+	// verify that auditor can list the admin-created assignment
+	lasp, err = srvBob.ListScopedRoleAssignments(ctx, &scopedaccessv1.ListScopedRoleAssignmentsRequest{})
+	require.NoError(t, err)
+	require.Empty(t, lasp.GetNextPageToken())
+	require.Len(t, lasp.GetAssignments(), 1)
+	require.Equal(t, acrsp.GetAssignment().GetMetadata().GetName(), lasp.GetAssignments()[0].GetMetadata().GetName())
+
+	// verify that admin can update roles
+
+	// start by getting the existing role
+	rrsp, err = srvAlice.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: "some-role",
+	})
+	require.NoError(t, err)
+	rrsp.Role.Metadata.Labels = map[string]string{
+		"key": "val",
+	}
+
+	// update the role
+	ursp, err := srvAlice.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: rrsp.GetRole(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, crsp.GetRole().GetMetadata().GetName(), ursp.GetRole().GetMetadata().GetName())
+	require.NotEqual(t, rrsp.GetRole().GetMetadata().GetRevision(), ursp.GetRole().GetMetadata().GetRevision())
+
+	// verify that auditor cannot update roles
+	rrsp, err = srvBob.GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+		Name: crsp.GetRole().GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+	rrsp.Role.Metadata.Labels = map[string]string{
+		"key": "val2",
+	}
+	ursp, err = srvBob.UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: rrsp.GetRole(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+	require.Nil(t, ursp)
+
+	// verify that auditor cannot delete assignments
+	_, err = srvBob.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: acrsp.GetAssignment().GetMetadata().GetName(),
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that admin can delete assignments
+	_, err = srvAlice.DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: acrsp.GetAssignment().GetMetadata().GetName(),
+	})
+	require.NoError(t, err)
+
+	// wait for deletion to be populated into cache
+	waitForAssignmentCondition(t, bk.cache, func(assignments []*scopedaccessv1.ScopedRoleAssignment) bool {
+		for _, assignment := range assignments {
+			if assignment.GetMetadata().GetName() == acrsp.GetAssignment().GetMetadata().GetName() {
+				return false
+			}
+		}
+		return true
+	})
+
+	// verify that auditor cannot delete roles
+	_, err = srvBob.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name: "some-role",
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsAccessDenied(err), "expected access denied error, got: %v", err)
+
+	// verify that admin can delete roles
+	_, err = srvAlice.DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name: "some-role",
+	})
+	require.NoError(t, err)
+	// wait for deletion to be populated into cache
+	waitForRoleCondition(t, bk.cache, func(roles []*scopedaccessv1.ScopedRole) bool {
+		for _, role := range roles {
+			if role.GetMetadata().GetName() == "some-role" {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func waitForRoleCondition(t *testing.T, reader services.ScopedRoleReader, condition func([]*scopedaccessv1.ScopedRole) bool) {
+	t.Helper()
+	timeout := time.After(30 * time.Second)
+	for {
+		var roles []*scopedaccessv1.ScopedRole
+		for role, err := range scopedaccesscache.StreamRoles(t.Context(), reader) {
+			require.NoError(t, err)
+			roles = append(roles, role)
+		}
+
+		if condition(roles) {
+			return
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 120):
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for role condition")
+		}
+	}
+}
+
+func waitForAssignmentCondition(t *testing.T, reader services.ScopedRoleAssignmentReader, condition func([]*scopedaccessv1.ScopedRoleAssignment) bool) {
+	t.Helper()
+	timeout := time.After(30 * time.Second)
+	for {
+		var assignments []*scopedaccessv1.ScopedRoleAssignment
+		for assignment, err := range scopedaccesscache.StreamAssignments(t.Context(), reader) {
+			require.NoError(t, err)
+			assignments = append(assignments, assignment)
+		}
+
+		if condition(assignments) {
+			return
+		}
+
+		select {
+		case <-time.After(time.Millisecond * 120):
+		case <-timeout:
+			require.FailNow(t, "timeout waiting for assignment condition")
+		}
+	}
+}

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -80,6 +80,14 @@ func (f *fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) 
 	}, nil
 }
 
+func (f *fakeAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	authzCtx, err := f.Authorize(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return authz.ScopedContextFromUnscopedContext(authzCtx), nil
+}
+
 type fakeAuthServer struct {
 	clusterName          types.ClusterName
 	generateHostCertData map[string]struct {
@@ -266,6 +274,26 @@ func TestRBAC(t *testing.T) {
 				},
 			},
 			expectChecks: []check{
+				{types.KindCertAuthority, types.VerbList}, // scoped access-checker interface halts on first disallowed verb
+			},
+		},
+		{
+			desc: "get authorities no read access",
+			f: func(t *testing.T, service *Service) {
+				_, err := service.GetCertAuthorities(ctx, &trustpb.GetCertAuthoritiesRequest{
+					Type: string(ca.GetType()),
+				})
+
+				require.True(t, trace.IsAccessDenied(err), "expected AccessDenied error, got %v", err)
+			},
+			authorizer: fakeAuthorizer{
+				checker: &fakeChecker{
+					allow: map[check]bool{
+						{types.KindCertAuthority, types.VerbList}: true,
+					},
+				},
+			},
+			expectChecks: []check{
 				{types.KindCertAuthority, types.VerbList},
 				{types.KindCertAuthority, types.VerbReadNoSecrets},
 			},
@@ -429,10 +457,11 @@ func TestRBAC(t *testing.T) {
 
 			trust := local.NewCAService(p.mem)
 			cfg := &ServiceConfig{
-				Cache:      trust,
-				Backend:    trust,
-				Authorizer: &test.authorizer,
-				AuthServer: &fakeAuthServer{},
+				Cache:            trust,
+				Backend:          trust,
+				Authorizer:       &test.authorizer,
+				ScopedAuthorizer: &test.authorizer,
+				AuthServer:       &fakeAuthServer{},
 			}
 
 			service, err := NewService(cfg)
@@ -463,10 +492,11 @@ func TestGetCertAuthority(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: &fakeAuthServer{},
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       &fakeAuthServer{},
 	}
 
 	service, err := NewService(cfg)
@@ -561,10 +591,11 @@ func TestGetCertAuthorities(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: &fakeAuthServer{},
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       &fakeAuthServer{},
 	}
 
 	service, err := NewService(cfg)
@@ -666,10 +697,11 @@ func TestDeleteCertAuthority(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: &fakeAuthServer{},
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       &fakeAuthServer{},
 	}
 
 	service, err := NewService(cfg)
@@ -740,10 +772,11 @@ func TestUpsertCertAuthority(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: &fakeAuthServer{},
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       &fakeAuthServer{},
 	}
 
 	service, err := NewService(cfg)
@@ -825,10 +858,11 @@ func TestRotateCertAuthority(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: authServer,
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       authServer,
 	}
 
 	tests := []struct {
@@ -982,6 +1016,9 @@ func TestRotateExternalCertAuthority(t *testing.T) {
 				Authorizer: &fakeAuthorizer{
 					authzCtx: test.authzCtx,
 				},
+				ScopedAuthorizer: &fakeAuthorizer{
+					authzCtx: test.authzCtx,
+				},
 				AuthServer: &fakeAuthServer{
 					clusterName: &types.ClusterNameV2{
 						Spec: types.ClusterNameSpecV2{
@@ -1032,10 +1069,11 @@ func TestGenerateHostCert(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: authorizer,
-		AuthServer: hostCertSigner,
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       hostCertSigner,
 	}
 
 	tests := []struct {

--- a/lib/auth/trust/trustv1/trustedcluster_test.go
+++ b/lib/auth/trust/trustv1/trustedcluster_test.go
@@ -42,10 +42,11 @@ func TestCloudProhibited(t *testing.T) {
 
 	trust := local.NewCAService(p.mem)
 	cfg := &ServiceConfig{
-		Cache:      trust,
-		Backend:    trust,
-		Authorizer: &fakeAuthorizer{},
-		AuthServer: &fakeAuthServer{},
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       &fakeAuthorizer{},
+		ScopedAuthorizer: &fakeAuthorizer{},
+		AuthServer:       &fakeAuthServer{},
 	}
 
 	service, err := NewService(cfg)
@@ -304,10 +305,11 @@ func TestTrustedClusterRBAC(t *testing.T) {
 		t.Run(test.desc, func(t *testing.T) {
 			trust := local.NewCAService(p.mem)
 			cfg := &ServiceConfig{
-				Cache:      trust,
-				Backend:    trust,
-				Authorizer: &test.authorizer,
-				AuthServer: &fakeAuthServer{},
+				Cache:            trust,
+				Backend:          trust,
+				Authorizer:       &test.authorizer,
+				ScopedAuthorizer: &test.authorizer,
+				AuthServer:       &fakeAuthServer{},
 			}
 
 			service, err := NewService(cfg)

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -62,10 +62,11 @@ func TestValidateAuthPreferenceOnCloud(t *testing.T) {
 
 	s, err := authtest.NewTestTLSServer(authtest.TLSServerConfig{
 		APIConfig: &auth.APIConfig{
-			AuthServer: testServer.AuthServer,
-			Authorizer: testServer.Authorizer,
-			AuditLog:   testServer.AuditLog,
-			Emitter:    testServer.AuditLog,
+			AuthServer:       testServer.AuthServer,
+			Authorizer:       testServer.Authorizer,
+			ScopedAuthorizer: testServer.ScopedAuthorizer,
+			AuditLog:         testServer.AuditLog,
+			Emitter:          testServer.AuditLog,
 		},
 		AuthServer: testServer,
 	})

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -936,10 +936,14 @@ func (s *server) keyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (perm *ssh.Pe
 		// effectively limit ourselves to only supporting local users by only checking the cert against local CAs.
 		clusterName = s.ClusterName
 
-		if len(ident.Roles) == 0 {
-			return nil, trace.BadParameter("certificate missing roles in %q extension; make sure your user has some roles assigned (or ask your Teleport admin to) and log in again (or export an identity file, if that's what you used)", teleport.CertExtensionTeleportRoles)
+		if ident.ScopePin != nil {
+			certRole = "scoped-identity@" + ident.ScopePin.GetScope()
+		} else {
+			if len(ident.Roles) == 0 {
+				return nil, trace.BadParameter("certificate missing roles in %q extension; make sure your user has some roles assigned (or ask your Teleport admin to) and log in again (or export an identity file, if that's what you used)", teleport.CertExtensionTeleportRoles)
+			}
+			certRole = ident.Roles[0]
 		}
-		certRole = ident.Roles[0]
 		certType = utils.ExtIntCertTypeUser
 		caType = types.UserCA
 	default:

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -1,0 +1,58 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package access
+
+import "github.com/gravitational/teleport/api/types"
+
+// isAllowedScopedVerb returns true if the given verb is allowed for the given scoped resource kind. Scoped roles are not sane
+// for use with all resource kind/verb combinations, so we restrict the allowed combinations here.
+func isAllowedScopedRule(kind string, verb string) bool {
+	switch kind {
+	case KindScopedRole:
+		// scoped roles can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
+	case KindScopedRoleAssignment:
+		// scoped role assignments can be read/written, and do not currently contain a concept of a secret.
+		return isReadWriteNoSecrets(verb)
+	default:
+		return false
+	}
+}
+
+// isReadWriteNoSecrets returns true if the given verb conforms to the "read-write-no-secrets" category of verbs.
+func isReadWriteNoSecrets(verb string) bool {
+	return isReadNoSecrets(verb) || isWrite(verb)
+}
+
+// isReadNoSecrets returns true if the given verb conforms to the "read-no-secrets" category of verbs.
+func isReadNoSecrets(verb string) bool {
+	switch verb {
+	case types.VerbList, types.VerbReadNoSecrets:
+		return true
+	default:
+		return false
+	}
+}
+
+// isWrite returns true if the given verb conforms to the "write" category of verbs.
+func isWrite(verb string) bool {
+	switch verb {
+	case types.VerbCreate, types.VerbUpdate, types.VerbDelete:
+		return true
+	default:
+		return false
+	}
+}

--- a/lib/scopes/cache/access/access.go
+++ b/lib/scopes/cache/access/access.go
@@ -82,6 +82,8 @@ type Cache struct {
 	state    state
 	ok       bool
 	closed   bool
+	init     chan struct{}
+	initOnce sync.Once
 	cancel   context.CancelFunc
 	ttlCache *utils.FnCache
 	done     chan struct{}
@@ -119,12 +121,21 @@ func NewCache(cfg CacheConfig) (*Cache, error) {
 		cfg:      cfg,
 		ttlCache: ttlCache,
 		cancel:   cancel,
+		init:     make(chan struct{}),
 		done:     make(chan struct{}),
 	}
 
 	go cache.update(closeContext, retry)
 
 	return cache, nil
+}
+
+// Init returns a channel that is closed when the cache has completed its first init. Used in tests that
+// want to wait for cache readiness. commonly this avoids the effect of the read state apparently
+// "skipping" back in time slightly early in the test if cache init happens after one or more pre-init
+// reads.
+func (c *Cache) Init() <-chan struct{} {
+	return c.init
 }
 
 // GetScopedRole retrieves a scoped role by name.
@@ -147,6 +158,17 @@ func (c *Cache) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListSco
 	return state.roles.ListScopedRoles(ctx, req)
 }
 
+// ListScopedRolesWithFilter returns a paginated list of scoped roles filtered by the provided filter function. This
+// method is used internally to implement access-controls on the ListScopedRoles grpc method.
+func (c *Cache) ListScopedRolesWithFilter(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest, filter func(*scopedaccessv1.ScopedRole) bool) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.roles.ListScopedRolesWithFilter(ctx, req, filter)
+}
+
 // GetScopedRoleAssignment retrieves a scoped role assignment by name.
 func (c *Cache) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
 	state, err := c.read(ctx)
@@ -165,6 +187,18 @@ func (c *Cache) ListScopedRoleAssignments(ctx context.Context, req *scopedaccess
 	}
 
 	return state.assignments.ListScopedRoleAssignments(ctx, req)
+}
+
+// ListScopedRoleAssignmentsWithFilter returns a paginated list of scoped role assignments filtered by the provided
+// filter function. This method is used internally to implement access-controls on the ListScopedRoleAssignments grpc
+// method.
+func (c *Cache) ListScopedRoleAssignmentsWithFilter(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest, filter func(*scopedaccessv1.ScopedRoleAssignment) bool) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	state, err := c.read(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return state.assignments.ListScopedRoleAssignmentsWithFilter(ctx, req, filter)
 }
 
 // PopulatePinnedAssignmentsForUser populates the provided scope pin with all relevant assignments related to the
@@ -269,6 +303,11 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry) error
 
 	slog.InfoContext(ctx, "scoped access cache successfully initialized")
 	retry.Reset()
+
+	// signal that init has completed
+	c.initOnce.Do(func() {
+		close(c.init)
+	})
 
 	// start processing and applying changes
 	for {

--- a/lib/services/local/scoped_access.go
+++ b/lib/services/local/scoped_access.go
@@ -277,6 +277,9 @@ func (s *ScopedAccessService) UpdateScopedRole(ctx context.Context, req *scopeda
 	// disallow change of resource scope via update. use of scopes.Compare directly is generally discouraged,
 	// but that is due to ease of misuse, which isn't really a concern for a simple equivalence check.
 	if scopes.Compare(role.GetScope(), extant.GetRole().GetScope()) != scopes.Equivalent {
+		// XXX: the current implementation of our access-control logic relies upon this invarient being enforced. if we ever
+		// relax this restriction here we *must* first modify the outer access-control logic to understand the concept of
+		// scope changing and correctly validate the transition.
 		return nil, trace.BadParameter("cannot modify the resource scope of scoped role %q (%q -> %q)", role.GetMetadata().GetName(), extant.GetRole().GetScope(), role.GetScope())
 	}
 

--- a/lib/services/scoped.go
+++ b/lib/services/scoped.go
@@ -36,6 +36,20 @@ type ScopedAccessReader interface {
 	ScopedRoleAssignmentReader
 }
 
+// CachedScopedAccessReader extends ScopedAccessReader with cache-specific methods.
+type CachedScopedAccessReader interface {
+	ScopedAccessReader
+
+	// ListScopedRolesWithFilter returns a paginated list of scoped roles filtered by the provided filter function. This
+	// method is used internally to implement access-controls on the ListScopedRoles grpc method.
+	ListScopedRolesWithFilter(context.Context, *scopedaccessv1.ListScopedRolesRequest, func(*scopedaccessv1.ScopedRole) bool) (*scopedaccessv1.ListScopedRolesResponse, error)
+
+	// ListScopedRoleAssignmentsWithFilter returns a paginated list of scoped role assignments filtered by the provided
+	// filter function. This method is used internally to implement access-controls on the ListScopedRoleAssignments grpc
+	// method.
+	ListScopedRoleAssignmentsWithFilter(context.Context, *scopedaccessv1.ListScopedRoleAssignmentsRequest, func(*scopedaccessv1.ScopedRoleAssignment) bool) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error)
+}
+
 // ScopedAccessWriter provides an interface for writing scoped access resources.
 type ScopedAccessWriter interface {
 	ScopedRoleWriter

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -19,13 +19,18 @@
 package services
 
 import (
+	"context"
 	"time"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 )
 
 // CommonAccessChecker defines the common methods that are identical across both scoped and unscoped access checkers.
@@ -40,6 +45,7 @@ type CommonAccessChecker interface {
 	CanForwardAgents() bool
 	PermitX11Forwarding() bool
 	LockingMode(defaultMode constants.LockingMode) constants.LockingMode
+	CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error
 }
 
 // ScopedAccessCheckerSubset defines the methods that are specific to scoped access checkers.
@@ -74,7 +80,7 @@ type SplitAccessChecker struct {
 
 func NewUnscopedSplitAccessChecker(checker AccessChecker) *SplitAccessChecker {
 	return &SplitAccessChecker{
-		common:   checker,
+		common:   &accessCheckerShim{checker},
 		unscoped: checker,
 	}
 }
@@ -99,4 +105,165 @@ func (c *SplitAccessChecker) Unscoped() (checker UnscopedAccessCheckerSubset, ok
 // Scoped gets the scoped access checker interface if it is present.
 func (c *SplitAccessChecker) Scoped() (checker ScopedAccessCheckerSubset, ok bool) {
 	return c.scoped, c.scoped != nil
+}
+
+// accessCheckerShim provides a compatibility shim to allow using an unscoped checker in a manner more consistent with
+// a scoped access checker. In particular, some scoped access checker methods are simpler than their unscoped equivalents
+// and this shim implemented the simplified versions of those methods.
+type accessCheckerShim struct {
+	AccessChecker
+}
+
+// CheckAccessToRules verifies that *all* of a series of verbs are permitted for the specified resource. This function differs from
+// the unscoped AccessChecker.CheckAccessToRule in a number of ways. It does not support advanced context-based features or namespacing,
+// and accepts a set of verbs all of which must evaluate to allow for the check to succeed.
+func (c *accessCheckerShim) CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
+	return checkAccessToRulesImpl(c.AccessChecker, ctx, resource, verbs...)
+}
+
+// CheckMaybeHasAccessToRules behaves like [AccessChecker.GuessIfAccessIsPossible], except that it supports multiple
+// verbs and does not support namespaces.
+func (c *accessCheckerShim) CheckMaybeHasAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
+	return checkMaybeHasAccessToRulesImpl(c.AccessChecker, ctx, resource, verbs...)
+}
+
+func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+	if len(verbs) == 0 {
+		return trace.BadParameter("malformed rule check for %q, no verbs provided (this is a bug)", resource)
+	}
+
+	for _, verb := range verbs {
+		if err := checker.CheckAccessToRule(ctx, apidefaults.Namespace, resource, verb); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+func checkMaybeHasAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
+	if len(verbs) == 0 {
+		return trace.BadParameter("malformed maybe has access to rule check for %q, no verbs provided (this is a bug)", resource)
+	}
+
+	for _, verb := range verbs {
+		if err := checker.GuessIfAccessIsPossible(ctx, apidefaults.Namespace, resource, verb); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// SplitAccessCheckerContext is an abstraction to allow passing either a scoped access checker context or a standard access checker
+// to functions that need to operate on either.
+type SplitAccessCheckerContext struct {
+	scopedContext   *ScopedAccessCheckerContext
+	unscopedChecker AccessChecker
+}
+
+// NewUnscopedSplitAccessCheckerContext creates a SplitAccessCheckerContext from an unscoped AccessChecker.
+func NewUnscopedSplitAccessCheckerContext(checker AccessChecker) *SplitAccessCheckerContext {
+	return &SplitAccessCheckerContext{
+		unscopedChecker: checker,
+	}
+}
+
+// NewScopedSplitAccessCheckerContext creates a SplitAccessCheckerContext from a scoped access checker context.
+func NewScopedSplitAccessCheckerContext(ctx *ScopedAccessCheckerContext) *SplitAccessCheckerContext {
+	return &SplitAccessCheckerContext{
+		scopedContext: ctx,
+	}
+}
+
+// CheckMaybeHasAccessToRules returns an error if the context definitely does not have access to the provided rules. in practice
+// this currently just serves to exit early in the event that we are dealing with an unscoped identity without appropriate
+// permissions, but it could be extended in future to perform more complex checks if needed.
+func (c *SplitAccessCheckerContext) CheckMaybeHasAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
+	if c.scopedContext == nil {
+		shim := accessCheckerShim{c.unscopedChecker}
+		return shim.CheckMaybeHasAccessToRules(ctx, resource, verbs...)
+	}
+
+	return nil
+}
+
+// CheckersForResourceScope returns a stream of SplitAccessCheckers that are appropriate for the provided resource scope. If the
+// underlying state is scoped this will be a stream of checkers descending to the target resource scope.
+func (c *SplitAccessCheckerContext) CheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*SplitAccessChecker] {
+	return func(yield func(*SplitAccessChecker, error) bool) {
+		if c.scopedContext == nil {
+			yield(NewUnscopedSplitAccessChecker(c.unscopedChecker), nil)
+			return
+		}
+
+		for checker, err := range c.scopedContext.CheckersForResourceScope(ctx, scope) {
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+			if !yield(NewScopedSplitAccessChecker(checker), nil) {
+				return
+			}
+		}
+	}
+}
+
+// RiskyUnpinnedCheckersForResourceScope is equivalent to CheckersForResourceScope except that it bypasses enforcement of pinning scope. This is a
+// risky operation that should only be used for certain APIs that make an exception to pinning exclusion rules
+func (c *SplitAccessCheckerContext) RiskyUnpinnedCheckersForResourceScope(ctx context.Context, scope string) stream.Stream[*SplitAccessChecker] {
+	return func(yield func(*SplitAccessChecker, error) bool) {
+		if c.scopedContext == nil {
+			yield(NewUnscopedSplitAccessChecker(c.unscopedChecker), nil)
+			return
+		}
+
+		for checker, err := range c.scopedContext.RiskyUnpinnedCheckersForResourceScope(ctx, scope) {
+			if err != nil {
+				yield(nil, trace.Wrap(err))
+				return
+			}
+			if !yield(NewScopedSplitAccessChecker(checker), nil) {
+				return
+			}
+		}
+	}
+}
+
+// Decision is a helper function that takes care of boilerplate for simple potentially scoped decisions.  It calls
+// the provided decision function until one of three conditions is met:
+//
+// 1. Decision function executes without error (allow)
+// 2. Decision function returns an AccessExplicitlyDenied error (explicit deny)
+// 3. Checkers for all scopes in resource scope path have been visited (implicit deny)
+func (c *SplitAccessCheckerContext) Decision(ctx context.Context, scope string, fn func(*SplitAccessChecker) error) error {
+	return c.decision(ctx, c.CheckersForResourceScope(ctx, scope), fn)
+}
+
+// RiskyUnpinnedDecision is equivalent to Decision except that it bypasses enforcement of pinning scope. This is a
+// risky operation that should only be used for certain APIs that make an exception to pinning exclusion rules
+// (e.g. allowing read operations to succeed for resources in a parent to the pinned scope).
+func (c *SplitAccessCheckerContext) RiskyUnpinnedDecision(ctx context.Context, scope string, fn func(*SplitAccessChecker) error) error {
+	return c.decision(ctx, c.RiskyUnpinnedCheckersForResourceScope(ctx, scope), fn)
+}
+
+func (c *SplitAccessCheckerContext) decision(ctx context.Context, checkers stream.Stream[*SplitAccessChecker], fn func(*SplitAccessChecker) error) error {
+	for checker, err := range checkers {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		err = fn(checker)
+		switch {
+		case err == nil:
+			return nil
+		case IsAccessExplicitlyDenied(err):
+			return trace.Wrap(err)
+		default:
+			// implicit deny, continue to the next check
+			continue
+		}
+	}
+
+	return trace.AccessDenied("access denied (decision)")
 }

--- a/tool/tctl/common/client/auth.go
+++ b/tool/tctl/common/client/auth.go
@@ -82,6 +82,7 @@ func GetInitFunc(ccf tctlcfg.GlobalCLIFlags, cfg *servicecfg.Config) InitFunc {
 
 		client, err := authclient.Connect(ctx, clientConfig)
 		if err != nil {
+			slog.WarnContext(ctx, "failed to connect to auth server", "error", err)
 			if utils.IsUntrustedCertErr(err) {
 				err = trace.WrapWithMessage(err, utils.SelfSignedCertsMsg)
 			}


### PR DESCRIPTION
This PR adds initial prototype support for resource verb rules in scoped roles, and adds the ability to perform resource verb rule checks in access-control logic that abstracts over scoped and unscoped caller identities.

With this functionality, it is now possible to define scoped admins who can then manage creation of scoped roles/assignments within their assigned scopes.

Example:

```shell
$ tsh login --user=alice # login as user with 'editor' role
# authentication flow

$ cat << EOF > staging-admin.yaml
kind: scoped_role
metadata:
  name: staging-admin
scope: /staging
spec:
  assignable_scopes:
    - /staging
  allow:
    rules:
      - resources: [scoped_role, scoped_role_assignment]
        verbs: [create, list, readnosecrets, update, delete]
version: v1
EOF

$ tctl create staging-admin.yaml

$ cat << EOF > staging-admin-assignment.yaml
kind: scoped_role_assignment
scope: /staging
spec:
  user: bob
  assignments:
    - role: staging-admin
      scope: /staging/west
    - role: staging-admin
      scope: /staging/east
version: v1
EOF

$ tctl create staging-admin-assignment.yaml

$ tsh login --scope=/staging/west --user=bob # login as user with 'staging-admin' role
# authentication flow

$ cat << EOF > staging-west-user.yaml
kind: scoped_role
metadata:
  name: staging-west-user
scope: /staging/west
spec:
  assignable_scopes:
  - /staging/west
  allow: 
    rules:
      - resources: [scoped_role, scoped_role_assignment]
        verbs: [list, readnosecrets]
version: v1
EOF

$ tctl create staging-west-user.yaml

$ cat << EOF > staging-west-user-assignment.yaml
kind: scoped_role_assignment
scope: /staging/west
spec:
  user: carol
  assignments:
    - role: staging-west-user
      scope: /staging/west
version: v1
EOF

$ tctl create staging-west-user-assignment.yaml

$ tsh login --scope=/staging/west --user=carol # login as user with 'staging-west-user' role
# authentication flow

$ tctl get scoped_role --format=json | jq -r '.[].metadata.name'
staging-admin
staging-west-user
```

Internally, this PR introduces a new flow for making access-control decisions inside of APIs which need to support both scoped and unscoped caller identities.  The patterns of scoped access-control checks differ in a number of ways that are difficult to hide from the caller.  First, scope pin enforcement rules require that the scope to which a certificate is *pinned* override all other permissions and deny access in the case the user is attempting to perform an action outside of their pinned scope.  Second, scoped allow decisions must be determined by traversing the scope hierarchy and attempting to make a sub-decision at each level, halting the process at the most ancestral/outer scope that permits the operation.

Abstractly, a scoped access-control decision for a resource in `/staging/east` being accessed by an identity pinned to `/staging` would look something like this:

```golang
if !pinScopeAppliesToResourceScope("/staging", "/staging/east") {
    return Deny
}

if checker := buildCheckerForScope("/", assignments) ; checker.CanAccessResource(resource) {
    return Allow
}

if checker := buildCheckerForScope("/staging", assignments) ; checker.CanAccessResource(resource) {
    return Allow
}

if checker := buildCheckerForScope("/staging/east", assignments) ; checker.CanAccessResource(resource) {
    return Allow
}

return Deny

```

In order to support this pattern, resource verb decisions that need to support scoped access checks pass the scope of the target resource and a decision callback to the checking context.  The checking context then ensures pin enforcement and repeatedly applies the decision function with the appropriate access checkers for the given scope.  As a side-effect, context information that used to be implicitly provided by wrappers at the `authz.Context` layer must now be explicitly captured by the callback to provide to the underlying check method.

Code that used to look like this:

```golang
if err := authzContext.CheckAccessToResource(ResourceKind, Verb); err != nil {
    return trace.Wrap(err)
}
```

Now looks like this:

```golang
ruleCtx := authzContext.RuleContext()
if err := authzContext.CheckerContext.Decision(ctx, resourceScope, func(checker *services.SplitAccessChecker) error {
    return checker.Common().CheckAccessToRules(&ruleCtx, ResourceKind, Verb)
}); err != nil {
    return nil, trace.Wrap(err)
}
```

This PR is the final step to enable scoped access-control on teleport APIs and represents the last of the initial batch of prototype work for "core" functionality.  After this point we will be beginning to work on making use-facing teleport functionality able to use scoping.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).