### PR TITLE
access_monitoring_rules: Add timezone to schedules spec

### DIFF
--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules.pb.go
@@ -395,7 +395,9 @@ type TimeSchedule struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Shifts contains a set of shifts that make up the schedule.
 	// Shifts are configured in UTC.
-	Shifts        []*TimeSchedule_Shift `protobuf:"bytes,1,rep,name=shifts,proto3" json:"shifts,omitempty"`
+	Shifts []*TimeSchedule_Shift `protobuf:"bytes,1,rep,name=shifts,proto3" json:"shifts,omitempty"`
+	// Timezone specifies the schedule timezone.
+	Timezone      string `protobuf:"bytes,2,opt,name=timezone,proto3" json:"timezone,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -435,6 +437,13 @@ func (x *TimeSchedule) GetShifts() []*TimeSchedule_Shift {
 		return x.Shifts
 	}
 	return nil
+}
+
+func (x *TimeSchedule) GetTimezone() string {
+	if x != nil {
+		return x.Timezone
+	}
+	return ""
 }
 
 // CreateAccessMonitoringRuleRequest is the request for CreateAccessMonitoringRule.
@@ -1014,9 +1023,10 @@ const file_teleport_accessmonitoringrules_v1_access_monitoring_rules_proto_rawDe
 	"\vintegration\x18\x01 \x01(\tR\vintegration\x12\x1a\n" +
 	"\bdecision\x18\x02 \x01(\tR\bdecision\"O\n" +
 	"\bSchedule\x12C\n" +
-	"\x04time\x18\x01 \x01(\v2/.teleport.accessmonitoringrules.v1.TimeScheduleR\x04time\"\xa8\x01\n" +
+	"\x04time\x18\x01 \x01(\v2/.teleport.accessmonitoringrules.v1.TimeScheduleR\x04time\"\xc4\x01\n" +
 	"\fTimeSchedule\x12M\n" +
-	"\x06shifts\x18\x01 \x03(\v25.teleport.accessmonitoringrules.v1.TimeSchedule.ShiftR\x06shifts\x1aI\n" +
+	"\x06shifts\x18\x01 \x03(\v25.teleport.accessmonitoringrules.v1.TimeSchedule.ShiftR\x06shifts\x12\x1a\n" +
+	"\btimezone\x18\x02 \x01(\tR\btimezone\x1aI\n" +
 	"\x05Shift\x12\x18\n" +
 	"\aweekday\x18\x01 \x01(\tR\aweekday\x12\x14\n" +
 	"\x05start\x18\x02 \x01(\tR\x05start\x12\x10\n" +

--- a/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules.pb.go
+++ b/api/gen/proto/go/teleport/accessmonitoringrules/v1/access_monitoring_rules.pb.go
@@ -394,9 +394,13 @@ func (x *Schedule) GetTime() *TimeSchedule {
 type TimeSchedule struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Shifts contains a set of shifts that make up the schedule.
-	// Shifts are configured in UTC.
 	Shifts []*TimeSchedule_Shift `protobuf:"bytes,1,rep,name=shifts,proto3" json:"shifts,omitempty"`
-	// Timezone specifies the schedule timezone.
+	// Timezone specifies the schedule timezone. This field is optional and defaults
+	// to "UTC". Accepted values use timezone locations as defined in the IANA
+	// Time Zone Database, such as "America/Los_Angeles", "Europe/Lisbon", or
+	// "Asia/Singapore".
+	//
+	// See https://data.iana.org/time-zones/tzdb/zone1970.tab for a list of supported values.
 	Timezone      string `protobuf:"bytes,2,opt,name=timezone,proto3" json:"timezone,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
+++ b/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
@@ -100,10 +100,14 @@ message Schedule {
 // TimeSchedule specifies an in-line schedule.
 message TimeSchedule {
   // Shifts contains a set of shifts that make up the schedule.
-  // Shifts are configured in UTC.
   repeated Shift shifts = 1;
 
-  // Timezone specifies the schedule timezone.
+  // Timezone specifies the schedule timezone. This field is optional and defaults
+  // to "UTC". Accepted values use timezone locations as defined in the IANA
+  // Time Zone Database, such as "America/Los_Angeles", "Europe/Lisbon", or
+  // "Asia/Singapore".
+  //
+  // See https://data.iana.org/time-zones/tzdb/zone1970.tab for a list of supported values.
   string timezone = 2;
 
   // Shift contains the weekday, start time, and end time of a shift.

--- a/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
+++ b/api/proto/teleport/accessmonitoringrules/v1/access_monitoring_rules.proto
@@ -103,6 +103,9 @@ message TimeSchedule {
   // Shifts are configured in UTC.
   repeated Shift shifts = 1;
 
+  // Timezone specifies the schedule timezone.
+  string timezone = 2;
+
   // Shift contains the weekday, start time, and end time of a shift.
   message Shift {
     // Weekday specifies the day of the week, e.g., "Sunday", "Monday", "Tuesday".

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -76,6 +76,7 @@ Optional:
 Optional:
 
 - `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
+- `timezone` (String) Timezone specifies the schedule timezone.
 
 ### Nested Schema for `spec.schedules.time.shifts`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -75,8 +75,8 @@ Optional:
 
 Optional:
 
-- `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
-- `timezone` (String) Timezone specifies the schedule timezone.
+- `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
+- `timezone` (String) Timezone specifies the schedule timezone. This field is optional and defaults to "UTC". Accepted values use timezone locations as defined in the IANA Time Zone Database, such as "America/Los_Angeles", "Europe/Lisbon", or "Asia/Singapore".  See https://data.iana.org/time-zones/tzdb/zone1970.tab for a list of supported values.
 
 ### Nested Schema for `spec.schedules.time.shifts`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -97,8 +97,8 @@ Optional:
 
 Optional:
 
-- `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
-- `timezone` (String) Timezone specifies the schedule timezone.
+- `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
+- `timezone` (String) Timezone specifies the schedule timezone. This field is optional and defaults to "UTC". Accepted values use timezone locations as defined in the IANA Time Zone Database, such as "America/Los_Angeles", "Europe/Lisbon", or "Asia/Singapore".  See https://data.iana.org/time-zones/tzdb/zone1970.tab for a list of supported values.
 
 ### Nested Schema for `spec.schedules.time.shifts`
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -98,6 +98,7 @@ Optional:
 Optional:
 
 - `shifts` (Attributes List) Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC. (see [below for nested schema](#nested-schema-for-specschedulestimeshifts))
+- `timezone` (String) Timezone specifies the schedule timezone.
 
 ### Nested Schema for `spec.schedules.time.shifts`
 

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -161,11 +161,11 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 										Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 									},
 								}),
-								Description: "Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC.",
+								Description: "Shifts contains a set of shifts that make up the schedule.",
 								Optional:    true,
 							},
 							"timezone": {
-								Description: "Timezone specifies the schedule timezone.",
+								Description: "Timezone specifies the schedule timezone. This field is optional and defaults to \"UTC\". Accepted values use timezone locations as defined in the IANA Time Zone Database, such as \"America/Los_Angeles\", \"Europe/Lisbon\", or \"Asia/Singapore\".  See https://data.iana.org/time-zones/tzdb/zone1970.tab for a list of supported values.",
 								Optional:    true,
 								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 							},

--- a/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
+++ b/integrations/terraform/tfschema/accessmonitoringrules/v1/access_monitoring_rules_terraform.go
@@ -142,27 +142,34 @@ func GenSchemaAccessMonitoringRule(ctx context.Context) (github_com_hashicorp_te
 				},
 				"schedules": {
 					Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.MapNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"time": {
-						Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"shifts": {
-							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
-								"end": {
-									Description: "End specifies the end time in the format HH:MM, e.g., \"12:30\".",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-								},
-								"start": {
-									Description: "Start specifies the start time in the format HH:MM, e.g., \"12:30\".",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-								},
-								"weekday": {
-									Description: "Weekday specifies the day of the week, e.g., \"Sunday\", \"Monday\", \"Tuesday\".",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
-								},
-							}),
-							Description: "Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC.",
-							Optional:    true,
-						}}),
+						Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+							"shifts": {
+								Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
+									"end": {
+										Description: "End specifies the end time in the format HH:MM, e.g., \"12:30\".",
+										Optional:    true,
+										Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+									},
+									"start": {
+										Description: "Start specifies the start time in the format HH:MM, e.g., \"12:30\".",
+										Optional:    true,
+										Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+									},
+									"weekday": {
+										Description: "Weekday specifies the day of the week, e.g., \"Sunday\", \"Monday\", \"Tuesday\".",
+										Optional:    true,
+										Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+									},
+								}),
+								Description: "Shifts contains a set of shifts that make up the schedule. Shifts are configured in UTC.",
+								Optional:    true,
+							},
+							"timezone": {
+								Description: "Timezone specifies the schedule timezone.",
+								Optional:    true,
+								Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+							},
+						}),
 						Description: "TimeSchedule specifies an in-line schedule.",
 						Optional:    true,
 					}}),
@@ -698,6 +705,23 @@ func CopyAccessMonitoringRuleFromTerraform(_ context.Context, tf github_com_hash
 																					}
 																				}
 																			}
+																		}
+																	}
+																}
+																{
+																	a, ok := tf.Attrs["timezone"]
+																	if !ok {
+																		diags.Append(attrReadMissingDiag{"AccessMonitoringRule.spec.schedules.time.timezone"})
+																	} else {
+																		v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrReadConversionFailureDiag{"AccessMonitoringRule.spec.schedules.time.timezone", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		} else {
+																			var t string
+																			if !v.Null && !v.Unknown {
+																				t = string(v.Value)
+																			}
+																			obj.Timezone = t
 																		}
 																	}
 																}
@@ -1522,6 +1546,28 @@ func CopyAccessMonitoringRuleToTerraform(ctx context.Context, obj *github_com_gr
 																		c.Unknown = false
 																		tf.Attrs["shifts"] = c
 																	}
+																}
+															}
+															{
+																t, ok := tf.AttrTypes["timezone"]
+																if !ok {
+																	diags.Append(attrWriteMissingDiag{"AccessMonitoringRule.spec.schedules.time.timezone"})
+																} else {
+																	v, ok := tf.Attrs["timezone"].(github_com_hashicorp_terraform_plugin_framework_types.String)
+																	if !ok {
+																		i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+																		if err != nil {
+																			diags.Append(attrWriteGeneralError{"AccessMonitoringRule.spec.schedules.time.timezone", err})
+																		}
+																		v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.String)
+																		if !ok {
+																			diags.Append(attrWriteConversionFailureDiag{"AccessMonitoringRule.spec.schedules.time.timezone", "github.com/hashicorp/terraform-plugin-framework/types.String"})
+																		}
+																		v.Null = string(obj.Timezone) == ""
+																	}
+																	v.Value = string(obj.Timezone)
+																	v.Unknown = false
+																	tf.Attrs["timezone"] = v
 																}
 															}
 														}

--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -156,6 +156,14 @@ func validateSchedules(schedules map[string]*accessmonitoringrulesv1.Schedule) e
 }
 
 func validateTimeSchedule(schedule *accessmonitoringrulesv1.TimeSchedule) error {
+	if schedule.GetTimezone() == "" {
+		return trace.BadParameter("timezone is required")
+	}
+
+	if _, err := time.LoadLocation(schedule.GetTimezone()); err != nil {
+		return trace.Wrap(err, "timezone is invalid")
+	}
+
 	if len(schedule.GetShifts()) == 0 {
 		return trace.BadParameter("at least one shift is required")
 	}

--- a/lib/services/access_monitoring_rules.go
+++ b/lib/services/access_monitoring_rules.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"slices"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/gravitational/trace"
 
@@ -156,12 +157,8 @@ func validateSchedules(schedules map[string]*accessmonitoringrulesv1.Schedule) e
 }
 
 func validateTimeSchedule(schedule *accessmonitoringrulesv1.TimeSchedule) error {
-	if schedule.GetTimezone() == "" {
-		return trace.BadParameter("timezone is required")
-	}
-
 	if _, err := time.LoadLocation(schedule.GetTimezone()); err != nil {
-		return trace.Wrap(err, "timezone is invalid")
+		return trace.Wrap(err, "invalid timezone: refer to the IANA Time Zone Database for valid options")
 	}
 
 	if len(schedule.GetShifts()) == 0 {

--- a/lib/services/access_monitoring_rules_test.go
+++ b/lib/services/access_monitoring_rules_test.go
@@ -131,6 +131,7 @@ func TestValidateAccessMonitoringRule(t *testing.T) {
 				amr.Spec.Schedules = map[string]*accessmonitoringrulesv1.Schedule{
 					"default": {
 						Time: &accessmonitoringrulesv1.TimeSchedule{
+							Timezone: time.UTC.String(),
 							Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 								{
 									Weekday: time.Monday.String(),
@@ -189,6 +190,7 @@ func TestValidateSchedules(t *testing.T) {
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Monday.String(),
@@ -206,6 +208,7 @@ func TestValidateSchedules(t *testing.T) {
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"on-call-1": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Saturday.String(),
@@ -217,6 +220,7 @@ func TestValidateSchedules(t *testing.T) {
 				},
 				"on-call-2": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Sunday.String(),
@@ -242,7 +246,9 @@ func TestValidateSchedules(t *testing.T) {
 			description: "does not contain any shifts",
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
-					Time: &accessmonitoringrulesv1.TimeSchedule{},
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: time.UTC.String(),
+					},
 				},
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
@@ -250,10 +256,31 @@ func TestValidateSchedules(t *testing.T) {
 			},
 		},
 		{
+			description: "invalid timezone",
+			schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: "invalid",
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+							{
+								Weekday: time.Monday.String(),
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
+				require.ErrorContains(t, err, "timezone is invalid")
+			},
+		},
+		{
 			description: "start time is not before end time",
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Monday.String(),

--- a/lib/services/access_monitoring_rules_test.go
+++ b/lib/services/access_monitoring_rules_test.go
@@ -338,7 +338,7 @@ func TestValidateSchedules(t *testing.T) {
 				},
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
-				require.ErrorContains(t, err, "timezone is invalid")
+				require.ErrorContains(t, err, "invalid timezone")
 			},
 		},
 		{

--- a/lib/services/access_monitoring_rules_test.go
+++ b/lib/services/access_monitoring_rules_test.go
@@ -131,7 +131,6 @@ func TestValidateAccessMonitoringRule(t *testing.T) {
 				amr.Spec.Schedules = map[string]*accessmonitoringrulesv1.Schedule{
 					"default": {
 						Time: &accessmonitoringrulesv1.TimeSchedule{
-							Timezone: time.UTC.String(),
 							Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 								{
 									Weekday: time.Monday.String(),
@@ -190,7 +189,6 @@ func TestValidateSchedules(t *testing.T) {
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
-						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Monday.String(),
@@ -208,7 +206,6 @@ func TestValidateSchedules(t *testing.T) {
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"on-call-1": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
-						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Saturday.String(),
@@ -220,7 +217,6 @@ func TestValidateSchedules(t *testing.T) {
 				},
 				"on-call-2": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
-						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Sunday.String(),
@@ -246,14 +242,84 @@ func TestValidateSchedules(t *testing.T) {
 			description: "does not contain any shifts",
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
-					Time: &accessmonitoringrulesv1.TimeSchedule{
-						Timezone: time.UTC.String(),
-					},
+					Time: &accessmonitoringrulesv1.TimeSchedule{},
 				},
 			},
 			assertErr: func(t require.TestingT, err error, _ ...interface{}) {
 				require.ErrorContains(t, err, "at least one shift is require")
 			},
+		},
+		{
+			description: "valid timezone (UTC)",
+			schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: "UTC",
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+							{
+								Weekday: time.Monday.String(),
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			description: "valid timezone (America/Los_Angeles)",
+			schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: "America/Los_Angeles",
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+							{
+								Weekday: time.Monday.String(),
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			description: "valid timezone (Europe/Lisbon)",
+			schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: "Europe/Lisbon",
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+							{
+								Weekday: time.Monday.String(),
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
+		},
+		{
+			description: "valid timezone (Asia/Singapore)",
+			schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Timezone: "Asia/Singapore",
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+							{
+								Weekday: time.Monday.String(),
+								Start:   "00:00",
+								End:     "23:59",
+							},
+						},
+					},
+				},
+			},
+			assertErr: require.NoError,
 		},
 		{
 			description: "invalid timezone",
@@ -280,7 +346,6 @@ func TestValidateSchedules(t *testing.T) {
 			schedules: map[string]*accessmonitoringrulesv1.Schedule{
 				"default": {
 					Time: &accessmonitoringrulesv1.TimeSchedule{
-						Timezone: time.UTC.String(),
 						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
 							{
 								Weekday: time.Monday.String(),


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport/issues/51682, https://github.com/gravitational/teleport/issues/55075
RFD: https://github.com/gravitational/teleport/pull/57334

This extends the access_monitoring_rules schedules spec with timezones.

This was previously omitted from https://github.com/gravitational/teleport/pull/59007 after choosing to store all schedules in the backend in UTC. However, after attempting to implement the timezone conversions on the frontend, I've realized this approach is not compatible with the frontend design for schedules.

There are a couple reasons why converting to UTC in the backend is not compatible with the design, but the main reason is that the frontend design limits 1 shift per day. This is a problem because valid schedules configured using the standard editor can easily be converted into a schedule that is not valid within the schedule editor.

For example, if a user configures the following schedule using the standard editor:
<img width="364" height="256" alt="Screenshot 2025-10-08 at 2 30 04 PM" src="https://github.com/user-attachments/assets/4cf35a94-e6ce-4991-9ea4-667c07a7db41" />

This schedule would then be converted into UTC in the backend, and stored as:
```yaml
schedules:
  default:
    time:
      shifts:
      - weekday: Monday
        start: 19:00
        end: 23:59
      - weekday: Tuesday
        start: 00:00
        end: 6:59
      - weekday: Tuesday
        start: 19:00
        end: 23:59
      - weekday: Wednesday
        start: 00:00
        end: 6:59
```

If the user attempts to edit this schedule again within the WebUI, they would not be able to use the standard editor because there are two shifts for Tuesday.