### PR TITLE
[v18] Fix code and type for sftp audit events

### DIFF
--- a/api/proto/teleport/legacy/types/events/events.proto
+++ b/api/proto/teleport/legacy/types/events/events.proto
@@ -1831,6 +1831,7 @@ message Exec {
 }
 
 // SCP is emitted when data transfer has occurred between server and client
+// Deprecated: use SFTP
 message SCP {
   // Metadata is a common event metadata
   Metadata Metadata = 1 [

--- a/api/types/events/events.pb.go
+++ b/api/types/events/events.pb.go
@@ -3332,6 +3332,7 @@ func (m *Exec) XXX_DiscardUnknown() {
 var xxx_messageInfo_Exec proto.InternalMessageInfo
 
 // SCP is emitted when data transfer has occurred between server and client
+// Deprecated: use SFTP
 type SCP struct {
 	// Metadata is a common event metadata
 	Metadata `protobuf:"bytes,1,opt,name=Metadata,proto3,embedded=Metadata" json:""`

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -259,8 +259,8 @@ func (e *localExec) transformSecureCopy() error {
 	if err != nil {
 		e.Ctx.GetServer().EmitAuditEvent(e.Ctx.CancelContext(), &apievents.SFTP{
 			Metadata: apievents.Metadata{
-				Code: events.SCPDisallowedCode,
-				Type: events.SCPEvent,
+				Code: events.SFTPDisallowedCode,
+				Type: events.SFTPEvent,
 				Time: time.Now(),
 			},
 			UserMetadata:   e.Ctx.Identity.GetUserMetadata(),
@@ -364,8 +364,8 @@ func (e *remoteExec) Start(ctx context.Context, ch ssh.Channel) (*ExecResult, er
 	if _, err := checkSCPAllowed(e.ctx, e.GetCommand()); err != nil {
 		e.ctx.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), &apievents.SFTP{
 			Metadata: apievents.Metadata{
-				Code: events.SCPDisallowedCode,
-				Type: events.SCPEvent,
+				Code: events.SFTPDisallowedCode,
+				Type: events.SFTPEvent,
 				Time: time.Now(),
 			},
 			UserMetadata:   e.ctx.Identity.GetUserMetadata(),


### PR DESCRIPTION
Backport #59882 to branch/v18

changelog: Fixed SFTP audit events breaking the audit log
