### PR TITLE
MWI: Wait for service health before sending first heartbeat

### DIFF
--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -218,6 +218,7 @@ func (b *Bot) buildServices(ctx context.Context, registry *readyz.Registry) ([]*
 	heartbeatService, err := b.buildHeartbeatService(
 		identityService,
 		startedAt,
+		registry,
 	)
 	if err != nil {
 		return nil, closeFn, trace.Wrap(err, "building heartbeat service")
@@ -390,6 +391,7 @@ func (b *Bot) buildIdentityService(
 func (b *Bot) buildHeartbeatService(
 	identityService *identity.Service,
 	startedAt time.Time,
+	statusRegistry *readyz.Registry,
 ) (*serviceHandle, error) {
 	handle := &serviceHandle{
 		serviceType:    "internal/heartbeat",
@@ -410,6 +412,7 @@ func (b *Bot) buildHeartbeatService(
 			teleport.Component(teleport.ComponentTBot, handle.name),
 		),
 		StatusReporter: handle.statusReporter,
+		StatusRegistry: statusRegistry,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -23,16 +23,15 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -60,78 +59,94 @@ func (f *fakeHeartbeatSubmitter) SubmitHeartbeat(
 func TestHeartbeatService(t *testing.T) {
 	t.Parallel()
 
-	log := logtest.NewLogger()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+	synctest.Test(t, func(t *testing.T) {
+		log := logtest.NewLogger()
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
 
-	fhs := &fakeHeartbeatSubmitter{
-		ch: make(chan *machineidv1pb.SubmitHeartbeatRequest, 2),
-	}
+		fhs := &fakeHeartbeatSubmitter{
+			ch: make(chan *machineidv1pb.SubmitHeartbeatRequest, 2),
+		}
 
-	reg := readyz.NewRegistry()
-	svcA := reg.AddService("a")
+		reg := readyz.NewRegistry()
+		svcA := reg.AddService("a")
 
-	now := time.Date(2024, time.April, 1, 12, 0, 0, 0, time.UTC)
-	svc, err := NewService(Config{
-		Interval:       time.Second,
-		RetryLimit:     3,
-		Client:         fhs,
-		Clock:          clockwork.NewFakeClockAt(now),
-		StartedAt:      time.Date(2024, time.April, 1, 11, 0, 0, 0, time.UTC),
-		Logger:         log,
-		JoinMethod:     types.JoinMethodGitHub,
-		StatusReporter: reg.AddService("heartbeat"),
-		StatusRegistry: reg,
-		BotKind:        machineidv1pb.BotKind_BOT_KIND_TBOT,
+		svc, err := NewService(Config{
+			Interval:       time.Second,
+			RetryLimit:     3,
+			Client:         fhs,
+			StartedAt:      time.Now().Add(-1 * time.Hour),
+			Logger:         log,
+			JoinMethod:     types.JoinMethodGitHub,
+			StatusReporter: reg.AddService("heartbeat"),
+			StatusRegistry: reg,
+			BotKind:        machineidv1pb.BotKind_BOT_KIND_TBOT,
+		})
+		require.NoError(t, err)
+
+		hostName, err := os.Hostname()
+		require.NoError(t, err)
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- svc.Run(ctx)
+		}()
+
+		synctest.Wait()
+		select {
+		case <-fhs.ch:
+			t.Fatal("should not have received a heartbeat until all services have reported their status")
+		default:
+		}
+
+		svcA.ReportReason(readyz.Unhealthy, "no more bananas")
+
+		want := &machineidv1pb.SubmitHeartbeatRequest{
+			Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{
+				Hostname:     hostName,
+				IsStartup:    true,
+				OneShot:      false,
+				Uptime:       durationpb.New(time.Hour),
+				Version:      teleport.Version,
+				Architecture: runtime.GOARCH,
+				Os:           runtime.GOOS,
+				JoinMethod:   string(types.JoinMethodGitHub),
+				Kind:         machineidv1pb.BotKind_BOT_KIND_TBOT,
+			},
+		}
+
+		compare := func(t *testing.T, want, got *machineidv1pb.SubmitHeartbeatRequest) {
+			t.Helper()
+
+			assert.Empty(t,
+				cmp.Diff(want, got,
+					protocmp.Transform(),
+					protocmp.IgnoreFields(&machineidv1pb.BotInstanceStatusHeartbeat{}, "recorded_at"),
+				),
+			)
+		}
+
+		synctest.Wait()
+		select {
+		case got := <-fhs.ch:
+			compare(t, want, got)
+		default:
+			t.Fatal("no heartbeat received")
+		}
+
+		time.Sleep(1 * time.Second)
+		synctest.Wait()
+
+		select {
+		case got := <-fhs.ch:
+			want.Heartbeat.IsStartup = false
+			want.Heartbeat.Uptime = durationpb.New(time.Hour + time.Second)
+			compare(t, want, got)
+		default:
+			t.Fatal("no heartbeat received")
+		}
+
+		cancel()
+		assert.NoError(t, <-errCh)
 	})
-	require.NoError(t, err)
-
-	hostName, err := os.Hostname()
-	require.NoError(t, err)
-
-	errCh := make(chan error, 1)
-	go func() {
-		errCh <- svc.Run(ctx)
-	}()
-
-	select {
-	case <-fhs.ch:
-		t.Fatal("should not have received a heartbeat until all services have reported their status")
-	case <-time.After(100 * time.Millisecond):
-	}
-
-	svcA.ReportReason(readyz.Unhealthy, "no more bananas")
-
-	want := &machineidv1pb.SubmitHeartbeatRequest{
-		Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{
-			RecordedAt:   timestamppb.New(now),
-			Hostname:     hostName,
-			IsStartup:    true,
-			OneShot:      false,
-			Uptime:       durationpb.New(time.Hour),
-			Version:      teleport.Version,
-			Architecture: runtime.GOARCH,
-			Os:           runtime.GOOS,
-			JoinMethod:   string(types.JoinMethodGitHub),
-			Kind:         machineidv1pb.BotKind_BOT_KIND_TBOT,
-		},
-	}
-
-	select {
-	case got := <-fhs.ch:
-		assert.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for heartbeat")
-	}
-
-	select {
-	case got := <-fhs.ch:
-		want.Heartbeat.IsStartup = false
-		assert.Empty(t, cmp.Diff(want, got, protocmp.Transform()))
-	case <-time.After(1 * time.Second):
-		t.Fatal("timeout waiting for heartbeat")
-	}
-
-	cancel()
-	assert.NoError(t, <-errCh)
 }

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -61,7 +61,7 @@ func TestHeartbeatService(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		log := logtest.NewLogger()
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		t.Cleanup(cancel)
 
 		fhs := &fakeHeartbeatSubmitter{

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -372,7 +372,6 @@ func (s *Service) Initialize(ctx context.Context) error {
 	s.mu.Unlock()
 
 	s.unblockWaiters()
-	s.cfg.StatusReporter.Report(readyz.Healthy)
 
 	s.log.InfoContext(ctx, "Identity initialized successfully")
 	return nil

--- a/lib/tbot/readyz/readyz.go
+++ b/lib/tbot/readyz/readyz.go
@@ -39,6 +39,9 @@ type Registry struct {
 // AddService adds a service to the registry so that its health will be reported
 // from our readyz endpoints. It returns a Reporter the service can use to report
 // status changes.
+//
+// Note: you should add all of your services before any service reports its status
+// otherwise AllServicesReported will unblock too early.
 func (r *Registry) AddService(name string) Reporter {
 	r.mu.Lock()
 	defer r.mu.Unlock()


### PR DESCRIPTION
Uses the new `AllServicesReported` method to wait for all services to report their initial status before sending the "startup" heartbeat, with a timeout of 30 seconds.

In one-shot mode, if the outer context is canceled (typically caused by another service returning an error) we'll hang on for up to 5 seconds to try to send the heartbeat before shutting down.
