### PR TITLE
Fix TestTrackingSession goroutine leak

### DIFF
--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -926,7 +926,6 @@ func (s sessionEvaluator) IsModerated() bool {
 
 func TestTrackingSession(t *testing.T) {
 	t.Parallel()
-	ctx := t.Context()
 
 	me, err := user.Current()
 	require.NoError(t, err)
@@ -1029,6 +1028,9 @@ func TestTrackingSession(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
 			srv := newMockServer(t)
 			srv.component = tt.component
 


### PR DESCRIPTION
The update loop spawned by trackSession
leaks writes to the backend causing race
fails with TempDir cleanup. Use cancel
context to ensure this is cleaned up
before test Cleanup runs.

Tested with
```
go test -timeout=5m -count=1000 -shuffle=on -run ^TestTrackingSession$ github.com/gravitational/teleport/lib/sr
```

Fixes: #60054