### PR TITLE
MWI: Add service health to bot heartbeats

### DIFF
--- a/api/gen/proto/go/teleport/machineid/v1/bot_instance_service.pb.go
+++ b/api/gen/proto/go/teleport/machineid/v1/bot_instance_service.pb.go
@@ -384,7 +384,9 @@ func (x *DeleteBotInstanceRequest) GetInstanceId() string {
 type SubmitHeartbeatRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The heartbeat data to submit.
-	Heartbeat     *BotInstanceStatusHeartbeat `protobuf:"bytes,1,opt,name=heartbeat,proto3" json:"heartbeat,omitempty"`
+	Heartbeat *BotInstanceStatusHeartbeat `protobuf:"bytes,1,opt,name=heartbeat,proto3" json:"heartbeat,omitempty"`
+	// The health of the services/output `tbot` is running.
+	ServiceHealth []*BotInstanceServiceHealth `protobuf:"bytes,2,rep,name=service_health,json=serviceHealth,proto3" json:"service_health,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -422,6 +424,13 @@ func (*SubmitHeartbeatRequest) Descriptor() ([]byte, []int) {
 func (x *SubmitHeartbeatRequest) GetHeartbeat() *BotInstanceStatusHeartbeat {
 	if x != nil {
 		return x.Heartbeat
+	}
+	return nil
+}
+
+func (x *SubmitHeartbeatRequest) GetServiceHealth() []*BotInstanceServiceHealth {
+	if x != nil {
+		return x.ServiceHealth
 	}
 	return nil
 }
@@ -564,9 +573,10 @@ const file_teleport_machineid_v1_bot_instance_service_proto_rawDesc = "" +
 	"\x18DeleteBotInstanceRequest\x12\x19\n" +
 	"\bbot_name\x18\x01 \x01(\tR\abotName\x12\x1f\n" +
 	"\vinstance_id\x18\x02 \x01(\tR\n" +
-	"instanceId\"i\n" +
+	"instanceId\"\xc1\x01\n" +
 	"\x16SubmitHeartbeatRequest\x12O\n" +
-	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\"\x19\n" +
+	"\theartbeat\x18\x01 \x01(\v21.teleport.machineid.v1.BotInstanceStatusHeartbeatR\theartbeat\x12V\n" +
+	"\x0eservice_health\x18\x02 \x03(\v2/.teleport.machineid.v1.BotInstanceServiceHealthR\rserviceHealth\"\x19\n" +
 	"\x17SubmitHeartbeatResponse2\xbb\x04\n" +
 	"\x12BotInstanceService\x12b\n" +
 	"\x0eGetBotInstance\x12,.teleport.machineid.v1.GetBotInstanceRequest\x1a\".teleport.machineid.v1.BotInstance\x12x\n" +
@@ -600,28 +610,30 @@ var file_teleport_machineid_v1_bot_instance_service_proto_goTypes = []any{
 	(*types.SortBy)(nil),                      // 8: types.SortBy
 	(*BotInstance)(nil),                       // 9: teleport.machineid.v1.BotInstance
 	(*BotInstanceStatusHeartbeat)(nil),        // 10: teleport.machineid.v1.BotInstanceStatusHeartbeat
-	(*emptypb.Empty)(nil),                     // 11: google.protobuf.Empty
+	(*BotInstanceServiceHealth)(nil),          // 11: teleport.machineid.v1.BotInstanceServiceHealth
+	(*emptypb.Empty)(nil),                     // 12: google.protobuf.Empty
 }
 var file_teleport_machineid_v1_bot_instance_service_proto_depIdxs = []int32{
 	8,  // 0: teleport.machineid.v1.ListBotInstancesRequest.sort:type_name -> types.SortBy
 	7,  // 1: teleport.machineid.v1.ListBotInstancesV2Request.filter:type_name -> teleport.machineid.v1.ListBotInstancesV2Request.Filters
 	9,  // 2: teleport.machineid.v1.ListBotInstancesResponse.bot_instances:type_name -> teleport.machineid.v1.BotInstance
 	10, // 3: teleport.machineid.v1.SubmitHeartbeatRequest.heartbeat:type_name -> teleport.machineid.v1.BotInstanceStatusHeartbeat
-	0,  // 4: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
-	1,  // 5: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
-	2,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
-	4,  // 7: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
-	5,  // 8: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
-	9,  // 9: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
-	3,  // 10: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
-	11, // 12: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
-	6,  // 13: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
-	9,  // [9:14] is the sub-list for method output_type
-	4,  // [4:9] is the sub-list for method input_type
-	4,  // [4:4] is the sub-list for extension type_name
-	4,  // [4:4] is the sub-list for extension extendee
-	0,  // [0:4] is the sub-list for field type_name
+	11, // 4: teleport.machineid.v1.SubmitHeartbeatRequest.service_health:type_name -> teleport.machineid.v1.BotInstanceServiceHealth
+	0,  // 5: teleport.machineid.v1.BotInstanceService.GetBotInstance:input_type -> teleport.machineid.v1.GetBotInstanceRequest
+	1,  // 6: teleport.machineid.v1.BotInstanceService.ListBotInstances:input_type -> teleport.machineid.v1.ListBotInstancesRequest
+	2,  // 7: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:input_type -> teleport.machineid.v1.ListBotInstancesV2Request
+	4,  // 8: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:input_type -> teleport.machineid.v1.DeleteBotInstanceRequest
+	5,  // 9: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:input_type -> teleport.machineid.v1.SubmitHeartbeatRequest
+	9,  // 10: teleport.machineid.v1.BotInstanceService.GetBotInstance:output_type -> teleport.machineid.v1.BotInstance
+	3,  // 11: teleport.machineid.v1.BotInstanceService.ListBotInstances:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	3,  // 12: teleport.machineid.v1.BotInstanceService.ListBotInstancesV2:output_type -> teleport.machineid.v1.ListBotInstancesResponse
+	12, // 13: teleport.machineid.v1.BotInstanceService.DeleteBotInstance:output_type -> google.protobuf.Empty
+	6,  // 14: teleport.machineid.v1.BotInstanceService.SubmitHeartbeat:output_type -> teleport.machineid.v1.SubmitHeartbeatResponse
+	10, // [10:15] is the sub-list for method output_type
+	5,  // [5:10] is the sub-list for method input_type
+	5,  // [5:5] is the sub-list for extension type_name
+	5,  // [5:5] is the sub-list for extension extendee
+	0,  // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_machineid_v1_bot_instance_service_proto_init() }

--- a/api/proto/teleport/machineid/v1/bot_instance_service.proto
+++ b/api/proto/teleport/machineid/v1/bot_instance_service.proto
@@ -104,6 +104,9 @@ message DeleteBotInstanceRequest {
 message SubmitHeartbeatRequest {
   // The heartbeat data to submit.
   BotInstanceStatusHeartbeat heartbeat = 1;
+
+  // The health of the services/output `tbot` is running.
+  repeated BotInstanceServiceHealth service_health = 2;
 }
 
 // The response for SubmitHeartbeat.

--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -86,7 +86,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 		// statuses. Otherwise we will not include the service in heartbeats or
 		// the `/readyz` endpoint.
 		if handle.statusReporter.used {
-			handle.statusReporter.reporter = registry.AddService(handle.name)
+			handle.statusReporter.reporter = registry.AddService(handle.serviceType, handle.name)
 		}
 	}
 
@@ -146,7 +146,7 @@ func (b *Bot) OneShot(ctx context.Context) (err error) {
 		}
 
 		// Add oneshot services to the registry.
-		handle.statusReporter.reporter = registry.AddService(handle.name)
+		handle.statusReporter.reporter = registry.AddService(handle.serviceType, handle.name)
 		oneShotServices = append(oneShotServices, handle)
 	}
 

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -32,6 +33,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -69,7 +71,9 @@ func TestHeartbeatService(t *testing.T) {
 		}
 
 		reg := readyz.NewRegistry()
+
 		svcA := reg.AddService("a", "a")
+		svcB := reg.AddService("b", strings.Repeat("b", 200))
 
 		svc, err := NewService(Config{
 			Interval:       time.Second,
@@ -100,6 +104,7 @@ func TestHeartbeatService(t *testing.T) {
 		}
 
 		svcA.ReportReason(readyz.Unhealthy, "no more bananas")
+		svcB.ReportReason(readyz.Unhealthy, strings.Repeat("b", 300))
 
 		want := &machineidv1pb.SubmitHeartbeatRequest{
 			Heartbeat: &machineidv1pb.BotInstanceStatusHeartbeat{
@@ -112,6 +117,35 @@ func TestHeartbeatService(t *testing.T) {
 				Os:           runtime.GOOS,
 				JoinMethod:   string(types.JoinMethodGitHub),
 				Kind:         machineidv1pb.BotKind_BOT_KIND_TBOT,
+			},
+			ServiceHealth: []*machineidv1pb.BotInstanceServiceHealth{
+				{
+					Service: &machineidv1pb.BotInstanceServiceIdentifier{
+						Name: "a",
+						Type: "a",
+					},
+					Reason:    ptr("no more bananas"),
+					Status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY,
+					UpdatedAt: timestamppb.New(time.Now()),
+				},
+				// Check limits were applied on user-controlled or dynamic fields.
+				{
+					Service: &machineidv1pb.BotInstanceServiceIdentifier{
+						Name: strings.Repeat("b", 64),
+						Type: "b",
+					},
+					Reason:    ptr(strings.Repeat("b", 256)),
+					Status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY,
+					UpdatedAt: timestamppb.New(time.Now()),
+				},
+				{
+					Service: &machineidv1pb.BotInstanceServiceIdentifier{
+						Name: "heartbeat",
+						Type: "internal/heartbeat",
+					},
+					Status:    machineidv1pb.BotInstanceHealthStatus_BOT_INSTANCE_HEALTH_STATUS_HEALTHY,
+					UpdatedAt: timestamppb.New(time.Now()),
+				},
 			},
 		}
 
@@ -150,3 +184,5 @@ func TestHeartbeatService(t *testing.T) {
 		assert.NoError(t, <-errCh)
 	})
 }
+
+func ptr[T any](v T) *T { return &v }

--- a/lib/tbot/internal/heartbeat/service_test.go
+++ b/lib/tbot/internal/heartbeat/service_test.go
@@ -69,7 +69,7 @@ func TestHeartbeatService(t *testing.T) {
 		}
 
 		reg := readyz.NewRegistry()
-		svcA := reg.AddService("a")
+		svcA := reg.AddService("a", "a")
 
 		svc, err := NewService(Config{
 			Interval:       time.Second,
@@ -78,7 +78,7 @@ func TestHeartbeatService(t *testing.T) {
 			StartedAt:      time.Now().Add(-1 * time.Hour),
 			Logger:         log,
 			JoinMethod:     types.JoinMethodGitHub,
-			StatusReporter: reg.AddService("heartbeat"),
+			StatusReporter: reg.AddService("internal/heartbeat", "heartbeat"),
 			StatusRegistry: reg,
 			BotKind:        machineidv1pb.BotKind_BOT_KIND_TBOT,
 		})

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -39,8 +39,8 @@ func TestReadyz(t *testing.T) {
 
 	reg := readyz.NewRegistry(readyz.WithClock(clock))
 
-	a := reg.AddService("a")
-	b := reg.AddService("b")
+	a := reg.AddService("svc", "a")
+	b := reg.AddService("svc", "b")
 
 	srv := httptest.NewServer(readyz.HTTPHandler(reg))
 	srv.URL = srv.URL + "/readyz"
@@ -156,8 +156,8 @@ func TestReadyz(t *testing.T) {
 func TestAllServicesReported(t *testing.T) {
 	reg := readyz.NewRegistry()
 
-	a := reg.AddService("a")
-	b := reg.AddService("b")
+	a := reg.AddService("svc", "a")
+	b := reg.AddService("svc", "b")
 
 	select {
 	case <-reg.AllServicesReported():

--- a/lib/tbot/readyz/reporter.go
+++ b/lib/tbot/readyz/reporter.go
@@ -18,7 +18,11 @@
 
 package readyz
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/jonboulle/clockwork"
+)
 
 // Reporter can be used by a service to report its status.
 type Reporter interface {
@@ -32,6 +36,7 @@ type Reporter interface {
 type reporter struct {
 	mu     *sync.Mutex
 	status *ServiceStatus
+	clock  clockwork.Clock
 	notify func()
 }
 
@@ -45,6 +50,10 @@ func (r *reporter) ReportReason(status Status, reason string) {
 
 	r.status.Status = status
 	r.status.Reason = reason
+
+	updatedAt := r.clock.Now()
+	r.status.UpdatedAt = &updatedAt
+
 	r.notify()
 }
 


### PR DESCRIPTION
See: [RFD 222: Bot Instances at Scale](https://github.com/gravitational/teleport/pull/57888) for more information.

changelog: MWI: Health of `tbot`'s services is now reported to the auth server in heartbeats
