### PR TITLE
send message when giving up on join attempt

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -36,6 +36,66 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Reason is the reason the client is giving up.
+type GivingUp_Reason int32
+
+const (
+	// REASON_UNSPECIFIED is an unspecified reason.
+	GivingUp_REASON_UNSPECIFIED GivingUp_Reason = 0
+	// REASON_UNSUPPORTED_JOIN_METHOD means the client does not support the
+	// join method sent by the server.
+	GivingUp_REASON_UNSUPPORTED_JOIN_METHOD GivingUp_Reason = 1
+	// REASON_UNSUPPORTED_MESSAGE_TYPE means the client can not handle a
+	// message type sent by the server.
+	GivingUp_REASON_UNSUPPORTED_MESSAGE_TYPE GivingUp_Reason = 2
+	// REASON_CHALLENGE_SOLUTION_FAILED means the client failed to solve a
+	// challenge sent by the server.
+	GivingUp_REASON_CHALLENGE_SOLUTION_FAILED GivingUp_Reason = 3
+)
+
+// Enum value maps for GivingUp_Reason.
+var (
+	GivingUp_Reason_name = map[int32]string{
+		0: "REASON_UNSPECIFIED",
+		1: "REASON_UNSUPPORTED_JOIN_METHOD",
+		2: "REASON_UNSUPPORTED_MESSAGE_TYPE",
+		3: "REASON_CHALLENGE_SOLUTION_FAILED",
+	}
+	GivingUp_Reason_value = map[string]int32{
+		"REASON_UNSPECIFIED":               0,
+		"REASON_UNSUPPORTED_JOIN_METHOD":   1,
+		"REASON_UNSUPPORTED_MESSAGE_TYPE":  2,
+		"REASON_CHALLENGE_SOLUTION_FAILED": 3,
+	}
+)
+
+func (x GivingUp_Reason) Enum() *GivingUp_Reason {
+	p := new(GivingUp_Reason)
+	*p = x
+	return p
+}
+
+func (x GivingUp_Reason) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (GivingUp_Reason) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_join_v1_joinservice_proto_enumTypes[0].Descriptor()
+}
+
+func (GivingUp_Reason) Type() protoreflect.EnumType {
+	return &file_teleport_join_v1_joinservice_proto_enumTypes[0]
+}
+
+func (x GivingUp_Reason) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use GivingUp_Reason.Descriptor instead.
+func (GivingUp_Reason) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16, 0}
+}
+
 // ClientInit is the first message sent from the client during the join process, it
 // holds parameters common to all join methods.
 type ClientInit struct {
@@ -1052,6 +1112,62 @@ func (*ChallengeSolution_BoundKeypairRotationResponse) isChallengeSolution_Paylo
 
 func (*ChallengeSolution_IamChallengeSolution) isChallengeSolution_Payload() {}
 
+// GivingUp should be sent by clients that fail to complete the join flow so
+// that the Auth service can log an informative error message.
+type GivingUp struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Reason is the reason the client is giving up.
+	Reason GivingUp_Reason `protobuf:"varint,1,opt,name=reason,proto3,enum=teleport.join.v1.GivingUp_Reason" json:"reason,omitempty"`
+	// Msg is an error message related to the failure.
+	Msg           string `protobuf:"bytes,2,opt,name=msg,proto3" json:"msg,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GivingUp) Reset() {
+	*x = GivingUp{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GivingUp) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GivingUp) ProtoMessage() {}
+
+func (x *GivingUp) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GivingUp.ProtoReflect.Descriptor instead.
+func (*GivingUp) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *GivingUp) GetReason() GivingUp_Reason {
+	if x != nil {
+		return x.Reason
+	}
+	return GivingUp_REASON_UNSPECIFIED
+}
+
+func (x *GivingUp) GetMsg() string {
+	if x != nil {
+		return x.Msg
+	}
+	return ""
+}
+
 // JoinRequest is the message type sent from the joining client to the server.
 type JoinRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1062,6 +1178,7 @@ type JoinRequest struct {
 	//	*JoinRequest_BoundKeypairInit
 	//	*JoinRequest_Solution
 	//	*JoinRequest_IamInit
+	//	*JoinRequest_GivingUp
 	Payload       isJoinRequest_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1069,7 +1186,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1081,7 +1198,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1094,7 +1211,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *JoinRequest) GetPayload() isJoinRequest_Payload {
@@ -1149,6 +1266,15 @@ func (x *JoinRequest) GetIamInit() *IAMInit {
 	return nil
 }
 
+func (x *JoinRequest) GetGivingUp() *GivingUp {
+	if x != nil {
+		if x, ok := x.Payload.(*JoinRequest_GivingUp); ok {
+			return x.GivingUp
+		}
+	}
+	return nil
+}
+
 type isJoinRequest_Payload interface {
 	isJoinRequest_Payload()
 }
@@ -1173,6 +1299,10 @@ type JoinRequest_IamInit struct {
 	IamInit *IAMInit `protobuf:"bytes,5,opt,name=iam_init,json=iamInit,proto3,oneof"`
 }
 
+type JoinRequest_GivingUp struct {
+	GivingUp *GivingUp `protobuf:"bytes,6,opt,name=giving_up,json=givingUp,proto3,oneof"`
+}
+
 func (*JoinRequest_ClientInit) isJoinRequest_Payload() {}
 
 func (*JoinRequest_TokenInit) isJoinRequest_Payload() {}
@@ -1182,6 +1312,8 @@ func (*JoinRequest_BoundKeypairInit) isJoinRequest_Payload() {}
 func (*JoinRequest_Solution) isJoinRequest_Payload() {}
 
 func (*JoinRequest_IamInit) isJoinRequest_Payload() {}
+
+func (*JoinRequest_GivingUp) isJoinRequest_Payload() {}
 
 // ServerInit is the first message sent from the server in response to the
 // ClientInit message.
@@ -1198,7 +1330,7 @@ type ServerInit struct {
 
 func (x *ServerInit) Reset() {
 	*x = ServerInit{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1210,7 +1342,7 @@ func (x *ServerInit) String() string {
 func (*ServerInit) ProtoMessage() {}
 
 func (x *ServerInit) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1223,7 +1355,7 @@ func (x *ServerInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerInit.ProtoReflect.Descriptor instead.
 func (*ServerInit) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ServerInit) GetJoinMethod() string {
@@ -1255,7 +1387,7 @@ type Challenge struct {
 
 func (x *Challenge) Reset() {
 	*x = Challenge{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1267,7 +1399,7 @@ func (x *Challenge) String() string {
 func (*Challenge) ProtoMessage() {}
 
 func (x *Challenge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1280,7 +1412,7 @@ func (x *Challenge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Challenge.ProtoReflect.Descriptor instead.
 func (*Challenge) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Challenge) GetPayload() isChallenge_Payload {
@@ -1355,7 +1487,7 @@ type Result struct {
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1367,7 +1499,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1380,7 +1512,7 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Result) GetPayload() isResult_Payload {
@@ -1443,7 +1575,7 @@ type Certificates struct {
 
 func (x *Certificates) Reset() {
 	*x = Certificates{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1455,7 +1587,7 @@ func (x *Certificates) String() string {
 func (*Certificates) ProtoMessage() {}
 
 func (x *Certificates) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1468,7 +1600,7 @@ func (x *Certificates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Certificates.ProtoReflect.Descriptor instead.
 func (*Certificates) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Certificates) GetTlsCert() []byte {
@@ -1512,7 +1644,7 @@ type HostResult struct {
 
 func (x *HostResult) Reset() {
 	*x = HostResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1524,7 +1656,7 @@ func (x *HostResult) String() string {
 func (*HostResult) ProtoMessage() {}
 
 func (x *HostResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1537,7 +1669,7 @@ func (x *HostResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostResult.ProtoReflect.Descriptor instead.
 func (*HostResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{21}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *HostResult) GetCertificates() *Certificates {
@@ -1567,7 +1699,7 @@ type BotResult struct {
 
 func (x *BotResult) Reset() {
 	*x = BotResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1579,7 +1711,7 @@ func (x *BotResult) String() string {
 func (*BotResult) ProtoMessage() {}
 
 func (x *BotResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1592,7 +1724,7 @@ func (x *BotResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotResult.ProtoReflect.Descriptor instead.
 func (*BotResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{22}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *BotResult) GetCertificates() *Certificates {
@@ -1624,7 +1756,7 @@ type JoinResponse struct {
 
 func (x *JoinResponse) Reset() {
 	*x = JoinResponse{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1636,7 +1768,7 @@ func (x *JoinResponse) String() string {
 func (*JoinResponse) ProtoMessage() {}
 
 func (x *JoinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1649,7 +1781,7 @@ func (x *JoinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinResponse.ProtoReflect.Descriptor instead.
 func (*JoinResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{23}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *JoinResponse) GetPayload() isJoinResponse_Payload {
@@ -1732,7 +1864,7 @@ type ClientInit_ProxySuppliedParams struct {
 
 func (x *ClientInit_ProxySuppliedParams) Reset() {
 	*x = ClientInit_ProxySuppliedParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1744,7 +1876,7 @@ func (x *ClientInit_ProxySuppliedParams) String() string {
 func (*ClientInit_ProxySuppliedParams) ProtoMessage() {}
 
 func (x *ClientInit_ProxySuppliedParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1850,7 +1982,15 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	" bound_keypair_challenge_solution\x18\x01 \x01(\v2/.teleport.join.v1.BoundKeypairChallengeSolutionH\x00R\x1dboundKeypairChallengeSolution\x12w\n" +
 	"\x1fbound_keypair_rotation_response\x18\x02 \x01(\v2..teleport.join.v1.BoundKeypairRotationResponseH\x00R\x1cboundKeypairRotationResponse\x12^\n" +
 	"\x16iam_challenge_solution\x18\x03 \x01(\v2&.teleport.join.v1.IAMChallengeSolutionH\x00R\x14iamChallengeSolutionB\t\n" +
-	"\apayload\"\xe6\x02\n" +
+	"\apayload\"\xe9\x01\n" +
+	"\bGivingUp\x129\n" +
+	"\x06reason\x18\x01 \x01(\x0e2!.teleport.join.v1.GivingUp.ReasonR\x06reason\x12\x10\n" +
+	"\x03msg\x18\x02 \x01(\tR\x03msg\"\x8f\x01\n" +
+	"\x06Reason\x12\x16\n" +
+	"\x12REASON_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eREASON_UNSUPPORTED_JOIN_METHOD\x10\x01\x12#\n" +
+	"\x1fREASON_UNSUPPORTED_MESSAGE_TYPE\x10\x02\x12$\n" +
+	" REASON_CHALLENGE_SOLUTION_FAILED\x10\x03\"\xa1\x03\n" +
 	"\vJoinRequest\x12?\n" +
 	"\vclient_init\x18\x01 \x01(\v2\x1c.teleport.join.v1.ClientInitH\x00R\n" +
 	"clientInit\x12<\n" +
@@ -1858,7 +1998,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"token_init\x18\x02 \x01(\v2\x1b.teleport.join.v1.TokenInitH\x00R\ttokenInit\x12R\n" +
 	"\x12bound_keypair_init\x18\x03 \x01(\v2\".teleport.join.v1.BoundKeypairInitH\x00R\x10boundKeypairInit\x12A\n" +
 	"\bsolution\x18\x04 \x01(\v2#.teleport.join.v1.ChallengeSolutionH\x00R\bsolution\x126\n" +
-	"\biam_init\x18\x05 \x01(\v2\x19.teleport.join.v1.IAMInitH\x00R\aiamInitB\t\n" +
+	"\biam_init\x18\x05 \x01(\v2\x19.teleport.join.v1.IAMInitH\x00R\aiamInit\x129\n" +
+	"\tgiving_up\x18\x06 \x01(\v2\x1a.teleport.join.v1.GivingUpH\x00R\bgivingUpB\t\n" +
 	"\apayload\"i\n" +
 	"\n" +
 	"ServerInit\x12\x1f\n" +
@@ -1910,71 +2051,76 @@ func file_teleport_join_v1_joinservice_proto_rawDescGZIP() []byte {
 	return file_teleport_join_v1_joinservice_proto_rawDescData
 }
 
-var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_teleport_join_v1_joinservice_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_teleport_join_v1_joinservice_proto_goTypes = []any{
-	(*ClientInit)(nil),                     // 0: teleport.join.v1.ClientInit
-	(*PublicKeys)(nil),                     // 1: teleport.join.v1.PublicKeys
-	(*HostParams)(nil),                     // 2: teleport.join.v1.HostParams
-	(*BotParams)(nil),                      // 3: teleport.join.v1.BotParams
-	(*ClientParams)(nil),                   // 4: teleport.join.v1.ClientParams
-	(*TokenInit)(nil),                      // 5: teleport.join.v1.TokenInit
-	(*BoundKeypairInit)(nil),               // 6: teleport.join.v1.BoundKeypairInit
-	(*BoundKeypairChallenge)(nil),          // 7: teleport.join.v1.BoundKeypairChallenge
-	(*BoundKeypairChallengeSolution)(nil),  // 8: teleport.join.v1.BoundKeypairChallengeSolution
-	(*BoundKeypairRotationRequest)(nil),    // 9: teleport.join.v1.BoundKeypairRotationRequest
-	(*BoundKeypairRotationResponse)(nil),   // 10: teleport.join.v1.BoundKeypairRotationResponse
-	(*BoundKeypairResult)(nil),             // 11: teleport.join.v1.BoundKeypairResult
-	(*IAMInit)(nil),                        // 12: teleport.join.v1.IAMInit
-	(*IAMChallenge)(nil),                   // 13: teleport.join.v1.IAMChallenge
-	(*IAMChallengeSolution)(nil),           // 14: teleport.join.v1.IAMChallengeSolution
-	(*ChallengeSolution)(nil),              // 15: teleport.join.v1.ChallengeSolution
-	(*JoinRequest)(nil),                    // 16: teleport.join.v1.JoinRequest
-	(*ServerInit)(nil),                     // 17: teleport.join.v1.ServerInit
-	(*Challenge)(nil),                      // 18: teleport.join.v1.Challenge
-	(*Result)(nil),                         // 19: teleport.join.v1.Result
-	(*Certificates)(nil),                   // 20: teleport.join.v1.Certificates
-	(*HostResult)(nil),                     // 21: teleport.join.v1.HostResult
-	(*BotResult)(nil),                      // 22: teleport.join.v1.BotResult
-	(*JoinResponse)(nil),                   // 23: teleport.join.v1.JoinResponse
-	(*ClientInit_ProxySuppliedParams)(nil), // 24: teleport.join.v1.ClientInit.ProxySuppliedParams
-	(*timestamppb.Timestamp)(nil),          // 25: google.protobuf.Timestamp
+	(GivingUp_Reason)(0),                   // 0: teleport.join.v1.GivingUp.Reason
+	(*ClientInit)(nil),                     // 1: teleport.join.v1.ClientInit
+	(*PublicKeys)(nil),                     // 2: teleport.join.v1.PublicKeys
+	(*HostParams)(nil),                     // 3: teleport.join.v1.HostParams
+	(*BotParams)(nil),                      // 4: teleport.join.v1.BotParams
+	(*ClientParams)(nil),                   // 5: teleport.join.v1.ClientParams
+	(*TokenInit)(nil),                      // 6: teleport.join.v1.TokenInit
+	(*BoundKeypairInit)(nil),               // 7: teleport.join.v1.BoundKeypairInit
+	(*BoundKeypairChallenge)(nil),          // 8: teleport.join.v1.BoundKeypairChallenge
+	(*BoundKeypairChallengeSolution)(nil),  // 9: teleport.join.v1.BoundKeypairChallengeSolution
+	(*BoundKeypairRotationRequest)(nil),    // 10: teleport.join.v1.BoundKeypairRotationRequest
+	(*BoundKeypairRotationResponse)(nil),   // 11: teleport.join.v1.BoundKeypairRotationResponse
+	(*BoundKeypairResult)(nil),             // 12: teleport.join.v1.BoundKeypairResult
+	(*IAMInit)(nil),                        // 13: teleport.join.v1.IAMInit
+	(*IAMChallenge)(nil),                   // 14: teleport.join.v1.IAMChallenge
+	(*IAMChallengeSolution)(nil),           // 15: teleport.join.v1.IAMChallengeSolution
+	(*ChallengeSolution)(nil),              // 16: teleport.join.v1.ChallengeSolution
+	(*GivingUp)(nil),                       // 17: teleport.join.v1.GivingUp
+	(*JoinRequest)(nil),                    // 18: teleport.join.v1.JoinRequest
+	(*ServerInit)(nil),                     // 19: teleport.join.v1.ServerInit
+	(*Challenge)(nil),                      // 20: teleport.join.v1.Challenge
+	(*Result)(nil),                         // 21: teleport.join.v1.Result
+	(*Certificates)(nil),                   // 22: teleport.join.v1.Certificates
+	(*HostResult)(nil),                     // 23: teleport.join.v1.HostResult
+	(*BotResult)(nil),                      // 24: teleport.join.v1.BotResult
+	(*JoinResponse)(nil),                   // 25: teleport.join.v1.JoinResponse
+	(*ClientInit_ProxySuppliedParams)(nil), // 26: teleport.join.v1.ClientInit.ProxySuppliedParams
+	(*timestamppb.Timestamp)(nil),          // 27: google.protobuf.Timestamp
 }
 var file_teleport_join_v1_joinservice_proto_depIdxs = []int32{
-	24, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
-	1,  // 1: teleport.join.v1.HostParams.public_keys:type_name -> teleport.join.v1.PublicKeys
-	1,  // 2: teleport.join.v1.BotParams.public_keys:type_name -> teleport.join.v1.PublicKeys
-	25, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
-	2,  // 4: teleport.join.v1.ClientParams.host_params:type_name -> teleport.join.v1.HostParams
-	3,  // 5: teleport.join.v1.ClientParams.bot_params:type_name -> teleport.join.v1.BotParams
-	4,  // 6: teleport.join.v1.TokenInit.client_params:type_name -> teleport.join.v1.ClientParams
-	4,  // 7: teleport.join.v1.BoundKeypairInit.client_params:type_name -> teleport.join.v1.ClientParams
-	4,  // 8: teleport.join.v1.IAMInit.client_params:type_name -> teleport.join.v1.ClientParams
-	8,  // 9: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
-	10, // 10: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
-	14, // 11: teleport.join.v1.ChallengeSolution.iam_challenge_solution:type_name -> teleport.join.v1.IAMChallengeSolution
-	0,  // 12: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
-	5,  // 13: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
-	6,  // 14: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
-	15, // 15: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
-	12, // 16: teleport.join.v1.JoinRequest.iam_init:type_name -> teleport.join.v1.IAMInit
-	7,  // 17: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
-	9,  // 18: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
-	13, // 19: teleport.join.v1.Challenge.iam_challenge:type_name -> teleport.join.v1.IAMChallenge
-	21, // 20: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
-	22, // 21: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
-	20, // 22: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
-	20, // 23: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
-	11, // 24: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
-	17, // 25: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
-	18, // 26: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
-	19, // 27: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
-	16, // 28: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
-	23, // 29: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
-	29, // [29:30] is the sub-list for method output_type
-	28, // [28:29] is the sub-list for method input_type
-	28, // [28:28] is the sub-list for extension type_name
-	28, // [28:28] is the sub-list for extension extendee
-	0,  // [0:28] is the sub-list for field type_name
+	26, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
+	2,  // 1: teleport.join.v1.HostParams.public_keys:type_name -> teleport.join.v1.PublicKeys
+	2,  // 2: teleport.join.v1.BotParams.public_keys:type_name -> teleport.join.v1.PublicKeys
+	27, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
+	3,  // 4: teleport.join.v1.ClientParams.host_params:type_name -> teleport.join.v1.HostParams
+	4,  // 5: teleport.join.v1.ClientParams.bot_params:type_name -> teleport.join.v1.BotParams
+	5,  // 6: teleport.join.v1.TokenInit.client_params:type_name -> teleport.join.v1.ClientParams
+	5,  // 7: teleport.join.v1.BoundKeypairInit.client_params:type_name -> teleport.join.v1.ClientParams
+	5,  // 8: teleport.join.v1.IAMInit.client_params:type_name -> teleport.join.v1.ClientParams
+	9,  // 9: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
+	11, // 10: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
+	15, // 11: teleport.join.v1.ChallengeSolution.iam_challenge_solution:type_name -> teleport.join.v1.IAMChallengeSolution
+	0,  // 12: teleport.join.v1.GivingUp.reason:type_name -> teleport.join.v1.GivingUp.Reason
+	1,  // 13: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
+	6,  // 14: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
+	7,  // 15: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
+	16, // 16: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
+	13, // 17: teleport.join.v1.JoinRequest.iam_init:type_name -> teleport.join.v1.IAMInit
+	17, // 18: teleport.join.v1.JoinRequest.giving_up:type_name -> teleport.join.v1.GivingUp
+	8,  // 19: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
+	10, // 20: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
+	14, // 21: teleport.join.v1.Challenge.iam_challenge:type_name -> teleport.join.v1.IAMChallenge
+	23, // 22: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
+	24, // 23: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
+	22, // 24: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
+	22, // 25: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
+	12, // 26: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
+	19, // 27: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
+	20, // 28: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
+	21, // 29: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
+	18, // 30: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
+	25, // 31: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
+	31, // [31:32] is the sub-list for method output_type
+	30, // [30:31] is the sub-list for method input_type
+	30, // [30:30] is the sub-list for extension type_name
+	30, // [30:30] is the sub-list for extension extendee
+	0,  // [0:30] is the sub-list for field type_name
 }
 
 func init() { file_teleport_join_v1_joinservice_proto_init() }
@@ -1993,24 +2139,25 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		(*ChallengeSolution_BoundKeypairRotationResponse)(nil),
 		(*ChallengeSolution_IamChallengeSolution)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[16].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[17].OneofWrappers = []any{
 		(*JoinRequest_ClientInit)(nil),
 		(*JoinRequest_TokenInit)(nil),
 		(*JoinRequest_BoundKeypairInit)(nil),
 		(*JoinRequest_Solution)(nil),
 		(*JoinRequest_IamInit)(nil),
+		(*JoinRequest_GivingUp)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[18].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[19].OneofWrappers = []any{
 		(*Challenge_BoundKeypairChallenge)(nil),
 		(*Challenge_BoundKeypairRotationRequest)(nil),
 		(*Challenge_IamChallenge)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[19].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[20].OneofWrappers = []any{
 		(*Result_HostResult)(nil),
 		(*Result_BotResult)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[22].OneofWrappers = []any{}
-	file_teleport_join_v1_joinservice_proto_msgTypes[23].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[23].OneofWrappers = []any{}
+	file_teleport_join_v1_joinservice_proto_msgTypes[24].OneofWrappers = []any{
 		(*JoinResponse_Init)(nil),
 		(*JoinResponse_Challenge)(nil),
 		(*JoinResponse_Result)(nil),
@@ -2020,13 +2167,14 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_join_v1_joinservice_proto_rawDesc), len(file_teleport_join_v1_joinservice_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   25,
+			NumEnums:      1,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_teleport_join_v1_joinservice_proto_goTypes,
 		DependencyIndexes: file_teleport_join_v1_joinservice_proto_depIdxs,
+		EnumInfos:         file_teleport_join_v1_joinservice_proto_enumTypes,
 		MessageInfos:      file_teleport_join_v1_joinservice_proto_msgTypes,
 	}.Build()
 	File_teleport_join_v1_joinservice_proto = out.File

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -231,6 +231,29 @@ message ChallengeSolution {
   }
 }
 
+// GivingUp should be sent by clients that fail to complete the join flow so
+// that the Auth service can log an informative error message.
+message GivingUp {
+  // Reason is the reason the client is giving up.
+  enum Reason {
+    // REASON_UNSPECIFIED is an unspecified reason.
+    REASON_UNSPECIFIED = 0;
+    // REASON_UNSUPPORTED_JOIN_METHOD means the client does not support the
+    // join method sent by the server.
+    REASON_UNSUPPORTED_JOIN_METHOD = 1;
+    // REASON_UNSUPPORTED_MESSAGE_TYPE means the client can not handle a
+    // message type sent by the server.
+    REASON_UNSUPPORTED_MESSAGE_TYPE = 2;
+    // REASON_CHALLENGE_SOLUTION_FAILED means the client failed to solve a
+    // challenge sent by the server.
+    REASON_CHALLENGE_SOLUTION_FAILED = 3;
+  }
+  // Reason is the reason the client is giving up.
+  Reason reason = 1;
+  // Msg is an error message related to the failure.
+  string msg = 2;
+}
+
 // JoinRequest is the message type sent from the joining client to the server.
 message JoinRequest {
   oneof payload {
@@ -239,6 +262,7 @@ message JoinRequest {
     BoundKeypairInit bound_keypair_init = 3;
     ChallengeSolution solution = 4;
     IAMInit iam_init = 5;
+    GivingUp giving_up = 6;
   }
 }
 

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -18,12 +18,14 @@ package messages
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 // Request is implemented by all join request messages.
@@ -379,6 +381,65 @@ type Certificates struct {
 	SSHCAKeys [][]byte
 }
 
+// GivingUpReason is the reason a client is giving up on a join attempt.
+type GivingUpReason int
+
+const (
+	// GivingUpReasonUnspecified is an unspecified reason.
+	GivingUpReasonUnspecified GivingUpReason = iota
+	// GivingUpReasonUnsupportedJoinMethod means the client does not support
+	// the join method sent by the server.
+	GivingUpReasonUnsupportedJoinMethod
+	// GivingUpReasonUnsupportedMessageType means the client can not handle a
+	// message type sent by the server.
+	GivingUpReasonUnsupportedMessageType
+	// GivingUpReasonChallengeSolutionFailed means the client failed to solve a
+	// challenge sent by the server.
+	GivingUpReasonChallengeSolutionFailed
+)
+
+// GivingUp should be sent by clients that fail to complete the join flow so
+// that the Auth service can log an informative error message.
+type GivingUp struct {
+	embedRequest
+
+	// Reason is the reason the client is giving up.
+	Reason GivingUpReason
+	// Msg is an error message related to the failure.
+	Msg string
+}
+
+// ClientGaveUpError is an error type returned when a client explicitly gave up
+// on a join attempt.
+type ClientGaveUpError struct {
+	// Reason is the reason the client is giving up.
+	Reason GivingUpReason
+	// Msg is an error message related to the failure.
+	Msg string
+}
+
+func (e *ClientGaveUpError) Error() string {
+	var msg strings.Builder
+	msg.WriteString("client gave up on join attempt: ")
+	switch e.Reason {
+	case GivingUpReasonUnspecified:
+		msg.WriteString("reason unspecified")
+	case GivingUpReasonUnsupportedJoinMethod:
+		msg.WriteString("unsupported join method")
+	case GivingUpReasonUnsupportedMessageType:
+		msg.WriteString("unsupported message type")
+	case GivingUpReasonChallengeSolutionFailed:
+		msg.WriteString("challenge solution failed")
+	default:
+		msg.WriteString("unhandled reason")
+	}
+	if e.Msg != "" {
+		msg.WriteString(": ")
+		msg.WriteString(joinutils.SanitizeUntrustedString(e.Msg))
+	}
+	return msg.String()
+}
+
 // ClientStream represents the client side of a join request stream.
 // It can send [Request]s and receive [Response]s.
 //
@@ -417,11 +478,15 @@ func RecvRequest[T Request](ss ServerStream) (T, error) {
 // AssertRequestType performs a type assertion on a request and returns an
 // appropriate error if the request has an unexpected type.
 func AssertRequestType[T Request](req Request) (T, error) {
-	// TODO(nklaassen): add ClientGivingUp request type and return an
-	// appropriate error here.
 	switch typedRequest := req.(type) {
 	case T:
 		return typedRequest, nil
+	case *GivingUp:
+		var nul T
+		return nul, trace.Wrap(&ClientGaveUpError{
+			Reason: typedRequest.Reason,
+			Msg:    typedRequest.Msg,
+		})
 	default:
 		var nul T
 		return nul, trace.BadParameter("expected client to send message of type %T, got %T", nul, req)
@@ -429,8 +494,9 @@ func AssertRequestType[T Request](req Request) (T, error) {
 }
 
 // RecvResponse calls [ClientStream.Recv] and asserts the expected type of
-// the received message, returning an appropriate error if the server sent a
-// message with an unexpected type.
+// the received message. If a message of any type other than T is received a
+// [GivingUp] message will be sent on the client stream and an error will be
+// returned.
 func RecvResponse[T Response](cs ClientStream) (T, error) {
 	var nul T
 	resp, err := cs.Recv()
@@ -439,7 +505,15 @@ func RecvResponse[T Response](cs ClientStream) (T, error) {
 	}
 	typedResp, ok := resp.(T)
 	if !ok {
-		return nul, trace.BadParameter("expected server to send message of type %T, got %T", nul, resp)
+		err = trace.Errorf("expected server to send message of type %T, got %T", nul, resp)
+		sendGivingUpErr := cs.Send(&GivingUp{
+			Reason: GivingUpReasonUnsupportedMessageType,
+			Msg:    err.Error(),
+		})
+		return nul, trace.NewAggregate(
+			err,
+			trace.Wrap(sendGivingUpErr, "sending GivingUp message to server"),
+		)
 	}
 	return typedResp, nil
 }

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
@@ -243,9 +244,13 @@ func newFakeAuthService(t *testing.T) *fakeAuthService {
 }
 
 func (s *fakeAuthService) lastEvent(ctx context.Context, eventType string) (apievents.AuditEvent, error) {
-	events, _, err := s.Auth().SearchEvents(ctx, events.SearchEventsRequest{
-		From:       s.Auth().GetClock().Now().Add(-time.Hour),
-		To:         s.Auth().GetClock().Now().Add(time.Hour),
+	return lastEvent(ctx, s.Auth(), s.Auth().GetClock(), eventType)
+}
+
+func lastEvent(ctx context.Context, auditLog events.AuditLogger, clock clockwork.Clock, eventType string) (apievents.AuditEvent, error) {
+	events, _, err := auditLog.SearchEvents(ctx, events.SearchEventsRequest{
+		From:       clock.Now().Add(-time.Hour),
+		To:         clock.Now().Add(time.Hour),
 		EventTypes: []string{eventType},
 		Limit:      1,
 		Order:      types.EventOrderDescending,

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -84,63 +84,36 @@ func boundKeypairJoin(
 			// Return the final result.
 			return kind, nil
 		case *messages.BoundKeypairChallenge:
-			signer, err := bkParams.GetSigner(string(kind.PublicKey))
+			solution, err := solveBoundKeypairChallenge(bkParams, kind)
 			if err != nil {
-				return nil, trace.Wrap(err, "could not lookup signer for public key %+v", string(kind.PublicKey))
-			}
-
-			alg, err := jwt.AlgorithmForPublicKey(signer.Public())
-			if err != nil {
-				return nil, trace.Wrap(err, "determining signing algorithm for public key")
-			}
-
-			opts := (&jose.SignerOptions{}).WithType("JWT")
-			key := jose.SigningKey{
-				Algorithm: alg,
-				Key:       signer,
-			}
-
-			joseSigner, err := jose.NewSigner(key, opts)
-			if err != nil {
-				return nil, trace.Wrap(err, "creating signer")
-			}
-
-			jws, err := joseSigner.Sign([]byte(kind.Challenge))
-			if err != nil {
-				return nil, trace.Wrap(err, "signing challenge")
-			}
-
-			serialized, err := jws.CompactSerialize()
-			if err != nil {
-				return nil, trace.Wrap(err, "serializing signed challenge")
+				sendGivingUpErr := stream.Send(&messages.GivingUp{
+					Reason: messages.GivingUpReasonChallengeSolutionFailed,
+					Msg:    err.Error(),
+				})
+				return nil, trace.NewAggregate(
+					err,
+					trace.Wrap(sendGivingUpErr, "sending GivingUp message to server"),
+				)
 			}
 			if err := stream.Send(&messages.BoundKeypairChallengeSolution{
-				Solution: []byte(serialized),
+				Solution: solution,
 			}); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		case *messages.BoundKeypairRotationRequest:
-			if bkParams.RequestNewKeypair == nil {
-				return nil, trace.BadParameter("RequestNewKeypair is required")
-			}
-
-			slog.InfoContext(ctx, "Server has requested keypair rotation", "suite", kind.SignatureAlgorithmSuite)
-
-			suite, err := types.SignatureAlgorithmSuiteFromString(kind.SignatureAlgorithmSuite)
+			newPubkey, err := handleBoundKeypairRotationRequest(ctx, bkParams, kind)
 			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			newSigner, err := bkParams.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(suite))
-			if err != nil {
-				return nil, trace.Wrap(err, "requesting new keypair")
-			}
-
-			newPubkey, err := sshPubKeyFromSigner(newSigner)
-			if err != nil {
-				return nil, trace.Wrap(err)
+				sendGivingUpErr := stream.Send(&messages.GivingUp{
+					Reason: messages.GivingUpReasonChallengeSolutionFailed,
+					Msg:    err.Error(),
+				})
+				return nil, trace.NewAggregate(
+					err,
+					trace.Wrap(sendGivingUpErr, "sending GivingUp message to server"),
+				)
 			}
 			if err := stream.Send(&messages.BoundKeypairRotationResponse{
-				PublicKey: []byte(newPubkey),
+				PublicKey: newPubkey,
 			}); err != nil {
 				return nil, trace.Wrap(err)
 			}
@@ -148,6 +121,63 @@ func boundKeypairJoin(
 			return nil, trace.Errorf("server sent unexpected message type %T", msg)
 		}
 	}
+}
+
+func solveBoundKeypairChallenge(bkParams *BoundKeypairParams, challengeMsg *messages.BoundKeypairChallenge) ([]byte, error) {
+	signer, err := bkParams.GetSigner(string(challengeMsg.PublicKey))
+	if err != nil {
+		return nil, trace.Wrap(err, "could not lookup signer for public key %s", string(challengeMsg.PublicKey))
+	}
+
+	alg, err := jwt.AlgorithmForPublicKey(signer.Public())
+	if err != nil {
+		return nil, trace.Wrap(err, "determining signing algorithm for public key")
+	}
+
+	opts := (&jose.SignerOptions{}).WithType("JWT")
+	key := jose.SigningKey{
+		Algorithm: alg,
+		Key:       signer,
+	}
+
+	joseSigner, err := jose.NewSigner(key, opts)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating signer")
+	}
+
+	jws, err := joseSigner.Sign([]byte(challengeMsg.Challenge))
+	if err != nil {
+		return nil, trace.Wrap(err, "signing challenge")
+	}
+
+	serialized, err := jws.CompactSerialize()
+	if err != nil {
+		return nil, trace.Wrap(err, "serializing signed challenge")
+	}
+	return []byte(serialized), nil
+}
+
+func handleBoundKeypairRotationRequest(ctx context.Context, bkParams *BoundKeypairParams, rotationRequest *messages.BoundKeypairRotationRequest) ([]byte, error) {
+	if bkParams.RequestNewKeypair == nil {
+		return nil, trace.BadParameter("RequestNewKeypair is required")
+	}
+
+	slog.InfoContext(ctx, "Server has requested keypair rotation", "suite", rotationRequest.SignatureAlgorithmSuite)
+
+	suite, err := types.SignatureAlgorithmSuiteFromString(rotationRequest.SignatureAlgorithmSuite)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	newSigner, err := bkParams.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(suite))
+	if err != nil {
+		return nil, trace.Wrap(err, "requesting new keypair")
+	}
+
+	newPubkey, err := sshPubKeyFromSigner(newSigner)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return []byte(newPubkey), nil
 }
 
 // sshPubKeyFromSigner returns the public key of the given signer in ssh

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -38,6 +38,8 @@ func requestToMessage(req *joinv1.JoinRequest) (messages.Request, error) {
 		return iamInitToMessage(msg.IamInit)
 	case *joinv1.JoinRequest_Solution:
 		return challengeSolutionToMessage(msg.Solution)
+	case *joinv1.JoinRequest_GivingUp:
+		return givingUpToMessage(msg.GivingUp), nil
 	default:
 		return nil, trace.BadParameter("unrecognized join request message type %T", msg)
 	}
@@ -93,6 +95,12 @@ func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
 		return &joinv1.JoinRequest{
 			Payload: &joinv1.JoinRequest_Solution{
 				Solution: solution,
+			},
+		}, nil
+	case *messages.GivingUp:
+		return &joinv1.JoinRequest{
+			Payload: &joinv1.JoinRequest_GivingUp{
+				GivingUp: givingUpFromMessage(typedMsg),
 			},
 		}, nil
 	default:
@@ -444,5 +452,37 @@ func certificatesFromMessage(certs *messages.Certificates) *joinv1.Certificates 
 		TlsCaCerts: certs.TLSCACerts,
 		SshCert:    certs.SSHCert,
 		SshCaKeys:  certs.SSHCAKeys,
+	}
+}
+
+func givingUpToMessage(req *joinv1.GivingUp) *messages.GivingUp {
+	reason := messages.GivingUpReasonUnspecified
+	switch req.Reason {
+	case joinv1.GivingUp_REASON_UNSUPPORTED_JOIN_METHOD:
+		reason = messages.GivingUpReasonUnsupportedJoinMethod
+	case joinv1.GivingUp_REASON_UNSUPPORTED_MESSAGE_TYPE:
+		reason = messages.GivingUpReasonUnsupportedMessageType
+	case joinv1.GivingUp_REASON_CHALLENGE_SOLUTION_FAILED:
+		reason = messages.GivingUpReasonChallengeSolutionFailed
+	}
+	return &messages.GivingUp{
+		Reason: reason,
+		Msg:    req.Msg,
+	}
+}
+
+func givingUpFromMessage(msg *messages.GivingUp) *joinv1.GivingUp {
+	reason := joinv1.GivingUp_REASON_UNSPECIFIED
+	switch msg.Reason {
+	case messages.GivingUpReasonUnsupportedJoinMethod:
+		reason = joinv1.GivingUp_REASON_UNSUPPORTED_JOIN_METHOD
+	case messages.GivingUpReasonUnsupportedMessageType:
+		reason = joinv1.GivingUp_REASON_UNSUPPORTED_MESSAGE_TYPE
+	case messages.GivingUpReasonChallengeSolutionFailed:
+		reason = joinv1.GivingUp_REASON_CHALLENGE_SOLUTION_FAILED
+	}
+	return &joinv1.GivingUp{
+		Reason: reason,
+		Msg:    msg.Msg,
 	}
 }

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -127,9 +127,9 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 	}
 	// Set any diagnostic info we can get from the ClientInit message.
 	diag.Set(func(i *diagnostic.Info) {
-		i.Role = clientInit.SystemRole
+		i.Role = joinutils.SanitizeUntrustedString(clientInit.SystemRole)
 		if clientInit.JoinMethod != nil {
-			i.RequestedJoinMethod = *clientInit.JoinMethod
+			i.RequestedJoinMethod = joinutils.SanitizeUntrustedString(*clientInit.JoinMethod)
 		}
 	})
 	if err := clientInit.Check(); err != nil {
@@ -559,7 +559,7 @@ func rawSSHPublicKeys(authorizedKeys [][]byte) ([][]byte, error) {
 func setDiagnosticClientParams(diag *diagnostic.Diagnostic, clientParams *messages.ClientParams) {
 	if clientParams.HostParams != nil {
 		diag.Set(func(i *diagnostic.Info) {
-			i.NodeName = clientParams.HostParams.HostName
+			i.NodeName = joinutils.SanitizeUntrustedString(clientParams.HostParams.HostName)
 		})
 	}
 }

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 // handleBoundKeypairJoin handles join attempts for the bound keypair join
@@ -136,7 +137,7 @@ func AdaptRegisterUsingBoundKeypairMethod(
 	diag := diagnostic.New()
 	diag.Set(func(i *diagnostic.Info) {
 		i.RemoteAddr = req.JoinRequest.RemoteAddr
-		i.Role = req.JoinRequest.Role.String()
+		i.Role = joinutils.SanitizeUntrustedString(req.JoinRequest.Role.String())
 		i.RequestedJoinMethod = string(types.JoinMethodBoundKeypair)
 		i.BotInstanceID = req.JoinRequest.BotInstanceID
 		i.BotGeneration = uint64(req.JoinRequest.BotGeneration)


### PR DESCRIPTION
This PR adds a GivingUp message that joining clients (hosts or bots) will send when they give up on a join attempt due to some error. This should help when debugging hosts or bots that are failing to join a cluster, as they are now able to send context about why they are failing to the auth server, which will include that message in a log message and audit event. This was prompted by Edoardo's comment on RFD 27e here https://github.com/gravitational/teleport.e/pull/6963#discussion_r2250796633