### PR TITLE
Standardize MWI storage directory prep guidance

### DIFF
--- a/docs/pages/includes/machine-id/machine-id-init-bot-data.mdx
+++ b/docs/pages/includes/machine-id/machine-id-init-bot-data.mdx
@@ -1,4 +1,5 @@
-Create the bot data directory and grant permissions to access it to the Linux user (in our example, `teleport`) which `tbot` will run as.
+Create the bot data directory and grant permissions to access it to the Linux
+user (in our example, `teleport`) which `tbot` will run as.
 
 ```code
 # Make the bot directory and assign ownership to teleport user

--- a/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/linux.mdx
@@ -88,23 +88,7 @@ run has completed, but there is no tangible security benefit to doing so.
 
 ### Prepare the storage directory
 
-When using the `token` join method, `tbot` must be able to persist its state
-across restarts. The destination used to persist this state is known as the
-bot's "storage destination". In this guide, the directory
-`/var/lib/teleport/bot` will be used.
-
-As this directory will store the bots sensitive credentials, it is important
-to protect it. To do this, you will configure the directory to only be
-accessible to the Linux user which `tbot` will run as.
-
-Execute the following, replacing `teleport` with the Linux user that you will
-run `tbot` as:
-
-```code
-# Make the bot directory and assign ownership to teleport user
-$ sudo mkdir -p /var/lib/teleport/bot
-$ sudo chown teleport:teleport /var/lib/teleport/bot
-```
+(!docs/pages/includes/machine-id/machine-id-init-bot-data.mdx!)
 
 ### Create a systemd service
 

--- a/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/getting-started.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/bound-keypair/getting-started.mdx
@@ -153,6 +153,12 @@ the `.status.bound_keypair.registration_secret` field.
 
 **This step is completed on the bot host.**
 
+### Prepare a storage directory
+
+(!docs/pages/includes/machine-id/machine-id-init-bot-data.mdx!)
+
+### Create a configuration file
+
 Create `/etc/tbot.yaml`:
 
 ```yaml


### PR DESCRIPTION
Closes #15787

For the most part, all MWI how-to guides that mention `/var/lib/teleport/bot` include instructions for preparing the storage directory. This change ensures that they all use a standard partial, and includes the partial in one guide that is missing it.