### PR TITLE
[backend/lite] refactor inTransaction rollback handler

### DIFF
--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -282,7 +282,8 @@ type Backend struct {
 	cancel context.CancelFunc
 
 	// mu guards the wait group and closed flag
-	mu        sync.Mutex
+	mu sync.Mutex
+	// wg tracks outstanding transactions
 	wg        sync.WaitGroup
 	closed    bool
 	closeOnce sync.Once


### PR DESCRIPTION
This change ensures that tx.Rollback is called on every transaction regardless of error.

On a successful commit the rollback has no effect and is always safe to call.

Additionally, this commit adds transaction tracking to ensure we wait for all outstanding transactions to conclude
for the DB to release the connections. 

This fixes the flaky tests we have observed when the backend is closed during a transaction.

Towards: #60127