### PR TITLE
Mask provision token key name in error messages

### DIFF
--- a/lib/services/local/provisioning.go
+++ b/lib/services/local/provisioning.go
@@ -193,7 +193,11 @@ func (s *ProvisioningService) GetTokens(ctx context.Context) ([]types.ProvisionT
 			services.WithRevision(item.Revision),
 		)
 		if err != nil {
-			return nil, trace.Wrap(err, "unmarshaling token (key: %q)", item.Key)
+			return nil, trace.Wrap(
+				err,
+				"unmarshaling token (key: %q)",
+				backend.MaskKeyName(item.Key.String()),
+			)
 		}
 		tokens[i] = t
 	}
@@ -226,7 +230,11 @@ func (s *ProvisioningService) ListProvisionTokens(ctx context.Context, pageSize 
 			services.WithRevision(item.Revision),
 		)
 		if err != nil {
-			return nil, "", trace.Wrap(err, "unmarshaling token (key: %q)", item.Key)
+			return nil, "", trace.Wrap(
+				err,
+				"unmarshaling token (key: %q)",
+				backend.MaskKeyName(item.Key.String()),
+			)
 		}
 
 		if len(out) == pageSize {


### PR DESCRIPTION
This PR masks the name of a token in the error messages emitted when it fails to unmarshal in `lib/services`. This avoids accidentally exposing a potentially secret value within logs.

The downside is that this will make resolving issues caused by an unmarshal failure more challenging, since they'd need to determine themselves which token is causing the issue based on what is visible of the key.