### PR TITLE
Use the correct icon for the resource in session recordings list

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -163,7 +163,7 @@ export function RecordingItem({
             <ArrowRight size="small" color="text.slightlyMuted" />
 
             <ItemSpan>
-              <Server size="small" color="sessionRecording.resource" />
+              <Icon size="small" color="sessionRecording.resource" />
 
               <Text>{recording.hostname}</Text>
             </ItemSpan>


### PR DESCRIPTION
Use the correct icon for the type of resource being connected to instead of always being a server icon