### PR TITLE
[v18] Add a button to copy session ID to session recording tiles

### DIFF
--- a/web/packages/shared/components/CopyButton/CopyButton.story.tsx
+++ b/web/packages/shared/components/CopyButton/CopyButton.story.tsx
@@ -1,0 +1,35 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Input from 'design/Input';
+
+import { CopyButton as CopyButtonComponent } from './CopyButton';
+
+export default {
+  title: 'Shared',
+  component: CopyButtonComponent,
+};
+
+export const CopyButton = () => (
+  <div>
+    <CopyButtonComponent value="Surprise!" />
+    Paste here to test: <Input />
+  </div>
+);
+
+CopyButton.storyName = 'CopyButton';

--- a/web/packages/shared/components/CopyButton/CopyButton.test.tsx
+++ b/web/packages/shared/components/CopyButton/CopyButton.test.tsx
@@ -34,7 +34,7 @@ describe('CopyButton', () => {
 
     render(
       <div onClick={parentClick}>
-        <CopyButton name="copy data" />
+        <CopyButton value="copy data" />
       </div>
     );
 

--- a/web/packages/shared/components/CopyButton/CopyButton.tsx
+++ b/web/packages/shared/components/CopyButton/CopyButton.tsx
@@ -24,12 +24,15 @@ import { Check, Copy } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
 import { copyToClipboard } from 'design/utils/copyToClipboard';
 
+/**
+ * Renders a button that copies the provided value to clipboard when clicked.
+ */
 export function CopyButton({
-  name,
+  value,
   mr,
   ml,
 }: {
-  name: string;
+  value: string;
   mr?: number;
   ml?: number;
 }) {
@@ -48,10 +51,11 @@ export function CopyButton({
 
   const handleCopy: MouseEventHandler<unknown> = e => {
     e.stopPropagation(); // Prevent parent onClick callbacks from stealing the click
+    e.preventDefault(); // Also prevent clicking links
 
     clearCurrentTimeout();
     setCopiedText(copySuccess);
-    copyToClipboard(name);
+    copyToClipboard(value);
     // Change to default text after 1 second
     timeout.current = setTimeout(() => {
       setCopiedText(copyDefault);

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -27,7 +27,7 @@ import { HoverTooltip } from 'design/Tooltip';
 // eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
-import { CopyButton } from '../shared/CopyButton';
+import { CopyButton } from '../../CopyButton/CopyButton';
 import {
   BackgroundColorProps,
   getBackgroundColor,
@@ -237,7 +237,7 @@ export function ResourceCard({
                   <Text typography="body1">{name}</Text>
                 </HoverTooltip>
               </SingleLineBox>
-              {hovered && <CopyButton name={name} />}
+              {hovered && <CopyButton value={name} />}
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
               </ResourceActionButtonWrapper>

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -28,7 +28,7 @@ import { HoverTooltip } from 'design/Tooltip';
 // eslint-disable-next-line no-restricted-imports -- FIXME
 import { makeLabelTag } from 'teleport/components/formatters';
 
-import { CopyButton } from '../shared/CopyButton';
+import { CopyButton } from '../../CopyButton/CopyButton';
 import {
   BackgroundColorProps,
   getBackgroundColor,
@@ -164,7 +164,7 @@ export function ResourceListItem({
               align-self: start;
             `}
           >
-            {hovered && <CopyButton name={name} ml={1} />}
+            {hovered && <CopyButton value={name} ml={1} />}
           </Box>
         </Flex>
 

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx
@@ -29,8 +29,8 @@ import { ArrowLeft } from 'design/Icon/Icons/ArrowLeft';
 import { Indicator } from 'design/Indicator/Indicator';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
+import { CopyButton } from 'shared/components/CopyButton/CopyButton';
 import TextEditor from 'shared/components/TextEditor/TextEditor';
-import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
 
 import {
   FeatureBox,
@@ -86,7 +86,7 @@ export function BotInstanceDetails(props: {
                 <MonoText>
                   {data.bot_instance.spec.instance_id.substring(0, 7)}
                 </MonoText>
-                <CopyButton name={data.bot_instance.spec.instance_id} />
+                <CopyButton value={data.bot_instance.spec.instance_id} />
               </Flex>
             </InstanceId>
           ) : undefined}

--- a/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
+++ b/web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx
@@ -28,8 +28,8 @@ import { FetchingConfig, SortType } from 'design/DataTable/types';
 import Flex from 'design/Flex';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
+import { CopyButton } from 'shared/components/CopyButton/CopyButton';
 import { SearchPanel } from 'shared/components/Search';
-import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
 
 import { BotInstanceSummary } from 'teleport/services/bot/types';
 
@@ -108,7 +108,7 @@ export function BotInstancesList({
             <Cell>
               <Flex inline alignItems={'center'} gap={1} mr={0}>
                 <MonoText>{instanceIdDisplay}</MonoText>
-                <CopyButton name={instance_id} />
+                <CopyButton value={instance_id} />
               </Flex>
             </Cell>
           ),

--- a/web/packages/teleport/src/Bots/Details/BotDetails.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.tsx
@@ -41,9 +41,9 @@ import Menu from 'design/Menu/Menu';
 import MenuItem from 'design/Menu/MenuItem';
 import Text from 'design/Text';
 import { HoverTooltip } from 'design/Tooltip/HoverTooltip';
+import { CopyButton } from 'shared/components/CopyButton/CopyButton';
 import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
 import { traitsPreset } from 'shared/components/TraitsEditor/TraitsEditor';
-import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
 
 import {
   FeatureBox,
@@ -241,7 +241,7 @@ export function BotDetails() {
                     overflow={'hidden'}
                   >
                     <MonoText>{data.name}</MonoText>
-                    <CopyButton name={data.name} />
+                    <CopyButton value={data.name} />
                   </Flex>
                   <GridLabel>Max session duration</GridLabel>
                   {data.max_session_ttl

--- a/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
+++ b/web/packages/teleport/src/JoinTokens/JoinTokens.tsx
@@ -43,6 +43,7 @@ import Dialog, {
 } from 'design/Dialog';
 import { Warning } from 'design/Icon';
 import { HoverTooltip } from 'design/Tooltip';
+import { CopyButton } from 'shared/components/CopyButton/CopyButton';
 import { MenuButton } from 'shared/components/MenuAction';
 import {
   InfoExternalTextLink,
@@ -50,7 +51,6 @@ import {
   InfoParagraph,
   ReferenceLinks,
 } from 'shared/components/SlidingSidePanel/InfoGuide';
-import { CopyButton } from 'shared/components/UnifiedResources/shared/CopyButton';
 import { Attempt, useAsync } from 'shared/hooks/useAsync';
 
 import { useTeleport } from 'teleport';
@@ -358,7 +358,7 @@ const NameCell = ({ token }: { token: JoinToken }) => {
             visibility: ${hovered ? 'visible' : 'hidden'};
           `}
         >
-          <CopyButton name={id} />
+          <CopyButton value={id} />
         </Box>
       </Flex>
     </Cell>

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -42,6 +42,7 @@ import {
 import { IconProps } from 'design/Icon/Icon';
 import { rotate360 } from 'design/keyframes';
 import Text from 'design/Text';
+import { CopyButton } from 'shared/components/CopyButton/CopyButton';
 
 import cfg from 'teleport/config';
 import {
@@ -172,7 +173,9 @@ export function RecordingItem({
             <Text color="text.slightlyMuted" fontSize="12px" fontFamily="mono">
               {recording.sid}
             </Text>
-
+            <Box flex="1">
+              <CopyButton value={recording.sid} ml={2} />
+            </Box>
             {actions}
           </Flex>
         </RecordingDetails>


### PR DESCRIPTION
Backport #58904 to branch/v18

Files resolved manually:
- `web/packages/teleport/src/Bots/Details/BotDetails.tsx`
- `web/packages/teleport/src/Bots/Details/Instance.tsx`
- `web/packages/teleport/src/WorkloadIdentity/List/WorkloadIdentitiesList.tsx` (file deleted)
- `web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.tsx`
- `web/packages/teleport/src/BotInstances/List/BotInstancesList.tsx`