### PR TITLE
Log errors in tbot Workload API gRPC handlers

### DIFF
--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -317,7 +317,7 @@ func (s *WorkloadAPIService) authenticateClient(
 func (s *WorkloadAPIService) FetchX509SVID(
 	_ *workloadpb.X509SVIDRequest,
 	srv workloadpb.SpiffeWorkloadAPI_FetchX509SVIDServer,
-) error {
+) (err error) {
 	ctx := srv.Context()
 
 	log, creds, err := s.authenticateClient(ctx)
@@ -326,7 +326,17 @@ func (s *WorkloadAPIService) FetchX509SVID(
 	}
 
 	log.InfoContext(ctx, "FetchX509SVID stream opened by workload")
-	defer log.InfoContext(ctx, "FetchX509SVID stream has closed")
+	defer func() {
+		if err != nil {
+			s.log.ErrorContext(
+				ctx,
+				"FetchX509SVID stream closed with error",
+				"err", err,
+			)
+			return
+		}
+		s.log.InfoContext(ctx, "FetchX509SVID stream has closed")
+	}()
 
 	bundleSet, err := s.trustBundleCache.GetBundleSet(ctx)
 	if err != nil {
@@ -428,10 +438,20 @@ func (s *WorkloadAPIService) FetchX509SVID(
 func (s *WorkloadAPIService) FetchX509Bundles(
 	_ *workloadpb.X509BundlesRequest,
 	srv workloadpb.SpiffeWorkloadAPI_FetchX509BundlesServer,
-) error {
+) (err error) {
 	ctx := srv.Context()
 	s.log.InfoContext(ctx, "FetchX509Bundles stream opened by workload")
-	defer s.log.InfoContext(ctx, "FetchX509Bundles stream has closed")
+	defer func() {
+		if err != nil {
+			s.log.ErrorContext(
+				ctx,
+				"FetchX509Bundles stream closed with error",
+				"err", err,
+			)
+			return
+		}
+		s.log.InfoContext(ctx, "FetchX509Bundles stream has closed")
+	}()
 
 	for {
 		bundleSet, err := s.trustBundleCache.GetBundleSet(ctx)
@@ -547,14 +567,24 @@ func (s *WorkloadAPIService) fetchX509SVIDs(
 func (s *WorkloadAPIService) FetchJWTSVID(
 	ctx context.Context,
 	req *workloadpb.JWTSVIDRequest,
-) (*workloadpb.JWTSVIDResponse, error) {
+) (res *workloadpb.JWTSVIDResponse, err error) {
 	log, attr, err := s.authenticateClient(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err, "authenticating client")
 	}
 
 	log.InfoContext(ctx, "FetchJWTSVID request received from workload")
-	defer log.InfoContext(ctx, "FetchJWTSVID request handled")
+	defer func() {
+		if err != nil {
+			s.log.ErrorContext(
+				ctx,
+				"FetchJWTSVID request handling failed",
+				"err", err,
+			)
+			return
+		}
+		s.log.InfoContext(ctx, "FetchJWTSVID request handled")
+	}()
 	if req.SpiffeId == "" {
 		log = log.With("requested_spiffe_id", req.SpiffeId)
 	}
@@ -659,10 +689,20 @@ func (s *WorkloadAPIService) FetchJWTSVID(
 func (s *WorkloadAPIService) FetchJWTBundles(
 	_ *workloadpb.JWTBundlesRequest,
 	srv workloadpb.SpiffeWorkloadAPI_FetchJWTBundlesServer,
-) error {
+) (err error) {
 	ctx := srv.Context()
 	s.log.InfoContext(ctx, "FetchJWTBundles stream started by workload")
-	defer s.log.InfoContext(ctx, "FetchJWTBundles stream ended")
+	defer func() {
+		if err != nil {
+			s.log.ErrorContext(
+				ctx,
+				"FetchJWTBundles stream closed with error",
+				"err", err,
+			)
+			return
+		}
+		s.log.InfoContext(ctx, "FetchJWTBundles stream has closed")
+	}()
 
 	for {
 		bundleSet, err := s.trustBundleCache.GetBundleSet(ctx)
@@ -702,10 +742,19 @@ func (s *WorkloadAPIService) FetchJWTBundles(
 func (s *WorkloadAPIService) ValidateJWTSVID(
 	ctx context.Context,
 	req *workloadpb.ValidateJWTSVIDRequest,
-) (*workloadpb.ValidateJWTSVIDResponse, error) {
+) (res *workloadpb.ValidateJWTSVIDResponse, err error) {
 	s.log.InfoContext(ctx, "ValidateJWTSVID request received from workload")
-	defer s.log.InfoContext(ctx, "ValidateJWTSVID request handled")
-
+	defer func() {
+		if err != nil {
+			s.log.ErrorContext(
+				ctx,
+				"ValidateJWTSVID request handling failed",
+				"err", err,
+			)
+			return
+		}
+		s.log.InfoContext(ctx, "ValidateJWTSVID request handled")
+	}()
 	// The SPIFFE Workload API (6.2.3):
 	// > All fields in the ValidateJWTSVIDRequest and ValidateJWTSVIDResponse
 	// > message are mandatory.


### PR DESCRIPTION
Whilst errors were being sent to the client, it's not always easy to find the logs from the client and there is no guarantee the client is actually logging errors it receives. This was noted today during an incident as the Go SPIFFE SDK client, by default, does not log errors.

This PR extends the logging within the Workload API server to log any errors encountered. 

I did consider implementing this as an interceptor, and, I think I'll likely revisit this in coming weeks as I think the interceptor implementation will need deeper consideration.

changelog: The `tbot` Workload API now logs errors encountered when handling requests