### PR TITLE
MWI: Automatically report service statuses in oneshot mode

### DIFF
--- a/lib/tbot/bot/bot.go
+++ b/lib/tbot/bot/bot.go
@@ -72,26 +72,32 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	services, closer, err := b.buildServices(ctx)
+	registry := readyz.NewRegistry()
+
+	services, closer, err := b.buildServices(ctx, registry)
 	defer closer()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
+	for _, handle := range services {
+		handle.statusReporter.reporter = registry.AddService(handle.name)
+	}
+
 	b.cfg.Logger.InfoContext(ctx, "Initialization complete. Starting services")
 
 	group, groupCtx := errgroup.WithContext(ctx)
-	for _, svc := range services {
-		svc := svc
-		log := b.cfg.Logger.With("service", svc.String())
+	for _, handle := range services {
+		handle := handle
+		log := b.cfg.Logger.With("service", handle.name)
 
 		group.Go(func() error {
 			log.InfoContext(groupCtx, "Starting service")
 
-			err := svc.Run(groupCtx)
+			err := handle.service.Run(groupCtx)
 			if err != nil {
 				log.ErrorContext(ctx, "Service exited with error", "error", err)
-				return trace.Wrap(err, "service(%s)", svc.String())
+				return trace.Wrap(err, "service(%s)", handle.name)
 			}
 
 			log.InfoContext(groupCtx, "Service exited")
@@ -113,32 +119,48 @@ func (b *Bot) OneShot(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	services, closer, err := b.buildServices(ctx)
+	registry := readyz.NewRegistry()
+
+	services, closer, err := b.buildServices(ctx, registry)
 	defer closer()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	group, groupCtx := errgroup.WithContext(ctx)
-	for _, service := range services {
-		log := b.cfg.Logger.With("service", service.String())
-
-		svc, ok := service.(OneShotService)
-		if !ok {
-			log.InfoContext(ctx, "Service does not support oneshot mode, will not run")
+	// Filter out the services that don't support oneshot mode.
+	oneShotServices := make([]*serviceHandle, 0, len(services))
+	for _, handle := range services {
+		handle := handle
+		if _, ok := handle.service.(OneShotService); !ok {
+			b.cfg.Logger.InfoContext(ctx,
+				"Service does not support oneshot mode, will not run",
+				"service", handle.name,
+			)
 			continue
 		}
+
+		// Add oneshot services to the registry.
+		handle.statusReporter.reporter = registry.AddService(handle.name)
+		oneShotServices = append(oneShotServices, handle)
+	}
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	for _, handle := range oneShotServices {
+		handle := handle
+		log := b.cfg.Logger.With("service", handle.name)
 
 		group.Go(func() error {
 			log.DebugContext(groupCtx, "Running service in oneshot mode")
 
-			err := svc.OneShot(groupCtx)
+			err := handle.service.(OneShotService).OneShot(groupCtx)
 			if err != nil {
 				log.ErrorContext(ctx, "Service exited with error", "error", err)
-				return trace.Wrap(err, "service(%s)", svc.String())
+				handle.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+				return trace.Wrap(err, "service(%s)", handle.name)
 			}
 
 			log.InfoContext(groupCtx, "Service finished")
+			handle.statusReporter.Report(readyz.Healthy)
 			return nil
 		})
 	}
@@ -152,19 +174,19 @@ func (b *Bot) checkStarted() error {
 	return trace.BadParameter("bot has already been started")
 }
 
-func (b *Bot) buildServices(ctx context.Context) ([]Service, func(), error) {
+func (b *Bot) buildServices(ctx context.Context, registry *readyz.Registry) ([]*serviceHandle, func(), error) {
 	startedAt := time.Now().UTC()
-	services := make([]Service, 0, len(b.cfg.Services))
 
-	var closers []func()
+	handles := make([]*serviceHandle, 0, len(b.cfg.Services))
 	closeFn := func() {
-		for _, fn := range closers {
-			fn()
+		for _, h := range handles {
+			if h.closeFn != nil {
+				h.closeFn()
+			}
 		}
 	}
 
 	// Build internal services and dependencies.
-	statusRegistry := readyz.NewRegistry()
 	reloadBroadcaster := b.buildReloadBroadcaster(ctx)
 
 	resolver, err := b.buildResolver(ctx)
@@ -177,37 +199,33 @@ func (b *Bot) buildServices(ctx context.Context) ([]Service, func(), error) {
 		return nil, closeFn, trace.Wrap(err, "building client builder")
 	}
 
-	identityService, closeIdentityService, err := b.buildIdentityService(
+	identityService, identityServiceHandle, err := b.buildIdentityService(
 		ctx,
 		reloadBroadcaster,
 		clientBuilder,
-		statusRegistry,
 	)
 	if err != nil {
 		return nil, closeFn, trace.Wrap(err, "building identity service")
 	}
-	services = append(services, identityService)
-	closers = append(closers, closeIdentityService)
+	handles = append(handles, identityServiceHandle)
 
 	heartbeatService, err := b.buildHeartbeatService(
 		identityService,
 		startedAt,
-		statusRegistry,
 	)
 	if err != nil {
 		return nil, closeFn, trace.Wrap(err, "building heartbeat service")
 	}
-	services = append(services, heartbeatService)
+	handles = append(handles, heartbeatService)
 
 	caRotationService, err := b.buildCARotationService(
 		reloadBroadcaster,
 		identityService,
-		statusRegistry,
 	)
 	if err != nil {
 		return nil, closeFn, trace.Wrap(err, "building CA rotation service")
 	}
-	services = append(services, caRotationService)
+	handles = append(handles, caRotationService)
 
 	proxyPinger, err := b.buildProxyPinger(identityService)
 	if err != nil {
@@ -222,15 +240,15 @@ func (b *Bot) buildServices(ctx context.Context) ([]Service, func(), error) {
 	// Build user services.
 	for idx, builder := range b.cfg.Services {
 		reloadCh, unsubscribe := reloadBroadcaster.Subscribe()
-		closers = append(closers, unsubscribe)
 
-		_, name := builder.GetTypeAndName()
+		handle := &serviceHandle{
+			closeFn:        unsubscribe,
+			statusReporter: &statusReporter{},
+		}
+		handle.serviceType, handle.name = builder.GetTypeAndName()
 
-		// TODO: Defer the actual registration until we filter out services
-		// that don't run in oneshot mode.
-		reporter := statusRegistry.AddService(name)
-
-		service, err := builder.Build(ServiceDependencies{
+		var err error
+		handle.service, err = builder.Build(ServiceDependencies{
 			Client:             identityService.GetClient(),
 			Resolver:           resolver,
 			ClientBuilder:      clientBuilder,
@@ -239,19 +257,20 @@ func (b *Bot) buildServices(ctx context.Context) ([]Service, func(), error) {
 			BotIdentity:        identityService.GetIdentity,
 			BotIdentityReadyCh: identityService.Ready(),
 			ReloadCh:           reloadCh,
-			StatusRegistry:     statusRegistry,
-			StatusReporter:     reporter,
+			StatusRegistry:     registry,
+			StatusReporter:     handle.statusReporter,
 			Logger: b.cfg.Logger.With(
 				teleport.ComponentKey,
-				teleport.Component(teleport.ComponentTBot, "svc", name),
+				teleport.Component(teleport.ComponentTBot, "svc", handle.name),
 			),
 		})
 		if err != nil {
 			return nil, closeFn, trace.Wrap(err, "building service [%d]", idx)
 		}
-		services = append(services, service)
+
+		handles = append(handles, handle)
 	}
-	return services, closeFn, nil
+	return handles, closeFn, nil
 }
 
 func (b *Bot) buildReloadBroadcaster(ctx context.Context) *internal.ChannelBroadcaster {
@@ -312,10 +331,14 @@ func (b *Bot) buildIdentityService(
 	ctx context.Context,
 	reloadBroadcaster *internal.ChannelBroadcaster,
 	clientBuilder *client.Builder,
-	statusRegistry *readyz.Registry,
-) (*identity.Service, func(), error) {
-	reloadCh, unsubscribe := reloadBroadcaster.Subscribe()
+) (*identity.Service, *serviceHandle, error) {
+	handle := &serviceHandle{
+		serviceType:    "internal/identity",
+		name:           "identity",
+		statusReporter: &statusReporter{},
+	}
 
+	reloadCh, unsubscribe := reloadBroadcaster.Subscribe()
 	identityService, err := identity.NewService(identity.Config{
 		Connection:      b.cfg.Connection,
 		Onboarding:      b.cfg.Onboarding,
@@ -325,18 +348,19 @@ func (b *Bot) buildIdentityService(
 		FIPS:            b.cfg.FIPS,
 		Logger: b.cfg.Logger.With(
 			teleport.ComponentKey,
-			teleport.Component(teleport.ComponentTBot, "identity"),
+			teleport.Component(teleport.ComponentTBot, handle.name),
 		),
 		ClientBuilder:  clientBuilder,
 		ReloadCh:       reloadCh,
-		StatusReporter: statusRegistry.AddService("identity"),
+		StatusReporter: handle.statusReporter,
 	})
 	if err != nil {
 		unsubscribe()
 		return nil, nil, trace.Wrap(err, "building identity service")
 	}
 
-	close := func() {
+	handle.service = identityService
+	handle.closeFn = func() {
 		if err := identityService.Close(); err != nil {
 			b.cfg.Logger.ErrorContext(
 				ctx,
@@ -348,20 +372,24 @@ func (b *Bot) buildIdentityService(
 	}
 
 	if err := identityService.Initialize(ctx); err != nil {
-		close()
+		handle.closeFn()
 		return nil, nil, trace.Wrap(err, "initializing identity service")
 	}
-
-	return identityService, close, nil
+	return identityService, handle, nil
 }
 
 func (b *Bot) buildHeartbeatService(
 	identityService *identity.Service,
 	startedAt time.Time,
-	statusRegistry *readyz.Registry,
-) (*heartbeat.Service, error) {
-	return heartbeat.NewService(heartbeat.Config{
-		BotKind:            machineidv1.BotKind(b.cfg.Kind),
+) (*serviceHandle, error) {
+	handle := &serviceHandle{
+		serviceType:    "internal/heartbeat",
+		name:           "heartbeat",
+		statusReporter: &statusReporter{},
+	}
+
+	var err error
+	handle.service, err = heartbeat.NewService(heartbeat.Config{
 		Interval:           30 * time.Minute,
 		RetryLimit:         5,
 		Client:             machineidv1.NewBotInstanceServiceClient(identityService.GetClient().GetConnection()),
@@ -369,10 +397,15 @@ func (b *Bot) buildHeartbeatService(
 		StartedAt:          startedAt,
 		JoinMethod:         b.cfg.Onboarding.JoinMethod,
 		Logger: b.cfg.Logger.With(
-			teleport.ComponentKey, teleport.Component(teleport.ComponentTBot, "heartbeat"),
+			teleport.ComponentKey,
+			teleport.Component(teleport.ComponentTBot, handle.name),
 		),
-		StatusReporter: statusRegistry.AddService("heartbeat"),
+		StatusReporter: handle.statusReporter,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return handle, nil
 }
 
 func (b *Bot) buildProxyPinger(identityService *identity.Service) (connection.ProxyPinger, error) {
@@ -389,17 +422,62 @@ func (b *Bot) buildProxyPinger(identityService *identity.Service) (connection.Pr
 func (b *Bot) buildCARotationService(
 	reloadBroadcaster *internal.ChannelBroadcaster,
 	identityService *identity.Service,
-	statusRegistry *readyz.Registry,
-) (*carotation.Service, error) {
-	return carotation.NewService(carotation.Config{
+) (*serviceHandle, error) {
+	handle := &serviceHandle{
+		serviceType:    "internal/ca-rotation",
+		name:           "ca-rotation",
+		statusReporter: &statusReporter{},
+	}
+
+	var err error
+	handle.service, err = carotation.NewService(carotation.Config{
 		BroadcastFn:        reloadBroadcaster.Broadcast,
 		Client:             identityService.GetClient(),
 		GetBotIdentityFn:   identityService.GetIdentity,
 		BotIdentityReadyCh: identityService.Ready(),
 		Logger: b.cfg.Logger.With(
 			teleport.ComponentKey,
-			teleport.Component(teleport.ComponentTBot, "ca-rotation"),
+			teleport.Component(teleport.ComponentTBot, handle.name),
 		),
-		StatusReporter: statusRegistry.AddService("ca-rotation"),
+		StatusReporter: handle.statusReporter,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return handle, nil
+}
+
+// serviceHandle contains a built service, its type/name, close function, and a
+// pointer to its status reporter - so we can automatically report statuses for
+// oneshot services.
+type serviceHandle struct {
+	serviceType, name string
+	service           Service
+	statusReporter    *statusReporter
+	closeFn           func()
+}
+
+// statusReporter wraps readyz.Reporter to break a circular dependency where:
+//
+//   - We need a status reporter to build a service
+//   - We must register the service in order to get the status reporter
+//   - We may not want to register the service in one-shot mode if it does not
+//     implement OneShotService
+//   - We can only know whether the service implements OneShotService after
+//     we've built it
+//
+// This wrapper allows us to defer the actual registration until we know whether
+// the service implements OneShotService.
+type statusReporter struct{ reporter readyz.Reporter }
+
+func (r *statusReporter) Report(status readyz.Status) {
+	if r.reporter != nil {
+		r.reporter.Report(status)
+	}
+}
+
+func (r *statusReporter) ReportReason(status readyz.Status, reason string) {
+	if r.reporter != nil {
+		r.reporter.ReportReason(status, reason)
+	}
 }

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -20,6 +20,7 @@ package bot
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"golang.org/x/sync/errgroup"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/client"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // Service is a long-running sub-component of tbot.
@@ -114,8 +116,14 @@ func NewServiceBuilder(
 	serviceType, name string,
 	buildFn func(ServiceDependencies) (Service, error),
 ) ServiceBuilder {
+	if name == "" {
+		suffix, _ := utils.CryptoRandomHex(4)
+		name = fmt.Sprintf("%s-%s", serviceType, suffix)
+	}
 	return &serviceBuilder{
-		buildFn: buildFn,
+		serviceType: serviceType,
+		name:        name,
+		buildFn:     buildFn,
 	}
 }
 

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -117,6 +117,13 @@ func NewServiceBuilder(
 	buildFn func(ServiceDependencies) (Service, error),
 ) ServiceBuilder {
 	if name == "" {
+		// The tbot binary will set default service names, so name could only
+		// realistically be empty if the bot were embedded somewhere else (e.g.
+		// the Terraform provider) in which case a randomly generated name is
+		// better than nothing.
+		//
+		// We do not handle the error from CryptoRandHex because the underlying
+		// call to rand.Read will never fail.
 		suffix, _ := utils.CryptoRandomHex(4)
 		name = fmt.Sprintf("%s-%s", serviceType, suffix)
 	}

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -93,9 +93,15 @@ type ServiceDependencies struct {
 	// it's time to reload their certificates (e.g. following a CA rotation).
 	ReloadCh <-chan struct{}
 
-	// StatusReporter is the reporter to which the service should report its
-	// health.
-	StatusReporter readyz.Reporter
+	// GetStatusReporter return the reporter to which the service should report
+	// its health.
+	//
+	// If a ServiceBuilder calls GetStatusReporter the service's Run method *MUST*
+	// call Report or ReportReason, otherwise it will delay the initial heartbeat
+	// and the `/readyz` endpoint will return 503. You do not have to do this in
+	// your service's OneShot method as we will automatically report status based
+	// on its return value.
+	GetStatusReporter func() readyz.Reporter
 
 	// StatusRegistry can be used to read the health of the bot's services.
 	StatusRegistry readyz.ReadOnlyRegistry

--- a/lib/tbot/bot/service.go
+++ b/lib/tbot/bot/service.go
@@ -93,14 +93,16 @@ type ServiceDependencies struct {
 	// it's time to reload their certificates (e.g. following a CA rotation).
 	ReloadCh <-chan struct{}
 
-	// GetStatusReporter return the reporter to which the service should report
+	// GetStatusReporter returns the reporter to which the service should report
 	// its health.
 	//
 	// If a ServiceBuilder calls GetStatusReporter the service's Run method *MUST*
-	// call Report or ReportReason, otherwise it will delay the initial heartbeat
-	// and the `/readyz` endpoint will return 503. You do not have to do this in
-	// your service's OneShot method as we will automatically report status based
-	// on its return value.
+	// call Report or ReportReason (or if using internal.RunOnInterval pass it the
+	// reporter) otherwise it will delay the initial heartbeat and the `/readyz`
+	// endpoint will return 503.
+	//
+	// You do not have to do this in your service's OneShot method as the bot
+	// will automatically report oneshot service status based on its return value.
 	GetStatusReporter func() readyz.Reporter
 
 	// StatusRegistry can be used to read the health of the bot's services.

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -103,6 +103,10 @@ type BotConfig struct {
 	// renewal.
 	ReloadCh <-chan struct{} `yaml:"-"`
 
+	// Testing is set in unit tests to attach a faux service which exposes the
+	// bot's underlying identity and client so we can make assertions on it.
+	Testing bool `yaml:"-"`
+
 	// Insecure configures the bot to trust the certificates from the Auth Server or Proxy on first connect without verification.
 	// Do not use in production.
 	Insecure bool `yaml:"insecure,omitempty"`

--- a/lib/tbot/internal/diagnostics/service.go
+++ b/lib/tbot/internal/diagnostics/service.go
@@ -36,9 +36,10 @@ import (
 
 // ServiceBuilder returns a builder for the diagnostics service.
 func ServiceBuilder(cfg Config) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		return NewService(cfg, deps.StatusRegistry)
 	}
+	return bot.NewServiceBuilder("internal/diagnostics", "diagnostics", buildFn)
 }
 
 // Config contains configuration for the diagnostics service.
@@ -59,7 +60,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 }
 
 // NewService creates a new diagnostics service.
-func NewService(cfg Config, registry *readyz.Registry) (*Service, error) {
+func NewService(cfg Config, registry readyz.ReadOnlyRegistry) (*Service, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -80,7 +81,7 @@ type Service struct {
 	log            *slog.Logger
 	diagAddr       string
 	pprofEnabled   bool
-	statusRegistry *readyz.Registry
+	statusRegistry readyz.ReadOnlyRegistry
 }
 
 func (s *Service) String() string {

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -401,8 +401,10 @@ func (s *Service) Run(ctx context.Context) error {
 	// etc)
 	storageDestination := s.cfg.Destination
 
-	// Keep retrying renewal if it failed on startup.
-	if !s.IsReady() {
+	if s.IsReady() {
+		s.cfg.StatusReporter.Report(readyz.Healthy)
+	} else {
+		// Keep retrying renewal if it failed on startup.
 		retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
 			Driver: retryutils.NewExponentialDriver(1 * time.Second),
 			Max:    1 * time.Minute,

--- a/lib/tbot/readyz/http.go
+++ b/lib/tbot/readyz/http.go
@@ -26,9 +26,16 @@ import (
 	"net/http"
 )
 
+// ReadOnlyRegistry is a version of the Registry which can only be read from,
+// not reported to.
+type ReadOnlyRegistry interface {
+	ServiceStatus(name string) (*ServiceStatus, bool)
+	OverallStatus() *OverallStatus
+}
+
 // HTTPHandler returns an HTTP handler that implements tbot's
 // /readyz(/{service}) endpoints.
-func HTTPHandler(reg *Registry) http.Handler {
+func HTTPHandler(reg ReadOnlyRegistry) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.Handle("/readyz/{service}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -38,7 +38,7 @@ import (
 )
 
 func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -51,11 +51,12 @@ func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.Crede
 			reloadCh:                  deps.ReloadCh,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(OutputServiceType, cfg.Name, buildFn)
 }
 
 // OutputService generates the artifacts necessary to connect to a

--- a/lib/tbot/services/application/output_service.go
+++ b/lib/tbot/services/application/output_service.go
@@ -52,7 +52,7 @@ func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.Crede
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/application/proxy_service.go
+++ b/lib/tbot/services/application/proxy_service.go
@@ -68,7 +68,7 @@ func ProxyServiceBuilder(
 			clientBuilder:             deps.ClientBuilder,
 			alpnUpgradeCache:          alpnUpgradeCache,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/application/proxy_service.go
+++ b/lib/tbot/services/application/proxy_service.go
@@ -52,7 +52,7 @@ func ProxyServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 	alpnUpgradeCache *internal.ALPNUpgradeCache,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -67,12 +67,12 @@ func ProxyServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			alpnUpgradeCache:          alpnUpgradeCache,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(ProxyServiceType, cfg.Name, buildFn)
 }
 
 // ProxyService presents a http_proxy compatible proxy on a listener which will

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -45,7 +45,7 @@ func TunnelServiceBuilder(
 	connCfg connection.Config,
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -59,11 +59,12 @@ func TunnelServiceBuilder(
 			cfg:                       cfg,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(TunnelServiceType, cfg.Name, buildFn)
 }
 
 // TunnelService is a service that listens on a socket and forwards

--- a/lib/tbot/services/application/tunnel_service.go
+++ b/lib/tbot/services/application/tunnel_service.go
@@ -60,7 +60,7 @@ func TunnelServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/awsra/service.go
+++ b/lib/tbot/services/awsra/service.go
@@ -61,7 +61,7 @@ func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
 			identityGenerator:  deps.IdentityGenerator,
 			clientBuilder:      deps.ClientBuilder,
 			log:                deps.Logger,
-			statusReporter:     deps.StatusReporter,
+			statusReporter:     deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/awsra/service.go
+++ b/lib/tbot/services/awsra/service.go
@@ -49,7 +49,7 @@ import (
 var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/services/awsra")
 
 func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -60,11 +60,12 @@ func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
 			reloadCh:           deps.ReloadCh,
 			identityGenerator:  deps.IdentityGenerator,
 			clientBuilder:      deps.ClientBuilder,
+			log:                deps.Logger,
+			statusReporter:     deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(ServiceType, cfg.Name, buildFn)
 }
 
 // Service is a service that retrieves X.509 certificates and exchanges them for

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -38,7 +38,7 @@ import (
 // Note: when using the client credentials service to provide credentials to
 // another service (e.g. the SPIFFE Workload API service) use NewSidecar instead.
 func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -49,11 +49,12 @@ func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifeti
 			cfg:                cfg,
 			reloadCh:           deps.ReloadCh,
 			identityGenerator:  deps.IdentityGenerator,
+			log:                deps.Logger,
+			statusReporter:     deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(ServiceType, cfg.Name, buildFn)
 }
 
 // NewSidecar creates a client credential service intended to provide credentials
@@ -68,8 +69,8 @@ func NewSidecar(deps bot.ServiceDependencies, credentialLifetime bot.CredentialL
 		reloadCh:           deps.ReloadCh,
 		identityGenerator:  deps.IdentityGenerator,
 		statusReporter:     readyz.NoopReporter(),
+		log:                deps.Logger,
 	}
-	svc.log = deps.LoggerForService(svc)
 	return svc, cfg
 }
 

--- a/lib/tbot/services/clientcredentials/service.go
+++ b/lib/tbot/services/clientcredentials/service.go
@@ -50,7 +50,7 @@ func ServiceBuilder(cfg *UnstableConfig, credentialLifetime bot.CredentialLifeti
 			reloadCh:           deps.ReloadCh,
 			identityGenerator:  deps.IdentityGenerator,
 			log:                deps.Logger,
-			statusReporter:     deps.StatusReporter,
+			statusReporter:     deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/database/output_service.go
+++ b/lib/tbot/services/database/output_service.go
@@ -38,7 +38,7 @@ import (
 )
 
 func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -50,11 +50,12 @@ func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.Crede
 			reloadCh:                  deps.ReloadCh,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(OutputServiceType, cfg.Name, buildFn)
 }
 
 // OutputService generates the artifacts necessary to connect to a

--- a/lib/tbot/services/database/output_service.go
+++ b/lib/tbot/services/database/output_service.go
@@ -51,7 +51,7 @@ func OutputServiceBuilder(cfg *OutputConfig, defaultCredentialLifetime bot.Crede
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -46,7 +46,7 @@ func TunnelServiceBuilder(
 	connCfg connection.Config,
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -60,11 +60,12 @@ func TunnelServiceBuilder(
 			botIdentityReadyCh:        deps.BotIdentityReadyCh,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(TunnelServiceType, cfg.Name, buildFn)
 }
 
 // TunnelService is a service that listens on a local port and forwards

--- a/lib/tbot/services/database/tunnel_service.go
+++ b/lib/tbot/services/database/tunnel_service.go
@@ -61,7 +61,7 @@ func TunnelServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/example/service.go
+++ b/lib/tbot/services/example/service.go
@@ -31,12 +31,13 @@ import (
 
 // ServiceBuilder returns an example service builder.
 func ServiceBuilder(cfg *Config) bot.ServiceBuilder {
-	return func(bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
 		return &Service{cfg: cfg}, nil
 	}
+	return bot.NewServiceBuilder(ServiceType, cfg.Name, buildFn)
 }
 
 // Service is a temporary example service for testing purposes. It is not

--- a/lib/tbot/services/identity/output.go
+++ b/lib/tbot/services/identity/output.go
@@ -50,7 +50,7 @@ func OutputServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 	insecure, fips bool,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -67,11 +67,12 @@ func OutputServiceBuilder(
 			proxyPinger:               deps.ProxyPinger,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(OutputServiceType, cfg.Name, buildFn)
 }
 
 // OutputService produces credentials which can be used to connect to

--- a/lib/tbot/services/identity/output.go
+++ b/lib/tbot/services/identity/output.go
@@ -68,7 +68,7 @@ func OutputServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -67,7 +67,7 @@ func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) 
 			reloadCh:                  deps.ReloadCh,
 			botIdentityReadyCh:        deps.BotIdentityReadyCh,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 
 		for _, opt := range opts {

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -52,7 +52,7 @@ import (
 
 // ArgoCDServiceBuilder builds a new ArgoCDOutput.
 func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -66,6 +66,8 @@ func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) 
 			clientBuilder:             deps.ClientBuilder,
 			reloadCh:                  deps.ReloadCh,
 			botIdentityReadyCh:        deps.BotIdentityReadyCh,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
 
 		for _, opt := range opts {
@@ -81,15 +83,13 @@ func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) 
 			}
 		}
 
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
-
 		if svc.alpnUpgradeCache == nil {
 			svc.alpnUpgradeCache = internal.NewALPNUpgradeCache(svc.log)
 		}
 
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(ArgoCDOutputServiceType, cfg.Name, buildFn)
 }
 
 // ArgoCDServiceOption is an option that can be provided to customize the service.

--- a/lib/tbot/services/k8s/output_v1.go
+++ b/lib/tbot/services/k8s/output_v1.go
@@ -67,7 +67,7 @@ func OutputV1ServiceBuilder(cfg *OutputV1Config, opts ...OutputV1Option) bot.Ser
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		for _, opt := range opts {
 			opt.applyToV1Output(svc)

--- a/lib/tbot/services/k8s/output_v1.go
+++ b/lib/tbot/services/k8s/output_v1.go
@@ -52,7 +52,7 @@ import (
 const defaultKubeconfigPath = "kubeconfig.yaml"
 
 func OutputV1ServiceBuilder(cfg *OutputV1Config, opts ...OutputV1Option) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -66,14 +66,15 @@ func OutputV1ServiceBuilder(cfg *OutputV1Config, opts ...OutputV1Option) bot.Ser
 			executablePath:            autoupdate.StableExecutable,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
 		for _, opt := range opts {
 			opt.applyToV1Output(svc)
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(OutputV1ServiceType, cfg.Name, buildFn)
 }
 
 // OutputV1Option is an option that can be provided to customize the service.

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -52,7 +52,7 @@ import (
 )
 
 func OutputV2ServiceBuilder(cfg *OutputV2Config, opts ...OutputV2Option) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -66,14 +66,15 @@ func OutputV2ServiceBuilder(cfg *OutputV2Config, opts ...OutputV2Option) bot.Ser
 			executablePath:            autoupdate.StableExecutable,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
 		for _, opt := range opts {
 			opt.applyToV2Output(svc)
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(OutputV2ServiceType, cfg.Name, buildFn)
 }
 
 // OutputV1Option is an option that can be provided to customize the service.

--- a/lib/tbot/services/k8s/output_v2.go
+++ b/lib/tbot/services/k8s/output_v2.go
@@ -67,7 +67,7 @@ func OutputV2ServiceBuilder(cfg *OutputV2Config, opts ...OutputV2Option) bot.Ser
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		for _, opt := range opts {
 			opt.applyToV2Output(svc)

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -44,7 +44,7 @@ import (
 )
 
 func HostOutputServiceBuilder(cfg *HostOutputConfig, defaultCredentialLifetime bot.CredentialLifetime) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -56,11 +56,12 @@ func HostOutputServiceBuilder(cfg *HostOutputConfig, defaultCredentialLifetime b
 			reloadCh:                  deps.ReloadCh,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(HostOutputServiceType, cfg.Name, buildFn)
 }
 
 type HostOutputService struct {

--- a/lib/tbot/services/ssh/host_output.go
+++ b/lib/tbot/services/ssh/host_output.go
@@ -57,7 +57,7 @@ func HostOutputServiceBuilder(cfg *HostOutputConfig, defaultCredentialLifetime b
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/ssh/multiplexer.go
+++ b/lib/tbot/services/ssh/multiplexer.go
@@ -116,7 +116,7 @@ func MultiplexerServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/ssh/multiplexer.go
+++ b/lib/tbot/services/ssh/multiplexer.go
@@ -99,7 +99,7 @@ func MultiplexerServiceBuilder(
 	defaultCredentialLifetime bot.CredentialLifetime,
 	clientMetrics *grpcprom.ClientMetrics,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -115,11 +115,12 @@ func MultiplexerServiceBuilder(
 			reloadCh:                  deps.ReloadCh,
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(MultiplexerServiceType, cfg.Name, buildFn)
 }
 
 // MultiplexerService is a long-lived local SSH proxy. It listens on a local Unix

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -42,7 +42,7 @@ func JWTOutputServiceBuilder(
 	trustBundleCache TrustBundleGetter,
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -54,11 +54,12 @@ func JWTOutputServiceBuilder(
 			identityGenerator:         deps.IdentityGenerator,
 			clientBuilder:             deps.ClientBuilder,
 			trustBundleCache:          trustBundleCache,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(JWTOutputServiceType, cfg.Name, buildFn)
 }
 
 // JWTOutputService is a service that retrieves JWT workload identity

--- a/lib/tbot/services/workloadidentity/jwt_output.go
+++ b/lib/tbot/services/workloadidentity/jwt_output.go
@@ -55,7 +55,7 @@ func JWTOutputServiceBuilder(
 			clientBuilder:             deps.ClientBuilder,
 			trustBundleCache:          trustBundleCache,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -64,7 +64,7 @@ func WorkloadAPIServiceBuilder(
 	crlCache CRLGetter,
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -76,11 +76,12 @@ func WorkloadAPIServiceBuilder(
 			trustBundleCache:          trustBundleCache,
 			crlCache:                  crlCache,
 			clientBuilder:             deps.ClientBuilder,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return bot.NewServicePair(svc, sidecar), nil
 	}
+	return bot.NewServiceBuilder(WorkloadAPIServiceType, cfg.Name, buildFn)
 }
 
 // WorkloadAPIService implements a gRPC server that fulfills the SPIFFE

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -77,7 +77,7 @@ func WorkloadAPIServiceBuilder(
 			crlCache:                  crlCache,
 			clientBuilder:             deps.ClientBuilder,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return bot.NewServicePair(svc, sidecar), nil
 	}

--- a/lib/tbot/services/workloadidentity/workload_api_test.go
+++ b/lib/tbot/services/workloadidentity/workload_api_test.go
@@ -130,8 +130,8 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 		Logger:     log,
 		Onboarding: *onboarding,
 		Services: []bot.ServiceBuilder{
-			trustBundleCache.BuildService,
-			crlCache.BuildService,
+			trustBundleCache.Builder(),
+			crlCache.Builder(),
 			WorkloadAPIServiceBuilder(
 				&WorkloadAPIConfig{
 					Selector: bot.WorkloadIdentitySelector{

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -55,7 +55,7 @@ func X509OutputServiceBuilder(
 	crlCache CRLGetter,
 	defaultCredentialLifetime bot.CredentialLifetime,
 ) bot.ServiceBuilder {
-	return func(deps bot.ServiceDependencies) (bot.Service, error) {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
 		if err := cfg.CheckAndSetDefaults(); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -68,11 +68,12 @@ func X509OutputServiceBuilder(
 			clientBuilder:             deps.ClientBuilder,
 			trustBundleCache:          trustBundleCache,
 			crlCache:                  crlCache,
+			log:                       deps.Logger,
+			statusReporter:            deps.StatusReporter,
 		}
-		svc.log = deps.LoggerForService(svc)
-		svc.statusReporter = deps.StatusRegistry.AddService(svc.String())
 		return svc, nil
 	}
+	return bot.NewServiceBuilder(X509OutputServiceType, cfg.Name, buildFn)
 }
 
 // X509OutputService is a service that retrieves X.509 certificates

--- a/lib/tbot/services/workloadidentity/x509_output.go
+++ b/lib/tbot/services/workloadidentity/x509_output.go
@@ -69,7 +69,7 @@ func X509OutputServiceBuilder(
 			trustBundleCache:          trustBundleCache,
 			crlCache:                  crlCache,
 			log:                       deps.Logger,
-			statusReporter:            deps.StatusReporter,
+			statusReporter:            deps.GetStatusReporter(),
 		}
 		return svc, nil
 	}

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -172,15 +172,18 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 
 	// This faux service allows us to get the bot's internal identity and client
 	// for tests, without exposing them on the core bot.Bot struct.
-	services = append(services, func(deps bot.ServiceDependencies) (bot.Service, error) {
-		b.mu.Lock()
-		defer b.mu.Unlock()
+	services = append(services,
+		bot.NewServiceBuilder("internal/client-fetcher", "client-fetcher",
+			func(deps bot.ServiceDependencies) (bot.Service, error) {
+				b.mu.Lock()
+				defer b.mu.Unlock()
 
-		b.identity = deps.BotIdentity
-		b.client = deps.Client
+				b.identity = deps.BotIdentity
+				b.client = deps.Client
 
-		return bot.NewNopService("client-fetcher"), nil
-	})
+				return bot.NewNopService("client-fetcher"), nil
+			}),
+	)
 
 	// We only want to create this service if it's needed by a dependent
 	// service.
@@ -193,7 +196,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			return trustBundleCache
 		}
 		trustBundleCache = workloadidentity.NewTrustBundleCacheFacade()
-		services = append(services, trustBundleCache.BuildService)
+		services = append(services, trustBundleCache.Builder())
 		return trustBundleCache
 	}
 
@@ -206,7 +209,7 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 			return crlCache
 		}
 		crlCache = workloadidentity.NewCRLCacheFacade()
-		services = append(services, crlCache.BuildService)
+		services = append(services, crlCache.Builder())
 		return crlCache
 	}
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -172,18 +172,20 @@ func (b *Bot) Run(ctx context.Context) (err error) {
 
 	// This faux service allows us to get the bot's internal identity and client
 	// for tests, without exposing them on the core bot.Bot struct.
-	services = append(services,
-		bot.NewServiceBuilder("internal/client-fetcher", "client-fetcher",
-			func(deps bot.ServiceDependencies) (bot.Service, error) {
-				b.mu.Lock()
-				defer b.mu.Unlock()
+	if b.cfg.Testing {
+		services = append(services,
+			bot.NewServiceBuilder("internal/client-fetcher", "client-fetcher",
+				func(deps bot.ServiceDependencies) (bot.Service, error) {
+					b.mu.Lock()
+					defer b.mu.Unlock()
 
-				b.identity = deps.BotIdentity
-				b.client = deps.Client
+					b.identity = deps.BotIdentity
+					b.client = deps.Client
 
-				return bot.NewNopService("client-fetcher"), nil
-			}),
-	)
+					return bot.NewNopService("client-fetcher"), nil
+				}),
+		)
+	}
 
 	// We only want to create this service if it's needed by a dependent
 	// service.

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -185,6 +185,7 @@ func defaultBotConfig(
 		// certs.
 		Insecure: opts.insecure,
 		Services: serviceConfigs,
+		Testing:  true,
 	}
 
 	require.NoError(t, cfg.CheckAndSetDefaults())
@@ -1308,6 +1309,7 @@ func TestBotJoiningURI(t *testing.T) {
 		},
 		Oneshot:  true,
 		Insecure: true,
+		Testing:  true,
 	}
 	require.NoError(t, cfg.CheckAndSetDefaults())
 

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
@@ -83,29 +82,29 @@ type CRLCacheFacade struct {
 	crlCache *CRLCache
 }
 
-// BuildService implements bot.ServiceBuilder to build the CRLCache once when the
-// bot starts up.
-func (f *CRLCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+// Builder returns a bot.ServiceBuilder to build the CRLCache once when the bot
+// starts up.
+func (f *CRLCacheFacade) Builder() bot.ServiceBuilder {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
 
-	if f.crlCache == nil {
-		var err error
-		f.crlCache, err = NewCRLCache(CRLCacheConfig{
-			RevocationsClient: deps.Client.WorkloadIdentityRevocationServiceClient(),
-			Logger: deps.Logger.With(
-				teleport.ComponentKey,
-				teleport.Component(teleport.ComponentTBot, "crl-cache"),
-			),
-			StatusReporter: deps.StatusRegistry.AddService("crl-cache"),
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
+		if f.crlCache == nil {
+			var err error
+			f.crlCache, err = NewCRLCache(CRLCacheConfig{
+				RevocationsClient: deps.Client.WorkloadIdentityRevocationServiceClient(),
+				Logger:            deps.Logger,
+				StatusReporter:    deps.StatusReporter,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			close(f.ready)
 		}
-		close(f.ready)
-	}
 
-	return f.crlCache, nil
+		return f.crlCache, nil
+	}
+	return bot.NewServiceBuilder("internal/crl-cache", "crl-cache", buildFn)
 }
 
 func (m *CRLCacheFacade) GetCRLSet(ctx context.Context) (*CRLSet, error) {

--- a/lib/tbot/workloadidentity/crl_cache.go
+++ b/lib/tbot/workloadidentity/crl_cache.go
@@ -94,7 +94,7 @@ func (f *CRLCacheFacade) Builder() bot.ServiceBuilder {
 			f.crlCache, err = NewCRLCache(CRLCacheConfig{
 				RevocationsClient: deps.Client.WorkloadIdentityRevocationServiceClient(),
 				Logger:            deps.Logger,
-				StatusReporter:    deps.StatusReporter,
+				StatusReporter:    deps.GetStatusReporter(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -234,7 +234,7 @@ func (f *TrustBundleCacheFacade) Builder() bot.ServiceBuilder {
 				ClusterName:        deps.BotIdentity().ClusterName,
 				BotIdentityReadyCh: deps.BotIdentityReadyCh,
 				Logger:             deps.Logger,
-				StatusReporter:     deps.StatusReporter,
+				StatusReporter:     deps.GetStatusReporter(),
 			})
 			if err != nil {
 				return nil, trace.Wrap(err)

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -34,7 +34,6 @@ import (
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"go.opentelemetry.io/otel"
 
-	"github.com/gravitational/teleport"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	trustv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -219,33 +218,37 @@ func NewTrustBundleCacheFacade() *TrustBundleCacheFacade {
 	return &TrustBundleCacheFacade{ready: make(chan struct{})}
 }
 
-// BuildService implements bot.ServiceBuilder to build the TrustBundleCache once
-// when the bot starts up.
-func (f *TrustBundleCacheFacade) BuildService(deps bot.ServiceDependencies) (bot.Service, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+// Builder returns a bot.ServiceBuilder to build the TrustBundleCache when the
+// bot starts up.
+func (f *TrustBundleCacheFacade) Builder() bot.ServiceBuilder {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
 
-	if f.bundleCache == nil {
-		var err error
-		f.bundleCache, err = NewTrustBundleCache(TrustBundleCacheConfig{
-			FederationClient:   deps.Client.SPIFFEFederationServiceClient(),
-			TrustClient:        deps.Client.TrustClient(),
-			EventsClient:       deps.Client,
-			ClusterName:        deps.BotIdentity().ClusterName,
-			BotIdentityReadyCh: deps.BotIdentityReadyCh,
-			Logger: deps.Logger.With(
-				teleport.ComponentKey,
-				teleport.Component(teleport.ComponentTBot, "spiffe-trust-bundle-cache"),
-			),
-			StatusReporter: deps.StatusRegistry.AddService("spiffe-trust-bundle-cache"),
-		})
-		if err != nil {
-			return nil, trace.Wrap(err)
+		if f.bundleCache == nil {
+			var err error
+			f.bundleCache, err = NewTrustBundleCache(TrustBundleCacheConfig{
+				FederationClient:   deps.Client.SPIFFEFederationServiceClient(),
+				TrustClient:        deps.Client.TrustClient(),
+				EventsClient:       deps.Client,
+				ClusterName:        deps.BotIdentity().ClusterName,
+				BotIdentityReadyCh: deps.BotIdentityReadyCh,
+				Logger:             deps.Logger,
+				StatusReporter:     deps.StatusReporter,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			close(f.ready)
 		}
-		close(f.ready)
+		return f.bundleCache, nil
 	}
 
-	return f.bundleCache, nil
+	return bot.NewServiceBuilder(
+		"internal/spiffe-trust-bundle-cache",
+		"spiffe-trust-bundle-cache",
+		buildFn,
+	)
 }
 
 func (f *TrustBundleCacheFacade) GetBundleSet(ctx context.Context) (*BundleSet, error) {


### PR DESCRIPTION
As of #60093, `tbot` will include the health of its services in heartbeats. It will also wait until all services have reported their health before sending the first heartbeat.

Unfortunately, this doesn't currently work on `--oneshot` mode, as most services do not report statuses from their `OneShot` method; because the `/readyz` endpoint is only really used when running `tbot` as a daemon, so there was previously no need.

Now, we'll automatically report service health based on whether the service's `OneShot` method returns an error.

To achieve this I've refactored things such that:

- The logger and status report are created "for you" rather than your service builder needing to create them
- The service builder exposes the service type and name
- If a service builder calls `ServiceDependencies.GetStatusReporter` we take that as a promise that the service's `Run` method will report statuses
