### PR TITLE
[v18] Fix empty example value in MWI reference documentation

### DIFF
--- a/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-id/configuration.mdx
@@ -1542,10 +1542,10 @@ name: my-secret
 # When using the Helm chart, and specifying a namespace other than the one that
 # `tbot` is running in, you must manually grant the `tbot` service account
 # privileges to read and write to secrets in that namespace.
-namespace:
+namespace: default
 # labels specifies the labels to apply to the Kubernetes Secret. This field is
 # optional.
-tags:
+labels:
   example: "foo"
 ```
 


### PR DESCRIPTION
Backport #60138 to branch/v18