### PR TITLE
Add eventschema-up-to-date to lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -267,6 +267,10 @@ jobs:
         # The protoc-gen-terraform version must match the version in integrations/terraform/Makefile
         run: git config --global --add safe.directory $(realpath .) && go install github.com/gravitational/protoc-gen-terraform/v3@v3.0.2 && make terraform-resources-up-to-date
 
+      - name: Check if event schema is up to date
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: git config --global --add safe.directory $(realpath .) && make eventschema-up-to-date
+
   lint-rfd:
     name: Lint (RFD)
     needs: changes

--- a/Makefile
+++ b/Makefile
@@ -1623,6 +1623,15 @@ derive-up-to-date: must-start-clean/host derive
 		exit 1; \
 	fi
 
+
+.PHONY: eventschema-up-to-date
+eventschema-up-to-date: must-start-clean/host
+	$(MAKE) -C build.assets generate-eventschema
+	@if ! git diff --quiet; then \
+		./build.assets/please-run.sh "event schema" "make generate-eventschema"; \
+		exit 1; \
+	fi
+
 # grpc generates gRPC stubs from service definitions.
 # This target runs in the buildbox container.
 .PHONY: grpc

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -348,6 +348,12 @@ grpc: grpcbox
 protos-up-to-date: grpcbox
 	$(GRPCBOX_RUN) make protos-up-to-date/host
 
+# eventschema-up-to-date checks if event schema is up to date from inside the buildbox
+.PHONY: eventschema-up-to-date
+eventschema-up-to-date: buildbox
+	docker run $(DOCKERFLAGS) $(NOROOT) -t $(BUILDBOX) \
+		/bin/bash -c "make -C $(SRCDIR) eventschema-up-to-date"
+
 # fix-imports runs GCI to sort and re-order Go imports in a deterministic way.
 .PHONY: fix-imports
 fix-imports: buildbox


### PR DESCRIPTION
### What

Mitigate issues like:  https://github.com/gravitational/teleport/issues/57606 caused by outdated Access Monitoring Athena Schema - [Access Monitoring Docs](https://goteleport.com/docs/identity-governance/access-monitoring/)

#### Desc:
AccessMonitoring flow is generting custom event schema to Athena Query mapping via grpc plugin: [protoc-gen-eventschema](https://github.com/gravitational/teleport/tree/master/build.assets/tooling/cmd/protoc-gen-eventschema )
If proto message was extended the `make generate-eventschema` is needed to add new filed to the Athena Query context 

#### How
Add a linter rule making sure that event schema is alway up to date. Otherwise the Athena Query schema is outdated making the debug flow very hard where some field can be missing from query response

With this change if schema is out of date  CI will report: `Error: Please run the command make generate-eventschema`: 
<img width="655" height="481" alt="Screenshot 2025-10-10 at 22 09 06" src="https://github.com/user-attachments/assets/5597e031-7e43-4ac1-bfa6-5f6c0a3b2252" />


#### Note:
Lint CI failure in this PR is expected - This PR will be merge after actual fix https://github.com/gravitational/teleport/pull/60161 to test the workflow. 

