### PR TITLE
[v18] use new join service for bot joins

### DIFF
--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -35,8 +35,12 @@ import (
 	"github.com/gravitational/teleport/lib/join/joinv1"
 )
 
-type JoinParams = authjoin.RegisterParams
-type JoinResult = authjoin.RegisterResult
+type (
+	JoinParams   = authjoin.RegisterParams
+	JoinResult   = authjoin.RegisterResult
+	AzureParams  = authjoin.AzureParams
+	GitlabParams = authjoin.GitlabParams
+)
 
 // Join is used to join a cluster. A host or bot calls this with the name of a
 // provision token to get its initial certificates.
@@ -126,7 +130,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	switch params.JoinMethod {
 	case types.JoinMethodUnspecified:
 		// leave joinMethodPtr nil to let the server pick based on the token
-	case types.JoinMethodToken:
+	case types.JoinMethodToken, types.JoinMethodBoundKeypair:
 		joinMethod := string(params.JoinMethod)
 		joinMethodPtr = &joinMethod
 	default:

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -37,12 +37,12 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/auth/join"
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -672,7 +672,7 @@ func botIdentityFromToken(
 	}
 
 	expires := time.Now().Add(cfg.TTL)
-	params := join.RegisterParams{
+	params := joinclient.JoinParams{
 		Token: token,
 		ID: state.IdentityID{
 			Role: types.RoleBot,
@@ -714,13 +714,13 @@ func botIdentityFromToken(
 
 	switch params.JoinMethod {
 	case types.JoinMethodAzure:
-		params.AzureParams = join.AzureParams{
+		params.AzureParams = joinclient.AzureParams{
 			ClientID: cfg.Onboarding.Azure.ClientID,
 		}
 	case types.JoinMethodTerraformCloud:
 		params.TerraformCloudAudienceTag = cfg.Onboarding.Terraform.AudienceTag
 	case types.JoinMethodGitLab:
-		params.GitlabParams = join.GitlabParams{
+		params.GitlabParams = joinclient.GitlabParams{
 			EnvVarName: cfg.Onboarding.Gitlab.TokenEnvVarName,
 		}
 	case types.JoinMethodBoundKeypair:
@@ -745,7 +745,7 @@ func botIdentityFromToken(
 		params.BoundKeypairParams = boundKeypairState.ToJoinParams(joinSecret)
 	}
 
-	result, err := join.Register(ctx, params)
+	result, err := joinclient.Join(ctx, params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Backport #59550 to branch/v18

I currently plan to hold off on merging this until either the next minor release or if/when a new join method available only in the new join service is required in v18