### PR TITLE
Attempt to deflake `TestBuildListDatabasesConfigureIAMScript` and `TestAzureOIDCConfigureScript`

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -9513,8 +9513,6 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		}
 		errChan <- err
 	}()
-	// wait for the watcher to init or it may race with test cleanup.
-	require.NoError(t, watcher.WaitInitialization())
 
 	// Waits for len(clusters) heartbeats to start
 	heartbeatsToExpect := len(cfg.clusters)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7107,7 +7107,11 @@ func TestDiagnoseKubeConnection(t *testing.T) {
 	}
 	require.NotNil(t, rolesWithoutAccessToKubeCluster)
 
-	env := newWebPack(t, 1)
+	env := newWebPack(t, 1,
+		withWebPackProxyOptions(
+			withKubeProxy(),
+		),
+	)
 
 	rt := http.NewServeMux()
 	rt.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -8427,6 +8431,7 @@ func (w *wrappedAuthClient) DevicesClient() devicepb.DeviceTrustServiceClient {
 type proxyConfig struct {
 	minimalHandler        bool
 	devicesClientOverride devicepb.DeviceTrustServiceClient
+	kubeProxy             bool
 }
 
 type proxyOption func(cfg *proxyConfig)
@@ -8434,6 +8439,12 @@ type proxyOption func(cfg *proxyConfig)
 func withDevicesClientOverride(c devicepb.DeviceTrustServiceClient) proxyOption {
 	return func(cfg *proxyConfig) {
 		cfg.devicesClientOverride = c
+	}
+}
+
+func withKubeProxy() proxyOption {
+	return func(cfg *proxyConfig) {
+		cfg.kubeProxy = true
 	}
 }
 
@@ -8733,16 +8744,18 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	require.NoError(t, err)
 	handler.handler.sshPort = sshPort
 
-	kubeProxyAddr := startKube(
-		ctx,
-		t,
-		startKubeOptions{
-			serviceType: kubeproxy.ProxyService,
-			authServer:  authServer,
-			revTunnel:   revTunServer,
-		},
-	)
-	handler.handler.cfg.ProxyKubeAddr = utils.FromAddr(kubeProxyAddr)
+	if cfg.kubeProxy {
+		kubeProxyAddr := startKube(
+			ctx,
+			t,
+			startKubeOptions{
+				serviceType: kubeproxy.ProxyService,
+				authServer:  authServer,
+				revTunnel:   revTunServer,
+			},
+		)
+		handler.handler.cfg.ProxyKubeAddr = utils.FromAddr(kubeProxyAddr)
+	}
 	handler.handler.cfg.PublicProxyAddr = webServer.Listener.Addr().String()
 	url, err := url.Parse("https://" + webServer.Listener.Addr().String())
 	require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -9394,6 +9394,10 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		KubernetesServerGetter: client,
 	})
 	require.NoError(t, err)
+	t.Cleanup(watcher.Close)
+
+	// wait for the watcher to init before continuing
+	require.NoError(t, watcher.WaitInitialization())
 
 	healthCheckManager, err := healthcheck.NewManager(
 		ctx,


### PR DESCRIPTION
This PR attempts to deflake `TestBuildListDatabasesConfigureIAMScript` and `TestAzureOIDCConfigureScript`

The test is flaky because the `kube_server` watcher used by teleport kube proxy doesn't init correctly.

Fixes #60160
Fixes #56227