### PR TITLE
[depreciated] Enable health checks on all Kubernetes clusters by default

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -775,9 +775,16 @@ const (
 var PresetRoles = []string{PresetEditorRoleName, PresetAccessRoleName, PresetAuditorRoleName}
 
 const (
-	// PresetDefaultHealthCheckConfigName is the name of a preset
-	// default health_check_config that enables health checks for all resources.
-	PresetDefaultHealthCheckConfigName = "default"
+	// PresetDefaultHealthCheckConfigDBName is the name of a preset
+	// health_check_config that enables health checks for all
+	// database resources. For historical reasons, this preset is named
+	// "default" even though it applies only to databases.
+	PresetDefaultHealthCheckConfigDBName = "default"
+
+	// PresetDefaultHealthCheckConfigKubeName is the name of a preset
+	// health_check_config that enables health checks for all
+	// Kubernetes resources.
+	PresetDefaultHealthCheckConfigKubeName = "default_kube"
 )
 
 const (

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -293,8 +293,8 @@ func CreatePresetRoles(ctx context.Context, um PresetRoleManager) error {
 	return createPresetRoles(ctx, um)
 }
 
-func CreatePresetHealthCheckConfig(ctx context.Context, svc services.HealthCheckConfig) error {
-	return createPresetHealthCheckConfig(ctx, svc)
+func CreatePresetHealthCheckConfigs(ctx context.Context, svc services.HealthCheckConfig) error {
+	return createPresetHealthCheckConfigs(ctx, svc)
 }
 
 func GetPresetUsers() []types.User {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1490,10 +1490,6 @@ func createPresetDatabaseObjectImportRule(ctx context.Context, rules services.Da
 // createPresetHealthCheckConfigs creates a preset health check config
 // for each resource using the healthcheck package.
 func createPresetHealthCheckConfigs(ctx context.Context, svc services.HealthCheckConfig) error {
-	// The choice to create a preset per-resource is motivated by:
-	// - Supporting existing Teleport clusters already using health checks with some resources
-	// - Avoiding migration of the backend database, which avoids downtime and headaches
-	// - Easing the adoption of health checks for new resources as they are developed over time
 
 	// Attempt to create each preset instead of loading all cfgs and checking existence.
 	// For cases of large quantities of cfgs, it's more efficient to attempt an insert.

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1021,18 +1021,25 @@ func TestPresets(t *testing.T) {
 		as.SetClock(clock)
 
 		// an existing health check config should not be modified by init
-		cfg := services.NewPresetHealthCheckConfigDB()
-		cfg.Spec.Interval = durationpb.New(42 * time.Second)
-		cfg, err := as.CreateHealthCheckConfig(ctx, cfg)
+		cfgDB := services.NewPresetHealthCheckConfigDB()
+		cfgDB.Spec.Interval = durationpb.New(42 * time.Second)
+		cfgDB, err := as.CreateHealthCheckConfig(ctx, cfgDB)
+		require.NoError(t, err)
+		cfgKube := services.NewPresetHealthCheckConfigKube()
+		cfgKube.Spec.Interval = durationpb.New(42 * time.Second)
+		cfgKube, err = as.CreateHealthCheckConfig(ctx, cfgKube)
 		require.NoError(t, err)
 
 		err = auth.CreatePresetHealthCheckConfigs(ctx, as)
 		require.NoError(t, err)
 
 		// Preset was created. Ensure it didn't overwrite the existing config
-		got, err := as.GetHealthCheckConfig(ctx, cfg.GetMetadata().GetName())
+		gotDB, err := as.GetHealthCheckConfig(ctx, cfgDB.GetMetadata().GetName())
 		require.NoError(t, err)
-		require.Equal(t, cfg.Spec.Interval.AsDuration(), got.Spec.Interval.AsDuration())
+		require.Equal(t, cfgDB.Spec.Interval.AsDuration(), gotDB.Spec.Interval.AsDuration())
+		gotKube, err := as.GetHealthCheckConfig(ctx, cfgKube.GetMetadata().GetName())
+		require.NoError(t, err)
+		require.Equal(t, cfgKube.Spec.Interval.AsDuration(), gotKube.Spec.Interval.AsDuration())
 	})
 
 	t.Run("AddAllHealthCheckConfigs", func(t *testing.T) {

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -855,15 +855,15 @@ func NewPresetMCPUserRole() types.Role {
 	return role
 }
 
-// NewPresetHealthCheckConfig returns a preset default health_check_config that
-// enables health checks for all resources.
-func NewPresetHealthCheckConfig() *healthcheckconfigv1.HealthCheckConfig {
+// NewPresetHealthCheckConfigDB returns a preset health_check_config
+// enabling health checks for all databases resources.
+func NewPresetHealthCheckConfigDB() *healthcheckconfigv1.HealthCheckConfig {
 	return &healthcheckconfigv1.HealthCheckConfig{
 		Kind:    types.KindHealthCheckConfig,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
-			Name:        teleport.PresetDefaultHealthCheckConfigName,
-			Description: "Enables all health checks by default",
+			Name:        teleport.PresetDefaultHealthCheckConfigDBName,
+			Description: "Enables health checks for all databases by default",
 			Namespace:   apidefaults.Namespace,
 			Labels: map[string]string{
 				types.TeleportInternalResourceType: types.PresetResource,
@@ -873,6 +873,32 @@ func NewPresetHealthCheckConfig() *healthcheckconfigv1.HealthCheckConfig {
 			Match: &healthcheckconfigv1.Matcher{
 				// match all databases
 				DbLabels: []*labelv1.Label{{
+					Name:   types.Wildcard,
+					Values: []string{types.Wildcard},
+				}},
+			},
+		},
+	}
+}
+
+// NewPresetHealthCheckConfigKube returns a preset health_check_config
+// enabling health checks for all Kubernetes resources.
+func NewPresetHealthCheckConfigKube() *healthcheckconfigv1.HealthCheckConfig {
+	return &healthcheckconfigv1.HealthCheckConfig{
+		Kind:    types.KindHealthCheckConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:        teleport.PresetDefaultHealthCheckConfigKubeName,
+			Description: "Enables health checks for all Kubernetes clusters by default",
+			Namespace:   apidefaults.Namespace,
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+			Match: &healthcheckconfigv1.Matcher{
+				// match all kubernetes clusters
+				KubernetesLabels: []*labelv1.Label{{
 					Name:   types.Wildcard,
 					Values: []string{types.Wildcard},
 				}},

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -864,7 +864,6 @@ func NewPresetHealthCheckConfigDB() *healthcheckconfigv1.HealthCheckConfig {
 		Metadata: &headerv1.Metadata{
 			Name:        teleport.PresetDefaultHealthCheckConfigDBName,
 			Description: "Enables health checks for all databases by default",
-			Namespace:   apidefaults.Namespace,
 			Labels: map[string]string{
 				types.TeleportInternalResourceType: types.PresetResource,
 			},
@@ -890,7 +889,6 @@ func NewPresetHealthCheckConfigKube() *healthcheckconfigv1.HealthCheckConfig {
 		Metadata: &headerv1.Metadata{
 			Name:        teleport.PresetDefaultHealthCheckConfigKubeName,
 			Description: "Enables health checks for all Kubernetes clusters by default",
-			Namespace:   apidefaults.Namespace,
 			Labels: map[string]string{
 				types.TeleportInternalResourceType: types.PresetResource,
 			},


### PR DESCRIPTION
Kubernetes health checks are enabled by default.

A per-resource health check config approach is implemented for enabling ease of adoption of new health checks, while avoiding migration of the backend database.

In this PR:
- Added `default_kube` health check config which enables health checks on all Kubernetes clusters
- Revised initialization and insert logic for health check configs

Manual testing:

Manual testing was done once with a new installation, and once with an upgrade path with the previous existing `default` health check config.

**Testing with a new installation**
- Deleted `/var/lib/teleport/backend/sqlite.db`.
- Ran `teleport` with PR changes

Teleport terminal output show Kubernetes health checks functioning.
```zsh
2025-10-15T14:57:07.188-07:00 DEBU [KUBERNETE] Target health status is unknown target_name:colima target_kind:kube_cluster target_origin: reason:initialized message:Health checker initialized healthcheck/worker.go:423
2025-10-15T14:57:07.188-07:00 INFO [KUBERNETE] Health checker started target_name:colima target_kind:kube_cluster target_origin: health_check_config:default_kube interval:30s timeout:5s healthy_threshold:2 unhealthy_threshold:1 healthcheck/worker.go:234
2025-10-15T14:57:07.195-07:00 INFO [KUBERNETE] Target became healthy target_name:colima target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:411
```

- Viewing the health check config records in the `kv` DB table shows a separate health check config for databases and Kubernetes.
```json
// DB Key: /health_check_config/default
{
    "kind": "health_check_config",
    "version": "v1",
    "metadata": {
        "name": "default",
        "namespace": "default",
        "description": "Enables health checks for all databases by default",
        "labels": {
            "teleport.internal/resource-type": "preset"
        }
    },
    "spec": {
        "match": {
            "dbLabels": [
                {
                    "name": "*",
                    "values": [
                        "*"
                    ]
                }
            ]
        }
    }
}

// DB Key: /health_check_config/default_kube
{
    "kind": "health_check_config",
    "version": "v1",
    "metadata": {
        "name": "default_kube",
        "namespace": "default",
        "description": "Enables health checks for all Kubernetes clusters by default",
        "labels": {
            "teleport.internal/resource-type": "preset"
        }
    },
    "spec": {
        "match": {
            "kubernetesLabels": [
                {
                    "name": "*",
                    "values": [
                        "*"
                    ]
                }
            ]
        }
    }
}
```

**Testing with a previous installation**
- Deleted `/var/lib/teleport/backend/sqlite.db`.
- Ran `teleport` without PR changes

Teleport terminal output show Kubernetes health checks are disabled.
```zsh
2025-10-15T15:01:58.465-07:00 DEBU [KUBERNETE] Target health status is unknown target_name:colima target_kind:kube_cluster target_origin: reason:disabled message:No health check config matches this resource healthcheck/worker.go:423
```

- Viewing the health check config records in the `kv` DB table shows a single health check config for databases.
```json
// DB Key: /health_check_config/default
{
    "kind": "health_check_config",
    "version": "v1",
    "metadata": {
        "name": "default",
        "namespace": "default",
        "description": "Enables all health checks by default",
        "labels": {
            "teleport.internal/resource-type": "preset"
        }
    },
    "spec": {
        "match": {
            "dbLabels": [
                {
                    "name": "*",
                    "values": [
                        "*"
                    ]
                }
            ]
        }
    }
}
```

- Ran `teleport` with PR changes
Teleport terminal output show Kubernetes health checks functioning.
```zsh
2025-10-15T15:06:52.318-07:00 DEBU [KUBERNETE] Target health status is unknown target_name:colima target_kind:kube_cluster target_origin: reason:initialized message:Health checker initialized healthcheck/worker.go:423
2025-10-15T15:06:52.318-07:00 INFO [KUBERNETE] Health checker started target_name:colima target_kind:kube_cluster target_origin: health_check_config:default_kube interval:30s timeout:5s healthy_threshold:2 unhealthy_threshold:1 healthcheck/worker.go:234
2025-10-15T15:06:52.326-07:00 INFO [KUBERNETE] Target became healthy target_name:colima target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:411
```

- Viewing the health check config records in the `kv` DB table shows a separate health check config for databases and Kubernetes clusters.
```json
// DB Key: /health_check_config/default
{
    "kind": "health_check_config",
    "version": "v1",
    "metadata": {
        "name": "default",
        "namespace": "default",
        "description": "Enables all health checks by default",
        "labels": {
            "teleport.internal/resource-type": "preset"
        }
    },
    "spec": {
        "match": {
            "dbLabels": [
                {
                    "name": "*",
                    "values": [
                        "*"
                    ]
                }
            ]
        }
    }
}

// DB Key: /health_check_config/default_kube
{
    "kind": "health_check_config",
    "version": "v1",
    "metadata": {
        "name": "default_kube",
        "namespace": "default",
        "description": "Enables health checks for all Kubernetes clusters by default",
        "labels": {
            "teleport.internal/resource-type": "preset"
        }
    },
    "spec": {
        "match": {
            "kubernetesLabels": [
                {
                    "name": "*",
                    "values": [
                        "*"
                    ]
                }
            ]
        }
    }
}
```

Relates to:
- #58413