### PR TITLE
[v16] fix: prevent `crypto/ssh` to block on dialing

### DIFF
--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -383,7 +383,7 @@ func newTLSRoutingWithConnUpgradeDialer(ssh ssh.ClientConfig, params connectPara
 // sshConnect upgrades the underling connection to ssh and connects to the Auth service.
 func sshConnect(ctx context.Context, conn net.Conn, ssh ssh.ClientConfig, dialTimeout time.Duration, addr string) (net.Conn, error) {
 	ssh.Timeout = dialTimeout
-	sconn, err := tracessh.NewClientConnWithDeadline(ctx, conn, addr, &ssh)
+	sconn, err := tracessh.NewClientWithTimeout(ctx, conn, addr, &ssh)
 	if err != nil {
 		return nil, trace.NewAggregate(err, conn.Close())
 	}

--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -49,6 +49,24 @@ const (
 	tracingSupported
 )
 
+// NewClientWithTimeout establishes a new client connection, honoring the earliest of the following:
+//
+// - The context's deadline or cancellation
+// - The timeout specified in the config
+// - A default timeout of 30 seconds if config doesn't specify a timeout
+//
+// - If config.Timeout > 0: the specified timeout is applied in addition to any context deadline.
+// - If config.Timeout == 0: a default timeout of 30 seconds is used to prevent indefinite hangs.
+// - If config.Timeout < 0: only the context's deadline or cancellation is respected if any.
+func NewClientWithTimeout(ctx context.Context, conn net.Conn, addr string, config *ssh.ClientConfig, opts ...tracing.Option) (*Client, error) {
+	c, chans, reqs, err := NewClientConnWithTimeout(ctx, conn, addr, config, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewClient(c, chans, reqs, opts...), nil
+}
+
 // NewClient creates a new Client.
 //
 // The server being connected to is probed to determine if it supports

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -23,10 +23,14 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"io"
 	"net"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -428,4 +432,70 @@ func TestWrapPayload(t *testing.T) {
 			tt.payloadAssertion(t, testPayload, payload)
 		})
 	}
+}
+
+func TestNewClientConnTimeout(t *testing.T) {
+	t.Parallel()
+
+	// This test ensure that NewClientConnWithTimeout respects the context
+	// timeout and does not hang indefinitely.
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+	t.Cleanup(func() { listener.Close() })
+
+	wg.Go(func() {
+		defer listener.Close()
+
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				assert.ErrorIs(t, err, net.ErrClosed)
+				return
+			}
+			require.NoError(t, err)
+			wg.Go(func() {
+				defer conn.Close()
+				// Simulate a server that does not respond so the ssh.NewClientConn
+				// call on the client side hangs indefinitely.
+				_, _ = io.Copy(io.Discard, conn)
+			})
+		}
+	})
+
+	t.Run("context timeout is respected", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+		t.Cleanup(cancel)
+
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		require.NoError(t, err)
+
+		_, _, _, err = NewClientConnWithTimeout(ctx, conn, listener.Addr().String(), &ssh.ClientConfig{
+			Timeout:         -1,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error, got: %v", err)
+	})
+
+	t.Run("config timeout is respected", func(t *testing.T) {
+		t.Parallel()
+
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		require.NoError(t, err)
+
+		_, _, _, err = NewClientConnWithTimeout(t.Context(), conn, listener.Addr().String(), &ssh.ClientConfig{
+			Timeout:         5 * time.Millisecond,
+			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		})
+
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.DeadlineExceeded, "expected context deadline exceeded error, got: %v", err)
+	})
+
 }

--- a/api/observability/tracing/ssh/ssh_test.go
+++ b/api/observability/tracing/ssh/ssh_test.go
@@ -446,7 +446,9 @@ func TestNewClientConnTimeout(t *testing.T) {
 	t.Cleanup(wg.Wait)
 	t.Cleanup(func() { listener.Close() })
 
-	wg.Go(func() {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		defer listener.Close()
 
 		for {
@@ -456,19 +458,21 @@ func TestNewClientConnTimeout(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			wg.Go(func() {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
 				defer conn.Close()
 				// Simulate a server that does not respond so the ssh.NewClientConn
 				// call on the client side hangs indefinitely.
 				_, _ = io.Copy(io.Discard, conn)
-			})
+			}()
 		}
-	})
+	}()
 
 	t.Run("context timeout is respected", func(t *testing.T) {
 		t.Parallel()
 
-		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 		t.Cleanup(cancel)
 
 		conn, err := net.Dial("tcp", listener.Addr().String())
@@ -489,7 +493,7 @@ func TestNewClientConnTimeout(t *testing.T) {
 		conn, err := net.Dial("tcp", listener.Addr().String())
 		require.NoError(t, err)
 
-		_, _, _, err = NewClientConnWithTimeout(t.Context(), conn, listener.Addr().String(), &ssh.ClientConfig{
+		_, _, _, err = NewClientConnWithTimeout(context.Background(), conn, listener.Addr().String(), &ssh.ClientConfig{
 			Timeout:         5 * time.Millisecond,
 			HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		})

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7910,7 +7910,7 @@ func testModeratedSFTP(t *testing.T, suite *integrationTestSuite) {
 	conn, details, err := modClusterClient.ProxyClient.DialHost(ctx, nodeDetails.Addr, nodeDetails.Cluster, modTC.LocalAgent().ExtendedAgent)
 	require.NoError(t, err)
 	sshConfig := modClusterClient.ProxyClient.SSHConfig(username)
-	modSSHConn, modSSHChans, modSSHReqs, err := tracessh.NewClientConn(ctx, conn, nodeDetails.ProxyFormat(), sshConfig)
+	modSSHConn, modSSHChans, modSSHReqs, err := tracessh.NewClientConnWithTimeout(ctx, conn, nodeDetails.ProxyFormat(), sshConfig)
 	require.NoError(t, err)
 
 	// We pass an empty channel which we close right away to ssh.NewClient

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -716,7 +716,7 @@ func newClientConn(
 		// Use a noop text map propagator so that the tracing context isn't included in
 		// the connection handshake. Since the provided conn will already include the tracing
 		// context we don't want to send it again.
-		conn, chans, reqs, err := tracessh.NewClientConn(ctx, conn, nodeAddress, config, tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator()))
+		conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, conn, nodeAddress, config, tracing.WithTextMapPropagator(propagation.NewCompositeTextMapPropagator()))
 		respCh <- response{conn, chans, reqs, err}
 	}()
 

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -94,7 +94,7 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 
 	// Build a new client connection. This is done to get access to incoming
 	// global requests which dialer.Dial would not provide.
-	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pconn, addr.Addr, &ssh.ClientConfig{
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, pconn, addr.Addr, &ssh.ClientConfig{
 		User:            d.username,
 		Auth:            d.authMethods,
 		HostKeyCallback: callback,

--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -23,6 +23,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"net"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -108,6 +109,16 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	ctx, cancel := context.WithTimeout(
+		ctx,
+		time.Minute, // default timeout to connect to server
+	)
+	defer cancel()
+	stopFn := context.AfterFunc(ctx, func() {
+		_ = sconn.Close()
+	})
+	defer stopFn()
 
 	// Build a net.Conn over the tunnel. Make this an exclusive connection:
 	// close the net.Conn as well as the channel upon close.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -767,7 +767,7 @@ func (s *Server) newRemoteClient(ctx context.Context, systemLogin string, netCon
 	// the correct host. It must occur in the list of principals presented by
 	// the remote server.
 	dstAddr := net.JoinHostPort(s.address, "0")
-	client, err := tracessh.NewClientConnWithDeadline(ctx, s.targetConn, dstAddr, clientConfig)
+	client, err := tracessh.NewClientWithTimeout(ctx, s.targetConn, dstAddr, clientConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1490,7 +1490,7 @@ func testClient(t *testing.T, f *sshTestFixture, proxyAddr, targetAddr, remoteAd
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via TCP
-	conn, chans, reqs, err := tracessh.NewClientConn(
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(
 		ctx,
 		pipeNetConn,
 		f.ssh.srv.Addr(),
@@ -2596,7 +2596,7 @@ func TestX11ProxySupport(t *testing.T) {
 	cltConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 
 	// Perform ssh handshake and setup client for X11 test server.
-	cltConn, chs, reqs, err := tracessh.NewClientConn(ctx, netConn, node.addr, &cltConfig)
+	cltConn, chs, reqs, err := tracessh.NewClientConnWithTimeout(ctx, netConn, node.addr, &cltConfig)
 	require.NoError(t, err)
 	clt := tracessh.NewClient(cltConn, chs, reqs)
 
@@ -2776,7 +2776,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 	defer pipeNetConn.Close()
 
 	// Open SSH connection via proxy subsystem's TCP tunnel
-	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pipeNetConn,
+	conn, chans, reqs, err := tracessh.NewClientConnWithTimeout(ctx, pipeNetConn,
 		f.ssh.srv.Addr(), sshConfig)
 	require.NoError(t, err)
 	defer conn.Close()

--- a/lib/utils/proxy/proxy.go
+++ b/lib/utils/proxy/proxy.go
@@ -64,7 +64,7 @@ func (d directDial) Dial(ctx context.Context, network string, addr string, confi
 
 	// Works around the case when net.DialWithTimeout succeeds, but key exchange hangs.
 	// Setting deadline on connection prevents this case from happening
-	return tracessh.NewClientConnWithDeadline(ctx, conn, addr, config)
+	return tracessh.NewClientWithTimeout(ctx, conn, addr, config)
 }
 
 // DialTimeout acts like Dial but takes a timeout.
@@ -126,23 +126,12 @@ func (d proxyDial) Dial(ctx context.Context, network string, addr string, config
 		return nil, trace.Wrap(err)
 	}
 
-	if config.Timeout > 0 {
-		if err := pconn.SetReadDeadline(time.Now().Add(config.Timeout)); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	// Do the same as ssh.Dial but pass in proxy connection.
-	c, chans, reqs, err := tracessh.NewClientConn(ctx, pconn, addr, config)
+	c, err := tracessh.NewClientWithTimeout(ctx, pconn, addr, config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if config.Timeout > 0 {
-		if err := pconn.SetReadDeadline(time.Time{}); err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-	return tracessh.NewClient(c, chans, reqs), nil
+
+	return c, nil
 }
 
 type dialerOptions struct {


### PR DESCRIPTION
Backport #59967 to branch/v16