### PR TITLE
[v18] MWI: Explicit time out for trust bundle watcher

### DIFF
--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -384,7 +384,7 @@ func (m *TrustBundleCache) watch(ctx context.Context) error {
 		// end users. This can happen if the auth cache fails to init. So
 		// instead, we give up after a reasonable amount of time and try again
 		// after a backoff.
-		return trace.Errorf("timeout waiting for watcher init")
+		return trace.LimitExceeded("timeout waiting for watcher init")
 	case <-watcher.Done():
 		return trace.Wrap(watcher.Error(), "watcher closed before initialization")
 	}

--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -290,7 +290,10 @@ func NewTrustBundleCache(cfg TrustBundleCacheConfig) (*TrustBundleCache, error) 
 	}, nil
 }
 
-const trustBundleInitFailureBackoff = 10 * time.Second
+const (
+	trustBundleInitFailureBackoff = 10 * time.Second
+	trustBundleInitTimeout        = 30 * time.Second
+)
 
 // Run initializes the cache and begins watching for events. It will block until
 // the context is canceled, at which point it will return nil.
@@ -367,12 +370,21 @@ func (m *TrustBundleCache) watch(ctx context.Context) error {
 	}()
 
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
 	case event := <-watcher.Events():
 		if event.Type != types.OpInit {
 			return trace.BadParameter("unexpected event type: %v", event.Type)
 		}
+		// When we receive the init event, we know the watcher is now active
+		// and we can begin streaming events.
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(trustBundleInitTimeout):
+		// If we don't explicitly time out here, then we'd "block" silently
+		// waiting for the init op to come through - which can be confusing to
+		// end users. This can happen if the auth cache fails to init. So
+		// instead, we give up after a reasonable amount of time and try again
+		// after a backoff.
+		return trace.Errorf("timeout waiting for watcher init")
 	case <-watcher.Done():
 		return trace.Wrap(watcher.Error(), "watcher closed before initialization")
 	}


### PR DESCRIPTION
Backport #60134 to branch/v18

changelog: Added explicit timeout to `tbot` when the Trust Bundle Cache is establishing an event watch.
