### PR TITLE
[v16] MWI: Explicit time out for trust bundle watcher (#60134)

### DIFF
--- a/lib/tbot/workloadidentity/trust_bundle_cache.go
+++ b/lib/tbot/workloadidentity/trust_bundle_cache.go
@@ -224,7 +224,10 @@ func NewTrustBundleCache(cfg TrustBundleCacheConfig) (*TrustBundleCache, error) 
 	}, nil
 }
 
-const trustBundleInitFailureBackoff = 10 * time.Second
+const (
+	trustBundleInitFailureBackoff = 10 * time.Second
+	trustBundleInitTimeout        = 30 * time.Second
+)
 
 // Run initializes the cache and begins watching for events. It will block until
 // the context is canceled, at which point it will return nil.
@@ -292,13 +295,10 @@ func (m *TrustBundleCache) watch(ctx context.Context) error {
 
 	authSupportsSPIFFEFederation := false
 	select {
-	case <-ctx.Done():
-		return ctx.Err()
 	case event := <-watcher.Events():
 		if event.Type != types.OpInit {
 			return trace.BadParameter("unexpected event type: %v", event.Type)
 		}
-
 		// Check whether the SPIFFEFederation kind was successfully watched.
 		// If not, we can assume that the Auth Server is too old and disable
 		// other functionality related to SPIFFEFederations.
@@ -323,6 +323,17 @@ func (m *TrustBundleCache) watch(ctx context.Context) error {
 				"Initialization indicates the auth server does not support the SPIFFEFederation resource. You will need to upgrade your Auth Server if you wish to use Workload Identity Federation features",
 			)
 		}
+		// When we receive the init event, we know the watcher is now active
+		// and we can begin streaming events.
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(trustBundleInitTimeout):
+		// If we don't explicitly time out here, then we'd "block" silently
+		// waiting for the init op to come through - which can be confusing to
+		// end users. This can happen if the auth cache fails to init. So
+		// instead, we give up after a reasonable amount of time and try again
+		// after a backoff.
+		return trace.LimitExceeded("timeout waiting for watcher init")
 	case <-watcher.Done():
 		return trace.Wrap(watcher.Error(), "watcher closed before initialization")
 	}


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/60134

changelog: Added explicit timeout to tbot when the Trust Bundle Cache is establishing an event watch.