### PR TITLE
Update `teleport_deactivate_user` to use `pg_auth_members`

### DIFF
--- a/lib/srv/db/postgres/sql/deactivate-user.sql
+++ b/lib/srv/db/postgres/sql/deactivate-user.sql
@@ -9,7 +9,11 @@ BEGIN
         RAISE NOTICE 'User has active connections';
     ELSE
         -- Revoke all role memberships except teleport-auto-user group.
-        FOR role_ IN SELECT a.rolname FROM pg_roles a WHERE pg_has_role(username, a.oid, 'member') AND a.rolname NOT IN (username, 'teleport-auto-user')
+        FOR role_ IN
+        SELECT r.rolname
+        FROM pg_roles r
+        WHERE r.rolname NOT IN (username, 'teleport-auto-user') AND
+              r.oid IN (select m.roleid from pg_auth_members m where m.member = to_regrole(username)::oid)
         LOOP
             EXECUTE FORMAT('REVOKE %I FROM %I', role_, username);
         END LOOP;


### PR DESCRIPTION
Moving away from `pg_has_role`, which matches inherited roles, to `pg_auth_members` that only contains direct assignements.

I considered changing `e2e` tests to cover this case, but the isolated character of databases makes it difficult to observe meaningful differences in behaviour.

I ended up testing it manually in different scenarios.

Closes #55395

Changelog: Fixed issue with inherited roles interfering with auto role provisioning cleanup in Postgres