### PR TITLE
docs: add embedded video to Identity Security docs homepage

### DIFF
--- a/docs/pages/identity-security/identity-security.mdx
+++ b/docs/pages/identity-security/identity-security.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Identity Security
 description: An overview of Teleport Identity Security.
-videoBanner: Vg5R6vpZffg
 template: landing-page
 tags:
  - identity-security
@@ -26,7 +25,7 @@ import video from "@site/src/components/Pages/Landing/TextWithMedia/identity-sec
 
 <LandingHero
   title="Teleport Identity Security"
-  image={identitySecurityImg}
+  youtubeVideoId="JJftMAwMld8"
   links={[
     {
       title: "Self-Hosting Guide",


### PR DESCRIPTION
This PR replaces the hero image on the Identity Security docs homepage with an embedded "Overview of Identity Security" YouTube video. It also removes the banner video.

Preview - https://add-video-to-identity-security-homepage.d3pp5qlev8mo18.amplifyapp.com/identity-security/