### PR TITLE
[tctl/debug] switch prometheus parser to `NewTextParser`

### DIFF
--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -192,7 +193,7 @@ func (c *Client) GetMetrics(ctx context.Context) (map[string]*dto.MetricFamily, 
 		return nil, trace.Wrap(err)
 	}
 	defer resp.Body.Close()
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	metrics, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/tool/tctl/common/top/client/diag/client.go
+++ b/tool/tctl/common/top/client/diag/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -92,7 +93,7 @@ func (c *Client) GetMetrics(ctx context.Context) (map[string]*dto.MetricFamily, 
 	}
 	defer resp.Body.Close()
 
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	metrics, err := parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
A default-constructed TextParser is invalid as of prom v0.66.0, switch to the new constructor.

Fixes: #60202