### PR TITLE
Allow `machineid.AutoUpdateVersionReporter` to shut down correctly

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -814,7 +814,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		return nil, trace.Wrap(err)
 	}
 
-	as.botVersionReporter, err = machineidv1.NewAutoUpdateVersionReporter(machineidv1.AutoUpdateVersionReporterConfig{
+	as.BotInstanceVersionReporter, err = machineidv1.NewAutoUpdateVersionReporter(machineidv1.AutoUpdateVersionReporterConfig{
 		Clock: cfg.Clock,
 		Logger: as.logger.With(
 			teleport.ComponentKey,
@@ -826,9 +826,6 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 		Cache:      as.Cache,
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := as.botVersionReporter.Run(as.CloseContext()); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -1340,9 +1337,9 @@ type Server struct {
 	// plugin. The summarizer itself summarizes session recordings.
 	sessionSummarizerProvider *summarizer.SessionSummarizerProvider
 
-	// botVersionReporter is called periodically to generate a report of the
-	// number of bot instances by version and update group.
-	botVersionReporter *machineidv1.AutoUpdateVersionReporter
+	// BotInstanceVersionReporter is called periodically to generate a report of
+	// the number of bot instances by version and update group.
+	BotInstanceVersionReporter *machineidv1.AutoUpdateVersionReporter
 }
 
 // SetSAMLService registers svc as the SAMLService that provides the SAML
@@ -1858,7 +1855,7 @@ func (a *Server) runPeriodicOperations() {
 			case autoUpdateAgentReportKey:
 				go a.reportAgentVersions(a.closeCtx)
 			case autoUpdateBotInstanceReportKey:
-				go a.botVersionReporter.Report(a.closeCtx)
+				go a.BotInstanceVersionReporter.Report(a.closeCtx)
 			case autoUpdateBotInstanceMetricsKey:
 				go a.updateBotInstanceMetrics()
 			}

--- a/lib/auth/machineid/machineidv1/auto_update_version_reporter.go
+++ b/lib/auth/machineid/machineidv1/auto_update_version_reporter.go
@@ -135,7 +135,7 @@ func (r *AutoUpdateVersionReporter) Run(ctx context.Context) error {
 	for {
 		started := r.clock.Now()
 		r.runLeader(ctx)
-		leaderFor := r.clock.Now().Sub(started)
+		leaderFor := r.clock.Since(started)
 
 		// Context is done, exit immediately.
 		if ctx.Err() != nil {

--- a/lib/auth/machineid/machineidv1/auto_update_version_reporter.go
+++ b/lib/auth/machineid/machineidv1/auto_update_version_reporter.go
@@ -130,36 +130,33 @@ func (r *AutoUpdateVersionReporter) Run(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	go func() {
-		defer r.logger.DebugContext(ctx, "Shutting down")
+	defer r.logger.DebugContext(ctx, "Shutting down")
 
-		for {
-			started := r.clock.Now()
-			r.runLeader(ctx)
-			leaderFor := r.clock.Now().Sub(started)
+	for {
+		started := r.clock.Now()
+		r.runLeader(ctx)
+		leaderFor := r.clock.Now().Sub(started)
 
-			// Context is done, exit immediately.
-			if ctx.Err() != nil {
-				return
-			}
-
-			// If we were leader for a decent amount of time, any previous
-			// backoff likely doesn't apply anymore.
-			if leaderFor > 5*time.Minute {
-				retry.Reset()
-			}
-
-			// Wait for the next retry interval.
-			retry.Inc()
-
-			select {
-			case <-retry.After():
-			case <-ctx.Done():
-				return
-			}
+		// Context is done, exit immediately.
+		if ctx.Err() != nil {
+			return nil
 		}
-	}()
-	return nil
+
+		// If we were leader for a decent amount of time, any previous
+		// backoff likely doesn't apply anymore.
+		if leaderFor > 5*time.Minute {
+			retry.Reset()
+		}
+
+		// Wait for the next retry interval.
+		retry.Inc()
+
+		select {
+		case <-retry.After():
+		case <-ctx.Done():
+			return nil
+		}
+	}
 }
 
 func (r *AutoUpdateVersionReporter) runLeader(ctx context.Context) error {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2852,6 +2852,9 @@ func (process *TeleportProcess) initAuthService() error {
 	process.RegisterFunc("auth.autoupdate_agent_rollout_controller", func() error {
 		return trace.Wrap(agentRolloutController.Run(process.GracefulExitContext()), "running autoupdate_agent_rollout controller")
 	})
+	process.RegisterFunc("auth.autoupdate_bot_instance_version_reporter", func() error {
+		return trace.Wrap(authServer.BotInstanceVersionReporter.Run(process.GracefulExitContext()))
+	})
 
 	process.RegisterFunc("auth.server_info", func() error {
 		return trace.Wrap(auth.ReconcileServerInfos(process.GracefulExitContext(), authServer))


### PR DESCRIPTION
Fixes an issue where, because we were starting the leader election routine inside `auth.NewServer`, nothing was waiting for it to shut down correctly, and we were failing to release the semaphore.

There wasn't a huge user-facing impact (as the semaphore lease would eventually expire) but it leads to a confusing error message in the logs and delays things unnecessarily.

Credit to @marcoandredinis for finding it.
