### PR TITLE
[v16] Connect: Close terminal tab if last input was Ctrl+D, even on non-zero exit code

### DIFF
--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyEventsStreamHandler.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyEventsStreamHandler.ts
@@ -113,7 +113,11 @@ export class PtyEventsStreamHandler {
   }
 
   onExit(
-    callback: (reason: { exitCode: number; signal?: number }) => void
+    callback: (reason: {
+      exitCode: number;
+      signal?: number;
+      lastInput: string;
+    }) => void
   ): RemoveListenerFunction {
     return this.addDataListenerAndReturnRemovalFunction(
       (event: PtyServerEvent) => {

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyProcess.ts
@@ -63,7 +63,13 @@ export function createPtyProcess(
       return exchangeEventsStream.onOpen(callback);
     },
 
-    onExit(callback: (reason: { exitCode: number; signal?: number }) => void) {
+    onExit(
+      callback: (reason: {
+        exitCode: number;
+        signal?: number;
+        lastInput: string;
+      }) => void
+    ) {
       return exchangeEventsStream.onExit(callback);
     },
 

--- a/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
+++ b/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
@@ -81,6 +81,7 @@ message PtyEventOpen {}
 message PtyEventExit {
   uint32 exit_code = 1;
   optional uint32 signal = 2;
+  string last_input = 3;
 }
 
 message PtyEventStartError {

--- a/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.ts
+++ b/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.ts
@@ -196,6 +196,10 @@ export interface PtyEventExit {
      * @generated from protobuf field: optional uint32 signal = 2;
      */
     signal?: number;
+    /**
+     * @generated from protobuf field: string last_input = 3;
+     */
+    lastInput: string;
 }
 /**
  * @generated from protobuf message PtyEventStartError
@@ -695,12 +699,14 @@ class PtyEventExit$Type extends MessageType<PtyEventExit> {
     constructor() {
         super("PtyEventExit", [
             { no: 1, name: "exit_code", kind: "scalar", T: 13 /*ScalarType.UINT32*/ },
-            { no: 2, name: "signal", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ }
+            { no: 2, name: "signal", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
+            { no: 3, name: "last_input", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<PtyEventExit>): PtyEventExit {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.exitCode = 0;
+        message.lastInput = "";
         if (value !== undefined)
             reflectionMergePartial<PtyEventExit>(this, message, value);
         return message;
@@ -715,6 +721,9 @@ class PtyEventExit$Type extends MessageType<PtyEventExit> {
                     break;
                 case /* optional uint32 signal */ 2:
                     message.signal = reader.uint32();
+                    break;
+                case /* string last_input */ 3:
+                    message.lastInput = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -734,6 +743,9 @@ class PtyEventExit$Type extends MessageType<PtyEventExit> {
         /* optional uint32 signal = 2; */
         if (message.signal !== undefined)
             writer.tag(2, WireType.Varint).uint32(message.signal);
+        /* string last_input = 3; */
+        if (message.lastInput !== "")
+            writer.tag(3, WireType.LengthDelimited).string(message.lastInput);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyEventsStreamHandler.ts
@@ -90,12 +90,12 @@ export class PtyEventsStreamHandler {
         })
       )
     );
-    this.ptyProcess.onExit(({ exitCode, signal }) =>
+    this.ptyProcess.onExit(payload =>
       this.stream.write(
         PtyServerEvent.create({
           event: {
             oneofKind: 'exit',
-            exit: PtyEventExit.create({ exitCode, signal }),
+            exit: PtyEventExit.create(payload),
           },
         })
       )

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.test.ts
@@ -52,4 +52,29 @@ describe('PtyProcess', () => {
       );
     });
   });
+
+  if (process.platform !== 'win32') {
+    test('including the last input in the exit event', async () => {
+      const pty = new PtyProcess({
+        path: 'sh',
+        env: {},
+        args: [],
+        useConpty: true,
+        ptyId: '1234',
+      });
+      await pty.start(80, 24);
+      const listener = jest.fn();
+      pty.onExit(listener);
+
+      pty.write('\x04');
+
+      await expect(() => listener.mock.calls.length > 0).toEventuallyBeTrue({
+        waitFor: 2000,
+        tick: 10,
+      });
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ lastInput: '\x04' })
+      );
+    });
+  }
 });

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -42,6 +42,7 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
   private _logger: Logger;
   private _status: Status = 'not_initialized';
   private _disposed = false;
+  private _lastInput = '';
 
   constructor(private options: PtyProcessOptions & { ptyId: string }) {
     super();
@@ -115,6 +116,7 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
       return;
     }
 
+    this._lastInput = data;
     this._process.write(data);
   }
 
@@ -184,7 +186,9 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
     return this.addListenerAndReturnRemovalFunction(TermEventEnum.Open, cb);
   }
 
-  onExit(cb: (ev: { exitCode: number; signal?: number }) => void) {
+  onExit(
+    cb: (ev: { exitCode: number; signal?: number; lastInput: string }) => void
+  ) {
     return this.addListenerAndReturnRemovalFunction(TermEventEnum.Exit, cb);
   }
 
@@ -229,7 +233,7 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
   }
 
   private _handleExit(e: { exitCode: number; signal?: number }) {
-    this.emit(TermEventEnum.Exit, e);
+    this.emit(TermEventEnum.Exit, { ...e, lastInput: this._lastInput });
     this._logger.info(`pty has been terminated with exit code: ${e.exitCode}`);
     this._setStatus('terminated');
   }

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
@@ -41,7 +41,7 @@ export type IPtyProcess = {
   onOpen(cb: () => void): RemoveListenerFunction;
   onStartError(cb: (message: string) => void): RemoveListenerFunction;
   onExit(
-    cb: (ev: { exitCode: number; signal?: number }) => void
+    cb: (ev: { exitCode: number; signal?: number; lastInput: string }) => void
   ): RemoveListenerFunction;
 };
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -321,15 +321,12 @@ async function setUpPtyProcess(
 
   ptyProcess.onExit(event => {
     // Not closing the tab on non-zero exit code lets us show the error to the user if, for example,
-    // tsh ssh cannot connect to the given node.
+    // tsh ssh couldn't connect to the given node.
     //
-    // The downside of this is that if you open a local shell, then execute a command that fails
-    // (for example, `cd` to a nonexistent directory), and then try to execute `exit` or press
-    // Ctrl + D, the tab won't automatically close, because the last exit code is not zero.
-    //
-    // We can look up how the terminal in vscode handles this problem, since in the scenario
-    // described above they do close the tab correctly.
-    if (event.exitCode === 0) {
+    // We also have to account for Ctrl+D, as executing it makes the shell exit with the last
+    // reported exit code. If we depended on the exit code alone, it'd mean that the terminal tab
+    // wouldn't close if Ctrl+D followed a command that failed, say cd to a nonexistent directory.
+    if (event.exitCode === 0 || event.lastInput === /* Ctrl+D */ '\x04') {
       documentsService.close(doc.uri);
     }
   });


### PR DESCRIPTION
Backport #59836.

changelog: Fixed an issue in Teleport Connect where Ctrl+D would sometimes not close a terminal tab

Release branches do not include #59832, so I had to manually "port" proto changes. But the rest of the changes went in without conflicts. I verified on each release branch that the change indeed works.