### PR TITLE
EC2 auto discovery: allow usage of pre-defined `AWS-RunShellScript` SSM Document

### DIFF
--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -41,6 +41,10 @@ const (
 	// that will be called when executing the SSM command.
 	AWSInstallerDocument = "TeleportDiscoveryInstaller"
 
+	// AWSSSMDocumentRunShellScript is the `AWS-RunShellScript` SSM Document name.
+	// It is available in all AWS accounts and does not need to be manually created.
+	AWSSSMDocumentRunShellScript = "AWS-RunShellScript"
+
 	// AWSAgentlessInstallerDocument is the name of the default AWS document
 	// that will be called when executing the SSM command .
 	AWSAgentlessInstallerDocument = "TeleportAgentlessDiscoveryInstaller"

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -168,7 +168,7 @@ func (process *TeleportProcess) publicProxyAddr(accessPoint proxiesGetter) (stri
 		}
 	}
 
-	return "", trace.NotFound("could not find the proxy public address for server discovery")
+	return "", trace.NotFound("could not find the public proxy address for server discovery")
 }
 
 // integrationOnlyCredentials indicates whether the DiscoveryService must only use Cloud APIs credentials using an integration.

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -75,6 +75,11 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		return trace.Wrap(err, "failed to build access graph configuration")
 	}
 
+	publicProxyAddress, err := process.publicProxyAddr(accessPoint)
+	if err != nil {
+		return trace.Wrap(err, "failed to determine the public proxy address")
+	}
+
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
 		IntegrationOnlyCredentials: process.integrationOnlyCredentials(),
 		Matchers: discovery.Matchers{
@@ -84,16 +89,17 @@ func (process *TeleportProcess) initDiscoveryService() error {
 			Kubernetes:  process.Config.Discovery.KubernetesMatchers,
 			AccessGraph: process.Config.Discovery.AccessGraph,
 		},
-		DiscoveryGroup:    process.Config.Discovery.DiscoveryGroup,
-		Emitter:           asyncEmitter,
-		AccessPoint:       accessPoint,
-		ServerID:          conn.HostUUID(),
-		Log:               process.logger,
-		ClusterName:       conn.ClusterName(),
-		ClusterFeatures:   process.GetClusterFeatures,
-		PollInterval:      process.Config.Discovery.PollInterval,
-		GetClientCert:     conn.ClientGetCertificate,
-		AccessGraphConfig: accessGraphCfg,
+		DiscoveryGroup:     process.Config.Discovery.DiscoveryGroup,
+		Emitter:            asyncEmitter,
+		AccessPoint:        accessPoint,
+		ServerID:           conn.HostUUID(),
+		Log:                process.logger,
+		ClusterName:        conn.ClusterName(),
+		ClusterFeatures:    process.GetClusterFeatures,
+		PollInterval:       process.Config.Discovery.PollInterval,
+		GetClientCert:      conn.ClientGetCertificate,
+		AccessGraphConfig:  accessGraphCfg,
+		PublicProxyAddress: publicProxyAddress,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -128,6 +134,41 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 
 	return nil
+}
+
+type proxiesGetter interface {
+	GetProxies() ([]types.Server, error)
+}
+
+func (process *TeleportProcess) publicProxyAddr(accessPoint proxiesGetter) (string, error) {
+	// If the proxy server is explicitly set, use that.
+	if !process.Config.ProxyServer.IsEmpty() {
+		return process.Config.ProxyServer.String(), nil
+	}
+
+	// If DiscoveryService is running alongside a Proxy, use the first
+	// public address of the Proxy.
+	if process.Config.Proxy.Enabled {
+		for _, proxyAddr := range process.Config.Proxy.PublicAddrs {
+			if !proxyAddr.IsEmpty() {
+				return proxyAddr.String(), nil
+			}
+		}
+	}
+
+	proxies, err := accessPoint.GetProxies()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	for _, proxy := range proxies {
+		for _, proxyAddr := range proxy.GetPublicAddrs() {
+			if proxyAddr != "" {
+				return proxyAddr, nil
+			}
+		}
+	}
+
+	return "", trace.NotFound("could not find the proxy public address for server discovery")
 }
 
 // integrationOnlyCredentials indicates whether the DiscoveryService must only use Cloud APIs credentials using an integration.

--- a/lib/srv/discovery/config_test.go
+++ b/lib/srv/discovery/config_test.go
@@ -113,6 +113,14 @@ func TestConfigCheckAndSetDefaults(t *testing.T) {
 			postCheckAndSetDefaultsFunc: func(t *testing.T, c *Config) {},
 		},
 		{
+			name:          "missing public proxy address",
+			errAssertFunc: require.Error,
+			cfgChange: func(c *Config) {
+				c.PublicProxyAddress = ""
+			},
+			postCheckAndSetDefaultsFunc: func(t *testing.T, c *Config) {},
+		},
+		{
 			name:          "missing cluster features",
 			errAssertFunc: require.Error,
 			cfgChange: func(c *Config) {
@@ -137,7 +145,8 @@ func TestConfigCheckAndSetDefaults(t *testing.T) {
 				ClusterFeatures: func() proto.Features {
 					return proto.Features{}
 				},
-				DiscoveryGroup: "test",
+				DiscoveryGroup:     "test",
+				PublicProxyAddress: "proxy.example.com",
 			}
 			tt.cfgChange(cfg)
 			err := cfg.CheckAndSetDefaults()

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -118,6 +118,11 @@ type Config struct {
 	// CloudClients is an interface for retrieving cloud clients.
 	CloudClients cloud.Clients
 
+	// PublicProxyAddress is the public address of the proxy.
+	// Used to configure installation scripts for Server auto discovery.
+	// Example: proxy.example.com:443 or proxy.example.com
+	PublicProxyAddress string
+
 	// AWSFetchersClients gets the AWS clients for the given region for the fetchers.
 	AWSFetchersClients fetchers.AWSClientGetter
 
@@ -232,6 +237,10 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	if c.AccessPoint == nil {
 		return trace.BadParameter("no AccessPoint configured for discovery")
+	}
+
+	if c.PublicProxyAddress == "" {
+		return trace.BadParameter("no PublicProxyAddress configured for discovery")
 	}
 
 	if len(c.Matchers.Kubernetes) > 0 && c.DiscoveryGroup == "" {
@@ -568,7 +577,11 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, ec2Matchers, s.GetEC2Client, noDiscoveryConfig)
+	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, server.MatcherParamsToEC2Fetcher{
+		Matchers:        ec2Matchers,
+		EC2ClientGetter: s.GetEC2Client,
+		PublicProxyAddr: s.PublicProxyAddress,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -687,7 +700,12 @@ func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []t
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, serverMatchers, s.GetEC2Client, discoveryConfigName)
+	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, server.MatcherParamsToEC2Fetcher{
+		Matchers:            serverMatchers,
+		EC2ClientGetter:     s.GetEC2Client,
+		DiscoveryConfigName: discoveryConfigName,
+		PublicProxyAddr:     s.PublicProxyAddress,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -577,7 +577,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, server.MatcherParamsToEC2Fetcher{
+	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, server.MatcherToEC2FetcherParams{
 		Matchers:        ec2Matchers,
 		EC2ClientGetter: s.GetEC2Client,
 		PublicProxyAddr: s.PublicProxyAddress,
@@ -700,7 +700,7 @@ func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []t
 		return matcherType == types.AWSMatcherEC2
 	})
 
-	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, server.MatcherParamsToEC2Fetcher{
+	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, server.MatcherToEC2FetcherParams{
 		Matchers:            serverMatchers,
 		EC2ClientGetter:     s.GetEC2Client,
 		DiscoveryConfigName: discoveryConfigName,

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -273,12 +273,13 @@ func TestDiscoveryServerEKS(t *testing.T) {
 						AWSConfigProvider: fakeConfigProvider,
 						eksClusters:       tt.eksClusters,
 					},
-					ClusterFeatures: func() proto.Features { return proto.Features{} },
-					AccessPoint:     mockAccessPoint,
-					Matchers:        Matchers{},
-					Emitter:         tt.emitter,
-					DiscoveryGroup:  defaultDiscoveryGroup,
-					Log:             logtest.NewLogger(),
+					ClusterFeatures:    func() proto.Features { return proto.Features{} },
+					AccessPoint:        mockAccessPoint,
+					Matchers:           Matchers{},
+					Emitter:            tt.emitter,
+					DiscoveryGroup:     defaultDiscoveryGroup,
+					Log:                logtest.NewLogger(),
+					PublicProxyAddress: "proxy.example.com",
 				})
 				require.NoError(t, err)
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -764,14 +764,15 @@ func TestDiscoveryServer(t *testing.T) {
 				AWSFetchersClients: &mockFetchersClients{
 					AWSConfigProvider: fakeConfigProvider,
 				},
-				ClusterFeatures:  func() proto.Features { return proto.Features{} },
-				KubernetesClient: fake.NewSimpleClientset(),
-				AccessPoint:      getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
-				Matchers:         tc.staticMatchers,
-				Emitter:          tc.emitter,
-				Log:              logger,
-				DiscoveryGroup:   defaultDiscoveryGroup,
-				clock:            fakeClock,
+				ClusterFeatures:    func() proto.Features { return proto.Features{} },
+				KubernetesClient:   fake.NewSimpleClientset(),
+				AccessPoint:        getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+				Matchers:           tc.staticMatchers,
+				Emitter:            tc.emitter,
+				Log:                logger,
+				DiscoveryGroup:     defaultDiscoveryGroup,
+				clock:              fakeClock,
+				PublicProxyAddress: "proxy.example.com",
 			})
 			require.NoError(t, err)
 			server.ec2Installer = installer
@@ -944,29 +945,31 @@ func TestDiscoveryServerConcurrency(t *testing.T) {
 
 	// Create Server1
 	server1, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
-		CloudClients:     testCloudClients,
-		GetEC2Client:     getEC2Client,
-		ClusterFeatures:  func() proto.Features { return proto.Features{} },
-		KubernetesClient: fake.NewSimpleClientset(),
-		AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
-		Matchers:         staticMatcher,
-		Emitter:          emitter,
-		Log:              logger,
-		DiscoveryGroup:   defaultDiscoveryGroup,
+		CloudClients:       testCloudClients,
+		GetEC2Client:       getEC2Client,
+		ClusterFeatures:    func() proto.Features { return proto.Features{} },
+		KubernetesClient:   fake.NewSimpleClientset(),
+		AccessPoint:        getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+		Matchers:           staticMatcher,
+		Emitter:            emitter,
+		Log:                logger,
+		DiscoveryGroup:     defaultDiscoveryGroup,
+		PublicProxyAddress: "proxy.example.com",
 	})
 	require.NoError(t, err)
 
 	// Create Server2
 	server2, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
-		CloudClients:     testCloudClients,
-		GetEC2Client:     getEC2Client,
-		ClusterFeatures:  func() proto.Features { return proto.Features{} },
-		KubernetesClient: fake.NewSimpleClientset(),
-		AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
-		Matchers:         staticMatcher,
-		Emitter:          emitter,
-		Log:              logger,
-		DiscoveryGroup:   defaultDiscoveryGroup,
+		CloudClients:       testCloudClients,
+		GetEC2Client:       getEC2Client,
+		ClusterFeatures:    func() proto.Features { return proto.Features{} },
+		KubernetesClient:   fake.NewSimpleClientset(),
+		AccessPoint:        getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+		Matchers:           staticMatcher,
+		Emitter:            emitter,
+		Log:                logger,
+		DiscoveryGroup:     defaultDiscoveryGroup,
+		PublicProxyAddress: "proxy.example.com",
 	})
 	require.NoError(t, err)
 
@@ -1168,9 +1171,10 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Matchers: Matchers{
 						Kubernetes: tt.kubernetesMatchers,
 					},
-					Emitter:         authClient,
-					DiscoveryGroup:  mainDiscoveryGroup,
-					protocolChecker: &noopProtocolChecker{},
+					PublicProxyAddress: "proxy.example.com",
+					Emitter:            authClient,
+					DiscoveryGroup:     mainDiscoveryGroup,
+					protocolChecker:    &noopProtocolChecker{},
 				})
 
 			require.NoError(t, err)
@@ -1506,6 +1510,7 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 					ClusterFeatures:    func() proto.Features { return proto.Features{} },
 					KubernetesClient:   fake.NewSimpleClientset(),
 					AccessPoint:        getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+					PublicProxyAddress: "proxy.example.com",
 					Matchers: Matchers{
 						AWS:   tc.awsMatchers,
 						Azure: tc.azureMatchers,
@@ -1659,6 +1664,7 @@ func TestDiscoveryServer_New(t *testing.T) {
 					Matchers:           tt.matchers,
 					Emitter:            &mockEmitter{},
 					protocolChecker:    &noopProtocolChecker{},
+					PublicProxyAddress: "proxy.example.com",
 				})
 
 			tt.errAssertion(t, err)
@@ -2453,6 +2459,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 					AccessPoint:               getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
 					AWSDatabaseFetcherFactory: dbFetcherFactory,
 					AWSConfigProvider:         fakeConfigProvider,
+					PublicProxyAddress:        "proxy.example.com",
 					Matchers: Matchers{
 						AWS:   tc.awsMatchers,
 						Azure: tc.azureMatchers,
@@ -2588,6 +2595,7 @@ func TestDiscoveryDatabaseRemovingDiscoveryConfigs(t *testing.T) {
 			Matchers:                  Matchers{},
 			Emitter:                   authClient,
 			DiscoveryGroup:            mainDiscoveryGroup,
+			PublicProxyAddress:        "proxy.example.com",
 			clock:                     clock,
 		})
 
@@ -3015,14 +3023,15 @@ func TestAzureVMDiscovery(t *testing.T) {
 			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
-				CloudClients:     testCloudClients,
-				ClusterFeatures:  func() proto.Features { return proto.Features{} },
-				KubernetesClient: fake.NewSimpleClientset(),
-				AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
-				Matchers:         tc.staticMatchers,
-				Emitter:          emitter,
-				Log:              logger,
-				DiscoveryGroup:   defaultDiscoveryGroup,
+				CloudClients:       testCloudClients,
+				ClusterFeatures:    func() proto.Features { return proto.Features{} },
+				KubernetesClient:   fake.NewSimpleClientset(),
+				AccessPoint:        getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+				Matchers:           tc.staticMatchers,
+				Emitter:            emitter,
+				Log:                logger,
+				DiscoveryGroup:     defaultDiscoveryGroup,
+				PublicProxyAddress: "proxy.example.com",
 			})
 
 			require.NoError(t, err)
@@ -3321,14 +3330,15 @@ func TestGCPVMDiscovery(t *testing.T) {
 			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
-				CloudClients:     testCloudClients,
-				ClusterFeatures:  func() proto.Features { return proto.Features{} },
-				KubernetesClient: fake.NewSimpleClientset(),
-				AccessPoint:      getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
-				Matchers:         tc.staticMatchers,
-				Emitter:          emitter,
-				Log:              logger,
-				DiscoveryGroup:   defaultDiscoveryGroup,
+				CloudClients:       testCloudClients,
+				ClusterFeatures:    func() proto.Features { return proto.Features{} },
+				KubernetesClient:   fake.NewSimpleClientset(),
+				AccessPoint:        getDiscoveryAccessPoint(tlsServer.Auth(), authClient),
+				Matchers:           tc.staticMatchers,
+				Emitter:            emitter,
+				Log:                logger,
+				DiscoveryGroup:     defaultDiscoveryGroup,
+				PublicProxyAddress: "proxy.example.com",
 			})
 
 			require.NoError(t, err)
@@ -3520,7 +3530,8 @@ func TestEmitUsageEvents(t *testing.T) {
 				ResourceTags:   types.Labels{"teleport": {"yes"}},
 			}},
 		},
-		Emitter: &mockEmitter{},
+		PublicProxyAddress: "proxy.example.com",
+		Emitter:            &mockEmitter{},
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -408,9 +408,10 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 					Matchers: Matchers{
 						AWS: tc.awsMatchers,
 					},
-					Emitter:        authClient,
-					Log:            logtest.NewLogger(),
-					DiscoveryGroup: mainDiscoveryGroup,
+					Emitter:            authClient,
+					Log:                logtest.NewLogger(),
+					DiscoveryGroup:     mainDiscoveryGroup,
+					PublicProxyAddress: "proxy.example.com",
 				})
 
 			require.NoError(t, err)

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -19,7 +19,9 @@
 package server
 
 import (
+	"cmp"
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -199,11 +201,27 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 // EC2ClientGetter gets an AWS EC2 client for the given region.
 type EC2ClientGetter func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
 
+// MatcherParamsToEC2Fetcher contains parameters for converting AWS EC2 Matchers
+// into AWS EC2 Fetchers.
+type MatcherParamsToEC2Fetcher struct {
+	// Matchers is a list of AWS EC2 Matchers.
+	Matchers []types.AWSMatcher
+	// EC2ClientGetter gets an AWS EC2.
+	EC2ClientGetter EC2ClientGetter
+	// DiscoveryConfigName is the name of the DiscoveryConfig that contains the matchers.
+	// Empty if using static matchers (coming from the `teleport.yaml`).
+	DiscoveryConfigName string
+	// PublicProxyAddr is the public proxy address to use for installation scripts.
+	// This is only used if the matcher does not specify a ProxyAddress.
+	// Example: proxy.example.com:3080 or proxy.example.com
+	PublicProxyAddr string
+}
+
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
-func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client EC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
-	return matchersToEC2InstanceFetchers(ctx, matchers, func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherParamsToEC2Fetcher) ([]Fetcher, error) {
+	return matchersToEC2InstanceFetchers(matcherParams, func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		if matcher == nil {
-			return getEC2Client(ctx, region, opts...)
+			return matcherParams.EC2ClientGetter(ctx, region, opts...)
 		}
 
 		newOpts := make([]awsconfig.OptionsFn, 0, len(opts)+1)
@@ -215,8 +233,8 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 
 		newOpts = append(newOpts, awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: matcher.Integration}))
 
-		return getEC2Client(ctx, region, newOpts...)
-	}, discoveryConfigName)
+		return matcherParams.EC2ClientGetter(ctx, region, newOpts...)
+	})
 }
 
 // matcherEC2ClientGetter is an EC2 client getter that builds an EC2 client for the given matcher.
@@ -230,11 +248,12 @@ func (g matcherEC2ClientGetter) withMatcher(matcher *types.AWSMatcher) EC2Client
 	}
 }
 
-func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatcher, getEC2Client matcherEC2ClientGetter, discoveryConfigName string) ([]Fetcher, error) {
+func matchersToEC2InstanceFetchers(matcherParams MatcherParamsToEC2Fetcher, getEC2Client matcherEC2ClientGetter) ([]Fetcher, error) {
 	ret := []Fetcher{}
-	for _, matcher := range matchers {
+	for _, matcher := range matcherParams.Matchers {
 		for _, region := range matcher.Regions {
 			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
+				ProxyPublicAddr:     matcherParams.PublicProxyAddr,
 				Matcher:             matcher,
 				Region:              region,
 				Document:            matcher.SSM.DocumentName,
@@ -243,7 +262,7 @@ func matchersToEC2InstanceFetchers(ctx context.Context, matchers []types.AWSMatc
 				EC2ClientGetter:     getEC2Client.withMatcher(&matcher),
 				Labels:              matcher.Tags,
 				Integration:         matcher.Integration,
-				DiscoveryConfigName: discoveryConfigName,
+				DiscoveryConfigName: matcherParams.DiscoveryConfigName,
 				EnrollMode:          matcher.Params.EnrollMode,
 			})
 			ret = append(ret, fetcher)
@@ -263,19 +282,14 @@ type ec2FetcherConfig struct {
 	Integration         string
 	DiscoveryConfigName string
 	EnrollMode          types.InstallParamEnrollMode
+	// ProxyPublicAddr is the public proxy address to use for installation scripts.
+	// Format: "proxy.example.com:443" or "proxy.example.com"
+	ProxyPublicAddr string
 }
 
 type ec2InstanceFetcher struct {
-	Filters             []ec2types.Filter
-	EC2ClientGetter     EC2ClientGetter
-	Region              string
-	DocumentName        string
-	Parameters          map[string]string
-	Integration         string
-	DiscoveryConfigName string
-	EnrollMode          types.InstallParamEnrollMode
-	AssumeRoleARN       string
-	ExternalID          string
+	ec2FetcherConfig
+	Filters []ec2types.Filter
 
 	// cachedInstances keeps all of the ec2 instances that were matched
 	// in the last run of GetInstances for use as a cache with
@@ -312,6 +326,7 @@ type cachedInstanceKey struct {
 	instanceID string
 }
 
+// SSM Run Command parameters for the TeleportDiscoveryInstaller SSM Document.
 const (
 	// ParamToken is the name of the invite token parameter sent in the SSM Document
 	ParamToken = "token"
@@ -321,6 +336,13 @@ const (
 	ParamSSHDConfigPath = "sshdConfigPath"
 	// ParamEnvVars is a parameter that contains environment variables to set before running the installation script.
 	ParamEnvVars = "env"
+)
+
+// SSM Run Command parameters for the AWS-RunShellScript managed SSM Document.
+const (
+	// ParamCommands is the name of the commands parameter sent in the SSM Document.
+	// This is a list of strings, which contain the command to execute.
+	ParamCommands = "commands"
 )
 
 // awsEC2APIChunkSize is the max number of instances SSM will send commands to at a time
@@ -345,23 +367,42 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 	} else {
 		slog.DebugContext(context.Background(), "Not setting any tag filters as there is a '*:...' tag present and AWS doesnt allow globbing on keys")
 	}
-	var parameters map[string]string
+
+	if cfg.Matcher.AssumeRole == nil {
+		cfg.Matcher.AssumeRole = &types.AssumeRole{}
+	}
+
+	return &ec2InstanceFetcher{
+		ec2FetcherConfig: cfg,
+		Filters:          tagFilters,
+		cachedInstances: &instancesCache{
+			instances: map[cachedInstanceKey]struct{}{},
+		},
+	}
+}
+
+func ssmRunCommandParametersForCustomDocuments(cfg ec2FetcherConfig, envVars []string) map[string]string {
 	if cfg.Matcher.Params == nil {
 		cfg.Matcher.Params = &types.InstallerParams{}
 	}
-	if cfg.Matcher.Params.InstallTeleport {
-		parameters = map[string]string{
-			ParamToken:      cfg.Matcher.Params.JoinToken,
-			ParamScriptName: cfg.Matcher.Params.ScriptName,
-		}
-	} else {
-		parameters = map[string]string{
-			ParamToken:          cfg.Matcher.Params.JoinToken,
-			ParamScriptName:     cfg.Matcher.Params.ScriptName,
-			ParamSSHDConfigPath: cfg.Matcher.Params.SSHDConfig,
-		}
+
+	parameters := map[string]string{
+		ParamToken:      cfg.Matcher.Params.JoinToken,
+		ParamScriptName: cfg.Matcher.Params.ScriptName,
 	}
 
+	if len(envVars) > 0 {
+		parameters[ParamEnvVars] = strings.Join(envVars, " ")
+	}
+
+	if !cfg.Matcher.Params.InstallTeleport {
+		parameters[ParamSSHDConfigPath] = cfg.Matcher.Params.SSHDConfig
+	}
+
+	return parameters
+}
+
+func ssmRunCommandParameters(cfg ec2FetcherConfig) map[string]string {
 	var envVars []string
 
 	// InstallSuffix and UpdateGroup only contains alphanumeric characters and hyphens.
@@ -374,36 +415,38 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		safeUpdateGroup := shsprintf.EscapeDefaultContext(cfg.UpdateGroup)
 		envVars = append(envVars, "TELEPORT_UPDATE_GROUP="+safeUpdateGroup)
 	}
-	if len(envVars) > 0 {
-		parameters["env"] = strings.Join(envVars, " ")
+
+	// For custom SSM Documents, the following parameters are used: env, scriptName and token.
+	//
+	// However, when using the pre-defined SSM Document AWS-RunShellScript, we need to construct
+	// the "commands" parameter.
+	if cfg.Document != types.AWSSSMDocumentRunShellScript {
+		return ssmRunCommandParametersForCustomDocuments(cfg, envVars)
 	}
 
-	fetcher := ec2InstanceFetcher{
-		EC2ClientGetter:     cfg.EC2ClientGetter,
-		Filters:             tagFilters,
-		Region:              cfg.Region,
-		DocumentName:        cfg.Document,
-		Parameters:          parameters,
-		Integration:         cfg.Integration,
-		DiscoveryConfigName: cfg.DiscoveryConfigName,
-		EnrollMode:          cfg.EnrollMode,
-		cachedInstances: &instancesCache{
-			instances: map[cachedInstanceKey]struct{}{},
-		},
+	publicProxyAddr := cmp.Or(cfg.Matcher.Params.PublicProxyAddr, cfg.ProxyPublicAddr)
+
+	command := fmt.Sprintf("curl -s -L https://%s/v1/webapi/scripts/installer/%s | bash -s %s",
+		publicProxyAddr,
+		cfg.Matcher.Params.ScriptName,
+		cfg.Matcher.Params.JoinToken,
+	)
+
+	if len(envVars) > 0 {
+		command = fmt.Sprintf("export %s; %s", strings.Join(envVars, " "), command)
 	}
-	if ar := cfg.Matcher.AssumeRole; ar != nil {
-		fetcher.AssumeRoleARN = ar.RoleARN
-		fetcher.ExternalID = ar.ExternalID
+
+	return map[string]string{
+		ParamCommands: command,
 	}
-	return &fetcher
 }
 
 // GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes
 func (f *ec2InstanceFetcher) GetMatchingInstances(nodes []types.Server, rotation bool) ([]Instances, error) {
 	insts := EC2Instances{
 		Region:              f.Region,
-		DocumentName:        f.DocumentName,
-		Parameters:          f.Parameters,
+		DocumentName:        f.Document,
+		Parameters:          ssmRunCommandParameters(f.ec2FetcherConfig),
 		Rotation:            rotation,
 		Integration:         f.Integration,
 		DiscoveryConfigName: f.DiscoveryConfigName,
@@ -491,13 +534,13 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 				inst := EC2Instances{
 					AccountID:           ownerID,
 					Region:              f.Region,
-					DocumentName:        f.DocumentName,
+					DocumentName:        f.Document,
 					Instances:           ToEC2Instances(res.Instances[i:end]),
-					Parameters:          f.Parameters,
+					Parameters:          ssmRunCommandParameters(f.ec2FetcherConfig),
 					Rotation:            rotation,
 					Integration:         f.Integration,
-					AssumeRoleARN:       f.AssumeRoleARN,
-					ExternalID:          f.ExternalID,
+					AssumeRoleARN:       f.Matcher.AssumeRole.RoleARN,
+					ExternalID:          f.Matcher.AssumeRole.ExternalID,
 					DiscoveryConfigName: f.DiscoveryConfigName,
 					EnrollMode:          f.EnrollMode,
 				}

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -277,7 +277,7 @@ func TestEC2Watcher(t *testing.T) {
 	})
 
 	fetchersFn := func() []Fetcher {
-		fetchers, err := matchersToEC2InstanceFetchers(MatcherParamsToEC2Fetcher{
+		fetchers, err := matchersToEC2InstanceFetchers(MatcherToEC2FetcherParams{
 			Matchers:        matchers,
 			PublicProxyAddr: "proxy.example.com:3080",
 		}, getClient)
@@ -347,7 +347,7 @@ func TestMatchersToEC2InstanceFetchers(t *testing.T) {
 		SSM:     &types.AWSSSM{},
 	}}
 
-	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherParamsToEC2Fetcher{
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
 		Matchers:        matchers,
 		EC2ClientGetter: ec2ClientGetter,
 	})

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -276,9 +276,11 @@ func TestEC2Watcher(t *testing.T) {
 		"alternate-role-arn": &altAccountOutput,
 	})
 
-	const noDiscoveryConfig = ""
 	fetchersFn := func() []Fetcher {
-		fetchers, err := matchersToEC2InstanceFetchers(t.Context(), matchers, getClient, noDiscoveryConfig)
+		fetchers, err := matchersToEC2InstanceFetchers(MatcherParamsToEC2Fetcher{
+			Matchers:        matchers,
+			PublicProxyAddr: "proxy.example.com:3080",
+		}, getClient)
 		require.NoError(t, err)
 
 		return fetchers
@@ -345,7 +347,10 @@ func TestMatchersToEC2InstanceFetchers(t *testing.T) {
 		SSM:     &types.AWSSSM{},
 	}}
 
-	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), matchers, ec2ClientGetter, "")
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherParamsToEC2Fetcher{
+		Matchers:        matchers,
+		EC2ClientGetter: ec2ClientGetter,
+	})
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 }
@@ -503,6 +508,91 @@ func TestToEC2Instances(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := ToEC2Instances(tt.input)
 			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestSSMRunCommandParameters(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		cfg            ec2FetcherConfig
+		expectedParams map[string]string
+	}{
+		{
+			name: "using custom ssm document",
+			cfg: ec2FetcherConfig{
+				Matcher: types.AWSMatcher{
+					Params: &types.InstallerParams{
+						InstallTeleport: true,
+						JoinToken:       "my-token",
+						ScriptName:      "default-installer",
+					},
+				},
+				Document: "TeleportDiscoveryInstaller",
+			},
+			expectedParams: map[string]string{
+				"token":      "my-token",
+				"scriptName": "default-installer",
+			},
+		},
+		{
+			name: "using custom ssm document without agentless install",
+			cfg: ec2FetcherConfig{
+				Matcher: types.AWSMatcher{
+					Params: &types.InstallerParams{
+						InstallTeleport: false,
+						JoinToken:       "my-token",
+						ScriptName:      "default-agentless-installer",
+						SSHDConfig:      "/etc/ssh/sshd_config",
+					},
+				},
+				Document: "TeleportDiscoveryInstaller",
+			},
+			expectedParams: map[string]string{
+				"token":          "my-token",
+				"scriptName":     "default-agentless-installer",
+				"sshdConfigPath": "/etc/ssh/sshd_config",
+			},
+		},
+		{
+			name: "using pre-defined AWS document",
+			cfg: ec2FetcherConfig{
+				Matcher: types.AWSMatcher{
+					Params: &types.InstallerParams{
+						InstallTeleport: true,
+						JoinToken:       "my-token",
+						ScriptName:      "default-installer",
+					},
+				},
+				Document:        "AWS-RunShellScript",
+				ProxyPublicAddr: "proxy.example.com",
+			},
+			expectedParams: map[string]string{
+				"commands": "curl -s -L https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token",
+			},
+		},
+		{
+			name: "using pre-defined AWS document with env vars defined",
+			cfg: ec2FetcherConfig{
+				Matcher: types.AWSMatcher{
+					Params: &types.InstallerParams{
+						InstallTeleport: true,
+						JoinToken:       "my-token",
+						ScriptName:      "default-installer",
+					},
+				},
+				Document:        "AWS-RunShellScript",
+				ProxyPublicAddr: "proxy.example.com",
+				InstallSuffix:   "cluster-green",
+			},
+			expectedParams: map[string]string{
+				"commands": "export TELEPORT_INSTALL_SUFFIX=cluster-green; curl -s -L https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ssmRunCommandParameters(tt.cfg)
+			require.Equal(t, tt.expectedParams, got)
 		})
 	}
 }


### PR DESCRIPTION
tldr: if you set the EC2 Discover SSM Document to `AWS-RunShellScript` you don't need to create a custom SSM Document (per account/per region).

EC2 Auto Discovery uses AWS SSM to install teleport into the EC2 target instances.
It calls `ssm.SendCommand` to execute an SSM Document which installs, configures and runs teleport.
The teleport instance running on the target instances will join the cluster afterwards.

In order to call `ssm.SendCommand` we need to pass an SSM Document.

So far, we asked users to create a specific SSM Document
Whether using the docs EC2 Discover guide:
https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual/#step-37-create-ssm-documents

Or the WebUI:
<img width="1064" height="687" alt="image" src="https://github.com/user-attachments/assets/a783cc05-e1d9-41a2-88ff-b4c565ad61bb" />

This requires a moving piece which is really not necessary.
**SSM Documents are per-region, which makes this an even worse problem**, eg, https://github.com/gravitational/teleport/issues/48532

This PR changes the discovery flow to ensure it knows about `AWS-RunShellScript` SSM document.
This document is managed by AWS and **exists in all accounts and regions**, thus we don't need to create a custom SSM document.

This change also brings the EC2 server discovery implementation closer to the one used for 
Azure:
https://github.com/gravitational/teleport/blob/5d2837182975d78d8d7665a1baf647da23929a03/lib/srv/server/azure_installer.go#L111

GCP:
https://github.com/gravitational/teleport/blob/5d2837182975d78d8d7665a1baf647da23929a03/lib/srv/server/gcp_installer.go#L84

In the future, the default SSM Document will be changed but for now users must set it in the matcher's SSM Document field.

**Backwards compat:**
Users which have an explicit SSM Document will see no change.
Users which have no explicit SSM Document (we default to TeleportDiscoveryInstaller) will see not change.

Only users that explicitly set the matcher's SSM Document to `AWS-RunShellScript` will get the new flow.

Docs will be updated with note explaining this change and marking the custom SSM Document creation step as optional.

WebUI flow should be updated afterwards to:
- set the SSM Document to `AWS-RunShellScript` in the DiscoveryConfig Matcher
- change one-off to not create the SSM Document

changelog: Adapts EC2 Server auto discovery to send the correct parameters when using the `AWS-RunShellScript` pre-defined SSM Document.