### PR TITLE
Fix spurious warning when `tbot` is initialised prior to `teleport configure`

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1012,7 +1012,16 @@ func onConfigDump(flags dumpFlags) error {
 			os.Stderr, "%s Could not check the contents of %s: %s\n         The data directory may contain existing cluster state.\n", utils.Color(utils.Yellow, "WARNING:"), flags.DataDir, err.Error())
 	}
 
-	if err == nil && len(entries) != 0 {
+	// Filter out the default directory /var/lib/teleport/bot used by `tbot` to
+	// avoid throwing a scary warning if `tbot` was installed prior to
+	// configuring teleport.
+	filteredEntries := make([]os.DirEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.Name() != "bot" {
+			filteredEntries = append(filteredEntries, entry)
+		}
+	}
+	if err == nil && len(filteredEntries) != 0 {
 		fmt.Fprintf(
 			os.Stderr,
 			"%s The data directory %s is not empty and may contain existing cluster state. Running this configuration is likely a mistake. To join a new cluster, specify an alternate --data-dir or clear the %s directory.\n",

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -1015,13 +1015,10 @@ func onConfigDump(flags dumpFlags) error {
 	// Filter out the default directory /var/lib/teleport/bot used by `tbot` to
 	// avoid throwing a scary warning if `tbot` was installed prior to
 	// configuring teleport.
-	filteredEntries := make([]os.DirEntry, 0, len(entries))
-	for _, entry := range entries {
-		if entry.Name() != "bot" {
-			filteredEntries = append(filteredEntries, entry)
-		}
-	}
-	if err == nil && len(filteredEntries) != 0 {
+	entries = slices.DeleteFunc(entries, func(entry os.DirEntry) bool {
+		return entry.Name() == "bot"
+	})
+	if err == nil && len(entries) != 0 {
 		fmt.Fprintf(
 			os.Stderr,
 			"%s The data directory %s is not empty and may contain existing cluster state. Running this configuration is likely a mistake. To join a new cluster, specify an alternate --data-dir or clear the %s directory.\n",


### PR DESCRIPTION
By default tbot will write internal state to /var/lib/teleport/bot. If a user installs tbot prior to installing Teleport, they'll receive a fairly scary message when they try to use teleport configure:

```
The data directory %s is not empty and may contain existing cluster state. Running this configuration is likely a mistake. To join a new cluster, specify an alternate --data-dir or clear the %s directory
```

This PR changes the implementation of `teleport configure` to ignore the bot subdirectory.

I've manually tested w/ and w/o this change - it doesn't appear we have a good scaffold for automated testing here based on logs.

Closes https://github.com/gravitational/teleport/issues/60214