### PR TITLE
AWS IAM Roles Anywhere: ignore sync profile when listing profiles

### DIFF
--- a/lib/auth/integration/integrationv1/awsra.go
+++ b/lib/auth/integration/integrationv1/awsra.go
@@ -232,6 +232,7 @@ func (s *AWSRolesAnywhereService) ListRolesAnywhereProfiles(ctx context.Context,
 	profileList, err := awsra.ListRolesAnywhereProfiles(ctx, listRolesAnywhereClient, awsra.ListRolesAnywhereProfilesRequest{
 		NextToken:          req.GetNextPageToken(),
 		ProfileNameFilters: req.GetProfileNameFilters(),
+		IgnoredProfileARNs: []string{spec.ProfileSyncConfig.ProfileARN},
 		PageSize:           int(req.GetPageSize()),
 	})
 	if err != nil {
@@ -321,7 +322,9 @@ func (s *AWSRolesAnywhereService) AWSRolesAnywherePing(ctx context.Context, req 
 		return nil, trace.Wrap(err)
 	}
 
-	pingResp, err := awsra.Ping(ctx, pingClient, profileARN)
+	ignoredProfiles := []string{profileARN}
+
+	pingResp, err := awsra.Ping(ctx, pingClient, ignoredProfiles)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/integrations/awsra/ping.go
+++ b/lib/integrations/awsra/ping.go
@@ -77,14 +77,15 @@ func NewPingClient(ctx context.Context, req *AWSClientConfig) (PingClient, error
 // It returns a list of Roles Anywhere Profiles that are enabled.
 //
 // It will ignore any profile matching ignoredProfileARN.
-func Ping(ctx context.Context, clt PingClient, ignoredProfileARN string) (*PingResponse, error) {
+func Ping(ctx context.Context, clt PingClient, ignoredProfileARNs []string) (*PingResponse, error) {
 	var errs []error
 
 	profileCounter := 0
 	var nextToken *string
 	for {
 		listReq := listRolesAnywhereProfilesRequest{
-			nextPage: nextToken,
+			nextPage:           nextToken,
+			ignoredProfileARNs: ignoredProfileARNs,
 		}
 		profiles, nextPageToken, err := listRolesAnywhereProfilesPage(ctx, clt, listReq)
 		if err != nil {
@@ -92,11 +93,8 @@ func Ping(ctx context.Context, clt PingClient, ignoredProfileARN string) (*PingR
 			break
 		}
 		for _, profile := range profiles {
-			// Ignore disabled profiles, profiles without assigned roles and the ignoreProfileARN.
-			if profile.Enabled &&
-				len(profile.Roles) > 0 &&
-				profile.Arn != ignoredProfileARN {
-
+			// Ignore disabled profiles and profiles without assigned roles.
+			if profile.Enabled && len(profile.Roles) > 0 {
 				profileCounter++
 			}
 		}

--- a/lib/integrations/awsra/ping_test.go
+++ b/lib/integrations/awsra/ping_test.go
@@ -75,7 +75,7 @@ func TestPing(t *testing.T) {
 				disabledProfile,
 				profileWithoutRoles,
 			},
-		}, *syncProfile.ProfileArn)
+		}, []string{*syncProfile.ProfileArn})
 		require.NoError(t, err)
 
 		require.Equal(t, "123456789012", resp.AccountID)


### PR DESCRIPTION
The AWS IAM Roles Anywhere integration syncs Profiles as Teleport AWS Apps.

In order to use the API, Teleport uses a specific Profile which is configured as the Profile Syncer's Profile.
This Profile is only meant to be used by Teleport for syncing profiles, and should not be available as an end-user Profile/Teleport AWS App.

During the Sync set up, we show the user all the available profiles. This listing operation, wrongly, returns the Profile used for the Profile Syncer.

We are showing a Profile that will not be available later on.

This PR changes the listing to only show the profiles that will be synced, removing the Profile used in the Profile Syncer.


Before
<img width="1868" height="1600" alt="image" src="https://github.com/user-attachments/assets/9809132b-ced2-4aa9-8069-ac07f565c47e" />


After
<img width="1524" height="1540" alt="image" src="https://github.com/user-attachments/assets/14ee4491-c9df-4506-94f8-c7c75f31c127" />
