### PR TITLE
Reduce the memory usage of the session recording processor by ~80%

### DIFF
--- a/lib/auth/recordingmetadata/recordingmetadatav1/thumbnails.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/thumbnails.go
@@ -37,8 +37,15 @@ type thumbnailBucketSampler struct {
 	startTime     time.Time
 }
 
+type thumbnailState struct {
+	svg           []byte
+	cols, rows    int
+	cursorVisible bool
+	cursor        vt10x.Cursor
+}
+
 type thumbnailEntry struct {
-	state       *vt10x.TerminalState
+	state       *thumbnailState
 	startOffset time.Duration
 	endOffset   time.Duration
 	timestamp   time.Time
@@ -56,7 +63,7 @@ func (s *thumbnailBucketSampler) shouldCapture(timestamp time.Time) bool {
 	return !timestamp.Before(s.nextTimestamp)
 }
 
-func (s *thumbnailBucketSampler) add(state *vt10x.TerminalState, timestamp time.Time) {
+func (s *thumbnailBucketSampler) add(state *thumbnailState, timestamp time.Time) {
 	if s.startTime.IsZero() {
 		s.startTime = timestamp
 	}

--- a/lib/auth/recordingmetadata/recordingmetadatav1/thumbnails_test.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/thumbnails_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hinshun/vt10x"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +31,7 @@ func TestThumbnailBucketSampler_ShouldCapture(t *testing.T) {
 
 	require.True(t, sampler.shouldCapture(baseTime))
 
-	sampler.add(&vt10x.TerminalState{}, baseTime)
+	sampler.add(&thumbnailState{}, baseTime)
 
 	require.False(t, sampler.shouldCapture(baseTime.Add(500*time.Millisecond)))
 	require.False(t, sampler.shouldCapture(baseTime.Add(999*time.Millisecond)))
@@ -44,9 +43,9 @@ func TestThumbnailBucketSampler_BasicAdd(t *testing.T) {
 	sampler := newThumbnailBucketSampler(10, time.Second)
 	baseTime := time.Now()
 
-	sampler.add(&vt10x.TerminalState{}, baseTime)
-	sampler.add(&vt10x.TerminalState{}, baseTime.Add(time.Second))
-	sampler.add(&vt10x.TerminalState{}, baseTime.Add(2*time.Second))
+	sampler.add(&thumbnailState{}, baseTime)
+	sampler.add(&thumbnailState{}, baseTime.Add(time.Second))
+	sampler.add(&thumbnailState{}, baseTime.Add(2*time.Second))
 
 	result := sampler.result()
 	require.Len(t, result, 3)
@@ -69,13 +68,13 @@ func TestThumbnailBucketSampler_AdaptInterval(t *testing.T) {
 	baseTime := time.Now()
 
 	for i := 0; i < 4; i++ {
-		sampler.add(&vt10x.TerminalState{}, baseTime.Add(time.Duration(i)*time.Second))
+		sampler.add(&thumbnailState{}, baseTime.Add(time.Duration(i)*time.Second))
 	}
 
 	require.Len(t, sampler.entries, 4)
 	require.Equal(t, time.Second, sampler.interval)
 
-	sampler.add(&vt10x.TerminalState{}, baseTime.Add(4*time.Second))
+	sampler.add(&thumbnailState{}, baseTime.Add(4*time.Second))
 
 	require.Len(t, sampler.entries, 3)
 	require.Equal(t, 2*time.Second, sampler.interval)
@@ -115,7 +114,7 @@ func TestThumbnailBucketSampler_MultipleAdaptations(t *testing.T) {
 	// Add 1500ms (4 entries)
 
 	for i := 0; i < 16; i++ {
-		sampler.add(&vt10x.TerminalState{}, baseTime.Add(time.Duration(i)*100*time.Millisecond))
+		sampler.add(&thumbnailState{}, baseTime.Add(time.Duration(i)*100*time.Millisecond))
 	}
 
 	require.Equal(t, 6400*time.Millisecond, sampler.interval)

--- a/lib/terminal/svg_test.go
+++ b/lib/terminal/svg_test.go
@@ -254,7 +254,7 @@ func TestTerminalStateToSVG(t *testing.T) {
 			tt.setup(vt)
 
 			state := vt.DumpState()
-			svg := string(VtStateToSvg(&state))
+			svg := string(VtToSvg(&state))
 
 			if golden.ShouldSet() {
 				golden.Set(t, []byte(svg))

--- a/lib/terminal/svg_test.go
+++ b/lib/terminal/svg_test.go
@@ -253,8 +253,7 @@ func TestTerminalStateToSVG(t *testing.T) {
 
 			tt.setup(vt)
 
-			state := vt.DumpState()
-			svg := string(VtToSvg(&state))
+			svg := string(VtToSvg(vt))
 
 			if golden.ShouldSet() {
 				golden.Set(t, []byte(svg))


### PR DESCRIPTION
This reduces the memory usage of the session recording processor by ~80%.

Instead of keeping the entire terminal state (primary and alternate buffers and all the information about the glyphs) to later reconstruct into an SVG, the SVG is generated immediately (as it doesn't have to store all of the same information).

Before (325mb)
<img width="1363" height="428" alt="before-memory" src="https://github.com/user-attachments/assets/591229a6-5862-48d8-a1b7-d041ed757e3e" />

After (62mb)
<img width="1381" height="422" alt="after-memory" src="https://github.com/user-attachments/assets/4bebd6d7-44f6-4eaa-87af-1814effe2525" />

changelog: Reduces the memory usage when processing a session recording by ~80%