### PR TITLE
Add a semaphore to recording processing

### DIFF
--- a/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
@@ -21,6 +21,13 @@ var sessionsProcessingMetric = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help:      "Number of session recordings being processed",
 })
 
+var sessionsPendingMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "recording_metadata",
+	Name:      "sessions_pending_total",
+	Help:      "Number of sessions waiting to be processed",
+})
+
 func init() {
 	metrics.RegisterPrometheusCollectors(
 		sessionsProcessedMetric,

--- a/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package recordingmetadatav1
 
 import (

--- a/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
@@ -7,23 +7,25 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
+const subsystem = "recording_metadata"
+
 var sessionsProcessedMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
 	Namespace: teleport.MetricNamespace,
-	Subsystem: "recording_metadata",
+	Subsystem: subsystem,
 	Name:      "sessions_processed_total",
 	Help:      "Total number of session recordings processed, with success or failure",
 }, []string{"success"})
 
 var sessionsProcessingMetric = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: teleport.MetricNamespace,
-	Subsystem: "recording_metadata",
+	Subsystem: subsystem,
 	Name:      "sessions_processing_total",
 	Help:      "Number of session recordings being processed",
 })
 
 var sessionsPendingMetric = prometheus.NewGauge(prometheus.GaugeOpts{
 	Namespace: teleport.MetricNamespace,
-	Subsystem: "recording_metadata",
+	Subsystem: subsystem,
 	Name:      "sessions_pending_total",
 	Help:      "Number of sessions waiting to be processed",
 })

--- a/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/metrics.go
@@ -1,0 +1,29 @@
+package recordingmetadatav1
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/observability/metrics"
+)
+
+var sessionsProcessedMetric = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "recording_metadata",
+	Name:      "sessions_processed_total",
+	Help:      "Total number of session recordings processed, with success or failure",
+}, []string{"success"})
+
+var sessionsProcessingMetric = prometheus.NewGauge(prometheus.GaugeOpts{
+	Namespace: teleport.MetricNamespace,
+	Subsystem: "recording_metadata",
+	Name:      "sessions_processing_total",
+	Help:      "Number of session recordings being processed",
+})
+
+func init() {
+	metrics.RegisterPrometheusCollectors(
+		sessionsProcessedMetric,
+		sessionsProcessingMetric,
+	)
+}

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -104,10 +104,15 @@ func NewRecordingMetadataService(cfg RecordingMetadataServiceConfig) (*Recording
 // ProcessSessionRecording processes the session recording associated with the provided session ID.
 // It streams session events, generates metadata, and uploads thumbnails and metadata.
 func (s *RecordingMetadataService) ProcessSessionRecording(ctx context.Context, sessionID session.ID) error {
+	sessionsPendingMetric.Inc()
+
 	if err := s.concurrencyLimiter.Acquire(ctx, 1); err != nil {
+		sessionsPendingMetric.Dec()
 		return trace.Wrap(err)
 	}
 	defer s.concurrencyLimiter.Release(1)
+
+	sessionsPendingMetric.Dec()
 
 	sessionsProcessingMetric.Inc()
 	defer sessionsProcessingMetric.Dec()

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -80,8 +80,8 @@ const (
 	// maxThumbnails is the maximum number of thumbnails to store in the session metadata.
 	maxThumbnails = 1000
 
-	// concurrencyLimit limits the number of concurrent processing operations.
-	concurrencyLimit = 20
+	// concurrencyLimit limits the number of concurrent processing operations (matches the session summarizer).
+	concurrencyLimit = 150
 )
 
 // NewRecordingMetadataService creates a new instance of RecordingMetadataService with the provided configuration.

--- a/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
+++ b/lib/auth/recordingmetadata/recordingmetadatav1/recordingmetadata.go
@@ -81,7 +81,7 @@ const (
 	maxThumbnails = 1000
 
 	// concurrencyLimit limits the number of concurrent processing operations.
-	concurrencyLimit = 5
+	concurrencyLimit = 20
 )
 
 // NewRecordingMetadataService creates a new instance of RecordingMetadataService with the provided configuration.


### PR DESCRIPTION
Limit the concurrency of session processing to 150 at a time, matching the session summarizer