### PR TITLE
Add nested AL tests + change IsAccessListMember behaviour

### DIFF
--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -305,7 +305,7 @@ func IsAccessListOwner(
 				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 			}
 			// Since we already verified that the user is not locked, don't provide lockGetter here
-			membershipType, err := IsAccessListMember(ctx, user, ownerAccessList, g, nil, clock)
+			_, err = IsAccessListMember(ctx, user, ownerAccessList, g, nil, clock)
 			if err != nil {
 				if trace.IsAccessDenied(err) {
 					ownershipErr = trace.Wrap(err)
@@ -313,13 +313,11 @@ func IsAccessListOwner(
 				}
 				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 			}
-			if membershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED {
-				if !UserMeetsRequirements(user, accessList.Spec.OwnershipRequires) {
-					ownershipErr = trace.AccessDenied("User '%s' does not meet the ownership requirements for Access List '%s'", user.GetName(), accessList.Spec.Title)
-					continue
-				}
-				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, nil
+			if !UserMeetsRequirements(user, accessList.Spec.OwnershipRequires) {
+				ownershipErr = trace.AccessDenied("User '%s' does not meet the ownership requirements for Access List '%s'", user.GetName(), accessList.Spec.Title)
+				continue
 			}
+			return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_INHERITED, nil
 		}
 	}
 

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -264,7 +264,7 @@ func IsUserLocked(err error) bool {
 
 // IsAccessListOwner checks if the given user is the Access List owner.
 // It returns an error matched by [IsUserLocked] if the user is locked.
-// If the user is not am owner, it returns a trace.AccessDenied error.
+// If the user is not an owner, it returns a trace.AccessDenied error.
 func IsAccessListOwner(
 	ctx context.Context,
 	user types.User,
@@ -305,8 +305,7 @@ func IsAccessListOwner(
 				return accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED, trace.Wrap(err)
 			}
 			// Since we already verified that the user is not locked, don't provide lockGetter here
-			_, err = IsAccessListMember(ctx, user, ownerAccessList, g, nil, clock)
-			if err != nil {
+			if _, err := IsAccessListMember(ctx, user, ownerAccessList, g, nil, clock); err != nil {
 				if trace.IsAccessDenied(err) {
 					ownershipErr = trace.Wrap(err)
 					continue

--- a/lib/accesslists/hierarchy_test.go
+++ b/lib/accesslists/hierarchy_test.go
@@ -275,7 +275,7 @@ func TestAccessListIsMember_RequirementsAndExpiry(t *testing.T) {
 
 func TestAccessListIsMember_NestedRequirements(t *testing.T) {
 	clock := clockwork.NewFakeClock()
-	ctx := context.Background()
+	ctx := t.Context()
 	locks := &mockLocksGetter{}
 
 	t.Run("nested lists with requirements at multiple levels", func(t *testing.T) {


### PR DESCRIPTION
This PR upstreams some part of https://github.com/gravitational/teleport/pull/60034 to reduce the size of the PR.

It contains:
- the `IsAccessListMember` behaviour change to always return an error if the user is not a member (reduced footgun risk)
- the `IsAccessListOwner` behaviour change to always return an error if the user is not an owner (reduced footgun risk)
- test coverage for nested access lists and cyclic graphs (cycles are skipped as they don't pass today)

The related e PR is :https://github.com/gravitational/teleport.e/pull/7423

This change slightly affects the semantics of returned errors. This doesn't affect the code in the OSS repo but one function in `e` had to be adapted. The semantic change will also be required for the visitor PR.