### PR TITLE
feat: Add filtering and sort to `tctl bots instances ls`

### DIFF
--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -508,7 +508,7 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 		if authentication != nil {
 			uiInstance.JoinMethodLatest = cmp.Or(
 				authentication.GetJoinAttrs().GetMeta().GetJoinMethod(),
-				authentication.JoinMethod,
+				authentication.GetJoinMethod(),
 			)
 		}
 

--- a/lib/web/machineid.go
+++ b/lib/web/machineid.go
@@ -17,6 +17,7 @@
 package web
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/http"
@@ -505,7 +506,10 @@ func (h *Handler) listBotInstancesV2(_ http.ResponseWriter, r *http.Request, _ h
 		}
 
 		if authentication != nil {
-			uiInstance.JoinMethodLatest = authentication.GetJoinMethod()
+			uiInstance.JoinMethodLatest = cmp.Or(
+				authentication.GetJoinAttrs().GetMeta().GetJoinMethod(),
+				authentication.JoinMethod,
+			)
 		}
 
 		if heartbeat != nil {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -74,6 +74,8 @@ type BotsCommand struct {
 	addLogins     string
 	setLogins     string
 
+	search string
+
 	botsList          *kingpin.CmdClause
 	botsAdd           *kingpin.CmdClause
 	botsRemove        *kingpin.CmdClause
@@ -128,6 +130,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
 	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
 	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 
 	c.botsInstancesAdd = c.botsInstances.Command("add", "Join a new instance onto an existing bot.").Alias("join")
 	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().StringVar(&c.botName)
@@ -556,6 +559,10 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 
 	if c.botName != "" {
 		req.Filter.BotName = c.botName
+	}
+
+	if c.search != "" {
+		req.Filter.SearchTerm = c.search
 	}
 
 	for {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -158,7 +158,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 // TryRun attempts to run subcommands.
 func (c *BotsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (bool, error) {
 	// If the `cmd` wont match a supported command, then exit before
-	// initialising the auth client
+	// initializing the auth client
 	if !c.match(cmd) {
 		return false, nil
 	}

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -617,7 +617,7 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 		return nil
 	}
 
-	t := asciitable.MakeTable([]string{"ID", "Join Method", "Version (tbot)", "Hostname", "Last Seen"})
+	t := asciitable.MakeTable([]string{"ID", "Join Method", "Version", "Hostname", "Last Seen"})
 	for _, i := range instances {
 		var (
 			joinMethod string

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -77,6 +77,9 @@ type BotsCommand struct {
 	search string
 	query  string
 
+	sortIndex string
+	sortOrder string
+
 	botsList          *kingpin.CmdClause
 	botsAdd           *kingpin.CmdClause
 	botsRemove        *kingpin.CmdClause
@@ -133,6 +136,8 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
+	c.botsInstancesList.Flag("sort-index", "Request sort index, 'bot_name', 'active_at_latest', 'version_latest' or 'host_name_latest'").Default("bot_name").StringVar(&c.sortIndex)
+	c.botsInstancesList.Flag("sort-order", "Request sort order, 'ascending' or 'descending'").Default("ascending").StringVar(&c.sortOrder)
 
 	c.botsInstancesAdd = c.botsInstances.Command("add", "Join a new instance onto an existing bot.").Alias("join")
 	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().StringVar(&c.botName)
@@ -557,6 +562,8 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 	var instances []*machineidv1pb.BotInstance
 	req := &machineidv1pb.ListBotInstancesV2Request{
 		Filter:    &machineidv1pb.ListBotInstancesV2Request_Filters{},
+		SortField: c.sortIndex,
+		SortDesc:  c.sortOrder == "descending",
 	}
 
 	if c.botName != "" {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -133,7 +133,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
 	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
-	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
+	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
 	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
 	c.botsInstancesList.Flag("sort-index", "Request sort index, 'bot_name', 'active_at_latest', 'version_latest' or 'host_name_latest'").Default("bot_name").StringVar(&c.sortIndex)

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -75,6 +75,7 @@ type BotsCommand struct {
 	setLogins     string
 
 	search string
+	query  string
 
 	botsList          *kingpin.CmdClause
 	botsAdd           *kingpin.CmdClause
@@ -131,6 +132,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
 	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 	c.botsInstancesList.Flag("search", "Fuzzy search query used to filter bot instances").StringVar(&c.search)
+	c.botsInstancesList.Flag("query", "An expression in the Teleport predicate language used to filter bot instances").StringVar(&c.query)
 
 	c.botsInstancesAdd = c.botsInstances.Command("add", "Join a new instance onto an existing bot.").Alias("join")
 	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().StringVar(&c.botName)
@@ -563,6 +565,10 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.C
 
 	if c.search != "" {
 		req.Filter.SearchTerm = c.search
+	}
+
+	if c.query != "" {
+		req.Filter.Query = c.query
 	}
 
 	for {

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -29,6 +29,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"text/template"
 	"time"
@@ -36,10 +37,13 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
@@ -150,45 +154,70 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 }
 
 // TryRun attempts to run subcommands.
-func (c *BotsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
-	var commandFunc func(ctx context.Context, client authclient.ClientI) error
-	switch cmd {
-	case c.botsList.FullCommand():
-		commandFunc = c.ListBots
-	case c.botsAdd.FullCommand():
-		commandFunc = c.AddBot
-	case c.botsRemove.FullCommand():
-		commandFunc = c.RemoveBot
-	case c.botsLock.FullCommand():
-		commandFunc = c.LockBot
-	case c.botsUpdate.FullCommand():
-		commandFunc = c.UpdateBot
-	case c.botsInstancesShow.FullCommand():
-		commandFunc = c.ShowBotInstance
-	case c.botsInstancesList.FullCommand():
-		commandFunc = c.ListBotInstances
-	case c.botsInstancesAdd.FullCommand():
-		commandFunc = c.AddBotInstance
-	default:
+func (c *BotsCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (bool, error) {
+	// If the `cmd` wont match a supported command, then exit before
+	// initialising the auth client
+	if !c.match(cmd) {
 		return false, nil
 	}
+
 	client, closeFn, err := clientFunc(ctx)
 	if err != nil {
 		return false, trace.Wrap(err)
 	}
-	err = commandFunc(ctx, client)
-	closeFn(ctx)
+	defer func() {
+		closeFn(ctx)
+	}()
+
+	switch cmd {
+	case c.botsList.FullCommand():
+		err = c.ListBots(ctx, &authClient{client})
+	case c.botsAdd.FullCommand():
+		err = c.AddBot(ctx, &authClient{client})
+	case c.botsRemove.FullCommand():
+		err = c.RemoveBot(ctx, &authClient{client})
+	case c.botsLock.FullCommand():
+		err = c.LockBot(ctx, &authClient{client})
+	case c.botsUpdate.FullCommand():
+		err = c.UpdateBot(ctx, &authClient{client})
+	case c.botsInstancesShow.FullCommand():
+		err = c.ShowBotInstance(ctx, &authClient{client})
+	case c.botsInstancesList.FullCommand():
+		err = c.ListBotInstances(ctx, &authClient{client})
+	case c.botsInstancesAdd.FullCommand():
+		err = c.AddBotInstance(ctx, &authClient{client})
+	default:
+		return false, nil
+	}
 
 	return true, trace.Wrap(err)
 }
 
+func (c *BotsCommand) match(cmd string) bool {
+	cmds := []string{
+		c.botsList.FullCommand(),
+		c.botsAdd.FullCommand(),
+		c.botsRemove.FullCommand(),
+		c.botsLock.FullCommand(),
+		c.botsUpdate.FullCommand(),
+		c.botsInstancesShow.FullCommand(),
+		c.botsInstancesList.FullCommand(),
+		c.botsInstancesAdd.FullCommand(),
+	}
+	return slices.ContainsFunc(cmds, func(c string) bool { return c == cmd })
+}
+
+type listBotsClient interface {
+	ListBots(ctx context.Context, in *machineidv1pb.ListBotsRequest, opts ...grpc.CallOption) (*machineidv1pb.ListBotsResponse, error)
+}
+
 // ListBots writes a listing of the cluster's certificate renewal bots
 // to standard out.
-func (c *BotsCommand) ListBots(ctx context.Context, client authclient.ClientI) error {
+func (c *BotsCommand) ListBots(ctx context.Context, client listBotsClient) error {
 	var bots []*machineidv1pb.Bot
 	req := &machineidv1pb.ListBotsRequest{}
 	for {
-		resp, err := client.BotServiceClient().ListBots(ctx, req)
+		resp, err := client.ListBots(ctx, req)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -229,6 +258,14 @@ func bold(text string) string {
 	return utils.Color(utils.Bold, text)
 }
 
+type addBotClient interface {
+	outputTokenClient
+	CreateBot(ctx context.Context, in *machineidv1pb.CreateBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error)
+	GetToken(ctx context.Context, name string) (types.ProvisionToken, error)
+	UpsertToken(ctx context.Context, token types.ProvisionToken) error
+	PerformMFACeremony(ctx context.Context, in *proto.CreateAuthenticateChallengeRequest, promptOpts ...mfa.PromptOpt) (*proto.MFAAuthenticateResponse, error)
+}
+
 var startMessageTemplate = template.Must(template.New("node").Funcs(template.FuncMap{
 	"bold": bold,
 }).Parse(`The bot token: {{.token}}{{if .minutes}}
@@ -267,7 +304,7 @@ Please note:
 `))
 
 // AddBot adds a new certificate renewal bot to the cluster.
-func (c *BotsCommand) AddBot(ctx context.Context, client authclient.ClientI) error {
+func (c *BotsCommand) AddBot(ctx context.Context, client addBotClient) error {
 	// Prompt for admin action MFA if required, allowing reuse for UpsertToken and CreateBot.
 	mfaResponse, err := mfa.PerformAdminActionMFACeremony(ctx, client.PerformMFACeremony, true /*allowReuse*/)
 	if err == nil {
@@ -346,7 +383,7 @@ func (c *BotsCommand) AddBot(ctx context.Context, client authclient.ClientI) err
 		},
 	}
 
-	bot, err = client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{
+	bot, err = client.CreateBot(ctx, &machineidv1pb.CreateBotRequest{
 		Bot: bot,
 	})
 	if err != nil {
@@ -356,8 +393,12 @@ func (c *BotsCommand) AddBot(ctx context.Context, client authclient.ClientI) err
 	return trace.Wrap(outputToken(c.stdout, c.format, client, bot, token))
 }
 
-func (c *BotsCommand) RemoveBot(ctx context.Context, client authclient.ClientI) error {
-	_, err := client.BotServiceClient().DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
+type removeBotClient interface {
+	DeleteBot(ctx context.Context, in *machineidv1pb.DeleteBotRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+}
+
+func (c *BotsCommand) RemoveBot(ctx context.Context, client removeBotClient) error {
+	_, err := client.DeleteBot(ctx, &machineidv1pb.DeleteBotRequest{
 		BotName: c.botName,
 	})
 	if err != nil {
@@ -369,7 +410,12 @@ func (c *BotsCommand) RemoveBot(ctx context.Context, client authclient.ClientI) 
 	return nil
 }
 
-func (c *BotsCommand) LockBot(ctx context.Context, client authclient.ClientI) error {
+type lockBotClient interface {
+	UpsertLock(ctx context.Context, lock types.Lock) error
+	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
+}
+
+func (c *BotsCommand) LockBot(ctx context.Context, client lockBotClient) error {
 	lockExpiry, err := computeLockExpiry(c.lockExpires, c.lockTTL)
 	if err != nil {
 		return trace.Wrap(err)
@@ -464,14 +510,13 @@ func (c *BotsCommand) updateBotLogins(ctx context.Context, bot *machineidv1pb.Bo
 	return trace.Wrap(mask.Append(&machineidv1pb.Bot{}, "spec.traits"))
 }
 
-// clientRoleGetter is a minimal mockable interface for the client API
-type clientRoleGetter interface {
+type updateBotRolesClient interface {
 	GetRole(context.Context, string) (types.Role, error)
 }
 
 // updateBotRoles applies updates from CLI arguments to a bot's roles, updating
 // the field mask as necessary if any updates were made.
-func (c *BotsCommand) updateBotRoles(ctx context.Context, client clientRoleGetter, bot *machineidv1pb.Bot, mask *fieldmaskpb.FieldMask) error {
+func (c *BotsCommand) updateBotRoles(ctx context.Context, client updateBotRolesClient, bot *machineidv1pb.Bot, mask *fieldmaskpb.FieldMask) error {
 	currentRoles := set.New[string](bot.Spec.Roles...)
 
 	var desiredRoles set.Set[string]
@@ -506,9 +551,15 @@ func (c *BotsCommand) updateBotRoles(ctx context.Context, client clientRoleGette
 	return trace.Wrap(mask.Append(&machineidv1pb.Bot{}, "spec.roles"))
 }
 
+type updateBotClient interface {
+	updateBotRolesClient
+	GetBot(ctx context.Context, in *machineidv1pb.GetBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error)
+	UpdateBot(ctx context.Context, in *machineidv1pb.UpdateBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error)
+}
+
 // UpdateBot performs various updates to existing bot users and roles.
-func (c *BotsCommand) UpdateBot(ctx context.Context, client authclient.ClientI) error {
-	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
+func (c *BotsCommand) UpdateBot(ctx context.Context, client updateBotClient) error {
+	bot, err := client.GetBot(ctx, &machineidv1pb.GetBotRequest{
 		BotName: c.botName,
 	})
 	if err != nil {
@@ -544,7 +595,7 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client authclient.ClientI) 
 		return nil
 	}
 
-	_, err = client.BotServiceClient().UpdateBot(ctx, &machineidv1pb.UpdateBotRequest{
+	_, err = client.UpdateBot(ctx, &machineidv1pb.UpdateBotRequest{
 		Bot:        bot,
 		UpdateMask: fieldMask,
 	})
@@ -557,9 +608,13 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client authclient.ClientI) 
 	return nil
 }
 
+type listBotInstancesClient interface {
+	ListBotInstances(ctx context.Context, in *machineidv1pb.ListBotInstancesRequest, opts ...grpc.CallOption) (*machineidv1pb.ListBotInstancesResponse, error)
+	ListBotInstancesV2(ctx context.Context, in *machineidv1pb.ListBotInstancesV2Request, opts ...grpc.CallOption) (*machineidv1pb.ListBotInstancesResponse, error)
+}
+
 // ListBotInstances lists bot instances, possibly filtering for a specific bot
-func (c *BotsCommand) ListBotInstances(ctx context.Context, client authclient.ClientI) error {
-	var instances []*machineidv1pb.BotInstance
+func (c *BotsCommand) ListBotInstances(ctx context.Context, client listBotInstancesClient) error {
 	req := &machineidv1pb.ListBotInstancesV2Request{
 		Filter:    &machineidv1pb.ListBotInstancesV2Request_Filters{},
 		SortField: c.sortIndex,
@@ -578,28 +633,26 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client authclient.Cl
 		req.Filter.Query = c.query
 	}
 
+	var instances []*machineidv1pb.BotInstance
 	for {
-		resp, err := client.BotInstanceServiceClient().ListBotInstancesV2(ctx, req)
-		if err != nil {
-			if trace.IsNotImplemented(err) && req.GetFilter().GetQuery() == "" {
-				// Fallback to increase backwards compatibility
-				// TODO(nicholasmarais1158): Remove in v20.0.0
-				//nolint:staticcheck // SA1019
-				resp, err = client.BotInstanceServiceClient().ListBotInstances(ctx, &machineidv1pb.ListBotInstancesRequest{
-					FilterBotName:    req.GetFilter().GetBotName(),
-					PageSize:         req.GetPageSize(),
-					PageToken:        req.GetPageToken(),
-					FilterSearchTerm: req.GetFilter().GetSearchTerm(),
-					Sort: &types.SortBy{
-						Field:  req.GetSortField(),
-						IsDesc: req.GetSortDesc(),
-					},
-				})
-				if err != nil {
-					return trace.Wrap(err)
-				}
-			}
+		resp, err := client.ListBotInstancesV2(ctx, req)
 
+		if trace.IsNotImplemented(err) && req.GetFilter().GetQuery() == "" {
+			// Fallback to increase backwards compatibility
+			// TODO(nicholasmarais1158): Remove in v20.0.0
+			resp, err = client.ListBotInstances(ctx, &machineidv1pb.ListBotInstancesRequest{
+				FilterBotName:    req.GetFilter().GetBotName(),
+				PageSize:         req.GetPageSize(),
+				PageToken:        req.GetPageToken(),
+				FilterSearchTerm: req.GetFilter().GetSearchTerm(),
+				Sort: &types.SortBy{
+					Field:  req.GetSortField(),
+					IsDesc: req.GetSortDesc(),
+				},
+			})
+		}
+
+		if err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -701,13 +754,20 @@ func (c *BotsCommand) ListBotInstances(ctx context.Context, client authclient.Cl
 	return nil
 }
 
+type addBotInstanceClient interface {
+	outputTokenClient
+	GetBot(ctx context.Context, in *machineidv1pb.GetBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error)
+	GetToken(ctx context.Context, name string) (types.ProvisionToken, error)
+	UpsertToken(ctx context.Context, token types.ProvisionToken) error
+}
+
 // AddBotInstance begins onboarding a new instance of an existing bot.
-func (c *BotsCommand) AddBotInstance(ctx context.Context, client authclient.ClientI) error {
+func (c *BotsCommand) AddBotInstance(ctx context.Context, client addBotInstanceClient) error {
 	// A bit of a misnomer but makes the terminology a bit more consistent. This
 	// doesn't directly create a bot instance, but creates token that allows a
 	// bot to join, which creates a new instance.
 
-	bot, err := client.BotServiceClient().GetBot(ctx, &machineidv1pb.GetBotRequest{
+	bot, err := client.GetBot(ctx, &machineidv1pb.GetBotRequest{
 		BotName: c.botName,
 	})
 	if err != nil {
@@ -764,6 +824,10 @@ func (c *BotsCommand) AddBotInstance(ctx context.Context, client authclient.Clie
 	return trace.Wrap(outputToken(c.stdout, c.format, client, bot, token))
 }
 
+type showBotInstanceClient interface {
+	GetBotInstance(ctx context.Context, in *machineidv1pb.GetBotInstanceRequest, opts ...grpc.CallOption) (*machineidv1pb.BotInstance, error)
+}
+
 var showMessageTemplate = template.Must(template.New("show").Funcs(template.FuncMap{
 	"bold": bold,
 }).Parse(`Bot: {{.instance.Spec.BotName}}
@@ -785,13 +849,13 @@ To onboard a new instance for this bot, run:
 > {{.executable}} bots instances add {{.instance.Spec.BotName}}
 `))
 
-func (c *BotsCommand) ShowBotInstance(ctx context.Context, client authclient.ClientI) error {
+func (c *BotsCommand) ShowBotInstance(ctx context.Context, client showBotInstanceClient) error {
 	botName, instanceID, err := parseInstanceID(c.instanceID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	instance, err := client.BotInstanceServiceClient().GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
+	instance, err := client.GetBotInstance(ctx, &machineidv1pb.GetBotInstanceRequest{
 		BotName:    botName,
 		InstanceId: instanceID,
 	})
@@ -837,8 +901,12 @@ type botJSONResponse struct {
 	TokenTTL time.Duration `json:"token_ttl"`
 }
 
+type outputTokenClient interface {
+	GetProxies() ([]types.Server, error)
+}
+
 // outputToken writes token information to stdout, depending on the token format.
-func outputToken(wr io.Writer, format string, client authclient.ClientI, bot *machineidv1pb.Bot, token types.ProvisionToken) error {
+func outputToken(wr io.Writer, format string, client outputTokenClient, bot *machineidv1pb.Bot, token types.ProvisionToken) error {
 	if format == teleport.JSON {
 		tokenTTL := time.Duration(0)
 		if exp := token.Expiry(); !exp.IsZero() {
@@ -961,4 +1029,52 @@ func indentString(s string, indent string) string {
 	}
 
 	return buf.String()
+}
+
+type authClient struct {
+	*authclient.Client
+}
+
+var _ listBotsClient = (*authClient)(nil)
+var _ addBotClient = (*authClient)(nil)
+var _ removeBotClient = (*authClient)(nil)
+var _ lockBotClient = (*authClient)(nil)
+var _ updateBotRolesClient = (*authClient)(nil)
+var _ updateBotClient = (*authClient)(nil)
+var _ listBotInstancesClient = (*authClient)(nil)
+var _ addBotInstanceClient = (*authClient)(nil)
+var _ showBotInstanceClient = (*authClient)(nil)
+
+func (c *authClient) CreateBot(ctx context.Context, in *machineidv1pb.CreateBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error) {
+	return c.BotServiceClient().CreateBot(ctx, in, opts...)
+}
+
+func (c *authClient) DeleteBot(ctx context.Context, in *machineidv1pb.DeleteBotRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	return c.BotServiceClient().DeleteBot(ctx, in, opts...)
+}
+
+func (c *authClient) GetBot(ctx context.Context, in *machineidv1pb.GetBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error) {
+	return c.BotServiceClient().GetBot(ctx, in, opts...)
+}
+
+func (c *authClient) GetBotInstance(ctx context.Context, in *machineidv1pb.GetBotInstanceRequest, opts ...grpc.CallOption) (*machineidv1pb.BotInstance, error) {
+	return c.BotInstanceServiceClient().GetBotInstance(ctx, in, opts...)
+}
+
+func (c *authClient) ListBotInstances(ctx context.Context, in *machineidv1pb.ListBotInstancesRequest, opts ...grpc.CallOption) (*machineidv1pb.ListBotInstancesResponse, error) {
+	// Needed for backwards compatibility
+	//nolint:staticcheck // SA1019
+	return c.BotInstanceServiceClient().ListBotInstances(ctx, in, opts...)
+}
+
+func (c *authClient) ListBotInstancesV2(ctx context.Context, in *machineidv1pb.ListBotInstancesV2Request, opts ...grpc.CallOption) (*machineidv1pb.ListBotInstancesResponse, error) {
+	return c.BotInstanceServiceClient().ListBotInstancesV2(ctx, in, opts...)
+}
+
+func (c *authClient) ListBots(ctx context.Context, in *machineidv1pb.ListBotsRequest, opts ...grpc.CallOption) (*machineidv1pb.ListBotsResponse, error) {
+	return c.BotServiceClient().ListBots(ctx, in, opts...)
+}
+
+func (c *authClient) UpdateBot(ctx context.Context, in *machineidv1pb.UpdateBotRequest, opts ...grpc.CallOption) (*machineidv1pb.Bot, error) {
+	return c.BotServiceClient().UpdateBot(ctx, in, opts...)
 }

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -550,16 +550,16 @@ func (c *BotsCommand) UpdateBot(ctx context.Context, client *authclient.Client) 
 // ListBotInstances lists bot instances, possibly filtering for a specific bot
 func (c *BotsCommand) ListBotInstances(ctx context.Context, client *authclient.Client) error {
 	var instances []*machineidv1pb.BotInstance
-	req := &machineidv1pb.ListBotInstancesRequest{}
+	req := &machineidv1pb.ListBotInstancesV2Request{
+		Filter:    &machineidv1pb.ListBotInstancesV2Request_Filters{},
+	}
 
 	if c.botName != "" {
-		req.FilterBotName = c.botName
+		req.Filter.BotName = c.botName
 	}
 
 	for {
-		// TODO(nicholasmarais1158) Use ListBotInstancesV2 instead.
-		//nolint:staticcheck // SA1019
-		resp, err := client.BotInstanceServiceClient().ListBotInstances(ctx, req)
+		resp, err := client.BotInstanceServiceClient().ListBotInstancesV2(ctx, req)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -127,6 +127,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIF
 
 	c.botsInstancesList = c.botsInstances.Command("list", "List bot instances.").Alias("ls")
 	c.botsInstancesList.Arg("name", "The name of the bot from which to list instances. If unset, lists instances from all bots.").StringVar(&c.botName)
+	c.botsInstancesList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
 	c.botsInstancesAdd = c.botsInstances.Command("add", "Join a new instance onto an existing bot.").Alias("join")
 	c.botsInstancesAdd.Arg("name", "The name of the existing bot for which to add a new instance.").Required().StringVar(&c.botName)

--- a/tool/tctl/common/bots_command_test.go
+++ b/tool/tctl/common/bots_command_test.go
@@ -547,7 +547,7 @@ func TestListBotInstancesFallback(t *testing.T) {
 
 		err := cmd.ListBotInstances(ctx, authClient)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "not implemeted in mock")
+		require.ErrorContains(t, err, "fallback not supported for requests with a query")
 	})
 }
 

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -217,6 +217,7 @@ type testServerOptions struct {
 	fileConfig      *config.FileConfig
 	fileDescriptors []*servicecfg.FileDescriptor
 	fakeClock       *clockwork.FakeClock
+	enableCache     bool
 }
 
 type testServerOptionFunc func(options *testServerOptions)
@@ -239,6 +240,12 @@ func withFakeClock(fakeClock *clockwork.FakeClock) testServerOptionFunc {
 	}
 }
 
+func withEnableCache(enableCache bool) testServerOptionFunc {
+	return func(options *testServerOptions) {
+		options.enableCache = enableCache
+	}
+}
+
 func makeAndRunTestAuthServer(t *testing.T, opts ...testServerOptionFunc) (auth *service.TeleportProcess) {
 	var options testServerOptions
 	for _, opt := range opts {
@@ -254,7 +261,7 @@ func makeAndRunTestAuthServer(t *testing.T, opts ...testServerOptionFunc) (auth 
 		require.NoError(t, err)
 	}
 
-	cfg.CachePolicy.Enabled = false
+	cfg.CachePolicy.Enabled = options.enableCache
 	cfg.Proxy.DisableWebInterface = true
 	cfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	if options.fakeClock != nil {


### PR DESCRIPTION
## Summary
This change extends `tctl bots instances ls` to support filtering and sort. These features are already available in the `ListBotInstances` rpc. It also removes the `generation` field from the output if favour of `version`.

Registered the `--format` flag - while it was supported in code, it wasn't added as a flag to the command.

Changelog: Added filter and sort flags to `tctl bots instances ls`
Updates: https://github.com/gravitational/teleport/issues/55926

## Changes
- Use v2 rpc
- Add `--format`, `--search`, `--query`, `--sort-index` and `--sort-order` flags
- Allow enabling the auth cache for the test process - required for sorting
- Added tests for `tctl bots instances ls`

## Demo
_Fuzzy search for "github" sorted by hostname_
<img width="986" height="721" alt="Screenshot 2025-10-15 at 16 14 56" src="https://github.com/user-attachments/assets/3f815ad5-f5cb-42a6-974b-6db3f81033b7" />

_Filter by bot name sorted with most recent first_
<img width="986" height="399" alt="Screenshot 2025-10-15 at 16 24 51" src="https://github.com/user-attachments/assets/71e71530-92e7-4bd2-a9e8-ac56922dd73b" />

_Advanced query for versions and join method showing oldest versions first_
<img width="1010" height="679" alt="Screenshot 2025-10-15 at 16 40 36" src="https://github.com/user-attachments/assets/a18fd02b-f833-4352-af6e-9034cd8a5040" />

## Reviewer notes
Here's a script to insert a bunch of bot instances to make testing easier; [bot_instances.sql](https://github.com/user-attachments/files/22849443/bot_instances.sql)

```
$ sqlite3 <your cluster's data dir>/backend/sqlite.db
sqlite> .read bot_instances.sql
```

The bots for these instances wont exist, but that not a problem within the scope of this change.

**Be sure to restart your cluster afterwards - the cache will not be notified of the changes.**

Delete **all** instances afterwards to tidy up, if you like;

```sql
delete from kv where key like '/bot_instance/%';
```