### PR TITLE
remove accidental second ServerInit message in bound keypair join flow

### DIFF
--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -144,6 +144,8 @@ func boundKeypairJoin(
 			}); err != nil {
 				return nil, trace.Wrap(err)
 			}
+		default:
+			return nil, trace.Errorf("server sent unexpected message type %T", msg)
 		}
 	}
 }


### PR DESCRIPTION
This PR removes a second ServerInit message that was accidentally being sent in the bound keypair join server implementation. The ServerInit message is already sent before calling `handleBoundKeypairJoin`. The client is currently silently dropping unexpected message types, I've updated the client to return an error in this case. Once approved I'll backport this fix along with the v18 backport of the bound keypair join method (https://github.com/gravitational/teleport/pull/59843) so that this isn't a problem in the wild.