### PR TITLE
docs: update k8s auto-discovery

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -290,6 +290,7 @@ machine that will run Kubernetes Discovery:
 
 ```code
 $ tctl tokens add --type=discovery,kube --format=text
+(=presets.tokens.first=)
 ```
 
 ### Configure the Teleport Kubernetes and Discovery Services

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -274,6 +274,13 @@ and create the `ClusterRole` and `ClusterRoleBinding` resources during cluster p
 
 ## Step 3/3. Configure Teleport to discover EKS clusters
 
+### Install Teleport
+
+Install Teleport on the host you are using to run the Kubernetes Service and
+Discovery Service:
+
+(!docs/pages/includes/install-linux.mdx!)
+
 ### Get a join token
 
 Teleport EKS Auto-Discovery requires a valid Teleport auth token for the Discovery and
@@ -282,10 +289,13 @@ command against your Teleport Auth Service and save it in `/tmp/token` on the
 machine that will run Kubernetes Discovery:
 
 ```code
-$ tctl tokens add --type=discovery,kube
+$ tctl tokens add --type=discovery,kube --format=text
 ```
 
 ### Configure the Teleport Kubernetes and Discovery Services
+
+On the host running the Kubernetes Service and Discovery Service, create a
+Teleport configuration file with the following content at `/etc/teleport.yaml`:
 
 (!docs/pages/includes/discovery/discovery-group.mdx!)
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -232,6 +232,7 @@ machine that will run Kubernetes Discovery:
 
 ```code
 $ tctl tokens add --type=discovery,kube --format=text
+(=presets.tokens.first=)
 ```
 
 ### Configure the Kubernetes Service and Discovery Service

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -216,14 +216,28 @@ associated with Teleport identity.
 
 ## Step 2/2. Configure Teleport to discover AKS clusters
 
+### Install Teleport
+
+Install Teleport on the host you are using to run the Kubernetes Service and
+Discovery Service:
+
+(!docs/pages/includes/install-linux.mdx!)
+
+### Get a join token
+
 Teleport AKS Auto-Discovery requires a valid auth token for the Discovery and
 Kubernetes services to join the cluster. Generate one by running the following
 command against your Teleport Auth Service and save it in `/tmp/token` on the
 machine that will run Kubernetes Discovery:
 
 ```code
-$ tctl tokens add --type=discovery,kube
+$ tctl tokens add --type=discovery,kube --format=text
 ```
+
+### Configure the Kubernetes Service and Discovery Service
+
+On the host running the Kubernetes Service and Discovery Service, create a
+Teleport configuration file with the following content at `/etc/teleport.yaml`:
 
 Enabling AKS Auto-Discovery requires that the `discovery_service.azure` section
 include at least one entry and that `discovery_service.azure.types` include `aks`.
@@ -266,6 +280,8 @@ kubernetes_service:
 
 Once you have added this configuration, start Teleport. AKS clusters matching the tags and regions
 specified in the Azure section will be added to the Teleport cluster automatically.
+
+(!docs/pages/includes/start-teleport.mdx service="the Kubernetes and Discovery Services"!)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/60289

The AWS and Azure k8s auto discovery did not have the install steps for the agent that has led to some confusion. Also did not match the google in terms of steps. 