### PR TITLE
[v18] fix kubernetes waiting containers cache index

### DIFF
--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
 
-	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	kubewaitingcontainerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -241,15 +240,6 @@ func newKubernetesWaitingContainerCollection(upstream services.KubeWaitingContai
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*kubewaitingcontainerv1.KubernetesWaitingContainer, error) {
 			out, err := stream.Collect(clientutils.Resources(ctx, upstream.ListKubernetesWaitingContainers))
 			return out, trace.Wrap(err)
-		},
-		headerTransform: func(hdr *types.ResourceHeader) *kubewaitingcontainerv1.KubernetesWaitingContainer {
-			return &kubewaitingcontainerv1.KubernetesWaitingContainer{
-				Kind:    hdr.Kind,
-				Version: hdr.Version,
-				Metadata: &headerv1.Metadata{
-					Name: hdr.Metadata.Name,
-				},
-			}
 		},
 		watch: w,
 	}, nil

--- a/lib/cache/kube.go
+++ b/lib/cache/kube.go
@@ -235,7 +235,7 @@ func newKubernetesWaitingContainerCollection(upstream services.KubeWaitingContai
 			proto.CloneOf[*kubewaitingcontainerv1.KubernetesWaitingContainer],
 			map[kubeWaitingContainerIndex]func(*kubewaitingcontainerv1.KubernetesWaitingContainer) string{
 				kubeWaitingContainerNameIndex: func(u *kubewaitingcontainerv1.KubernetesWaitingContainer) string {
-					return u.GetMetadata().GetName()
+					return u.GetSpec().GetUsername() + "/" + u.GetSpec().GetCluster() + "/" + u.GetSpec().GetNamespace() + "/" + u.GetSpec().GetPodName() + "/" + u.GetMetadata().GetName()
 				},
 			}),
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]*kubewaitingcontainerv1.KubernetesWaitingContainer, error) {

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/kubewaitingcontainer"
 )
 
 // TestKubernetes tests that CRUD operations on kubernetes clusters resources are
@@ -130,6 +132,56 @@ func TestKubernetesServers(t *testing.T) {
 				return p.presenceS.DeleteAllKubernetesServers(ctx)
 			},
 		})
+	})
+
+}
+
+func TestKubernetesWaitingContainers(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForProxy)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
+		newResource: func(name string) (*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
+			u := uuid.NewString()
+			waitingCont, err := kubewaitingcontainer.NewKubeWaitingContainer(
+				u,
+				&kubewaitingcontainerpb.KubernetesWaitingContainerSpec{
+					Username:      "user",
+					Cluster:       "cluster",
+					Namespace:     "namespace",
+					PodName:       "pod",
+					ContainerName: u,
+					Patch:         []byte("{}"),
+					PatchType:     "application/json-patch+json",
+				})
+
+			return waitingCont, trace.Wrap(err)
+		},
+		create: func(ctx context.Context, kwc *kubewaitingcontainerpb.KubernetesWaitingContainer) error {
+			_, err := p.kubeWaitingContainers.CreateKubernetesWaitingContainer(ctx, kwc)
+			return trace.Wrap(err)
+		},
+		cacheGet: func(ctx context.Context, name string) (*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
+			return p.cache.GetKubernetesWaitingContainer(ctx, &kubewaitingcontainerpb.GetKubernetesWaitingContainerRequest{
+				Username:      "user",
+				Cluster:       "cluster",
+				Namespace:     "namespace",
+				PodName:       "pod",
+				ContainerName: name,
+			})
+		},
+		list: func(ctx context.Context, i int, s string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, string, error) {
+			return p.kubeWaitingContainers.ListKubernetesWaitingContainers(ctx, i, s)
+		},
+		cacheList: func(ctx context.Context, i int, s string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, string, error) {
+			return p.cache.ListKubernetesWaitingContainers(ctx, i, s)
+		},
+
+		deleteAll: func(ctx context.Context) error {
+			return p.kubeWaitingContainers.DeleteAllKubernetesWaitingContainers(ctx)
+		},
 	})
 
 }

--- a/lib/cache/kube_test.go
+++ b/lib/cache/kube_test.go
@@ -144,15 +144,14 @@ func TestKubernetesWaitingContainers(t *testing.T) {
 
 	testResources153(t, p, testFuncs[*kubewaitingcontainerpb.KubernetesWaitingContainer]{
 		newResource: func(name string) (*kubewaitingcontainerpb.KubernetesWaitingContainer, error) {
-			u := uuid.NewString()
 			waitingCont, err := kubewaitingcontainer.NewKubeWaitingContainer(
-				u,
+				name,
 				&kubewaitingcontainerpb.KubernetesWaitingContainerSpec{
 					Username:      "user",
 					Cluster:       "cluster",
 					Namespace:     "namespace",
 					PodName:       "pod",
-					ContainerName: u,
+					ContainerName: name,
 					Patch:         []byte("{}"),
 					PatchType:     "application/json-patch+json",
 				})
@@ -178,7 +177,15 @@ func TestKubernetesWaitingContainers(t *testing.T) {
 		cacheList: func(ctx context.Context, i int, s string) ([]*kubewaitingcontainerpb.KubernetesWaitingContainer, string, error) {
 			return p.cache.ListKubernetesWaitingContainers(ctx, i, s)
 		},
-
+		delete: func(ctx context.Context, s string) error {
+			return p.kubeWaitingContainers.DeleteKubernetesWaitingContainer(ctx, &kubewaitingcontainerpb.DeleteKubernetesWaitingContainerRequest{
+				Username:      "user",
+				Cluster:       "cluster",
+				Namespace:     "namespace",
+				PodName:       "pod",
+				ContainerName: s,
+			})
+		},
 		deleteAll: func(ctx context.Context) error {
 			return p.kubeWaitingContainers.DeleteAllKubernetesWaitingContainers(ctx)
 		},


### PR DESCRIPTION
Backport #60284 to branch/v18

changelog: Fixed an issue that caused Kubernetes debug containers to fail with a “container not valid” error when launched by a user requiring moderated sessions.
