### PR TITLE
tctl resources: convert users

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -152,26 +152,6 @@ func (s *serverCollection) writeJSON(w io.Writer) error {
 	return utils.WriteJSONArray(w, s.servers)
 }
 
-type userCollection struct {
-	users []types.User
-}
-
-func (u *userCollection) Resources() (r []types.Resource) {
-	for _, resource := range u.users {
-		r = append(r, resource)
-	}
-	return r
-}
-
-func (u *userCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"User"})
-	for _, user := range u.users {
-		t.AddRow([]string{user.GetName()})
-	}
-	fmt.Println(t.AsBuffer().String())
-	return nil
-}
-
 type authorityCollection struct {
 	cas []types.CertAuthority
 }

--- a/tool/tctl/common/edit_command_test.go
+++ b/tool/tctl/common/edit_command_test.go
@@ -223,7 +223,7 @@ func testEditUser(t *testing.T, clt *authclient.Client) {
 		expected.SetCreatedBy(created.GetCreatedBy())
 		expected.SetWeakestDevice(created.GetWeakestDevice())
 
-		collection := &userCollection{users: []types.User{expected}}
+		collection := resources.NewUserCollection([]types.User{expected})
 		return trace.NewAggregate(writeYAML(collection, f), f.Close())
 	}
 

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -137,7 +137,6 @@ Same as above, but using JSON output:
 // Initialize allows ResourceCommand to plug itself into the CLI parser
 func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
 	rc.CreateHandlers = map[string]ResourceCreateHandler{
-		types.KindUser:                               rc.createUser,
 		types.KindTrustedCluster:                     rc.createTrustedCluster,
 		types.KindGithubConnector:                    rc.createGithubConnector,
 		types.KindCertAuthority:                      rc.createCertAuthority,
@@ -197,7 +196,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindInferencePolicy:                    rc.createInferencePolicy,
 	}
 	rc.UpdateHandlers = map[string]ResourceCreateHandler{
-		types.KindUser:                               rc.updateUser,
 		types.KindGithubConnector:                    rc.updateGithubConnector,
 		types.KindOIDCConnector:                      rc.updateOIDCConnector,
 		types.KindSAMLConnector:                      rc.updateSAMLConnector,
@@ -566,44 +564,6 @@ func (rc *ResourceCommand) updateGithubConnector(ctx context.Context, client *au
 	return nil
 }
 
-// createUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) createUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	user, err := services.UnmarshalUser(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	userName := user.GetName()
-	existingUser, err := client.GetUser(ctx, userName, false)
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	exists := (err == nil)
-
-	if exists {
-		if !rc.force {
-			return trace.AlreadyExists("user %q already exists", userName)
-		}
-
-		// Unmarshalling user sets createdBy to zero values which will overwrite existing data.
-		// This field should not be allowed to be overwritten.
-		user.SetCreatedBy(existingUser.GetCreatedBy())
-
-		if _, err := client.UpsertUser(ctx, user); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("user %q has been updated\n", userName)
-
-	} else {
-		if _, err := client.CreateUser(ctx, user); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("user %q has been created\n", userName)
-	}
-
-	return nil
-}
-
 func (rc *ResourceCommand) createBot(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	bot := &machineidv1pb.Bot{}
 	if err := (protojson.UnmarshalOptions{}).Unmarshal(raw.Raw, bot); err != nil {
@@ -673,21 +633,6 @@ func (rc *ResourceCommand) createDatabaseObject(ctx context.Context, client *aut
 		return trace.Wrap(err)
 	}
 	fmt.Printf("object %q has been created\n", object.GetMetadata().GetName())
-	return nil
-}
-
-// updateUser implements `tctl create user.yaml` command.
-func (rc *ResourceCommand) updateUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	user, err := services.UnmarshalUser(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if _, err := client.UpdateUser(ctx, user); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("user %q has been updated\n", user.GetName())
-
 	return nil
 }
 
@@ -1829,11 +1774,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("node %v has been deleted\n", rc.ref.Name)
-	case types.KindUser:
-		if err = client.DeleteUser(ctx, rc.ref.Name); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("user %q has been deleted\n", rc.ref.Name)
 	case types.KindToken:
 		if err = client.DeleteToken(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
@@ -2449,19 +2389,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 	// The resource hasn't been migrated yet, falling back to the old logic.
 
 	switch rc.ref.Kind {
-	case types.KindUser:
-		if rc.ref.Name == "" {
-			users, err := client.GetUsers(ctx, rc.withSecrets)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return &userCollection{users: users}, nil
-		}
-		user, err := client.GetUser(ctx, rc.ref.Name, rc.withSecrets)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return &userCollection{users: services.Users{user}}, nil
 	case types.KindConnectors:
 		sc, scErr := getSAMLConnectors(ctx, client, rc.ref.Name, rc.withSecrets)
 		oc, ocErr := getOIDCConnectors(ctx, client, rc.ref.Name, rc.withSecrets)

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -34,6 +34,7 @@ import (
 func Handlers() map[string]Handler {
 	return map[string]Handler{
 		types.KindRole: roleHandler(),
+		types.KindUser: userHandler(),
 	}
 }
 

--- a/tool/tctl/common/resources/user.go
+++ b/tool/tctl/common/resources/user.go
@@ -1,0 +1,146 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type userCollection struct {
+	users []types.User
+}
+
+// NewUserCollection creates a [Collection] over the provided users.
+func NewUserCollection(users []types.User) Collection {
+	return &userCollection{users: users}
+}
+
+func (u *userCollection) Resources() []types.Resource {
+	r := make([]types.Resource, 0, len(u.users))
+	for _, resource := range u.users {
+		r = append(r, resource)
+	}
+	return r
+}
+
+func (u *userCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"User"})
+	for _, user := range u.users {
+		t.AddRow([]string{user.GetName()})
+	}
+	fmt.Println(t.AsBuffer().String())
+	return nil
+}
+
+func userHandler() Handler {
+	return Handler{
+		getHandler:    getUser,
+		createHandler: createUser,
+		updateHandler: updateUser,
+		deleteHandler: deleteUser,
+		singleton:     false,
+		mfaRequired:   true,
+		description:   "A human user within Teleport.",
+	}
+}
+
+// createUser implements `tctl create user.yaml` command.
+func createUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	user, err := services.UnmarshalUser(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	userName := user.GetName()
+	existingUser, err := client.GetUser(ctx, userName, false)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	exists := (err == nil)
+
+	if exists {
+		if !opts.Force {
+			return trace.AlreadyExists("user %q already exists", userName)
+		}
+
+		// Unmarshalling user sets createdBy to zero values which will overwrite existing data.
+		// This field should not be allowed to be overwritten.
+		user.SetCreatedBy(existingUser.GetCreatedBy())
+
+		if _, err := client.UpsertUser(ctx, user); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("user %q has been updated\n", userName)
+
+	} else {
+		if _, err := client.CreateUser(ctx, user); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("user %q has been created\n", userName)
+	}
+
+	return nil
+}
+
+// getUser implements `tctl get user/russell` command.
+func getUser(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name == "" {
+		users, err := client.GetUsers(ctx, opts.WithSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &userCollection{users: users}, nil
+	}
+	user, err := client.GetUser(ctx, ref.Name, opts.WithSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &userCollection{users: services.Users{user}}, nil
+}
+
+// updateUser implements `tctl create user.yaml` command.
+func updateUser(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	user, err := services.UnmarshalUser(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := client.UpdateUser(ctx, user); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("user %q has been updated\n", user.GetName())
+
+	return nil
+}
+
+// deleteUser implements `tctl delete user/russell` command.
+func deleteUser(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.DeleteUser(ctx, ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("user %q has been deleted\n", ref.Name)
+	return nil
+}


### PR DESCRIPTION
Convert users to the new tctl resource handler format that was introduced in https://github.com/gravitational/teleport/pull/59518.