### PR TITLE
Reduce time to report Kubernetes health checks to the UI

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -225,6 +225,9 @@ func compareKubernetesServers(a, b types.KubeServer) int {
 	if !slices.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {
 		return Different
 	}
+	if a.GetTargetHealthStatus() != b.GetTargetHealthStatus() {
+		return Different
+	}
 	// OnlyTimestampsDifferent check must be after all Different checks.
 	if !a.Expiry().Equal(b.Expiry()) {
 		return OnlyTimestampsDifferent


### PR DESCRIPTION
The time to report a health change from a Kubernetes cluster to the auth server and UI is reduced to the `HealthCheckConfig.Spec.Interval` of `30s`.

Adding a health comparison to function `compareKubernetesServers` effects the call chain `(*kubeServerHeartbeatV2).Poll` -> `GetServerInfo`, and reduces the communication time. `GetServerInfo` is called every `5s`, and notices changes updated by the `healthcheck` package every `30s`. Prior to this change, health was reported approximately every `6m` during the `(*kubeServerHeartbeatV2).Announce` function.

In this PR:
- Compare health status in function `compareKubernetesServers`

Relates to:
- #58413