### PR TITLE
Increase LDAP dial timeout

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -40,7 +40,7 @@ import (
 const (
 	// ldapDialTimeout is the timeout for dialing the LDAP server
 	// when making an initial connection
-	ldapDialTimeout = 15 * time.Second
+	ldapDialTimeout = 30 * time.Second
 
 	// ldapRequestTimeout is the timeout for making LDAP requests.
 	// It is larger than the dial timeout because LDAP queries in large


### PR DESCRIPTION
Customer is seeing intermittent LDAP dial timeouts, so we're increasing the timeout to account for this.

changelog: Updated LDAP dial timeout from 15 seconds to 30 seconds