### PR TITLE
[v16] Add extraEnv extraArgs to teleport-operator chart.

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -218,6 +218,22 @@ is false and the operator must use an existing `ServiceAccount`.
 This value can be set to `false` when deploying in constrained environments
 where the user deploying the operator is not allowed to edit RBAC resources.
 
+## `extraEnv`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraEnv` contains extra environment to be configured on the pod.
+
+## `extraArgs`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraArgs` contains extra arguments to pass to the operator
+
 ## `imagePullPolicy`
 
 | Type | Default |

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/extra-args.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/extra-args.yaml
@@ -1,0 +1,6 @@
+extraArgs:
+  - "--namespace"
+  - "teleport"
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/.lint/extra-env.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/.lint/extra-env.yaml
@@ -1,0 +1,6 @@
+extraEnv:
+  - name: SOME_ENVIRONMENT_VARIABLE
+    value: "some-value"
+teleportAddress: "example.teleport.sh:443"
+token: "my-operator-bot"
+teleportClusterName: "example.teleport.sh"

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -60,8 +60,14 @@ spec:
             - -ca-pin
             - '{{ join "," .Values.caPins }}'
   {{- end }}
-  {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) }}
+  {{- if .Values.extraArgs }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+  {{- end }}
+  {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) (.Values.extraEnv)  }}
           env:
+    {{- if (gt (len .Values.extraEnv) 0) }}
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+    {{- end }}
     {{- if .Values.tls.existingCASecretName }}
             - name: SSL_CERT_FILE
               value: /etc/teleport-tls-ca/ca.pem

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
   {{- end }}
   {{- if or (.Values.tls.existingCASecretName) (.Values.teleportClusterName) (.Values.extraEnv)  }}
           env:
-    {{- if (gt (len .Values.extraEnv) 0) }}
+    {{- if .Values.extraEnv }}
           {{- toYaml .Values.extraEnv | nindent 12 }}
     {{- end }}
     {{- if .Values.tls.existingCASecretName }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/tests/deployment_test.yaml
@@ -216,3 +216,22 @@ tests:
           content:
             name: KUBERNETES_TOKEN_PATH
             value: /var/run/secrets/teleport/serviceaccount/token
+
+  - it: should set environment when extraEnv set in values
+    values:
+      - ../.lint/extra-env.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SOME_ENVIRONMENT_VARIABLE
+            value: "some-value"
+
+  - it: should set additional arguments when extraArgs set in values
+    values:
+      - ../.lint/extra-args.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: "--namespace"
+

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -129,6 +129,13 @@ rbac:
   # where the user deploying the operator is not allowed to edit RBAC resources.
   create: true
 
+# extraEnv(list)
+# Extra environment to be configured on the pod
+extraEnv: []
+
+# extraArgs(list) -- contains extra arguments to pass to the operator
+extraArgs: []
+
 # imagePullPolicy(string) -- sets the pull policy for any pods created by the chart.
 # See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
 # for more details.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -129,8 +129,7 @@ rbac:
   # where the user deploying the operator is not allowed to edit RBAC resources.
   create: true
 
-# extraEnv(list)
-# Extra environment to be configured on the pod
+extraEnv(list) -- contains extra environment to be configured on the pod.
 extraEnv: []
 
 # extraArgs(list) -- contains extra arguments to pass to the operator

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -129,7 +129,7 @@ rbac:
   # where the user deploying the operator is not allowed to edit RBAC resources.
   create: true
 
-extraEnv(list) -- contains extra environment to be configured on the pod.
+# extraEnv(list) -- contains extra environment to be configured on the pod.
 extraEnv: []
 
 # extraArgs(list) -- contains extra arguments to pass to the operator


### PR DESCRIPTION
Backport #46488 to branch/v16

changelog: added `extraEnv` and `extraArgs` to the teleport-operator helm chart.
