### PR TITLE
Fix database user in MySQL guide

### DIFF
--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx
@@ -190,7 +190,7 @@ the [RBAC](../rbac.mdx) guide for more details.
 To retrieve credentials for a database and connect to it:
 
 ```code
-$ tsh db connect --db-user=root --db-name=mysql example-mysql
+$ tsh db connect --db-user=alice --db-name=mysql example-mysql
 ```
 
 <Admonition type="note" title="Note">


### PR DESCRIPTION
Closes #60179

The example command for connecting to the database lists `root` as the database user, when it should be the user the guide told us to create in an earlier step.