### PR TITLE
Add a note about stable egress IPs

### DIFF
--- a/docs/pages/ips.mdx
+++ b/docs/pages/ips.mdx
@@ -13,7 +13,12 @@ While not required for most deployments, this configuration can be useful in env
 connections are blocked by default, for example, when firewalls deny all internet access unless explicitly allowed.
 
 <Admonition type="note">
-    If you are a Teleport Enterprise customer and plan to use this allowlist, please open a support ticket to let us know. This allows us to provide advance notice whenever the list is updated.
+
+Teleport Cloud does **not** provide stable egress IPs for traffic from the Auth
+Service and Proxy Service. If you are a Teleport Enterprise customer and plan to
+use this allowlist, please open a support ticket to let us know. This allows us
+to provide advance notice whenever the list is updated.
+
 </Admonition>
 
 ```

--- a/docs/pages/ips.mdx
+++ b/docs/pages/ips.mdx
@@ -12,14 +12,18 @@ you can allowlist these IPs in your firewall or proxy configuration to ensure th
 While not required for most deployments, this configuration can be useful in environments where outbound
 connections are blocked by default, for example, when firewalls deny all internet access unless explicitly allowed.
 
-<Admonition type="note">
+## Using the allowlist
 
 Teleport Cloud does **not** provide stable egress IPs for traffic from the Auth
-Service and Proxy Service. If you are a Teleport Enterprise customer and plan to
-use this allowlist, please open a support ticket to let us know. This allows us
-to provide advance notice whenever the list is updated.
+Service and Proxy Service. 
 
-</Admonition>
+If you are a Teleport Cloud customer and plan to use the allowlist of ingress
+IPs, please open a support ticket to let us know. This allows us to provide
+advance notice whenever the list is updated.
+
+## Teleport Cloud ingress IPs
+
+Teleport Cloud uses the following IP addresses for ingress:
 
 ```
 3.7.23.103/32
@@ -45,23 +49,26 @@ to provide advance notice whenever the list is updated.
 54.185.13.106/32
 ```
 
-<Admonition type="info">
-IP addresses may be added or removed from the above list over time.
-</Admonition>
+## Teleport Agent update domains
 
-When this list is modified, we will provide at least two weeks notice by:
-1. Updating the Changelog below.
-1. Notifying cloud-hosted Teleport Enterprise customers via email.
-1. Providing a [Status Page](https://status.teleport.sh/) update.
-1. Reaching out directly to Enterprise customers that have requested advanced notice.
-
-Additionally, to receive Teleport Agent updates, nodes must be able to reach the following domains via HTTPS during the update.
+To receive Teleport Agent updates, nodes must be able to reach the
+following domains via HTTPS during the update.
 
 ```
 apt.releases.teleport.dev
 yum.releases.teleport.dev
 cdn.teleport.dev
 ```
+
+## Modifications to the list
+
+IP addresses may be added or removed from the above list over time.
+
+When this list is modified, we will provide at least two weeks notice by:
+1. Updating the Changelog below.
+1. Notifying cloud-hosted Teleport Enterprise customers via email.
+1. Providing a [Status Page](https://status.teleport.sh/) update.
+1. Reaching out directly to Enterprise customers that have requested advanced notice.
 
 ## Changelog
 


### PR DESCRIPTION
Closes #59140

Add a brief note about Teleport Cloud not supporting stable Auth Service and Proxy Service IPs for egress traffic. Add the note in the first Admonition of the guide, both to avoid adding another Admonition and because this Admonition already advises the customer to reach out to the Teleport team: if the customer is reaching out anyway, including our egress IP policy here allows the reader to consider this while writing the support ticket.