### PR TITLE
[api] Add ListUserAccessLists

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist.pb.go
@@ -1309,6 +1309,61 @@ func (x *CurrentUserAssignments) GetMembershipType() AccessListUserAssignmentTyp
 	return AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
 }
 
+// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+type UserAssignments struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	OwnershipType AccessListUserAssignmentType `protobuf:"varint,1,opt,name=ownership_type,json=ownershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"ownership_type,omitempty"`
+	// membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	MembershipType AccessListUserAssignmentType `protobuf:"varint,2,opt,name=membership_type,json=membershipType,proto3,enum=teleport.accesslist.v1.AccessListUserAssignmentType" json:"membership_type,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *UserAssignments) Reset() {
+	*x = UserAssignments{}
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserAssignments) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserAssignments) ProtoMessage() {}
+
+func (x *UserAssignments) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserAssignments.ProtoReflect.Descriptor instead.
+func (*UserAssignments) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *UserAssignments) GetOwnershipType() AccessListUserAssignmentType {
+	if x != nil {
+		return x.OwnershipType
+	}
+	return AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
+func (x *UserAssignments) GetMembershipType() AccessListUserAssignmentType {
+	if x != nil {
+		return x.MembershipType
+	}
+	return AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
 // AccessListStatus contains dynamic fields calculated during retrieval.
 type AccessListStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1322,13 +1377,15 @@ type AccessListStatus struct {
 	MemberOf []string `protobuf:"bytes,4,rep,name=member_of,json=memberOf,proto3" json:"member_of,omitempty"`
 	// current_user_assignments describes the current user's ownership and membership status in the access list.
 	CurrentUserAssignments *CurrentUserAssignments `protobuf:"bytes,5,opt,name=current_user_assignments,json=currentUserAssignments,proto3" json:"current_user_assignments,omitempty"`
-	unknownFields          protoimpl.UnknownFields
-	sizeCache              protoimpl.SizeCache
+	// user_assignments describes the requested user's ownership and membership assignment types in the access list.
+	UserAssignments *UserAssignments `protobuf:"bytes,6,opt,name=user_assignments,json=userAssignments,proto3" json:"user_assignments,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AccessListStatus) Reset() {
 	*x = AccessListStatus{}
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1340,7 +1397,7 @@ func (x *AccessListStatus) String() string {
 func (*AccessListStatus) ProtoMessage() {}
 
 func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[14]
+	mi := &file_teleport_accesslist_v1_accesslist_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1353,7 +1410,7 @@ func (x *AccessListStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AccessListStatus.ProtoReflect.Descriptor instead.
 func (*AccessListStatus) Descriptor() ([]byte, []int) {
-	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{14}
+	return file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *AccessListStatus) GetMemberCount() uint32 {
@@ -1387,6 +1444,13 @@ func (x *AccessListStatus) GetMemberOf() []string {
 func (x *AccessListStatus) GetCurrentUserAssignments() *CurrentUserAssignments {
 	if x != nil {
 		return x.CurrentUserAssignments
+	}
+	return nil
+}
+
+func (x *AccessListStatus) GetUserAssignments() *UserAssignments {
+	if x != nil {
+		return x.UserAssignments
 	}
 	return nil
 }
@@ -1472,13 +1536,17 @@ const file_teleport_accesslist_v1_accesslist_proto_rawDesc = "" +
 	"\x1breview_day_of_month_changed\x18\x05 \x01(\x0e2(.teleport.accesslist.v1.ReviewDayOfMonthR\x17reviewDayOfMonthChangedJ\x04\b\x01\x10\x02R\x11frequency_changed\"\xd4\x01\n" +
 	"\x16CurrentUserAssignments\x12[\n" +
 	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
-	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xb4\x02\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\xcd\x01\n" +
+	"\x0fUserAssignments\x12[\n" +
+	"\x0eownership_type\x18\x01 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\rownershipType\x12]\n" +
+	"\x0fmembership_type\x18\x02 \x01(\x0e24.teleport.accesslist.v1.AccessListUserAssignmentTypeR\x0emembershipType\"\x88\x03\n" +
 	"\x10AccessListStatus\x12&\n" +
 	"\fmember_count\x18\x01 \x01(\rH\x00R\vmemberCount\x88\x01\x01\x12/\n" +
 	"\x11member_list_count\x18\x02 \x01(\rH\x01R\x0fmemberListCount\x88\x01\x01\x12\x19\n" +
 	"\bowner_of\x18\x03 \x03(\tR\aownerOf\x12\x1b\n" +
 	"\tmember_of\x18\x04 \x03(\tR\bmemberOf\x12h\n" +
-	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignmentsB\x0f\n" +
+	"\x18current_user_assignments\x18\x05 \x01(\v2..teleport.accesslist.v1.CurrentUserAssignmentsR\x16currentUserAssignments\x12R\n" +
+	"\x10user_assignments\x18\x06 \x01(\v2'.teleport.accesslist.v1.UserAssignmentsR\x0fuserAssignmentsB\x0f\n" +
 	"\r_member_countB\x14\n" +
 	"\x12_member_list_count*\xb6\x01\n" +
 	"\x0fReviewFrequency\x12 \n" +
@@ -1520,7 +1588,7 @@ func file_teleport_accesslist_v1_accesslist_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_accesslist_v1_accesslist_proto_enumTypes = make([]protoimpl.EnumInfo, 5)
-var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_teleport_accesslist_v1_accesslist_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(ReviewFrequency)(0),              // 0: teleport.accesslist.v1.ReviewFrequency
 	(ReviewDayOfMonth)(0),             // 1: teleport.accesslist.v1.ReviewDayOfMonth
@@ -1541,16 +1609,17 @@ var file_teleport_accesslist_v1_accesslist_proto_goTypes = []any{
 	(*ReviewSpec)(nil),                // 16: teleport.accesslist.v1.ReviewSpec
 	(*ReviewChanges)(nil),             // 17: teleport.accesslist.v1.ReviewChanges
 	(*CurrentUserAssignments)(nil),    // 18: teleport.accesslist.v1.CurrentUserAssignments
-	(*AccessListStatus)(nil),          // 19: teleport.accesslist.v1.AccessListStatus
-	(*v1.ResourceHeader)(nil),         // 20: teleport.header.v1.ResourceHeader
-	(*timestamppb.Timestamp)(nil),     // 21: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),       // 22: google.protobuf.Duration
-	(*v11.Trait)(nil),                 // 23: teleport.trait.v1.Trait
+	(*UserAssignments)(nil),           // 19: teleport.accesslist.v1.UserAssignments
+	(*AccessListStatus)(nil),          // 20: teleport.accesslist.v1.AccessListStatus
+	(*v1.ResourceHeader)(nil),         // 21: teleport.header.v1.ResourceHeader
+	(*timestamppb.Timestamp)(nil),     // 22: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 23: google.protobuf.Duration
+	(*v11.Trait)(nil),                 // 24: teleport.trait.v1.Trait
 }
 var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
-	20, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
+	21, // 0: teleport.accesslist.v1.AccessList.header:type_name -> teleport.header.v1.ResourceHeader
 	6,  // 1: teleport.accesslist.v1.AccessList.spec:type_name -> teleport.accesslist.v1.AccessListSpec
-	19, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
+	20, // 2: teleport.accesslist.v1.AccessList.status:type_name -> teleport.accesslist.v1.AccessListStatus
 	7,  // 3: teleport.accesslist.v1.AccessListSpec.owners:type_name -> teleport.accesslist.v1.AccessListOwner
 	8,  // 4: teleport.accesslist.v1.AccessListSpec.audit:type_name -> teleport.accesslist.v1.AccessListAudit
 	11, // 5: teleport.accesslist.v1.AccessListSpec.membership_requires:type_name -> teleport.accesslist.v1.AccessListRequires
@@ -1559,35 +1628,38 @@ var file_teleport_accesslist_v1_accesslist_proto_depIdxs = []int32{
 	12, // 8: teleport.accesslist.v1.AccessListSpec.owner_grants:type_name -> teleport.accesslist.v1.AccessListGrants
 	3,  // 9: teleport.accesslist.v1.AccessListOwner.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 10: teleport.accesslist.v1.AccessListOwner.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	21, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
+	22, // 11: teleport.accesslist.v1.AccessListAudit.next_audit_date:type_name -> google.protobuf.Timestamp
 	9,  // 12: teleport.accesslist.v1.AccessListAudit.recurrence:type_name -> teleport.accesslist.v1.Recurrence
 	10, // 13: teleport.accesslist.v1.AccessListAudit.notifications:type_name -> teleport.accesslist.v1.Notifications
 	0,  // 14: teleport.accesslist.v1.Recurrence.frequency:type_name -> teleport.accesslist.v1.ReviewFrequency
 	1,  // 15: teleport.accesslist.v1.Recurrence.day_of_month:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
-	22, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
-	23, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
-	23, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
-	20, // 19: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
+	23, // 16: teleport.accesslist.v1.Notifications.start:type_name -> google.protobuf.Duration
+	24, // 17: teleport.accesslist.v1.AccessListRequires.traits:type_name -> teleport.trait.v1.Trait
+	24, // 18: teleport.accesslist.v1.AccessListGrants.traits:type_name -> teleport.trait.v1.Trait
+	21, // 19: teleport.accesslist.v1.Member.header:type_name -> teleport.header.v1.ResourceHeader
 	14, // 20: teleport.accesslist.v1.Member.spec:type_name -> teleport.accesslist.v1.MemberSpec
-	21, // 21: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
-	21, // 22: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
+	22, // 21: teleport.accesslist.v1.MemberSpec.joined:type_name -> google.protobuf.Timestamp
+	22, // 22: teleport.accesslist.v1.MemberSpec.expires:type_name -> google.protobuf.Timestamp
 	3,  // 23: teleport.accesslist.v1.MemberSpec.ineligible_status:type_name -> teleport.accesslist.v1.IneligibleStatus
 	2,  // 24: teleport.accesslist.v1.MemberSpec.membership_kind:type_name -> teleport.accesslist.v1.MembershipKind
-	20, // 25: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
+	21, // 25: teleport.accesslist.v1.Review.header:type_name -> teleport.header.v1.ResourceHeader
 	16, // 26: teleport.accesslist.v1.Review.spec:type_name -> teleport.accesslist.v1.ReviewSpec
-	21, // 27: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
+	22, // 27: teleport.accesslist.v1.ReviewSpec.review_date:type_name -> google.protobuf.Timestamp
 	17, // 28: teleport.accesslist.v1.ReviewSpec.changes:type_name -> teleport.accesslist.v1.ReviewChanges
 	11, // 29: teleport.accesslist.v1.ReviewChanges.membership_requirements_changed:type_name -> teleport.accesslist.v1.AccessListRequires
 	0,  // 30: teleport.accesslist.v1.ReviewChanges.review_frequency_changed:type_name -> teleport.accesslist.v1.ReviewFrequency
 	1,  // 31: teleport.accesslist.v1.ReviewChanges.review_day_of_month_changed:type_name -> teleport.accesslist.v1.ReviewDayOfMonth
 	4,  // 32: teleport.accesslist.v1.CurrentUserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
 	4,  // 33: teleport.accesslist.v1.CurrentUserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
-	18, // 34: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
-	35, // [35:35] is the sub-list for method output_type
-	35, // [35:35] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	4,  // 34: teleport.accesslist.v1.UserAssignments.ownership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	4,  // 35: teleport.accesslist.v1.UserAssignments.membership_type:type_name -> teleport.accesslist.v1.AccessListUserAssignmentType
+	18, // 36: teleport.accesslist.v1.AccessListStatus.current_user_assignments:type_name -> teleport.accesslist.v1.CurrentUserAssignments
+	19, // 37: teleport.accesslist.v1.AccessListStatus.user_assignments:type_name -> teleport.accesslist.v1.UserAssignments
+	38, // [38:38] is the sub-list for method output_type
+	38, // [38:38] is the sub-list for method input_type
+	38, // [38:38] is the sub-list for extension type_name
+	38, // [38:38] is the sub-list for extension extendee
+	0,  // [0:38] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_proto_init() }
@@ -1595,14 +1667,14 @@ func file_teleport_accesslist_v1_accesslist_proto_init() {
 	if File_teleport_accesslist_v1_accesslist_proto != nil {
 		return
 	}
-	file_teleport_accesslist_v1_accesslist_proto_msgTypes[14].OneofWrappers = []any{}
+	file_teleport_accesslist_v1_accesslist_proto_msgTypes[15].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_proto_rawDesc)),
 			NumEnums:      5,
-			NumMessages:   15,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
@@ -2551,6 +2551,127 @@ func (x *GetSuggestedAccessListsResponse) GetAccessLists() []*AccessList {
 	return nil
 }
 
+// ListUserAccessListsRequest is the request for getting access lists where the
+// user is an owner or member.
+type ListUserAccessListsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// username is the name of the user to get access lists for.
+	Username string `protobuf:"bytes,1,opt,name=username,proto3" json:"username,omitempty"`
+	// page_size is the size of the page to request.
+	PageSize int32 `protobuf:"varint,2,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// page_token is the page token.
+	PageToken     string `protobuf:"bytes,3,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUserAccessListsRequest) Reset() {
+	*x = ListUserAccessListsRequest{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[49]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUserAccessListsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUserAccessListsRequest) ProtoMessage() {}
+
+func (x *ListUserAccessListsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[49]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListUserAccessListsRequest.ProtoReflect.Descriptor instead.
+func (*ListUserAccessListsRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{49}
+}
+
+func (x *ListUserAccessListsRequest) GetUsername() string {
+	if x != nil {
+		return x.Username
+	}
+	return ""
+}
+
+func (x *ListUserAccessListsRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListUserAccessListsRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+// ListUserAccessListsResponse is the response for getting access lists where the
+// user is an owner or member.
+type ListUserAccessListsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// access_lists are the access lists where the user is a member or owner.
+	AccessLists []*AccessList `protobuf:"bytes,1,rep,name=access_lists,json=accessLists,proto3" json:"access_lists,omitempty"`
+	// next_page_token is the next page token.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUserAccessListsResponse) Reset() {
+	*x = ListUserAccessListsResponse{}
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[50]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUserAccessListsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUserAccessListsResponse) ProtoMessage() {}
+
+func (x *ListUserAccessListsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_accesslist_v1_accesslist_service_proto_msgTypes[50]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListUserAccessListsResponse.ProtoReflect.Descriptor instead.
+func (*ListUserAccessListsResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP(), []int{50}
+}
+
+func (x *ListUserAccessListsResponse) GetAccessLists() []*AccessList {
+	if x != nil {
+		return x.AccessLists
+	}
+	return nil
+}
+
+func (x *ListUserAccessListsResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 var File_teleport_accesslist_v1_accesslist_service_proto protoreflect.FileDescriptor
 
 const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
@@ -2707,7 +2828,15 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x1eGetSuggestedAccessListsRequest\x12*\n" +
 	"\x11access_request_id\x18\x01 \x01(\tR\x0faccessRequestId\"h\n" +
 	"\x1fGetSuggestedAccessListsResponse\x12E\n" +
-	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists2\xc8\x1d\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\"t\n" +
+	"\x1aListUserAccessListsRequest\x12\x1a\n" +
+	"\busername\x18\x01 \x01(\tR\busername\x12\x1b\n" +
+	"\tpage_size\x18\x02 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x03 \x01(\tR\tpageToken\"\x8c\x01\n" +
+	"\x1bListUserAccessListsResponse\x12E\n" +
+	"\faccess_lists\x18\x01 \x03(\v2\".teleport.accesslist.v1.AccessListR\vaccessLists\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\xc8\x1e\n" +
 	"\x11AccessListService\x12o\n" +
 	"\x0eGetAccessLists\x12-.teleport.accesslist.v1.GetAccessListsRequest\x1a..teleport.accesslist.v1.GetAccessListsResponse\x12w\n" +
 	"\x0fListAccessLists\x12..teleport.accesslist.v1.ListAccessListsRequest\x1a/.teleport.accesslist.v1.ListAccessListsResponse\"\x03\x88\x02\x01\x12x\n" +
@@ -2738,7 +2867,8 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"\x16DeleteAccessListReview\x125.teleport.accesslist.v1.DeleteAccessListReviewRequest\x1a\x16.google.protobuf.Empty\x12\x81\x01\n" +
 	"\x14AccessRequestPromote\x123.teleport.accesslist.v1.AccessRequestPromoteRequest\x1a4.teleport.accesslist.v1.AccessRequestPromoteResponse\x12\x8a\x01\n" +
 	"\x17GetSuggestedAccessLists\x126.teleport.accesslist.v1.GetSuggestedAccessListsRequest\x1a7.teleport.accesslist.v1.GetSuggestedAccessListsResponse\x12{\n" +
-	"\x12GetInheritedGrants\x121.teleport.accesslist.v1.GetInheritedGrantsRequest\x1a2.teleport.accesslist.v1.GetInheritedGrantsResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
+	"\x12GetInheritedGrants\x121.teleport.accesslist.v1.GetInheritedGrantsRequest\x1a2.teleport.accesslist.v1.GetInheritedGrantsResponse\x12~\n" +
+	"\x13ListUserAccessLists\x122.teleport.accesslist.v1.ListUserAccessListsRequest\x1a3.teleport.accesslist.v1.ListUserAccessListsResponseBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1;accesslistv1b\x06proto3"
 
 var (
 	file_teleport_accesslist_v1_accesslist_service_proto_rawDescOnce sync.Once
@@ -2752,7 +2882,7 @@ func file_teleport_accesslist_v1_accesslist_service_proto_rawDescGZIP() []byte {
 	return file_teleport_accesslist_v1_accesslist_service_proto_rawDescData
 }
 
-var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_teleport_accesslist_v1_accesslist_service_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*GetAccessListsRequest)(nil),                          // 0: teleport.accesslist.v1.GetAccessListsRequest
 	(*GetAccessListsResponse)(nil),                         // 1: teleport.accesslist.v1.GetAccessListsResponse
@@ -2803,109 +2933,114 @@ var file_teleport_accesslist_v1_accesslist_service_proto_goTypes = []any{
 	(*AccessRequestPromoteResponse)(nil),                   // 46: teleport.accesslist.v1.AccessRequestPromoteResponse
 	(*GetSuggestedAccessListsRequest)(nil),                 // 47: teleport.accesslist.v1.GetSuggestedAccessListsRequest
 	(*GetSuggestedAccessListsResponse)(nil),                // 48: teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	(*AccessList)(nil),                                     // 49: teleport.accesslist.v1.AccessList
-	(*types.SortBy)(nil),                                   // 50: types.SortBy
-	(*AccessListGrants)(nil),                               // 51: teleport.accesslist.v1.AccessListGrants
-	(*Member)(nil),                                         // 52: teleport.accesslist.v1.Member
-	(*AccessListOwner)(nil),                                // 53: teleport.accesslist.v1.AccessListOwner
-	(*Review)(nil),                                         // 54: teleport.accesslist.v1.Review
-	(*timestamppb.Timestamp)(nil),                          // 55: google.protobuf.Timestamp
-	(*types.AccessRequestV3)(nil),                          // 56: types.AccessRequestV3
-	(*emptypb.Empty)(nil),                                  // 57: google.protobuf.Empty
+	(*ListUserAccessListsRequest)(nil),                     // 49: teleport.accesslist.v1.ListUserAccessListsRequest
+	(*ListUserAccessListsResponse)(nil),                    // 50: teleport.accesslist.v1.ListUserAccessListsResponse
+	(*AccessList)(nil),                                     // 51: teleport.accesslist.v1.AccessList
+	(*types.SortBy)(nil),                                   // 52: types.SortBy
+	(*AccessListGrants)(nil),                               // 53: teleport.accesslist.v1.AccessListGrants
+	(*Member)(nil),                                         // 54: teleport.accesslist.v1.Member
+	(*AccessListOwner)(nil),                                // 55: teleport.accesslist.v1.AccessListOwner
+	(*Review)(nil),                                         // 56: teleport.accesslist.v1.Review
+	(*timestamppb.Timestamp)(nil),                          // 57: google.protobuf.Timestamp
+	(*types.AccessRequestV3)(nil),                          // 58: types.AccessRequestV3
+	(*emptypb.Empty)(nil),                                  // 59: google.protobuf.Empty
 }
 var file_teleport_accesslist_v1_accesslist_service_proto_depIdxs = []int32{
-	49, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	49, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	50, // 2: teleport.accesslist.v1.ListAccessListsV2Request.sort_by:type_name -> types.SortBy
+	51, // 0: teleport.accesslist.v1.GetAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	51, // 1: teleport.accesslist.v1.ListAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	52, // 2: teleport.accesslist.v1.ListAccessListsV2Request.sort_by:type_name -> types.SortBy
 	5,  // 3: teleport.accesslist.v1.ListAccessListsV2Request.filter:type_name -> teleport.accesslist.v1.AccessListsFilter
-	49, // 4: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	51, // 5: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
-	49, // 6: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	49, // 7: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	49, // 8: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	52, // 9: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	52, // 10: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	49, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
-	52, // 12: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
-	49, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
-	52, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
-	52, // 15: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	53, // 16: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
-	52, // 17: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	52, // 18: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	52, // 19: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
-	52, // 20: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
-	54, // 21: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	54, // 22: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
-	54, // 23: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
-	55, // 24: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
-	56, // 25: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
-	49, // 26: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	0,  // 27: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
-	2,  // 28: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
-	4,  // 29: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
-	9,  // 30: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
-	10, // 31: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
-	11, // 32: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
-	12, // 33: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
-	13, // 34: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
-	14, // 35: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
-	16, // 36: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
-	18, // 37: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
-	20, // 38: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
-	24, // 39: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
-	25, // 40: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
-	27, // 41: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
-	29, // 42: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
-	30, // 43: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
-	32, // 44: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
-	33, // 45: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
-	34, // 46: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
-	36, // 47: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
-	37, // 48: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
-	22, // 49: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
-	38, // 50: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
-	40, // 51: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
-	42, // 52: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
-	44, // 53: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
-	45, // 54: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
-	47, // 55: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
-	7,  // 56: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
-	1,  // 57: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
-	3,  // 58: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
-	6,  // 59: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
-	49, // 60: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
-	49, // 61: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
-	49, // 62: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
-	57, // 63: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
-	57, // 64: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
-	15, // 65: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
-	17, // 66: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
-	19, // 67: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
-	21, // 68: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
-	52, // 69: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
-	26, // 70: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
-	28, // 71: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
-	52, // 72: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
-	31, // 73: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
-	52, // 74: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
-	57, // 75: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
-	35, // 76: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
-	57, // 77: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
-	57, // 78: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
-	23, // 79: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
-	39, // 80: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
-	41, // 81: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
-	43, // 82: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
-	57, // 83: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
-	46, // 84: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
-	48, // 85: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
-	8,  // 86: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
-	57, // [57:87] is the sub-list for method output_type
-	27, // [27:57] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	51, // 4: teleport.accesslist.v1.ListAccessListsV2Response.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	53, // 5: teleport.accesslist.v1.GetInheritedGrantsResponse.grants:type_name -> teleport.accesslist.v1.AccessListGrants
+	51, // 6: teleport.accesslist.v1.UpsertAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	51, // 7: teleport.accesslist.v1.UpdateAccessListRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	51, // 8: teleport.accesslist.v1.GetAccessListsToReviewResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	54, // 9: teleport.accesslist.v1.ListAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	54, // 10: teleport.accesslist.v1.ListAllAccessListMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	51, // 11: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.access_list:type_name -> teleport.accesslist.v1.AccessList
+	54, // 12: teleport.accesslist.v1.UpsertAccessListWithMembersRequest.members:type_name -> teleport.accesslist.v1.Member
+	51, // 13: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.access_list:type_name -> teleport.accesslist.v1.AccessList
+	54, // 14: teleport.accesslist.v1.UpsertAccessListWithMembersResponse.members:type_name -> teleport.accesslist.v1.Member
+	54, // 15: teleport.accesslist.v1.GetStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	55, // 16: teleport.accesslist.v1.GetAccessListOwnersResponse.owners:type_name -> teleport.accesslist.v1.AccessListOwner
+	54, // 17: teleport.accesslist.v1.UpsertAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	54, // 18: teleport.accesslist.v1.UpsertStaticAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	54, // 19: teleport.accesslist.v1.UpsertStaticAccessListMemberResponse.member:type_name -> teleport.accesslist.v1.Member
+	54, // 20: teleport.accesslist.v1.UpdateAccessListMemberRequest.member:type_name -> teleport.accesslist.v1.Member
+	56, // 21: teleport.accesslist.v1.ListAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	56, // 22: teleport.accesslist.v1.ListAllAccessListReviewsResponse.reviews:type_name -> teleport.accesslist.v1.Review
+	56, // 23: teleport.accesslist.v1.CreateAccessListReviewRequest.review:type_name -> teleport.accesslist.v1.Review
+	57, // 24: teleport.accesslist.v1.CreateAccessListReviewResponse.next_audit_date:type_name -> google.protobuf.Timestamp
+	58, // 25: teleport.accesslist.v1.AccessRequestPromoteResponse.access_request:type_name -> types.AccessRequestV3
+	51, // 26: teleport.accesslist.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	51, // 27: teleport.accesslist.v1.ListUserAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	0,  // 28: teleport.accesslist.v1.AccessListService.GetAccessLists:input_type -> teleport.accesslist.v1.GetAccessListsRequest
+	2,  // 29: teleport.accesslist.v1.AccessListService.ListAccessLists:input_type -> teleport.accesslist.v1.ListAccessListsRequest
+	4,  // 30: teleport.accesslist.v1.AccessListService.ListAccessListsV2:input_type -> teleport.accesslist.v1.ListAccessListsV2Request
+	9,  // 31: teleport.accesslist.v1.AccessListService.GetAccessList:input_type -> teleport.accesslist.v1.GetAccessListRequest
+	10, // 32: teleport.accesslist.v1.AccessListService.UpsertAccessList:input_type -> teleport.accesslist.v1.UpsertAccessListRequest
+	11, // 33: teleport.accesslist.v1.AccessListService.UpdateAccessList:input_type -> teleport.accesslist.v1.UpdateAccessListRequest
+	12, // 34: teleport.accesslist.v1.AccessListService.DeleteAccessList:input_type -> teleport.accesslist.v1.DeleteAccessListRequest
+	13, // 35: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:input_type -> teleport.accesslist.v1.DeleteAllAccessListsRequest
+	14, // 36: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:input_type -> teleport.accesslist.v1.GetAccessListsToReviewRequest
+	16, // 37: teleport.accesslist.v1.AccessListService.CountAccessListMembers:input_type -> teleport.accesslist.v1.CountAccessListMembersRequest
+	18, // 38: teleport.accesslist.v1.AccessListService.ListAccessListMembers:input_type -> teleport.accesslist.v1.ListAccessListMembersRequest
+	20, // 39: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:input_type -> teleport.accesslist.v1.ListAllAccessListMembersRequest
+	24, // 40: teleport.accesslist.v1.AccessListService.GetAccessListMember:input_type -> teleport.accesslist.v1.GetAccessListMemberRequest
+	25, // 41: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:input_type -> teleport.accesslist.v1.GetStaticAccessListMemberRequest
+	27, // 42: teleport.accesslist.v1.AccessListService.GetAccessListOwners:input_type -> teleport.accesslist.v1.GetAccessListOwnersRequest
+	29, // 43: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:input_type -> teleport.accesslist.v1.UpsertAccessListMemberRequest
+	30, // 44: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:input_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberRequest
+	32, // 45: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:input_type -> teleport.accesslist.v1.UpdateAccessListMemberRequest
+	33, // 46: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:input_type -> teleport.accesslist.v1.DeleteAccessListMemberRequest
+	34, // 47: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:input_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberRequest
+	36, // 48: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersForAccessListRequest
+	37, // 49: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:input_type -> teleport.accesslist.v1.DeleteAllAccessListMembersRequest
+	22, // 50: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:input_type -> teleport.accesslist.v1.UpsertAccessListWithMembersRequest
+	38, // 51: teleport.accesslist.v1.AccessListService.ListAccessListReviews:input_type -> teleport.accesslist.v1.ListAccessListReviewsRequest
+	40, // 52: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:input_type -> teleport.accesslist.v1.ListAllAccessListReviewsRequest
+	42, // 53: teleport.accesslist.v1.AccessListService.CreateAccessListReview:input_type -> teleport.accesslist.v1.CreateAccessListReviewRequest
+	44, // 54: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:input_type -> teleport.accesslist.v1.DeleteAccessListReviewRequest
+	45, // 55: teleport.accesslist.v1.AccessListService.AccessRequestPromote:input_type -> teleport.accesslist.v1.AccessRequestPromoteRequest
+	47, // 56: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:input_type -> teleport.accesslist.v1.GetSuggestedAccessListsRequest
+	7,  // 57: teleport.accesslist.v1.AccessListService.GetInheritedGrants:input_type -> teleport.accesslist.v1.GetInheritedGrantsRequest
+	49, // 58: teleport.accesslist.v1.AccessListService.ListUserAccessLists:input_type -> teleport.accesslist.v1.ListUserAccessListsRequest
+	1,  // 59: teleport.accesslist.v1.AccessListService.GetAccessLists:output_type -> teleport.accesslist.v1.GetAccessListsResponse
+	3,  // 60: teleport.accesslist.v1.AccessListService.ListAccessLists:output_type -> teleport.accesslist.v1.ListAccessListsResponse
+	6,  // 61: teleport.accesslist.v1.AccessListService.ListAccessListsV2:output_type -> teleport.accesslist.v1.ListAccessListsV2Response
+	51, // 62: teleport.accesslist.v1.AccessListService.GetAccessList:output_type -> teleport.accesslist.v1.AccessList
+	51, // 63: teleport.accesslist.v1.AccessListService.UpsertAccessList:output_type -> teleport.accesslist.v1.AccessList
+	51, // 64: teleport.accesslist.v1.AccessListService.UpdateAccessList:output_type -> teleport.accesslist.v1.AccessList
+	59, // 65: teleport.accesslist.v1.AccessListService.DeleteAccessList:output_type -> google.protobuf.Empty
+	59, // 66: teleport.accesslist.v1.AccessListService.DeleteAllAccessLists:output_type -> google.protobuf.Empty
+	15, // 67: teleport.accesslist.v1.AccessListService.GetAccessListsToReview:output_type -> teleport.accesslist.v1.GetAccessListsToReviewResponse
+	17, // 68: teleport.accesslist.v1.AccessListService.CountAccessListMembers:output_type -> teleport.accesslist.v1.CountAccessListMembersResponse
+	19, // 69: teleport.accesslist.v1.AccessListService.ListAccessListMembers:output_type -> teleport.accesslist.v1.ListAccessListMembersResponse
+	21, // 70: teleport.accesslist.v1.AccessListService.ListAllAccessListMembers:output_type -> teleport.accesslist.v1.ListAllAccessListMembersResponse
+	54, // 71: teleport.accesslist.v1.AccessListService.GetAccessListMember:output_type -> teleport.accesslist.v1.Member
+	26, // 72: teleport.accesslist.v1.AccessListService.GetStaticAccessListMember:output_type -> teleport.accesslist.v1.GetStaticAccessListMemberResponse
+	28, // 73: teleport.accesslist.v1.AccessListService.GetAccessListOwners:output_type -> teleport.accesslist.v1.GetAccessListOwnersResponse
+	54, // 74: teleport.accesslist.v1.AccessListService.UpsertAccessListMember:output_type -> teleport.accesslist.v1.Member
+	31, // 75: teleport.accesslist.v1.AccessListService.UpsertStaticAccessListMember:output_type -> teleport.accesslist.v1.UpsertStaticAccessListMemberResponse
+	54, // 76: teleport.accesslist.v1.AccessListService.UpdateAccessListMember:output_type -> teleport.accesslist.v1.Member
+	59, // 77: teleport.accesslist.v1.AccessListService.DeleteAccessListMember:output_type -> google.protobuf.Empty
+	35, // 78: teleport.accesslist.v1.AccessListService.DeleteStaticAccessListMember:output_type -> teleport.accesslist.v1.DeleteStaticAccessListMemberResponse
+	59, // 79: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembersForAccessList:output_type -> google.protobuf.Empty
+	59, // 80: teleport.accesslist.v1.AccessListService.DeleteAllAccessListMembers:output_type -> google.protobuf.Empty
+	23, // 81: teleport.accesslist.v1.AccessListService.UpsertAccessListWithMembers:output_type -> teleport.accesslist.v1.UpsertAccessListWithMembersResponse
+	39, // 82: teleport.accesslist.v1.AccessListService.ListAccessListReviews:output_type -> teleport.accesslist.v1.ListAccessListReviewsResponse
+	41, // 83: teleport.accesslist.v1.AccessListService.ListAllAccessListReviews:output_type -> teleport.accesslist.v1.ListAllAccessListReviewsResponse
+	43, // 84: teleport.accesslist.v1.AccessListService.CreateAccessListReview:output_type -> teleport.accesslist.v1.CreateAccessListReviewResponse
+	59, // 85: teleport.accesslist.v1.AccessListService.DeleteAccessListReview:output_type -> google.protobuf.Empty
+	46, // 86: teleport.accesslist.v1.AccessListService.AccessRequestPromote:output_type -> teleport.accesslist.v1.AccessRequestPromoteResponse
+	48, // 87: teleport.accesslist.v1.AccessListService.GetSuggestedAccessLists:output_type -> teleport.accesslist.v1.GetSuggestedAccessListsResponse
+	8,  // 88: teleport.accesslist.v1.AccessListService.GetInheritedGrants:output_type -> teleport.accesslist.v1.GetInheritedGrantsResponse
+	50, // 89: teleport.accesslist.v1.AccessListService.ListUserAccessLists:output_type -> teleport.accesslist.v1.ListUserAccessListsResponse
+	59, // [59:90] is the sub-list for method output_type
+	28, // [28:59] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_teleport_accesslist_v1_accesslist_service_proto_init() }
@@ -2920,7 +3055,7 @@ func file_teleport_accesslist_v1_accesslist_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc), len(file_teleport_accesslist_v1_accesslist_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   49,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service_grpc.pb.go
@@ -64,6 +64,7 @@ const (
 	AccessListService_AccessRequestPromote_FullMethodName                    = "/teleport.accesslist.v1.AccessListService/AccessRequestPromote"
 	AccessListService_GetSuggestedAccessLists_FullMethodName                 = "/teleport.accesslist.v1.AccessListService/GetSuggestedAccessLists"
 	AccessListService_GetInheritedGrants_FullMethodName                      = "/teleport.accesslist.v1.AccessListService/GetInheritedGrants"
+	AccessListService_ListUserAccessLists_FullMethodName                     = "/teleport.accesslist.v1.AccessListService/ListUserAccessLists"
 )
 
 // AccessListServiceClient is the client API for AccessListService service.
@@ -152,6 +153,9 @@ type AccessListServiceClient interface {
 	GetSuggestedAccessLists(ctx context.Context, in *GetSuggestedAccessListsRequest, opts ...grpc.CallOption) (*GetSuggestedAccessListsResponse, error)
 	// GetInheritedGrants returns the inherited grants for an access list.
 	GetInheritedGrants(ctx context.Context, in *GetInheritedGrantsRequest, opts ...grpc.CallOption) (*GetInheritedGrantsResponse, error)
+	// ListUserAccessLists returns a paginated list of all access lists where the
+	// user is an owner or member.
+	ListUserAccessLists(ctx context.Context, in *ListUserAccessListsRequest, opts ...grpc.CallOption) (*ListUserAccessListsResponse, error)
 }
 
 type accessListServiceClient struct {
@@ -463,6 +467,16 @@ func (c *accessListServiceClient) GetInheritedGrants(ctx context.Context, in *Ge
 	return out, nil
 }
 
+func (c *accessListServiceClient) ListUserAccessLists(ctx context.Context, in *ListUserAccessListsRequest, opts ...grpc.CallOption) (*ListUserAccessListsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListUserAccessListsResponse)
+	err := c.cc.Invoke(ctx, AccessListService_ListUserAccessLists_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AccessListServiceServer is the server API for AccessListService service.
 // All implementations must embed UnimplementedAccessListServiceServer
 // for forward compatibility.
@@ -549,6 +563,9 @@ type AccessListServiceServer interface {
 	GetSuggestedAccessLists(context.Context, *GetSuggestedAccessListsRequest) (*GetSuggestedAccessListsResponse, error)
 	// GetInheritedGrants returns the inherited grants for an access list.
 	GetInheritedGrants(context.Context, *GetInheritedGrantsRequest) (*GetInheritedGrantsResponse, error)
+	// ListUserAccessLists returns a paginated list of all access lists where the
+	// user is an owner or member.
+	ListUserAccessLists(context.Context, *ListUserAccessListsRequest) (*ListUserAccessListsResponse, error)
 	mustEmbedUnimplementedAccessListServiceServer()
 }
 
@@ -648,6 +665,9 @@ func (UnimplementedAccessListServiceServer) GetSuggestedAccessLists(context.Cont
 }
 func (UnimplementedAccessListServiceServer) GetInheritedGrants(context.Context, *GetInheritedGrantsRequest) (*GetInheritedGrantsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method GetInheritedGrants not implemented")
+}
+func (UnimplementedAccessListServiceServer) ListUserAccessLists(context.Context, *ListUserAccessListsRequest) (*ListUserAccessListsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListUserAccessLists not implemented")
 }
 func (UnimplementedAccessListServiceServer) mustEmbedUnimplementedAccessListServiceServer() {}
 func (UnimplementedAccessListServiceServer) testEmbeddedByValue()                           {}
@@ -1210,6 +1230,24 @@ func _AccessListService_GetInheritedGrants_Handler(srv interface{}, ctx context.
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AccessListService_ListUserAccessLists_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListUserAccessListsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessListServiceServer).ListUserAccessLists(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: AccessListService_ListUserAccessLists_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessListServiceServer).ListUserAccessLists(ctx, req.(*ListUserAccessListsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // AccessListService_ServiceDesc is the grpc.ServiceDesc for AccessListService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -1336,6 +1374,10 @@ var AccessListService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetInheritedGrants",
 			Handler:    _AccessListService_GetInheritedGrants_Handler,
+		},
+		{
+			MethodName: "ListUserAccessLists",
+			Handler:    _AccessListService_ListUserAccessLists_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/accesslist/v1/accesslist.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist.proto
@@ -309,6 +309,14 @@ message CurrentUserAssignments {
   AccessListUserAssignmentType membership_type = 2;
 }
 
+// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+message UserAssignments {
+  // ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+  AccessListUserAssignmentType ownership_type = 1;
+  // membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+  AccessListUserAssignmentType membership_type = 2;
+}
+
 // AccessListStatus contains dynamic fields calculated during retrieval.
 message AccessListStatus {
   // member_count is the number of members in the Access List.
@@ -321,4 +329,6 @@ message AccessListStatus {
   repeated string member_of = 4;
   // current_user_assignments describes the current user's ownership and membership status in the access list.
   CurrentUserAssignments current_user_assignments = 5;
+  // user_assignments describes the requested user's ownership and membership assignment types in the access list.
+  UserAssignments user_assignments = 6;
 }

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -112,6 +112,10 @@ service AccessListService {
 
   // GetInheritedGrants returns the inherited grants for an access list.
   rpc GetInheritedGrants(GetInheritedGrantsRequest) returns (GetInheritedGrantsResponse);
+
+  // ListUserAccessLists returns a paginated list of all access lists where the
+  // user is an owner or member.
+  rpc ListUserAccessLists(ListUserAccessListsRequest) returns (ListUserAccessListsResponse);
 }
 
 // GetAccessListsRequest is the request for getting all access lists.
@@ -504,4 +508,24 @@ message GetSuggestedAccessListsRequest {
 message GetSuggestedAccessListsResponse {
   // access_lists is the list of suggested lists.
   repeated AccessList access_lists = 1;
+}
+
+// ListUserAccessListsRequest is the request for getting access lists where the
+// user is an owner or member.
+message ListUserAccessListsRequest {
+  // username is the name of the user to get access lists for.
+  string username = 1;
+  // page_size is the size of the page to request.
+  int32 page_size = 2;
+  // page_token is the page token.
+  string page_token = 3;
+}
+
+// ListUserAccessListsResponse is the response for getting access lists where the
+// user is an owner or member.
+message ListUserAccessListsResponse {
+  // access_lists are the access lists where the user is a member or owner.
+  repeated AccessList access_lists = 1;
+  // next_page_token is the next page token.
+  string next_page_token = 2;
 }

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -326,6 +326,8 @@ type Status struct {
 
 	// CurrentUserAssignments describes the current user's ownership and membership in the access list.
 	CurrentUserAssignments *CurrentUserAssignments `json:"-" yaml:"-"`
+	// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+	UserAssignments *UserAssignments `json:"-" yaml:"-"`
 }
 
 // CurrentUserAssignments describes the current user's ownership and membership status in the access list.
@@ -344,6 +346,24 @@ func (c *CurrentUserAssignments) IsMember() bool {
 // IsOwner returns true if the OwnershipType is either explicit or inherited.
 func (c *CurrentUserAssignments) IsOwner() bool {
 	return c.OwnershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
+// UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+type UserAssignments struct {
+	// OwnershipType represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+	OwnershipType accesslistv1.AccessListUserAssignmentType `json:"ownership_type" yaml:"ownership_type"`
+	// MembershipType represents the requested user's membership type (explicit, inherited, or none) in the access list.
+	MembershipType accesslistv1.AccessListUserAssignmentType `json:"membership_type" yaml:"membership_type"`
+}
+
+// IsMember returns true if the MembershipType is either explicit or inherited.
+func (u *UserAssignments) IsMember() bool {
+	return u.MembershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
+}
+
+// IsOwner returns true if the OwnershipType is either explicit or inherited.
+func (u *UserAssignments) IsOwner() bool {
+	return u.OwnershipType != accesslistv1.AccessListUserAssignmentType_ACCESS_LIST_USER_ASSIGNMENT_TYPE_UNSPECIFIED
 }
 
 // NewAccessList will create a new access list.

--- a/api/types/accesslist/convert/v1/accesslist.go
+++ b/api/types/accesslist/convert/v1/accesslist.go
@@ -219,6 +219,7 @@ func convertStatusToProto(status *accesslist.Status) *accesslistv1.AccessListSta
 		OwnerOf:                status.OwnerOf,
 		MemberOf:               status.MemberOf,
 		CurrentUserAssignments: toCurrentUserAssignmentsProto(status.CurrentUserAssignments),
+		UserAssignments:        toUserAssignmentsProto(status.UserAssignments),
 	}
 }
 
@@ -234,6 +235,7 @@ func fromStatusProto(msg *accesslistv1.AccessList) *accesslist.Status {
 		OwnerOf:                protoStatus.GetOwnerOf(),
 		MemberOf:               protoStatus.GetMemberOf(),
 		CurrentUserAssignments: fromCurrentUserAssignmentsProto(protoStatus.GetCurrentUserAssignments()),
+		UserAssignments:        fromUserAssignmentsProto(protoStatus.GetUserAssignments()),
 	}
 }
 
@@ -255,11 +257,31 @@ func toCurrentUserAssignmentsProto(assignments *accesslist.CurrentUserAssignment
 	}
 }
 
+func toUserAssignmentsProto(assignments *accesslist.UserAssignments) *accesslistv1.UserAssignments {
+	if assignments == nil {
+		return nil
+	}
+	return &accesslistv1.UserAssignments{
+		OwnershipType:  assignments.OwnershipType,
+		MembershipType: assignments.MembershipType,
+	}
+}
+
 func fromCurrentUserAssignmentsProto(assignments *accesslistv1.CurrentUserAssignments) *accesslist.CurrentUserAssignments {
 	if assignments == nil {
 		return nil
 	}
 	return &accesslist.CurrentUserAssignments{
+		OwnershipType:  assignments.GetOwnershipType(),
+		MembershipType: assignments.GetMembershipType(),
+	}
+}
+
+func fromUserAssignmentsProto(assignments *accesslistv1.UserAssignments) *accesslist.UserAssignments {
+	if assignments == nil {
+		return nil
+	}
+	return &accesslist.UserAssignments{
 		OwnershipType:  assignments.GetOwnershipType(),
 		MembershipType: assignments.GetMembershipType(),
 	}

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -205,6 +205,12 @@ func deriveDeepCopy_1(dst, src *Status) {
 		dst.CurrentUserAssignments = new(CurrentUserAssignments)
 		*dst.CurrentUserAssignments = *src.CurrentUserAssignments
 	}
+	if src.UserAssignments == nil {
+		dst.UserAssignments = nil
+	} else {
+		dst.UserAssignments = new(UserAssignments)
+		*dst.UserAssignments = *src.UserAssignments
+	}
 }
 
 // deriveDeepCopy_2 recursively copies the contents of src into dst.

--- a/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
+++ b/gen/proto/ts/teleport/accesslist/v1/accesslist_pb.ts
@@ -453,6 +453,25 @@ export interface CurrentUserAssignments {
     membershipType: AccessListUserAssignmentType;
 }
 /**
+ * UserAssignments describes the requested user's ownership and membership assignment types in the access list.
+ *
+ * @generated from protobuf message teleport.accesslist.v1.UserAssignments
+ */
+export interface UserAssignments {
+    /**
+     * ownership_type represents the requested user's ownership type (explicit, inherited, or none) in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1;
+     */
+    ownershipType: AccessListUserAssignmentType;
+    /**
+     * membership_type represents the requested user's membership type (explicit, inherited, or none) in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2;
+     */
+    membershipType: AccessListUserAssignmentType;
+}
+/**
  * AccessListStatus contains dynamic fields calculated during retrieval.
  *
  * @generated from protobuf message teleport.accesslist.v1.AccessListStatus
@@ -488,6 +507,12 @@ export interface AccessListStatus {
      * @generated from protobuf field: teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5;
      */
     currentUserAssignments?: CurrentUserAssignments;
+    /**
+     * user_assignments describes the requested user's ownership and membership assignment types in the access list.
+     *
+     * @generated from protobuf field: teleport.accesslist.v1.UserAssignments user_assignments = 6;
+     */
+    userAssignments?: UserAssignments;
 }
 /**
  * ReviewFrequency is the frequency of reviews.
@@ -1550,6 +1575,61 @@ class CurrentUserAssignments$Type extends MessageType<CurrentUserAssignments> {
  */
 export const CurrentUserAssignments = new CurrentUserAssignments$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class UserAssignments$Type extends MessageType<UserAssignments> {
+    constructor() {
+        super("teleport.accesslist.v1.UserAssignments", [
+            { no: 1, name: "ownership_type", kind: "enum", T: () => ["teleport.accesslist.v1.AccessListUserAssignmentType", AccessListUserAssignmentType, "ACCESS_LIST_USER_ASSIGNMENT_TYPE_"] },
+            { no: 2, name: "membership_type", kind: "enum", T: () => ["teleport.accesslist.v1.AccessListUserAssignmentType", AccessListUserAssignmentType, "ACCESS_LIST_USER_ASSIGNMENT_TYPE_"] }
+        ]);
+    }
+    create(value?: PartialMessage<UserAssignments>): UserAssignments {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.ownershipType = 0;
+        message.membershipType = 0;
+        if (value !== undefined)
+            reflectionMergePartial<UserAssignments>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UserAssignments): UserAssignments {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* teleport.accesslist.v1.AccessListUserAssignmentType ownership_type */ 1:
+                    message.ownershipType = reader.int32();
+                    break;
+                case /* teleport.accesslist.v1.AccessListUserAssignmentType membership_type */ 2:
+                    message.membershipType = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UserAssignments, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* teleport.accesslist.v1.AccessListUserAssignmentType ownership_type = 1; */
+        if (message.ownershipType !== 0)
+            writer.tag(1, WireType.Varint).int32(message.ownershipType);
+        /* teleport.accesslist.v1.AccessListUserAssignmentType membership_type = 2; */
+        if (message.membershipType !== 0)
+            writer.tag(2, WireType.Varint).int32(message.membershipType);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.accesslist.v1.UserAssignments
+ */
+export const UserAssignments = new UserAssignments$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class AccessListStatus$Type extends MessageType<AccessListStatus> {
     constructor() {
         super("teleport.accesslist.v1.AccessListStatus", [
@@ -1557,7 +1637,8 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
             { no: 2, name: "member_list_count", kind: "scalar", opt: true, T: 13 /*ScalarType.UINT32*/ },
             { no: 3, name: "owner_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 4, name: "member_of", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
-            { no: 5, name: "current_user_assignments", kind: "message", T: () => CurrentUserAssignments }
+            { no: 5, name: "current_user_assignments", kind: "message", T: () => CurrentUserAssignments },
+            { no: 6, name: "user_assignments", kind: "message", T: () => UserAssignments }
         ]);
     }
     create(value?: PartialMessage<AccessListStatus>): AccessListStatus {
@@ -1588,6 +1669,9 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
                 case /* teleport.accesslist.v1.CurrentUserAssignments current_user_assignments */ 5:
                     message.currentUserAssignments = CurrentUserAssignments.internalBinaryRead(reader, reader.uint32(), options, message.currentUserAssignments);
                     break;
+                case /* teleport.accesslist.v1.UserAssignments user_assignments */ 6:
+                    message.userAssignments = UserAssignments.internalBinaryRead(reader, reader.uint32(), options, message.userAssignments);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -1615,6 +1699,9 @@ class AccessListStatus$Type extends MessageType<AccessListStatus> {
         /* teleport.accesslist.v1.CurrentUserAssignments current_user_assignments = 5; */
         if (message.currentUserAssignments)
             CurrentUserAssignments.internalBinaryWrite(message.currentUserAssignments, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.accesslist.v1.UserAssignments user_assignments = 6; */
+        if (message.userAssignments)
+            UserAssignments.internalBinaryWrite(message.userAssignments, writer.tag(6, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -53,6 +53,9 @@ type AccessListsGetter interface {
 	GetAccessListsToReview(context.Context) ([]*accesslist.AccessList, error)
 	// GetInheritedGrants returns grants inherited by access list accessListID from parent access lists.
 	GetInheritedGrants(context.Context, string) (*accesslist.Grants, error)
+	// ListUserAccessLists returns a paginated list of all access lists where the
+	// user is explicitly an owner or member.
+	ListUserAccessLists(context.Context, *accesslistv1.ListUserAccessListsRequest) ([]*accesslist.AccessList, string, error)
 }
 
 // AccessListsSuggestionsGetter defines an interface for reading access lists suggestions.

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -1130,3 +1130,8 @@ func keepAWSIdentityCenterLabels(old, new *accesslist.AccessListMember) {
 		new.Metadata.Labels = old.GetAllLabels()
 	}
 }
+
+// ListUserAccessLists is not implemented in the local service.
+func (a *AccessListService) ListUserAccessLists(ctx context.Context, req *accesslistv1.ListUserAccessListsRequest) ([]*accesslist.AccessList, string, error) {
+	return nil, "", trace.NotImplemented("ListUserAccessLists should not be called on local service")
+}


### PR DESCRIPTION
## Description
Issue: https://github.com/gravitational/teleport/issues/60398
`e` PR:  https://github.com/gravitational/teleport.e/pull/7437

Added `ListUserAccessList` rpc and endpoint that returns access list for a given user (owner, member)

## Context

This will be used in follow up UI work to add a User Details view to the users table which will display access lists that are associated with the user.