### PR TITLE
[v18] feat: IAM method support in new join service

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -801,6 +801,158 @@ func (x *BoundKeypairResult) GetPublicKey() []byte {
 	return nil
 }
 
+// IAMInit is sent from the client in response to the ServerInit message for
+// the IAM join method.
+//
+// The IAM method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: IAMInit
+// 4. server->client: IAMChallenge
+// 5. client->server: IAMChallengeSolution
+// 6. server->client: Result
+type IAMInit struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams  *ClientParams `protobuf:"bytes,1,opt,name=client_params,json=clientParams,proto3" json:"client_params,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IAMInit) Reset() {
+	*x = IAMInit{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IAMInit) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IAMInit) ProtoMessage() {}
+
+func (x *IAMInit) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IAMInit.ProtoReflect.Descriptor instead.
+func (*IAMInit) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *IAMInit) GetClientParams() *ClientParams {
+	if x != nil {
+		return x.ClientParams
+	}
+	return nil
+}
+
+// IAMChallenge is from the server in response to the IAMInit message from the client.
+// The client is expected to respond with a IAMChallengeSolution.
+type IAMChallenge struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Challenge is a a crypto-random string that should be included by the
+	// client in the IAMChallengeSolution message.
+	Challenge     string `protobuf:"bytes,1,opt,name=challenge,proto3" json:"challenge,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IAMChallenge) Reset() {
+	*x = IAMChallenge{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IAMChallenge) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IAMChallenge) ProtoMessage() {}
+
+func (x *IAMChallenge) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IAMChallenge.ProtoReflect.Descriptor instead.
+func (*IAMChallenge) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *IAMChallenge) GetChallenge() string {
+	if x != nil {
+		return x.Challenge
+	}
+	return ""
+}
+
+// IAMChallengeSolution must be sent from the client in response to the
+// IAMChallenge message.
+type IAMChallengeSolution struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// STSIdentityRequest is a signed sts:GetCallerIdentity API request used
+	// to prove the AWS identity of a joining node. It must include the
+	// challenge string as a signed header.
+	StsIdentityRequest []byte `protobuf:"bytes,1,opt,name=sts_identity_request,json=stsIdentityRequest,proto3" json:"sts_identity_request,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *IAMChallengeSolution) Reset() {
+	*x = IAMChallengeSolution{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IAMChallengeSolution) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IAMChallengeSolution) ProtoMessage() {}
+
+func (x *IAMChallengeSolution) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IAMChallengeSolution.ProtoReflect.Descriptor instead.
+func (*IAMChallengeSolution) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *IAMChallengeSolution) GetStsIdentityRequest() []byte {
+	if x != nil {
+		return x.StsIdentityRequest
+	}
+	return nil
+}
+
 // ChallengeSolution holds a solution to a challenge issued by the server.
 type ChallengeSolution struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -808,6 +960,7 @@ type ChallengeSolution struct {
 	//
 	//	*ChallengeSolution_BoundKeypairChallengeSolution
 	//	*ChallengeSolution_BoundKeypairRotationResponse
+	//	*ChallengeSolution_IamChallengeSolution
 	Payload       isChallengeSolution_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -815,7 +968,7 @@ type ChallengeSolution struct {
 
 func (x *ChallengeSolution) Reset() {
 	*x = ChallengeSolution{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -827,7 +980,7 @@ func (x *ChallengeSolution) String() string {
 func (*ChallengeSolution) ProtoMessage() {}
 
 func (x *ChallengeSolution) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[12]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -840,7 +993,7 @@ func (x *ChallengeSolution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChallengeSolution.ProtoReflect.Descriptor instead.
 func (*ChallengeSolution) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{12}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ChallengeSolution) GetPayload() isChallengeSolution_Payload {
@@ -868,6 +1021,15 @@ func (x *ChallengeSolution) GetBoundKeypairRotationResponse() *BoundKeypairRotat
 	return nil
 }
 
+func (x *ChallengeSolution) GetIamChallengeSolution() *IAMChallengeSolution {
+	if x != nil {
+		if x, ok := x.Payload.(*ChallengeSolution_IamChallengeSolution); ok {
+			return x.IamChallengeSolution
+		}
+	}
+	return nil
+}
+
 type isChallengeSolution_Payload interface {
 	isChallengeSolution_Payload()
 }
@@ -880,9 +1042,15 @@ type ChallengeSolution_BoundKeypairRotationResponse struct {
 	BoundKeypairRotationResponse *BoundKeypairRotationResponse `protobuf:"bytes,2,opt,name=bound_keypair_rotation_response,json=boundKeypairRotationResponse,proto3,oneof"`
 }
 
+type ChallengeSolution_IamChallengeSolution struct {
+	IamChallengeSolution *IAMChallengeSolution `protobuf:"bytes,3,opt,name=iam_challenge_solution,json=iamChallengeSolution,proto3,oneof"`
+}
+
 func (*ChallengeSolution_BoundKeypairChallengeSolution) isChallengeSolution_Payload() {}
 
 func (*ChallengeSolution_BoundKeypairRotationResponse) isChallengeSolution_Payload() {}
+
+func (*ChallengeSolution_IamChallengeSolution) isChallengeSolution_Payload() {}
 
 // JoinRequest is the message type sent from the joining client to the server.
 type JoinRequest struct {
@@ -893,6 +1061,7 @@ type JoinRequest struct {
 	//	*JoinRequest_TokenInit
 	//	*JoinRequest_BoundKeypairInit
 	//	*JoinRequest_Solution
+	//	*JoinRequest_IamInit
 	Payload       isJoinRequest_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -900,7 +1069,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -912,7 +1081,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[13]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -925,7 +1094,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{13}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *JoinRequest) GetPayload() isJoinRequest_Payload {
@@ -971,6 +1140,15 @@ func (x *JoinRequest) GetSolution() *ChallengeSolution {
 	return nil
 }
 
+func (x *JoinRequest) GetIamInit() *IAMInit {
+	if x != nil {
+		if x, ok := x.Payload.(*JoinRequest_IamInit); ok {
+			return x.IamInit
+		}
+	}
+	return nil
+}
+
 type isJoinRequest_Payload interface {
 	isJoinRequest_Payload()
 }
@@ -991,6 +1169,10 @@ type JoinRequest_Solution struct {
 	Solution *ChallengeSolution `protobuf:"bytes,4,opt,name=solution,proto3,oneof"`
 }
 
+type JoinRequest_IamInit struct {
+	IamInit *IAMInit `protobuf:"bytes,5,opt,name=iam_init,json=iamInit,proto3,oneof"`
+}
+
 func (*JoinRequest_ClientInit) isJoinRequest_Payload() {}
 
 func (*JoinRequest_TokenInit) isJoinRequest_Payload() {}
@@ -998,6 +1180,8 @@ func (*JoinRequest_TokenInit) isJoinRequest_Payload() {}
 func (*JoinRequest_BoundKeypairInit) isJoinRequest_Payload() {}
 
 func (*JoinRequest_Solution) isJoinRequest_Payload() {}
+
+func (*JoinRequest_IamInit) isJoinRequest_Payload() {}
 
 // ServerInit is the first message sent from the server in response to the
 // ClientInit message.
@@ -1014,7 +1198,7 @@ type ServerInit struct {
 
 func (x *ServerInit) Reset() {
 	*x = ServerInit{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1026,7 +1210,7 @@ func (x *ServerInit) String() string {
 func (*ServerInit) ProtoMessage() {}
 
 func (x *ServerInit) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[14]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1039,7 +1223,7 @@ func (x *ServerInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerInit.ProtoReflect.Descriptor instead.
 func (*ServerInit) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{14}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ServerInit) GetJoinMethod() string {
@@ -1063,6 +1247,7 @@ type Challenge struct {
 	//
 	//	*Challenge_BoundKeypairChallenge
 	//	*Challenge_BoundKeypairRotationRequest
+	//	*Challenge_IamChallenge
 	Payload       isChallenge_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1070,7 +1255,7 @@ type Challenge struct {
 
 func (x *Challenge) Reset() {
 	*x = Challenge{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1082,7 +1267,7 @@ func (x *Challenge) String() string {
 func (*Challenge) ProtoMessage() {}
 
 func (x *Challenge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1095,7 +1280,7 @@ func (x *Challenge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Challenge.ProtoReflect.Descriptor instead.
 func (*Challenge) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{15}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *Challenge) GetPayload() isChallenge_Payload {
@@ -1123,6 +1308,15 @@ func (x *Challenge) GetBoundKeypairRotationRequest() *BoundKeypairRotationReques
 	return nil
 }
 
+func (x *Challenge) GetIamChallenge() *IAMChallenge {
+	if x != nil {
+		if x, ok := x.Payload.(*Challenge_IamChallenge); ok {
+			return x.IamChallenge
+		}
+	}
+	return nil
+}
+
 type isChallenge_Payload interface {
 	isChallenge_Payload()
 }
@@ -1135,9 +1329,15 @@ type Challenge_BoundKeypairRotationRequest struct {
 	BoundKeypairRotationRequest *BoundKeypairRotationRequest `protobuf:"bytes,2,opt,name=bound_keypair_rotation_request,json=boundKeypairRotationRequest,proto3,oneof"`
 }
 
+type Challenge_IamChallenge struct {
+	IamChallenge *IAMChallenge `protobuf:"bytes,3,opt,name=iam_challenge,json=iamChallenge,proto3,oneof"`
+}
+
 func (*Challenge_BoundKeypairChallenge) isChallenge_Payload() {}
 
 func (*Challenge_BoundKeypairRotationRequest) isChallenge_Payload() {}
+
+func (*Challenge_IamChallenge) isChallenge_Payload() {}
 
 // Result is the final message sent from the cluster back to the client, it
 // contains the result of the joining process including the assigned host ID
@@ -1155,7 +1355,7 @@ type Result struct {
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1167,7 +1367,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1180,7 +1380,7 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *Result) GetPayload() isResult_Payload {
@@ -1243,7 +1443,7 @@ type Certificates struct {
 
 func (x *Certificates) Reset() {
 	*x = Certificates{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1255,7 +1455,7 @@ func (x *Certificates) String() string {
 func (*Certificates) ProtoMessage() {}
 
 func (x *Certificates) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1268,7 +1468,7 @@ func (x *Certificates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Certificates.ProtoReflect.Descriptor instead.
 func (*Certificates) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Certificates) GetTlsCert() []byte {
@@ -1312,7 +1512,7 @@ type HostResult struct {
 
 func (x *HostResult) Reset() {
 	*x = HostResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1324,7 +1524,7 @@ func (x *HostResult) String() string {
 func (*HostResult) ProtoMessage() {}
 
 func (x *HostResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1337,7 +1537,7 @@ func (x *HostResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostResult.ProtoReflect.Descriptor instead.
 func (*HostResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *HostResult) GetCertificates() *Certificates {
@@ -1367,7 +1567,7 @@ type BotResult struct {
 
 func (x *BotResult) Reset() {
 	*x = BotResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1379,7 +1579,7 @@ func (x *BotResult) String() string {
 func (*BotResult) ProtoMessage() {}
 
 func (x *BotResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1392,7 +1592,7 @@ func (x *BotResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotResult.ProtoReflect.Descriptor instead.
 func (*BotResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *BotResult) GetCertificates() *Certificates {
@@ -1424,7 +1624,7 @@ type JoinResponse struct {
 
 func (x *JoinResponse) Reset() {
 	*x = JoinResponse{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1436,7 +1636,7 @@ func (x *JoinResponse) String() string {
 func (*JoinResponse) ProtoMessage() {}
 
 func (x *JoinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1449,7 +1649,7 @@ func (x *JoinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinResponse.ProtoReflect.Descriptor instead.
 func (*JoinResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *JoinResponse) GetPayload() isJoinResponse_Payload {
@@ -1532,7 +1732,7 @@ type ClientInit_ProxySuppliedParams struct {
 
 func (x *ClientInit_ProxySuppliedParams) Reset() {
 	*x = ClientInit_ProxySuppliedParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1544,7 +1744,7 @@ func (x *ClientInit_ProxySuppliedParams) String() string {
 func (*ClientInit_ProxySuppliedParams) ProtoMessage() {}
 
 func (x *ClientInit_ProxySuppliedParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1639,27 +1839,36 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\n" +
 	"join_state\x18\x02 \x01(\fR\tjoinState\x12\x1d\n" +
 	"\n" +
-	"public_key\x18\x03 \x01(\fR\tpublicKey\"\x93\x02\n" +
+	"public_key\x18\x03 \x01(\fR\tpublicKey\"N\n" +
+	"\aIAMInit\x12C\n" +
+	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\",\n" +
+	"\fIAMChallenge\x12\x1c\n" +
+	"\tchallenge\x18\x01 \x01(\tR\tchallenge\"H\n" +
+	"\x14IAMChallengeSolution\x120\n" +
+	"\x14sts_identity_request\x18\x01 \x01(\fR\x12stsIdentityRequest\"\xf3\x02\n" +
 	"\x11ChallengeSolution\x12z\n" +
 	" bound_keypair_challenge_solution\x18\x01 \x01(\v2/.teleport.join.v1.BoundKeypairChallengeSolutionH\x00R\x1dboundKeypairChallengeSolution\x12w\n" +
-	"\x1fbound_keypair_rotation_response\x18\x02 \x01(\v2..teleport.join.v1.BoundKeypairRotationResponseH\x00R\x1cboundKeypairRotationResponseB\t\n" +
-	"\apayload\"\xae\x02\n" +
+	"\x1fbound_keypair_rotation_response\x18\x02 \x01(\v2..teleport.join.v1.BoundKeypairRotationResponseH\x00R\x1cboundKeypairRotationResponse\x12^\n" +
+	"\x16iam_challenge_solution\x18\x03 \x01(\v2&.teleport.join.v1.IAMChallengeSolutionH\x00R\x14iamChallengeSolutionB\t\n" +
+	"\apayload\"\xe6\x02\n" +
 	"\vJoinRequest\x12?\n" +
 	"\vclient_init\x18\x01 \x01(\v2\x1c.teleport.join.v1.ClientInitH\x00R\n" +
 	"clientInit\x12<\n" +
 	"\n" +
 	"token_init\x18\x02 \x01(\v2\x1b.teleport.join.v1.TokenInitH\x00R\ttokenInit\x12R\n" +
 	"\x12bound_keypair_init\x18\x03 \x01(\v2\".teleport.join.v1.BoundKeypairInitH\x00R\x10boundKeypairInit\x12A\n" +
-	"\bsolution\x18\x04 \x01(\v2#.teleport.join.v1.ChallengeSolutionH\x00R\bsolutionB\t\n" +
+	"\bsolution\x18\x04 \x01(\v2#.teleport.join.v1.ChallengeSolutionH\x00R\bsolution\x126\n" +
+	"\biam_init\x18\x05 \x01(\v2\x19.teleport.join.v1.IAMInitH\x00R\aiamInitB\t\n" +
 	"\apayload\"i\n" +
 	"\n" +
 	"ServerInit\x12\x1f\n" +
 	"\vjoin_method\x18\x01 \x01(\tR\n" +
 	"joinMethod\x12:\n" +
-	"\x19signature_algorithm_suite\x18\x02 \x01(\tR\x17signatureAlgorithmSuite\"\xef\x01\n" +
+	"\x19signature_algorithm_suite\x18\x02 \x01(\tR\x17signatureAlgorithmSuite\"\xb6\x02\n" +
 	"\tChallenge\x12a\n" +
 	"\x17bound_keypair_challenge\x18\x01 \x01(\v2'.teleport.join.v1.BoundKeypairChallengeH\x00R\x15boundKeypairChallenge\x12t\n" +
-	"\x1ebound_keypair_rotation_request\x18\x02 \x01(\v2-.teleport.join.v1.BoundKeypairRotationRequestH\x00R\x1bboundKeypairRotationRequestB\t\n" +
+	"\x1ebound_keypair_rotation_request\x18\x02 \x01(\v2-.teleport.join.v1.BoundKeypairRotationRequestH\x00R\x1bboundKeypairRotationRequest\x12E\n" +
+	"\riam_challenge\x18\x03 \x01(\v2\x1e.teleport.join.v1.IAMChallengeH\x00R\fiamChallengeB\t\n" +
 	"\apayload\"\x92\x01\n" +
 	"\x06Result\x12?\n" +
 	"\vhost_result\x18\x01 \x01(\v2\x1c.teleport.join.v1.HostResultH\x00R\n" +
@@ -1701,7 +1910,7 @@ func file_teleport_join_v1_joinservice_proto_rawDescGZIP() []byte {
 	return file_teleport_join_v1_joinservice_proto_rawDescData
 }
 
-var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
 var file_teleport_join_v1_joinservice_proto_goTypes = []any{
 	(*ClientInit)(nil),                     // 0: teleport.join.v1.ClientInit
 	(*PublicKeys)(nil),                     // 1: teleport.join.v1.PublicKeys
@@ -1715,50 +1924,57 @@ var file_teleport_join_v1_joinservice_proto_goTypes = []any{
 	(*BoundKeypairRotationRequest)(nil),    // 9: teleport.join.v1.BoundKeypairRotationRequest
 	(*BoundKeypairRotationResponse)(nil),   // 10: teleport.join.v1.BoundKeypairRotationResponse
 	(*BoundKeypairResult)(nil),             // 11: teleport.join.v1.BoundKeypairResult
-	(*ChallengeSolution)(nil),              // 12: teleport.join.v1.ChallengeSolution
-	(*JoinRequest)(nil),                    // 13: teleport.join.v1.JoinRequest
-	(*ServerInit)(nil),                     // 14: teleport.join.v1.ServerInit
-	(*Challenge)(nil),                      // 15: teleport.join.v1.Challenge
-	(*Result)(nil),                         // 16: teleport.join.v1.Result
-	(*Certificates)(nil),                   // 17: teleport.join.v1.Certificates
-	(*HostResult)(nil),                     // 18: teleport.join.v1.HostResult
-	(*BotResult)(nil),                      // 19: teleport.join.v1.BotResult
-	(*JoinResponse)(nil),                   // 20: teleport.join.v1.JoinResponse
-	(*ClientInit_ProxySuppliedParams)(nil), // 21: teleport.join.v1.ClientInit.ProxySuppliedParams
-	(*timestamppb.Timestamp)(nil),          // 22: google.protobuf.Timestamp
+	(*IAMInit)(nil),                        // 12: teleport.join.v1.IAMInit
+	(*IAMChallenge)(nil),                   // 13: teleport.join.v1.IAMChallenge
+	(*IAMChallengeSolution)(nil),           // 14: teleport.join.v1.IAMChallengeSolution
+	(*ChallengeSolution)(nil),              // 15: teleport.join.v1.ChallengeSolution
+	(*JoinRequest)(nil),                    // 16: teleport.join.v1.JoinRequest
+	(*ServerInit)(nil),                     // 17: teleport.join.v1.ServerInit
+	(*Challenge)(nil),                      // 18: teleport.join.v1.Challenge
+	(*Result)(nil),                         // 19: teleport.join.v1.Result
+	(*Certificates)(nil),                   // 20: teleport.join.v1.Certificates
+	(*HostResult)(nil),                     // 21: teleport.join.v1.HostResult
+	(*BotResult)(nil),                      // 22: teleport.join.v1.BotResult
+	(*JoinResponse)(nil),                   // 23: teleport.join.v1.JoinResponse
+	(*ClientInit_ProxySuppliedParams)(nil), // 24: teleport.join.v1.ClientInit.ProxySuppliedParams
+	(*timestamppb.Timestamp)(nil),          // 25: google.protobuf.Timestamp
 }
 var file_teleport_join_v1_joinservice_proto_depIdxs = []int32{
-	21, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
+	24, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
 	1,  // 1: teleport.join.v1.HostParams.public_keys:type_name -> teleport.join.v1.PublicKeys
 	1,  // 2: teleport.join.v1.BotParams.public_keys:type_name -> teleport.join.v1.PublicKeys
-	22, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
+	25, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
 	2,  // 4: teleport.join.v1.ClientParams.host_params:type_name -> teleport.join.v1.HostParams
 	3,  // 5: teleport.join.v1.ClientParams.bot_params:type_name -> teleport.join.v1.BotParams
 	4,  // 6: teleport.join.v1.TokenInit.client_params:type_name -> teleport.join.v1.ClientParams
 	4,  // 7: teleport.join.v1.BoundKeypairInit.client_params:type_name -> teleport.join.v1.ClientParams
-	8,  // 8: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
-	10, // 9: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
-	0,  // 10: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
-	5,  // 11: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
-	6,  // 12: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
-	12, // 13: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
-	7,  // 14: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
-	9,  // 15: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
-	18, // 16: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
-	19, // 17: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
-	17, // 18: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
-	17, // 19: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
-	11, // 20: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
-	14, // 21: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
-	15, // 22: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
-	16, // 23: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
-	13, // 24: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
-	20, // 25: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
-	25, // [25:26] is the sub-list for method output_type
-	24, // [24:25] is the sub-list for method input_type
-	24, // [24:24] is the sub-list for extension type_name
-	24, // [24:24] is the sub-list for extension extendee
-	0,  // [0:24] is the sub-list for field type_name
+	4,  // 8: teleport.join.v1.IAMInit.client_params:type_name -> teleport.join.v1.ClientParams
+	8,  // 9: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
+	10, // 10: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
+	14, // 11: teleport.join.v1.ChallengeSolution.iam_challenge_solution:type_name -> teleport.join.v1.IAMChallengeSolution
+	0,  // 12: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
+	5,  // 13: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
+	6,  // 14: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
+	15, // 15: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
+	12, // 16: teleport.join.v1.JoinRequest.iam_init:type_name -> teleport.join.v1.IAMInit
+	7,  // 17: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
+	9,  // 18: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
+	13, // 19: teleport.join.v1.Challenge.iam_challenge:type_name -> teleport.join.v1.IAMChallenge
+	21, // 20: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
+	22, // 21: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
+	20, // 22: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
+	20, // 23: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
+	11, // 24: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
+	17, // 25: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
+	18, // 26: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
+	19, // 27: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
+	16, // 28: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
+	23, // 29: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
+	29, // [29:30] is the sub-list for method output_type
+	28, // [28:29] is the sub-list for method input_type
+	28, // [28:28] is the sub-list for extension type_name
+	28, // [28:28] is the sub-list for extension extendee
+	0,  // [0:28] is the sub-list for field type_name
 }
 
 func init() { file_teleport_join_v1_joinservice_proto_init() }
@@ -1772,26 +1988,29 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		(*ClientParams_HostParams)(nil),
 		(*ClientParams_BotParams)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[12].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[15].OneofWrappers = []any{
 		(*ChallengeSolution_BoundKeypairChallengeSolution)(nil),
 		(*ChallengeSolution_BoundKeypairRotationResponse)(nil),
+		(*ChallengeSolution_IamChallengeSolution)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[13].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[16].OneofWrappers = []any{
 		(*JoinRequest_ClientInit)(nil),
 		(*JoinRequest_TokenInit)(nil),
 		(*JoinRequest_BoundKeypairInit)(nil),
 		(*JoinRequest_Solution)(nil),
+		(*JoinRequest_IamInit)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[15].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[18].OneofWrappers = []any{
 		(*Challenge_BoundKeypairChallenge)(nil),
 		(*Challenge_BoundKeypairRotationRequest)(nil),
+		(*Challenge_IamChallenge)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[16].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[19].OneofWrappers = []any{
 		(*Result_HostResult)(nil),
 		(*Result_BotResult)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[19].OneofWrappers = []any{}
-	file_teleport_join_v1_joinservice_proto_msgTypes[20].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[22].OneofWrappers = []any{}
+	file_teleport_join_v1_joinservice_proto_msgTypes[23].OneofWrappers = []any{
 		(*JoinResponse_Init)(nil),
 		(*JoinResponse_Challenge)(nil),
 		(*JoinResponse_Result)(nil),
@@ -1802,7 +2021,7 @@ func file_teleport_join_v1_joinservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_join_v1_joinservice_proto_rawDesc), len(file_teleport_join_v1_joinservice_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -190,11 +190,44 @@ message BoundKeypairResult {
   bytes public_key = 3;
 }
 
+// IAMInit is sent from the client in response to the ServerInit message for
+// the IAM join method.
+//
+// The IAM method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: IAMInit
+// 4. server->client: IAMChallenge
+// 5. client->server: IAMChallengeSolution
+// 6. server->client: Result
+message IAMInit {
+  // ClientParams holds parameters for the specific type of client trying to join.
+  ClientParams client_params = 1;
+}
+
+// IAMChallenge is from the server in response to the IAMInit message from the client.
+// The client is expected to respond with a IAMChallengeSolution.
+message IAMChallenge {
+  // Challenge is a a crypto-random string that should be included by the
+  // client in the IAMChallengeSolution message.
+  string challenge = 1;
+}
+
+// IAMChallengeSolution must be sent from the client in response to the
+// IAMChallenge message.
+message IAMChallengeSolution {
+  // STSIdentityRequest is a signed sts:GetCallerIdentity API request used
+  // to prove the AWS identity of a joining node. It must include the
+  // challenge string as a signed header.
+  bytes sts_identity_request = 1;
+}
+
 // ChallengeSolution holds a solution to a challenge issued by the server.
 message ChallengeSolution {
   oneof payload {
     BoundKeypairChallengeSolution bound_keypair_challenge_solution = 1;
     BoundKeypairRotationResponse bound_keypair_rotation_response = 2;
+    IAMChallengeSolution iam_challenge_solution = 3;
   }
 }
 
@@ -205,6 +238,7 @@ message JoinRequest {
     TokenInit token_init = 2;
     BoundKeypairInit bound_keypair_init = 3;
     ChallengeSolution solution = 4;
+    IAMInit iam_init = 5;
   }
 }
 
@@ -223,6 +257,7 @@ message Challenge {
   oneof payload {
     BoundKeypairChallenge bound_keypair_challenge = 1;
     BoundKeypairRotationRequest bound_keypair_rotation_request = 2;
+    IAMChallenge iam_challenge = 3;
   }
 }
 

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/jonboulle/clockwork"
 	"github.com/julienschmidt/httprouter"
 	"google.golang.org/grpc/credentials"
@@ -195,10 +194,6 @@ func (a *Server) CheckPasswordWOToken(ctx context.Context, user string, password
 
 func (a *Server) ResetPassword(ctx context.Context, username string) error {
 	return a.resetPassword(ctx, username)
-}
-
-func (a *Server) SetHTTPClientForAWSSTS(clt utils.HTTPDoClient) {
-	a.httpClientForAWSSTS = clt
 }
 
 func (a *Server) SetJWKSValidator(clt JWKSValidator) {
@@ -410,7 +405,6 @@ func CheckOracleAllowRules(claims oracle.Claims, token string, allowRules []*typ
 }
 
 type GitHubManager = githubManager
-type AWSIdentity = awsIdentity
 type AttestedData = attestedData
 type SignedAttestedData = signedAttestedData
 type JWKSValidator = k8sJWKSValidator
@@ -421,7 +415,6 @@ type AzureVerifyTokenFunc = azureVerifyTokenFunc
 type AccessTokenClaims = accessTokenClaims
 type EC2Client = ec2Client
 type EC2ClientKey = ec2ClientKey
-type IAMRegisterOption = iamRegisterOption
 
 func WithAzureCerts(certs []*x509.Certificate) AzureRegisterOption {
 	return func(cfg *AzureRegisterConfig) {
@@ -439,14 +432,6 @@ func WithAzureVMClientGetter(getVMClient vmClientGetter) AzureRegisterOption {
 	return func(cfg *AzureRegisterConfig) {
 		cfg.getVMClient = getVMClient
 	}
-}
-
-func WithFIPS(b bool) iamRegisterOption {
-	return withFips(b)
-}
-
-func WithAuthVersion(v *semver.Version) iamRegisterOption {
-	return withAuthVersion(v)
 }
 
 func (s *TLSServer) GRPCServer() *GRPCServer {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5851,6 +5851,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		Authorizer:  cfg.Authorizer,
 		AuthService: cfg.AuthServer,
 		Clock:       cfg.AuthServer.clock,
+		FIPS:        cfg.AuthServer.fips,
 	}))
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{

--- a/lib/auth/join/iam/iam.go
+++ b/lib/auth/join/iam/iam.go
@@ -48,18 +48,18 @@ type stsIdentityRequestOptions struct {
 	imdsClient imdsClient
 }
 
-type stsIdentityRequestOption func(cfg *stsIdentityRequestOptions)
+type STSIdentityRequestOption func(cfg *stsIdentityRequestOptions)
 
 // WithFIPSEndpoint is a functional option to use a FIPS STS endpoint. In non-US
 // regions, this will use the us-east-1 FIPS endpoint.
-func WithFIPSEndpoint(useFIPS bool) stsIdentityRequestOption {
+func WithFIPSEndpoint(useFIPS bool) STSIdentityRequestOption {
 	return func(opts *stsIdentityRequestOptions) {
 		opts.useFIPS = useFIPS
 	}
 }
 
 // WithIMDSClient is a functional option to use a custom IMDS client.
-func WithIMDSClient(clt imdsClient) stsIdentityRequestOption {
+func WithIMDSClient(clt imdsClient) STSIdentityRequestOption {
 	return func(opts *stsIdentityRequestOptions) {
 		opts.imdsClient = clt
 	}
@@ -75,7 +75,7 @@ type imdsClient interface {
 
 // CreateSignedSTSIdentityRequest is called on the client side and returns an
 // sts:GetCallerIdentity request signed with the local AWS credentials
-func CreateSignedSTSIdentityRequest(ctx context.Context, challenge string, opts ...stsIdentityRequestOption) ([]byte, error) {
+func CreateSignedSTSIdentityRequest(ctx context.Context, challenge string, opts ...STSIdentityRequestOption) ([]byte, error) {
 	var options stsIdentityRequestOptions
 	for _, opt := range opts {
 		opt(&options)

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -190,6 +190,9 @@ type RegisterParams struct {
 	GitlabParams GitlabParams
 	// BoundKeypairParams contains parameters specific to bound keypair joining.
 	BoundKeypairParams *BoundKeypairParams
+	// CreateSignedSTSIdentityRequestFunc overrides the function used to
+	// generate a signed AWs sts:GetCallerIdentity request.
+	CreateSignedSTSIdentityRequestFunc func(ctx context.Context, challenge string, opts ...iam.STSIdentityRequestOption) ([]byte, error)
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {
@@ -203,6 +206,10 @@ func (r *RegisterParams) CheckAndSetDefaults() error {
 
 	if err := r.verifyAuthOrProxyAddress(); err != nil {
 		return trace.BadParameter("no auth or proxy servers set")
+	}
+
+	if r.CreateSignedSTSIdentityRequestFunc == nil {
+		r.CreateSignedSTSIdentityRequestFunc = iam.CreateSignedSTSIdentityRequest
 	}
 
 	return nil
@@ -793,7 +800,7 @@ func registerUsingIAMMethod(
 	// Call RegisterUsingIAMMethod and pass a callback to respond to the challenge with a signed join request.
 	certs, err := joinServiceClient.RegisterUsingIAMMethod(ctx, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 		// create the signed sts:GetCallerIdentity request and include the challenge
-		signedRequest, err := iam.CreateSignedSTSIdentityRequest(ctx, challenge,
+		signedRequest, err := params.CreateSignedSTSIdentityRequestFunc(ctx, challenge,
 			iam.WithFIPSEndpoint(params.FIPS),
 		)
 		if err != nil {

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -44,6 +44,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -430,7 +431,7 @@ func (a *Server) checkAzureRequest(
 }
 
 func generateAzureChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.RawURLEncoding, 24)
+	challenge, err := joinutils.GenerateChallenge(base64.RawURLEncoding, 24)
 	return challenge, trace.Wrap(err)
 }
 

--- a/lib/auth/join_gitlab.go
+++ b/lib/auth/join_gitlab.go
@@ -20,13 +20,12 @@ package auth
 
 import (
 	"context"
-	"regexp"
-	"strings"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/gitlab"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 type gitlabIDTokenValidator interface {
@@ -87,20 +86,7 @@ func joinRuleGlobMatch(want string, got string) (bool, error) {
 	if want == "" {
 		return true, nil
 	}
-	return globMatch(want, got)
-}
-
-// globMatch performs simple a simple glob-style match test on a string.
-// - '*' matches zero or more characters.
-// - '?' matches any single character.
-// It returns true if a match is detected.
-func globMatch(pattern, str string) (bool, error) {
-	pattern = regexp.QuoteMeta(pattern)
-	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
-	pattern = strings.ReplaceAll(pattern, `\?`, ".")
-	pattern = "^" + pattern + "$"
-	matched, err := regexp.MatchString(pattern, str)
-	return matched, trace.Wrap(err)
+	return joinutils.GlobMatch(want, got)
 }
 
 func checkGitLabAllowRules(token *types.ProvisionTokenV2, claims *gitlab.IDTokenClaims) error {

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -19,345 +19,41 @@
 package auth
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"net/http"
-	"net/url"
-	"slices"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/teleport/lib/utils/aws"
 )
 
-const (
-	// Hardcoding the sts API version here may be more strict than necessary,
-	// but this is set by the Teleport node and can only be changed when we
-	// update our AWS SDK dependency. Since Auth should always be upgraded
-	// before nodes, we will have a chance to update the check on Auth if we
-	// ever have a need to allow a newer API version.
-	expectedSTSIdentityRequestBody = "Action=GetCallerIdentity&Version=2011-06-15"
-
-	// AWS SignedHeaders will always be lowercase
-	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html#sigv4-auth-header-overview
-	challengeHeaderKey = "x-teleport-challenge"
-)
-
-// validateSTSHost returns an error if the given stsHost is not a valid regional
-// endpoint for the AWS STS service, or nil if it is valid. If fips is true, the
-// endpoint must be a valid FIPS endpoint.
-//
-// This is a security-critical check: we are allowing the client to tell us
-// which URL we should use to validate their identity. If the client could pass
-// off an attacker-controlled URL as the STS endpoint, the entire security
-// mechanism of the IAM join method would be compromised.
-//
-// To keep this validation simple and secure, we check the given endpoint
-// against a static list of known valid endpoints. We will need to update this
-// list as AWS adds new regions.
-func validateSTSHost(stsHost string, cfg *iamRegisterConfig) error {
-	valid := slices.Contains(iam.ValidSTSEndpoints(), stsHost)
-	if !valid {
-		return trace.AccessDenied("IAM join request uses unknown STS host %q. "+
-			"This could mean that the Teleport Node attempting to join the cluster is "+
-			"running in a new AWS region which is unknown to this Teleport auth server. "+
-			"Alternatively, if this URL looks suspicious, an attacker may be attempting to "+
-			"join your Teleport cluster. "+
-			"Following is the list of valid STS endpoints known to this auth server. "+
-			"If a legitimate STS endpoint is not included, please file an issue at "+
-			"https://github.com/gravitational/teleport. %v",
-			stsHost, iam.ValidSTSEndpoints())
-	}
-
-	if cfg.fips && !slices.Contains(iam.FIPSSTSEndpoints(), stsHost) {
-		return trace.AccessDenied("node selected non-FIPS STS endpoint (%s) for the IAM join method", stsHost)
-	}
-
-	return nil
+// SetHTTPClientForAWSSTS sets an HTTP client that will be used for sending
+// client-signed sts:GetCallerIdentity requests to AWS, for tests.
+func (a *Server) SetHTTPClientForAWSSTS(clt utils.HTTPDoClient) {
+	a.httpClientForAWSSTS = clt
 }
 
-// validateSTSIdentityRequest checks that a received sts:GetCallerIdentity
-// request is valid and includes the challenge as a signed header. An example
-// valid request looks like:
-// ```
-// POST / HTTP/1.1
-// Host: sts.amazonaws.com
-// Accept: application/json
-// Authorization: AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20211108/us-east-1/sts/aws4_request, SignedHeaders=accept;content-length;content-type;host;x-amz-date;x-amz-security-token;x-teleport-challenge, Signature=999...
-// Content-Length: 43
-// Content-Type: application/x-www-form-urlencoded; charset=utf-8
-// User-Agent: aws-sdk-go/1.37.17 (go1.17.1; darwin; amd64)
-// X-Amz-Date: 20211108T190420Z
-// X-Amz-Security-Token: aaa...
-// X-Teleport-Challenge: 0ezlc3usTAkXeZTcfOazUq0BGrRaKmb4EwODk8U7J5A
-//
-// Action=GetCallerIdentity&Version=2011-06-15
-// ```
-func validateSTSIdentityRequest(req *http.Request, challenge string, cfg *iamRegisterConfig) (err error) {
-	defer func() {
-		// Always log a warning on the Auth server if the function detects an
-		// invalid sts:GetCallerIdentity request, it's either going to be caused
-		// by a node in a unknown region or an attacker.
-		if err != nil {
-			logger.WarnContext(req.Context(), "Detected an invalid sts:GetCallerIdentity used by a client attempting to use the IAM join method", "error", err)
-		}
-	}()
-
-	if err := validateSTSHost(req.Host, cfg); err != nil {
-		return trace.Wrap(err)
-	}
-
-	if req.Method != http.MethodPost {
-		return trace.AccessDenied("sts identity request method %q does not match expected method %q", req.RequestURI, http.MethodPost)
-	}
-
-	if req.Header.Get(challengeHeaderKey) != challenge {
-		return trace.AccessDenied("sts identity request does not include challenge header or it does not match")
-	}
-
-	authHeader := req.Header.Get(aws.AuthorizationHeader)
-
-	sigV4, err := aws.ParseSigV4(authHeader)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !slices.Contains(sigV4.SignedHeaders, challengeHeaderKey) {
-		return trace.AccessDenied("sts identity request auth header %q does not include "+
-			challengeHeaderKey+" as a signed header", authHeader)
-	}
-
-	body, err := utils.GetAndReplaceRequestBody(req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if !bytes.Equal([]byte(expectedSTSIdentityRequestBody), body) {
-		return trace.BadParameter("sts request body %q does not equal expected %q", string(body), expectedSTSIdentityRequestBody)
-	}
-
-	return nil
+// GetHTTPClientForAWSSTS returns an HTTP client that should be used for sending
+// client-signed sts:GetCallerIdentity requests to AWS.
+func (a *Server) GetHTTPClientForAWSSTS() utils.HTTPDoClient {
+	return a.httpClientForAWSSTS
 }
 
-func parseSTSRequest(req []byte) (*http.Request, error) {
-	httpReq, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(req)))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Unset RequestURI and set req.URL instead (necessary quirk of sending a
-	// request parsed by http.ReadRequest). Also, force https here.
-	if httpReq.RequestURI != "/" {
-		return nil, trace.AccessDenied("unexpected sts identity request URI: %q", httpReq.RequestURI)
-	}
-	httpReq.RequestURI = ""
-	httpReq.URL = &url.URL{
-		Scheme: "https",
-		Host:   httpReq.Host,
-	}
-	return httpReq, nil
-}
-
-// awsIdentity holds aws Account and Arn, used for JSON parsing
-type awsIdentity struct {
-	Account string `json:"Account"`
-	Arn     string `json:"Arn"`
-}
-
-// JoinAttrs returns the protobuf representation of the attested identity.
-// This is used for auditing and for evaluation of WorkloadIdentity rules and
-// templating.
-func (c *awsIdentity) JoinAttrs() *workloadidentityv1pb.JoinAttrsAWSIAM {
-	attrs := &workloadidentityv1pb.JoinAttrsAWSIAM{
-		Account: c.Account,
-		Arn:     c.Arn,
-	}
-
-	return attrs
-}
-
-// getCallerIdentityReponse is used for JSON parsing
-type getCallerIdentityResponse struct {
-	GetCallerIdentityResult awsIdentity `json:"GetCallerIdentityResult"`
-}
-
-// stsIdentityResponse is used for JSON parsing
-type stsIdentityResponse struct {
-	GetCallerIdentityResponse getCallerIdentityResponse `json:"GetCallerIdentityResponse"`
-}
-
-// executeSTSIdentityRequest sends the sts:GetCallerIdentity HTTP request to the
-// AWS API, parses the response, and returns the awsIdentity
-func executeSTSIdentityRequest(ctx context.Context, client utils.HTTPDoClient, req *http.Request) (*awsIdentity, error) {
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	// set the http request context so it can be canceled
-	req = req.WithContext(ctx)
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer resp.Body.Close()
-
-	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, trace.AccessDenied("aws sts api returned status: %q body: %q",
-			resp.Status, body)
-	}
-
-	var identityResponse stsIdentityResponse
-	if err := json.Unmarshal(body, &identityResponse); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	id := &identityResponse.GetCallerIdentityResponse.GetCallerIdentityResult
-	if id.Account == "" {
-		return nil, trace.BadParameter("received empty AWS account ID from sts API")
-	}
-	if id.Arn == "" {
-		return nil, trace.BadParameter("received empty AWS identity ARN from sts API")
-	}
-	return id, nil
-}
-
-// arnMatches returns true if arn matches the pattern.
-// Pattern should be an AWS ARN which may include "*" to match any combination
-// of zero or more characters and "?" to match any single character.
-// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
-func arnMatches(pattern, arn string) (bool, error) {
-	return globMatch(pattern, arn)
-}
-
-// checkIAMAllowRules checks if the given identity matches any of the given
-// allowRules.
-func checkIAMAllowRules(identity *awsIdentity, token string, allowRules []*types.TokenRule) error {
-	for _, rule := range allowRules {
-		// if this rule specifies an AWS account, the identity must match
-		if len(rule.AWSAccount) > 0 {
-			if rule.AWSAccount != identity.Account {
-				// account doesn't match, continue to check the next rule
-				continue
-			}
-		}
-		// if this rule specifies an AWS ARN, the identity must match
-		if len(rule.AWSARN) > 0 {
-			matches, err := arnMatches(rule.AWSARN, identity.Arn)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			if !matches {
-				// arn doesn't match, continue to check the next rule
-				continue
-			}
-		}
-		// node identity matches this allow rule
-		return nil
-	}
-	return trace.AccessDenied("instance %v did not match any allow rules in token %v", identity.Arn, token)
-}
-
-// checkIAMRequest checks if the given request satisfies the token rules and
-// included the required challenge.
-//
-// If the joining entity presents a valid IAM identity, this will be returned,
-// even if the identity does not match the token's allow rules. This is to
-// support inclusion in audit logs.
-func (a *Server) checkIAMRequest(ctx context.Context, challenge string, req *proto.RegisterUsingIAMMethodRequest, cfg *iamRegisterConfig) (*awsIdentity, error) {
-	tokenName := req.RegisterUsingTokenRequest.Token
-	provisionToken, err := a.GetToken(ctx, tokenName)
-	if err != nil {
-		return nil, trace.Wrap(err, "getting token")
-	}
-	if provisionToken.GetJoinMethod() != types.JoinMethodIAM {
-		return nil, trace.AccessDenied("this token does not support the IAM join method")
-	}
-
-	// parse the incoming http request to the sts:GetCallerIdentity endpoint
-	identityRequest, err := parseSTSRequest(req.StsIdentityRequest)
-	if err != nil {
-		return nil, trace.Wrap(err, "parsing STS request")
-	}
-
-	// validate that the host, method, and headers are correct and the expected
-	// challenge is included in the signed portion of the request
-	if err := validateSTSIdentityRequest(identityRequest, challenge, cfg); err != nil {
-		return nil, trace.Wrap(err, "validating STS request")
-	}
-
-	// send the signed request to the public AWS API and get the node identity
-	// from the response
-	identity, err := executeSTSIdentityRequest(ctx, a.httpClientForAWSSTS, identityRequest)
-	if err != nil {
-		return nil, trace.Wrap(err, "executing STS request")
-	}
-
-	// check that the node identity matches an allow rule for this token
-	if err := checkIAMAllowRules(identity, provisionToken.GetName(), provisionToken.GetAllowRules()); err != nil {
-		// We return the identity since it's "validated" but does not match the
-		// rules. This allows us to include it in a failed join audit event
-		// as additional context to help the user understand why the join failed.
-		return identity, trace.Wrap(err, "checking allow rules")
-	}
-
-	return identity, nil
-}
-
-func generateIAMChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.RawStdEncoding, 32)
-	return challenge, trace.Wrap(err)
-}
-
-type iamRegisterConfig struct {
-	authVersion *semver.Version
-	fips        bool
-}
-
-func defaultIAMRegisterConfig(fips bool) *iamRegisterConfig {
-	return &iamRegisterConfig{
-		authVersion: teleport.SemVer(),
-		fips:        fips,
-	}
-}
-
-type iamRegisterOption func(cfg *iamRegisterConfig)
-
-func withAuthVersion(v *semver.Version) iamRegisterOption {
-	return func(cfg *iamRegisterConfig) {
-		cfg.authVersion = v
-	}
-}
-
-func withFips(fips bool) iamRegisterOption {
-	return func(cfg *iamRegisterConfig) {
-		cfg.fips = fips
-	}
-}
-
-// RegisterUsingIAMMethodWithOpts registers the caller using the IAM join method and
+// RegisterUsingIAMMethod registers the caller using the IAM join method and
 // returns signed certs to join the cluster.
 //
 // The caller must provide a ChallengeResponseFunc which returns a
 // *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
 // including the challenge as a signed header.
-func (a *Server) RegisterUsingIAMMethodWithOpts(
+//
+// TODO(nklaassen): DELETE IN 20 when removing the legacy join service.
+func (a *Server) RegisterUsingIAMMethod(
 	ctx context.Context,
 	challengeResponse client.RegisterIAMChallengeResponseFunc,
-	opts ...iamRegisterOption,
 ) (certs *proto.Certs, err error) {
 	var provisionToken types.ProvisionToken
 	var joinRequest *types.RegisterUsingTokenRequest
@@ -371,12 +67,7 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 		}
 	}()
 
-	cfg := defaultIAMRegisterConfig(a.fips)
-	for _, opt := range opts {
-		opt(cfg)
-	}
-
-	challenge, err := generateIAMChallenge()
+	challenge, err := iamjoin.GenerateIAMChallenge()
 	if err != nil {
 		return nil, trace.Wrap(err, "generating IAM challenge")
 	}
@@ -398,7 +89,13 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 	}
 
 	// check that the GetCallerIdentity request is valid and matches the token
-	verifiedIdentity, err := a.checkIAMRequest(ctx, challenge, req, cfg)
+	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
+		Challenge:          challenge,
+		ProvisionToken:     provisionToken,
+		STSIdentityRequest: req.StsIdentityRequest,
+		HTTPClient:         a.GetHTTPClientForAWSSTS(),
+		FIPS:               a.fips,
+	})
 	if verifiedIdentity != nil {
 		joinFailureMetadata = verifiedIdentity
 	}
@@ -416,17 +113,4 @@ func (a *Server) RegisterUsingIAMMethodWithOpts(
 	params := makeHostCertsParams(req.RegisterUsingTokenRequest, verifiedIdentity)
 	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
 	return certs, trace.Wrap(err, "generating certs")
-}
-
-// RegisterUsingIAMMethod registers the caller using the IAM join method and
-// returns signed certs to join the cluster.
-//
-// The caller must provide a ChallengeResponseFunc which returns a
-// *types.RegisterUsingTokenRequest with a signed sts:GetCallerIdentity request
-// including the challenge as a signed header.
-func (a *Server) RegisterUsingIAMMethod(
-	ctx context.Context,
-	challengeResponse client.RegisterIAMChallengeResponseFunc,
-) (certs *proto.Certs, err error) {
-	return a.RegisterUsingIAMMethodWithOpts(ctx, challengeResponse)
 }

--- a/lib/auth/join_oracle.go
+++ b/lib/auth/join_oracle.go
@@ -32,6 +32,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 )
 
 // RegisterUsingOracleMethod registers the caller using the Oracle join method and
@@ -95,7 +96,7 @@ func (a *Server) registerUsingOracleMethod(
 }
 
 func generateOracleChallenge() (string, error) {
-	challenge, err := generateChallenge(base64.StdEncoding, 32)
+	challenge, err := joinutils.GenerateChallenge(base64.StdEncoding, 32)
 	return challenge, trace.Wrap(err)
 }
 

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -1,0 +1,325 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package iamjoin
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"slices"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/aws"
+)
+
+const (
+	// Hardcoding the sts API version here may be more strict than necessary,
+	// but this is set by the Teleport node and can only be changed when we
+	// update our AWS SDK dependency. Since Auth should always be upgraded
+	// before nodes, we will have a chance to update the check on Auth if we
+	// ever have a need to allow a newer API version.
+	expectedSTSIdentityRequestBody = "Action=GetCallerIdentity&Version=2011-06-15"
+
+	// AWS SignedHeaders will always be lowercase
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html#sigv4-auth-header-overview
+	challengeHeaderKey = "x-teleport-challenge"
+)
+
+// validateSTSHost returns an error if the given stsHost is not a valid regional
+// endpoint for the AWS STS service, or nil if it is valid. If fips is true, the
+// endpoint must be a valid FIPS endpoint.
+//
+// This is a security-critical check: we are allowing the client to tell us
+// which URL we should use to validate their identity. If the client could pass
+// off an attacker-controlled URL as the STS endpoint, the entire security
+// mechanism of the IAM join method would be compromised.
+//
+// To keep this validation simple and secure, we check the given endpoint
+// against a static list of known valid endpoints. We will need to update this
+// list as AWS adds new regions.
+func validateSTSHost(stsHost string, fips bool) error {
+	valid := slices.Contains(iam.ValidSTSEndpoints(), stsHost)
+	if !valid {
+		return trace.AccessDenied("IAM join request uses unknown STS host %q. "+
+			"This could mean that the Teleport Node attempting to join the cluster is "+
+			"running in a new AWS region which is unknown to this Teleport auth server. "+
+			"Alternatively, if this URL looks suspicious, an attacker may be attempting to "+
+			"join your Teleport cluster. "+
+			"Following is the list of valid STS endpoints known to this auth server. "+
+			"If a legitimate STS endpoint is not included, please file an issue at "+
+			"https://github.com/gravitational/teleport. %v",
+			stsHost, iam.ValidSTSEndpoints())
+	}
+
+	if fips && !slices.Contains(iam.FIPSSTSEndpoints(), stsHost) {
+		return trace.AccessDenied("node selected non-FIPS STS endpoint (%s) for the IAM join method", stsHost)
+	}
+
+	return nil
+}
+
+// validateSTSIdentityRequest checks that a received sts:GetCallerIdentity
+// request is valid and includes the challenge as a signed header. An example
+// valid request looks like:
+// ```
+// POST / HTTP/1.1
+// Host: sts.amazonaws.com
+// Accept: application/json
+// Authorization: AWS4-HMAC-SHA256 Credential=AAAAAAAAAAAAAAAAAAAA/20211108/us-east-1/sts/aws4_request, SignedHeaders=accept;content-length;content-type;host;x-amz-date;x-amz-security-token;x-teleport-challenge, Signature=999...
+// Content-Length: 43
+// Content-Type: application/x-www-form-urlencoded; charset=utf-8
+// User-Agent: aws-sdk-go/1.37.17 (go1.17.1; darwin; amd64)
+// X-Amz-Date: 20211108T190420Z
+// X-Amz-Security-Token: aaa...
+// X-Teleport-Challenge: 0ezlc3usTAkXeZTcfOazUq0BGrRaKmb4EwODk8U7J5A
+//
+// Action=GetCallerIdentity&Version=2011-06-15
+// ```
+func validateSTSIdentityRequest(req *http.Request, challenge string, fips bool) (err error) {
+	if err := validateSTSHost(req.Host, fips); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if req.Method != http.MethodPost {
+		return trace.AccessDenied("sts identity request method %q does not match expected method %q", req.RequestURI, http.MethodPost)
+	}
+
+	if req.Header.Get(challengeHeaderKey) != challenge {
+		return trace.AccessDenied("sts identity request does not include challenge header or it does not match")
+	}
+
+	authHeader := req.Header.Get(aws.AuthorizationHeader)
+
+	sigV4, err := aws.ParseSigV4(authHeader)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !slices.Contains(sigV4.SignedHeaders, challengeHeaderKey) {
+		return trace.AccessDenied("sts identity request auth header %q does not include "+
+			challengeHeaderKey+" as a signed header", authHeader)
+	}
+
+	body, err := utils.GetAndReplaceRequestBody(req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !bytes.Equal([]byte(expectedSTSIdentityRequestBody), body) {
+		return trace.BadParameter("sts request body %q does not equal expected %q", string(body), expectedSTSIdentityRequestBody)
+	}
+
+	return nil
+}
+
+func parseSTSRequest(req []byte) (*http.Request, error) {
+	httpReq, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(req)))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Unset RequestURI and set req.URL instead (necessary quirk of sending a
+	// request parsed by http.ReadRequest). Also, force https here.
+	if httpReq.RequestURI != "/" {
+		return nil, trace.AccessDenied("unexpected sts identity request URI: %q", httpReq.RequestURI)
+	}
+	httpReq.RequestURI = ""
+	httpReq.URL = &url.URL{
+		Scheme: "https",
+		Host:   httpReq.Host,
+	}
+	return httpReq, nil
+}
+
+// AWSIdentity holds aws Account and Arn, used for JSON parsing
+type AWSIdentity struct {
+	Account string `json:"Account"`
+	Arn     string `json:"Arn"`
+}
+
+// JoinAttrs returns the protobuf representation of the attested identity.
+// This is used for auditing and for evaluation of WorkloadIdentity rules and
+// templating.
+func (c *AWSIdentity) JoinAttrs() *workloadidentityv1pb.JoinAttrsAWSIAM {
+	attrs := &workloadidentityv1pb.JoinAttrsAWSIAM{
+		Account: c.Account,
+		Arn:     c.Arn,
+	}
+
+	return attrs
+}
+
+// getCallerIdentityReponse is used for JSON parsing
+type getCallerIdentityResponse struct {
+	GetCallerIdentityResult AWSIdentity `json:"GetCallerIdentityResult"`
+}
+
+// stsIdentityResponse is used for JSON parsing
+type stsIdentityResponse struct {
+	GetCallerIdentityResponse getCallerIdentityResponse `json:"GetCallerIdentityResponse"`
+}
+
+// executeSTSIdentityRequest sends the sts:GetCallerIdentity HTTP request to the
+// AWS API, parses the response, and returns the awsIdentity
+func executeSTSIdentityRequest(ctx context.Context, client utils.HTTPDoClient, req *http.Request) (*AWSIdentity, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// set the http request context so it can be canceled
+	req = req.WithContext(ctx)
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, trace.AccessDenied("aws sts api returned status: %q body: %q",
+			resp.Status, body)
+	}
+
+	var identityResponse stsIdentityResponse
+	if err := json.Unmarshal(body, &identityResponse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	id := &identityResponse.GetCallerIdentityResponse.GetCallerIdentityResult
+	if id.Account == "" {
+		return nil, trace.BadParameter("received empty AWS account ID from sts API")
+	}
+	if id.Arn == "" {
+		return nil, trace.BadParameter("received empty AWS identity ARN from sts API")
+	}
+	return id, nil
+}
+
+// arnMatches returns true if arn matches the pattern.
+// Pattern should be an AWS ARN which may include "*" to match any combination
+// of zero or more characters and "?" to match any single character.
+// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html
+func arnMatches(pattern, arn string) (bool, error) {
+	return joinutils.GlobMatch(pattern, arn)
+}
+
+// checkIAMAllowRules checks if the given identity matches any of the given
+// allowRules.
+func checkIAMAllowRules(identity *AWSIdentity, allowRules []*types.TokenRule) error {
+	for _, rule := range allowRules {
+		// if this rule specifies an AWS account, the identity must match
+		if len(rule.AWSAccount) > 0 {
+			if rule.AWSAccount != identity.Account {
+				// account doesn't match, continue to check the next rule
+				continue
+			}
+		}
+		// if this rule specifies an AWS ARN, the identity must match
+		if len(rule.AWSARN) > 0 {
+			matches, err := arnMatches(rule.AWSARN, identity.Arn)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if !matches {
+				// arn doesn't match, continue to check the next rule
+				continue
+			}
+		}
+		// node identity matches this allow rule
+		return nil
+	}
+	return trace.AccessDenied("instance %v did not match any allow rules", identity.Arn)
+}
+
+// CheckIAMRequestParams holds parameters for checking an IAM-method join request.
+type CheckIAMRequestParams struct {
+	// Challenge is the challenge that was sent to the client.
+	Challenge string
+	// ProvisionToken is the provision token being used.
+	ProvisionToken types.ProvisionToken
+	// STSIdentityRequest is the signed sts:GetCallerIdentity request sent by
+	// the client in response to the challenge.
+	STSIdentityRequest []byte
+	// HTTPClient is an optional HTTP client to use for sending
+	// STSIdentityRequest to AWS, if nil a default client will be used.
+	HTTPClient utils.HTTPDoClient
+	// FIPS must be true if the server is in FIPS mode.
+	FIPS bool
+}
+
+// CheckIAMRequest checks if the given request satisfies the token rules and
+// included the required challenge.
+//
+// If the joining entity presents a valid IAM identity, this will be returned,
+// even if the identity does not match the token's allow rules. This is to
+// support inclusion in audit logs.
+func CheckIAMRequest(ctx context.Context, params *CheckIAMRequestParams) (*AWSIdentity, error) {
+	if params.ProvisionToken.GetJoinMethod() != types.JoinMethodIAM {
+		return nil, trace.AccessDenied("this token does not support the IAM join method")
+
+	}
+
+	// parse the incoming http request to the sts:GetCallerIdentity endpoint
+	identityRequest, err := parseSTSRequest(params.STSIdentityRequest)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing STS request")
+	}
+
+	// validate that the host, method, and headers are correct and the expected
+	// challenge is included in the signed portion of the request
+	if err := validateSTSIdentityRequest(identityRequest, params.Challenge, params.FIPS); err != nil {
+		return nil, trace.Wrap(err, "validating STS request")
+	}
+
+	// send the signed request to the public AWS API and get the node identity
+	// from the response
+	identity, err := executeSTSIdentityRequest(ctx, params.HTTPClient, identityRequest)
+	if err != nil {
+		return nil, trace.Wrap(err, "executing STS request")
+	}
+
+	// check that the node identity matches an allow rule for this token
+	if err := checkIAMAllowRules(identity, params.ProvisionToken.GetAllowRules()); err != nil {
+		// We return the identity since it's "validated" but does not match the
+		// rules. This allows us to include it in a failed join audit event
+		// as additional context to help the user understand why the join failed.
+		return identity, trace.Wrap(err, "checking allow rules")
+	}
+
+	return identity, nil
+}
+
+// GenerateIAMChallenge generates a random challenge string for the IAM join method.
+func GenerateIAMChallenge() (string, error) {
+	challenge, err := joinutils.GenerateChallenge(base64.RawStdEncoding, 32)
+	return challenge, trace.Wrap(err)
+}

--- a/lib/join/internal/diagnostic/diagnostic.go
+++ b/lib/join/internal/diagnostic/diagnostic.go
@@ -47,6 +47,7 @@ type Info struct {
 	BotGeneration       uint64
 	BotInstanceID       string
 	Error               error
+	RawJoinAttrs        any
 }
 
 // New returns an empty diagnostic ready to use.
@@ -72,8 +73,7 @@ func (d *Diagnostic) Set(f func(*Info)) {
 // SlogAttrs returns the current collected info as a slice of [slog.Attr]
 // suitable for logging. Unset fields will be included as an empty [slog.Attr]
 // which are conventionally ignored by log handlers.
-func (d *Diagnostic) SlogAttrs() []slog.Attr {
-	info := d.Get()
+func (info *Info) SlogAttrs() []slog.Attr {
 	return []slog.Attr{
 		stringAttr("error", info.Error.Error()),
 		stringAttr("remote_addr", info.RemoteAddr),

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -284,6 +284,44 @@ type BoundKeypairResult struct {
 	PublicKey []byte
 }
 
+// IAMInit is sent from the client in response to the ServerInit message for
+// the IAM join method.
+//
+// The IAM method join flow is:
+// 1. client->server: ClientInit
+// 2. client<-server: ServerInit
+// 3. client->server: IAMInit
+// 4. client<-server: IAMChallenge
+// 5. client->server: IAMChallengeSolution
+// 6. client<-server: Result
+type IAMInit struct {
+	embedRequest
+
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams ClientParams
+}
+
+// IAMChallenge is from the server in response to the IAMInit message from the client.
+// The client is expected to respond with a IAMChallengeSolution.
+type IAMChallenge struct {
+	embedResponse
+
+	// Challenge is a a crypto-random string that should be included by the
+	// client in the IAMChallengeSolution message.
+	Challenge string
+}
+
+// IAMChallengeSolution must be sent from the client in response to the
+// IAMChallenge message.
+type IAMChallengeSolution struct {
+	embedRequest
+
+	// STSIdentityRequest is a signed sts:GetCallerIdentity API request used
+	// to prove the AWS identity of a joining node. It must include the
+	// challenge string as a signed header.
+	STSIdentityRequest []byte
+}
+
 // Response is implemented by all join response messages.
 type Response interface {
 	isResponse()

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth_test
+package join_test
 
 import (
 	"bytes"
@@ -29,19 +29,20 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authtest"
-	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func responseFromAWSIdentity(id auth.AWSIdentity) string {
+func responseFromAWSIdentity(id iamjoin.AWSIdentity) string {
 	return fmt.Sprintf(`{
 		"GetCallerIdentityResponse": {
 			"GetCallerIdentityResult": {
@@ -109,21 +110,38 @@ func withChallenge(challenge string) challengeResponseOption {
 	}
 }
 
-func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
+type iamJoinTestCase struct {
+	desc                     string
+	authServer               *authtest.Server
+	tokenName                string
+	requestTokenName         string
+	tokenSpec                types.ProvisionTokenSpecV2
+	stsClient                utils.HTTPDoClient
+	challengeResponseOptions []challengeResponseOption
+	challengeResponseErr     error
+	assertError              require.ErrorAssertionFunc
+}
+
+func TestJoinIAM(t *testing.T) {
 	t.Parallel()
+	ctx := t.Context()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p, err := newTestPack(ctx, t.TempDir())
+	regularServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir: t.TempDir(),
+		},
+	})
 	require.NoError(t, err)
-	a := p.a
+	t.Cleanup(func() { assert.NoError(t, regularServer.Shutdown(ctx)) })
 
-	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
+	fipsServer, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			Dir:  t.TempDir(),
+			FIPS: true,
+		},
+	})
 	require.NoError(t, err)
-
-	tlsPublicKey, err := authtest.PrivateKeyToPublicKeyTLS(sshPrivateKey)
-	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, regularServer.Shutdown(ctx)) })
 
 	isAccessDenied := func(t require.TestingT, err error, _ ...interface{}) {
 		require.True(t, trace.IsAccessDenied(err), "expected Access Denied error, actual error: %v", err)
@@ -132,19 +150,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		require.True(t, trace.IsBadParameter(err), "expected Bad Parameter error, actual error: %v", err)
 	}
 
-	testCases := []struct {
-		desc                     string
-		tokenName                string
-		requestTokenName         string
-		tokenSpec                types.ProvisionTokenSpecV2
-		stsClient                utils.HTTPDoClient
-		iamRegisterOptions       []auth.IAMRegisterOption
-		challengeResponseOptions []challengeResponseOption
-		challengeResponseErr     error
-		assertError              require.ErrorAssertionFunc
-	}{
+	testCases := []iamJoinTestCase{
 		{
 			desc:             "basic passing case",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -159,7 +168,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -168,6 +177,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn 1",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -182,7 +192,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-test",
 				}),
@@ -191,6 +201,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn 2",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -205,7 +216,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-123",
 				}),
@@ -214,6 +225,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -228,7 +240,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -237,6 +249,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -251,7 +264,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -260,6 +273,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wildcard 2 arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -274,7 +288,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-001-test-role/my-session-name",
 				}),
@@ -283,6 +297,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong wildcard arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -297,7 +312,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name",
 				}),
@@ -306,6 +321,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong wildcard 2 arn assumed role",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -320,7 +336,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "123456789012",
 					Arn:     "arn:aws:sts::123456789012:assumed-role/my-super-002-test-role/my-session-name2",
 				}),
@@ -329,6 +345,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong token",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "wrong-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -343,7 +360,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -352,6 +369,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "challenge response error",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -366,7 +384,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -376,6 +394,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong arn",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -390,7 +409,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::role/admins-1234",
 				}),
@@ -399,6 +418,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong challenge",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -413,7 +433,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -425,6 +445,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong account",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -439,7 +460,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "5678",
 					Arn:     "arn:aws::1111",
 				}),
@@ -448,6 +469,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "sts api error",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -468,6 +490,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "wrong sts host",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -482,7 +505,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -494,6 +517,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "regional sts endpoint",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -508,7 +532,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -520,6 +544,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "unsigned challenge header",
+			authServer:       regularServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -534,7 +559,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
@@ -546,6 +571,7 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 		},
 		{
 			desc:             "fips pass",
+			authServer:       fipsServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -560,14 +586,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
-			},
-			iamRegisterOptions: []auth.IAMRegisterOption{
-				auth.WithFIPS(true),
-				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts-fips.us-east-1.amazonaws.com"),
@@ -575,7 +597,8 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			assertError: require.NoError,
 		},
 		{
-			desc:             "non-fips client fail v12",
+			desc:             "non-fips client fail",
+			authServer:       fipsServer,
 			tokenName:        "test-token",
 			requestTokenName: "test-token",
 			tokenSpec: types.ProvisionTokenSpecV2{
@@ -590,14 +613,10 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 			},
 			stsClient: &mockClient{
 				respStatusCode: http.StatusOK,
-				respBody: responseFromAWSIdentity(auth.AWSIdentity{
+				respBody: responseFromAWSIdentity(iamjoin.AWSIdentity{
 					Account: "1234",
 					Arn:     "arn:aws::1111",
 				}),
-			},
-			iamRegisterOptions: []auth.IAMRegisterOption{
-				auth.WithFIPS(true),
-				auth.WithAuthVersion(&semver.Version{Major: 12}),
 			},
 			challengeResponseOptions: []challengeResponseOption{
 				withHost("sts.us-east-1.amazonaws.com"),
@@ -608,41 +627,76 @@ func TestAuth_RegisterUsingIAMMethod(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			// Set mock client.
-			a.SetHTTPClientForAWSSTS(tc.stsClient)
-
-			// add token to auth server
-			token, err := types.NewProvisionTokenFromSpec(
-				tc.tokenName,
-				time.Now().Add(time.Minute),
-				tc.tokenSpec)
-			require.NoError(t, err)
-			require.NoError(t, a.UpsertToken(ctx, token))
-			defer func() {
-				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
-			}()
-
-			_, err = a.RegisterUsingIAMMethodWithOpts(context.Background(), func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
-				templateInput := defaultIdentityRequestTemplateInput(challenge)
-				for _, opt := range tc.challengeResponseOptions {
-					opt(&templateInput)
-				}
-				var identityRequest bytes.Buffer
-				require.NoError(t, identityRequestTemplate.Execute(&identityRequest, templateInput))
-
-				req := &proto.RegisterUsingIAMMethodRequest{
-					RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
-						Token:        tc.requestTokenName,
-						HostID:       "test-node",
-						Role:         types.RoleNode,
-						PublicSSHKey: sshPublicKey,
-						PublicTLSKey: tlsPublicKey,
-					},
-					StsIdentityRequest: identityRequest.Bytes(),
-				}
-				return req, tc.challengeResponseErr
-			}, tc.iamRegisterOptions...)
-			tc.assertError(t, err)
+			testIAMJoin(t, &tc)
 		})
 	}
+}
+
+func testIAMJoin(t *testing.T, tc *iamJoinTestCase) {
+	ctx := t.Context()
+	// Set mock client.
+	tc.authServer.Auth().SetHTTPClientForAWSSTS(tc.stsClient)
+
+	// Add token to auth server.
+	token, err := types.NewProvisionTokenFromSpec(
+		tc.tokenName,
+		time.Now().Add(time.Minute),
+		tc.tokenSpec)
+	require.NoError(t, err)
+	require.NoError(t, tc.authServer.Auth().UpsertToken(ctx, token))
+	t.Cleanup(func() {
+		assert.NoError(t, tc.authServer.Auth().DeleteToken(ctx, token.GetName()))
+	})
+
+	// Make an unauthenticated auth client that will be used for the join.
+	nopClient, err := tc.authServer.NewClient(authtest.TestNop())
+	require.NoError(t, err)
+	defer nopClient.Close()
+
+	createSignedSTSIdentityRequest := func(ctx context.Context, challenge string, opts ...iam.STSIdentityRequestOption) ([]byte, error) {
+		if tc.challengeResponseErr != nil {
+			return nil, trace.Wrap(tc.challengeResponseErr)
+		}
+		templateInput := defaultIdentityRequestTemplateInput(challenge)
+		for _, opt := range tc.challengeResponseOptions {
+			opt(&templateInput)
+		}
+		var identityRequest bytes.Buffer
+		if err := identityRequestTemplate.Execute(&identityRequest, templateInput); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return identityRequest.Bytes(), nil
+	}
+
+	// Test joining via the legacy join service.
+	//
+	// TODO(nklaassen): DELETE IN 20 when removing the legacy join service.
+	t.Run("legacy", func(t *testing.T) {
+		_, err := joinclient.LegacyJoin(ctx, joinclient.JoinParams{
+			Token:      tc.requestTokenName,
+			JoinMethod: types.JoinMethodIAM,
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				HostUUID: "test-uuid",
+				NodeName: "test-node",
+			},
+			CreateSignedSTSIdentityRequestFunc: createSignedSTSIdentityRequest,
+			AuthClient:                         nopClient,
+		})
+		tc.assertError(t, err)
+	})
+
+	// Tests joining via the new join service with auth-assigned host UUIDs.
+	t.Run("new", func(t *testing.T) {
+		_, err := joinclient.Join(ctx, joinclient.JoinParams{
+			Token: tc.requestTokenName,
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				NodeName: "test-node",
+			},
+			CreateSignedSTSIdentityRequestFunc: createSignedSTSIdentityRequest,
+			AuthClient:                         nopClient,
+		})
+		tc.assertError(t, err)
+	})
 }

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -21,6 +21,7 @@ import (
 	"crypto"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"log/slog"
 
 	"github.com/gravitational/trace"
@@ -33,10 +34,15 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinv1"
+	"github.com/gravitational/teleport/lib/utils/hostid"
 )
 
-type JoinParams = authjoin.RegisterParams
-type JoinResult = authjoin.RegisterResult
+type (
+	JoinParams   = authjoin.RegisterParams
+	JoinResult   = authjoin.RegisterResult
+	AzureParams  = authjoin.AzureParams
+	GitlabParams = authjoin.GitlabParams
+)
 
 // Join is used to join a cluster. A host or bot calls this with the name of a
 // provision token to get its initial certificates.
@@ -44,14 +50,41 @@ func Join(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	if err := params.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if params.AuthClient == nil && params.ID.HostUUID != "" {
+		// This check is skipped if AuthClient is provided because this is a
+		// re-join with an existing identity and the HostUUID will be
+		// maintained.
+		return nil, trace.BadParameter("HostUUID must not be provided to Join, it will be assigned by the Auth server")
+	}
+	if params.ID.Role != types.RoleInstance && params.ID.Role != types.RoleBot {
+		return nil, trace.BadParameter("Only Instance and Bot roles may be used for direct join attempts")
+	}
 	slog.InfoContext(ctx, "Trying to join with the new join service")
 	result, err := joinNew(ctx, params)
-	if trace.IsNotImplemented(err) {
+	if trace.IsNotImplemented(err) || errors.As(err, new(*connectionError)) {
 		// Fall back to joining via legacy service.
 		slog.InfoContext(ctx, "Falling back to joining via the legacy join service", "error", err)
-		result, err := authjoin.Register(ctx, params)
+		// Non-bots must generate their own host UUID when joining via legacy service.
+		if params.ID.Role != types.RoleBot {
+			hostID, err := hostid.Generate(ctx, params.JoinMethod)
+			if err != nil {
+				return nil, trace.Wrap(err, "generating host ID")
+			}
+			params.ID.HostUUID = hostID
+		}
+		result, err := LegacyJoin(ctx, params)
 		return result, trace.Wrap(err)
 	}
+	return result, trace.Wrap(err)
+}
+
+// LegacyJoin is used to join the cluster via the legacy service with client-chosen host UUIDs.
+func LegacyJoin(ctx context.Context, params JoinParams) (*JoinResult, error) {
+	if params.ID.Role != types.RoleBot && params.ID.HostUUID == "" {
+		return nil, trace.BadParameter("HostUUID is required for LegacyJoin")
+	}
+	//nolint:staticcheck // SA1019 falling back to deprecated method for compatibility.
+	result, err := authjoin.Register(ctx, params)
 	return result, trace.Wrap(err)
 }
 
@@ -100,7 +133,7 @@ func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*Jo
 		},
 	)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, &connectionError{trace.Wrap(err, "building proxy client")}
 	}
 	defer conn.Close()
 	return joinWithClient(ctx, params, joinv1.NewClientFromConn(conn))
@@ -109,7 +142,7 @@ func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*Jo
 func joinViaAuth(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	authClient, err := authjoin.NewAuthClient(ctx, params)
 	if err != nil {
-		return nil, trace.Wrap(err, "building auth client")
+		return nil, &connectionError{trace.Wrap(err, "building auth client")}
 	}
 	defer authClient.Close()
 	return joinViaAuthClient(ctx, params, authClient)
@@ -126,7 +159,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	switch params.JoinMethod {
 	case types.JoinMethodUnspecified:
 		// leave joinMethodPtr nil to let the server pick based on the token
-	case types.JoinMethodToken:
+	case types.JoinMethodToken, types.JoinMethodBoundKeypair:
 		joinMethod := string(params.JoinMethod)
 		joinMethodPtr = &joinMethod
 	default:
@@ -139,7 +172,10 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	defer cancel()
 	stream, err := client.Join(ctx)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		// Connection errors are usually delayed until the first request is
+		// attempted, wrap with a connectionError here to allow a fallback to
+		// the legacy join method.
+		return nil, &connectionError{trace.Wrap(err, "initiating join stream")}
 	}
 	defer stream.CloseSend()
 
@@ -333,4 +369,16 @@ func generateKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (cry
 		PublicTLSKey: tlsPub,
 		PublicSSHKey: sshPub.Marshal(),
 	}, nil
+}
+
+type connectionError struct {
+	wrapped error
+}
+
+func (e *connectionError) Error() string {
+	return e.wrapped.Error()
+}
+
+func (e *connectionError) Unwrap() error {
+	return e.wrapped
 }

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -154,12 +154,12 @@ func joinViaAuthClient(ctx context.Context, params JoinParams, authClient authjo
 
 func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Client) (*JoinResult, error) {
 	// Clients may specify the join method or not, to let the server choose the
-	// method based on the provsion token.
+	// method based on the provision token.
 	var joinMethodPtr *string
 	switch params.JoinMethod {
 	case types.JoinMethodUnspecified:
 		// leave joinMethodPtr nil to let the server pick based on the token
-	case types.JoinMethodToken, types.JoinMethodBoundKeypair:
+	case types.JoinMethodToken, types.JoinMethodBoundKeypair, types.JoinMethodIAM:
 		joinMethod := string(params.JoinMethod)
 		joinMethodPtr = &joinMethod
 	default:
@@ -196,7 +196,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	}
 
 	// Generate keys based on the signature algorithm suite from the ServerInit message.
-	signer, publicKeys, err := generateKeys(ctx, serverInit.SignatureAlgorithmSuite)
+	signer, publicKeys, err := GenerateKeys(ctx, serverInit.SignatureAlgorithmSuite)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -242,6 +242,8 @@ func joinWithMethod(
 		return tokenJoin(stream, clientParams)
 	case types.JoinMethodBoundKeypair:
 		return boundKeypairJoin(ctx, stream, joinParams, clientParams)
+	case types.JoinMethodIAM:
+		return iamJoin(ctx, stream, joinParams, clientParams)
 	default:
 		// TODO(nklaassen): implement remaining join methods.
 		return nil, trace.NotImplemented("server selected join method %v which is not supported by this client", method)
@@ -348,7 +350,9 @@ func pemEncodeTLSCert(rawCert []byte) []byte {
 	})
 }
 
-func generateKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (crypto.Signer, *messages.PublicKeys, error) {
+// GenerateKeys generates host keys appropriate for a cluster join request
+// according to the cluster's configured signature algorithm suite.
+func GenerateKeys(ctx context.Context, suite types.SignatureAlgorithmSuite) (crypto.Signer, *messages.PublicKeys, error) {
 	signer, err := cryptosuites.GenerateKey(
 		ctx,
 		cryptosuites.StaticAlgorithmSuite(suite),

--- a/lib/join/joinclient/join_iam.go
+++ b/lib/join/joinclient/join_iam.go
@@ -1,0 +1,72 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinclient
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/auth/join/iam"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+func iamJoin(
+	ctx context.Context,
+	stream messages.ClientStream,
+	joinParams JoinParams,
+	clientParams messages.ClientParams,
+) (messages.Response, error) {
+	// The IAM join method involves the following messages:
+	//
+	// client->server ClientInit
+	// client<-server ServerInit
+	// client->server IAMInit
+	// client<-server IAMChallenge
+	// client->server IAMChallengeSolution
+	// client<-server Result
+	//
+	// At this point the ServerInit messages has already been received, what's
+	// left is to send the IAMInit message, handle the challenge-response, and
+	// receive and return the final result.
+	if err := stream.Send(&messages.IAMInit{
+		ClientParams: clientParams,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending IAMInit")
+	}
+
+	challenge, err := messages.RecvResponse[*messages.IAMChallenge](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving IAMChallenge")
+	}
+
+	signedRequest, err := joinParams.CreateSignedSTSIdentityRequestFunc(ctx, challenge.Challenge,
+		iam.WithFIPSEndpoint(joinParams.FIPS),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err, "creating signed sts:GetCallerIdentity request")
+	}
+
+	if err := stream.Send(&messages.IAMChallengeSolution{
+		STSIdentityRequest: signedRequest,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending IAMChallengeSolution")
+	}
+
+	result, err := stream.Recv()
+	return result, trace.Wrap(err, "receiving join result")
+}

--- a/lib/join/joinutils/utils.go
+++ b/lib/join/joinutils/utils.go
@@ -1,0 +1,72 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinutils
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+)
+
+// GlobMatch performs simple a simple glob-style match test on a string.
+// - '*' matches zero or more characters.
+// - '?' matches any single character.
+// It returns true if a match is detected.
+func GlobMatch(pattern, str string) (bool, error) {
+	pattern = regexp.QuoteMeta(pattern)
+	pattern = strings.ReplaceAll(pattern, `\*`, ".*")
+	pattern = strings.ReplaceAll(pattern, `\?`, ".")
+	pattern = "^" + pattern + "$"
+	matched, err := regexp.MatchString(pattern, str)
+	return matched, trace.Wrap(err)
+}
+
+// GenerateChallenge generates a crypto-random challenge with length random
+// bytes and encodes it to base64.
+func GenerateChallenge(encoding *base64.Encoding, length int) (string, error) {
+	// read crypto-random bytes to generate the challenge
+	challengeRawBytes := make([]byte, length)
+	if _, err := rand.Read(challengeRawBytes); err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// encode the challenge to base64 so it can be sent over HTTP
+	return encoding.EncodeToString(challengeRawBytes), nil
+}
+
+// RawJoinAttrsToStruct converts raw join attributes into a struct suitable for
+// logging or audit events.
+func RawJoinAttrsToStruct(in any) (*apievents.Struct, error) {
+	if in == nil {
+		return nil, nil
+	}
+	attrBytes, err := json.Marshal(in)
+	if err != nil {
+		return nil, trace.Wrap(err, "marshaling join attributes")
+	}
+	out := &apievents.Struct{}
+	if err := out.UnmarshalJSON(attrBytes); err != nil {
+		return nil, trace.Wrap(err, "unmarshaling join attributes")
+	}
+	return out, nil
+}

--- a/lib/join/joinv1/messages_iam.go
+++ b/lib/join/joinv1/messages_iam.go
@@ -1,0 +1,68 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinv1
+
+import (
+	"github.com/gravitational/trace"
+
+	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+func iamInitToMessage(req *joinv1.IAMInit) (*messages.IAMInit, error) {
+	clientParams, err := clientParamsToMessage(req.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &messages.IAMInit{
+		ClientParams: clientParams,
+	}, nil
+}
+
+func iamInitFromMessage(msg *messages.IAMInit) (*joinv1.IAMInit, error) {
+	clientParams, err := clientParamsFromMessage(msg.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &joinv1.IAMInit{
+		ClientParams: clientParams,
+	}, nil
+}
+
+func iamChallengeToMessage(req *joinv1.IAMChallenge) *messages.IAMChallenge {
+	return &messages.IAMChallenge{
+		Challenge: req.Challenge,
+	}
+}
+
+func iamChallengeFromMessage(msg *messages.IAMChallenge) *joinv1.IAMChallenge {
+	return &joinv1.IAMChallenge{
+		Challenge: msg.Challenge,
+	}
+}
+
+func iamChallengeSolutionToMessage(req *joinv1.IAMChallengeSolution) *messages.IAMChallengeSolution {
+	return &messages.IAMChallengeSolution{
+		STSIdentityRequest: req.StsIdentityRequest,
+	}
+}
+
+func iamChallengeSolutionFromMessage(msg *messages.IAMChallengeSolution) *joinv1.IAMChallengeSolution {
+	return &joinv1.IAMChallengeSolution{
+		StsIdentityRequest: msg.STSIdentityRequest,
+	}
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -46,7 +47,9 @@ import (
 	joinauthz "github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/hostid"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
@@ -69,6 +72,7 @@ type AuthService interface {
 	UpsertLock(context.Context, types.Lock) error
 	CheckLockInForce(constants.LockingMode, []types.LockTarget) error
 	GetClock() clockwork.Clock
+	GetHTTPClientForAWSSTS() utils.HTTPDoClient
 }
 
 // ServerConfig holds configuration parameters for [Server].
@@ -76,6 +80,7 @@ type ServerConfig struct {
 	AuthService AuthService
 	Authorizer  authz.Authorizer
 	Clock       clockwork.Clock
+	FIPS        bool
 }
 
 // Server implements cluster joining for nodes and bots.
@@ -201,6 +206,8 @@ func (s *Server) handleJoinMethod(
 		return s.handleTokenJoin(stream, authCtx, clientInit, provisionToken)
 	case types.JoinMethodBoundKeypair:
 		return s.handleBoundKeypairJoin(stream, authCtx, clientInit, provisionToken)
+	case types.JoinMethodIAM:
+		return s.handleIAMJoin(stream, authCtx, clientInit, provisionToken)
 	default:
 		// TODO(nklaassen): implement checks for all join methods.
 		return nil, trace.NotImplemented("join method %s is not yet implemented by the new join service", joinMethod)
@@ -326,14 +333,15 @@ func (s *Server) makeResult(
 	authCtx *joinauthz.Context,
 	clientInit *messages.ClientInit,
 	clientParams *messages.ClientParams,
-	rawClaims any,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (messages.Response, error) {
 	switch types.SystemRole(clientInit.SystemRole) {
 	case types.RoleInstance:
-		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, provisionToken)
+		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, provisionToken, rawClaims)
 	case types.RoleBot:
-		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, rawClaims, provisionToken)
+		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, provisionToken, rawClaims, attrs)
 		return result, trace.Wrap(err)
 	default:
 		return nil, trace.NotImplemented("new join service only supports Instance and Bot system roles, client requested %s", clientInit.SystemRole)
@@ -346,8 +354,9 @@ func (s *Server) makeHostResult(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
 ) (*messages.HostResult, error) {
-	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(provisionToken))
+	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(provisionToken), rawClaims)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -373,11 +382,12 @@ func makeHostCertsParams(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	joinMethod types.JoinMethod,
+	rawClaims any,
 ) (*HostCertsParams, error) {
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(hostParams.PublicKeys.PublicTLSKey)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("failed to parse TLS public key")
 	}
 	tlsPubPEM, err := keys.MarshalPublicKey(crypto.PublicKey(tlsPub))
 	if err != nil {
@@ -387,7 +397,7 @@ func makeHostCertsParams(
 	// GenerateHostCertsForJoin requires the SSH key to be in authorized keys format.
 	sshPub, err := ssh.ParsePublicKey(hostParams.PublicKeys.PublicSSHKey)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("failed to parse SSH public key")
 	}
 	sshAuthorizedKey := ssh.MarshalAuthorizedKey(sshPub)
 
@@ -399,6 +409,7 @@ func makeHostCertsParams(
 		AdditionalPrincipals: hostParams.AdditionalPrincipals,
 		DNSNames:             hostParams.DNSNames,
 		RemoteAddr:           diag.Get().RemoteAddr,
+		RawJoinClaims:        rawClaims,
 	}
 
 	if authCtx.IsInstance {
@@ -424,10 +435,11 @@ func (s *Server) makeBotResult(
 	diag *diagnostic.Diagnostic,
 	authCtx *joinauthz.Context,
 	botParams *messages.BotParams,
-	rawClaims any,
 	provisionToken types.ProvisionToken,
+	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*messages.BotResult, string, error) {
-	certsParams, err := makeBotCertsParams(diag, authCtx, botParams, rawClaims)
+	certsParams, err := makeBotCertsParams(diag, authCtx, botParams, rawClaims, attrs)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -451,6 +463,7 @@ func makeBotCertsParams(
 	authCtx *joinauthz.Context,
 	botParams *messages.BotParams,
 	rawClaims any,
+	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*BotCertsParams, error) {
 	// GenerateBotCertsForJoin requires the TLS key to be PEM-encoded.
 	tlsPub, err := x509.ParsePKIXPublicKey(botParams.PublicKeys.PublicTLSKey)
@@ -477,6 +490,7 @@ func makeBotCertsParams(
 		Expires:       botParams.Expires,
 		RemoteAddr:    diag.Get().RemoteAddr,
 		RawJoinClaims: rawClaims,
+		Attrs:         attrs,
 	}, nil
 }
 
@@ -551,14 +565,25 @@ func setDiagnosticClientParams(diag *diagnostic.Diagnostic, clientParams *messag
 }
 
 func handleJoinFailure(ctx context.Context, emitter apievents.Emitter, diag *diagnostic.Diagnostic) {
-	log.LogAttrs(ctx, slog.LevelWarn, "Failure to join cluster occurred", diag.SlogAttrs()...)
-	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diag)); err != nil {
+	diagInfo := diag.Get()
+	slogAttrs := diagInfo.SlogAttrs()
+
+	// Fetch and encode RawJoinAttrs if they are available.
+	attributesStruct, err := joinutils.RawJoinAttrsToStruct(diagInfo.RawJoinAttrs)
+	if err != nil {
+		log.WarnContext(ctx, "Unable to fetch join attributes from join method", "error", err)
+	}
+	if attributesStruct != nil {
+		slogAttrs = append(slogAttrs, slog.Any("attributes", attributesStruct))
+	}
+
+	log.LogAttrs(ctx, slog.LevelWarn, "Failure to join cluster occurred", slogAttrs...)
+	if err := emitter.EmitAuditEvent(context.WithoutCancel(ctx), makeAuditEvent(diagInfo, attributesStruct)); err != nil {
 		log.WarnContext(ctx, "Failed to emit failed join event", "error", err)
 	}
 }
 
-func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
-	info := d.Get()
+func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) apievents.AuditEvent {
 	errorMessage := info.Error.Error()
 	if errors.Is(info.Error, context.Canceled) || status.Code(info.Error) == codes.Canceled {
 		errorMessage = "join attempt timed out or was aborted"
@@ -582,6 +607,7 @@ func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
 			TokenName:     info.SafeTokenName,
 			BotName:       info.BotName,
 			BotInstanceID: info.BotInstanceID,
+			Attributes:    attributesStruct,
 		}
 	}
 	return &apievents.InstanceJoin{
@@ -599,6 +625,7 @@ func makeAuditEvent(d *diagnostic.Diagnostic) apievents.AuditEvent {
 		TokenExpires: info.TokenExpires,
 		Role:         info.Role,
 		NodeName:     info.NodeName,
+		Attributes:   attributesStruct,
 	}
 }
 

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -84,7 +84,13 @@ func (s *Server) handleBoundKeypairJoin(
 		return rotationResp, trace.Wrap(err)
 	}
 	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
-		botCertsParams, err := makeBotCertsParams(diag, authCtx, boundKeypairInit.ClientParams.BotParams, claims)
+		botCertsParams, err := makeBotCertsParams(
+			diag,
+			authCtx,
+			boundKeypairInit.ClientParams.BotParams,
+			claims,
+			nil, // TODO(timothyb89): workload id claims
+		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -188,7 +194,13 @@ func AdaptRegisterUsingBoundKeypairMethod(
 	}
 
 	generateBotCerts := func(ctx context.Context, previousBotInstanceID string, claims any) (*messages.Certificates, string, error) {
-		botCertsParams, err := makeBotCertsParams(diag, authCtx, clientParams.BotParams, claims)
+		botCertsParams, err := makeBotCertsParams(
+			diag,
+			authCtx,
+			clientParams.BotParams,
+			claims,
+			nil, // TODO(timothyb89): workload id claims
+		)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -1,0 +1,108 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join
+
+import (
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/join/internal/authz"
+	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+// handleIAMJoin handles join attempts for the IAM join method.
+//
+// The IAM join method involves the following messages:
+//
+// client->server ClientInit
+// client<-server ServerInit
+// client->server IAMInit
+// client<-server IAMChallenge
+// client->server IAMChallengeSolution
+// client<-server Result
+//
+// At this point the ServerInit message has already been sent, what's left is
+// to receive the IAMInit message, handle the challenge-response, and send the
+// final result if everything checks out.
+func (s *Server) handleIAMJoin(
+	stream messages.ServerStream,
+	authCtx *authz.Context,
+	clientInit *messages.ClientInit,
+	provisionToken types.ProvisionToken,
+) (messages.Response, error) {
+	// Receive the IAMInit message from the client.
+	iamInit, err := messages.RecvRequest[*messages.IAMInit](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving IAMInit message")
+	}
+	// Set any diagnostic info from the ClientParams.
+	setDiagnosticClientParams(stream.Diagnostic(), &iamInit.ClientParams)
+
+	// Generate and send the challenge.
+	challenge, err := iamjoin.GenerateIAMChallenge()
+	if err != nil {
+		return nil, trace.Wrap(err, "generating challenge")
+	}
+	if err := stream.Send(&messages.IAMChallenge{
+		Challenge: challenge,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending challenge")
+	}
+
+	// Receive the solution from the client.
+	solution, err := messages.RecvRequest[*messages.IAMChallengeSolution](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving challenge solution")
+	}
+
+	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
+	// the verified identity matches allow rules in the provision token.
+	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
+		Challenge:          challenge,
+		ProvisionToken:     provisionToken,
+		STSIdentityRequest: solution.STSIdentityRequest,
+		HTTPClient:         s.cfg.AuthService.GetHTTPClientForAWSSTS(),
+		FIPS:               s.cfg.FIPS,
+	})
+	// An identity will be returned even on error if the sts:GetCallerIdentity
+	// request was completed but no allow rules were matched, include it in the
+	// diagnostic for debugging.
+	stream.Diagnostic().Set(func(info *diagnostic.Info) {
+		info.RawJoinAttrs = verifiedIdentity
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "verifying challenge response")
+	}
+
+	// Make and return the final result message.
+	result, err := s.makeResult(
+		stream.Context(),
+		stream.Diagnostic(),
+		authCtx,
+		clientInit,
+		&iamInit.ClientParams,
+		provisionToken,
+		verifiedIdentity,
+		&workloadidentityv1pb.JoinAttrs{
+			Iam: verifiedIdentity.JoinAttrs(),
+		},
+	)
+	return result, trace.Wrap(err)
+}

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -47,8 +47,9 @@ func (s *Server) handleTokenJoin(
 		authCtx,
 		clientInit,
 		&tokenInit.ClientParams,
-		nil, /*rawClaims*/
 		provisionToken,
+		nil, /*rawClaims*/
+		nil, /*attrs*/
 	)
 	return result, trace.Wrap(err)
 }


### PR DESCRIPTION
Backport #60032 to branch/v18
Backport #60033 to branch/v18

This PR backports IAM method support in the new join service to branch/v18

I first included the changes to lib/join from https://github.com/gravitational/teleport/pull/60293 in this PR which I'm not merging to v18 yet because it changes the way bot and nodes actually join, that shows up as the first commit in this branch.