### PR TITLE
[v17] Fix long role names for MySQL auto users

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -544,7 +544,7 @@ func getCreateProcedureCommand(conn *clientConn, procedureName string) (string, 
 const (
 	// procedureVersion is a hard-coded string that is set as procedure
 	// comments to indicate the procedure version.
-	procedureVersion = "teleport-auto-user-v4"
+	procedureVersion = "teleport-auto-user-v5"
 
 	// mysqlMaxUsernameLength is the maximum username/role length for MySQL.
 	//

--- a/lib/srv/db/mysql/sql/mariadb_deactivate_user.sql
+++ b/lib/srv/db/mysql/sql/mariadb_deactivate_user.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE teleport_deactivate_user(IN username VARCHAR(80))
+CREATE PROCEDURE teleport_deactivate_user(IN username TEXT)
 BEGIN
     DECLARE is_active INT DEFAULT 0;
     SELECT COUNT(USER) INTO is_active FROM information_schema.processlist WHERE USER = username;

--- a/lib/srv/db/mysql/sql/mariadb_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mariadb_delete_user.sql
@@ -1,7 +1,7 @@
-CREATE PROCEDURE teleport_delete_user(IN username VARCHAR(80))
+CREATE PROCEDURE teleport_delete_user(IN username TEXT)
 BEGIN
     -- Defaults to dropping user.
-    DECLARE state VARCHAR(5);
+    DECLARE state TEXT;
     DECLARE is_active INT DEFAULT 0;
     DECLARE view_count INT DEFAULT 0;
     DECLARE procedure_count INT DEFAULT 0;

--- a/lib/srv/db/mysql/sql/mariadb_revoke_roles.sql
+++ b/lib/srv/db/mysql/sql/mariadb_revoke_roles.sql
@@ -1,7 +1,7 @@
-CREATE PROCEDURE teleport_revoke_roles(IN username VARCHAR(80))
+CREATE PROCEDURE teleport_revoke_roles(IN username TEXT)
 BEGIN
-    DECLARE cur_user CHAR(128);
-    DECLARE cur_role CHAR(128);
+    DECLARE cur_user TEXT;
+    DECLARE cur_role TEXT;
     DECLARE done INT DEFAULT FALSE;
     -- Revoke all roles assigned to the all-in-one role, and all roles assigned
     -- to the username (expect 'teleport-auto-user')

--- a/lib/srv/db/mysql/sql/mysql_activate_user.sql
+++ b/lib/srv/db/mysql/sql/mysql_activate_user.sql
@@ -1,11 +1,11 @@
-CREATE PROCEDURE teleport_activate_user(IN username VARCHAR(32), IN details JSON)
+CREATE PROCEDURE teleport_activate_user(IN username TEXT, IN details JSON)
 proc_label:BEGIN
     DECLARE is_auto_user INT DEFAULT 0;
     DECLARE is_active INT DEFAULT 0;
     DECLARE is_same_user INT DEFAULT 0; 
     DECLARE are_roles_same INT DEFAULT 0; 
     DECLARE role_index INT DEFAULT 0;
-    DECLARE role VARCHAR(32) DEFAULT '';
+    DECLARE role TEXT DEFAULT '';
     DECLARE cur_roles TEXT DEFAULT '';
     SET @roles = details->"$.roles";
     SET @teleport_user = details->>"$.attributes.user";
@@ -57,11 +57,10 @@ proc_label:BEGIN
 
     -- Assign roles.
     WHILE role_index < JSON_LENGTH(@roles) DO
-        SELECT JSON_EXTRACT(@roles, CONCAT('$[',role_index,']')) INTO role;
+        SELECT JSON_UNQUOTE(JSON_EXTRACT(@roles, CONCAT('$[',role_index,']'))) INTO role;
         SELECT role_index + 1 INTO role_index;
 
-        -- role extracted from JSON already has double quotes.
-        SET @sql := CONCAT_WS(' ', 'GRANT', role, 'TO', QUOTE(username));
+        SET @sql := CONCAT_WS(' ', 'GRANT', QUOTE(role), 'TO', QUOTE(username));
         PREPARE stmt FROM @sql;
         EXECUTE stmt;
         DEALLOCATE PREPARE stmt;

--- a/lib/srv/db/mysql/sql/mysql_deactivate_user.sql
+++ b/lib/srv/db/mysql/sql/mysql_deactivate_user.sql
@@ -1,4 +1,4 @@
-CREATE PROCEDURE teleport_deactivate_user(IN username VARCHAR(32))
+CREATE PROCEDURE teleport_deactivate_user(IN username TEXT)
 BEGIN
     DECLARE is_active INT DEFAULT 0;
     SELECT COUNT(USER) INTO is_active FROM information_schema.processlist WHERE USER = username;

--- a/lib/srv/db/mysql/sql/mysql_delete_user.sql
+++ b/lib/srv/db/mysql/sql/mysql_delete_user.sql
@@ -1,7 +1,7 @@
-CREATE PROCEDURE teleport_delete_user(IN username VARCHAR(32))
+CREATE PROCEDURE teleport_delete_user(IN username TEXT)
 BEGIN
     -- Defaults to dropping user.
-    DECLARE state VARCHAR(5) DEFAULT 'TP003';
+    DECLARE state TEXT DEFAULT 'TP003';
     DECLARE is_active INT DEFAULT 0;
 
     -- Views and procedures rely on the definer to work correctly. Dropping the

--- a/lib/srv/db/mysql/sql/mysql_revoke_roles.sql
+++ b/lib/srv/db/mysql/sql/mysql_revoke_roles.sql
@@ -1,6 +1,6 @@
-CREATE PROCEDURE teleport_revoke_roles(IN username VARCHAR(32))
+CREATE PROCEDURE teleport_revoke_roles(IN username TEXT)
 BEGIN
-    DECLARE role VARCHAR(32) DEFAULT '';
+    DECLARE role TEXT DEFAULT '';
     DECLARE done INT DEFAULT 0;
     DECLARE role_cursor CURSOR FOR SELECT FROM_USER FROM mysql.role_edges WHERE FROM_USER != 'teleport-auto-user' AND TO_USER = username;
     DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;


### PR DESCRIPTION
Backport #60339 to branch/v17

changelog: Fixed a bug that prevented using database role names longer than 30 chars for MySQL auto user provisioning. Now role names as long as 32 chars, which is the MySQL limit, can be used.
