### PR TITLE
Add metrics for major version `rollout_target` and `build_info`

### DIFF
--- a/lib/autoupdate/rollout/metrics.go
+++ b/lib/autoupdate/rollout/metrics.go
@@ -176,7 +176,7 @@ func newMetrics(reg prometheus.Registerer) (*metrics, error) {
 			Namespace: teleport.MetricNamespace,
 			Subsystem: metricsSubsystem,
 			Name:      "rollout_target_major",
-			Help:      "Metric describing the agent target major version from the autoupdate_gent_rollout resource.",
+			Help:      "Metric describing the target major version from the autoupdate_agent_rollout resource.",
 		}),
 		buildInfoMajor: prometheus.NewGauge(prometheus.GaugeOpts{
 			Namespace: teleport.MetricNamespace,


### PR DESCRIPTION
In this PR, I added an additional metric that exposes the current build’s major version and the managed update’s target major version. This metric can be used for alerting when the target major version is two versions behind or one version ahead of the current build.

Currently, it’s not possible to work with existing metrics that use string labels, as PromQL does not support string-to-number conversion or arithmetic operations.

```
# HELP teleport_agent_autoupdates_build_info_major Metric describing the auth major version.
# TYPE teleport_agent_autoupdates_build_info_major gauge
teleport_agent_autoupdates_build_info_major 19

# HELP teleport_agent_autoupdates_rollout_target_major Metric describing the agent target major version from the autoupdate_gent_rollout resource.
# TYPE teleport_agent_autoupdates_rollout_target_major gauge
teleport_agent_autoupdates_rollout_target_major 18

# HELP teleport_client_autoupdates_version_target_major Metric describing the client tools target major version from the autoupdate_version resource.
# TYPE teleport_client_autoupdates_version_target_major gauge
teleport_client_autoupdates_version_target_major 18
```

Related: https://github.com/gravitational/cloud/issues/14225