### PR TITLE
message types for ec2 joining via new service

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -93,7 +93,7 @@ func (x GivingUp_Reason) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use GivingUp_Reason.Descriptor instead.
 func (GivingUp_Reason) EnumDescriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16, 0}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17, 0}
 }
 
 // ClientInit is the first message sent from the client during the join process, it
@@ -1013,6 +1013,69 @@ func (x *IAMChallengeSolution) GetStsIdentityRequest() []byte {
 	return nil
 }
 
+// EC2Init is sent from the client in response to the ServerInit message for
+// the EC2 join method.
+//
+// The EC2 method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: EC2Init
+// 4. server->client: Result
+type EC2Init struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams *ClientParams `protobuf:"bytes,1,opt,name=client_params,json=clientParams,proto3" json:"client_params,omitempty"`
+	// Document is a signed EC2 Instance Identity Document used to prove the
+	// identity of a joining EC2 instance.
+	Document      []byte `protobuf:"bytes,2,opt,name=document,proto3" json:"document,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EC2Init) Reset() {
+	*x = EC2Init{}
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EC2Init) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EC2Init) ProtoMessage() {}
+
+func (x *EC2Init) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EC2Init.ProtoReflect.Descriptor instead.
+func (*EC2Init) Descriptor() ([]byte, []int) {
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *EC2Init) GetClientParams() *ClientParams {
+	if x != nil {
+		return x.ClientParams
+	}
+	return nil
+}
+
+func (x *EC2Init) GetDocument() []byte {
+	if x != nil {
+		return x.Document
+	}
+	return nil
+}
+
 // ChallengeSolution holds a solution to a challenge issued by the server.
 type ChallengeSolution struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1028,7 +1091,7 @@ type ChallengeSolution struct {
 
 func (x *ChallengeSolution) Reset() {
 	*x = ChallengeSolution{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1040,7 +1103,7 @@ func (x *ChallengeSolution) String() string {
 func (*ChallengeSolution) ProtoMessage() {}
 
 func (x *ChallengeSolution) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[15]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1053,7 +1116,7 @@ func (x *ChallengeSolution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ChallengeSolution.ProtoReflect.Descriptor instead.
 func (*ChallengeSolution) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{15}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ChallengeSolution) GetPayload() isChallengeSolution_Payload {
@@ -1126,7 +1189,7 @@ type GivingUp struct {
 
 func (x *GivingUp) Reset() {
 	*x = GivingUp{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1138,7 +1201,7 @@ func (x *GivingUp) String() string {
 func (*GivingUp) ProtoMessage() {}
 
 func (x *GivingUp) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[16]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1151,7 +1214,7 @@ func (x *GivingUp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GivingUp.ProtoReflect.Descriptor instead.
 func (*GivingUp) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{16}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GivingUp) GetReason() GivingUp_Reason {
@@ -1179,6 +1242,7 @@ type JoinRequest struct {
 	//	*JoinRequest_Solution
 	//	*JoinRequest_IamInit
 	//	*JoinRequest_GivingUp
+	//	*JoinRequest_Ec2Init
 	Payload       isJoinRequest_Payload `protobuf_oneof:"payload"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1186,7 +1250,7 @@ type JoinRequest struct {
 
 func (x *JoinRequest) Reset() {
 	*x = JoinRequest{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1198,7 +1262,7 @@ func (x *JoinRequest) String() string {
 func (*JoinRequest) ProtoMessage() {}
 
 func (x *JoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[17]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1211,7 +1275,7 @@ func (x *JoinRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinRequest.ProtoReflect.Descriptor instead.
 func (*JoinRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{17}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *JoinRequest) GetPayload() isJoinRequest_Payload {
@@ -1275,6 +1339,15 @@ func (x *JoinRequest) GetGivingUp() *GivingUp {
 	return nil
 }
 
+func (x *JoinRequest) GetEc2Init() *EC2Init {
+	if x != nil {
+		if x, ok := x.Payload.(*JoinRequest_Ec2Init); ok {
+			return x.Ec2Init
+		}
+	}
+	return nil
+}
+
 type isJoinRequest_Payload interface {
 	isJoinRequest_Payload()
 }
@@ -1303,6 +1376,10 @@ type JoinRequest_GivingUp struct {
 	GivingUp *GivingUp `protobuf:"bytes,6,opt,name=giving_up,json=givingUp,proto3,oneof"`
 }
 
+type JoinRequest_Ec2Init struct {
+	Ec2Init *EC2Init `protobuf:"bytes,7,opt,name=ec2_init,json=ec2Init,proto3,oneof"`
+}
+
 func (*JoinRequest_ClientInit) isJoinRequest_Payload() {}
 
 func (*JoinRequest_TokenInit) isJoinRequest_Payload() {}
@@ -1314,6 +1391,8 @@ func (*JoinRequest_Solution) isJoinRequest_Payload() {}
 func (*JoinRequest_IamInit) isJoinRequest_Payload() {}
 
 func (*JoinRequest_GivingUp) isJoinRequest_Payload() {}
+
+func (*JoinRequest_Ec2Init) isJoinRequest_Payload() {}
 
 // ServerInit is the first message sent from the server in response to the
 // ClientInit message.
@@ -1330,7 +1409,7 @@ type ServerInit struct {
 
 func (x *ServerInit) Reset() {
 	*x = ServerInit{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1342,7 +1421,7 @@ func (x *ServerInit) String() string {
 func (*ServerInit) ProtoMessage() {}
 
 func (x *ServerInit) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[18]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1355,7 +1434,7 @@ func (x *ServerInit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerInit.ProtoReflect.Descriptor instead.
 func (*ServerInit) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{18}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *ServerInit) GetJoinMethod() string {
@@ -1387,7 +1466,7 @@ type Challenge struct {
 
 func (x *Challenge) Reset() {
 	*x = Challenge{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1399,7 +1478,7 @@ func (x *Challenge) String() string {
 func (*Challenge) ProtoMessage() {}
 
 func (x *Challenge) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[19]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1412,7 +1491,7 @@ func (x *Challenge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Challenge.ProtoReflect.Descriptor instead.
 func (*Challenge) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{19}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *Challenge) GetPayload() isChallenge_Payload {
@@ -1487,7 +1566,7 @@ type Result struct {
 
 func (x *Result) Reset() {
 	*x = Result{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1499,7 +1578,7 @@ func (x *Result) String() string {
 func (*Result) ProtoMessage() {}
 
 func (x *Result) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[20]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1512,7 +1591,7 @@ func (x *Result) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Result.ProtoReflect.Descriptor instead.
 func (*Result) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{20}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *Result) GetPayload() isResult_Payload {
@@ -1575,7 +1654,7 @@ type Certificates struct {
 
 func (x *Certificates) Reset() {
 	*x = Certificates{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1666,7 @@ func (x *Certificates) String() string {
 func (*Certificates) ProtoMessage() {}
 
 func (x *Certificates) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[21]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1679,7 @@ func (x *Certificates) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Certificates.ProtoReflect.Descriptor instead.
 func (*Certificates) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{21}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *Certificates) GetTlsCert() []byte {
@@ -1644,7 +1723,7 @@ type HostResult struct {
 
 func (x *HostResult) Reset() {
 	*x = HostResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1656,7 +1735,7 @@ func (x *HostResult) String() string {
 func (*HostResult) ProtoMessage() {}
 
 func (x *HostResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[22]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1669,7 +1748,7 @@ func (x *HostResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostResult.ProtoReflect.Descriptor instead.
 func (*HostResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{22}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *HostResult) GetCertificates() *Certificates {
@@ -1699,7 +1778,7 @@ type BotResult struct {
 
 func (x *BotResult) Reset() {
 	*x = BotResult{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1711,7 +1790,7 @@ func (x *BotResult) String() string {
 func (*BotResult) ProtoMessage() {}
 
 func (x *BotResult) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[23]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1724,7 +1803,7 @@ func (x *BotResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotResult.ProtoReflect.Descriptor instead.
 func (*BotResult) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{23}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *BotResult) GetCertificates() *Certificates {
@@ -1756,7 +1835,7 @@ type JoinResponse struct {
 
 func (x *JoinResponse) Reset() {
 	*x = JoinResponse{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1768,7 +1847,7 @@ func (x *JoinResponse) String() string {
 func (*JoinResponse) ProtoMessage() {}
 
 func (x *JoinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[24]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1781,7 +1860,7 @@ func (x *JoinResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use JoinResponse.ProtoReflect.Descriptor instead.
 func (*JoinResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{24}
+	return file_teleport_join_v1_joinservice_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *JoinResponse) GetPayload() isJoinResponse_Payload {
@@ -1864,7 +1943,7 @@ type ClientInit_ProxySuppliedParams struct {
 
 func (x *ClientInit_ProxySuppliedParams) Reset() {
 	*x = ClientInit_ProxySuppliedParams{}
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1876,7 +1955,7 @@ func (x *ClientInit_ProxySuppliedParams) String() string {
 func (*ClientInit_ProxySuppliedParams) ProtoMessage() {}
 
 func (x *ClientInit_ProxySuppliedParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[25]
+	mi := &file_teleport_join_v1_joinservice_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1977,7 +2056,10 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\fIAMChallenge\x12\x1c\n" +
 	"\tchallenge\x18\x01 \x01(\tR\tchallenge\"H\n" +
 	"\x14IAMChallengeSolution\x120\n" +
-	"\x14sts_identity_request\x18\x01 \x01(\fR\x12stsIdentityRequest\"\xf3\x02\n" +
+	"\x14sts_identity_request\x18\x01 \x01(\fR\x12stsIdentityRequest\"j\n" +
+	"\aEC2Init\x12C\n" +
+	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\x12\x1a\n" +
+	"\bdocument\x18\x02 \x01(\fR\bdocument\"\xf3\x02\n" +
 	"\x11ChallengeSolution\x12z\n" +
 	" bound_keypair_challenge_solution\x18\x01 \x01(\v2/.teleport.join.v1.BoundKeypairChallengeSolutionH\x00R\x1dboundKeypairChallengeSolution\x12w\n" +
 	"\x1fbound_keypair_rotation_response\x18\x02 \x01(\v2..teleport.join.v1.BoundKeypairRotationResponseH\x00R\x1cboundKeypairRotationResponse\x12^\n" +
@@ -1990,7 +2072,7 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\x12REASON_UNSPECIFIED\x10\x00\x12\"\n" +
 	"\x1eREASON_UNSUPPORTED_JOIN_METHOD\x10\x01\x12#\n" +
 	"\x1fREASON_UNSUPPORTED_MESSAGE_TYPE\x10\x02\x12$\n" +
-	" REASON_CHALLENGE_SOLUTION_FAILED\x10\x03\"\xa1\x03\n" +
+	" REASON_CHALLENGE_SOLUTION_FAILED\x10\x03\"\xd9\x03\n" +
 	"\vJoinRequest\x12?\n" +
 	"\vclient_init\x18\x01 \x01(\v2\x1c.teleport.join.v1.ClientInitH\x00R\n" +
 	"clientInit\x12<\n" +
@@ -1999,7 +2081,8 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"\x12bound_keypair_init\x18\x03 \x01(\v2\".teleport.join.v1.BoundKeypairInitH\x00R\x10boundKeypairInit\x12A\n" +
 	"\bsolution\x18\x04 \x01(\v2#.teleport.join.v1.ChallengeSolutionH\x00R\bsolution\x126\n" +
 	"\biam_init\x18\x05 \x01(\v2\x19.teleport.join.v1.IAMInitH\x00R\aiamInit\x129\n" +
-	"\tgiving_up\x18\x06 \x01(\v2\x1a.teleport.join.v1.GivingUpH\x00R\bgivingUpB\t\n" +
+	"\tgiving_up\x18\x06 \x01(\v2\x1a.teleport.join.v1.GivingUpH\x00R\bgivingUp\x126\n" +
+	"\bec2_init\x18\a \x01(\v2\x19.teleport.join.v1.EC2InitH\x00R\aec2InitB\t\n" +
 	"\apayload\"i\n" +
 	"\n" +
 	"ServerInit\x12\x1f\n" +
@@ -2052,7 +2135,7 @@ func file_teleport_join_v1_joinservice_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_join_v1_joinservice_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
+var file_teleport_join_v1_joinservice_proto_msgTypes = make([]protoimpl.MessageInfo, 27)
 var file_teleport_join_v1_joinservice_proto_goTypes = []any{
 	(GivingUp_Reason)(0),                   // 0: teleport.join.v1.GivingUp.Reason
 	(*ClientInit)(nil),                     // 1: teleport.join.v1.ClientInit
@@ -2070,57 +2153,60 @@ var file_teleport_join_v1_joinservice_proto_goTypes = []any{
 	(*IAMInit)(nil),                        // 13: teleport.join.v1.IAMInit
 	(*IAMChallenge)(nil),                   // 14: teleport.join.v1.IAMChallenge
 	(*IAMChallengeSolution)(nil),           // 15: teleport.join.v1.IAMChallengeSolution
-	(*ChallengeSolution)(nil),              // 16: teleport.join.v1.ChallengeSolution
-	(*GivingUp)(nil),                       // 17: teleport.join.v1.GivingUp
-	(*JoinRequest)(nil),                    // 18: teleport.join.v1.JoinRequest
-	(*ServerInit)(nil),                     // 19: teleport.join.v1.ServerInit
-	(*Challenge)(nil),                      // 20: teleport.join.v1.Challenge
-	(*Result)(nil),                         // 21: teleport.join.v1.Result
-	(*Certificates)(nil),                   // 22: teleport.join.v1.Certificates
-	(*HostResult)(nil),                     // 23: teleport.join.v1.HostResult
-	(*BotResult)(nil),                      // 24: teleport.join.v1.BotResult
-	(*JoinResponse)(nil),                   // 25: teleport.join.v1.JoinResponse
-	(*ClientInit_ProxySuppliedParams)(nil), // 26: teleport.join.v1.ClientInit.ProxySuppliedParams
-	(*timestamppb.Timestamp)(nil),          // 27: google.protobuf.Timestamp
+	(*EC2Init)(nil),                        // 16: teleport.join.v1.EC2Init
+	(*ChallengeSolution)(nil),              // 17: teleport.join.v1.ChallengeSolution
+	(*GivingUp)(nil),                       // 18: teleport.join.v1.GivingUp
+	(*JoinRequest)(nil),                    // 19: teleport.join.v1.JoinRequest
+	(*ServerInit)(nil),                     // 20: teleport.join.v1.ServerInit
+	(*Challenge)(nil),                      // 21: teleport.join.v1.Challenge
+	(*Result)(nil),                         // 22: teleport.join.v1.Result
+	(*Certificates)(nil),                   // 23: teleport.join.v1.Certificates
+	(*HostResult)(nil),                     // 24: teleport.join.v1.HostResult
+	(*BotResult)(nil),                      // 25: teleport.join.v1.BotResult
+	(*JoinResponse)(nil),                   // 26: teleport.join.v1.JoinResponse
+	(*ClientInit_ProxySuppliedParams)(nil), // 27: teleport.join.v1.ClientInit.ProxySuppliedParams
+	(*timestamppb.Timestamp)(nil),          // 28: google.protobuf.Timestamp
 }
 var file_teleport_join_v1_joinservice_proto_depIdxs = []int32{
-	26, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
+	27, // 0: teleport.join.v1.ClientInit.proxy_supplied_parameters:type_name -> teleport.join.v1.ClientInit.ProxySuppliedParams
 	2,  // 1: teleport.join.v1.HostParams.public_keys:type_name -> teleport.join.v1.PublicKeys
 	2,  // 2: teleport.join.v1.BotParams.public_keys:type_name -> teleport.join.v1.PublicKeys
-	27, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
+	28, // 3: teleport.join.v1.BotParams.expires:type_name -> google.protobuf.Timestamp
 	3,  // 4: teleport.join.v1.ClientParams.host_params:type_name -> teleport.join.v1.HostParams
 	4,  // 5: teleport.join.v1.ClientParams.bot_params:type_name -> teleport.join.v1.BotParams
 	5,  // 6: teleport.join.v1.TokenInit.client_params:type_name -> teleport.join.v1.ClientParams
 	5,  // 7: teleport.join.v1.BoundKeypairInit.client_params:type_name -> teleport.join.v1.ClientParams
 	5,  // 8: teleport.join.v1.IAMInit.client_params:type_name -> teleport.join.v1.ClientParams
-	9,  // 9: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
-	11, // 10: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
-	15, // 11: teleport.join.v1.ChallengeSolution.iam_challenge_solution:type_name -> teleport.join.v1.IAMChallengeSolution
-	0,  // 12: teleport.join.v1.GivingUp.reason:type_name -> teleport.join.v1.GivingUp.Reason
-	1,  // 13: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
-	6,  // 14: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
-	7,  // 15: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
-	16, // 16: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
-	13, // 17: teleport.join.v1.JoinRequest.iam_init:type_name -> teleport.join.v1.IAMInit
-	17, // 18: teleport.join.v1.JoinRequest.giving_up:type_name -> teleport.join.v1.GivingUp
-	8,  // 19: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
-	10, // 20: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
-	14, // 21: teleport.join.v1.Challenge.iam_challenge:type_name -> teleport.join.v1.IAMChallenge
-	23, // 22: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
-	24, // 23: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
-	22, // 24: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
-	22, // 25: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
-	12, // 26: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
-	19, // 27: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
-	20, // 28: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
-	21, // 29: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
-	18, // 30: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
-	25, // 31: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
-	31, // [31:32] is the sub-list for method output_type
-	30, // [30:31] is the sub-list for method input_type
-	30, // [30:30] is the sub-list for extension type_name
-	30, // [30:30] is the sub-list for extension extendee
-	0,  // [0:30] is the sub-list for field type_name
+	5,  // 9: teleport.join.v1.EC2Init.client_params:type_name -> teleport.join.v1.ClientParams
+	9,  // 10: teleport.join.v1.ChallengeSolution.bound_keypair_challenge_solution:type_name -> teleport.join.v1.BoundKeypairChallengeSolution
+	11, // 11: teleport.join.v1.ChallengeSolution.bound_keypair_rotation_response:type_name -> teleport.join.v1.BoundKeypairRotationResponse
+	15, // 12: teleport.join.v1.ChallengeSolution.iam_challenge_solution:type_name -> teleport.join.v1.IAMChallengeSolution
+	0,  // 13: teleport.join.v1.GivingUp.reason:type_name -> teleport.join.v1.GivingUp.Reason
+	1,  // 14: teleport.join.v1.JoinRequest.client_init:type_name -> teleport.join.v1.ClientInit
+	6,  // 15: teleport.join.v1.JoinRequest.token_init:type_name -> teleport.join.v1.TokenInit
+	7,  // 16: teleport.join.v1.JoinRequest.bound_keypair_init:type_name -> teleport.join.v1.BoundKeypairInit
+	17, // 17: teleport.join.v1.JoinRequest.solution:type_name -> teleport.join.v1.ChallengeSolution
+	13, // 18: teleport.join.v1.JoinRequest.iam_init:type_name -> teleport.join.v1.IAMInit
+	18, // 19: teleport.join.v1.JoinRequest.giving_up:type_name -> teleport.join.v1.GivingUp
+	16, // 20: teleport.join.v1.JoinRequest.ec2_init:type_name -> teleport.join.v1.EC2Init
+	8,  // 21: teleport.join.v1.Challenge.bound_keypair_challenge:type_name -> teleport.join.v1.BoundKeypairChallenge
+	10, // 22: teleport.join.v1.Challenge.bound_keypair_rotation_request:type_name -> teleport.join.v1.BoundKeypairRotationRequest
+	14, // 23: teleport.join.v1.Challenge.iam_challenge:type_name -> teleport.join.v1.IAMChallenge
+	24, // 24: teleport.join.v1.Result.host_result:type_name -> teleport.join.v1.HostResult
+	25, // 25: teleport.join.v1.Result.bot_result:type_name -> teleport.join.v1.BotResult
+	23, // 26: teleport.join.v1.HostResult.certificates:type_name -> teleport.join.v1.Certificates
+	23, // 27: teleport.join.v1.BotResult.certificates:type_name -> teleport.join.v1.Certificates
+	12, // 28: teleport.join.v1.BotResult.bound_keypair_result:type_name -> teleport.join.v1.BoundKeypairResult
+	20, // 29: teleport.join.v1.JoinResponse.init:type_name -> teleport.join.v1.ServerInit
+	21, // 30: teleport.join.v1.JoinResponse.challenge:type_name -> teleport.join.v1.Challenge
+	22, // 31: teleport.join.v1.JoinResponse.result:type_name -> teleport.join.v1.Result
+	19, // 32: teleport.join.v1.JoinService.Join:input_type -> teleport.join.v1.JoinRequest
+	26, // 33: teleport.join.v1.JoinService.Join:output_type -> teleport.join.v1.JoinResponse
+	33, // [33:34] is the sub-list for method output_type
+	32, // [32:33] is the sub-list for method input_type
+	32, // [32:32] is the sub-list for extension type_name
+	32, // [32:32] is the sub-list for extension extendee
+	0,  // [0:32] is the sub-list for field type_name
 }
 
 func init() { file_teleport_join_v1_joinservice_proto_init() }
@@ -2134,30 +2220,31 @@ func file_teleport_join_v1_joinservice_proto_init() {
 		(*ClientParams_HostParams)(nil),
 		(*ClientParams_BotParams)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[15].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[16].OneofWrappers = []any{
 		(*ChallengeSolution_BoundKeypairChallengeSolution)(nil),
 		(*ChallengeSolution_BoundKeypairRotationResponse)(nil),
 		(*ChallengeSolution_IamChallengeSolution)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[17].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[18].OneofWrappers = []any{
 		(*JoinRequest_ClientInit)(nil),
 		(*JoinRequest_TokenInit)(nil),
 		(*JoinRequest_BoundKeypairInit)(nil),
 		(*JoinRequest_Solution)(nil),
 		(*JoinRequest_IamInit)(nil),
 		(*JoinRequest_GivingUp)(nil),
+		(*JoinRequest_Ec2Init)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[19].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[20].OneofWrappers = []any{
 		(*Challenge_BoundKeypairChallenge)(nil),
 		(*Challenge_BoundKeypairRotationRequest)(nil),
 		(*Challenge_IamChallenge)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[20].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[21].OneofWrappers = []any{
 		(*Result_HostResult)(nil),
 		(*Result_BotResult)(nil),
 	}
-	file_teleport_join_v1_joinservice_proto_msgTypes[23].OneofWrappers = []any{}
-	file_teleport_join_v1_joinservice_proto_msgTypes[24].OneofWrappers = []any{
+	file_teleport_join_v1_joinservice_proto_msgTypes[24].OneofWrappers = []any{}
+	file_teleport_join_v1_joinservice_proto_msgTypes[25].OneofWrappers = []any{
 		(*JoinResponse_Init)(nil),
 		(*JoinResponse_Challenge)(nil),
 		(*JoinResponse_Result)(nil),
@@ -2168,7 +2255,7 @@ func file_teleport_join_v1_joinservice_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_join_v1_joinservice_proto_rawDesc), len(file_teleport_join_v1_joinservice_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   26,
+			NumMessages:   27,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -222,6 +222,22 @@ message IAMChallengeSolution {
   bytes sts_identity_request = 1;
 }
 
+// EC2Init is sent from the client in response to the ServerInit message for
+// the EC2 join method.
+//
+// The EC2 method join flow is:
+// 1. client->server: ClientInit
+// 2. server->client: ServerInit
+// 3. client->server: EC2Init
+// 4. server->client: Result
+message EC2Init {
+  // ClientParams holds parameters for the specific type of client trying to join.
+  ClientParams client_params = 1;
+  // Document is a signed EC2 Instance Identity Document used to prove the
+  // identity of a joining EC2 instance.
+  bytes document = 2;
+}
+
 // ChallengeSolution holds a solution to a challenge issued by the server.
 message ChallengeSolution {
   oneof payload {
@@ -263,6 +279,7 @@ message JoinRequest {
     ChallengeSolution solution = 4;
     IAMInit iam_init = 5;
     GivingUp giving_up = 6;
+    EC2Init ec2_init = 7;
   }
 }
 

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -324,6 +324,24 @@ type IAMChallengeSolution struct {
 	STSIdentityRequest []byte
 }
 
+// EC2Init is sent from the client in response to the ServerInit message for
+// the EC2 join method.
+//
+// The EC2 method join flow is:
+// 1. client->server: ClientInit
+// 2. client<-server: ServerInit
+// 3. client->server: EC2Init
+// 4. client<-server: Result
+type EC2Init struct {
+	embedRequest
+
+	// ClientParams holds parameters for the specific type of client trying to join.
+	ClientParams ClientParams
+	// Document is a signed EC2 Instance Identity Document used to prove the
+	// identity of a joining EC2 instance.
+	Document []byte
+}
+
 // Response is implemented by all join response messages.
 type Response interface {
 	isResponse()

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -36,6 +36,8 @@ func requestToMessage(req *joinv1.JoinRequest) (messages.Request, error) {
 		return boundKeypairInitToMessage(msg.BoundKeypairInit)
 	case *joinv1.JoinRequest_IamInit:
 		return iamInitToMessage(msg.IamInit)
+	case *joinv1.JoinRequest_Ec2Init:
+		return ec2InitToMessage(msg.Ec2Init)
 	case *joinv1.JoinRequest_Solution:
 		return challengeSolutionToMessage(msg.Solution)
 	case *joinv1.JoinRequest_GivingUp:
@@ -83,6 +85,16 @@ func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
 		return &joinv1.JoinRequest{
 			Payload: &joinv1.JoinRequest_IamInit{
 				IamInit: iamInit,
+			},
+		}, nil
+	case *messages.EC2Init:
+		ec2Init, err := ec2InitFromMessage(typedMsg)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &joinv1.JoinRequest{
+			Payload: &joinv1.JoinRequest_Ec2Init{
+				Ec2Init: ec2Init,
 			},
 		}, nil
 	case *messages.BoundKeypairChallengeSolution,

--- a/lib/join/joinv1/messages_ec2.go
+++ b/lib/join/joinv1/messages_ec2.go
@@ -1,0 +1,46 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinv1
+
+import (
+	"github.com/gravitational/trace"
+
+	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+func ec2InitToMessage(req *joinv1.EC2Init) (*messages.EC2Init, error) {
+	clientParams, err := clientParamsToMessage(req.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &messages.EC2Init{
+		ClientParams: clientParams,
+		Document:     req.Document,
+	}, nil
+}
+
+func ec2InitFromMessage(msg *messages.EC2Init) (*joinv1.EC2Init, error) {
+	clientParams, err := clientParamsFromMessage(msg.ClientParams)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &joinv1.EC2Init{
+		ClientParams: clientParams,
+		Document:     msg.Document,
+	}, nil
+}


### PR DESCRIPTION
This commit defines messages types for joining via the EC2 join method according to [RFD 27e](https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md).

The messages will be used in a follow-up PR.