### PR TITLE
[v17] Increase LDAP dial timeout

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -73,7 +73,7 @@ const (
 
 	// ldapDialTimeout is the timeout for dialing the LDAP server
 	// when making an initial connection
-	ldapDialTimeout = 15 * time.Second
+	ldapDialTimeout = 30 * time.Second
 
 	// ldapRequestTimeout is the timeout for making LDAP requests.
 	// It is larger than the dial timeout because LDAP queries in large


### PR DESCRIPTION
Customer is seeing intermittent LDAP dial timeouts, so we're increasing the timeout to account for this.

Backport #60354 to branch/v17

changelog: Updated LDAP dial timeout from 15 seconds to 30 seconds