### PR TITLE
Add a resource reference generator

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -263,6 +263,10 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make protos-up-to-date/host
 
+      - name: Check if resource reference docs are up to date
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: git config --global --add safe.directory $(realpath .) && make resource-docs-up-to-date
+
       - name: Check if Operator CRDs are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make crds-up-to-date

--- a/Makefile
+++ b/Makefile
@@ -2025,8 +2025,18 @@ access-monitoring-reference-up-to-date: access-monitoring-reference
 	fi
 
 .PHONY: gen-docs
-gen-docs:
+gen-docs: gen-resource-docs audit-event-reference
 	$(MAKE) -C integrations/terraform docs
 	$(MAKE) -C integrations/operator crd-docs
 	$(MAKE) -C examples/chart render-chart-ref
-	$(MAKE) audit-event-reference
+
+.PHONY: gen-resource-docs
+gen-resource-docs:
+	cd build.assets/tooling/cmd/resource-ref-generator && go run . -config config.yaml
+
+.PHONY: resource-docs-up-to-date
+resource-docs-up-to-date: must-start-clean/host gen-resource-docs
+	@if ! git diff --quiet; then \
+		./build.assets/please-run.sh "tctl resource reference docs" "make gen-resource-docs"; \
+		exit 1; \
+	fi

--- a/build.assets/tooling/cmd/resource-ref-generator/README.md
+++ b/build.assets/tooling/cmd/resource-ref-generator/README.md
@@ -1,0 +1,84 @@
+# Resource reference generator
+
+The resource reference generator is a Go program that produces a comprehensive
+reference guide for all dynamic Teleport resources and the fields they include.
+It uses the Teleport source as the basis for the guide. 
+
+## Usage
+
+From the root of your `gravitational/teleport` clone:
+
+```
+$ make gen-resource-docs
+```
+
+## How it works
+
+The resource reference generator works by:
+
+1. Identifying Go types that represent to the fields of each dynamic resource
+   struct identified in a configuration file.
+1. Retrieving reference information about dynamic resources and their fields
+   using a combination of Go comments and type information.
+
+### Editing source files
+
+The resource reference indicates which Go source files the reference generator
+used for each entry. The generator is only aware of Go source files, not
+protobuf message definitions.
+
+If a source file is based on a protobuf message definition, edit the message
+definition first, then run:
+
+```
+$ make grpc
+```
+
+After that, you can run the reference generator.
+
+## Configuration
+
+The generator uses a YAML configuration file with the following fields.
+
+### Main config
+
+- `source` (string): the path to the root of a Go project directory.
+
+- `destination` (string): the directory path in which to place reference pages.
+
+- `resources` (array of resource configuration objects): Teleport dynamic
+  resources to represent in the reference docs.
+
+### Resource configuration
+
+In the `resources` field of the configuration file, each resource configuration
+object has the following structure:
+
+- `type`: The name of the struct type declaration that represents the resource,
+  e.g., `RoleV6`.
+- `package`: The name of the Go package that includes the type declaration,
+  e.g., `types`.
+- `yaml_kind`: The value of `kind` to include in the resource manifest, e.g.,
+  "role".
+- `yaml_version`: The value of `version` to include in the resource manifest,
+  e.g., "v6".
+
+### Example
+
+```yaml
+source: "../../../../api"
+destination: "../../../../docs/pages/reference/tctl-resources"
+resources:
+  - type: RoleV6
+    package: types
+    yaml_kind: "role"
+    yaml_version: "v6"
+  - type: OIDCConnectorV3
+    package: types
+    yaml_kind: "oidc"
+    yaml_version: "v3"
+  - type: SAMLConnectorV2
+    package: types
+    yaml_kind: "saml"
+    yaml_version: "v2"
+```

--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -1,0 +1,11 @@
+source: "../../../../api"
+destination: "../../../../docs/pages/reference/infrastructure-as-code/teleport-resources"
+resources:
+  - type: OIDCConnectorV3
+    package: types
+    yaml_kind: "oidc"
+    yaml_version: "v3"
+  - type: SAMLConnectorV2
+    package: types
+    yaml_kind: "saml"
+    yaml_version: "v2"

--- a/build.assets/tooling/cmd/resource-ref-generator/main.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/main.go
@@ -1,0 +1,64 @@
+// Teleport
+// Copyright (C) 2025  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport/build.assets/tooling/cmd/resource-ref-generator/reference"
+)
+
+const tmplBase = "reference.tmpl"
+
+var tmplPath = filepath.Join("reference", tmplBase)
+
+const configHelp string = `The path to a YAML configuration file (see the README)`
+
+func main() {
+	conf := flag.String("config", "conf.yaml", configHelp)
+	flag.Parse()
+
+	conffile, err := os.Open(*conf)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not open the configuration file %v: %v\n", *conf, err)
+		os.Exit(1)
+	}
+	defer conffile.Close()
+
+	var genconf reference.GeneratorConfig
+	if err := yaml.NewDecoder(conffile).Decode(&genconf); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid configuration file: %v\n", err)
+		os.Exit(1)
+	}
+	tmpl, err := template.New(tmplBase).ParseFiles(tmplPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Cannot open resource reference template at %v: %v\n", tmplPath, err)
+		os.Exit(1)
+	}
+
+	err = reference.Generate(genconf, tmpl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not generate the resource reference: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
@@ -1,0 +1,154 @@
+// Teleport
+// Copyright (C) 2025  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package reference
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/gravitational/teleport/build.assets/tooling/cmd/resource-ref-generator/resource"
+)
+
+// pageContent represents a reference page for a single resource and its related
+// fields. Fields must be exported so we can use them in templates.
+type pageContent struct {
+	Resource resourceSection
+	Fields   map[resource.PackageInfo]resource.ReferenceEntry
+}
+
+// resourceSection represents a top-level section of the resource reference
+// dedicated to a dynamic resource.
+type resourceSection struct {
+	Version string
+	Kind    string
+	resource.ReferenceEntry
+}
+
+// TypeInfo represents the name and package name of an exported Go type. It
+// makes no guarantees about whether the type was actually declared within the
+// package.
+type TypeInfo struct {
+	// Go package path (not a file path)
+	Package string `yaml:"package"`
+	// Name of the type, e.g., Metadata
+	Name string `yaml:"name"`
+}
+
+// ResourceConfig describes a resource type to include in the reference.
+type ResourceConfig struct {
+	// The name of the struct type as declared in the Go source, e.g.,
+	// RoleV6.
+	TypeName string `yaml:"type"`
+	// The final path segment in the name of the Go package containing this
+	// type declaration, e.g., "api".
+	PackageName string `yaml:"package"`
+	// The value of the "kind" field within a YAML manifest for this
+	// resource, e.g., "role".
+	KindValue string `yaml:"yaml_kind"`
+	// The value of the "version" field within a YAML manifest for this
+	// resource, e.g., "v6".
+	VersionValue string `yaml:"yaml_version"`
+}
+
+// GeneratorConfig is the user-facing configuration for the resource reference
+// generator.
+type GeneratorConfig struct {
+	Resources []ResourceConfig `yaml:"resources"`
+	// Path to the root of the Go project directory.
+	SourcePath string `yaml:"source"`
+	// Directory where the generator writes reference pages.
+	DestinationDirectory string `yaml:"destination"`
+}
+
+type GenerationError struct {
+	messages []error
+}
+
+func (g GenerationError) Error() string {
+	// Begin with a newline to format the first list item below the outer
+	// error.
+	final := "\n"
+	for _, e := range g.messages {
+		final += fmt.Sprintf("- %v\n", e)
+	}
+	return final
+}
+
+// Generate uses the provided user-facing configuration to write the resource
+// reference to fs.
+func Generate(conf GeneratorConfig, tmpl *template.Template) error {
+	sourceData, err := resource.NewSourceData(conf.SourcePath)
+	if err != nil {
+		return fmt.Errorf("loading Go source files: %w", err)
+	}
+
+	var errs GenerationError
+	for _, r := range conf.Resources {
+		k := resource.PackageInfo{
+			DeclName:    r.TypeName,
+			PackageName: r.PackageName,
+		}
+
+		decl, ok := sourceData.TypeDecls[k]
+		if !ok {
+			errs.messages = append(errs.messages, fmt.Errorf("creating a reference entry for declaration %v.%v: cannot find a declaration of this resource type", k.PackageName, k.DeclName))
+			continue
+		}
+
+		pc := pageContent{}
+
+		// decl is a dynamic resource type, so get data for the type and
+		// its dependencies.
+		entries, err := resource.ReferenceDataFromDeclaration(decl, sourceData.TypeDecls)
+		if errors.Is(err, resource.NotAGenDeclError{}) {
+			continue
+		}
+		if err != nil {
+			errs.messages = append(errs.messages, fmt.Errorf("creating a reference entry for declaration %v.%v in file %v: %w", k.PackageName, k.DeclName, decl.FilePath, err))
+		}
+
+		pc.Resource.ReferenceEntry = entries[k]
+		delete(entries, k)
+		pc.Fields = entries
+
+		pc.Resource.Kind = r.KindValue
+		pc.Resource.Version = r.VersionValue
+
+		filename := strings.ReplaceAll(strings.ToLower(pc.Resource.SectionName), " ", "-")
+		docpath := filepath.Join(conf.DestinationDirectory, filename+".mdx")
+		doc, err := os.Create(docpath)
+		if err != nil {
+			errs.messages = append(errs.messages, fmt.Errorf("cannot create page at %v: %w", docpath, err))
+			continue
+		}
+		defer doc.Close()
+
+		if err := tmpl.Execute(doc, pc); err != nil {
+			errs.messages = append(errs.messages, fmt.Errorf("cannot populate the resource reference template: %w", err))
+		}
+	}
+	if len(errs.messages) > 0 {
+		return errs
+	}
+
+	return nil
+}

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
@@ -17,7 +17,6 @@
 package reference
 
 import (
-	_ "embed"
 	"errors"
 	"fmt"
 	"os"
@@ -119,7 +118,7 @@ func Generate(conf GeneratorConfig, tmpl *template.Template) error {
 		// decl is a dynamic resource type, so get data for the type and
 		// its dependencies.
 		entries, err := resource.ReferenceDataFromDeclaration(decl, sourceData.TypeDecls)
-		if errors.Is(err, resource.NotAGenDeclError{}) {
+		if errors.As(err, &resource.NotAGenDeclError{}) {
 			continue
 		}
 		if err != nil {

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
@@ -1,0 +1,49 @@
+---
+title: {{ .Resource.SectionName }} Reference
+description: Provides a reference of fields within the {{ .Resource.SectionName }} resource, which you can manage with tctl.
+sidebar_label: {{ .Resource.SectionName }}
+---
+{/* vale 3rd-party-products.former-names = NO */}
+{/* vale messaging.capitalization = NO */}
+{/* Automatically generated from: {{ .Resource.SourcePath}} */}
+{/* DO NOT EDIT */}
+
+**Kind**: `{{ .Resource.Kind }}`<br/>
+**Version**: `{{ .Resource.Version }}`
+
+{{ .Resource.Description }}
+
+Example:
+
+```yaml
+{{ .Resource.YAMLExample -}}
+```
+
+{{- if gt (len .Resource.Fields) 0 }}
+|Field Name|Description|Type|
+|---|---|---|
+{{ range .Resource.Fields -}}
+|{{.Name}}|{{.Description}}|{{.Type}}|
+{{ end }} 
+{{- end }}
+
+{{- range .Fields }}
+## {{ .SectionName }}
+
+{{ .Description }}
+
+{{ if ne .YAMLExample "" }}
+Example:
+
+```yaml
+{{ .YAMLExample -}}
+```
+{{ end }}
+{{- if gt (len .Fields) 0 }}
+|Field Name|Description|Type|
+|---|---|---|
+{{ range .Fields -}}
+|{{.Name}}|{{.Description}}|{{.Type}}|
+{{ end }} 
+{{- end }}
+{{- end }}

--- a/build.assets/tooling/cmd/resource-ref-generator/resource/resource.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource/resource.go
@@ -1,0 +1,931 @@
+// Teleport
+// Copyright (C) 2025  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resource
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// PackageInfo is used to look up a Go declaration in a map of declaration names
+// to resource data.
+type PackageInfo struct {
+	DeclName    string
+	PackageName string
+}
+
+// ReferenceEntry represents a section in the resource reference docs.
+type ReferenceEntry struct {
+	SectionName string
+	Description string
+	SourcePath  string
+	Fields      []Field
+	YAMLExample string
+}
+
+// Len returns the number of fields in the ReferenceEntry. Required for sorting.
+func (re ReferenceEntry) Len() int {
+	return len(re.Fields)
+}
+
+// Less compares field names in order to sort them.
+func (re ReferenceEntry) Less(i, j int) bool {
+	return re.Fields[i].Name < re.Fields[j].Name
+}
+
+// Swap swaps the order of reference fields in order to sort them.
+func (re ReferenceEntry) Swap(i, j int) {
+	re.Fields[i], re.Fields[j] = re.Fields[j], re.Fields[i]
+}
+
+// DeclarationInfo includes data about a declaration so the generator can
+// convert it into a ReferenceEntry.
+type DeclarationInfo struct {
+	FilePath    string
+	Decl        ast.Decl
+	PackageName string
+	// Maps the file-scoped name of each import (if given) to the
+	// corresponding full package path.
+	NamedImports map[string]string
+}
+
+// Field represents a row in a table that provides information about a field in
+// the resource reference.
+type Field struct {
+	Name        string
+	Description string
+	Type        string
+}
+
+type SourceData struct {
+	// TypeDecls maps package and declaration names to data that the generator
+	// uses to format documentation for dynamic resource fields.
+	TypeDecls map[PackageInfo]DeclarationInfo
+}
+
+func NewSourceData(rootPath string) (SourceData, error) {
+	// All declarations within the source tree. We use this to extract
+	// information about dynamic resource fields, which we can look up by
+	// package and declaration name.
+	typeDecls := make(map[PackageInfo]DeclarationInfo)
+	possibleFuncDecls := []DeclarationInfo{}
+
+	// Load each file in the source directory individually. Not using
+	// packages.Load here since the resulting []*Package does not expose
+	// individual file names, which we need so contributors who want to edit
+	// the resulting docs page know which files to modify.
+	err := filepath.Walk(rootPath, func(currentPath string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("loading Go source: %w", err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if filepath.Ext(info.Name()) != ".go" {
+			return nil
+		}
+
+		// Open the file so we can pass it to ParseFile. Otherwise,
+		// ParseFile always reads from the OS FS, not from fs.
+		f, err := os.Open(currentPath)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, currentPath, f, parser.ParseComments)
+		if err != nil {
+			return err
+		}
+
+		// Use a relative path from the source directory for cleaner
+		// paths
+		relDeclPath, err := filepath.Rel(rootPath, currentPath)
+		if err != nil {
+			return err
+		}
+
+		// Collect information from each file:
+		// - Imported packages and their aliases
+		// - Possible function declarations (for identifying relevant
+		//   methods later)
+		// - Type declarations
+		pn := NamedImports(file)
+		for _, decl := range file.Decls {
+			di := DeclarationInfo{
+				Decl:         decl,
+				FilePath:     relDeclPath,
+				PackageName:  file.Name.Name,
+				NamedImports: pn,
+			}
+			l, ok := decl.(*ast.GenDecl)
+			if !ok {
+				possibleFuncDecls = append(possibleFuncDecls, di)
+				continue
+			}
+			if len(l.Specs) != 1 {
+				continue
+			}
+			spec, ok := l.Specs[0].(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+
+			typeDecls[PackageInfo{
+				DeclName:    spec.Name.Name,
+				PackageName: file.Name.Name,
+			}] = DeclarationInfo{
+				Decl:         l,
+				FilePath:     relDeclPath,
+				PackageName:  file.Name.Name,
+				NamedImports: pn,
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return SourceData{}, fmt.Errorf("loading Go source files: %w", err)
+	}
+	return SourceData{
+		TypeDecls: typeDecls,
+	}, nil
+}
+
+// rawField contains simplified information about a struct field type. This
+// prevents passing around AST nodes and makes testing easier.
+type rawField struct {
+	// Package that declares the field type
+	packageName string
+	// A declaration's GoDoc, including newline characters but not comment
+	// characters.
+	doc string
+	// The type of the field.
+	kind yamlKindNode
+	// Original name of the field.
+	name string
+	// Name as it appears in YAML, based on the "json" struct tag and
+	// marshaling rules in the encoding/json package.
+	jsonName string
+	// The entire struct tag expression for the field.
+	tags string
+}
+
+// rawType contains simplified information about a type, which may or may not be
+// a struct. This prevents passing around AST nodes and makes testing easier.
+type rawType struct {
+	// A declaration's GoDoc, including newline characters but not comment
+	// characters.
+	doc string
+	// The name of the type declaration.
+	name string
+	// Struct fields within the type. Empty if not a struct.
+	fields []rawField
+}
+
+// yamlKindNode represents a node in a potentially recursive YAML type, such as
+// an integer, a map of integers to strings, a sequence of maps of strings to
+// strings, etc. Used for printing example YAML documents and tables of fields.
+// This is not intended to be a comprehensive YAML AST.
+type yamlKindNode interface {
+	// Generate a string representation to include in a table of fields.
+	formatForTable() string
+	// Generate an example YAML value for the type with the provided number
+	// of indendations.
+	formatForExampleYAML(indents int) string
+	// Get the custom children of this yamlKindNode. Must call
+	// customFieldData on its own children before returning.
+	customFieldData() []PackageInfo
+}
+
+// nonYAMLKind represents a field type that we cannot convert to YAML. Consumers
+// should return an error if there is no way to avoid creating a reference entry
+// for this kind.
+type nonYAMLKind struct{}
+
+func (n nonYAMLKind) formatForTable() string {
+	return ""
+}
+
+func (n nonYAMLKind) formatForExampleYAML(indents int) string {
+	return "# See description"
+}
+
+func (n nonYAMLKind) customFieldData() []PackageInfo {
+	return []PackageInfo{}
+}
+
+// yamlSequence is a list of elements.
+type yamlSequence struct {
+	elementKind yamlKindNode
+}
+
+func (y yamlSequence) formatForTable() string {
+	return `[]` + y.elementKind.formatForTable()
+}
+
+func (y yamlSequence) formatForExampleYAML(indents int) string {
+	var leading string
+	indents++
+	for i := 0; i < indents; i++ {
+		leading += "  "
+	}
+	el := y.elementKind.formatForExampleYAML(indents)
+	// Trim leading indentation since each element is already indented.
+	el = strings.TrimLeft(el, " ")
+	// Always start a sequence on a new line
+	return fmt.Sprintf(`
+%v- %v
+%v- %v
+%v- %v`,
+		leading, el,
+		leading, el,
+		leading, el,
+	)
+}
+
+func (y yamlSequence) customFieldData() []PackageInfo {
+	return y.elementKind.customFieldData()
+}
+
+// yamlMapping is a mapping of keys to values.
+type yamlMapping struct {
+	keyKind   yamlKindNode
+	valueKind yamlKindNode
+}
+
+func (y yamlMapping) formatForExampleYAML(indents int) string {
+	var leading string
+	// Add an extra indent for mappings
+	indents = indents + 1
+	for i := 0; i < indents; i++ {
+		leading += "  "
+	}
+
+	val := y.valueKind.formatForExampleYAML(indents)
+	// Remove leading indentation on the first line of the value since the
+	// key/value pair is already indented. This does not affect subsequent
+	// lines of the value.
+	val = strings.TrimLeft(val, " ")
+
+	kv := fmt.Sprintf("%v%v: %v", leading, y.keyKind.formatForExampleYAML(0), val)
+	return fmt.Sprintf("\n%v\n%v\n%v", kv, kv, kv)
+}
+
+func (y yamlMapping) formatForTable() string {
+	return fmt.Sprintf("map[%v]%v", y.keyKind.formatForTable(), y.valueKind.formatForTable())
+}
+
+func (y yamlMapping) customFieldData() []PackageInfo {
+	k := y.keyKind.customFieldData()
+	v := y.valueKind.customFieldData()
+	return append(k, v...)
+}
+
+type yamlString struct{}
+
+func (y yamlString) formatForTable() string {
+	return "string"
+}
+
+func (y yamlString) formatForExampleYAML(indents int) string {
+	return `"string"`
+}
+
+func (y yamlString) customFieldData() []PackageInfo {
+	return []PackageInfo{}
+}
+
+type yamlBase64 struct{}
+
+func (y yamlBase64) formatForTable() string {
+	return "base64-encoded string"
+}
+
+func (y yamlBase64) formatForExampleYAML(indents int) string {
+	return "BASE64_STRING"
+}
+
+func (y yamlBase64) customFieldData() []PackageInfo {
+	return []PackageInfo{}
+}
+
+type yamlNumber struct{}
+
+func (y yamlNumber) formatForTable() string {
+	return "number"
+}
+
+func (y yamlNumber) formatForExampleYAML(indents int) string {
+	return "1"
+}
+
+func (y yamlNumber) customFieldData() []PackageInfo {
+	return []PackageInfo{}
+}
+
+type yamlBool struct{}
+
+func (y yamlBool) formatForTable() string {
+	return "Boolean"
+}
+
+func (y yamlBool) formatForExampleYAML(indents int) string {
+	return "true"
+}
+
+func (y yamlBool) customFieldData() []PackageInfo {
+	return []PackageInfo{}
+}
+
+// A type declared by the program, i.e., not one of Go's predeclared types.
+type yamlCustomType struct {
+	name string
+	// Used to look up more information about the declaration of the custom
+	// type so we can populate additional reference entries.
+	declarationInfo PackageInfo
+}
+
+func (y yamlCustomType) customFieldData() []PackageInfo {
+	return []PackageInfo{
+		y.declarationInfo,
+	}
+}
+
+func (y yamlCustomType) formatForExampleYAML(indents int) string {
+	var leading string
+	for i := 0; i < indents; i++ {
+		leading += "  "
+	}
+
+	return leading + "# [...]"
+}
+
+func (y yamlCustomType) formatForTable() string {
+	return fmt.Sprintf(
+		"[%v](#%v)",
+		y.name,
+		strings.ReplaceAll(strings.ToLower(y.name), " ", "-"),
+	)
+}
+
+type NotAGenDeclError struct{}
+
+func (e NotAGenDeclError) Error() string {
+	return "the declaration is not a GenDecl"
+}
+
+// getRawTypes returns a representation of the type spec of decl to use for
+// further processing. Returns an error if there is either no type spec or more
+// than one.
+func getRawTypes(decl DeclarationInfo, allDecls map[PackageInfo]DeclarationInfo) (rawType, error) {
+	gendecl, ok := decl.Decl.(*ast.GenDecl)
+	if !ok {
+		return rawType{}, NotAGenDeclError{}
+	}
+
+	if len(gendecl.Specs) == 0 {
+		return rawType{}, errors.New("declaration has no specs")
+	}
+
+	if len(gendecl.Specs) > 1 {
+		return rawType{}, errors.New("declaration contains more than one type spec")
+	}
+
+	if gendecl.Specs[0] == nil {
+		return rawType{}, errors.New("no spec found")
+	}
+
+	t, ok := gendecl.Specs[0].(*ast.TypeSpec)
+	if !ok {
+		return rawType{}, errors.New("no type spec found")
+	}
+
+	str, ok := t.Type.(*ast.StructType)
+	// The declaration is not a struct, but we may still want to include it
+	// in the reference. Return a rawType with no fields.
+	if !ok {
+		return rawType{
+			name:   t.Name.Name,
+			doc:    gendecl.Doc.Text(),
+			fields: []rawField{},
+		}, nil
+	}
+
+	// We have determined that decl is a struct type, so collect its fields.
+	var rawFields []rawField
+	for _, field := range str.Fields.List {
+		f, err := makeRawField(field, decl.PackageName, allDecls, decl.NamedImports)
+		if err != nil {
+			return rawType{}, err
+		}
+
+		// The struct field name is lowercased, so the field is not
+		// exported. Ignore it.
+		if f.name != "" && f.name[0] >= 'a' && f.name[0] <= 122 {
+			continue
+		}
+
+		jsonName := getJSONTag(f.tags)
+		// This field is ignored, so skip it.
+		// See: https://pkg.go.dev/encoding/json#Marshal
+		if jsonName == "-" {
+			continue
+		}
+		// Using the exported field declaration name as the field name
+		// per JSON marshaling rules.
+		if jsonName == "" {
+			f.jsonName = f.name
+		}
+
+		rawFields = append(rawFields, f)
+	}
+
+	result := rawType{
+		name: t.Name.Name,
+		// Preserving newlines for downstream processing
+		doc:    gendecl.Doc.Text(),
+		fields: rawFields,
+	}
+
+	return result, nil
+}
+
+// makeYAMLExample creates an example YAML document illustrating the fields
+// within a declaration. This appears at the end of a section within the
+// reference.
+func makeYAMLExample(fields []rawField) (string, error) {
+	var buf bytes.Buffer
+
+	for _, field := range fields {
+		example := field.kind.formatForExampleYAML(0) + "\n"
+		buf.WriteString(getJSONTag(field.tags) + ": ")
+		buf.WriteString(example)
+	}
+
+	return buf.String(), nil
+}
+
+// Key-value pair for the "json" tag within a struct tag.  See:
+// https://pkg.go.dev/reflect#StructTag
+var jsonTagKeyValue = regexp.MustCompile(`json:"([^"]+)"`)
+
+// getYAMLTag returns the "json" tag value from the provided struct tag
+// expression.
+func getJSONTag(tags string) string {
+	kv := jsonTagKeyValue.FindStringSubmatch(tags)
+
+	// No "json" tag, or a "json" tag with no value.
+	if len(kv) != 2 {
+		return ""
+	}
+
+	return strings.TrimSuffix(kv[1], ",omitempty")
+}
+
+var camelCaseExceptions = []string{
+	"IdP",
+}
+var abbreviationWordBoundary *regexp.Regexp = regexp.MustCompile(`([A-Z]{2,})([A-Z][a-z0-9])`)
+var camelCaseWordBoundary *regexp.Regexp = regexp.MustCompile(
+	fmt.Sprintf(`(%v|[a-z]+)([A-Z])`, strings.Join(camelCaseExceptions, "|")),
+)
+
+// makeSectionName edits the original name of a declaration to make it more
+// suitable as a section within the resource reference.
+func makeSectionName(original string) string {
+	s := abbreviationWordBoundary.ReplaceAllString(original, "$1 $2")
+	s = camelCaseWordBoundary.ReplaceAllString(s, "$1 $2")
+	return s
+}
+
+// isByteSlice returns whether t is a []byte.
+func isByteSlice(t *ast.ArrayType) bool {
+	i, ok := t.Elt.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return i.Name == "byte"
+}
+
+// getYAMLTypeForExpr takes an AST type expression and recursively
+// traverses it to populate a yamlKindNode. Each iteration converts a
+// single *ast.Expr into a single yamlKindNode, returning the new node.
+func getYAMLTypeForExpr(exp ast.Expr, pkg string, allDecls map[PackageInfo]DeclarationInfo, namedImports map[string]string) (yamlKindNode, error) {
+	switch t := exp.(type) {
+	case *ast.StarExpr:
+		// Ignore the star, since YAML fields are unmarshaled as the
+		// values they point to.
+		return getYAMLTypeForExpr(t.X, pkg, allDecls, namedImports)
+	case *ast.Ident:
+		switch t.Name {
+		case "string":
+			return yamlString{}, nil
+		case "uint", "uint8", "uint16", "uint32", "uint64", "int", "int8", "int16", "int32", "int64", "float32", "float64":
+			return yamlNumber{}, nil
+		case "bool":
+			return yamlBool{}, nil
+		default:
+			info := PackageInfo{
+				DeclName:    t.Name,
+				PackageName: pkg,
+			}
+			if _, ok := allDecls[info]; !ok {
+				return nonYAMLKind{}, nil
+			}
+
+			return yamlCustomType{
+				name:            makeSectionName(t.Name),
+				declarationInfo: info,
+			}, nil
+		}
+	case *ast.MapType:
+		k, err := getYAMLTypeForExpr(t.Key, pkg, allDecls, namedImports)
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := getYAMLTypeForExpr(t.Value, pkg, allDecls, namedImports)
+		if err != nil {
+			return nil, err
+		}
+		return yamlMapping{
+			keyKind:   k,
+			valueKind: v,
+		}, nil
+	case *ast.ArrayType:
+		// Bite slices marshal to base64 strings
+		if isByteSlice(t) {
+			return yamlBase64{}, nil
+		}
+		e, err := getYAMLTypeForExpr(t.Elt, pkg, allDecls, namedImports)
+		if err != nil {
+			return nil, err
+		}
+		return yamlSequence{
+			elementKind: e,
+		}, nil
+	case *ast.SelectorExpr:
+		var pkg string
+		x, ok := t.X.(*ast.Ident)
+		if ok {
+			pkg = x.Name
+			if i, ok := namedImports[x.Name]; ok {
+				pkg = i
+			}
+		}
+		info := PackageInfo{
+			DeclName:    t.Sel.Name,
+			PackageName: pkg,
+		}
+		if _, ok := allDecls[info]; !ok {
+			return nonYAMLKind{}, nil
+		}
+
+		return yamlCustomType{
+			name:            makeSectionName(t.Sel.Name),
+			declarationInfo: info,
+		}, nil
+	default:
+		return nonYAMLKind{}, nil
+	}
+}
+
+// getYAMLType returns YAML type information for a struct field so we can print
+// information about it in the resource reference.
+func getYAMLType(field *ast.Field, pkg string, allDecls map[PackageInfo]DeclarationInfo, namedImports map[string]string) (yamlKindNode, error) {
+	return getYAMLTypeForExpr(field.Type, pkg, allDecls, namedImports)
+}
+
+// makeRawField translates an *ast.Field into a rawField for downstream
+// processing. packageName is the name of the package that includes this name in
+// a struct declaration.
+func makeRawField(field *ast.Field, packageName string, allDecls map[PackageInfo]DeclarationInfo, namedImports map[string]string) (rawField, error) {
+	doc := field.Doc.Text()
+	if len(field.Names) > 1 {
+		return rawField{}, fmt.Errorf("field %+v in %v contains more than one name", field, packageName)
+	}
+
+	var name string
+	// Otherwise, the field is likely an embedded struct.
+	if len(field.Names) == 1 {
+		name = field.Names[0].Name
+	}
+
+	tn, err := getYAMLType(field, packageName, allDecls, namedImports)
+	if err != nil {
+		return rawField{}, err
+	}
+
+	// Indicate which package declared this field depending on whether the
+	// field's type name includes the name of another package.
+	pkg := packageName
+	s, ok := field.Type.(*ast.SelectorExpr)
+	if ok {
+		i, ok := s.X.(*ast.Ident)
+		if ok {
+			pkg = i.Name
+		}
+	}
+
+	var tag string
+	if field.Tag != nil {
+		tag = field.Tag.Value
+	}
+
+	return rawField{
+		packageName: pkg,
+		doc:         doc,
+		kind:        tn,
+		name:        name,
+		jsonName:    getJSONTag(tag),
+		tags:        tag,
+	}, nil
+}
+
+// makeFieldTableInfo assembles a slice of human-readable information about
+// fields within a Go struct to include within the resource reference.
+func makeFieldTableInfo(fields []rawField) ([]Field, error) {
+	var result []Field
+	for _, field := range fields {
+		var desc string
+		var typ string
+
+		desc = field.doc
+		typ = field.kind.formatForTable()
+		// Escape pipes so they do not affect table rendering.
+		desc = strings.ReplaceAll(desc, "|", `\|`)
+		// Remove surrounding spaces and inner line breaks.
+		desc = strings.Trim(strings.ReplaceAll(desc, "\n", " "), " ")
+
+		// Escape angle brackets so the docs engine handles them as
+		// strings instead of HTML tags.
+		desc = strings.ReplaceAll(desc, "<", `\<`)
+		desc = strings.ReplaceAll(desc, ">", `\>`)
+
+		result = append(result, Field{
+			Description: printableDescription(desc, field.name),
+			Name:        field.jsonName,
+			Type:        typ,
+		})
+	}
+	return result, nil
+}
+
+// curlyBracePairPattern matches a pair of curly braces, with a capture group
+// for the content enclosed by the braces.
+var curlyBracePairPattern = regexp.MustCompile(`\{([^}]*)\}`)
+
+// printableDescription modifies a field or type description to make it suitable
+// for reading on a docs page.
+//
+// ident is the name of a Go identifier. printableDescription removes the name
+// from the description so we can include it within the resource reference,
+// fixing capitalization issues resulting from removing the name. Since the
+// identifier's name within the source won't mean anything to a docs reader,
+// removing it makes the description easier to read.
+//
+// Since curly brace pairs break docs site builds, printableDescription also
+// encloses any curly brace pairs with backticks.
+func printableDescription(description, ident string) string {
+	result := curlyBracePairPattern.ReplaceAllString(description, "`{$1}`")
+	// Replace any double-backticks resulting from the previous operation.
+	// This is a hack to avoid the need for more complex logic. Double
+	// backticks won't render as expected in the docs anyway, so it's fine
+	// to replace ones that don't result from the earlier replacement.
+	result = strings.ReplaceAll(result, "``", "`")
+
+	// Not possible to trim the name from description
+	if len(ident) > len(result) {
+		return result
+	}
+
+	switch {
+	case strings.HasPrefix(result, ident+" are "):
+		result = strings.TrimPrefix(result, ident+" are ")
+	case strings.HasPrefix(result, ident+" is "):
+		result = strings.TrimPrefix(result, ident+" is ")
+	case strings.HasPrefix(result, ident+" "):
+		result = strings.TrimPrefix(result, ident+" ")
+	case strings.HasPrefix(result, ident):
+		result = strings.TrimPrefix(result, ident)
+	}
+
+	// Make sure the result begins with a capital letter
+	if len(result) > 0 {
+		result = strings.ToUpper(result[:1]) + result[1:]
+	}
+
+	return result
+}
+
+// handleEmbeddedStructFields finds embedded structs within fld and recursively
+// processes the fields of those structs as though the fields belonged to the
+// containing struct. Uses decl and allDecls to look up fields within the base
+// structs. Returns a modified slice of fields that include all non-embedded
+// fields within fld.
+func handleEmbeddedStructFields(decl DeclarationInfo, fld []rawField, allDecls map[PackageInfo]DeclarationInfo) ([]rawField, error) {
+	fieldsToProcess := []rawField{}
+	for _, l := range fld {
+		// Not an embedded struct field, so append it to the final
+		// result.
+		if l.name != "" {
+			fieldsToProcess = append(fieldsToProcess, l)
+			continue
+		}
+		c, ok := l.kind.(yamlCustomType)
+		// Not an embedded struct since it's not a declared type.
+		if !ok {
+			continue
+		}
+
+		// Find the package name to use to look up the declaration from
+		// its identifier.
+		var pkg string
+		i, ok := decl.NamedImports[l.packageName]
+		switch {
+		// The file that made the declaration provided a name for the
+		// package associated with the identifier, so find the full
+		// package path and use that to look up the declaration.
+		case ok:
+			pkg = i
+		case l.packageName != "":
+			pkg = l.packageName
+		// If the field's type has no package name, assume the field's
+		// package name is the same as the one for decl.
+		default:
+			pkg = decl.PackageName
+
+		}
+		p := PackageInfo{
+			DeclName:    c.declarationInfo.DeclName,
+			PackageName: pkg,
+		}
+
+		// We expect to find a declaration of the embedded struct.
+		d, ok := allDecls[p]
+		if !ok {
+			return nil, fmt.Errorf(
+				"%v: field %v.%v is not declared anywhere",
+				decl.FilePath,
+				l.packageName,
+				c.name,
+			)
+		}
+		e, err := getRawTypes(d, allDecls)
+		if err != nil && !errors.Is(err, NotAGenDeclError{}) {
+			return nil, err
+		}
+
+		// The embedded struct field may have its own embedded struct
+		// fields.
+		nf, err := handleEmbeddedStructFields(decl, e.fields, allDecls)
+		if err != nil {
+			return nil, err
+		}
+
+		fieldsToProcess = append(fieldsToProcess, nf...)
+	}
+	return fieldsToProcess, nil
+}
+
+// NamedImports creates a mapping from the provided name of each package import
+// to the original package path.
+func NamedImports(file *ast.File) map[string]string {
+	m := make(map[string]string)
+	for _, i := range file.Imports {
+		if i.Name == nil {
+			continue
+		}
+		s := strings.Trim(i.Path.Value, "\"")
+		p := strings.Split(s, "/")
+		// Consumers check the named imports map against the final path
+		// segment of a package path.
+		if len(p) > 1 {
+			s = p[len(p)-1]
+		}
+		m[i.Name.Name] = s
+	}
+	return m
+}
+
+// ReferenceDataFromDeclaration gets data for the reference by examining decl.
+// Looks up decl's fields in allDecls and methods in allMethods.
+func ReferenceDataFromDeclaration(decl DeclarationInfo, allDecls map[PackageInfo]DeclarationInfo) (map[PackageInfo]ReferenceEntry, error) {
+	rs, err := getRawTypes(decl, allDecls)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldsToProcess, err := handleEmbeddedStructFields(decl, rs.fields, allDecls)
+	if err != nil {
+		return nil, err
+	}
+
+	description := rs.doc
+	var example string
+
+	example, err = makeYAMLExample(fieldsToProcess)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the return value and insert the root reference entry
+	// provided by decl.
+	refs := make(map[PackageInfo]ReferenceEntry)
+	description = strings.Trim(strings.ReplaceAll(description, "\n", " "), " ")
+	entry := ReferenceEntry{
+		SectionName: makeSectionName(rs.name),
+		Description: printableDescription(description, rs.name),
+		SourcePath:  decl.FilePath,
+		YAMLExample: example,
+		Fields:      []Field{},
+	}
+	key := PackageInfo{
+		DeclName:    rs.name,
+		PackageName: decl.PackageName,
+	}
+
+	fld, err := makeFieldTableInfo(fieldsToProcess)
+	if err != nil {
+		return nil, err
+	}
+	entry.Fields = fld
+	sort.Sort(entry)
+	refs[key] = entry
+
+	// For any fields within decl that have a custom type, look up the
+	// declaration for that type and create a separate reference entry for
+	// it.
+	for _, f := range rs.fields {
+		// Don't make separate reference entries for embedded structs
+		// since they are part of the containing struct for the purposes
+		// of unmarshaling YAML.
+		//
+		if f.name == "" {
+			continue
+		}
+
+		c := f.kind.customFieldData()
+
+		for _, d := range c {
+			// Find the package name to use to look up the declaration from
+			// its identifier.
+			i, ok := decl.NamedImports[d.PackageName]
+			// The file that made the declaration provided a name for the
+			// package associated with the identifier, so find the full
+			// package path and use that to look up the declaration.
+			if ok {
+				d.PackageName = i
+			}
+
+			// Get information about the field type's declaration.
+			// If we can't find it, it means the field type was
+			// probably declared in the standard library or
+			// third-party package. In this case, leave it to the
+			// GoDoc to describe the field type.
+			gd, ok := allDecls[d]
+			if !ok {
+				continue
+			}
+			r, err := ReferenceDataFromDeclaration(gd, allDecls)
+			if errors.Is(err, NotAGenDeclError{}) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+
+			for k, v := range r {
+				sort.Sort(v)
+				refs[k] = v
+			}
+		}
+	}
+	return refs, nil
+}

--- a/build.assets/tooling/cmd/resource-ref-generator/resource/resource_test.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource/resource_test.go
@@ -1,0 +1,2020 @@
+// Teleport
+// Copyright (C) 2025  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resource
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// replaceBackticks replaces the "BACKTICK" placeholder text with backticks so
+// we can include struct tags within source fixtures.
+func replaceBackticks(source string) string {
+	return strings.ReplaceAll(source, "BACKTICK", "`")
+}
+
+func TestReferenceDataFromDeclaration(t *testing.T) {
+	cases := []struct {
+		description string
+		source      string
+		expected    map[PackageInfo]ReferenceEntry
+		// Go source fixtures that the test uses for named type fields.
+		declSources []string
+		// Substring to expect in a resulting error message
+		errorSubstring string
+		declInfo       PackageInfo
+	}{
+		{
+			description: "scalar fields with one field ignored",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Namespace is the resource's namespace
+    Namespace string BACKTICKprotobuf:"bytes,2,opt,name=Namespace,proto3" json:"-"BACKTICK
+    // Description is the resource's description.
+    Description string BACKTICKprotobuf:"bytes,3,opt,name=Description,proto3" json:"description,omitempty"BACKTICK
+    // Age is the resource's age in seconds.
+    Age uint BACKTICKjson:"age"BACKTICK
+    // Active indicates whether the resource is currently in use.
+    Active bool BACKTICKjson:"active"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+description: "string"
+age: 1
+active: true
+`,
+					Fields: []Field{
+						Field{
+							Name:        "active",
+							Description: "Indicates whether the resource is currently in use.",
+							Type:        "Boolean",
+						},
+						Field{
+							Name:        "age",
+							Description: "The resource's age in seconds.",
+							Type:        "number",
+						},
+						Field{
+							Name:        "description",
+							Description: "The resource's description.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "sequences of scalars",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Names is a list of names.
+    Names []string BACKTICKjson:"names"BACKTICK
+    // Numbers is a list of numbers.
+    Numbers []int BACKTICKjson:"numbers"BACKTICK
+    // Booleans is a list of Booleans.
+    Booleans []bool BACKTICKjson:"booleans"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `names: 
+  - "string"
+  - "string"
+  - "string"
+numbers: 
+  - 1
+  - 1
+  - 1
+booleans: 
+  - true
+  - true
+  - true
+`,
+					Fields: []Field{
+						Field{
+							Name:        "booleans",
+							Description: "A list of Booleans.",
+							Type:        "[]Boolean",
+						},
+						Field{
+							Name:        "names",
+							Description: "A list of names.",
+							Type:        "[]string",
+						},
+						Field{
+							Name:        "numbers",
+							Description: "A list of numbers.",
+							Type:        "[]number",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "a map of strings to sequences",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+  // Attributes indicates additional data for the resource.
+  Attributes map[string][]string BACKTICKjson:"attributes"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `attributes: 
+  "string": 
+    - "string"
+    - "string"
+    - "string"
+  "string": 
+    - "string"
+    - "string"
+    - "string"
+  "string": 
+    - "string"
+    - "string"
+    - "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "attributes",
+							Description: "Indicates additional data for the resource.",
+							Type:        "map[string][]string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "an undeclared custom type field",
+			declInfo: PackageInfo{
+				DeclName:    "Server",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "",
+						},
+					},
+					YAMLExample: "name: \"string\"\nspec: # See description\n",
+				},
+			},
+		},
+		{
+			description: "named scalar type",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Server",
+			},
+			source: `package mypkg
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+    // Label specifies labels for the server.
+    Label Labels BACKTICKjson:"labels"BACKTICK
+}
+`,
+			declSources: []string{
+				`package mypkg
+
+// Labels is a slice of strings that we'll process downstream
+type Labels []string
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "labels",
+							Description: "Specifies labels for the server.",
+							Type:        "[Labels](#labels)",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "",
+						},
+					},
+					YAMLExample: "name: \"string\"\nspec: # See description\nlabels: # [...]\n",
+				},
+				PackageInfo{
+					DeclName:    "Labels",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Labels",
+					Description: "A slice of strings that we'll process downstream",
+					SourcePath:  "src/myfile0.go",
+					Fields:      nil,
+					YAMLExample: "",
+				},
+			},
+		},
+		{
+			description: "custom type fields with a custom JSON unmarshaller",
+			declInfo: PackageInfo{
+				DeclName:    "Server",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			declSources: []string{
+				`package mypkg
+
+func (s *Server) UnmarshalJSON (b []byte) error {
+  return nil
+}
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "",
+						},
+					},
+					YAMLExample: "name: \"string\"\nspec: # See description\n",
+				},
+			},
+		},
+		{
+			description: "custom type with custom YAML unmarshaller",
+			declInfo: PackageInfo{
+				DeclName:    "Application",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Application includes information about an application registered with Teleport.
+type Application struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the application.
+    Spec types.AppSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			declSources: []string{
+				`package mypkg
+
+func (a *Application) UnmarshalYAML(value *yaml.Node) error {
+  return nil
+}
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Application",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Application",
+					Description: "Includes information about an application registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "spec",
+							Description: "Contains information about the application.",
+							Type:        "",
+						},
+					},
+					YAMLExample: "name: \"string\"\nspec: # See description\n",
+				},
+			},
+		},
+		{
+			description: "a custom type field declared in a second source file",
+			declInfo: PackageInfo{
+				DeclName:    "Server",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			declSources: []string{`package types
+// ServerSpecV1 includes aspects of a proxied server.
+type ServerSpecV1 struct {
+    // The address of the server.
+    Address string BACKTICKjson:"address"BACKTICK
+    // How long the resource is valid.
+    TTL int BACKTICKjson:"ttl"BACKTICK
+    // Whether the server is active.
+    IsActive bool BACKTICKjson:"is_active"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+spec: # [...]
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "[Server Spec V1](#server-spec-v1)",
+						},
+					},
+				},
+				PackageInfo{
+					DeclName:    "ServerSpecV1",
+					PackageName: "types",
+				}: {
+					SectionName: "Server Spec V1",
+					Description: "Includes aspects of a proxied server.",
+					SourcePath:  "src/myfile0.go",
+					YAMLExample: `address: "string"
+ttl: 1
+is_active: true
+`,
+					Fields: []Field{
+						Field{
+							Name:        "address",
+							Description: "The address of the server.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "is_active",
+							Description: "Whether the server is active.",
+							Type:        "Boolean",
+						},
+						Field{
+							Name:        "ttl",
+							Description: "How long the resource is valid.",
+							Type:        "number",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "composite field type with named scalar type",
+			declInfo: PackageInfo{
+				DeclName:    "Server",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+    // LabelMaps includes a map of strings to labels.
+    LabelMaps []map[string]types.Label BACKTICKjson:"label_maps"BACKTICK
+}
+`,
+			declSources: []string{`package types
+// ServerSpecV1 includes aspects of a proxied server.
+type ServerSpecV1 struct {
+    // The address of the server.
+    Address string BACKTICKjson:"address"BACKTICK
+}`,
+				`package types
+
+// Label is a custom type that we unmarshal in a non-default way.
+type Label string
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `spec: # [...]
+label_maps: 
+  - 
+    "string": # [...]
+    "string": # [...]
+    "string": # [...]
+  - 
+    "string": # [...]
+    "string": # [...]
+    "string": # [...]
+  - 
+    "string": # [...]
+    "string": # [...]
+    "string": # [...]
+`,
+					Fields: []Field{
+						Field{
+							Name:        "label_maps",
+							Description: "Includes a map of strings to labels.",
+							Type:        "[]map[string][Label](#label)",
+						},
+						Field{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "[Server Spec V1](#server-spec-v1)",
+						},
+					},
+				},
+				PackageInfo{
+					DeclName:    "ServerSpecV1",
+					PackageName: "types",
+				}: {
+					SectionName: "Server Spec V1",
+					Description: "Includes aspects of a proxied server.",
+					SourcePath:  "src/myfile0.go",
+					YAMLExample: `address: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "address",
+							Description: "The address of the server.",
+							Type:        "string",
+						},
+					},
+				},
+				PackageInfo{
+					DeclName:    "Label",
+					PackageName: "types",
+				}: {
+					SectionName: "Label",
+					Description: "A custom type that we unmarshal in a non-default way.",
+					SourcePath:  "src/myfile1.go",
+					Fields:      nil,
+				},
+			},
+		},
+		{
+			description: "struct type with an interface field",
+			declInfo: PackageInfo{
+				DeclName:    "Server",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+  // The name of the server.
+  Name string BACKTICK:json:"name"BACKTICK
+  // Impl is the implementation of the server.
+  Impl ServerImplementation BACKTICK:json:"impl"BACKTICK
+}
+`,
+			declSources: []string{`package mypkg
+// ServerImplementation is a remote service with a URL.
+type ServerImplementation interface{
+  GetURL() string
+}
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "impl",
+							Description: "The implementation of the server.",
+							Type:        "[Server Implementation](#server-implementation)",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the server.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `name: "string"
+impl: # [...]
+`,
+				},
+				PackageInfo{
+					DeclName:    "ServerImplementation",
+					PackageName: "mypkg",
+				}: ReferenceEntry{
+					SectionName: "Server Implementation",
+					Description: "A remote service with a URL.",
+					SourcePath:  "src/myfile0.go",
+					Fields:      nil,
+					YAMLExample: "",
+				},
+			},
+		},
+		{
+			description: "embedded struct",
+			declInfo: PackageInfo{
+				DeclName:    "MyResource",
+				PackageName: "mypkg",
+			},
+			source: `package mypkg
+// MyResource is a resource declared for testing.
+type MyResource struct{
+  // Alias is another name to call the resource.
+  Alias string BACKTICKjson:"alias"BACKTICK
+  types.Metadata
+}
+`,
+			declSources: []string{
+				`package types
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Active indicates whether the resource is currently in use.
+    Active bool BACKTICKjson:"active"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "MyResource",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "My Resource",
+					Description: "A resource declared for testing.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "active",
+							Description: "Indicates whether the resource is currently in use.",
+							Type:        "Boolean",
+						},
+						{
+							Name:        "alias",
+							Description: "Another name to call the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `alias: "string"
+name: "string"
+active: true
+`,
+				},
+			},
+		},
+		{
+			description: "embedded struct with base in the same package",
+			declInfo: PackageInfo{
+				DeclName:    "MyResource",
+				PackageName: "mypkg",
+			},
+			source: `package mypkg
+// MyResource is a resource declared for testing.
+type MyResource struct{
+  // Alias is another name to call the resource.
+  Alias string BACKTICKjson:"alias"BACKTICK
+  Metadata
+}
+`,
+			declSources: []string{
+				`package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Active indicates whether the resource is currently in use.
+    Active bool BACKTICKjson:"active"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "MyResource",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "My Resource",
+					Description: "A resource declared for testing.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "active",
+							Description: "Indicates whether the resource is currently in use.",
+							Type:        "Boolean",
+						},
+						{
+							Name:        "alias",
+							Description: "Another name to call the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `alias: "string"
+name: "string"
+active: true
+`,
+				},
+			},
+		},
+		{
+			description: "struct with two embedded structs",
+			declInfo: PackageInfo{
+				DeclName:    "MyResource",
+				PackageName: "mypkg",
+			},
+			source: `package mypkg
+// MyResource is a resource declared for testing.
+type MyResource struct{
+  // Alias is another name to call the resource.
+  Alias string BACKTICKjson:"alias"BACKTICK
+  types.Metadata
+  moretypes.ActivityStatus
+}
+`,
+			declSources: []string{
+				`package types
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+}`,
+				`package moretypes
+
+// ActivityStatus indicates the status of a resource
+type ActivityStatus struct{
+    // Active indicates whether the resource is currently in use.
+    Active bool BACKTICKjson:"active"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "MyResource",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "My Resource",
+					Description: "A resource declared for testing.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "active",
+							Description: "Indicates whether the resource is currently in use.",
+							Type:        "Boolean",
+						},
+						{
+							Name:        "alias",
+							Description: "Another name to call the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `alias: "string"
+name: "string"
+active: true
+`,
+				},
+			},
+		},
+		{
+			description: "embedded struct with an embedded struct",
+			declInfo: PackageInfo{
+				DeclName:    "MyResource",
+				PackageName: "mypkg",
+			},
+			source: `package mypkg
+// MyResource is a resource declared for testing.
+type MyResource struct{
+  // Alias is another name to call the resource.
+  Alias string BACKTICKjson:"alias"BACKTICK
+  types.Metadata
+}
+`,
+			declSources: []string{
+				`package types
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    moretypes.ActivityStatus
+}`,
+				`package moretypes
+
+// ActivityStatus indicates the status of a resource
+type ActivityStatus struct{
+    // Active indicates whether the resource is currently in use.
+    Active bool BACKTICKjson:"active"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "MyResource",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "My Resource",
+					Description: "A resource declared for testing.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						{
+							Name:        "active",
+							Description: "Indicates whether the resource is currently in use.",
+							Type:        "Boolean",
+						},
+						{
+							Name:        "alias",
+							Description: "Another name to call the resource.",
+							Type:        "string",
+						},
+						{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `alias: "string"
+name: "string"
+active: true
+`,
+				},
+			},
+		},
+		{
+			description: "ignored fields with non-YAML-comptabible types",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    XXX_NoUnkeyedLiteral struct{} BACKTICKjson:"-"BACKTICK
+    XXX_unrecognized     []byte   BACKTICKjson:"-"BACKTICK
+
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "non-embedded custom field type declared in the same package as the containing struct",
+			declInfo: PackageInfo{
+				DeclName:    "DatabaseServerV3",
+				PackageName: "typestest",
+			},
+			source: `package typestest
+
+// DatabaseServerV3 represents a database access server.
+type DatabaseServerV3 struct {
+	// Kind is the database server resource kind.
+	Kind string BACKTICKprotobuf:"bytes,1,opt,name=Kind,proto3" json:"kind"BACKTICK
+	// Metadata is the database server metadata.
+	Metadata Metadata BACKTICKprotobuf:"bytes,4,opt,name=Metadata,proto3" json:"metadata"BACKTICK
+}
+`,
+			declSources: []string{
+				`package typestest
+
+// Metadata is resource metadata
+type Metadata struct {
+	// Name is an object name
+	Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+	// Description is object description
+	Description string BACKTICKprotobuf:"bytes,3,opt,name=Description,proto3" json:"description,omitempty"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "DatabaseServerV3",
+					PackageName: "typestest",
+				}: ReferenceEntry{
+					SectionName: "Database Server V3",
+					Description: "Represents a database access server.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						Field{
+							Name:        "kind",
+							Description: "The database server resource kind.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "metadata",
+							Description: "The database server metadata.",
+							Type:        "[Metadata](#metadata)",
+						},
+					},
+					YAMLExample: `kind: "string"
+metadata: # [...]
+`,
+				},
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "typestest",
+				}: ReferenceEntry{
+					SectionName: "Metadata",
+					Description: "Resource metadata",
+					SourcePath:  "src/myfile0.go",
+					Fields: []Field{
+						{
+							Name:        "description",
+							Description: "Object description",
+							Type:        "string",
+						},
+						{
+							Name:        "name",
+							Description: "An object name",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `name: "string"
+description: "string"
+`,
+				},
+			},
+		},
+		{
+			description: "pointer field",
+			declInfo: PackageInfo{
+				DeclName:    "DatabaseServerV3",
+				PackageName: "typestest",
+			},
+			source: `package typestest
+
+// DatabaseServerV3 represents a database access server.
+type DatabaseServerV3 struct {
+	// Metadata is the database server metadata.
+	Metadata *Metadata BACKTICKprotobuf:"bytes,4,opt,name=Metadata,proto3" json:"metadata"BACKTICK
+}
+`,
+			declSources: []string{
+				`package typestest
+
+// Metadata is resource metadata
+type Metadata struct {
+	// Name is an object name
+	Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "DatabaseServerV3",
+					PackageName: "typestest",
+				}: ReferenceEntry{
+					SectionName: "Database Server V3",
+					Description: "Represents a database access server.",
+					SourcePath:  "src/myfile.go",
+					Fields: []Field{
+						Field{
+							Name:        "metadata",
+							Description: "The database server metadata.",
+							Type:        "[Metadata](#metadata)",
+						},
+					},
+					YAMLExample: `metadata: # [...]
+`,
+				},
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "typestest",
+				}: ReferenceEntry{
+					SectionName: "Metadata",
+					Description: "Resource metadata",
+					SourcePath:  "src/myfile0.go",
+					Fields: []Field{
+						{
+							Name:        "name",
+							Description: "An object name",
+							Type:        "string",
+						},
+					},
+					YAMLExample: `name: "string"
+`,
+				},
+			},
+		},
+		{
+			description: "map of strings to an undeclared field",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Server",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the server.
+    Name string BACKTICKjson:"name"BACKTICK
+    // LabelMaps includes a map of strings to labels.
+    LabelMaps []map[string]types.Label BACKTICKjson:"label_maps"BACKTICK
+}
+`,
+			declSources: []string{`package types
+// ServerSpecV1 includes aspects of a proxied server.
+type ServerSpecV1 struct {
+    // The address of the server.
+    Address string BACKTICKjson:"address"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+label_maps: 
+  - 
+    "string": # See description
+    "string": # See description
+    "string": # See description
+  - 
+    "string": # See description
+    "string": # See description
+    "string": # See description
+  - 
+    "string": # See description
+    "string": # See description
+    "string": # See description
+`,
+					Fields: []Field{
+						Field{
+							Name:        "label_maps",
+							Description: "Includes a map of strings to labels.",
+							Type:        "[]map[string]",
+						},
+						Field{
+							Name:        "name",
+							Description: "The name of the server.",
+							Type:        "string"},
+					},
+				},
+			},
+		},
+		{
+			description: "type parameter",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Resource",
+			},
+			source: `package mypkg
+// Resource is a resource.
+type Resource struct {
+  // The name of the resource.
+  Name string BACKTICKjson:"name"BACKTICK
+}
+`,
+			declSources: []string{
+				`package mypkg
+// streamFunc is a wrapper that converts a closure into a stream.
+type streamFunc[T any] struct {
+	fn        func() (T, error)
+	doneFuncs []func()
+	item      T
+	err       error
+}
+
+func (stream *streamFunc[T]) Next() bool {
+	stream.item, stream.err = stream.fn()
+	return stream.err == nil
+}
+`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					PackageName: "mypkg",
+					DeclName:    "Resource",
+				}: ReferenceEntry{
+					SectionName: "Resource",
+					Description: "A resource.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "field type not declared in a loaded package",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Resource",
+			},
+			source: `package mypkg
+
+// Resource is a resource.
+type Resource struct {
+  // The name of the resource.
+  Name string BACKTICKjson:"name"BACKTICK
+  // How much time must elapse before the resource expires.
+  Expiry time.Time BACKTICKjson:"expiry"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					PackageName: "mypkg",
+					DeclName:    "Resource",
+				}: ReferenceEntry{
+					SectionName: "Resource",
+					Description: "A resource.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+expiry: # See description
+`,
+					Fields: []Field{
+						Field{
+							Name:        "expiry",
+							Description: "How much time must elapse before the resource expires.",
+							Type:        "",
+						},
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+			declSources: []string{},
+		},
+		{
+			description: "byte slice",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Metadata",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // PrivateKey is the private key of the resource.
+    PrivateKey []byte BACKTICKjson:"private_key"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+private_key: BASE64_STRING
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "private_key",
+							Description: "The private key of the resource.",
+							Type:        "base64-encoded string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "named import in embedded struct field",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Server",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			declSources: []string{`package types
+
+import alias "otherpkg"
+
+// ServerSpecV1 includes aspects of a proxied server.
+type ServerSpecV1 struct {
+  alias.ServerSpec
+}`,
+				`package otherpkg
+
+type ServerSpec struct {
+    // The address of the server.
+    Address string BACKTICKjson:"address"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+spec: # [...]
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "[Server Spec V1](#server-spec-v1)",
+						},
+					},
+				},
+				PackageInfo{
+					DeclName:    "ServerSpecV1",
+					PackageName: "types",
+				}: {
+					SectionName: "Server Spec V1",
+					Description: "Includes aspects of a proxied server.",
+					SourcePath:  "src/myfile0.go",
+					YAMLExample: `address: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "address",
+							Description: "The address of the server.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "named import in named struct field",
+			declInfo: PackageInfo{
+				PackageName: "mypkg",
+				DeclName:    "Server",
+			},
+			source: `
+package mypkg
+
+// Server includes information about a server registered with Teleport.
+type Server struct {
+    // Spec contains information about the server.
+    Spec types.ServerSpecV1 BACKTICKjson:"spec"BACKTICK
+}
+`,
+			declSources: []string{`package types
+import alias "otherpkg"
+
+// ServerSpecV1 includes aspects of a proxied server.
+type ServerSpecV1 struct {
+  // Address information.
+  Info alias.AddressInfo BACKTICKjson:"info"BACKTICK
+}`,
+
+				`package otherpkg
+// AddressInfo provides information about an address.
+type AddressInfo struct {
+    // The address of the server.
+    Address string BACKTICKjson:"address"BACKTICK
+}`,
+			},
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "AddressInfo",
+					PackageName: "otherpkg",
+				}: {
+					SectionName: "Address Info",
+					Description: "Provides information about an address.",
+					SourcePath:  "src/myfile1.go",
+					Fields: []Field{
+						{
+							Name:        "address",
+							Description: "The address of the server.",
+							Type:        "string",
+						},
+					},
+					YAMLExample: "address: \"string\"\n",
+				},
+				PackageInfo{
+					DeclName:    "Server",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Server",
+					Description: "Includes information about a server registered with Teleport.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `spec: # [...]
+`,
+					Fields: []Field{
+						Field{
+							Name:        "spec",
+							Description: "Contains information about the server.",
+							Type:        "[Server Spec V1](#server-spec-v1)"},
+					},
+				},
+				PackageInfo{
+					DeclName:    "ServerSpecV1",
+					PackageName: "types",
+				}: {
+					SectionName: "Server Spec V1",
+					Description: "Includes aspects of a proxied server.",
+					SourcePath:  "src/myfile0.go",
+					YAMLExample: `info: # [...]
+`,
+					Fields: []Field{
+						Field{
+							Name:        "info",
+							Description: "Address information.",
+							Type:        "[Address Info](#address-info)",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "scalar fields with two unexported fields",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a dynamic resource. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the name of the resource.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+    // Description is the resource's description.
+    Description string BACKTICKprotobuf:"bytes,3,opt,name=Description,proto3" json:"description,omitempty"BACKTICK
+    state protoimpl.MessageState BACKTICKprotogen:"open.v1"BACKTICK
+    unknownFields protoimpl.UnknownFields
+    sizeCache     protoimpl.SizeCache
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+description: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "description",
+							Description: "The resource's description.",
+							Type:        "string",
+						},
+						Field{
+							Name:        "name",
+							Description: "The name of the resource.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "curly braces in descriptions",
+			declInfo: PackageInfo{
+				DeclName:    "Metadata",
+				PackageName: "mypkg",
+			},
+			source: `
+package mypkg
+
+// Metadata describes information about a {dynamic resource}. Every dynamic
+// resource in Teleport has a metadata object.
+type Metadata struct {
+    // Name is the {name of the resource}.
+    Name string BACKTICKprotobuf:"bytes,1,opt,name=Name,proto3" json:"name"BACKTICK
+}
+`,
+			expected: map[PackageInfo]ReferenceEntry{
+				PackageInfo{
+					DeclName:    "Metadata",
+					PackageName: "mypkg",
+				}: {
+					SectionName: "Metadata",
+					Description: "Describes information about a `{dynamic resource}`. Every dynamic resource in Teleport has a metadata object.",
+					SourcePath:  "src/myfile.go",
+					YAMLExample: `name: "string"
+`,
+					Fields: []Field{
+						Field{
+							Name:        "name",
+							Description: "The `{name of the resource}`.",
+							Type:        "string",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			tmp := t.TempDir()
+			if err := os.Mkdir(filepath.Join(tmp, "src"), 0777); err != nil {
+				t.Fatal(err)
+			}
+
+			// Make a map of filenames to content
+			sources := make(map[string][]byte)
+			sources[filepath.Join(tmp, "src", "myfile.go")] = []byte(replaceBackticks(tc.source))
+			for i, s := range tc.declSources {
+				sources[filepath.Join(tmp, "src", "myfile"+strconv.Itoa(i)+".go")] = []byte(replaceBackticks(s))
+			}
+
+			// Write the source content to a temporary directory
+			for n, v := range sources {
+				f, err := os.Create(n)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if _, err := f.Write(v); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			sourceData, err := NewSourceData(tmp)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			di, ok := sourceData.TypeDecls[tc.declInfo]
+			if !ok {
+				t.Fatalf("expected data for %v.%v not found in the source", tc.declInfo.PackageName, tc.declInfo.DeclName)
+			}
+
+			r, err := ReferenceDataFromDeclaration(di, sourceData.TypeDecls)
+			if tc.errorSubstring == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.errorSubstring)
+			}
+
+			assert.Equal(t, tc.expected, r)
+		})
+	}
+}
+
+func TestNamedImports(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		expected    map[string]string
+	}{
+		{
+			description: "single-line format",
+			input: `package mypkg
+import alias "otherpkg"
+`,
+			expected: map[string]string{
+				"alias": "otherpkg",
+			},
+		},
+		{
+			description: "multi-line format",
+			input: `package mypkg
+import (
+    alias "first"
+    alias2 "second"
+)
+`,
+			expected: map[string]string{
+				"alias":  "first",
+				"alias2": "second",
+			},
+		},
+		{
+			description: "multi-segment package path",
+			input: `package mypkg
+import alias "my/multi/segment/package"
+`,
+			expected: map[string]string{
+				"alias": "package",
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset,
+				"myfile.go",
+				c.input,
+				parser.ParseComments,
+			)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, NamedImports(f))
+		})
+	}
+}
+
+func TestMakeFieldTableInfo(t *testing.T) {
+	cases := []struct {
+		description string
+		input       []rawField
+		expected    []Field
+	}{
+		{
+			description: "angle brackets in GoDoc",
+			input: []rawField{
+				rawField{
+					packageName: "mypkg",
+					doc:         `An ID, e.g., "<myid>"`,
+					kind:        yamlString{},
+					name:        "ObjectID",
+					jsonName:    "object_id",
+					tags:        `json:"object_id"`,
+				},
+			},
+			expected: []Field{
+				{
+					Name:        "object_id",
+					Description: `An ID, e.g., "\<myid\>"`,
+					Type:        "string",
+				},
+			},
+		},
+		{
+			description: "pipe in field description",
+			input: []rawField{
+				{
+					packageName: "mypkg",
+					doc:         "Specifies the locking mode (strict|best_effort) to be applied with the role.",
+					kind: yamlCustomType{
+						name: "LockingMode",
+						declarationInfo: PackageInfo{
+							DeclName:    "LockingMode",
+							PackageName: "mypkg",
+						},
+					},
+					name:     "LockingMode",
+					jsonName: "locking_mode",
+					tags:     "json:\"locking_mode\"",
+				},
+			},
+			expected: []Field{
+				{
+					Name:        "locking_mode",
+					Description: `Specifies the locking mode (strict\|best_effort) to be applied with the role.`,
+					Type:        "[LockingMode](#lockingmode)",
+				},
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			f, err := makeFieldTableInfo(c.input)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, f)
+		})
+	}
+}
+
+func TestGetJSONTag(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		expected    string
+	}{
+		{
+			description: "one well-formed struct tag",
+			input:       `json:"my_tag"`,
+			expected:    "my_tag",
+		},
+		{
+			description: "multiple well-formed struct tags",
+			input:       `json:"json_tag" yaml:"yaml_tag" other:"other-tag"`,
+			expected:    "json_tag",
+		},
+		{
+			description: "omitempty option in tag value",
+			input:       `json:"json_tag,omitempty" yaml:"yaml_tag" other:"other-tag"`,
+			expected:    "json_tag",
+		},
+		{
+			description: "No JSON tag",
+			input:       `other:"other-tag"`,
+			expected:    "",
+		},
+		{
+			description: "Empty JSON tag with the omitempty option",
+			input:       `json:",omitempty" other:"other-tag"`,
+			expected:    "",
+		},
+		{
+			description: "Ignored JSON field",
+			input:       `json:"-" other:"other-tag"`,
+			expected:    "-",
+		},
+		{
+			description: "empty JSON tag",
+			input:       `json:"" yaml:"yaml_tag" other:"other-tag"`,
+			expected:    "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			g := getJSONTag(c.input)
+			assert.Equal(t, c.expected, g)
+		})
+	}
+}
+
+func TestPrintableDescription(t *testing.T) {
+	cases := []struct {
+		description string
+		input       string
+		name        string
+		expected    string
+	}{
+		{
+			description: "short description",
+			input:       "A",
+			name:        "MyDecl",
+			expected:    "A",
+		},
+		{
+			description: "no description",
+			input:       "",
+			name:        "MyDecl",
+			expected:    "",
+		},
+		{
+			description: "GoDoc consists only of declaration name",
+			input:       "MyDecl",
+			name:        "MyDecl",
+			expected:    "",
+		},
+		{
+			description: "description containing name",
+			input:       "MyDecl is a declaration that we will describe in the docs.",
+			name:        "MyDecl",
+			expected:    "A declaration that we will describe in the docs.",
+		},
+		{
+			description: "description containing name and \"are\"",
+			input:       "MyDecls are things that we will describe in the docs.",
+			name:        "MyDecls",
+			expected:    "Things that we will describe in the docs.",
+		},
+
+		{
+			description: "description with no name",
+			input:       "Declaration that we will describe in the docs.",
+			name:        "MyDecl",
+			expected:    "Declaration that we will describe in the docs.",
+		},
+		{
+			description: "description beginning with name and non-is verb",
+			input:       "MyDecl performs an action.",
+			name:        "MyDecl",
+			expected:    "Performs an action.",
+		},
+		{
+			description: "curly brace pair and identifier name",
+			input:       "MyDecl performs an action, such as {updating, deleting}",
+			name:        "MyDecl",
+			expected:    "Performs an action, such as `{updating, deleting}`",
+		},
+		{
+			description: "curly brace pair and no identifier name",
+			input:       "Performs an action, such as {updating, deleting}",
+			name:        "MyDecl",
+			expected:    "Performs an action, such as `{updating, deleting}`",
+		},
+		{
+			description: "curly brace pair with existing backticks",
+			input:       "Performs an action, such as `{updating, deleting}`",
+			name:        "MyDecl",
+			expected:    "Performs an action, such as `{updating, deleting}`",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.Equal(t, c.expected, printableDescription(c.input, c.name))
+		})
+	}
+}
+
+func TestMakeYAMLExample(t *testing.T) {
+	cases := []struct {
+		description string
+		input       []rawField
+		expected    string
+	}{
+		{
+			description: "all scalars",
+			input: []rawField{
+				rawField{
+					doc:  "myInt is an int",
+					kind: yamlNumber{},
+					name: "myInt",
+					tags: `json:"my_int"`,
+				},
+				rawField{
+					doc:  "myBool is a Boolean",
+					kind: yamlBool{},
+					name: "myBool",
+					tags: `json:"my_bool"`,
+				},
+				rawField{
+					doc:  "myString is a string",
+					kind: yamlString{},
+					tags: `json:"my_string"`,
+				},
+			},
+			expected: `my_int: 1
+my_bool: true
+my_string: "string"
+`,
+		},
+		{
+			description: "sequence of sequence of strings",
+			input: []rawField{
+				rawField{
+					name:     "mySeq",
+					jsonName: "my_seq",
+					doc:      "mySeq is a sequence of sequences of strings",
+					tags:     `json:"my_seq"`,
+					kind: yamlSequence{
+						elementKind: yamlSequence{
+							elementKind: yamlString{},
+						},
+					},
+				},
+			},
+			expected: `my_seq: 
+  - 
+    - "string"
+    - "string"
+    - "string"
+  - 
+    - "string"
+    - "string"
+    - "string"
+  - 
+    - "string"
+    - "string"
+    - "string"
+`,
+		},
+		{
+			description: "maps of numbers to strings",
+			input: []rawField{
+				rawField{
+					name:     "myMap",
+					jsonName: "my_map",
+					doc:      "myMap is a map of ints to strings",
+					tags:     `json:"my_map"`,
+					kind: yamlMapping{
+						keyKind:   yamlNumber{},
+						valueKind: yamlString{},
+					},
+				},
+			},
+			expected: `my_map: 
+  1: "string"
+  1: "string"
+  1: "string"
+`,
+		},
+		{
+			description: "sequence of maps of strings to Booleans",
+			input: []rawField{
+				rawField{
+					name:     "mySeq",
+					jsonName: "my_seq",
+					doc:      "mySeq is a complex type",
+					tags:     `json:"my_seq"`,
+					kind: yamlSequence{
+						elementKind: yamlMapping{
+							keyKind:   yamlString{},
+							valueKind: yamlBool{},
+						},
+					},
+				},
+			},
+			expected: `my_seq: 
+  - 
+    "string": true
+    "string": true
+    "string": true
+  - 
+    "string": true
+    "string": true
+    "string": true
+  - 
+    "string": true
+    "string": true
+    "string": true
+`,
+		},
+		{
+			description: "sequences of custom types",
+			input: []rawField{
+				rawField{
+					name:     "labels",
+					jsonName: "labels",
+					doc:      "labels is a list of labels",
+					tags:     `json:"labels"`,
+					kind: yamlSequence{
+						elementKind: yamlCustomType{
+							name: "label",
+							declarationInfo: PackageInfo{
+								DeclName:    "label",
+								PackageName: "mypkg",
+							},
+						},
+					},
+				},
+			},
+			expected: `labels: 
+  - # [...]
+  - # [...]
+  - # [...]
+`,
+		},
+		{
+			description: "maps of strings to custom types",
+			input: []rawField{
+				rawField{
+					name:     "labels",
+					jsonName: "labels",
+					doc:      "labels is a map of strings to labels",
+					tags:     `json:"labels"`,
+					kind: yamlMapping{
+						keyKind: yamlString{},
+						valueKind: yamlCustomType{
+							name: "label",
+							declarationInfo: PackageInfo{
+								DeclName:    "label",
+								PackageName: "mypkg",
+							},
+						},
+					},
+				},
+			},
+			expected: `labels: 
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
+`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			e, err := makeYAMLExample(c.input)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expected, e)
+		})
+	}
+}
+
+func TestMakeSectionName(t *testing.T) {
+	cases := []struct {
+		description string
+		original    string
+		expected    string
+	}{
+		{
+			description: "camel-case name",
+			original:    "ServerSpec",
+			expected:    "Server Spec",
+		},
+		{
+			description: "camel-case name with three words",
+			original:    "MyExcellentResource",
+			expected:    "My Excellent Resource",
+		},
+		{
+			description: "camel-case name with version",
+			original:    "ServerSpecV2",
+			expected:    "Server Spec V2",
+		},
+		{
+			description: "abbreviation",
+			original:    "SAMLConnector",
+			expected:    "SAML Connector",
+		},
+		{
+			description: "IdP",
+			original:    "IdPSAMLOptions",
+			expected:    "IdP SAML Options",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			assert.Equal(t, c.expected, makeSectionName(c.original))
+		})
+	}
+}

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/oidc-connector-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/oidc-connector-v3.mdx
@@ -5,6 +5,8 @@ sidebar_label: OIDC Connector V3
 ---
 {/* vale 3rd-party-products.former-names = NO */}
 {/* vale messaging.capitalization = NO */}
+{/* Automatically generated from: types/types.pb.go */}
+{/* DO NOT EDIT */}
 
 **Kind**: `oidc`<br/>
 **Version**: `v3`

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/saml-connector-v2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/saml-connector-v2.mdx
@@ -5,6 +5,8 @@ sidebar_label: SAML Connector V2
 ---
 {/* vale 3rd-party-products.former-names = NO */}
 {/* vale messaging.capitalization = NO */}
+{/* Automatically generated from: types/types.pb.go */}
+{/* DO NOT EDIT */}
 
 **Kind**: `saml`<br/>
 **Version**: `v2`

--- a/rfd/0130-autogenerate-resource-reference.md
+++ b/rfd/0130-autogenerate-resource-reference.md
@@ -6,8 +6,8 @@ title: 0130 - Automatically Generate the Teleport Resource Reference
 
 ## Required Approvers
 
-- Engineering: @codingllama, @zmb3
-- Product: (@alexfornuto || @xinding33)
+- Engineering: @zmb3
+- Product: @roraback
 
 ## What
 
@@ -15,15 +15,13 @@ Dynamic resources (also called "Teleport resources" in this RFD) are
 configuration objects that Teleport users can apply using `tctl`, Terraform, and
 other methods.
 
-The scope of this RFD is to automatically generate the "Dynamic resources"
-section of the resource reference (`docs/pages/reference/resources.mdx`), a list
-of the dynamic resources you can apply via `tctl`, from the Teleport source
-code. 
+The scope of this RFD is to automatically generate reference documents for
+resources you can apply via `tctl` from the Teleport source code. 
 
-To do this, write a program that we can run as a new Make target in a clone of
-`gravitational/teleport`. When we make changes to Teleport's dynamic resources,
-we can run the program manually, generate a new iteration of the reference, and
-manually open a pull request with the new content.
+To do this, we can write a program that we can run as a new Make target in a
+clone of `gravitational/teleport`. When we make changes to Teleport's dynamic
+resources, we can run the program manually, generate a new iteration of the
+reference, and manually open a pull request with the new content.
 
 The Make target will depend on `make grpc` so the generator always works from
 the latest `proto` files.
@@ -37,19 +35,14 @@ load.
 In general, we should strive to automatically generate reference guides whenever
 possible to ensure accuracy. While adding entries incrementally over time can be
 sustainable at a certain scale, adding many entries at once is a daunting task
-that is difficult for a documentation team to schedule. Our `tctl` resource
-reference is particularly lagging, with only five resources documented at the
-[time of
-writing](https://github.com/gravitational/teleport/blob/58f20f0c3fcc9bb281528915125b95dfaee6cec5/docs/pages/reference/resources.mdx).
+that is difficult for a documentation team to schedule.
 
 ## Details
 
-The generator reads a [configuration](#configuration) that specifies struct
-types to generate references from. After parsing Go source files, the generator
-uses the resulting AST information to [populate a template](#the-output). 
-
-To do so, it builds [mappings](#working-with-parsed-go-source) that it can use
-to track type declarations in source packages. Using these mappings, it
+After parsing Go source files, the generator uses AST information to [populate a
+template](#the-output). To do so, it builds
+[mappings](#working-with-parsed-go-source) that it can use to track type
+declarations in source packages. Using these mappings, it
 [converts](#converting-structs-to-resources) struct types to template data. To
 document the types of struct fields, the generator writes [additional
 entries](#processing-field-types) to the reference template as appropriate.
@@ -57,30 +50,11 @@ entries](#processing-field-types) to the reference template as appropriate.
 ### Configuration
 
 By default, the generator will attempt to include an entry in the resource
-reference for every struct type in the Teleport source that includes a field of
-the `github.com/gravitational/teleport/api/types.Metadata` type, since we
-include this field in all types that correspond to Teleport resources.
-
-For resources that we want to _exclude_ from the reference, the generator will
-read from a mapping of package paths to lists of named struct types within each
-package. 
-
-The program will declare the mapping within the Go code as a `map`.
-
-Here is an example:
-
-```go
-var exclude = map[string][]string{
-  "github.com/gravitational/teleport/api/types": {
-    "ProvisionTokenV2",
-    "AuthPreferenceV2",
-    "AccessRequestV3,
-  },
-  "github.com/gravitational/teleport/api/loginrulev1": {
-    "LoginRule",
-  },
-}
-```
+reference for every struct type in the Teleport source that we specify in a
+configuration file. Specifying resources (rather than automatically collecting
+them based on expected properties) allows us to gradually roll out the reference
+and catch bugs, hide resources meant for internal use, and control which
+versions of a resource we want to display.
 
 #### Alternative: Working from protobuf message definitions
 
@@ -113,157 +87,6 @@ I don't imagine this will be prohibitive, though, as long as we:
   consistency, clarity, and grammatical correctness.
 
 Having this Make target depend on `make grpc` will also automate this flow.
-
-### The output
-
-The output of the program will be a Teleport resource reference generated
-from a template.
-
-#### Template format and data
-
-The generator will produce a template based on a `Resource` struct with the
-following fields:
-
-```go
-type Resource struct {
-  SectionName string
-  Description string
-  SourcePath  string
-  Fields      []Field
-  YAMLExample string
-}
-
-type Field struct{
-  Name        string
-  Description string
-  Type        string
-}
-```
-
-The template will look similar to this, anticipating a `[]Resource`:
-
-```text
-{{ range . }}
-## {{ .SectionName }}
-
-{{ .Description }}
-
-{/*Automatically generated from: {{ .SourcePath}}*/}
-
-|Field Name|Description|Type|
-|---|---|---|
-{{ range .Fields }}
-|.Name|.Description|.Type|
-{{ end }} 
-
-{{ .YAMLExample }}
-{{ end }}
-```
-
-#### Template example
-
-Here is an example of a populated template for an application (`AppSpecV3` in
-`api/types/types.pb.go`): 
-
-```markdown
-## App Spec V3
-
-App Spec V3 is the specification for an application registered with Teleport.
-
-{/*Automatically generated from: api/types/types.pb.go*/}
-
-|Field Name|Description|Type|
-|---|---|---|
-|`uri`|The web app endpoint.|`string`|
-|`public_addr`|The public address the application is accessible at.|`string`|
-|`dynamic_labels`|The app's command labels.|`map[string]`[Command LabelV2](#command-label-v2)|
-|`insecure_skip_verify`|Disables app's TLS certificate verification.|`boolean`|
-|`rewrite`|A list of rewriting rules to apply to requests and responses.|[Rewrite](#rewrite)|
-|`aws`|Contains additional options for AWS applications.|[App AWS](#app-aws)|
-|`cloud`|Identifies the cloud instance the app represents.|`string`|
-
-\`\`\`yaml
-uri: string
-public_addr: string
-dynamic_labels:
- # ...
-insecure_skip_verify: true
-rewrite: 
- # ...
-aws:
- # ...
-cloud:
- # ...
-\`\`\`
-
-## Command Label V2
-
-Command Label V2 is a label that has a value as a result of the output generated
-by running command, e.g. hostname.
-
-{/*Automatically generated from: api/types/types.pb.go*/}
-
-|Field Name|Description|Type|
-|---|---|---|
-|`period`|A time between command runs.|[Duration](#duration)|
-|`command`|A command to run|`[]string`|
-|`result`|Captures standard output|`string`|
-
-\`\`\`yaml
-period: 10s
-command:
-- string
-- string
-- string
-result: string
-\`\`\`
-
-## Duration
-
-Duration is a Go [duration type](https://pkg.go.dev/time#Duration).
-
-{/*Loaded from example file at autogen/examples/duration.mdx*/}
-
-\`\`\`yaml
-10s
-\`\`\`
-
-## Rewrite
-
-Rewrite is a list of rewriting rules to apply to requests and responses.
-
-{/*Automatically generated from: api/types/types.pb.go*/}
-
-|Field Name|Description|Type|
-|---|---|---|
-|`redirect`|Defines a list of hosts which will be rewritten to the public address of the application if they occur in the "Location" header.|`[]string`|
-|`headers`|A list of headers to inject when passing the request over to the application.|`[]`[Header](#header)|
-
-\`\`\`yaml
-redirect: 
-- string
-- string
-- string
-headers:
-# ...
-\`\`\`
-
-## Header
-
-Header represents a single http header passed over to the proxied application.
-
-{/*Automatically generated from: api/types/types.pb.go*/}
-
-|Field Name|Description|Type|
-|---|---|---|
-|`name`|The http header name.|`string`|
-|`value`|The http header value.|`string`|
-
-\`\`\`yaml
-name: string
-value: string
-\`\`\`
-```
 
 ### Working with parsed Go source
 
@@ -303,12 +126,10 @@ begin generating a `Resource` for that struct type, plus additional `Resource`
 structs for the types of its fields (and their types and so on). The sequence
 is:
 
-- Iterate through each struct type within the declaration map.
-- If a struct type is named within the configuration as a type to exclude, skip
-  it.
-- If a struct type has a `types.Metadata` field, construct a `Resource` from the
-  struct type and insert it into the final data map (unless a `Resource` already
-  exists there).
+- Iterate through each struct type named in the configuration file.
+- If a struct has a corresponding declaration in the source, construct a
+  `Resource` from the struct type and insert it into the final data map (unless
+  a `Resource` already exists there).
 - Process the fields of the struct type using the rules described
   [below](#processing-field-types), looking up declaration data from the
   declaration map.
@@ -378,26 +199,6 @@ exit with an error message.
 
 #### Custom fields
 
-Entries in the reference for custom fields, e.g., `Labels`, don't lend
-themselves to automatic generation because they implement custom unmarshalers,
-and we can't rely on `json` struct tags to indicate the types of these fields.
-
-For simplicity, we can describe custom fields by hardcoding their descriptions
-and example YAML values. The generator expects a custom type to include a
-comment with a description and example YAML. Everything in a custom type's
-comment between the following delimiters is treated as example YAML:
-
-```
-Example YAML:
----
-```
-
-Comments before the `Example YAML` delimiter are treated as the type's
-description.
-
-The generator exits with an error if a custom type has no `Example YAML` comment
-block, giving the operator an opportunity to add this.
-
 If a field of a struct type has a custom type, we will include a link to an
 entry for that type in the struct type's table. The YAML example will include an
 ellipsis, leaving it to the custom field's entry in the reference to provide the
@@ -418,37 +219,16 @@ example:
 \`\`\`
 ```
 
-Here is an example of a comment we could add to the `Labels` [type
-declaration](https://github.com/gravitational/teleport/blob/c91da46765953688d218dcba4a4ce7acf606639f/api/types/role.go#L1137-L1140):
+Entries in the reference for custom fields, e.g., `Labels`, don't lend
+themselves to automatic generation because they implement custom unmarshalers,
+and we can't rely on `json` struct tags to indicate the types of these fields.
+For the following field types, leave the `Type` column of the field table blank,
+and do not attempt to populate an example YAML value:
 
-```go
-// Labels is a wrapper around map
-// that can marshal and unmarshal itself
-// from scalar and list values
-// Example YAML:
-// 'env': 'test'
-// '*': '*'
-// 'region': ['us-west-1', -eu-central-1]
-// 'reg': ^us-west-1|eu-central-1$'
-// ---
-type Labels map[string]utils.Strings
-```
-
-This would lead to the following entry in the reference:
-
-```markdown
-## Labels
-
-Labels is a wrapper around map that can marshal and unmarshal itself from scalar
-and list values.
-
-\`\`\`yaml
-'env': 'test'
-'*': '*'
-'region': ['us-west-1', 'eu-central-1']
-'reg': '^us-west-1|eu-central-1$'
-\`\`\`
-```
+- Scalars with a custom type
+- Custom types declared outside the source tree, or in the standard library
+- Interfaces
+- Types with a custom unmarshaler
 
 #### Predeclared scalar types
 
@@ -555,44 +335,6 @@ field:
 ```
 
 The same rule would apply to, for example, `map[string]map[string]Header`.
-
-#### Named types
-
-For both named scalar types and named composite types, if the named type is not
-a struct, the generator looks for a manual override and returns an error if one
-is not available. This is because, for named composite types (e.g., `Labels`),
-it's likely that the source contains some custom unmarshaling logic that we will
-need to explain.
-
-If the type of a field is a named struct, the generator will produce another
-`Resource` based on that struct and insert it elsewhere in the reference
-template.
-
-For all named field types, the reference entry for the struct that contains the
-named field type will include an ellipsis in the example YAML. For example, the
-`CommandLabelV2` type appears within the `AppSpecV3` struct in the
-`dynamic_labels` field as shown below:
-
-```yaml
-uri: string
-public_addr: string
-dynamic_labels:
- # ...
-insecure_skip_verify: true
-rewrite: 
- # ...
-aws:
- # ...
-cloud:
- # ...
-```
-
-Users can then navigate to the `Command Label V2` section (using the link in the
-table above the example YAML) to see an example YAML document for this type.
-
-If the type of the field is an embedded struct, the generator will act as if the
-fields of the embedded struct are fields within the outer struct. Otherwise, the
-generator will follow the rules above.
 
 ## Test plan
 


### PR DESCRIPTION
Closes #16948
Closes #9949

Implements RFD 130.

See the included README for information about how the generator works.

This implementation breaks from, and updates, RFD 130:

- The reference includes separate pages for dynamic resources in order to make it easier to read. Edit the RFD to be less specific about the output template so this isn't wedded to implementation details.
- The generator uses a YAML configuration file. This is because the config ended up including more fields than specified in the RFD, so separating the config from the source made sense to give users less noise to deal with.
- The generator requires that a user specify the resources to include in the reference docs. This makes it easier to start with a smaller, more manageable set of resource reference docs.
- Support RFD 153 in the reference generator: RFD 153 resource types include unexported fields and include a `Metadata` field from a different package than legacy resources types. They also include the `Metadata` field with a pointer. Adjust the generator to ignore unexported fields in struct declarations, and to treat pointer field types the same way as value field types.
- Remove the description of example YAML delimiters. These are no longer viable, as we maintain several documentation generators that extract comments from the source. Instead, if we can't generate example YAML, show a comment in the YAML example advising the reader to read the description of a field.

Other changes:

 - Add a Make target for generating dynamic resource reference documentation.
 - Generate reference docs for Bot, RoleV6, OIDCConnectorV3, and SAMLConnectorV2.