### PR TITLE
[v18] Improve tsh debug messages with client version output

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1627,7 +1627,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// print tsh version when --debug flag is set
 	// to diagnose potential client version mismatch
 	if cf.Debug && command != ver.FullCommand() {
-		logger.InfoContext(ctx, "Debugging tsh client",
+		logger.InfoContext(ctx, "Initializing tsh",
 			"version", slog.GroupValue(
 				slog.String("teleport", teleport.Version),
 				slog.String("teleport_git", teleport.Gitref),

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1627,7 +1627,13 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	// print tsh version when --debug flag is set
 	// to diagnose potential client version mismatch
 	if cf.Debug && command != ver.FullCommand() {
-		modules.GetModules().PrintVersion()
+		logger.InfoContext(ctx, "Debugging tsh client",
+			"version", slog.GroupValue(
+				slog.String("teleport", teleport.Version),
+				slog.String("teleport_git", teleport.Gitref),
+				slog.String("go", runtime.Version()),
+			),
+		)
 	}
 
 	switch command {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1624,6 +1624,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		defer runtimetrace.Stop()
 	}
 
+	// print tsh version when --debug flag is set
+	// to diagnose potential client version mismatch
+	if cf.Debug && command != ver.FullCommand() {
+		modules.GetModules().PrintVersion()
+	}
+
 	switch command {
 	case ver.FullCommand():
 		err = onVersion(&cf)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -7718,5 +7718,15 @@ func TestDebugVersionOutput(t *testing.T) {
 
 	output, err := exec.Command(testExecutable, "logout", "--debug").CombinedOutput()
 	require.NoError(t, err)
+
+	vers := []string{
+		teleport.Version,
+		teleport.Gitref,
+		runtime.Version(),
+	}
+
 	require.Contains(t, string(output), "Initializing tsh version")
+	for _, v := range vers {
+		require.Contains(t, string(output), v)
+	}
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -7710,3 +7710,13 @@ func Test_humanFriendlyValidUntilDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestDebugVersionOutput(t *testing.T) {
+	t.Setenv(tshBinMainTestEnv, "1")
+	testExecutable, err := os.Executable()
+	require.NoError(t, err)
+
+	output, err := exec.Command(testExecutable, "logout", "--debug").CombinedOutput()
+	require.NoError(t, err)
+	require.Contains(t, string(output), "Initializing tsh version")
+}


### PR DESCRIPTION
Backport #60297 to branch/v18

changelog: Updated tsh debug output to include tsh client version when --debug flag is set.
