### PR TITLE
[v16] Add OS and ARCH info for client tools managed updates

### DIFF
--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -52,20 +52,6 @@ func TestUpdate(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
 	ctx := context.Background()
 
-	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
-	tctlPath, err := updater.ToolPath("tctl", testVersions[0])
-	require.NoError(t, err)
-
 	// Verify that the installed version is equal to requested one.
 	cmd := exec.CommandContext(ctx, tctlPath, "version")
 	out, err := cmd.Output()
@@ -86,27 +72,16 @@ func TestUpdate(t *testing.T) {
 	matchVersion(t, string(out), testVersions[1])
 }
 
-// TestUpdateDifferentOSArch verifies the update logic and matching operating system and architecture,
-// if it different that current we have initiate new download even if we have same version installed.
+// TestUpdateDifferentOSArch verifies the update logic for matching operating system
+// and architecture. If they differ from the current system, a new download must be
+// initiated even when the same version is already installed.
 func TestUpdateDifferentOSArch(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv(types.HomeEnvVar, home)
 	ctx := context.Background()
 
-	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
-
-	// Execute version command again with setting the new version which must
-	// trigger re-execution of the same command after downloading requested version.
+	// Execute version command with setting the new version which must trigger update and
+	// re-execution of the same command after downloading requested version.
 	cmd := exec.CommandContext(ctx, tshPath, "version")
 	cmd.Env = append(
 		os.Environ(),
@@ -124,15 +99,16 @@ func TestUpdateDifferentOSArch(t *testing.T) {
 	require.Equal(t, runtime.GOOS, ctc.Tools[0].OS)
 	require.Equal(t, runtime.GOARCH, ctc.Tools[0].Arch)
 
-	// Update architecture to non-existing ones, to ensure that triggers re-download package.
+	// Update the architecture to a non-existing value.
 	err = tools.UpdateToolsConfig(configPath, func(ctc *tools.ClientToolsConfig) error {
 		ctc.Tools[0].Arch = "unknown"
 		return nil
 	})
 	require.NoError(t, err)
 
-	// After executing version we shouldn't match architecture of already installed tool version,
-	// this must trigger re-download package of required architecture and re-execute.
+	// After executing the version command, we should not match the architecture of the
+	// previously installed tool version. Since the package does not match, we must
+	// re-download the package for the required architecture and re-execute.
 	cmd = exec.CommandContext(ctx, tshPath, "version")
 	cmd.Env = append(
 		os.Environ(),
@@ -144,8 +120,8 @@ func TestUpdateDifferentOSArch(t *testing.T) {
 
 	ctc, err = tools.GetToolsConfig(configPath)
 	require.NoError(t, err)
-	// After second version check we have to update one more time and re-download version to match
-	// architecture, as result we should see two tools with different arch in the list.
+	// The second call to the version command installs another package with the required
+	// OS and architecture, and we should then see two packages in the list.
 	require.Len(t, ctc.Tools, 2)
 }
 
@@ -156,18 +132,6 @@ func TestUpdateDifferentOSArch(t *testing.T) {
 func TestParallelUpdate(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
 	ctx := context.Background()
-
-	// Initial fetch the updater binary un-archive and replace.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
 
 	tCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	t.Cleanup(cancel)
@@ -185,7 +149,7 @@ func TestParallelUpdate(t *testing.T) {
 			os.Environ(),
 			fmt.Sprintf("%s=%s", teleportToolsVersion, testVersions[1]),
 		)
-		err = cmd.Start()
+		err := cmd.Start()
 		require.NoError(t, err, "failed to start updater")
 
 		go func(cmd *exec.Cmd) {
@@ -217,18 +181,6 @@ func TestParallelUpdate(t *testing.T) {
 // TestUpdateInterruptSignal verifies the interrupt signal send to the process must stop downloading.
 func TestUpdateInterruptSignal(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
-	ctx := context.Background()
-
-	// Initial fetch the updater binary un-archive and replace.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
 
 	var output bytes.Buffer
 	cmd := exec.Command(tshPath, "version")
@@ -238,7 +190,7 @@ func TestUpdateInterruptSignal(t *testing.T) {
 		os.Environ(),
 		fmt.Sprintf("%s=%s", teleportToolsVersion, testVersions[1]),
 	)
-	err = cmd.Start()
+	err := cmd.Start()
 	require.NoError(t, err, "failed to start updater")
 	pid := cmd.Process.Pid
 
@@ -285,17 +237,6 @@ func TestUpdateForOSSBuild(t *testing.T) {
 	// Enable OSS build.
 	t.Setenv(updater.TestBuild, modules.BuildOSS)
 	t.Setenv(autoupdate.BaseURLEnvVar, "")
-
-	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
 
 	// Verify that requested update is ignored by OSS build and version wasn't updated.
 	cmd := exec.CommandContext(ctx, tshPath, "version")

--- a/integration/autoupdate/tools/updater_tsh_test.go
+++ b/integration/autoupdate/tools/updater_tsh_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	"github.com/gravitational/teleport/integration/autoupdate/tools/updater"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/autoupdate/tools"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -59,19 +58,11 @@ import (
 func TestAliasLoginWithUpdater(t *testing.T) {
 	ctx := context.Background()
 
-	rootServer, homeDir, installDir := bootstrapTestServer(t)
+	rootServer, homeDir := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeEnabled, testVersions[1])
 
 	// Assign alias to the login command for test cluster.
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary and install to tools dir [v1.0.0].
-	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
-	require.NoError(t, updater.Update(ctx, testVersions[0]))
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
-	tctlPath, err := updater.ToolPath("tctl", testVersions[0])
 	require.NoError(t, err)
 
 	configPath := filepath.Join(homeDir, client.TSHConfigPath)
@@ -119,16 +110,10 @@ func TestAliasLoginWithUpdater(t *testing.T) {
 func TestSequentialUpdate(t *testing.T) {
 	ctx := context.Background()
 
-	rootServer, _, installDir := bootstrapTestServer(t)
+	rootServer, _ := bootstrapTestServer(t)
 
 	// Assign alias to the login command for test cluster.
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary and install to tools dir [v1.0.0].
-	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
-	require.NoError(t, updater.Update(ctx, testVersions[0]))
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
 	for _, testVersion := range testVersions[1:] {
@@ -162,16 +147,10 @@ func TestSequentialUpdate(t *testing.T) {
 func TestLoginWithUpdaterAndProfile(t *testing.T) {
 	ctx := context.Background()
 
-	rootServer, _, installDir := bootstrapTestServer(t)
+	rootServer, _ := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeDisabled, testVersions[1])
 
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary and install to tools dir [v1.0.0].
-	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
-	require.NoError(t, updater.Update(ctx, testVersions[0]))
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
 	// First login with set version during login process
@@ -205,16 +184,10 @@ func TestLoginWithUpdaterAndProfile(t *testing.T) {
 func TestLoginWithDisabledUpdateInProfile(t *testing.T) {
 	ctx := context.Background()
 
-	rootServer, _, installDir := bootstrapTestServer(t)
+	rootServer, _ := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeDisabled, testVersions[1])
 
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary and install to tools dir [v1.0.0].
-	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
-	require.NoError(t, updater.Update(ctx, testVersions[0]))
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
 	// Set env variable to forcibly request update on version command.
@@ -257,16 +230,10 @@ func TestLoginWithDisabledUpdateInProfile(t *testing.T) {
 func TestLoginWithDisabledUpdateForcedByEnv(t *testing.T) {
 	ctx := context.Background()
 
-	rootServer, _, installDir := bootstrapTestServer(t)
+	rootServer, _ := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeDisabled, testVersions[1])
 
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary and install to tools dir [v1.0.0].
-	updater := tools.NewUpdater(installDir, testVersions[0], tools.WithBaseURL(baseURL))
-	require.NoError(t, updater.Update(ctx, testVersions[0]))
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
 	// Second login has to update profile and disable further managed updates.
@@ -304,18 +271,6 @@ func TestMigratedUpdateNotReExec(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, testToolsDir)
 	ctx := context.Background()
 
-	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
-	updater := tools.NewUpdater(
-		testToolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err := updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
-	require.NoError(t, err)
-
 	require.NoError(t, os.MkdirAll(filepath.Join(testToolsDir, "bin"), 0755))
 	require.NoError(t, os.WriteFile(filepath.Join(testToolsDir, "bin", "tsh"), []byte("#!/bin/sh\n echo 'Teleport v5.5.5 git'\n"), 0755))
 
@@ -335,22 +290,10 @@ func TestUpdateConfigReExecPath(t *testing.T) {
 	t.Setenv(types.HomeEnvVar, t.TempDir())
 	ctx := context.Background()
 
-	rootServer, _, _ := bootstrapTestServer(t)
+	rootServer, _ := bootstrapTestServer(t)
 	setupManagedUpdates(t, rootServer.GetAuthServer(), autoupdate.ToolsUpdateModeEnabled, testVersions[1])
 
 	proxyAddr, err := rootServer.ProxyWebAddr()
-	require.NoError(t, err)
-
-	// Fetch compiled test binary with updater logic and install to $TELEPORT_HOME.
-	updater := tools.NewUpdater(
-		toolsDir,
-		testVersions[0],
-		tools.WithBaseURL(baseURL),
-	)
-	err = updater.Update(ctx, testVersions[0])
-	require.NoError(t, err)
-
-	tshPath, err := updater.ToolPath("tsh", testVersions[0])
 	require.NoError(t, err)
 
 	cmd := exec.CommandContext(ctx, tshPath,
@@ -379,12 +322,10 @@ func TestUpdateConfigReExecPath(t *testing.T) {
 	require.Contains(t, string(out), `ProxyCommand "`+tshPath+`" `)
 }
 
-func bootstrapTestServer(t *testing.T) (*service.TeleportProcess, string, string) {
+func bootstrapTestServer(t *testing.T) (*service.TeleportProcess, string) {
 	t.Helper()
 	homeDir := filepath.Join(t.TempDir(), "home")
 	require.NoError(t, os.MkdirAll(homeDir, 0700))
-	installDir := filepath.Join(t.TempDir(), "local")
-	require.NoError(t, os.MkdirAll(installDir, 0700))
 
 	t.Setenv(types.HomeEnvVar, homeDir)
 
@@ -419,7 +360,7 @@ func bootstrapTestServer(t *testing.T) (*service.TeleportProcess, string, string
 	err = authService.UpsertPassword("alice", []byte(password))
 	require.NoError(t, err)
 
-	return rootServer, homeDir, installDir
+	return rootServer, homeDir
 }
 
 func setupManagedUpdates(t *testing.T, server *auth.Server, muMode string, muVersion string) {

--- a/lib/autoupdate/tools/migration.go
+++ b/lib/autoupdate/tools/migration.go
@@ -51,7 +51,7 @@ func migrateV1AndUpdateConfig(toolsDir string, tools []string) error {
 		}
 
 		for _, tool := range migratedTools {
-			ctc.AddTool(tool)
+			ctc.AddTool(toolsDir, tool)
 		}
 		return nil
 	}); err != nil {

--- a/lib/autoupdate/tools/migration.go
+++ b/lib/autoupdate/tools/migration.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/google/uuid"
@@ -40,7 +41,7 @@ const (
 // migrateV1AndUpdateConfig launches migration process and add migrated
 // tools to configuration file.
 func migrateV1AndUpdateConfig(toolsDir string, tools []string) error {
-	if err := updateToolsConfig(toolsDir, func(ctc *ClientToolsConfig) error {
+	if err := UpdateToolsConfig(toolsDir, func(ctc *ClientToolsConfig) error {
 		migratedTools, err := migrateV1(toolsDir, tools)
 		if err != nil {
 			return trace.Wrap(err)
@@ -106,6 +107,8 @@ func migrateV1(toolsDir string, tools []string) (map[string]Tool, error) {
 			} else {
 				migratedTools[toolVersion] = Tool{
 					Version: toolVersion,
+					OS:      runtime.GOOS,
+					Arch:    runtime.GOARCH,
 					PathMap: map[string]string{tool: filepath.Join(newPkg, relPath)},
 				}
 			}
@@ -129,6 +132,8 @@ func migrateV1(toolsDir string, tools []string) (map[string]Tool, error) {
 			}
 			migratedTools[toolVersion] = Tool{
 				Version: toolVersion,
+				OS:      runtime.GOOS,
+				Arch:    runtime.GOARCH,
 				PathMap: map[string]string{tool: filepath.Join(newPkg, tool)},
 			}
 		}

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -195,7 +195,7 @@ func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *Upd
 		return nil, trace.Wrap(err)
 	}
 
-	if !ctc.HasVersion(toolsVersion, runtime.GOOS, runtime.GOARCH) {
+	if !ctc.HasVersion(u.toolsDir, toolsVersion, runtime.GOOS, runtime.GOARCH) {
 		if err := migrateV1AndUpdateConfig(u.toolsDir, u.tools); err != nil {
 			// Execution should not be interrupted if migration fails. Instead, it's better to
 			// re-download the version that was supposed to be migrated but failed for some reason.
@@ -301,7 +301,7 @@ func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
 			// If the version of the running binary or the version downloaded to
 			// tools directory is the same as the requested version of client tools,
 			// nothing to be done, exit early.
-			if tool.IsEqual(toolsVersion, runtime.GOOS, runtime.GOARCH) {
+			if tool.IsEqual(u.toolsDir, toolsVersion, runtime.GOOS, runtime.GOARCH) {
 				return nil
 			}
 			ignoreTools = append(ignoreTools, tool.PackageNames()...)
@@ -383,7 +383,7 @@ func (u *Updater) update(ctx context.Context, ctc *ClientToolsConfig, pkg packag
 	for key, val := range toolsMap {
 		toolsMap[key] = filepath.Join(pkgName, val)
 	}
-	ctc.AddTool(Tool{Version: pkg.Version, OS: runtime.GOOS, Arch: runtime.GOARCH, PathMap: toolsMap})
+	ctc.AddTool(u.toolsDir, Tool{Version: pkg.Version, OS: runtime.GOOS, Arch: runtime.GOARCH, PathMap: toolsMap})
 
 	return nil
 }
@@ -392,7 +392,7 @@ func (u *Updater) update(ctx context.Context, ctc *ClientToolsConfig, pkg packag
 func (u *Updater) ToolPath(toolName, toolVersion string) (path string, err error) {
 	var tool *Tool
 	if err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
-		tool = ctc.SelectVersion(toolVersion, runtime.GOOS, runtime.GOARCH)
+		tool = ctc.SelectVersion(u.toolsDir, toolVersion, runtime.GOOS, runtime.GOARCH)
 		return nil
 	}); err != nil {
 		return "", trace.Wrap(err)

--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -172,7 +172,7 @@ func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *Upd
 	// We should acquire and release the lock before checking the version
 	// by executing the binary, as it might block tool execution until the version
 	// check is completed, which can take several seconds.
-	ctc, err := getToolsConfig(u.toolsDir)
+	ctc, err := GetToolsConfig(u.toolsDir)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -195,7 +195,7 @@ func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *Upd
 		return nil, trace.Wrap(err)
 	}
 
-	if !ctc.HasVersion(toolsVersion) {
+	if !ctc.HasVersion(toolsVersion, runtime.GOOS, runtime.GOARCH) {
 		if err := migrateV1AndUpdateConfig(u.toolsDir, u.tools); err != nil {
 			// Execution should not be interrupted if migration fails. Instead, it's better to
 			// re-download the version that was supposed to be migrated but failed for some reason.
@@ -227,7 +227,7 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 		return &UpdateResponse{Version: "", ReExec: false}, nil
 	// Requested version already the same as client version.
 	case u.localVersion:
-		if err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+		if err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
 			ctc.SetConfig(proxyHost, requestedVersion, false)
 			return nil
 		}); err != nil {
@@ -244,7 +244,7 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 		// If the environment variable is set during a remote check,
 		// prioritize this version for the current host and use it as the default
 		// for all commands under the current profile.
-		if err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+		if err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
 			ctc.SetConfig(proxyHost, requestedVersion, false)
 			return nil
 		}); err != nil {
@@ -279,7 +279,7 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 		updateResp = &UpdateResponse{Version: resp.AutoUpdate.ToolsVersion, ReExec: true}
 	}
 
-	if err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+	if err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
 		ctc.SetConfig(proxyHost, updateResp.Version, updateResp.Disabled)
 		return nil
 	}); err != nil {
@@ -292,7 +292,7 @@ func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bo
 // Update acquires filesystem lock, downloads requested version package, unarchive, replace
 // existing one and cleanups the previous downloads with defined updater directory suffix.
 func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
-	err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+	err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
 		// ignoreTools is the list of tools installed and tracked by the config.
 		// They should be preserved during cleanup. If we have more than [defaultSizeStoredVersion]
 		// versions, the updater will forget about the least used version.
@@ -301,7 +301,7 @@ func (u *Updater) Update(ctx context.Context, toolsVersion string) error {
 			// If the version of the running binary or the version downloaded to
 			// tools directory is the same as the requested version of client tools,
 			// nothing to be done, exit early.
-			if tool.Version == toolsVersion {
+			if tool.IsEqual(toolsVersion, runtime.GOOS, runtime.GOARCH) {
 				return nil
 			}
 			ignoreTools = append(ignoreTools, tool.PackageNames()...)
@@ -383,7 +383,7 @@ func (u *Updater) update(ctx context.Context, ctc *ClientToolsConfig, pkg packag
 	for key, val := range toolsMap {
 		toolsMap[key] = filepath.Join(pkgName, val)
 	}
-	ctc.AddTool(Tool{Version: pkg.Version, PathMap: toolsMap})
+	ctc.AddTool(Tool{Version: pkg.Version, OS: runtime.GOOS, Arch: runtime.GOARCH, PathMap: toolsMap})
 
 	return nil
 }
@@ -391,8 +391,8 @@ func (u *Updater) update(ctx context.Context, ctc *ClientToolsConfig, pkg packag
 // ToolPath loads full path from config file to specific tool and version.
 func (u *Updater) ToolPath(toolName, toolVersion string) (path string, err error) {
 	var tool *Tool
-	if err := updateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
-		tool = ctc.SelectVersion(toolVersion)
+	if err := UpdateToolsConfig(u.toolsDir, func(ctc *ClientToolsConfig) error {
+		tool = ctc.SelectVersion(toolVersion, runtime.GOOS, runtime.GOARCH)
 		return nil
 	}); err != nil {
 		return "", trace.Wrap(err)


### PR DESCRIPTION
Backport #59891 to branch/v16

changelog: Client tools managed updates stores OS and ARCH in the configuration. This ensures compatibility when `TELEPORT_HOME` directory is shared with a virtual instance running a different OS or architecture.
