### PR TITLE
add env var to disable legacy join service

### DIFF
--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 )
 
 // checkTokenJoinRequestCommon checks all token join rules that are common to
@@ -183,6 +184,10 @@ func (a *Server) RegisterUsingToken(ctx context.Context, req *types.RegisterUsin
 			a.handleJoinFailure(ctx, err, provisionToken, rawClaims, req)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -454,6 +455,10 @@ func (a *Server) RegisterUsingAzureMethodWithOpts(
 			a.handleJoinFailure(ctx, err, provisionToken, nil, joinRequest)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	cfg := &azureRegisterConfig{}
 	for _, opt := range opts {

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -28,6 +28,7 @@ import (
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -66,6 +67,10 @@ func (a *Server) RegisterUsingIAMMethod(
 			)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	challenge, err := iamjoin.GenerateIAMChallenge()
 	if err != nil {

--- a/lib/auth/join_oracle.go
+++ b/lib/auth/join_oracle.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 )
 
 // RegisterUsingOracleMethod registers the caller using the Oracle join method and
@@ -64,6 +65,10 @@ func (a *Server) registerUsingOracleMethod(
 			)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	challenge, err := generateOracleChallenge()
 	if err != nil {

--- a/lib/auth/join_tpm.go
+++ b/lib/auth/join_tpm.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tpm"
 )
@@ -49,6 +50,10 @@ func (a *Server) RegisterUsingTPMMethod(
 			)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	// First, check the specified token exists, and is a TPM-type join token.
 	if err := initReq.JoinRequest.CheckAndSetDefaults(); err != nil {

--- a/lib/join/legacyjoin/joinserver.go
+++ b/lib/join/legacyjoin/joinserver.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"log/slog"
 	"net"
+	"os"
 	"slices"
 	"time"
 
@@ -37,6 +38,17 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
+
+// Disabled returns true if the legacy join service is disabled in this environment.
+func Disabled() bool {
+	return os.Getenv("TELEPORT_UNSTABLE_NO_AGENT_ID_SELECTION") != ""
+}
+
+// ErrDisabled is an error that will be returned of all legacy join RPCs when
+// Disabled returns true.
+var ErrDisabled = &trace.AccessDeniedError{
+	Message: "legacy join service has been disabled in this environment",
+}
 
 const (
 	joinRequestTimeout = time.Minute

--- a/lib/join/legacyjoin/joinserver.go
+++ b/lib/join/legacyjoin/joinserver.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"slices"
+	"strconv"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -41,7 +42,11 @@ import (
 
 // Disabled returns true if the legacy join service is disabled in this environment.
 func Disabled() bool {
-	return os.Getenv("TELEPORT_UNSTABLE_NO_AGENT_ID_SELECTION") != ""
+	disabledVar := os.Getenv("TELEPORT_UNSTABLE_NO_AGENT_ID_SELECTION")
+	// Some of our env variables support strconv.ParseBool, others "yes", this will handle both.
+	truthy, _ := strconv.ParseBool(disabledVar)
+	truthy = truthy || disabledVar == "yes"
+	return truthy
 }
 
 // ErrDisabled is an error that will be returned of all legacy join RPCs when

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
 )
 
 // handleBoundKeypairJoin handles join attempts for the bound keypair join
@@ -148,6 +149,10 @@ func AdaptRegisterUsingBoundKeypairMethod(
 			handleJoinFailure(ctx, a, diag)
 		}
 	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
 
 	// Construct an [authz.Context] to pass to HandleBoundKeypairJoin.
 	authCtx := &authz.Context{


### PR DESCRIPTION
As described in [RFD 27e](https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md#re-joining-with-new-system-roles) this PR adds an environment variable `TELEPORT_UNSTABLE_NO_AGENT_ID_SELECTION` which disables the legacy join endpoints that allow agents to select their own host UUID when joining. I opted to check this after the deferred `handleJoinFailure` method was set up in each join method handler, instead of centrally disabling the entire gRPC service, so that any join failures caused by enabling this var will result in join failed audit events to help with visibility.