### PR TITLE
Allow disabling health check configs

### DIFF
--- a/api/gen/proto/go/teleport/healthcheckconfig/v1/health_check_config.pb.go
+++ b/api/gen/proto/go/teleport/healthcheckconfig/v1/health_check_config.pb.go
@@ -223,8 +223,10 @@ type Matcher struct {
 	// empty value is ignored. The match result is logically ANDed with KubernetesLabels,
 	// if both are non-empty.
 	KubernetesLabelsExpression string `protobuf:"bytes,4,opt,name=kubernetes_labels_expression,json=kubernetesLabelsExpression,proto3" json:"kubernetes_labels_expression,omitempty"`
-	unknownFields              protoimpl.UnknownFields
-	sizeCache                  protoimpl.SizeCache
+	// Disabled disables matches for all labels and expressions.
+	Disabled      bool `protobuf:"varint,5,opt,name=disabled,proto3" json:"disabled,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Matcher) Reset() {
@@ -285,6 +287,13 @@ func (x *Matcher) GetKubernetesLabelsExpression() string {
 	return ""
 }
 
+func (x *Matcher) GetDisabled() bool {
+	if x != nil {
+		return x.Disabled
+	}
+	return false
+}
+
 var File_teleport_healthcheckconfig_v1_health_check_config_proto protoreflect.FileDescriptor
 
 const file_teleport_healthcheckconfig_v1_health_check_config_proto_rawDesc = "" +
@@ -301,12 +310,13 @@ const file_teleport_healthcheckconfig_v1_health_check_config_proto_rawDesc = "" 
 	"\atimeout\x18\x02 \x01(\v2\x19.google.protobuf.DurationR\atimeout\x125\n" +
 	"\binterval\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\binterval\x12+\n" +
 	"\x11healthy_threshold\x18\x04 \x01(\rR\x10healthyThreshold\x12/\n" +
-	"\x13unhealthy_threshold\x18\x05 \x01(\rR\x12unhealthyThreshold\"\xfb\x01\n" +
+	"\x13unhealthy_threshold\x18\x05 \x01(\rR\x12unhealthyThreshold\"\x97\x02\n" +
 	"\aMatcher\x125\n" +
 	"\tdb_labels\x18\x01 \x03(\v2\x18.teleport.label.v1.LabelR\bdbLabels\x120\n" +
 	"\x14db_labels_expression\x18\x02 \x01(\tR\x12dbLabelsExpression\x12E\n" +
 	"\x11kubernetes_labels\x18\x03 \x03(\v2\x18.teleport.label.v1.LabelR\x10kubernetesLabels\x12@\n" +
-	"\x1ckubernetes_labels_expression\x18\x04 \x01(\tR\x1akubernetesLabelsExpressionBfZdgithub.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1;healthcheckconfigv1b\x06proto3"
+	"\x1ckubernetes_labels_expression\x18\x04 \x01(\tR\x1akubernetesLabelsExpression\x12\x1a\n" +
+	"\bdisabled\x18\x05 \x01(\bR\bdisabledBfZdgithub.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1;healthcheckconfigv1b\x06proto3"
 
 var (
 	file_teleport_healthcheckconfig_v1_health_check_config_proto_rawDescOnce sync.Once

--- a/api/proto/teleport/healthcheckconfig/v1/health_check_config.proto
+++ b/api/proto/teleport/healthcheckconfig/v1/health_check_config.proto
@@ -71,4 +71,6 @@ message Matcher {
   // empty value is ignored. The match result is logically ANDed with KubernetesLabels,
   // if both are non-empty.
   string kubernetes_labels_expression = 4;
+  // Disabled disables matches for all labels and expressions.
+  bool disabled = 5;
 }

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
@@ -67,6 +67,7 @@ Optional:
 
 - `db_labels` (Attributes List) DBLabels matches database labels. An empty value is ignored. The match result is logically ANDed with DBLabelsExpression, if both are non-empty. (see [below for nested schema](#nested-schema-for-specmatchdb_labels))
 - `db_labels_expression` (String) DBLabelsExpression is a label predicate expression to match databases. An empty value is ignored. The match result is logically ANDed with DBLabels, if both are non-empty.
+- `disabled` (Boolean) Disabled disables matches for all labels and expressions.
 - `kubernetes_labels` (Attributes List) KubernetesLabels matches Kubernetes labels. An empty value is ignored. The match result is logically ANDed with KubernetesLabelsExpression, if both are non-empty. (see [below for nested schema](#nested-schema-for-specmatchkubernetes_labels))
 - `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a label predicate expression to match Kubernetes. An empty value is ignored. The match result is logically ANDed with KubernetesLabels, if both are non-empty.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
@@ -96,6 +96,7 @@ Optional:
 
 - `db_labels` (Attributes List) DBLabels matches database labels. An empty value is ignored. The match result is logically ANDed with DBLabelsExpression, if both are non-empty. (see [below for nested schema](#nested-schema-for-specmatchdb_labels))
 - `db_labels_expression` (String) DBLabelsExpression is a label predicate expression to match databases. An empty value is ignored. The match result is logically ANDed with DBLabels, if both are non-empty.
+- `disabled` (Boolean) Disabled disables matches for all labels and expressions.
 - `kubernetes_labels` (Attributes List) KubernetesLabels matches Kubernetes labels. An empty value is ignored. The match result is logically ANDed with KubernetesLabelsExpression, if both are non-empty. (see [below for nested schema](#nested-schema-for-specmatchkubernetes_labels))
 - `kubernetes_labels_expression` (String) KubernetesLabelsExpression is a label predicate expression to match Kubernetes. An empty value is ignored. The match result is logically ANDed with KubernetesLabels, if both are non-empty.
 

--- a/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
+++ b/integrations/terraform/tfschema/healthcheckconfig/v1/health_check_config_terraform.go
@@ -137,6 +137,11 @@ func GenSchemaHealthCheckConfig(ctx context.Context) (github_com_hashicorp_terra
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
+						"disabled": {
+							Description: "Disabled disables matches for all labels and expressions.",
+							Optional:    true,
+							Type:        github_com_hashicorp_terraform_plugin_framework_types.BoolType,
+						},
 						"kubernetes_labels": {
 							Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.ListNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{
 								"name": {
@@ -569,6 +574,23 @@ func CopyHealthCheckConfigFromTerraform(_ context.Context, tf github_com_hashico
 													t = string(v.Value)
 												}
 												obj.KubernetesLabelsExpression = t
+											}
+										}
+									}
+									{
+										a, ok := tf.Attrs["disabled"]
+										if !ok {
+											diags.Append(attrReadMissingDiag{"HealthCheckConfig.spec.match.disabled"})
+										} else {
+											v, ok := a.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												diags.Append(attrReadConversionFailureDiag{"HealthCheckConfig.spec.match.disabled", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+											} else {
+												var t bool
+												if !v.Null && !v.Unknown {
+													t = bool(v.Value)
+												}
+												obj.Disabled = t
 											}
 										}
 									}
@@ -1244,6 +1266,28 @@ func CopyHealthCheckConfigToTerraform(ctx context.Context, obj *github_com_gravi
 											v.Value = string(obj.KubernetesLabelsExpression)
 											v.Unknown = false
 											tf.Attrs["kubernetes_labels_expression"] = v
+										}
+									}
+									{
+										t, ok := tf.AttrTypes["disabled"]
+										if !ok {
+											diags.Append(attrWriteMissingDiag{"HealthCheckConfig.spec.match.disabled"})
+										} else {
+											v, ok := tf.Attrs["disabled"].(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+											if !ok {
+												i, err := t.ValueFromTerraform(ctx, github_com_hashicorp_terraform_plugin_go_tftypes.NewValue(t.TerraformType(ctx), nil))
+												if err != nil {
+													diags.Append(attrWriteGeneralError{"HealthCheckConfig.spec.match.disabled", err})
+												}
+												v, ok = i.(github_com_hashicorp_terraform_plugin_framework_types.Bool)
+												if !ok {
+													diags.Append(attrWriteConversionFailureDiag{"HealthCheckConfig.spec.match.disabled", "github.com/hashicorp/terraform-plugin-framework/types.Bool"})
+												}
+												v.Null = bool(obj.Disabled) == false
+											}
+											v.Value = bool(obj.Disabled)
+											v.Unknown = false
+											tf.Attrs["disabled"] = v
 										}
 									}
 								}

--- a/lib/healthcheck/config.go
+++ b/lib/healthcheck/config.go
@@ -38,6 +38,7 @@ type healthCheckConfig struct {
 	timeout                 time.Duration
 	healthyThreshold        uint32
 	unhealthyThreshold      uint32
+	disabled                bool
 	databaseLabelMatchers   types.LabelMatchers
 	kubernetesLabelMatchers types.LabelMatchers
 }
@@ -53,6 +54,7 @@ func newHealthCheckConfig(cfg *healthcheckconfigv1.HealthCheckConfig) *healthChe
 		interval:                cmp.Or(spec.GetInterval().AsDuration(), defaults.HealthCheckInterval),
 		healthyThreshold:        cmp.Or(spec.GetHealthyThreshold(), defaults.HealthCheckHealthyThreshold),
 		unhealthyThreshold:      cmp.Or(spec.GetUnhealthyThreshold(), defaults.HealthCheckUnhealthyThreshold),
+		disabled:                match.Disabled,
 		databaseLabelMatchers:   newLabelMatchers(match.GetDbLabelsExpression(), match.GetDbLabels()),
 		kubernetesLabelMatchers: newLabelMatchers(match.GetKubernetesLabelsExpression(), match.GetKubernetesLabels()),
 	}
@@ -67,20 +69,23 @@ func (h *healthCheckConfig) equivalent(other *healthCheckConfig) bool {
 			h.interval == other.interval &&
 			h.timeout == other.timeout &&
 			h.healthyThreshold == other.healthyThreshold &&
-			h.unhealthyThreshold == other.unhealthyThreshold
+			h.unhealthyThreshold == other.unhealthyThreshold &&
+			h.disabled == other.disabled
 }
 
 // getLabelMatchers returns the label matchers to use for the given resource
 // kind.
 func (h *healthCheckConfig) getLabelMatchers(kind string) types.LabelMatchers {
-	switch kind {
-	case types.KindDatabase:
-		return h.databaseLabelMatchers
-	case types.KindKubernetesCluster:
-		return h.kubernetesLabelMatchers
+	if !h.disabled {
+		switch kind {
+		case types.KindDatabase:
+			return h.databaseLabelMatchers
+		case types.KindKubernetesCluster:
+			return h.kubernetesLabelMatchers
+		}
 	}
-	// unreachable since we enforce a list of supported target resource kinds,
-	// but empty matchers do the right thing anyway: don't match anything.
+
+	// empty matchers don't match anything.
 	return types.LabelMatchers{}
 }
 

--- a/lib/healthcheck/config_test.go
+++ b/lib/healthcheck/config_test.go
@@ -39,6 +39,7 @@ func Test_newHealthCheckConfig(t *testing.T) {
 		"full",
 		&healthcheckconfigv1.HealthCheckConfigSpec{
 			Match: &healthcheckconfigv1.Matcher{
+				Disabled: true,
 				DbLabels: []*labelv1.Label{{
 					Name:   "foo",
 					Values: []string{"bar", "baz"},
@@ -83,6 +84,7 @@ func Test_newHealthCheckConfig(t *testing.T) {
 				interval:           time.Second * 43,
 				healthyThreshold:   7,
 				unhealthyThreshold: 8,
+				disabled:           true,
 				databaseLabelMatchers: types.LabelMatchers{
 					Labels: types.Labels{
 						"foo": utils.Strings{"bar", "baz"},
@@ -157,6 +159,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
 				unhealthyThreshold: 5,
+				disabled:           true,
 			},
 			b: &healthCheckConfig{
 				name:               "test",
@@ -164,6 +167,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				timeout:            500 * time.Millisecond,
 				healthyThreshold:   3,
 				unhealthyThreshold: 5,
+				disabled:           true,
 			},
 			want: true,
 		},
@@ -175,6 +179,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				timeout:                 500 * time.Millisecond,
 				healthyThreshold:        3,
 				unhealthyThreshold:      5,
+				disabled:                true,
 				databaseLabelMatchers:   types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
 				kubernetesLabelMatchers: types.LabelMatchers{Expression: "a", Labels: types.Labels{"a": {"a"}}},
 			},
@@ -184,6 +189,7 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 				timeout:                 500 * time.Millisecond,
 				healthyThreshold:        3,
 				unhealthyThreshold:      5,
+				disabled:                true,
 				databaseLabelMatchers:   types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
 				kubernetesLabelMatchers: types.LabelMatchers{Expression: "b", Labels: types.Labels{"b": {"b"}}},
 			},
@@ -236,6 +242,16 @@ func TestHealthCheckConfig_equivalent(t *testing.T) {
 			},
 			b: &healthCheckConfig{
 				unhealthyThreshold: 3,
+			},
+			want: false,
+		},
+		{
+			desc: "different disabled",
+			a: &healthCheckConfig{
+				disabled: true,
+			},
+			b: &healthCheckConfig{
+				disabled: false,
 			},
 			want: false,
 		},


### PR DESCRIPTION
Health check configuration can be disabled and enabled through the matcher. Disabling the matcher disables health checks for this configuration's resources including databases, Kubernetes clusters, and any future resources.

Changes:
- Added `disabled` field to health check matcher proto
- Updated matcher selection logic
- Updated unit tests

Manual testing:
Updating the health check config matcher `disabled` field is effective at disabling matching.

Cluster with existing preset `default_kube`.

Before adding `disabled: true`:
```
2025-10-21T16:01:06.283-07:00 INFO [KUBERNETE] Health checker started target_name:colima target_kind:kube_cluster target_origin: health_check_config:default_kube interval:30s timeout:5s healthy_threshold:2 unhealthy_threshold:1 healthcheck/worker.go:234
2025-10-21T16:01:06.293-07:00 INFO [KUBERNETE] Target became healthy target_name:colima target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:411
```

After adding `disabled: true`:
```
2025-10-21T16:01:29.831-07:00 INFO  emitting audit event event_type:health_check_config.update fields:map[addr.remote:127.0.0.1:53508 cluster_name:teleport-laptop code:THCC002I ei:0 event:health_check_config.update expires:0001-01-01T00:00:00Z name:default_kube time:2025-10-21T23:01:29.831Z trace.component:audit uid:686b8d85-284f-4ac4-90e6-f299717e88c6 user:00cc8873-5888-4da6-8428-836660e5c8cf.teleport-laptop user_cluster_name:teleport-laptop user_kind:3 user_roles:[Admin]] events/emitter.go:287
2025-10-21T16:01:30.166-07:00 DEBU [KUBERNETE] List of known resources updated resources:[default default_kube] services/watcher.go:858
2025-10-21T16:01:30.166-07:00 DEBU [PROXY:PRO] List of known resources updated resources:[default default_kube] services/watcher.go:858
2025-10-21T16:01:30.166-07:00 INFO [KUBERNETE] Health checker stopped target_name:colima target_kind:kube_cluster target_origin: healthcheck/worker.go:251
2025-10-21T16:01:30.166-07:00 DEBU [KUBERNETE] Target health status is unknown target_name:colima target_kind:kube_cluster target_origin: reason:disabled message:No health check config matches this resource healthcheck/worker.go:423
```

Relates to:
- #58413