### PR TITLE
[v18] Add configurable playback speed to session recording player

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/player/PlayerControls.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/PlayerControls.tsx
@@ -41,6 +41,8 @@ import { HoverTooltip } from 'design/Tooltip';
 
 import { PlayerState } from 'teleport/SessionRecordings/view/stream/SessionStream';
 
+import { PlayerSpeed } from './PlayerSpeed';
+
 export interface PlayerControlsHandle {
   setTime: (time: number) => void;
 }
@@ -50,6 +52,8 @@ interface PlayerControlsProps {
   onPlay: () => void;
   onPause: () => void;
   onSeek: (time: number) => void;
+  speed: number;
+  onSpeedChange: (speed: number) => void;
   state: PlayerState;
   ref: RefObject<PlayerControlsHandle>;
   onToggleFullscreen?: () => void;
@@ -65,6 +69,8 @@ export function PlayerControls({
   onPlay,
   onPause,
   onSeek,
+  speed,
+  onSpeedChange,
   fullscreen,
   onToggleFullscreen,
   onToggleTimeline,
@@ -215,6 +221,12 @@ export function PlayerControls({
           <ProgressBar ref={progressBarRef} />
         </ProgressBarContainer>
       </ProgressBarArea>
+
+      <PlayerSpeed
+        speed={speed}
+        onSpeedChange={onSpeedChange}
+        portalRoot={containerRef.current}
+      />
 
       {onToggleTimeline && (
         <HoverTooltip

--- a/web/packages/teleport/src/SessionRecordings/view/player/PlayerSpeed.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/PlayerSpeed.tsx
@@ -1,3 +1,21 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 

--- a/web/packages/teleport/src/SessionRecordings/view/player/PlayerSpeed.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/PlayerSpeed.tsx
@@ -1,0 +1,102 @@
+import { useMemo, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import Flex from 'design/Flex';
+import { Check } from 'design/Icon';
+import Menu, { MenuItem } from 'design/Menu';
+import { HoverTooltip } from 'design/Tooltip';
+
+interface PlayerSpeedProps {
+  speed: number;
+  portalRoot: HTMLElement;
+  onSpeedChange: (speed: number) => void;
+}
+
+const SpeedButton = styled.button`
+  background: transparent;
+  border: none;
+  color: ${p => p.theme.colors.text.main};
+  cursor: pointer;
+  height: 32px;
+  font-size: ${p => p.theme.fontSizes[2]}px;
+  padding: ${p => p.theme.space[1]}px
+    ${p => p.theme.space[2] + p.theme.space[1]}px;
+  line-height: 1;
+  border-radius: ${p => p.theme.radii[3]}px;
+
+  &:hover {
+    background: ${p => p.theme.colors.spotBackground[1]};
+  }
+`;
+
+const StyledMenu = styled(Menu)`
+  width: 150px;
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  font-size: ${p => p.theme.fontSizes[2]}px;
+  display: flex;
+  align-items: center;
+`;
+
+const AVAILABLE_SPEEDS = [0.25, 0.5, 1, 1.5, 2, 3, 4];
+
+export function PlayerSpeed({
+  onSpeedChange,
+  portalRoot,
+  speed,
+}: PlayerSpeedProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const ref = useRef<HTMLButtonElement>(null);
+
+  const items = useMemo(() => {
+    return AVAILABLE_SPEEDS.map(s => (
+      <StyledMenuItem
+        key={s}
+        onClick={() => {
+          onSpeedChange(s);
+        }}
+      >
+        <Flex height="24px" width="24px">
+          {s === speed && <Check size="small" />}
+        </Flex>
+        {s}x
+      </StyledMenuItem>
+    ));
+  }, [onSpeedChange, speed]);
+
+  return (
+    <>
+      <HoverTooltip tipContent="Playback Speed" portalRoot={portalRoot}>
+        <SpeedButton
+          onClick={() => {
+            setIsOpen(true);
+          }}
+          ref={ref}
+        >
+          {speed}x
+        </SpeedButton>
+      </HoverTooltip>
+
+      <StyledMenu
+        anchorEl={ref.current}
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        // hack to properly position the menu
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        transformOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
+        menuListProps={{ onClick: () => setIsOpen(false) }}
+      >
+        {items}
+      </StyledMenu>
+    </>
+  );
+}

--- a/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
@@ -85,6 +85,7 @@ export function RecordingPlayer<
   ws,
 }: RecordingPlayerProps<TEvent>) {
   const [playerState, setPlayerState] = useState(PlayerState.Loading);
+  const [speed, setSpeed] = useState(1);
 
   const [showPlayButton, setShowPlayButton] = useState(true);
 
@@ -118,6 +119,10 @@ export function RecordingPlayer<
       stream.destroy();
     };
   }, [stream, onTimeChange]);
+
+  useEffect(() => {
+    stream.setSpeed(speed);
+  }, [speed, stream]);
 
   useEffect(() => {
     if (!playerRef.current) {
@@ -201,6 +206,8 @@ export function RecordingPlayer<
           onPlay={handlePlay}
           onPause={handlePause}
           onSeek={handleSeek}
+          onSpeedChange={setSpeed}
+          speed={speed}
           state={playerState}
           ref={controlsRef}
         />

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -330,11 +330,7 @@ export class SessionStream<
 
     const remainingBufferTime = lastEventTime - currentTime;
 
-    if (
-      !this.atEnd &&
-      !this.loading &&
-      remainingBufferTime < loadThreshold
-    ) {
+    if (!this.atEnd && !this.loading && remainingBufferTime < loadThreshold) {
       const newStartTime = this.loadedRange.end;
       const newEndTime = newStartTime + this.getLoadChunkMs();
 

--- a/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
+++ b/web/packages/teleport/src/SessionRecordings/view/stream/SessionStream.ts
@@ -85,7 +85,7 @@ export class SessionStream<
   private requestId = 0;
   private state: PlayerState = PlayerState.Loading;
   private wasPlayingBeforeSeek = false;
-  private playbackSpeed = 0.5;
+  private playbackSpeed = 1;
 
   constructor(
     private ws: WebSocket,


### PR DESCRIPTION
Backport #59641 to branch/v18

changelog: Playback speed can be changed in the new SSH/k8s recording player
