### PR TITLE
Fix Discovery boot when Proxy is not yet available

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -75,11 +75,6 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		return trace.Wrap(err, "failed to build access graph configuration")
 	}
 
-	publicProxyAddress, err := process.publicProxyAddr(accessPoint)
-	if err != nil {
-		return trace.Wrap(err, "failed to determine the public proxy address")
-	}
-
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
 		IntegrationOnlyCredentials: process.integrationOnlyCredentials(),
 		Matchers: discovery.Matchers{
@@ -89,17 +84,16 @@ func (process *TeleportProcess) initDiscoveryService() error {
 			Kubernetes:  process.Config.Discovery.KubernetesMatchers,
 			AccessGraph: process.Config.Discovery.AccessGraph,
 		},
-		DiscoveryGroup:     process.Config.Discovery.DiscoveryGroup,
-		Emitter:            asyncEmitter,
-		AccessPoint:        accessPoint,
-		ServerID:           conn.HostUUID(),
-		Log:                process.logger,
-		ClusterName:        conn.ClusterName(),
-		ClusterFeatures:    process.GetClusterFeatures,
-		PollInterval:       process.Config.Discovery.PollInterval,
-		GetClientCert:      conn.ClientGetCertificate,
-		AccessGraphConfig:  accessGraphCfg,
-		PublicProxyAddress: publicProxyAddress,
+		DiscoveryGroup:    process.Config.Discovery.DiscoveryGroup,
+		Emitter:           asyncEmitter,
+		AccessPoint:       accessPoint,
+		ServerID:          conn.HostUUID(),
+		Log:               process.logger,
+		ClusterName:       conn.ClusterName(),
+		ClusterFeatures:   process.GetClusterFeatures,
+		PollInterval:      process.Config.Discovery.PollInterval,
+		GetClientCert:     conn.ClientGetCertificate,
+		AccessGraphConfig: accessGraphCfg,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -134,41 +128,6 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 
 	return nil
-}
-
-type proxiesGetter interface {
-	GetProxies() ([]types.Server, error)
-}
-
-func (process *TeleportProcess) publicProxyAddr(accessPoint proxiesGetter) (string, error) {
-	// If the proxy server is explicitly set, use that.
-	if !process.Config.ProxyServer.IsEmpty() {
-		return process.Config.ProxyServer.String(), nil
-	}
-
-	// If DiscoveryService is running alongside a Proxy, use the first
-	// public address of the Proxy.
-	if process.Config.Proxy.Enabled {
-		for _, proxyAddr := range process.Config.Proxy.PublicAddrs {
-			if !proxyAddr.IsEmpty() {
-				return proxyAddr.String(), nil
-			}
-		}
-	}
-
-	proxies, err := accessPoint.GetProxies()
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-	for _, proxy := range proxies {
-		for _, proxyAddr := range proxy.GetPublicAddrs() {
-			if proxyAddr != "" {
-				return proxyAddr, nil
-			}
-		}
-	}
-
-	return "", trace.NotFound("could not find the public proxy address for server discovery")
 }
 
 // integrationOnlyCredentials indicates whether the DiscoveryService must only use Cloud APIs credentials using an integration.

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -27,13 +27,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestTeleportProcessIntegrationsOnly(t *testing.T) {
@@ -166,81 +164,6 @@ func TestTeleportProcess_initDiscoveryService(t *testing.T) {
 			require.Equal(t, tt.want, accessGraphCfg)
 		})
 	}
-}
-func TestProcessPublicProxyAddr(t *testing.T) {
-	proxyServerWithPublicAddr := func(addr string) *types.ServerV2 {
-		return &types.ServerV2{
-			Spec: types.ServerSpecV2{
-				PublicAddrs: []string{addr},
-			},
-		}
-	}
-
-	tests := []struct {
-		name        string
-		config      *servicecfg.Config
-		proxyGetter proxiesGetter
-		wantAddr    string
-		errCheck    require.ErrorAssertionFunc
-	}{
-		{
-			name: "proxy server was set in config",
-			config: &servicecfg.Config{
-				ProxyServer: utils.NetAddr{Addr: "proxy.example.com:3080"},
-			},
-			wantAddr: "proxy.example.com:3080",
-			errCheck: require.NoError,
-		},
-		{
-			name: "proxy is running alongside discovery service",
-			config: &servicecfg.Config{
-				Proxy: servicecfg.ProxyConfig{
-					Enabled: true,
-					PublicAddrs: []utils.NetAddr{
-						{Addr: "public.proxy.com:443"},
-					},
-				},
-			},
-			wantAddr: "public.proxy.com:443",
-			errCheck: require.NoError,
-		},
-		{
-			name:   "discovery service is running alongside auth, (no proxy server defined and no proxy service enabled)",
-			config: &servicecfg.Config{},
-			proxyGetter: &mockProxyGetter{
-				servers: []types.Server{proxyServerWithPublicAddr("proxy.example:8080")},
-			},
-			wantAddr: "proxy.example:8080",
-			errCheck: require.NoError,
-		},
-		{
-			name:   "no proxy available",
-			config: &servicecfg.Config{},
-			proxyGetter: &mockProxyGetter{
-				servers: []types.Server{},
-			},
-			errCheck: require.Error,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			process := &TeleportProcess{
-				Config: tt.config,
-			}
-			addr, err := process.publicProxyAddr(tt.proxyGetter)
-			tt.errCheck(t, err)
-			require.Equal(t, tt.wantAddr, addr)
-		})
-	}
-}
-
-type mockProxyGetter struct {
-	servers []types.Server
-}
-
-func (f *mockProxyGetter) GetProxies() ([]types.Server, error) {
-	return f.servers, nil
 }
 
 type fakeClient struct {

--- a/lib/srv/discovery/config_test.go
+++ b/lib/srv/discovery/config_test.go
@@ -113,14 +113,6 @@ func TestConfigCheckAndSetDefaults(t *testing.T) {
 			postCheckAndSetDefaultsFunc: func(t *testing.T, c *Config) {},
 		},
 		{
-			name:          "missing public proxy address",
-			errAssertFunc: require.Error,
-			cfgChange: func(c *Config) {
-				c.PublicProxyAddress = ""
-			},
-			postCheckAndSetDefaultsFunc: func(t *testing.T, c *Config) {},
-		},
-		{
 			name:          "missing cluster features",
 			errAssertFunc: require.Error,
 			cfgChange: func(c *Config) {
@@ -145,8 +137,7 @@ func TestConfigCheckAndSetDefaults(t *testing.T) {
 				ClusterFeatures: func() proto.Features {
 					return proto.Features{}
 				},
-				DiscoveryGroup:     "test",
-				PublicProxyAddress: "proxy.example.com",
+				DiscoveryGroup: "test",
 			}
 			tt.cfgChange(cfg)
 			err := cfg.CheckAndSetDefaults()

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -273,13 +273,12 @@ func TestDiscoveryServerEKS(t *testing.T) {
 						AWSConfigProvider: fakeConfigProvider,
 						eksClusters:       tt.eksClusters,
 					},
-					ClusterFeatures:    func() proto.Features { return proto.Features{} },
-					AccessPoint:        mockAccessPoint,
-					Matchers:           Matchers{},
-					Emitter:            tt.emitter,
-					DiscoveryGroup:     defaultDiscoveryGroup,
-					Log:                logtest.NewLogger(),
-					PublicProxyAddress: "proxy.example.com",
+					ClusterFeatures: func() proto.Features { return proto.Features{} },
+					AccessPoint:     mockAccessPoint,
+					Matchers:        Matchers{},
+					Emitter:         tt.emitter,
+					DiscoveryGroup:  defaultDiscoveryGroup,
+					Log:             logtest.NewLogger(),
 				})
 				require.NoError(t, err)
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -408,10 +408,9 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 					Matchers: Matchers{
 						AWS: tc.awsMatchers,
 					},
-					Emitter:            authClient,
-					Log:                logtest.NewLogger(),
-					DiscoveryGroup:     mainDiscoveryGroup,
-					PublicProxyAddress: "proxy.example.com",
+					Emitter:        authClient,
+					Log:            logtest.NewLogger(),
+					DiscoveryGroup: mainDiscoveryGroup,
 				})
 
 			require.NoError(t, err)


### PR DESCRIPTION
If teleport is started with just Auth and Discovery in the same process, the Public Proxy Addr is not available.

Even tho this means that Discovery will not be able to enroll Servers, this is a valid set up.

When the Proxy becomes available, the next Discovery iteration will correctly enroll servers.

Not adding a changelog because this didn't made into any release branch.

Thank you @smallinsky for reporting this early.