### PR TITLE
Switch `tbot` to using internal rolesanywhere credential exchange implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -217,7 +217,6 @@ require (
 	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/snowflakedb/gosnowflake v1.17.0
 	github.com/spf13/cobra v1.10.1
-	github.com/spiffe/aws-spiffe-workload-helper v0.0.4
 	github.com/spiffe/go-spiffe/v2 v2.6.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.39.0
@@ -327,7 +326,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.29.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.1 // indirect
-	github.com/aws/rolesanywhere-credential-helper v1.2.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -912,8 +912,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.38.6 h1:p3jIvqYwUZgu/XYeI48bJxOhvm47
 github.com/aws/aws-sdk-go-v2/service/sts v1.38.6/go.mod h1:WtKK+ppze5yKPkZ0XwqIVWD4beCwv056ZbPQNoeHqM8=
 github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v1.1.0 h1:EJsHUYgFBV7/N1YtL73lsfZODAOU+CnNSZfEAlqqQaA=
 github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v1.1.0/go.mod h1:AxKuXHc0zv2yYaeueUG7R3ONbcnQIuDj0bkdFmPVRzU=
-github.com/aws/rolesanywhere-credential-helper v1.2.0 h1:eLqJvSznH8nJk48dwFc0raWOpbTGgBeNYH3Q8UQFVx4=
-github.com/aws/rolesanywhere-credential-helper v1.2.0/go.mod h1:YRxmRrAaqbVVXPNH1gHT76nWaMGvpAziHAHw8UwKrpU=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.23.0 h1:8n6I3gXzWJB2DxBDnfxgBaSX6oe0d/t10qGz7OKqMCE=
 github.com/aws/smithy-go v1.23.0/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
@@ -2130,8 +2128,6 @@ github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.20.1 h1:ZMi+z/lvLyPSCoNtFCpqjy0S4kPbirhpTMwl8BkW9X4=
 github.com/spf13/viper v1.20.1/go.mod h1:P9Mdzt1zoHIG8m2eZQinpiBjo6kCmZSKBClNNqjJvu4=
-github.com/spiffe/aws-spiffe-workload-helper v0.0.4 h1:P39B0/nXbSHm2WIBkHgKYclGzu2AZVjTA5keEa6CnOk=
-github.com/spiffe/aws-spiffe-workload-helper v0.0.4/go.mod h1:off3o6L61qUpoyoHIBSC7W75EVzAwMIRr2Va6Oy9988=
 github.com/spiffe/go-spiffe/v2 v2.6.0 h1:l+DolpxNWYgruGQVV0xsfeya3CsC7m8iBzDnMpsbLuo=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/lib/integrations/awsra/createsession/createsession.go
+++ b/lib/integrations/awsra/createsession/createsession.go
@@ -145,16 +145,16 @@ func (req *CreateSessionRequest) checkAndSetDefaults() error {
 // > algorithm is used. This, in turn, is determined by the key bound to the
 // > signing certificate.
 const (
-	awsV4X509RSASHA256   = "AWS4-X509-RSA-SHA256"
-	awsV4X509ECDSASHA256 = "AWS4-X509-ECDSA-SHA256"
+	algoRSA   = "AWS4-X509-RSA-SHA256"
+	algoECDSA = "AWS4-X509-ECDSA-SHA256"
 )
 
 func algoForKey(key crypto.Signer) (string, error) {
 	switch key.(type) {
 	case *rsa.PrivateKey:
-		return awsV4X509RSASHA256, nil
+		return algoRSA, nil
 	case *ecdsa.PrivateKey:
-		return awsV4X509ECDSASHA256, nil
+		return algoECDSA, nil
 	default:
 		return "", trace.BadParameter("unsupported key type: %T", key)
 	}

--- a/lib/integrations/awsra/createsession/createsession_test.go
+++ b/lib/integrations/awsra/createsession/createsession_test.go
@@ -186,7 +186,7 @@ func TestCreateSession(t *testing.T) {
 		}
 
 		req := baseReq()
-		req.httpClient = httpClient
+		req.HTTPClient = httpClient
 		req.clock = clock
 		req.Certificate = x509Cert
 		req.PrivateKey = privateKey

--- a/lib/tbot/services/awsra/config.go
+++ b/lib/tbot/services/awsra/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -91,10 +92,9 @@ type Config struct {
 	// it.
 	OverwriteCredentialFile bool `yaml:"overwrite_credential_file,omitempty"`
 
-	// EndpointOverride is the endpoint to use for the AWS Roles Anywhere service.
-	// This is designed to be leveraged by tests and unset in production
-	// circumstances.
-	EndpointOverride string `yaml:"-"`
+	// ClientOverride is designed to be leveraged by tests and unset in
+	// production circumstances.
+	ClientOverride utils.HTTPDoClient `yaml:"-"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/56114

This drops another dependency on the v1 of the AWS SDK, getting us one step closer to banishing it from Teleport for good 🚀 

To do this, I had to extend our internal rolesanywhere implementation to support certificate chains and RSA algorithm - but this was fairly trivial.

With some luck, this has actually removed v1 of the SDK from the tbot binary as well:

```
Before:
➤  ls -lah build/tbot
-rwxr-xr-x@ 1 noah  staff   109M Oct 22 13:09 build/tbot
➤  strings build/tbot | grep github.com/aws/aws-sdk-go/
.... many many lines ...
After:
➤  ls -lah build/tbot
-rwxr-xr-x@ 1 noah  staff   105M Oct 22 13:08 build/tbot
➤  strings build/tbot | grep github.com/aws/aws-sdk-go/
... nothing! ...
```