### PR TITLE
Connect: do not use cluster from profile as root cluster name

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
@@ -151,7 +151,9 @@ type Cluster struct {
 	// For leaf clusters, it has the form of /clusters/:rootClusterId/leaves/:leafClusterId where
 	// leafClusterId is equal to the name property of the cluster.
 	Uri string `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
-	// name is used throughout the Teleport Connect codebase as the cluster name.
+	// name is a site name of Teleport cluster.
+	// Only present in root clusters if the user has logged in (the name comes from the key).
+	// Always available for leaf clusters.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// proxy_host is address of the proxy used to connect to this cluster.
 	// Always includes port number. Present only for root clusters.

--- a/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
@@ -152,7 +152,7 @@ type Cluster struct {
 	// leafClusterId is equal to the name property of the cluster.
 	Uri string `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
 	// name is the site name of Teleport cluster.
-	// Only present in root clusters if the user has logged in (the name comes from the cluster).
+	// Only present in root clusters if the user has logged in (the name comes from the certificate).
 	// Always available for leaf clusters.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// proxy_host is address of the proxy used to connect to this cluster.

--- a/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
@@ -151,8 +151,8 @@ type Cluster struct {
 	// For leaf clusters, it has the form of /clusters/:rootClusterId/leaves/:leafClusterId where
 	// leafClusterId is equal to the name property of the cluster.
 	Uri string `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
-	// name is a site name of Teleport cluster.
-	// Only present in root clusters if the user has logged in (the name comes from the key).
+	// name is the site name of Teleport cluster.
+	// Only present in root clusters if the user has logged in (the name comes from the cluster).
 	// Always available for leaf clusters.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
 	// proxy_host is address of the proxy used to connect to this cluster.

--- a/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
@@ -50,7 +50,9 @@ export interface Cluster {
      */
     uri: string;
     /**
-     * name is used throughout the Teleport Connect codebase as the cluster name.
+     * name is a site name of Teleport cluster.
+     * Only present in root clusters if the user has logged in (the name comes from the key).
+     * Always available for leaf clusters.
      *
      * @generated from protobuf field: string name = 2;
      */

--- a/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
@@ -50,8 +50,8 @@ export interface Cluster {
      */
     uri: string;
     /**
-     * name is a site name of Teleport cluster.
-     * Only present in root clusters if the user has logged in (the name comes from the key).
+     * name is the site name of Teleport cluster.
+     * Only present in root clusters if the user has logged in (the name comes from the cluster).
      * Always available for leaf clusters.
      *
      * @generated from protobuf field: string name = 2;

--- a/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
@@ -51,7 +51,7 @@ export interface Cluster {
     uri: string;
     /**
      * name is the site name of Teleport cluster.
-     * Only present in root clusters if the user has logged in (the name comes from the cluster).
+     * Only present in root clusters if the user has logged in (the name comes from the certificate).
      * Always available for leaf clusters.
      *
      * @generated from protobuf field: string name = 2;

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -213,6 +213,10 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 		clusterNameForKey = leafClusterName
 		clusterURI = clusterURI.AppendLeafCluster(leafClusterName)
 		cfg.SiteName = leafClusterName
+	} else {
+		// Reset SiteName as it may reference a leaf cluster.
+		// The correct root cluster value will be set during loadProfileStatusAndClusterKey.
+		cfg.SiteName = ""
 	}
 
 	clusterClient, err := client.NewClient(cfg)
@@ -243,13 +247,28 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 	status := &client.ProfileStatus{}
 
 	// load profile status if key exists
-	_, err := clusterClient.LocalAgent().GetKeyRing(clusterNameForKey)
+	key, err := clusterClient.LocalAgent().GetKeyRing(clusterNameForKey)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			s.Logger.InfoContext(context.Background(), "No keys found for cluster", "cluster", clusterNameForKey)
 		} else {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	// If the key exists, and clusterClient is a root cluster client,
+	// extract the name from the key.
+	// We don't use SiteName from the profile as it can be changed
+	// through "tsh login leaf", so we would return a client that incorrectly
+	// points to the leaf cluster.
+	if err == nil && clusterClient.Config.SiteName == "" {
+		var rootClusterName string
+		rootClusterName, err = key.RootClusterName()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		clusterClient.Config.SiteName = rootClusterName
+		clusterClient.SiteName = rootClusterName
 	}
 
 	if err == nil && clusterClient.Username != "" {

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -214,8 +214,9 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, *c
 		clusterURI = clusterURI.AppendLeafCluster(leafClusterName)
 		cfg.SiteName = leafClusterName
 	} else {
-		// Reset SiteName as it may reference a leaf cluster.
-		// The correct root cluster value will be set during loadProfileStatusAndClusterKey.
+		// Reset SiteName as it may reference a leaf cluster (the cluster can be changed
+		// through "tsh login <leaf>").
+		// The correct root cluster value will be set in loadProfileStatusAndClusterKey.
 		cfg.SiteName = ""
 	}
 
@@ -259,7 +260,7 @@ func (s *Storage) loadProfileStatusAndClusterKey(clusterClient *client.TeleportC
 	// If the key exists, and clusterClient is a root cluster client,
 	// extract the name from the key.
 	// We don't use SiteName from the profile as it can be changed
-	// through "tsh login leaf", so we would return a client that incorrectly
+	// through "tsh login <leaf>", so we would return a client that incorrectly
 	// points to the leaf cluster.
 	if err == nil && clusterClient.Config.SiteName == "" {
 		var rootClusterName string

--- a/proto/teleport/lib/teleterm/v1/cluster.proto
+++ b/proto/teleport/lib/teleterm/v1/cluster.proto
@@ -34,7 +34,9 @@ message Cluster {
   // For leaf clusters, it has the form of /clusters/:rootClusterId/leaves/:leafClusterId where
   // leafClusterId is equal to the name property of the cluster.
   string uri = 1;
-  // name is used throughout the Teleport Connect codebase as the cluster name.
+  // name is the site name of Teleport cluster.
+  // Only present in root clusters if the user has logged in (the name comes from the key).
+  // Always available for leaf clusters.
   string name = 2;
   // proxy_host is address of the proxy used to connect to this cluster.
   // Always includes port number. Present only for root clusters.

--- a/proto/teleport/lib/teleterm/v1/cluster.proto
+++ b/proto/teleport/lib/teleterm/v1/cluster.proto
@@ -35,7 +35,7 @@ message Cluster {
   // leafClusterId is equal to the name property of the cluster.
   string uri = 1;
   // name is the site name of Teleport cluster.
-  // Only present in root clusters if the user has logged in (the name comes from the cluster).
+  // Only present in root clusters if the user has logged in (the name comes from the certificate).
   // Always available for leaf clusters.
   string name = 2;
   // proxy_host is address of the proxy used to connect to this cluster.

--- a/proto/teleport/lib/teleterm/v1/cluster.proto
+++ b/proto/teleport/lib/teleterm/v1/cluster.proto
@@ -35,7 +35,7 @@ message Cluster {
   // leafClusterId is equal to the name property of the cluster.
   string uri = 1;
   // name is the site name of Teleport cluster.
-  // Only present in root clusters if the user has logged in (the name comes from the key).
+  // Only present in root clusters if the user has logged in (the name comes from the cluster).
   // Always available for leaf clusters.
   string name = 2;
   // proxy_host is address of the proxy used to connect to this cluster.

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -312,9 +312,6 @@ function WidgetAndDetails(storyProps: StoryProps) {
         <WidgetView
           platform={storyProps.platform}
           updateEvent={state}
-          clusterGetter={{
-            findCluster: () => undefined,
-          }}
           onMore={() => {}}
           onDownload={() => {}}
           onInstall={() => {}}
@@ -332,9 +329,6 @@ function WidgetAndDetails(storyProps: StoryProps) {
         <DetailsView
           platform={storyProps.platform}
           updateEvent={state}
-          clusterGetter={{
-            findCluster: () => undefined,
-          }}
           changeManagingCluster={() => {}}
           onCheckForUpdates={() => {}}
           onDownload={() => {}}

--- a/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
@@ -164,13 +164,13 @@ function makeOptions({
     value: '',
   };
 
-  const getClusterName = (uri: RootClusterUri) => routing.parseClusterName(uri);
+  const getProfileName = (uri: RootClusterUri) => routing.parseClusterName(uri);
 
   const candidateClusters = status.options.clusters
     .filter(c => c.toolsAutoUpdate)
     .map(c => {
       const otherCompatibleClusters = c.otherCompatibleClusters.map(c =>
-        getClusterName(c)
+        getProfileName(c)
       );
       const compatibility = otherCompatibleClusters.length
         ? `Also compatible with ${pluralize(otherCompatibleClusters.length, 'cluster')} ${listFormatter.format(otherCompatibleClusters.toSorted())}.`
@@ -178,7 +178,7 @@ function makeOptions({
 
       return {
         disabled,
-        label: getClusterName(c.clusterUri),
+        label: getProfileName(c.clusterUri),
         helperText: [`Teleport Connect ${c.toolsVersion}`, compatibility]
           .filter(Boolean)
           .join(' · '),
@@ -191,7 +191,7 @@ function makeOptions({
     .map(c => {
       return {
         disabled,
-        label: getClusterName(c.clusterUri),
+        label: getProfileName(c.clusterUri),
         helperText: (
           <>
             Teleport Connect {c.toolsVersion}
@@ -206,7 +206,7 @@ function makeOptions({
   const unreachableClusters = status.options.unreachableClusters.map(
     cluster => ({
       disabled,
-      label: getClusterName(cluster.clusterUri),
+      label: getProfileName(cluster.clusterUri),
       helperText: (
         <UnreachableClusterHelper
           onRetry={onRetry}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.test.tsx
@@ -52,9 +52,6 @@ test('download button is available when autoDownload is false', async () => {
           },
         }
       )}
-      clusterGetter={{
-        findCluster: () => undefined,
-      }}
       platform="darwin"
       onCheckForUpdates={() => {}}
       onDownload={() => {}}
@@ -99,9 +96,6 @@ test('when there are multiple clusters available, managing cluster can be select
           ],
         },
       })}
-      clusterGetter={{
-        findCluster: () => undefined,
-      }}
       platform="darwin"
       onCheckForUpdates={() => {}}
       onDownload={() => {}}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -39,7 +39,6 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { AutoUpdatesManagement } from './AutoUpdatesManagement';
 import {
-  ClusterGetter,
   formatMB,
   iconMac,
   iconWinLinux,
@@ -55,7 +54,6 @@ import {
  */
 export function DetailsView({
   changeManagingCluster,
-  clusterGetter,
   updateEvent,
   platform,
   onCheckForUpdates,
@@ -65,7 +63,6 @@ export function DetailsView({
 }: {
   updateEvent: AppUpdateEvent;
   platform: Platform;
-  clusterGetter: ClusterGetter;
   onCheckForUpdates(): void;
   onInstall(): void;
   onDownload(): void;
@@ -76,7 +73,6 @@ export function DetailsView({
     <Stack gap={3} width="100%">
       {updateEvent.autoUpdatesStatus && (
         <AutoUpdatesManagement
-          clusterGetter={clusterGetter}
           status={updateEvent.autoUpdatesStatus}
           updateEventKind={updateEvent.kind}
           onCheckForUpdates={onCheckForUpdates}

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.test.tsx
@@ -52,9 +52,6 @@ test('download button is available when autoDownload is false', async () => {
           },
         }
       )}
-      clusterGetter={{
-        findCluster: () => undefined,
-      }}
       platform="darwin"
       onDownload={() => {}}
       onMore={() => {}}
@@ -95,9 +92,6 @@ test('error is displayed when cluster specify incompatible versions', async () =
           unreachableClusters: [],
         },
       })}
-      clusterGetter={{
-        findCluster: () => undefined,
-      }}
       platform="darwin"
       onDownload={() => {}}
       onMore={() => {}}

--- a/web/packages/teleterm/src/ui/AppUpdater/common.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/common.ts
@@ -17,11 +17,10 @@
  */
 
 import { UnreachableCluster } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
-import { Cluster as TshdCluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { pluralize } from 'shared/utils/text';
 
 import { AppUpdateEvent } from 'teleterm/services/appUpdater';
-import { RootClusterUri, routing } from 'teleterm/ui/uri';
+import { routing } from 'teleterm/ui/uri';
 
 import iconWinLinux from '../../../build_resources/icon-linux/512x512.png';
 import iconMac from '../../../build_resources/icon-mac.png';
@@ -50,27 +49,17 @@ export function isTeleportDownloadHost(host: string): boolean {
   return host === 'cdn.teleport.dev';
 }
 
-export interface ClusterGetter {
-  findCluster(clusterUri: RootClusterUri): TshdCluster | undefined;
-}
-
-export const clusterNameGetter =
-  (clusterService: ClusterGetter) => (clusterUri: RootClusterUri) =>
-    clusterService.findCluster(clusterUri)?.name ||
-    routing.parseClusterName(clusterUri);
-
 const listFormatter = new Intl.ListFormat('en', {
   style: 'long',
   type: 'conjunction',
 });
 
 export function makeUnreachableClusterText(
-  unreachableClusters: UnreachableCluster[],
-  getClusterName: (clusterUri: RootClusterUri) => string
+  unreachableClusters: UnreachableCluster[]
 ) {
   return (
     `Unable to retrieve accepted client versions` +
     ` from the ${pluralize(unreachableClusters.length, 'cluster')}` +
-    ` ${listFormatter.format(unreachableClusters.map(c => getClusterName(c.clusterUri)))}.`
+    ` ${listFormatter.format(unreachableClusters.map(c => routing.parseClusterName(c.clusterUri)))}.`
   );
 }

--- a/web/packages/teleterm/src/ui/AppUpdater/index.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/index.ts
@@ -19,4 +19,3 @@
 export * from './DetailsView';
 export * from './WidgetView';
 export * from './AppUpdaterContext';
-export { type ClusterGetter } from './common';

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -92,7 +92,6 @@ function ClusterLoginForm({
   platform,
   next,
   refCallback,
-  clusterGetter,
   changeAppUpdatesManagingCluster,
   appUpdateEvent,
   cancelAppUpdateDownload,
@@ -155,7 +154,6 @@ function ClusterLoginForm({
             shouldSkipVersionCheck={shouldSkipVersionCheck}
             disableVersionCheck={disableVersionCheck}
             platform={platform}
-            clusterGetter={clusterGetter}
             checkForAppUpdates={checkForAppUpdates}
             changeAppUpdatesManagingCluster={changeAppUpdatesManagingCluster}
             appUpdateEvent={appUpdateEvent}
@@ -179,7 +177,6 @@ const AppUpdateDetails = ({
   quitAndInstallAppUpdate,
   changeAppUpdatesManagingCluster,
   appUpdateEvent,
-  clusterGetter,
   onCloseDialog,
   prev,
 }: ClusterLoginPresentationProps & StepComponentProps) => {
@@ -206,7 +203,6 @@ const AppUpdateDetails = ({
           updateEvent={appUpdateEvent}
           onDownload={() => downloadAppUpdate()}
           onCancelDownload={() => cancelAppUpdateDownload()}
-          clusterGetter={clusterGetter}
           onCheckForUpdates={() => checkForAppUpdates()}
         />
       </Flex>

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/FormLogin/FormLogin.tsx
@@ -31,7 +31,7 @@ import type { PrimaryAuthType } from 'shared/services';
 
 import { Platform } from 'teleterm/mainProcess/types';
 import { AppUpdateEvent } from 'teleterm/services/appUpdater';
-import { ClusterGetter, WidgetView } from 'teleterm/ui/AppUpdater';
+import { WidgetView } from 'teleterm/ui/AppUpdater';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { outermostPadding } from '../../spacing';
@@ -85,7 +85,6 @@ export default function LoginForm(props: Props) {
     onInstall: () => props.quitAndInstallAppUpdate(),
     platform: props.platform,
     onMore: () => props.switchToAppUpdateDetails(),
-    clusterGetter: props.clusterGetter,
   };
   const ssoEnabled = authProviders?.length > 0;
 
@@ -349,7 +348,6 @@ export type Props = {
   checkForAppUpdates(): Promise<void>;
   quitAndInstallAppUpdate(): void;
   changeAppUpdatesManagingCluster(clusterUri: RootClusterUri): Promise<void>;
-  clusterGetter: ClusterGetter;
 };
 
 const OutermostPadding = styled(Box).attrs({ px: outermostPadding })``;

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -83,9 +83,6 @@ export function makeProps(
     changeAppUpdatesManagingCluster: async () => {},
     checkForAppUpdates: async () => {},
     downloadAppUpdate: async () => {},
-    clusterGetter: {
-      findCluster: () => undefined,
-    },
     quitAndInstallAppUpdate: async () => {},
     cancelAppUpdateDownload: async () => {},
     appUpdateEvent: {

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/useClusterLogin.ts
@@ -33,7 +33,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useAppUpdaterContext } from 'teleterm/ui/AppUpdater';
 import { IAppContext } from 'teleterm/ui/types';
 import * as uri from 'teleterm/ui/uri';
-import { RootClusterUri } from 'teleterm/ui/uri';
+import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 export type SsoPrompt =
   /**
@@ -190,7 +190,7 @@ export function useClusterLogin(props: Props) {
   return {
     ssoPrompt,
     passwordlessLoginState,
-    title: cluster?.name,
+    title: routing.parseClusterName(clusterUri),
     loggedInUserName,
     onLoginWithLocal,
     onLoginWithPasswordless,
@@ -211,10 +211,6 @@ export function useClusterLogin(props: Props) {
     quitAndInstallAppUpdate: mainProcessClient.quitAndInstallAppUpdate,
     changeAppUpdatesManagingCluster:
       mainProcessClient.changeAppUpdatesManagingCluster,
-    clusterGetter: {
-      findCluster: (clusterUri: RootClusterUri) =>
-        clustersService.findCluster(clusterUri),
-    },
   };
 }
 

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
@@ -27,11 +27,7 @@ export default {
 export const Story = () => {
   return (
     <MockAppContextProvider>
-      <ClusterLogout
-        onClose={() => {}}
-        clusterUri="/clusters/foo"
-        clusterTitle="foo"
-      />
+      <ClusterLogout onClose={() => {}} clusterUri="/clusters/foo" />
     </MockAppContextProvider>
   );
 };

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -28,17 +28,15 @@ import { P } from 'design/Text/Text';
 import { useAsync } from 'shared/hooks/useAsync';
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-import { RootClusterUri } from 'teleterm/ui/uri';
+import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 import { logoutWithCleanup } from './logoutWithCleanup';
 
 export function ClusterLogout({
   clusterUri,
   onClose,
-  clusterTitle,
   hidden,
 }: {
-  clusterTitle: string;
   clusterUri: RootClusterUri;
   hidden?: boolean;
   onClose(): void;
@@ -54,6 +52,8 @@ export function ClusterLogout({
       onClose();
     }
   }
+
+  const profileName = routing.parseClusterName(clusterUri);
 
   return (
     <DialogConfirmation
@@ -72,7 +72,7 @@ export function ClusterLogout({
         }}
       >
         <DialogHeader justifyContent="space-between">
-          <H2 style={{ whiteSpace: 'nowrap' }}>Log out from {clusterTitle}</H2>
+          <H2 style={{ whiteSpace: 'nowrap' }}>Log out from {profileName}</H2>
           <ButtonIcon
             type="button"
             disabled={status === 'processing'}

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.story.tsx
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
-
 import { DocumentsReopen } from './DocumentsReopen';
 
 export default {
@@ -26,55 +24,47 @@ export default {
 
 export const Story = () => {
   return (
-    <MockAppContextProvider>
-      <DocumentsReopen
-        rootClusterUri="/clusters/foo.cloud.gravitational.io"
-        numberOfDocuments={8}
-        onConfirm={() => {}}
-        onDiscard={() => {}}
-      />
-    </MockAppContextProvider>
+    <DocumentsReopen
+      rootClusterUri="/clusters/foo.cloud.gravitational.io"
+      numberOfDocuments={8}
+      onConfirm={() => {}}
+      onDiscard={() => {}}
+    />
   );
 };
 
 export const OneTab = () => {
   return (
-    <MockAppContextProvider>
-      <DocumentsReopen
-        rootClusterUri="/clusters/foo.cloud.gravitational.io"
-        numberOfDocuments={1}
-        onConfirm={() => {}}
-        onDiscard={() => {}}
-      />
-    </MockAppContextProvider>
+    <DocumentsReopen
+      rootClusterUri="/clusters/foo.cloud.gravitational.io"
+      numberOfDocuments={1}
+      onConfirm={() => {}}
+      onDiscard={() => {}}
+    />
   );
 };
 
 export const LongClusterName = () => {
   return (
-    <MockAppContextProvider>
-      <DocumentsReopen
-        rootClusterUri="/clusters/foo.bar.baz.quux.cloud.gravitational.io"
-        numberOfDocuments={42}
-        onConfirm={() => {}}
-        onDiscard={() => {}}
-      />
-    </MockAppContextProvider>
+    <DocumentsReopen
+      rootClusterUri="/clusters/foo.bar.baz.quux.cloud.gravitational.io"
+      numberOfDocuments={42}
+      onConfirm={() => {}}
+      onDiscard={() => {}}
+    />
   );
 };
 
 export const LongContinuousClusterName = () => {
   return (
-    <MockAppContextProvider>
-      <DocumentsReopen
-        rootClusterUri={`/clusters/${Array(10)
-          .fill(['foo', 'bar', 'baz', 'quux'], 0)
-          .flat()
-          .join('')}`}
-        numberOfDocuments={680}
-        onConfirm={() => {}}
-        onDiscard={() => {}}
-      />
-    </MockAppContextProvider>
+    <DocumentsReopen
+      rootClusterUri={`/clusters/${Array(10)
+        .fill(['foo', 'bar', 'baz', 'quux'], 0)
+        .flat()
+        .join('')}`}
+      numberOfDocuments={680}
+      onConfirm={() => {}}
+      onDiscard={() => {}}
+    />
   );
 };

--- a/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
+++ b/web/packages/teleterm/src/ui/DocumentsReopen/DocumentsReopen.tsx
@@ -26,7 +26,6 @@ import { Cross } from 'design/Icon';
 import { P } from 'design/Text/Text';
 import { pluralize } from 'shared/utils/text';
 
-import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 export function DocumentsReopen(props: {
@@ -37,12 +36,7 @@ export function DocumentsReopen(props: {
   hidden?: boolean;
 }) {
   const { rootClusterUri } = props;
-  const { clustersService } = useAppContext();
-  // TODO(ravicious): Use a profile name here from the URI and remove the dependency on
-  // clustersService. https://github.com/gravitational/teleport/issues/33733
-  const clusterName =
-    clustersService.findCluster(rootClusterUri)?.name ||
-    routing.parseClusterName(rootClusterUri);
+  const clusterName = routing.parseClusterName(rootClusterUri);
 
   return (
     <DialogConfirmation

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessAuthentication.tsx
@@ -22,6 +22,7 @@ import { HeadlessAuthenticationState } from 'gen-proto-ts/teleport/lib/teleterm/
 import { useAsync } from 'shared/hooks/useAsync';
 
 import { cloneAbortSignal } from 'teleterm/services/tshd/cloneableClient';
+import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
@@ -38,9 +39,8 @@ interface HeadlessAuthenticationProps {
 }
 
 export function HeadlessAuthentication(props: HeadlessAuthenticationProps) {
-  const { headlessAuthenticationService, clustersService } = useAppContext();
+  const { headlessAuthenticationService } = useAppContext();
   const refAbortCtrl = useRef(new AbortController());
-  const cluster = clustersService.findCluster(props.rootClusterUri);
 
   const [updateHeadlessStateAttempt, updateHeadlessState] = useAsync(
     (state: HeadlessAuthenticationState) =>
@@ -81,7 +81,7 @@ export function HeadlessAuthentication(props: HeadlessAuthenticationProps) {
   return (
     <HeadlessPrompt
       hidden={props.hidden}
-      cluster={cluster}
+      rootClusterUri={rootClusterUri}
       clientIp={props.clientIp}
       skipConfirm={props.skipConfirm}
       onApprove={handleHeadlessApprove}

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.story.tsx
@@ -18,7 +18,7 @@
 
 import { makeEmptyAttempt } from 'shared/hooks/useAsync';
 
-import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
 
 import { HeadlessPrompt } from './HeadlessPrompt';
 
@@ -28,7 +28,7 @@ export default {
 
 export const Story = () => (
   <HeadlessPrompt
-    cluster={makeRootCluster()}
+    rootClusterUri={rootClusterUri}
     clientIp="localhost"
     skipConfirm={false}
     onApprove={async () => {}}

--- a/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
+++ b/web/packages/teleterm/src/ui/HeadlessAuthn/HeadlessPrompt/HeadlessPrompt.tsx
@@ -37,12 +37,12 @@ import * as Icons from 'design/Icon';
 import { P, P3 } from 'design/Text/Text';
 import { Attempt } from 'shared/hooks/useAsync';
 
-import type * as tsh from 'teleterm/services/tshd/types';
 import svgHardwareKey from 'teleterm/ui/ClusterConnect/ClusterLogin/FormLogin/PromptPasswordless/hardware.svg';
 import { LinearProgress } from 'teleterm/ui/components/LinearProgress';
+import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 export type HeadlessPromptProps = {
-  cluster: tsh.Cluster;
+  rootClusterUri: RootClusterUri;
   clientIp: string;
   skipConfirm: boolean;
   onApprove(): Promise<void>;
@@ -62,7 +62,7 @@ export type HeadlessPromptProps = {
 };
 
 export function HeadlessPrompt({
-  cluster,
+  rootClusterUri,
   clientIp,
   skipConfirm,
   onApprove,
@@ -88,7 +88,7 @@ export function HeadlessPrompt({
     >
       <DialogHeader justifyContent="space-between" mb={0} alignItems="baseline">
         <H2 mb={4}>
-          Headless command on <b>{cluster.name}</b>
+          Headless command on <b>{routing.parseClusterName(rootClusterUri)}</b>
         </H2>
         <ButtonIcon
           type="button"

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -108,7 +108,6 @@ function renderDialog({
         <ClusterLogout
           hidden={hidden}
           clusterUri={dialog.clusterUri}
-          clusterTitle={dialog.clusterTitle}
           onClose={handleClose}
         />
       );

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/AppUpdates.tsx
@@ -73,7 +73,6 @@ export function AppUpdates(props: { hidden?: boolean; onClose(): void }) {
         <DetailsView
           platform={platform}
           updateEvent={updateEvent}
-          clusterGetter={appContext.clustersService}
           onCancelDownload={() => void cancelAppUpdateDownload()}
           onDownload={() => void downloadAppUpdate()}
           onCheckForUpdates={() => void checkForAppUpdates()}

--- a/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/modals/ReAuthenticate/ReAuthenticate.tsx
@@ -77,22 +77,17 @@ export const ReAuthenticate: FC<{
 
   const { clusterUri } = req;
   const { clustersService } = useAppContext();
-  // TODO(ravicious): Use a profile name here from the URI and remove the dependency on
-  // clustersService. https://github.com/gravitational/teleport/issues/33733
   const rootClusterUri = routing.ensureRootClusterUri(clusterUri);
   const rootCluster = clustersService.findRootClusterByResource(rootClusterUri);
-  const rootClusterName =
-    rootCluster?.name || routing.parseClusterName(rootClusterUri);
+  const rootClusterName = routing.parseClusterName(rootClusterUri);
   const rootClusterProxyHost =
     // As a fallback, we read the proxy hostname from the URI. One small issue is that URIs don't
     // include the port number, so if the actual proxy host has a port number other than 443,
     // rootClusterProxyHost will not point to the proxy service.
     // In practice though we should not end up in a situation where this modal is shown but the
     // cluster does not exist in the app.
-    rootCluster?.proxyHost || routing.parseClusterName(rootClusterUri);
-  const clusterName =
-    clustersService.findCluster(clusterUri)?.name ||
-    routing.parseClusterName(clusterUri);
+    rootCluster?.proxyHost || rootClusterName;
+  const clusterName = routing.parseClusterName(clusterUri);
   const isLeafCluster = routing.isLeafCluster(clusterUri);
 
   let $totpPrompt = (

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -51,6 +51,7 @@ import {
 } from 'teleterm/ui/Search/searchResult';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import * as uri from 'teleterm/ui/uri';
+import { routing } from 'teleterm/ui/uri';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
 import { useVnetContext } from 'teleterm/ui/Vnet';
@@ -103,8 +104,8 @@ export function ActionPicker(props: { input: ReactElement }) {
     (resourceUri: uri.ClusterOrResourceUri) => {
       const clusterUri = uri.routing.ensureClusterUri(resourceUri);
       const cluster = clustersService.findCluster(clusterUri);
-
-      return cluster ? cluster.name : uri.routing.parseClusterName(resourceUri);
+      // Name is empty if the user hasn't logged into that cluster yet.
+      return cluster?.name || uri.routing.parseClusterName(resourceUri);
     },
     [clustersService]
   );
@@ -540,7 +541,10 @@ function ClusterFilterItem(props: SearchResultItem<SearchResultCluster>) {
         Search only in{' '}
         <strong>
           <Highlight
-            text={props.searchResult.resource.name}
+            text={
+              props.searchResult.resource.name ||
+              routing.parseClusterName(props.searchResult.resource.uri)
+            }
             keywords={[props.searchResult.nameMatch]}
           />
         </strong>

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -51,7 +51,6 @@ import {
 } from 'teleterm/ui/Search/searchResult';
 import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import * as uri from 'teleterm/ui/uri';
-import { routing } from 'teleterm/ui/uri';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
 import { useVnetContext } from 'teleterm/ui/Vnet';
@@ -541,10 +540,7 @@ function ClusterFilterItem(props: SearchResultItem<SearchResultCluster>) {
         Search only in{' '}
         <strong>
           <Highlight
-            text={
-              props.searchResult.resource.name ||
-              routing.parseClusterName(props.searchResult.resource.uri)
-            }
+            text={props.searchResult.resource.name}
             keywords={[props.searchResult.nameMatch]}
           />
         </strong>

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -169,20 +169,25 @@ export function useFilterSearch() {
   return useCallback(
     (search: string, filters: SearchFilter[]): FilterSearchResult[] => {
       const getClusters = () => {
-        let clusters = clustersService.getClusters();
+        const clusters = clustersService.getClusters();
         // Cluster filter should not be visible if there is only one cluster
         if (clusters.length === 1) {
           return [];
         }
+        let clustersWithName = clusters.map(c => ({
+          ...c,
+          // Name is empty if the user hasn't logged into that cluster yet.
+          nameOrProfile: c.name || routing.parseClusterName(c.uri),
+        }));
         if (search) {
-          clusters = clusters.filter(cluster =>
-            cluster.name
+          clustersWithName = clustersWithName.filter(cluster =>
+            cluster.nameOrProfile
               .toLocaleLowerCase()
               .includes(search.toLocaleLowerCase())
           );
         }
-        return clusters.map(cluster => {
-          let score = getLengthScore(search, cluster.name);
+        return clustersWithName.map(cluster => {
+          let score = getLengthScore(search, cluster.nameOrProfile);
           if (
             cluster.uri ===
             workspacesService.getActiveWorkspace()?.localClusterUri

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -169,25 +169,25 @@ export function useFilterSearch() {
   return useCallback(
     (search: string, filters: SearchFilter[]): FilterSearchResult[] => {
       const getClusters = () => {
-        const clusters = clustersService.getClusters();
+        let clusters = clustersService.getClusters();
         // Cluster filter should not be visible if there is only one cluster
         if (clusters.length === 1) {
           return [];
         }
-        let clustersWithName = clusters.map(c => ({
+        clusters = clusters.map(c => ({
           ...c,
           // Name is empty if the user hasn't logged into that cluster yet.
-          nameOrProfile: c.name || routing.parseClusterName(c.uri),
+          name: c.name || routing.parseClusterName(c.uri),
         }));
         if (search) {
-          clustersWithName = clustersWithName.filter(cluster =>
-            cluster.nameOrProfile
+          clusters = clusters.filter(cluster =>
+            cluster.name
               .toLocaleLowerCase()
               .includes(search.toLocaleLowerCase())
           );
         }
-        return clustersWithName.map(cluster => {
-          let score = getLengthScore(search, cluster.nameOrProfile);
+        return clusters.map(cluster => {
+          let score = getLengthScore(search, cluster.name);
           if (
             cluster.uri ===
             workspacesService.getActiveWorkspace()?.localClusterUri

--- a/web/packages/teleterm/src/ui/StatusBar/useActiveDocumentClusterBreadcrumbs.ts
+++ b/web/packages/teleterm/src/ui/StatusBar/useActiveDocumentClusterBreadcrumbs.ts
@@ -62,8 +62,10 @@ export function useActiveDocumentClusterBreadcrumbs(): Breadcrumb[] {
   }
 
   return [
-    { name: rootCluster.name },
-    clusterUri !== rootClusterUri && { name: cluster.name },
+    { name: `${routing.parseClusterName(rootClusterUri)}` },
+    clusterUri !== rootClusterUri && {
+      name: routing.parseClusterName(clusterUri),
+    },
     {
       name: staticNameAndIcon.name,
       Icon: staticNameAndIcon.Icon,

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -27,7 +27,7 @@ import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { ProfileStatusError } from 'teleterm/ui/components/ProfileStatusError';
 import { WorkspaceColor } from 'teleterm/ui/services/workspacesService';
 import { DeviceTrustStatus } from 'teleterm/ui/TopBar/Identity/Identity';
-import { RootClusterUri } from 'teleterm/ui/uri';
+import { RootClusterUri, routing } from 'teleterm/ui/uri';
 
 import { ColorPicker } from './ColorPicker';
 import {
@@ -45,6 +45,7 @@ export function ActiveCluster(props: {
   onRefresh(): void;
   onLogout(): void;
 }) {
+  const clusterName = routing.parseClusterName(props.activeCluster.uri);
   return (
     <>
       <Flex p={3} pb={2} flexWrap="nowrap" gap={2} flexDirection="column">
@@ -56,21 +57,21 @@ export function ActiveCluster(props: {
               setColor={props.onChangeColor}
             />
             <TitleAndSubtitle
-              title={props.activeCluster.name}
+              title={clusterName}
               subtitle={props.activeCluster.loggedInUser?.name}
             />
           </Flex>
 
           <Flex flexDirection="row" alignItems="flex-start" gap={1}>
             <ButtonText
-              title={`Refresh session in ${props.activeCluster.name}`}
+              title={`Refresh session in ${clusterName}`}
               size="small"
               onClick={() => props.onRefresh()}
             >
               <Refresh size="small" />
             </ButtonText>
             <ButtonText
-              title={`Log out from ${props.activeCluster.name}`}
+              title={`Log out from ${clusterName}`}
               onClick={() => props.onLogout()}
               intent="danger"
               size="small"

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -32,7 +32,7 @@ import { RootClusterUri, routing } from 'teleterm/ui/uri';
 import { ColorPicker } from './ColorPicker';
 import {
   AddClusterItem,
-  getClusterLetter,
+  getProfileNameLetter,
   IdentityListItem,
   TitleAndSubtitle,
 } from './IdentityListItem';
@@ -52,7 +52,7 @@ export function ActiveCluster(props: {
         <Flex gap={4} justifyContent="space-between">
           <Flex alignItems="center" flex={1} minWidth="0" gap={2}>
             <ColorPicker
-              letter={getClusterLetter(props.activeCluster)}
+              letter={getProfileNameLetter(props.activeCluster)}
               color={props.activeColor}
               setColor={props.onChangeColor}
             />

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
@@ -27,6 +27,7 @@ import { ListItem } from 'teleterm/ui/components/ListItem';
 import { ProfileStatusError } from 'teleterm/ui/components/ProfileStatusError';
 import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 import { WorkspaceColor } from 'teleterm/ui/services/workspacesService';
+import { routing } from 'teleterm/ui/uri';
 
 import { UserIcon } from '../IdentitySelector/UserIcon';
 
@@ -49,6 +50,8 @@ export function IdentityListItem(props: {
     )
   );
 
+  const clusterName = routing.parseClusterName(props.cluster.uri);
+
   return (
     <StyledListItem
       onClick={props.onSelect}
@@ -56,13 +59,13 @@ export function IdentityListItem(props: {
         (e.key === 'Enter' || e.key === 'Space') && props.onSelect()
       }
       isActive={isActive}
-      title={`Switch to ${props.cluster.name}`}
+      title={`Switch to ${clusterName}`}
     >
       <Flex width="100%" justifyContent="space-between">
         <WithIconItem
           letter={getClusterLetter(props.cluster)}
           color={workspaceColor}
-          title={props.cluster.name}
+          title={clusterName}
           subtitle={props.cluster.loggedInUser?.name}
         />
         {props.onLogout && (
@@ -76,7 +79,7 @@ export function IdentityListItem(props: {
             `}
             p={1}
             ml={4}
-            title={`Log out from ${props.cluster.name}`}
+            title={`Log out from ${clusterName}`}
             onClick={e => {
               e.stopPropagation();
               props.onLogout();
@@ -167,5 +170,5 @@ export function TitleAndSubtitle(props: { title: string; subtitle?: string }) {
 }
 
 export function getClusterLetter(cluster: Cluster): string {
-  return cluster.name.at(0);
+  return routing.parseClusterName(cluster.uri).at(0);
 }

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityListItem.tsx
@@ -50,7 +50,7 @@ export function IdentityListItem(props: {
     )
   );
 
-  const clusterName = routing.parseClusterName(props.cluster.uri);
+  const profileName = routing.parseClusterName(props.cluster.uri);
 
   return (
     <StyledListItem
@@ -59,13 +59,13 @@ export function IdentityListItem(props: {
         (e.key === 'Enter' || e.key === 'Space') && props.onSelect()
       }
       isActive={isActive}
-      title={`Switch to ${clusterName}`}
+      title={`Switch to ${profileName}`}
     >
       <Flex width="100%" justifyContent="space-between">
         <WithIconItem
-          letter={getClusterLetter(props.cluster)}
+          letter={getProfileNameLetter(props.cluster)}
           color={workspaceColor}
-          title={clusterName}
+          title={profileName}
           subtitle={props.cluster.loggedInUser?.name}
         />
         {props.onLogout && (
@@ -79,7 +79,7 @@ export function IdentityListItem(props: {
             `}
             p={1}
             ml={4}
-            title={`Log out from ${clusterName}`}
+            title={`Log out from ${profileName}`}
             onClick={e => {
               e.stopPropagation();
               props.onLogout();
@@ -169,6 +169,6 @@ export function TitleAndSubtitle(props: { title: string; subtitle?: string }) {
   );
 }
 
-export function getClusterLetter(cluster: Cluster): string {
+export function getProfileNameLetter(cluster: Cluster): string {
   return routing.parseClusterName(cluster.uri).at(0);
 }

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
@@ -25,6 +25,7 @@ import { WorkspaceColor } from 'teleterm/ui/services/workspacesService';
 import { ConnectionStatusIndicator } from 'teleterm/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator';
 import { DeviceTrustStatus } from 'teleterm/ui/TopBar/Identity/Identity';
 import { TopBarButton } from 'teleterm/ui/TopBar/TopBarButton';
+import { routing } from 'teleterm/ui/uri';
 import { getUserWithClusterName } from 'teleterm/ui/utils';
 
 import { getClusterLetter } from '../IdentityList/IdentityListItem';
@@ -44,7 +45,7 @@ export const IdentitySelector = forwardRef<
   const selectorText =
     props.activeCluster &&
     getUserWithClusterName({
-      clusterName: props.activeCluster.name,
+      clusterName: routing.parseClusterName(props.activeCluster.uri),
       userName: props.activeCluster.loggedInUser?.name,
     });
   const title = props.makeTitle(selectorText);

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentitySelector/IdentitySelector.tsx
@@ -28,7 +28,7 @@ import { TopBarButton } from 'teleterm/ui/TopBar/TopBarButton';
 import { routing } from 'teleterm/ui/uri';
 import { getUserWithClusterName } from 'teleterm/ui/utils';
 
-import { getClusterLetter } from '../IdentityList/IdentityListItem';
+import { getProfileNameLetter } from '../IdentityList/IdentityListItem';
 import { UserIcon } from './UserIcon';
 
 export const IdentitySelector = forwardRef<
@@ -64,7 +64,7 @@ export const IdentitySelector = forwardRef<
         <Box>
           <UserIcon
             color={props.activeColor}
-            letter={getClusterLetter(props.activeCluster)}
+            letter={getProfileNameLetter(props.activeCluster)}
           />
           {props.deviceTrustStatus === 'requires-enrollment' && (
             <ConnectionStatusIndicator

--- a/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/integration.test.tsx
@@ -29,6 +29,7 @@ import { proxyHostname } from 'teleterm/services/tshd/cluster';
 import { makeApp, makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 import { App } from 'teleterm/ui/App';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { routing } from 'teleterm/ui/uri';
 
 beforeAll(() => {
   Logger.init(new NullService());
@@ -96,7 +97,9 @@ test.each(tests)(
 
     render(<App ctx={ctx} />);
 
-    await user.click(await screen.findByText(rootCluster.name));
+    await user.click(
+      await screen.findByText(routing.parseClusterName(rootCluster.uri))
+    );
     act(mio.enterAll);
 
     expect(
@@ -190,7 +193,9 @@ test.each(tests)(
 
     render(<App ctx={ctx} />);
 
-    await user.click(await screen.findByText(rootCluster.name));
+    await user.click(
+      await screen.findByText(routing.parseClusterName(rootCluster.uri))
+    );
     act(mio.enterAll);
 
     expect(
@@ -249,7 +254,9 @@ test('launching VNet for the first time from the connections panel does not open
 
   render(<App ctx={ctx} />);
 
-  await user.click(await screen.findByText(rootCluster.name));
+  await user.click(
+    await screen.findByText(routing.parseClusterName(rootCluster.uri))
+  );
   act(mio.enterAll);
 
   // Start VNet.

--- a/web/packages/teleterm/src/ui/commandLauncher.ts
+++ b/web/packages/teleterm/src/ui/commandLauncher.ts
@@ -90,11 +90,9 @@ const commands = {
     displayName: '',
     description: '',
     run(ctx: IAppContext, args: { clusterUri: RootClusterUri }) {
-      const cluster = ctx.clustersService.findCluster(args.clusterUri);
       ctx.modalsService.openRegularDialog({
         kind: 'cluster-logout',
-        clusterUri: cluster.uri,
-        clusterTitle: cluster.name,
+        clusterUri: args.clusterUri,
       });
     },
   },

--- a/web/packages/teleterm/src/ui/services/modals/modalsService.ts
+++ b/web/packages/teleterm/src/ui/services/modals/modalsService.ts
@@ -214,7 +214,6 @@ export type ClusterConnectReason =
 export interface DialogClusterLogout {
   kind: 'cluster-logout';
   clusterUri: RootClusterUri;
-  clusterTitle: string;
 }
 
 export interface DialogDocumentsReopen {

--- a/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
+++ b/web/packages/teleterm/src/ui/services/tshdNotifications/tshdNotificationService.ts
@@ -148,6 +148,6 @@ export class TshdNotificationsService {
     const clusterUri = routing.ensureClusterUri(uri);
     const cluster = this.clustersService.findCluster(clusterUri);
 
-    return cluster ? cluster.name : routing.parseClusterName(clusterUri);
+    return cluster?.name || routing.parseClusterName(clusterUri);
   }
 }

--- a/web/packages/teleterm/src/ui/services/usage/usageService.ts
+++ b/web/packages/teleterm/src/ui/services/usage/usageService.ts
@@ -308,7 +308,14 @@ export class UsageService {
   private getClusterProperties(uri: ClusterOrResourceUri) {
     const rootClusterUri = routing.ensureRootClusterUri(uri);
     const cluster = this.findCluster(rootClusterUri);
-    if (!(cluster && cluster.loggedInUser && cluster.authClusterId)) {
+    if (
+      !(
+        cluster &&
+        cluster.loggedInUser &&
+        cluster.authClusterId &&
+        cluster.name
+      )
+    ) {
       return;
     }
 

--- a/web/packages/teleterm/src/ui/services/usage/usageService.ts
+++ b/web/packages/teleterm/src/ui/services/usage/usageService.ts
@@ -63,6 +63,11 @@ export class UsageService {
     private runtimeSettings: RuntimeSettings
   ) {}
 
+  /**
+   * Should be called only after a successful cluster sync.
+   * Otherwise, details of the root cluster (`authClusterId` and `name`)
+   * will be empty and this event won't be captured.
+   */
   captureUserLogin(uri: ClusterOrResourceUri, connectorType: string): void {
     const clusterProperties = this.getClusterProperties(uri);
     if (!clusterProperties) {

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -178,11 +178,13 @@ export const routing = {
   },
 
   /**
-   * parseClusterName should be used only when getting the cluster object from ClustersService is
-   * not possible.
+   * Returns the profile name for root clusters and the cluster name for leaf clusters.
    *
-   * rootClusterId in the URI is not the name of the cluster but rather just the hostname of the
-   * proxy. These two might be different.
+   * In the URI, `rootClusterId` may not be the root cluster's name but the hostname
+   * of its proxy (these may differ).
+   * `leafClusterId`, on the other hand, always matches the leaf cluster's name.
+   *
+   * TODO(gzdunek): Split this function into `parseProfileName` and `parseLeafClusterName`.
    */
   parseClusterName(clusterUri: string) {
     const parsed = routing.parseClusterUri(clusterUri);


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/33733
Contributes to https://github.com/gravitational/teleport/issues/25806

Currently, when using trusted clusters, running `tsh login <leaf-cluster>` and restarting the app, Teleport Connect incorrectly treats the leaf cluster as the root cluster. The leaf cluster's name appears in the profile switcher, and the cluster client created in tshd for the root cluster is actually a leaf cluster client.

Until now, we didn't get any user reports about that issue, but it may become much more visible once we start sharing ~/.tsh dir between tsh and Connect.

#### Proposed Fix
Instead of relying on the cluster name from the YAML profile file (which may point to a leaf cluster), we can derive the cluster name from the issuer field of the Teleport TLS certificate (unfortunately, setting `clusterClient.Config.SiteName` to an empty string is not working).
However, this change introduces another problem: the cluster name is not available if there's no certificate. This lead to me to addressing https://github.com/gravitational/teleport/issues/33733.

This greatly decreases number of places that display the cluster name, which now need to fall back to the profile name.
The only difficult part about that is when to use the profile name vs. the cluster name:
* I believe that displaying the profile name in places like the status bar, login and logout dialog, or the app updater makes sense since it's a general identifier of the workspace and clusters in it.
* On the other hand, places like the Resources tab name should continue to use the actual cluster name, since resources are rather tied to the cluster than the profile.

changelog: Teleport Connect now displays the profile name (instead of the cluster name) in the UI when referring to the profile