### PR TITLE
Still summarize sessions if the session metadata isn't generated

### DIFF
--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -839,8 +839,6 @@ func (w *sliceWriter) completeStream() {
 				if !w.sessionStartTime.IsZero() && !w.sessionEndTime.IsZero() {
 					duration := w.sessionEndTime.Sub(w.sessionStartTime)
 
-					// Process every session recording, as there may not be an end event.
-					// The processor will immediately return if the session recording type is not supported.
 					if err := recordingMetadata.ProcessSessionRecording(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID, duration); err != nil {
 						slog.WarnContext(w.proto.cancelCtx, "Failed to process session recording metadata", "error", err)
 					}

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -835,22 +835,18 @@ func (w *sliceWriter) completeStream() {
 		if w.proto.cfg.RecordingMetadataProvider != nil {
 			recordingMetadata := w.proto.cfg.RecordingMetadataProvider.Service()
 
-			if !w.shouldProcessSession {
-				return
-			}
+			if w.shouldProcessSession {
+				if !w.sessionStartTime.IsZero() && !w.sessionEndTime.IsZero() {
+					duration := w.sessionEndTime.Sub(w.sessionStartTime)
 
-			if w.sessionStartTime.IsZero() || w.sessionEndTime.IsZero() {
-				slog.WarnContext(w.proto.cancelCtx, "Session start or end time is not set, skipping recording metadata processing")
-				return
-			}
-
-			duration := w.sessionEndTime.Sub(w.sessionStartTime)
-
-			// Process every session recording, as there may not be an end event.
-			// The processor will immediately return if the session recording type is not supported.
-			if err := recordingMetadata.ProcessSessionRecording(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID, duration); err != nil {
-				slog.WarnContext(w.proto.cancelCtx, "Failed to process session recording metadata", "error", err)
-				return
+					// Process every session recording, as there may not be an end event.
+					// The processor will immediately return if the session recording type is not supported.
+					if err := recordingMetadata.ProcessSessionRecording(w.proto.cancelCtx, w.proto.cfg.Upload.SessionID, duration); err != nil {
+						slog.WarnContext(w.proto.cancelCtx, "Failed to process session recording metadata", "error", err)
+					}
+				} else {
+					slog.WarnContext(w.proto.cancelCtx, "Session start or end time is not set, skipping recording metadata processing")
+				}
 			}
 		}
 


### PR DESCRIPTION
This inverts the logic and doesn't return early if a session doesn't have its metadata generated for whatever reason

This is so the session is still summarized 