### PR TITLE
[v18] Warn on "Bot" role in auth server static token config

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1017,6 +1017,9 @@ func (t StaticToken) Parse() ([]types.ProvisionTokenV1, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if roles.Include(types.RoleBot) {
+		return nil, trace.BadParameter("role %q is not allowed in static token configuration", types.RoleBot)
+	}
 
 	tokenPart, err := utils.TryReadValueAsFile(parts[1])
 	if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1018,7 +1018,10 @@ func (t StaticToken) Parse() ([]types.ProvisionTokenV1, error) {
 		return nil, trace.Wrap(err)
 	}
 	if roles.Include(types.RoleBot) {
-		return nil, trace.BadParameter("role %q is not allowed in static token configuration", types.RoleBot)
+		slog.WarnContext(
+			context.Background(),
+			"Role 'Bot' is not supported in static token configurations and will not function as expected. In Teleport V19.0.0, this will become an error.",
+		)
 	}
 
 	tokenPart, err := utils.TryReadValueAsFile(parts[1])

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -597,11 +597,6 @@ func TestAuthenticationConfig_Parse_StaticToken(t *testing.T) {
 				types.RoleAuth, types.RoleNode, types.RoleProxy,
 			},
 		},
-		{
-			desc:      "reject bot role",
-			input:     "Bot:some-literal-token",
-			wantError: "role \"Bot\" is not allowed in static token configuration",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
Backport #53495 to branch/v18

Backport modified to emit warning instead of returning error.