### PR TITLE
Remove tctl get namespaces

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -82,26 +82,6 @@ func (c namedResourceCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(t.WriteTo(w))
 }
 
-type namespaceCollection struct {
-	namespaces []types.Namespace
-}
-
-func (n *namespaceCollection) Resources() (r []types.Resource) {
-	for i := range n.namespaces {
-		r = append(r, &n.namespaces[i])
-	}
-	return r
-}
-
-func (n *namespaceCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name"})
-	for _, n := range n.namespaces {
-		t.AddRow([]string{n.Metadata.Name})
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
 func printMetadataLabels(labels map[string]string) string {
 	pairs := []string{}
 	for key, value := range labels {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1989,8 +1989,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &authorityCollection{cas: []types.CertAuthority{authority}}, nil
-	case types.KindNamespace:
-		return &namespaceCollection{namespaces: []types.Namespace{types.DefaultNamespace()}}, nil
 	case types.KindTrustedCluster:
 		if rc.ref.Name == "" {
 			// TODO(okraport): DELETE IN v21.0.0, replace with regular Collect


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/60370 
Updates https://github.com/gravitational/teleport/issues/49509

Namesapces are a vestigial concept that do not apply to modern Teleport. Instead of migrating namespaces to the new tctl resources format they have been removed entirely.