### PR TITLE
Prevent mutation in `backend.Key.components`

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -296,7 +296,7 @@ type KeyedItem interface {
 // have the HostID part.
 func GetPaginationKey(ki KeyedItem) string {
 	if h, ok := ki.(HostID); ok {
-		return internalKey(h.GetHostID(), h.GetName()).String()
+		return h.GetHostID() + SeparatorString + h.GetName()
 	}
 
 	return ki.GetName()

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -41,8 +41,11 @@ const (
 // NewKey joins parts into path separated by [Separator],
 // makes sure path always starts with [Separator].
 func NewKey(components ...string) Key {
-	k := internalKey("", components...)
-	k.exactKey = k.s != "" && k.s[len(k.s)-1] == Separator
+	k := Key{
+		components: slices.Clone(components),
+		s:          SeparatorString + strings.Join(components, SeparatorString),
+	}
+	k.exactKey = k.s[len(k.s)-1] == Separator
 	return k
 }
 
@@ -51,7 +54,10 @@ func NewKey(components ...string) Key {
 // math child paths and not other paths that have the resulting path
 // as a prefix.
 func ExactKey(components ...string) Key {
-	k := NewKey(append(components, "")...)
+	k := Key{
+		components: slices.Concat(components, []string{""}),
+		s:          SeparatorString + strings.Join(components, SeparatorString),
+	}
 	k.exactKey = true
 	return k
 }
@@ -75,13 +81,6 @@ func KeyFromString(s string) Key {
 
 func (k Key) IsZero() bool {
 	return len(k.components) == 0 && k.s == ""
-}
-
-func internalKey(internalPrefix string, components ...string) Key {
-	return Key{
-		components: components,
-		s:          strings.Join(append([]string{internalPrefix}, components...), SeparatorString),
-	}
 }
 
 // ExactKey appends a [Separator] to the key, if one does not already
@@ -130,10 +129,10 @@ func (k Key) PrependKey(p Key) Key {
 	}
 
 	newKey := Key{
-		components: append(slices.Clone(p.components), k.components...),
+		components: slices.Concat(p.components, k.components),
 	}
 	if strings.HasPrefix(p.s, SeparatorString) {
-		newKey.s = strings.Join(append([]string{""}, newKey.components...), SeparatorString)
+		newKey.s = SeparatorString + strings.Join(newKey.components, SeparatorString)
 	} else {
 		newKey.s = strings.Join(newKey.components, SeparatorString)
 	}
@@ -149,10 +148,10 @@ func (k Key) AppendKey(p Key) Key {
 	}
 
 	newKey := Key{
-		components: append(k.components, slices.Clone(p.components)...),
+		components: slices.Concat(k.components, p.components),
 	}
 	if strings.HasPrefix(k.s, SeparatorString) {
-		newKey.s = strings.Join(append([]string{""}, newKey.components...), SeparatorString)
+		newKey.s = SeparatorString + strings.Join(newKey.components, SeparatorString)
 	} else {
 		newKey.s = strings.Join(newKey.components, SeparatorString)
 	}

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -41,6 +41,9 @@ const (
 // NewKey joins parts into path separated by [Separator],
 // makes sure path always starts with [Separator].
 func NewKey(components ...string) Key {
+	if len(components) < 1 {
+		return Key{}
+	}
 	k := Key{
 		components: slices.Clone(components),
 		s:          SeparatorString + strings.Join(components, SeparatorString),

--- a/lib/backend/key.go
+++ b/lib/backend/key.go
@@ -46,8 +46,8 @@ func NewKey(components ...string) Key {
 	}
 	k := Key{
 		components: slices.Clone(components),
-		s:          SeparatorString + strings.Join(components, SeparatorString),
 	}
+	k.s = SeparatorString + strings.Join(k.components, SeparatorString)
 	k.exactKey = k.s[len(k.s)-1] == Separator
 	return k
 }
@@ -59,8 +59,8 @@ func NewKey(components ...string) Key {
 func ExactKey(components ...string) Key {
 	k := Key{
 		components: slices.Concat(components, []string{""}),
-		s:          SeparatorString + strings.Join(components, SeparatorString),
 	}
+	k.s = SeparatorString + strings.Join(k.components, SeparatorString)
 	k.exactKey = true
 	return k
 }

--- a/lib/backend/key_test.go
+++ b/lib/backend/key_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/backend"
 )
@@ -489,6 +490,22 @@ func TestKeyAppendKey(t *testing.T) {
 			assert.Equal(t, test.expected, appended)
 		})
 	}
+}
+
+func TestKeyAppendKeyNoOverwrite(t *testing.T) {
+	var components []string
+	for range 3 {
+		components = append(components, "a")
+	}
+	k := backend.NewKey(components...)
+
+	k1 := k.AppendKey(backend.NewKey("b"))
+	require.Equal(t, "/a/a/a/b", k1.String())
+
+	_ = k.AppendKey(backend.NewKey("c"))
+
+	k2 := k1.AppendKey(backend.NewKey("b"))
+	require.Equal(t, "/a/a/a/b/b", k2.String())
 }
 
 func TestKeyCompare(t *testing.T) {

--- a/lib/backend/lock.go
+++ b/lib/backend/lock.go
@@ -40,6 +40,7 @@ func lockKey(parts ...string) Key {
 		components: append([]string{locksPrefix}, parts...),
 	}
 	key.s = strings.Join(key.components, SeparatorString)
+	key.exactKey = key.s[len(key.s)-1] == Separator
 
 	return key
 }

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -55,15 +55,14 @@ func isValidKeyByte(b byte) bool {
 
 // IsKeySafe checks if the passed in key conforms to whitelist
 func IsKeySafe(key Key) bool {
-	components := key.Components()
-	for i, k := range components {
+	for i, k := range key.components {
 		switch k {
 		case noEnd:
 			continue
 		case ".", "..":
 			return false
 		case "":
-			return key.exactKey && i == len(components)-1
+			return key.exactKey && i == len(key.components)-1
 		}
 
 		for _, b := range []byte(k) {


### PR DESCRIPTION
This PR cleans up some weirdness in `backend.Key` that can lead to corruption of the internal state due to overwriting of extra slice capacity.