### PR TITLE
docs: Add filter, sort and format flags to `tctl bots instances ls` reference

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -587,7 +587,7 @@ $ tctl bots instances list [<name>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | `--search` | none | A search term | Optional. Filters the returned bot instances using a fuzzy search based on the term provided. |
-| `--query` | none | Teleport predicate language query | Optional. Filters the returned bot instances based on the Teleport Predicate Language query provided. |
+| `--query` | none | Teleport predicate language query | Optional. Filters the returned bot instances based on the Teleport predicate language query provided. |
 | `--sort-index` | `bot_name` | `bot_name`, `active_at_latest`, `version_latest`, `host_name_latest` | Optional. Sorts the returned bot instances using the given field. |
 | `--sort-order` | `ascending` | `ascending`, `descending` | Optional. Sorts the returned bot instances in the given order. |
 | `--format` | `text` | `text`, `json` | If set to `json`, returns results as a machine-readable JSON string. |

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -582,6 +582,16 @@ $ tctl bots instances list [<name>]
 - `[<name>]` - an optional bot name. If provided, filters the result to show
   only instances for the named bot. Otherwise, shows all instances for all bots.
 
+### Flags
+
+| Name | Default Value(s) | Allowed Value(s) | Description |
+| - | - | - | - |
+| `--search` | none | A search term | Optional. Filters the returned bot instances using a fuzzy search based on the term provided. |
+| `--query` | none | Teleport predicate language query | Optional. Filters the returned bot instances based on the Teleport Predicate Language query provided. |
+| `--sort-index` | `bot_name` | `bot_name`, `active_at_latest`, `version_latest`, `host_name_latest` | Optional. Sorts the returned bot instances using the given field. |
+| `--sort-order` | `ascending` | `ascending`, `descending` | Optional. Sorts the returned bot instances in the given order. |
+| `--format` | `text` | `text`, `json` | If set to `json`, returns results as a machine-readable JSON string. |
+
 ### Examples
 
 This shows all known instances for the bot named "example":
@@ -589,6 +599,25 @@ This shows all known instances for the bot named "example":
 ```code
 $ tctl bots instance list example
 ```
+
+This shows all known instances which contain the term "github";
+
+```code
+$ tctl bots instance list --search github
+```
+
+Searchable fields include; bot name, instance id, hostname, join method, version
+
+This shows all known instances with a version older than "18.0.0";
+
+```code
+$ tctl bots instance list --query `older_than(status.latest_heartbeat.version, "18.0.0")`
+```
+Version-specific functions include;
+
+- `newer_than(version, comparison)`
+- `older_than(version, comparison)`
+- `between(version, lower (inclusive), upper (exclusive))`
 
 ### Global flags
 


### PR DESCRIPTION
## Summary
Documents the filter, sort and format features added to `tctl bots instances ls` in #60273.

## Changes
- Document `--search`, `--query`, `--sort-index`, `--sort-order` and `--format` flags.
- Add examples for fuzzy search and predicate language filter