### PR TITLE
Add AccessList Equal func

### DIFF
--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -7,6 +7,14 @@ import (
 	"time"
 )
 
+// deriveTeleportEqualAccessList returns whether this and that are equal.
+func deriveTeleportEqualAccessList(this, that *AccessList) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual(&this.ResourceHeader, &that.ResourceHeader) &&
+			deriveTeleportEqual_(&this.Spec, &that.Spec)
+}
+
 // deriveDeepCopyAccessList recursively copies the contents of src into dst.
 func deriveDeepCopyAccessList(dst, src *AccessList) {
 	func() {
@@ -52,6 +60,31 @@ func deriveDeepCopyReview(dst, src *Review) {
 		deriveDeepCopy_3(field, &src.Spec)
 		dst.Spec = *field
 	}()
+}
+
+// deriveTeleportEqual returns whether this and that are equal.
+func deriveTeleportEqual(this, that *header.ResourceHeader) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Kind == that.Kind &&
+			this.SubKind == that.SubKind &&
+			this.Version == that.Version &&
+			deriveTeleportEqual_1(&this.Metadata, &that.Metadata)
+}
+
+// deriveTeleportEqual_ returns whether this and that are equal.
+func deriveTeleportEqual_(this, that *Spec) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Type == that.Type &&
+			this.Title == that.Title &&
+			this.Description == that.Description &&
+			deriveTeleportEqual_2(this.Owners, that.Owners) &&
+			deriveTeleportEqual_3(&this.Audit, &that.Audit) &&
+			deriveTeleportEqual_4(&this.MembershipRequires, &that.MembershipRequires) &&
+			deriveTeleportEqual_4(&this.OwnershipRequires, &that.OwnershipRequires) &&
+			deriveTeleportEqual_5(&this.Grants, &that.Grants) &&
+			deriveTeleportEqual_5(&this.OwnerGrants, &that.OwnerGrants)
 }
 
 // deriveDeepCopy recursively copies the contents of src into dst.
@@ -229,6 +262,57 @@ func deriveDeepCopy_3(dst, src *ReviewSpec) {
 	}()
 }
 
+// deriveTeleportEqual_1 returns whether this and that are equal.
+func deriveTeleportEqual_1(this, that *header.Metadata) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Name == that.Name &&
+			this.Description == that.Description &&
+			deriveTeleportEqual_6(this.Labels, that.Labels) &&
+			this.Expires.Equal(that.Expires)
+}
+
+// deriveTeleportEqual_2 returns whether this and that are equal.
+func deriveTeleportEqual_2(this, that []Owner) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(this[i] == that[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_3 returns whether this and that are equal.
+func deriveTeleportEqual_3(this, that *Audit) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.NextAuditDate.Equal(that.NextAuditDate) &&
+			this.Recurrence == that.Recurrence &&
+			this.Notifications == that.Notifications
+}
+
+// deriveTeleportEqual_4 returns whether this and that are equal.
+func deriveTeleportEqual_4(this, that *Requires) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_7(this.Roles, that.Roles) &&
+			deriveTeleportEqual_8(this.Traits, that.Traits)
+}
+
+// deriveTeleportEqual_5 returns whether this and that are equal.
+func deriveTeleportEqual_5(this, that *Grants) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_7(this.Roles, that.Roles) &&
+			deriveTeleportEqual_8(this.Traits, that.Traits)
+}
+
 // deriveDeepCopy_4 recursively copies the contents of src into dst.
 func deriveDeepCopy_4(dst, src *header.Metadata) {
 	dst.Name = src.Name
@@ -347,6 +431,62 @@ func deriveDeepCopy_9(dst, src *ReviewChanges) {
 	}
 	dst.ReviewFrequencyChanged = src.ReviewFrequencyChanged
 	dst.ReviewDayOfMonthChanged = src.ReviewDayOfMonthChanged
+}
+
+// deriveTeleportEqual_6 returns whether this and that are equal.
+func deriveTeleportEqual_6(this, that map[string]string) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for k, v := range this {
+		thatv, ok := that[k]
+		if !ok {
+			return false
+		}
+		if !(v == thatv) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_7 returns whether this and that are equal.
+func deriveTeleportEqual_7(this, that []string) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(this[i] == that[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_8 returns whether this and that are equal.
+func deriveTeleportEqual_8(this, that map[string][]string) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for k, v := range this {
+		thatv, ok := that[k]
+		if !ok {
+			return false
+		}
+		if !(deriveTeleportEqual_7(v, thatv)) {
+			return false
+		}
+	}
+	return true
 }
 
 // deriveDeepCopy_10 recursively copies the contents of src into dst.


### PR DESCRIPTION
### What

Create `EqualAccessListForReconciliation`  that can be use in the access list reconciliation flow 
The `EqualAccessListForReconciliation` works the same as https://github.com/gravitational/teleport/blob/master/lib/services/compare.go#L35 for the `AccessList` type

Ignoring `Status, Ineligibility, Revision` fields 

### Why ? 

+ Performance improvement  see https://github.com/gravitational/teleport.e/pull/7453 for benchmark 

+ First small step to deprecate the  `cmp.Equal` call from reconsider flow ( `cmp.Equal` should be used only in tests) 

