### PR TITLE
Fix Var usage

### DIFF
--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -219,7 +219,8 @@ the dataset to be at least:
 
 An additional 20-40% safety margin is recommended for metadata and fragmentation overhead.
 
-Given an existing resource you can estimate its size with the following command:
+Given an existing resource you can estimate its size with the following command,
+assigning <Var name="resource" /> to the resource name, e.g., `role/editor`:
 
 ```code
 tctl get <Var name="resource" /> --format=json | awk '{ total += length($0) } END { print total * 2 }'


### PR DESCRIPTION
Prepare for the migration of the Vale linter for Var component usage to `remark` by editing a Var that only has a single occurrence. This linter ensures that each Var has at least two occurrences on a page so we can take advantage of the reused Var values or provide instructions on assigning a Var.