### PR TITLE
[v18] Fix Var usage

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -58,15 +58,15 @@ workflow for using `tsh` to access an infrastructure resource.
 ### Log in to Teleport 
 
 Log in to your Teleport cluster, assigning <Var name="teleport.example.com" />
-to the domain name of the Teleport Proxy Service in your cluster and <Var
-name="myser" /> to your Teleport username:
+to the domain name of the Teleport Proxy Service in your cluster and 
+<Var name="myuser" /> to your Teleport username:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="myuser" />
 ```
 
-This command retrieves the user's certificates and saves them into `~/.tsh/<Var
-name="teleport.example.com" />`.
+This command retrieves the user's certificates and saves them into 
+`~/.tsh/<Var name="teleport.example.com" />`.
 
 ### List resources that you can access
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -209,8 +209,10 @@ following IAM policy and attach it to the new role:
     ]
 }
 ```
-Edit the trust policy of the new role to allow the Discovery Service
-to assume it:
+
+Edit the trust policy of the new role to allow the Discovery Service to assume
+it, adding the <Var name="Discovery Service role's ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",
@@ -218,15 +220,17 @@ to assume it:
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "<Var name="discovery service role's ARN" />"
+                "AWS": "<Var name="Discovery Service role's ARN" />"
             },
             "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+
 Create the following policy in the Discovery Service's account and attach it
-to the Discovery Service's role:
+to the Discovery Service's role, adding the <Var name="new role ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -202,8 +202,10 @@ following IAM policy and attach it to the new role:
     ]
 }
 ```
+
 Edit the trust policy of the new role to allow the Discovery Service
-to assume it:
+to assume it, including the <Var name="Discovery Service role's ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",
@@ -211,15 +213,17 @@ to assume it:
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "<Var name="discovery service role's ARN" />"
+                "AWS": "<Var name="Discovery Service role's ARN" />"
             },
             "Action": "sts:AssumeRole"
         }
     ]
 }
 ```
+
 Create the following policy in the Discovery Service's account and attach it
-to the Discovery Service's role:
+to the Discovery Service's role, adding the <Var name="new role ARN" />:
+
 ```json
 {
     "Version": "2012-10-17",

--- a/docs/pages/identity-governance/integrations/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/manual-installation.mdx
@@ -86,13 +86,14 @@ The following permissions need to be added to the application.
 
 ## Step 5/5. Install the Entra ID plugin
 
-Now run the `tctl plugins install entraid` command.
+Now run the `tctl plugins install entraid` command, including the name of the
+<Var name="Access List owner"/>:
 
 ```code
 $ tctl plugins install entraid \
     --name entra-id-default \
     --auth-connector-name entra-id \
-    --default-owner=<Var name="Access List Owner"/> \
+    --default-owner=<Var name="Access List owner"/> \
     --no-access-graph \
     --manual-setup
 ```

--- a/docs/pages/identity-governance/integrations/entra-id/terraform.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/terraform.mdx
@@ -142,8 +142,13 @@ foreach ($appRole in $appRoles) {
 
 </details>
 
-Once you have the permission IDs and the principal ID of the managed identity ready,
-create `tfvars` with your inputs.
+Once you have the permission IDs and the principal ID of the managed identity
+ready, create `tfvars` with your inputs. Assign values to the variables below:
+
+- <Var name="Permission IDs"/> 
+- <Var name="Principal ID of the managed identity"/>
+
+Enter the following command to populate your `tfvars` file:
 
 ```bash
 cat > variables.auto.tfvars << EOF

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-token.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-token.mdx
@@ -1,5 +1,6 @@
 Add a new entry to `spec.allow` in `token.yaml` and set `aws_account` to the
-account number of the new account.
+account number of the new account, including the 
+<Var name="destination AWS account ID" />:
 
 ```diff
 # token.yaml

--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -219,7 +219,8 @@ the dataset to be at least:
 
 An additional 20-40% safety margin is recommended for metadata and fragmentation overhead.
 
-Given an existing resource you can estimate its size with the following command:
+Given an existing resource you can estimate its size with the following command,
+assigning <Var name="resource" /> to the resource name, e.g., `role/editor`:
 
 ```code
 tctl get <Var name="resource" /> --format=json | awk '{ total += length($0) } END { print total * 2 }'

--- a/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
@@ -196,7 +196,23 @@ Microsoft Graph API.
 Before creating the Auth Connector resource, its useful to first generate the 
 configuration spec and test the configuration.
 
-The Auth Connector spec can be configured by using the `tctl sso configure` command. 
+The Auth Connector spec can be configured by using the `tctl sso configure`
+command. We will show you how to run the command with the following flags:
+
+- `--name`: Teleport resource name for the Microsoft Entra ID Auth Connector. 
+- `--display`: Display name for the Microsoft Entra ID Auth Connector
+- `--issuer-url`: Microsoft Entra ID OIDC issuer URL. You need your Microsoft Entra 
+  ID tenant ID to configure this URL. Assign it to <Var name="Entra ID tenant ID" />.
+- `--id`: The application (client) ID of the enterprise application you created in 
+  Step 2. This value can be copied from the "Overview" section of the enterprise 
+  application in the Azure Portal. Assign it to <Var name="Enterprise application client ID" />.
+- `--secret`: The client secret we created in Step 4.
+- `--claims-to-roles`: A mapping of OIDC claims/values to be associated with
+  Teleport roles. Note that the Entra ID `groups` claim includes group's object
+  ID. As such, you will need to map groups by using groups object ID. Assign
+  <Var name="Object ID of ad-app-admin group" /> to the object ID ot
+  `ad-app-admin` and <Var name="Object ID of ad-app-support group" /> to the
+  object ID of `ad-app-support`:
 
 ```code
 $ tctl sso configure oidc --name "entra-id" \
@@ -210,18 +226,6 @@ $ tctl sso configure oidc --name "entra-id" \
   --scope email \
   --scope profile > entraid-oidc-connector.yaml
 ```
-
-- `--name`: Teleport resource name for the Microsoft Entra ID Auth Connector. 
-- `--display`: Display name for the Microsoft Entra ID Auth Connector
-- `--issuer-url`: Microsoft Entra ID OIDC issuer URL. You need your Microsoft Entra 
-  ID tenant ID to configure this URL.
-- `--id`: The application (client) ID of the enterprise application you created in 
-  Step 2. This value can be copied from the "Overview" section of the enterprise 
-  application in the Azure Portal. 
-- `--secret`: The client secret we created in Step 4.
-- `--claims-to-roles`: A mapping of OIDC claims/values to be associated with
-  Teleport roles. Note that the Entra ID `groups` claim includes group's object ID.
-  As such, you will need to map groups by using groups object ID.
 
 <details>
 <summary>Example YAML Auth Connector resource file created by the `tctl sso configure` command</summary>
@@ -245,7 +249,7 @@ spec:
   client_secret: example-secret-value
   display: Entra ID
   issuer_url: https://login.microsoftonline.com/0297d2f3-62c3-4598-aaa1-2104929ba73c/v2.0
-  redirect_url: https://example.teleport.sh:443/v1/webapi/oidc/callback
+  redirect_url: https://<Var name="example.teleport.sh" />:443/v1/webapi/oidc/callback
   scope:
   - openid
   - email


### PR DESCRIPTION
Prepare for the migration of the Vale linter for Var component usage to `remark` by editing a Var that only has a single occurrence. This linter ensures that each Var has at least two occurrences on a page so we can take advantage of the reused Var values or provide instructions on assigning a Var.