### PR TITLE
[v17] Fix Var usage

### DIFF
--- a/docs/pages/identity-governance/entra-id/manual-installation.mdx
+++ b/docs/pages/identity-governance/entra-id/manual-installation.mdx
@@ -84,13 +84,14 @@ The following permissions need to be added to the application.
 
 ## Step 5/5. Install the Entra ID plugin
 
-Now run the `tctl plugins install entraid` command.
+Now run the `tctl plugins install entraid` command, including the name of the
+<Var name="Access List owner"/>:
 
 ```code
 $ tctl plugins install entraid \
     --name entra-id-default \
     --auth-connector-name entra-id \
-    --default-owner=<Var name="Access List Owner"/> \
+    --default-owner=<Var name="Access List owner"/> \
     --no-access-graph \
     --manual-setup
 ```

--- a/docs/pages/identity-security/integrations/netiq.mdx
+++ b/docs/pages/identity-security/integrations/netiq.mdx
@@ -92,7 +92,8 @@ This command will generate an encrypted value:
 InSKM1mSmpWfjPk6etI/...
 ```
 
-Then, update `ism-configuration.properties` by adding:  
+Then, update `ism-configuration.properties` by adding the following, assigning
+<Var name="InSKM1mSmpWfjPk6etI/...." /> to your client password:
 
 ```code
 com.example.<Var name="client-id" />.clientID = <Var name="client-id" />

--- a/docs/pages/includes/database-access/custom-db-ca.mdx
+++ b/docs/pages/includes/database-access/custom-db-ca.mdx
@@ -1,5 +1,7 @@
 {{ scheme="" query="" }}
-Modify the Teleport Database Service to trust your {{ db }} CA:
+Modify the Teleport Database Service to trust your {{ db }} CA, assigning
+<Var name='/path/to/your/ca.crt' /> to the path to your CA certificate:
+
   ```yaml
     databases:
     - name: "example-{{ protocol }}"

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -23,7 +23,7 @@ Session ended at Mon Jul 20 20:30 UTC
 
 All database protocols recordings are supported in JSON format (`--format json`):
 ```code
-$ tsh play --format json <Var name="database.session" />
+$ tsh play --format json 307b49d6-56c7-4d20-8cf0-5bc5348a7101
 ```
 
 ```json

--- a/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
+++ b/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
@@ -9,6 +9,8 @@ generally required:
 policy.
 <Tabs>
 <TabItem label="Role as principal">
+
+Assign <Var name="aws-account-id"/> to your AWS account ID:
 ```json
 {
   "Version": "2012-10-17",
@@ -25,6 +27,9 @@ policy.
 ```
 </TabItem>
 <TabItem label="Account as principal">
+
+Assign <Var name="aws-account-id"/> to your AWS account ID:
+
 ```json
 {
   "Version": "2012-10-17",
@@ -41,6 +46,9 @@ policy.
 ```
 </TabItem>
 <TabItem label="Cross-account with external-id">
+
+Assign <Var name="external-aws-account-id"/> to an external AWS account ID:
+
 ```json
 {
   "Version": "2012-10-17",

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -219,7 +219,8 @@ the dataset to be at least:
 
 An additional 20-40% safety margin is recommended for metadata and fragmentation overhead.
 
-Given an existing resource you can estimate its size with the following command:
+Given an existing resource you can estimate its size with the following command,
+assigning <Var name="resource" /> to the resource name, e.g., `role/editor`:
 
 ```code
 tctl get <Var name="resource" /> --format=json | awk '{ total += length($0) } END { print total * 2 }'


### PR DESCRIPTION
Prepare for the migration of the Vale linter for Var component usage to `remark` by editing a Var that only has a single occurrence. This linter ensures that each Var has at least two occurrences on a page so we can take advantage of the reused Var values or provide instructions on assigning a Var.