### PR TITLE
Remove `(auth.Server) SetClock`

### DIFF
--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -437,7 +437,7 @@ func (p *DatabasePack) testMongoLeafCluster(t *testing.T) {
 // TestRootLeafIdleTimeout tests idle client connection termination by proxy and DB services in
 // trusted cluster setup.
 func TestDatabaseRootLeafIdleTimeout(t *testing.T) {
-	clock := clockwork.NewFakeClockAt(time.Now())
+	clock := clockwork.NewFakeClock()
 	pack := SetupDatabaseTest(t, WithClock(clock))
 	pack.WaitForLeaf(t)
 
@@ -449,9 +449,6 @@ func TestDatabaseRootLeafIdleTimeout(t *testing.T) {
 
 		idleTimeout = time.Minute
 	)
-
-	rootAuthServer.SetClock(clockwork.NewFakeClockAt(time.Now()))
-	leafAuthServer.SetClock(clockwork.NewFakeClockAt(time.Now()))
 
 	mkMySQLLeafDBClient := func(t *testing.T) mysql.TestClientConn {
 		// Connect to the database service in leaf cluster via root cluster.

--- a/integration/db/fixture.go
+++ b/integration/db/fixture.go
@@ -276,6 +276,7 @@ func SetupDatabaseTest(t *testing.T, options ...TestOptionFunc) *DatabasePack {
 		Priv:        privateKey,
 		Pub:         publicKey,
 		Logger:      log,
+		Clock:       opts.clock,
 	}
 	rootCfg.Listeners = opts.listenerSetup(t, &rootCfg.Fds)
 	p.Root.Cluster = helpers.NewInstance(t, rootCfg)
@@ -288,6 +289,7 @@ func SetupDatabaseTest(t *testing.T, options ...TestOptionFunc) *DatabasePack {
 		Priv:        privateKey,
 		Pub:         publicKey,
 		Logger:      log,
+		Clock:       opts.clock,
 	}
 	leafCfg.Listeners = opts.listenerSetup(t, &leafCfg.Fds)
 	p.Leaf.Cluster = helpers.NewInstance(t, leafCfg)
@@ -296,6 +298,7 @@ func SetupDatabaseTest(t *testing.T, options ...TestOptionFunc) *DatabasePack {
 	rcConf := servicecfg.MakeDefaultConfig()
 	rcConf.DataDir = t.TempDir()
 	rcConf.Auth.Enabled = true
+	rcConf.Auth.Clock = p.clock
 	rcConf.Auth.Preference.SetSecondFactor("off")
 	rcConf.Proxy.Enabled = true
 	rcConf.Proxy.DisableWebInterface = true
@@ -309,6 +312,7 @@ func SetupDatabaseTest(t *testing.T, options ...TestOptionFunc) *DatabasePack {
 	lcConf := servicecfg.MakeDefaultConfig()
 	lcConf.DataDir = t.TempDir()
 	lcConf.Auth.Enabled = true
+	lcConf.Auth.Clock = p.clock
 	lcConf.Auth.Preference.SetSecondFactor("off")
 	lcConf.Proxy.Enabled = true
 	lcConf.Proxy.DisableWebInterface = true

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -115,6 +115,7 @@ func newAuthConfig(t *testing.T, clock clockwork.Clock) *servicecfg.Config {
 	config.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{},
 	})
+	config.Auth.Clock = clock
 	require.NoError(t, err)
 	config.Proxy.Enabled = false
 	config.SSH.Enabled = false
@@ -188,7 +189,6 @@ func TestEC2NodeJoin(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, authSvc.Close()) })
 
 	authServer := authSvc.GetAuthServer()
-	authServer.SetClock(clock)
 
 	err = authServer.UpsertToken(ctx, token)
 	require.NoError(t, err)

--- a/lib/auth/access_test.go
+++ b/lib/auth/access_test.go
@@ -47,9 +47,7 @@ import (
 func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 	t.Parallel()
 	clientAddr := &net.TCPAddr{IP: net.IPv4(10, 255, 0, 0)}
-	ctx := authz.ContextWithClientSrcAddr(context.Background(), clientAddr)
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	p := newAuthSuite(t)
 
 	// test create new role
 	role, err := types.NewRole("test-role", types.RoleSpecV6{
@@ -59,6 +57,7 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 	require.NoError(t, err)
 
 	// Creating a role should emit a RoleCreatedEvent.
+	ctx := authz.ContextWithClientSrcAddr(t.Context(), clientAddr)
 	role, err = p.a.CreateRole(ctx, role)
 	require.NoError(t, err)
 	require.Equal(t, events.RoleCreatedEvent, p.mockEmitter.LastEvent().GetType())
@@ -103,9 +102,8 @@ func TestUpsertDeleteRoleEventsEmitted(t *testing.T) {
 
 func TestUpsertDeleteDependentRoles(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 
 	// test create new role
 	role, err := types.NewRole("test-role", types.RoleSpecV6{
@@ -1120,9 +1118,8 @@ func TestDeleteRole(t *testing.T) {
 
 func TestUpsertDeleteLockEventsEmitted(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 
 	lock, err := types.NewLock("test-lock", types.LockSpecV2{
 		Target: types.LockTarget{MFADevice: "mfa-device-id"},

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -248,6 +248,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			ClusterName:          cfg.ClusterName,
 			AuthPreferenceGetter: cfg.ClusterConfiguration,
 			FIPS:                 cfg.FIPS,
+			Clock:                cfg.Clock,
 		}
 		if cfg.KeyStoreConfig.PKCS11 != (servicecfg.PKCS11Config{}) {
 			if !modules.GetModules().Features().GetEntitlement(entitlements.HSM).Enabled {
@@ -2316,16 +2317,7 @@ func (a *Server) Close() error {
 }
 
 func (a *Server) GetClock() clockwork.Clock {
-	a.lock.RLock()
-	defer a.lock.RUnlock()
 	return a.clock
-}
-
-// SetClock sets clock, used in tests
-func (a *Server) SetClock(clock clockwork.Clock) {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-	a.clock = clock
 }
 
 // SetBcryptCost sets bcryptCostOverride, used in tests

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -215,14 +215,6 @@ func (a *Server) Shutdown(ctx context.Context) error {
 	)
 }
 
-// WithClock is a functional server option that sets the server's clock
-func WithClock(clock clockwork.Clock) auth.ServerOption {
-	return func(s *auth.Server) error {
-		s.SetClock(clock)
-		return nil
-	}
-}
-
 // WithBcryptCost is a functional server option that sets the server's bcrypt cost.
 func WithBcryptCost(cost int) auth.ServerOption {
 	return func(s *auth.Server) error {
@@ -334,7 +326,6 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 		MultipartHandler:          cfg.UploadHandler,
 		SessionSummarizerProvider: cfg.SessionSummarizerProvider,
 	},
-		WithClock(cfg.Clock),
 		// Reduce auth.Server bcrypt costs when testing.
 		WithBcryptCost(bcrypt.MinCost),
 	)

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -664,17 +664,14 @@ func TestRegisterBotCertificateExtensions(t *testing.T) {
 func TestRegisterBot_RemoteAddr(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 	a := p.a
 
 	_, sshPubKey, _, tlsPubKey := newSSHAndTLSKeyPairs(t)
 
 	roleName := "test-role"
-	_, err = authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
+	_, err := authtest.CreateRole(ctx, a, roleName, types.RoleSpecV6{})
 	require.NoError(t, err)
 
 	botName := "botty"

--- a/lib/auth/desktop_test.go
+++ b/lib/auth/desktop_test.go
@@ -19,7 +19,6 @@
 package auth_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,9 +40,8 @@ func TestDesktopAccessDisabled(t *testing.T) {
 		},
 	})
 
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 
 	r, err := p.a.GenerateWindowsDesktopCert(ctx, &proto.WindowsDesktopCertRequest{})
 	require.Nil(t, r)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -962,8 +962,6 @@ func TestPresets(t *testing.T) {
 
 	t.Run("EmptyCluster", func(t *testing.T) {
 		as := newTestAuthServer(ctx, t)
-		clock := clockwork.NewFakeClock()
-		as.SetClock(clock)
 
 		err := auth.CreatePresetRoles(ctx, as)
 		require.NoError(t, err)
@@ -982,8 +980,6 @@ func TestPresets(t *testing.T) {
 	// Makes sure that existing role with the same name is not modified
 	t.Run("ExistingRole", func(t *testing.T) {
 		as := newTestAuthServer(ctx, t)
-		clock := clockwork.NewFakeClock()
-		as.SetClock(clock)
 
 		access := services.NewPresetEditorRole()
 		access.SetLogins(types.Allow, []string{"root"})
@@ -1007,8 +1003,6 @@ func TestPresets(t *testing.T) {
 	// If a default allow condition is not present, ensure it gets added.
 	t.Run("AddDefaultAllowConditions", func(t *testing.T) {
 		as := newTestAuthServer(ctx, t)
-		clock := clockwork.NewFakeClock()
-		as.SetClock(clock)
 
 		editorRole := services.NewPresetEditorRole()
 		rules := editorRole.GetRules(types.Allow)
@@ -1059,8 +1053,6 @@ func TestPresets(t *testing.T) {
 	// Either as part of allowing or denying rules.
 	t.Run("DefaultAllowRulesNotAppliedIfExplicitlyDefined", func(t *testing.T) {
 		as := newTestAuthServer(ctx, t)
-		clock := clockwork.NewFakeClock()
-		as.SetClock(clock)
 
 		// Set up a changed Editor Role
 		editorRole := services.NewPresetEditorRole()
@@ -1302,8 +1294,6 @@ func TestPresets(t *testing.T) {
 
 		t.Run("EmptyCluster", func(t *testing.T) {
 			as := newTestAuthServer(ctx, t)
-			clock := clockwork.NewFakeClock()
-			as.SetClock(clock)
 
 			// Run multiple times to simulate starting auth on an
 			// existing cluster and asserting that everything still

--- a/lib/auth/join_azure_devops_test.go
+++ b/lib/auth/join_azure_devops_test.go
@@ -86,10 +86,13 @@ func TestAuth_RegisterUsingToken_AzureDevops(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
-		server.SetAzureDevopsIDTokenValidator(idTokenValidator)
-		return nil
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir: t.TempDir(),
+		MutateAuth: func(server *auth.Server) error {
+			server.SetAzureDevopsIDTokenValidator(idTokenValidator)
+			return nil
+		},
 	})
 	require.NoError(t, err)
 	auth := p.a

--- a/lib/auth/join_azure_test.go
+++ b/lib/auth/join_azure_test.go
@@ -157,11 +157,8 @@ func makeToken(managedIdentityResourceID, azureResourceID string, issueTime time
 func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 	a := p.a
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()
@@ -542,11 +539,8 @@ func TestAuth_RegisterUsingAzureMethod(t *testing.T) {
 func TestAuth_RegisterUsingAzureClaims(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 	a := p.a
 
 	sshPrivateKey, sshPublicKey, err := testauthority.New().GenerateKeyPair()

--- a/lib/auth/join_bitbucket_test.go
+++ b/lib/auth/join_bitbucket_test.go
@@ -83,10 +83,13 @@ func TestAuth_RegisterUsingToken_Bitbucket(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
-		server.SetBitbucketIDTokenValidator(idTokenValidator)
-		return nil
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir: t.TempDir(),
+		MutateAuth: func(server *auth.Server) error {
+			server.SetBitbucketIDTokenValidator(idTokenValidator)
+			return nil
+		},
 	})
 	require.NoError(t, err)
 	auth := p.a

--- a/lib/auth/join_circleci_test.go
+++ b/lib/auth/join_circleci_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestAuth_RegisterUsingToken_CircleCI(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := t.Context()
 	var (
 		validIDToken  = "valid-token"
 		validOrg      = "valid-org"
@@ -60,7 +60,11 @@ func TestAuth_RegisterUsingToken_CircleCI(t *testing.T) {
 		})
 		return nil
 	}
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	auth := p.a
 

--- a/lib/auth/join_gcp_test.go
+++ b/lib/auth/join_gcp_test.go
@@ -68,8 +68,12 @@ func TestAuth_RegisterUsingToken_GCP(t *testing.T) {
 		server.SetGCPIDTokenValidator(idTokenValidator)
 		return nil
 	}
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	auth := p.a
 

--- a/lib/auth/join_github_test.go
+++ b/lib/auth/join_github_test.go
@@ -96,8 +96,11 @@ func TestAuth_RegisterUsingToken_GHA(t *testing.T) {
 		server.SetGHAIDTokenJWKSValidator(idTokenValidator.ValidateJWKS)
 		return nil
 	}
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	authServer := p.a
 

--- a/lib/auth/join_gitlab_test.go
+++ b/lib/auth/join_gitlab_test.go
@@ -93,8 +93,11 @@ func TestAuth_RegisterUsingToken_GitLab(t *testing.T) {
 		server.SetGitlabIDTokenValidator(idTokenValidator)
 		return nil
 	}
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	auth := p.a
 

--- a/lib/auth/join_oracle_test.go
+++ b/lib/auth/join_oracle_test.go
@@ -305,9 +305,8 @@ func mapFromHeader(header http.Header) map[string]string {
 
 func TestRegisterUsingOracleMethod(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 	a := p.a
 
 	pemBytes, ok := fixtures.PEMBytes["rsa"]

--- a/lib/auth/join_spacelift_test.go
+++ b/lib/auth/join_spacelift_test.go
@@ -74,8 +74,12 @@ func TestAuth_RegisterUsingToken_Spacelift(t *testing.T) {
 		server.SetSpaceliftIDTokenValidator(idTokenValidator)
 		return nil
 	}
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	auth := p.a
 

--- a/lib/auth/join_terraformcloud_test.go
+++ b/lib/auth/join_terraformcloud_test.go
@@ -81,8 +81,11 @@ func TestAuth_RegisterUsingToken_Terraform(t *testing.T) {
 		server.SetTerraformIDTokenValidator(idTokenValidator)
 		return nil
 	}
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir(), withTokenValidator)
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir:    t.TempDir(),
+		MutateAuth: withTokenValidator,
+	})
 	require.NoError(t, err)
 	auth := p.a
 

--- a/lib/auth/join_test.go
+++ b/lib/auth/join_test.go
@@ -47,9 +47,8 @@ import (
 )
 
 func TestAuth_RegisterUsingToken(t *testing.T) {
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
-	require.NoError(t, err)
+	ctx := t.Context()
+	p := newAuthSuite(t)
 
 	// create a static token
 	staticToken := types.ProvisionTokenV1{

--- a/lib/auth/join_tpm_test.go
+++ b/lib/auth/join_tpm_test.go
@@ -77,11 +77,14 @@ func (m *mockTPMValidator) validate(
 }
 
 func TestServer_RegisterUsingTPMMethod(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	mockValidator := &mockTPMValidator{}
-	p, err := newTestPack(ctx, t.TempDir(), func(server *auth.Server) error {
-		server.SetTPMValidator(mockValidator.validate)
-		return nil
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir: t.TempDir(),
+		MutateAuth: func(server *auth.Server) error {
+			server.SetTPMValidator(mockValidator.validate)
+			return nil
+		},
 	})
 	require.NoError(t, err)
 	authServer := p.a

--- a/lib/auth/keygen/keygen.go
+++ b/lib/auth/keygen/keygen.go
@@ -55,11 +55,13 @@ func SetClock(clock clockwork.Clock) Option {
 
 // New returns a new key generator.
 func New(_ context.Context, opts ...Option) *Keygen {
-	k := &Keygen{
-		clock: clockwork.NewRealClock(),
-	}
+	k := &Keygen{}
 	for _, opt := range opts {
 		opt(k)
+	}
+
+	if k.clock == nil {
+		k.clock = clockwork.NewRealClock()
 	}
 
 	return k

--- a/lib/auth/keystore/aws_kms.go
+++ b/lib/auth/keystore/aws_kms.go
@@ -138,7 +138,7 @@ func newAWSKMSKeystore(ctx context.Context, cfg *servicecfg.AWSKMSConfig, opts *
 		tags[clusterTagKey] = opts.ClusterName.GetClusterName()
 	}
 
-	clock := opts.clockworkOverride
+	clock := opts.Clock
 	if clock == nil {
 		clock = clockwork.NewRealClock()
 	}

--- a/lib/auth/keystore/aws_kms_test.go
+++ b/lib/auth/keystore/aws_kms_test.go
@@ -111,7 +111,7 @@ func TestAWSKMS_DeleteUnusedKeys(t *testing.T) {
 				awsSTSClient: &fakeAWSSTSClient{
 					account: "123456789012",
 				},
-				clockworkOverride: clock,
+				Clock: clock,
 			}
 			keyStore, err := NewManager(ctx, &cfg, opts)
 			require.NoError(t, err)
@@ -222,7 +222,7 @@ func TestAWSKMS_RetryWhilePending(t *testing.T) {
 		awsSTSClient: &fakeAWSSTSClient{
 			account: "111111111111",
 		},
-		clockworkOverride: clock,
+		Clock: clock,
 	}
 	manager, err := NewManager(ctx, cfg, opts)
 	require.NoError(t, err)
@@ -282,7 +282,7 @@ func TestAWSKeyCreationParameters(t *testing.T) {
 		awsSTSClient: &fakeAWSSTSClient{
 			account: "123456789012",
 		},
-		clockworkOverride: clock,
+		Clock: clock,
 	}
 
 	for _, tc := range []struct {
@@ -865,7 +865,7 @@ func TestMultiRegionKeyReplication(t *testing.T) {
 				awsSTSClient: &fakeAWSSTSClient{
 					account: testAccount,
 				},
-				clockworkOverride: clock,
+				Clock: clock,
 			}
 
 			existingPrimary := tc.existingPrimary

--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -603,8 +603,8 @@ func newTestPack(ctx context.Context, t *testing.T) *testPack {
 		awsSTSClient: &fakeAWSSTSClient{
 			account: "123456789012",
 		},
-		kmsClient:         testGCPKMSClient,
-		clockworkOverride: clock,
+		kmsClient: testGCPKMSClient,
+		Clock:     clock,
 		RSAKeyPairSource: func(alg cryptosuites.Algorithm) ([]byte, []byte, error) {
 			switch alg {
 			case cryptosuites.RSA2048:

--- a/lib/auth/usage_test.go
+++ b/lib/auth/usage_test.go
@@ -118,8 +118,13 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 		TestFeatures: features,
 	})
 
-	ctx := context.Background()
-	p, err := newTestPack(ctx, t.TempDir())
+	// Create a clock in the middle of the month for easy manipulation
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 07, 15, 1, 2, 3, 0, time.UTC))
+	ctx := t.Context()
+	p, err := newTestPack(ctx, testPackOptions{
+		DataDir: t.TempDir(),
+		Clock:   clock,
+	})
 	require.NoError(t, err)
 
 	// Set up RBAC
@@ -143,12 +148,6 @@ func setUpAccessRequestLimitForJulyAndAugust(t *testing.T, username string, role
 	require.NoError(t, err)
 	_, err = p.a.CreateUser(ctx, alice)
 	require.NoError(t, err)
-
-	// Mock audit log
-	// Create a clock in the middle of the month for easy manipulation
-	clock := clockwork.NewFakeClockAt(
-		time.Date(2023, 07, 15, 1, 2, 3, 0, time.UTC))
-	p.a.SetClock(clock)
 
 	july := clock.Now()
 	august := clock.Now().AddDate(0, 1, 0)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -286,7 +286,7 @@ func TestTeleportClient_Login_local(t *testing.T) {
 			t.Parallel()
 
 			// Start Teleport.
-			clock := clockwork.NewFakeClockAt(time.Now())
+			clock := clockwork.NewFakeClock()
 			sa := newStandaloneTeleport(t, clock)
 			username := sa.Username
 			password := sa.Password
@@ -623,10 +623,7 @@ func newStandaloneTeleport(t *testing.T, clock clockwork.Clock) *standaloneBundl
 	authAddr, err := authProcess.AuthAddr()
 	require.NoError(t, err)
 
-	// Use the same clock on AuthServer, it doesn't appear to cascade from
-	// configs.
 	authServer := authProcess.GetAuthServer()
-	authServer.SetClock(clock)
 
 	// Initialize user's password and MFA.
 	ctx := context.Background()

--- a/lib/hardwarekey/agent.go
+++ b/lib/hardwarekey/agent.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
@@ -140,7 +141,7 @@ func newAgentListener(ctx context.Context, keyAgentDir string) (net.Listener, er
 }
 
 func generateServerCert(keyAgentDir string) (tls.Certificate, error) {
-	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil /*ipAddresses*/)
+	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, nil, time.Now)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "failed to generate the certificate")
 	}

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -145,29 +145,7 @@ func (c ec2ClientRunning) DescribeInstances(ctx context.Context, params *ec2.Des
 }
 
 func TestJoinEC2(t *testing.T) {
-	ctx := context.Background()
-
-	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
-		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
-		},
-	})
-	require.NoError(t, err)
-
-	// upsert a node to test duplicates
-	node := &types.ServerV2{
-		Kind:    types.KindNode,
-		Version: types.V2,
-		Metadata: types.Metadata{
-			Name:      instance2.account + "-" + instance2.instanceID,
-			Namespace: defaults.Namespace,
-		},
-	}
-	_, err = testServer.Auth().UpsertNode(ctx, node)
-	require.NoError(t, err)
-
-	nopClient, err := testServer.NewClient(authtest.TestNop())
-	require.NoError(t, err)
+	t.Parallel()
 
 	isAccessDenied := func(t require.TestingT, err error, args ...any) {
 		if helper, ok := t.(interface{ Helper() }); ok {
@@ -176,7 +154,7 @@ func TestJoinEC2(t *testing.T) {
 		require.ErrorAs(t, err, new(*trace.AccessDeniedError), args...)
 	}
 
-	badInstanceId := instance1.account + "-i-99999999"
+	badInstanceID := instance1.account + "-i-99999999"
 
 	testCases := []struct {
 		desc          string
@@ -304,7 +282,7 @@ func TestJoinEC2(t *testing.T) {
 				},
 			},
 			ec2Client:     ec2ClientRunning{},
-			requestHostID: badInstanceId,
+			requestHostID: badInstanceID,
 			document:      instance1.iid,
 			expectError:   isAccessDenied,
 			clock:         clockwork.NewFakeClockAt(instance1.pendingTime),
@@ -466,11 +444,30 @@ func TestJoinEC2(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			clock := tc.clock
-			if clock == nil {
-				clock = clockwork.NewRealClock()
+			t.Parallel()
+
+			testServer, err := authtest.NewTestServer(authtest.ServerConfig{
+				Auth: authtest.AuthServerConfig{
+					Dir:   t.TempDir(),
+					Clock: tc.clock,
+				},
+			})
+			require.NoError(t, err)
+
+			// upsert a node to test duplicates
+			node := &types.ServerV2{
+				Kind:    types.KindNode,
+				Version: types.V2,
+				Metadata: types.Metadata{
+					Name:      instance2.account + "-" + instance2.instanceID,
+					Namespace: defaults.Namespace,
+				},
 			}
-			testServer.Auth().SetClock(clock)
+			_, err = testServer.Auth().UpsertNode(t.Context(), node)
+			require.NoError(t, err)
+
+			nopClient, err := testServer.NewClient(authtest.TestNop())
+			require.NoError(t, err)
 
 			token, err := types.NewProvisionTokenFromSpec(
 				"test_token",
@@ -478,13 +475,13 @@ func TestJoinEC2(t *testing.T) {
 				tc.tokenSpec)
 			require.NoError(t, err)
 
-			err = testServer.Auth().UpsertToken(context.Background(), token)
+			err = testServer.Auth().UpsertToken(t.Context(), token)
 			require.NoError(t, err)
 
 			testServer.Auth().SetEC2ClientForEC2JoinMethod(tc.ec2Client)
 
 			t.Run("new", func(t *testing.T) {
-				if tc.requestHostID == badInstanceId {
+				if tc.requestHostID == badInstanceID {
 					// New join method does not allow the client so request a
 					// specific host ID, so the join would pass and fail the
 					// error assertion.
@@ -520,7 +517,7 @@ func TestJoinEC2(t *testing.T) {
 				tc.expectError(t, err)
 			})
 
-			err = testServer.Auth().DeleteToken(context.Background(), token.GetName())
+			err = testServer.Auth().DeleteToken(t.Context(), token.GetName())
 			require.NoError(t, err)
 		})
 	}
@@ -530,7 +527,8 @@ func TestJoinEC2(t *testing.T) {
 func TestHostUniqueCheck(t *testing.T) {
 	testServer, err := authtest.NewTestServer(authtest.ServerConfig{
 		Auth: authtest.AuthServerConfig{
-			Dir: t.TempDir(),
+			Dir:   t.TempDir(),
+			Clock: clockwork.NewFakeClockAt(instance1.pendingTime),
 		},
 	})
 	require.NoError(t, err)
@@ -728,7 +726,6 @@ func TestHostUniqueCheck(t *testing.T) {
 	a.SetEC2ClientForEC2JoinMethod(ec2ClientRunning{})
 	nopClient, err := testServer.NewClient(authtest.TestNop())
 	require.NoError(t, err)
-	a.SetClock(clockwork.NewFakeClockAt(instance1.pendingTime))
 
 	for _, tc := range testCases {
 		t.Run(string(tc.role), func(t *testing.T) {

--- a/lib/proxy/peer/client.go
+++ b/lib/proxy/peer/client.go
@@ -767,7 +767,7 @@ func (c *Client) connect(params connectParams) (internal.ClientConn, error) {
 		return tlsCert, nil
 	}
 	tlsConfig.InsecureSkipVerify = true
-	tlsConfig.VerifyConnection = utils.VerifyConnectionWithRoots(c.config.GetTLSRoots)
+	tlsConfig.VerifyConnection = utils.VerifyConnection(c.config.Clock.Now, c.config.GetTLSRoots)
 
 	expectedPeer := utils.HostFQDN(params.peerID, c.config.ClusterName)
 

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -130,7 +130,7 @@ func (s *leafCluster) getLeafClient() (authclient.ClientI, bool, error) {
 		return tlsCert, nil
 	}
 	tlsConfig.InsecureSkipVerify = true
-	tlsConfig.VerifyConnection = utils.VerifyConnectionWithRoots(func() (*x509.CertPool, error) {
+	tlsConfig.VerifyConnection = utils.VerifyConnection(s.clock.Now, func() (*x509.CertPool, error) {
 		pool, _, err := authclient.ClientCertPool(s.ctx, s.srv.localAccessPoint, s.domainName, types.HostCA)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1343,7 +1343,7 @@ func (process *TeleportProcess) newClient(connector *Connector) (*authclient.Cli
 	}
 	tlsConfig.ServerName = apiutils.EncodeClusterName(connector.ClusterName())
 	tlsConfig.InsecureSkipVerify = true
-	tlsConfig.VerifyConnection = utils.VerifyConnectionWithRoots(connector.ClientGetPool)
+	tlsConfig.VerifyConnection = utils.VerifyConnection(process.Clock.Now, connector.ClientGetPool)
 
 	sshClientConfig, err := connector.clientSSHClientConfig(process.Config.FIPS)
 	if err != nil {

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -110,7 +110,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	tlsConfig, err := conn.ServerTLSConfig(process.Config.CipherSuites)
+	tlsConfig, err := process.ServerTLSConfig(conn)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -171,7 +171,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		return trace.Wrap(err)
 	}
 
-	tlsConfig, err := conn.ServerTLSConfig(cfg.CipherSuites)
+	tlsConfig, err := process.ServerTLSConfig(conn)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -193,7 +193,7 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	tlsConfig, err := conn.ServerTLSConfig(cfg.CipherSuites)
+	tlsConfig, err := process.ServerTLSConfig(conn)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -203,7 +203,7 @@ func (process *TeleportProcess) runRelayService() error {
 	}
 	defer peerServer.Close()
 
-	transportTLSConfig, err := conn.ServerTLSConfig(process.Config.CipherSuites)
+	transportTLSConfig, err := process.ServerTLSConfig(conn)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2196,6 +2196,7 @@ func (process *TeleportProcess) initAuthService() error {
 		ClusterName:          cn,
 		AuthPreferenceGetter: clusterConfig,
 		FIPS:                 cfg.FIPS,
+		Clock:                cfg.Clock,
 	}
 
 	switch {
@@ -2673,7 +2674,7 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 
 	// Register TLS endpoint of the auth service
-	tlsConfig, err := connector.ServerTLSConfig(cfg.CipherSuites)
+	tlsConfig, err := process.ServerTLSConfig(connector)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -3285,6 +3286,19 @@ func (process *TeleportProcess) NewAsyncEmitter(clt apievents.Emitter) (*events.
 	return events.NewAsyncEmitter(events.AsyncEmitterConfig{
 		Inner: emitter,
 	})
+}
+
+// ServerTLSConfig returns a new server-side [*tls.Config] that presents the
+// connector's credentials as its certificate. The returned tls.Config doesn't
+// request or trust any client certificates, so the caller is responsible for
+// configuring it.
+func (process *TeleportProcess) ServerTLSConfig(conn *Connector) (*tls.Config, error) {
+	conf := utils.TLSConfig(process.Config.CipherSuites)
+	conf.Time = process.Clock.Now
+	conf.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return conn.serverGetCertificate()
+	}
+	return conf, nil
 }
 
 // initInstance initializes the pseudo-service "Instance" that is active on all teleport instances.
@@ -4898,7 +4912,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
-	serverTLSConfig, err := conn.ServerTLSConfig(cfg.CipherSuites)
+	serverTLSConfig, err := process.ServerTLSConfig(conn)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -6672,7 +6686,7 @@ func (process *TeleportProcess) initApps() {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		tlsConfig, err := conn.ServerTLSConfig(process.Config.CipherSuites)
+		tlsConfig, err := process.ServerTLSConfig(conn)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -7010,7 +7024,11 @@ func initSelfSignedHTTPSCert(cfg *servicecfg.Config) (err error) {
 		}
 	}
 
-	creds, err := cert.GenerateSelfSignedCert(hosts, ips)
+	now := time.Now
+	if cfg.Clock != nil {
+		now = cfg.Clock.Now
+	}
+	creds, err := cert.GenerateSelfSignedCert(hosts, ips, nil, now)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -7216,7 +7234,7 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 		return nil, nil
 	}
 	clusterName := cfg.conn.ClusterName()
-	serverTLSConfig, err := cfg.conn.ServerTLSConfig(process.Config.CipherSuites)
+	serverTLSConfig, err := process.ServerTLSConfig(cfg.conn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2238,7 +2238,7 @@ func (c *testContext) createUserAndRole(ctx context.Context, t testing.TB, userN
 
 // makeTLSConfig returns tls configuration for the test's tls listener.
 func (c *testContext) makeTLSConfig(t testing.TB) *tls.Config {
-	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
+	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, nil, time.Now)
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair(creds.Cert, creds.PrivateKey)
 	require.NoError(t, err)

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -141,16 +141,15 @@ func newMockServer(t *testing.T) *mockServer {
 	})
 	require.NoError(t, err)
 
-	authCfg := &auth.InitConfig{
+	authServer, err := auth.NewServer(&auth.InitConfig{
 		Backend:        bk,
 		VersionStorage: authtest.NewFakeTeleportVersion(),
 		Authority:      testauthority.New(),
 		ClusterName:    clusterName,
 		StaticTokens:   staticTokens,
 		HostUUID:       uuid.NewString(),
-	}
-
-	authServer, err := auth.NewServer(authCfg, authtest.WithClock(clock))
+		Clock:          clock,
+	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, authServer.Close())

--- a/lib/teleterm/gateway/db_middleware_test.go
+++ b/lib/teleterm/gateway/db_middleware_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func TestDBMiddleware_OnNewConnection(t *testing.T) {
-	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
+	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, nil, time.Now)
 	require.NoError(t, err)
 	tlsCert, err := keys.X509KeyPair(testCert.Cert, testCert.PrivateKey)
 	require.NoError(t, err)

--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/grpc"
@@ -131,7 +132,7 @@ func generateAndSaveCert(targetPath string, eku ...x509.ExtKeyUsage) (tls.Certif
 	}
 	defer os.Remove(tempFile.Name())
 
-	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, eku...)
+	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil, eku, time.Now)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "failed to generate the certificate")
 	}

--- a/lib/utils/cert/selfsigned.go
+++ b/lib/utils/cert/selfsigned.go
@@ -51,7 +51,7 @@ type Credentials struct {
 // GenerateSelfSignedCert generates a self-signed certificate that
 // is valid for given domain names and IPs. If extended key usage
 // is not specified, the cert will be generated for server auth.
-func GenerateSelfSignedCert(hostNames []string, ipAddresses []string, eku ...x509.ExtKeyUsage) (*Credentials, error) {
+func GenerateSelfSignedCert(hostNames []string, ipAddresses []string, eku []x509.ExtKeyUsage, now func() time.Time) (*Credentials, error) {
 	if len(eku) == 0 {
 		// if not specified, assume this cert is for server auth,
 		// which is required for validation on macOS:
@@ -63,7 +63,12 @@ func GenerateSelfSignedCert(hostNames []string, ipAddresses []string, eku ...x50
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	notBefore := time.Now()
+
+	if now == nil {
+		now = time.Now
+	}
+
+	notBefore := now()
 	notAfter := notBefore.Add(macMaxTLSCertValidityPeriod)
 
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 func TestSelfSignedCert(t *testing.T) {
 	t.Parallel()
 
-	creds, err := cert.GenerateSelfSignedCert([]string{"example.com"}, nil)
+	creds, err := cert.GenerateSelfSignedCert([]string{"example.com"}, nil, nil, time.Now)
 	require.NoError(t, err)
 	signer, err := keys.ParsePrivateKey(creds.PrivateKey)
 	require.NoError(t, err)

--- a/lib/web/sessions_test.go
+++ b/lib/web/sessions_test.go
@@ -225,7 +225,7 @@ func TestSessionCache_watcher(t *testing.T) {
 
 	// Create realistic keys and certificates, newSessionContextFromSession
 	// requires it.
-	creds, err := cert.GenerateSelfSignedCert(nil /* hostNames */, nil /* ipAddresses */)
+	creds, err := cert.GenerateSelfSignedCert(nil, nil, nil, time.Now)
 	require.NoError(t, err, "GenerateSelfSignedCert() failed")
 
 	// Create "fake" sessions with the same sessionID using newSession.

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -309,6 +309,7 @@ func makeAndRunTestAuthServer(t *testing.T, opts ...testServerOptionFunc) (auth 
 	cfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	if options.fakeClock != nil {
 		cfg.Clock = options.fakeClock
+		cfg.Auth.Clock = options.fakeClock
 	}
 	auth, err = service.NewTeleport(cfg)
 

--- a/tool/tctl/common/lock_command_test.go
+++ b/tool/tctl/common/lock_command_test.go
@@ -20,7 +20,6 @@ package common
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -54,9 +53,8 @@ func TestLocks(t *testing.T) {
 		},
 	}
 
-	timeNow := time.Now().UTC()
-	fakeClock := clockwork.NewFakeClockAt(timeNow)
-	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withFakeClock(fakeClock))
+	clock := clockwork.NewFakeClock()
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withFakeClock(clock))
 	clt, err := testenv.NewDefaultAuthClient(process)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = clt.Close() })
@@ -79,7 +77,7 @@ func TestLocks(t *testing.T) {
 		expected.SetCreatedBy(string(types.RoleAdmin))
 
 		require.NoError(t, err)
-		expected.SetCreatedAt(timeNow)
+		expected.SetCreatedAt(clock.Now())
 
 		require.Empty(t, cmp.Diff([]*types.LockV2{expected.(*types.LockV2)}, out,
 			cmpopts.IgnoreFields(types.LockV2{}, "Metadata")))


### PR DESCRIPTION
The ability to alter the auth server clock existed to allow tests to inject a fake clock. While this sounds great it introduces opportunity for data races if other components are already consuming the existing clock. For example:

```
==================
WARNING: DATA RACE
Write at 0x00c003014720 by goroutine 168:
  github.com/gravitational/teleport/lib/auth.(*Server).SetClock()
      /__w/teleport.e/teleport.e/lib/auth/auth.go:2308 +0x88
  github.com/gravitational/teleport/lib/client_test.newStandaloneTeleport()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:629 +0x11ad
  github.com/gravitational/teleport/lib/client_test.newStandaloneTeleport()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:621 +0x1092
  github.com/gravitational/teleport/lib/client_test.TestTeleportClient_Login_local.func21()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:290 +0x14e
  testing.tRunner()
      /opt/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/go/src/testing/testing.go:1997 +0x44

Previous read at 0x00c003014720 by goroutine 9018:
  github.com/gravitational/teleport/lib/auth.(*Server).GenerateHostCerts()
      /__w/teleport.e/teleport.e/lib/auth/auth.go:5127 +0x59d
  github.com/gravitational/teleport/lib/auth.GenerateIdentity()
      /__w/teleport.e/teleport.e/lib/auth/init.go:1606 +0x450
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).reRegister()
      /__w/teleport.e/teleport.e/lib/service/connect.go:450 +0x25a
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).rotate()
      /__w/teleport.e/teleport.e/lib/service/connect.go:1160 +0xaa7
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).syncServiceRotationState()
      /__w/teleport.e/teleport.e/lib/service/connect.go:1017 +0x20b
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).syncRotationState()
      /__w/teleport.e/teleport.e/lib/service/connect.go:996 +0x1c9
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).syncRotationStateAndBroadcast()
      /__w/teleport.e/teleport.e/lib/service/connect.go:962 +0x4e
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).syncRotationStateCycle()
      /__w/teleport.e/teleport.e/lib/service/connect.go:906 +0xcb
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).periodicSyncRotationState()
      /__w/teleport.e/teleport.e/lib/service/connect.go:870 +0x5f3
  github.com/gravitational/teleport/lib/service.(*TeleportProcess).periodicSyncRotationState-fm()
      <autogenerated>:1 +0x33
  github.com/gravitational/teleport/lib/service.(*LocalService).Serve()
      /__w/teleport.e/teleport.e/lib/service/supervisor.go:605 +0x35
  github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1()
      /__w/teleport.e/teleport.e/lib/service/supervisor.go:328 +0x4a2

Goroutine 168 (running) created at:
  testing.(*T).Run()
      /opt/go/src/testing/testing.go:1997 +0x9d2
  github.com/gravitational/teleport/lib/client_test.TestTeleportClient_Login_local()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:285 +0x691
  testing.tRunner()
      /opt/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/go/src/testing/testing.go:1997 +0x44

Goroutine 9018 (running) created at:
  github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve()
      /__w/teleport.e/teleport.e/lib/service/supervisor.go:317 +0x10a
  github.com/gravitational/teleport/lib/service.(*LocalSupervisor).Start()
      /__w/teleport.e/teleport.e/lib/service/supervisor.go:360 +0x2f6
  github.com/gravitational/teleport/lib/client_test.startAndWait()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:804 +0x91
  github.com/gravitational/teleport/lib/client_test.startAndWait()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:802 +0x45
  github.com/gravitational/teleport/lib/client_test.newStandaloneTeleport()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:621 +0x1092
  github.com/gravitational/teleport/lib/client_test.TestTeleportClient_Login_local.func21()
      /__w/teleport.e/teleport.e/lib/client/api_login_test.go:290 +0x14e
  testing.tRunner()
      /opt/go/src/testing/testing.go:1934 +0x21c
  testing.(*T).Run.gowrap1()
      /opt/go/src/testing/testing.go:1997 +0x44
==================  
```

The setter is also redundant - Auth already exposes a way to be constructed with a custom clock. In order to get rid of the races once and for all, the clock setter was removed and all tests have been updated to plumb the clock through on construction. The knock on effect to this change, is that all components within a Teleport process used in tests need to use the same clock. This required extending existing components which use time when generating certificates, or validating certificates to use the same clock. 