### PR TITLE
[v16] Fix Var usage

### DIFF
--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -125,7 +125,7 @@ AWS APIs.
    ```
    
    Create a file called `app-service-tp.json` with the following content,
-   assigning <Var name="oidc-issuer" /> to the issuer string you retrieved and
+   assigning <Var name="OIDC_ISSUER" /> to the issuer string you retrieved and
    <Var name="EKS_ACCOUNT" /> to the ID of the AWS account that belongs to your
    EKS cluster:
    
@@ -389,7 +389,8 @@ $ tctl tokens add --type=app --ttl=1h --format=text
 <TabItem label="EC2">
 
 On the host where you will install the Teleport Application Service, create a
-file called `/tmp/token` that consists only of your token:
+file called `/tmp/token` that consists only of your token, assigning 
+<Var name="join-token" /> to the value of the token:
 
 ```code
 $ echo <Var name="join-token" /> | sudo tee /tmp/token

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -43,12 +43,17 @@ the client IDs of the managed identities for user access. This managed identity
 will be assigned as the default identity for the Kubernetes service account.
 
 Log in to your Azure admin account with `az login` command if you haven't
-already, and prepare some environment variables for later steps:
+already, and prepare some environment variables for later steps. Assign <Var
+name="eastus" /> to an Azure region name, <Var name="myResourceGroup" /> to the
+name of your Azure resource group, <Var name="myAKSCluster" /> to the name of
+your AKS cluster, and <Var name="teleport-azure-cli-aks-agent" /> to the Azure
+identity to assign to the Teleport Agent:
+
 ```code
 $ export SUBSCRIPTION="$(az account show --query id --output tsv)"
 $ export LOCATION="<Var name="eastus" />"
 $ export RESOURCE_GROUP="<Var name="myResourceGroup" />"
-$ export AKS_CLUSTER_NAME="<Var name="myASKCluster" />"
+$ export AKS_CLUSTER_NAME="<Var name="myAKSCluster" />"
 $ export USER_ASSIGNED_IDENTITY_NAME="<Var name="teleport-azure-cli-aks-agent" />"
 ```
 

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -339,7 +339,8 @@ Cloud CLI via Teleport, the Teleport Auth Service populates the
 service accounts you have assigned to the user.
 
 Assign the target service account we created earlier (or another service
-account) to your Teleport user by running the following command:
+account) to your Teleport user by running the following command, setting 
+<Var name="teleport-user" /> to the name of your Teleport user:
 
 ```code
 $ tctl users update <Var name="teleport-user" /> \

--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -189,8 +189,10 @@ To access the server using commands in a terminal:
 
 1. Open a new terminal window.
 
-1. Sign in to your Teleport cluster by running the `tsh login` command  with the URL 
-of your cluster and the name of your Teleport user:
+1. Sign in to your Teleport cluster by running the `tsh login` command  with the
+   URL of your cluster and the name of your Teleport user, assigning 
+   <Var name="example" /> to your account subdomain and <Var name="username" /> to
+   your Teleport username:
    
    ```code
    $ tsh login --proxy=<Var name="example" />.teleport.sh --user=<Var name="username" />
@@ -227,7 +229,7 @@ of your cluster and the name of your Teleport user:
 1. Access your server as the `root` user:
 
    ```code
-   $ tsh ssh root@<Var name="node-name" />
+   $ tsh ssh root@b6c1072b5af5
    ```
 
 ## Next steps

--- a/docs/pages/identity-governance/device-trust/device-management.mdx
+++ b/docs/pages/identity-governance/device-trust/device-management.mdx
@@ -71,9 +71,9 @@ $ tsh device asset-tag
 </details>
 
 
-Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to
-be registered"/> with the serial number of the device you wish to enroll and run
-the `tctl devices add` command:
+Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/>
+with the serial number of the device you wish to enroll and <Var name="macos" /> with your operating
+system. Run the `tctl devices add` command:
 
 ```code
 $ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'

--- a/docs/pages/identity-governance/device-trust/jamf-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/jamf-integration.mdx
@@ -50,12 +50,17 @@ specific for Teleport.
 
 Make sure that your Jamf role has the "Read Computers" privilege.
 
-You can test your client credentials using the following Jamf query:
+You can test your client credentials using the following Jamf query, replacing
+<Var name="(=jamf.api_endpoint=)" description="Jamf API URL" /> with your Jamf
+API endpoint, <Var name="(=jamf.client_id=)" description="Jamf API client ID" />
+with your client ID, and 
+<Var name="(=jamf.client_secret=)" description="Jamf API client secret" /> with
+your client secret:
 
 ```code
-$ URL='<Var name="(=jamf.api_endpoint=)" description="Jamf API URL"/>'
-$ CLIENT_ID='<Var name="(=jamf.client_id=)" description="Jamf API client ID" />'
-$ CLIENT_SECRET='<Var name="(=jamf.client_secret=)" description="Jamf API client secret" />'
+$ URL='<Var name="(=jamf.api_endpoint=)" />'
+$ CLIENT_ID='<Var name="(=jamf.client_id=)" />'
+$ CLIENT_SECRET='<Var name="(=jamf.client_secret=)" />'
 
 ## Acquire access token from Jamf.
 $ TOKEN_RESP="$(curl -X POST "$URL/api/oauth/token" \

--- a/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
@@ -206,8 +206,10 @@ If not using the `teleport-cluster` Helm chart, you will need to do the equivale
 - Add the `access_graph:` section at the top-level of the YAML config file for the Teleport Auth Service.
 - Mount the created ConfigMap as a volume so that the Auth Service can read the CA certificate.
 
-Finally, redeploy the Helm chart (assuming the values are stored in `values-teleport.yaml`).
-Once the Auth Service changes succeed, restart the Proxy Service.
+Finally, redeploy the Helm chart (assuming the values are stored in
+`values-teleport.yaml`).  Once the Auth Service changes succeed, restart the
+Proxy Service. Assign <Var name="teleport-cluster-deployment-name" /> to the
+name of your `teleport-cluster` deployment:
 
 ```code
 $ helm upgrade -n <Var name="teleport-cluster-namespace" /> -f values-teleport.yaml \

--- a/docs/pages/includes/database-access/custom-db-ca.mdx
+++ b/docs/pages/includes/database-access/custom-db-ca.mdx
@@ -1,5 +1,7 @@
 {{ scheme="" query="" }}
-Modify the Teleport Database Service to trust your {{ db }} CA:
+Modify the Teleport Database Service to trust your {{ db }} CA, assigning
+<Var name='/path/to/your/ca.crt' /> to the path to your CA certificate:
+
   ```yaml
     databases:
     - name: "example-{{ protocol }}"

--- a/docs/pages/includes/database-access/db-audit-events.mdx
+++ b/docs/pages/includes/database-access/db-audit-events.mdx
@@ -23,7 +23,7 @@ Session ended at Mon Jul 20 20:30 UTC
 
 All database protocols recordings are supported in JSON format (`--format json`):
 ```code
-$ tsh play --format json <Var name="database.session" />
+$ tsh play --format json 307b49d6-56c7-4d20-8cf0-5bc5348a7101
 ```
 
 ```json

--- a/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
+++ b/docs/pages/includes/database-access/iam_role_trust_relationship.mdx
@@ -9,6 +9,8 @@ generally required:
 policy.
 <Tabs>
 <TabItem label="Role as principal">
+
+Assign <Var name="aws-account-id"/> to your AWS account ID:
 ```json
 {
   "Version": "2012-10-17",
@@ -25,6 +27,9 @@ policy.
 ```
 </TabItem>
 <TabItem label="Account as principal">
+
+Assign <Var name="aws-account-id"/> to your AWS account ID:
+
 ```json
 {
   "Version": "2012-10-17",
@@ -41,6 +46,9 @@ policy.
 ```
 </TabItem>
 <TabItem label="Cross-account with external-id">
+
+Assign <Var name="external-aws-account-id"/> to an external AWS account ID:
+
 ```json
 {
   "Version": "2012-10-17",

--- a/docs/pages/includes/database-access/reference/aws-iam/redshift-serverless/role-as-user-policy.mdx
+++ b/docs/pages/includes/database-access/reference/aws-iam/redshift-serverless/role-as-user-policy.mdx
@@ -1,5 +1,7 @@
 The following permissions policy should be attached to an IAM role that Teleport
-users can specify as a database user.
+users can specify as a database user. Assign <Var name="us-east-2"/> to an AWS
+region, <Var name="aws-account-id"/> to your AWS account ID, and 
+<Var name="workgroup-id"/> to a workgroup ID:
 
 ```json
 {

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -10,7 +10,7 @@ mode for your cluster.
 1. Run your cluster's install script:
 
    ```code
-   $ curl "https://<Var name="example.teleport.sh:443"/>/scripts/install.sh" | sudo bash
+   $ curl "https://<Var name="teleport.example.com:443"/>/scripts/install.sh" | sudo bash
    ```
 
 On *older Teleport versions*:

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,7 +1,9 @@
 To check that you can connect to your Teleport cluster, sign in with `tsh login`, then 
 verify that you can run `tctl` commands using your current credentials. 
 
-For example:
+For example, run the following command, assigning 
+<Var name="teleport.example.com" /> to the domain name of the Teleport Proxy Service
+in your cluster and <Var name="email@example.com" /> to your Teleport username:
 
 ```code
 $ tsh login --proxy=<Var name="teleport.example.com" /> --user=<Var name="email@example.com" />

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -128,7 +128,8 @@ Overriding a block is available to users with rights to maintain `user` resource
 available in the built-in `editor` role. To turn off a block, update the user entry,
 following these steps.
 
-Open the user resource in your editor:
+Open the user resource in your editor, assigning <Var name="username" /> to the
+name of your Teleport user:
 
 ```code
 $ tctl edit users/<Var name="username" />

--- a/docs/pages/reference/architecture/tls-routing.mdx
+++ b/docs/pages/reference/architecture/tls-routing.mdx
@@ -249,7 +249,7 @@ and long-lived connections.
 You can set up a Teleport Proxy Service behind the reverse proxy and run the
 following command to test the connection:
 ```code
-$ curl -v https://<Var name="teleport.example.com" />/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping" --no-alpn
+$ curl -v https://teleport.example.com/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping" --no-alpn
 ```
 
 For a successful upgrade, the server should return "101 Switching Protocols"

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -219,7 +219,8 @@ the dataset to be at least:
 
 An additional 20-40% safety margin is recommended for metadata and fragmentation overhead.
 
-Given an existing resource you can estimate its size with the following command:
+Given an existing resource you can estimate its size with the following command,
+assigning <Var name="resource" /> to the resource name, e.g., `role/editor`:
 
 ```code
 tctl get <Var name="resource" /> --format=json | awk '{ total += length($0) } END { print total * 2 }'

--- a/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/webauthn.mdx
@@ -293,9 +293,11 @@ $ tsh device asset-tag
 </Tabs>
 </details>
 
-Replace <Var name="(=devicetrust.asset_tag=)" description="The serial number to
-be registered"/> with the serial number of the device you wish to enroll and run
-the `tctl devices add` command:
+Replace 
+<Var name="(=devicetrust.asset_tag=)" description="The serial number to be registered"/> 
+with the serial number of the device you wish to enroll, and
+<Var name="macos" /> with your operating system. Run the
+`tctl devices add` command:
 
 ```code
 $ tctl devices add --os='<Var name="macos"/>' --asset-tag='<Var name="(=devicetrust.asset_tag=)"/>'

--- a/docs/pages/zero-trust-access/access-controls/login-rules/guide.mdx
+++ b/docs/pages/zero-trust-access/access-controls/login-rules/guide.mdx
@@ -184,7 +184,7 @@ provider and how they are being mapped by your Login Rules.
 
 `tctl sso test` expects a connector spec.
 Run the following command to debug with a connector currently installed in your
-cluster.
+cluster, assigning <Var name="SSO connector name"/> to the connector name:
 
 ```code
 $ tctl get connector/<Var name="SSO connector name"/> --with-secrets | tctl sso test

--- a/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
@@ -148,7 +148,9 @@ $ iptables -A OUTPUT -m owner ! --uid-owner 0 -d 169.254.169.254 -j REJECT
 CA key parameters are statically configured in the `teleport.yaml` configuration
 file of the Teleport Auth Service instances in your cluster.
 
-Include the following `ca_key_params` configuration in the `auth_service` section.
+Include the following `ca_key_params` configuration in the `auth_service`
+section. Assign <Var name="AWS account"/> to your AWS account ID and 
+"<Var name="AWS region"/>" to the name of your AWS region:
 
 ```yaml
 # /etc/teleport.yaml

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -160,7 +160,7 @@ These are regions that support [DynamoDB encryption at rest](https://docs.aws.am
 ### cluster_name
 
 ```code
-$ export TF_VAR_cluster_name="<Var name="teleport-example" />"
+$ export TF_VAR_cluster_name=teleport-example
 ```
 
 This is the internal Teleport cluster name to use. This should be unique, and not contain spaces, dots (.) or other
@@ -252,7 +252,7 @@ You should use the appropriate domain without the trailing dot.
 ### route53\_domain
 
 ```code
-$ export TF_VAR_route53_domain="<Var name="teleport.example.com" />"
+$ export TF_VAR_route53_domain=teleport.example.com
 ```
 
 A subdomain to set up as an A record pointing to the IP of the Teleport cluster host for web access. This will be the public-facing domain

--- a/docs/pages/zero-trust-access/management/admin/labels.mdx
+++ b/docs/pages/zero-trust-access/management/admin/labels.mdx
@@ -318,14 +318,14 @@ To add resource-based labels first get the SSH server details.
 1. Retrieve the SSH server that you wish to apply labels to.
 
 ```code
-$ tctl get node/<Var name="foo" />
+$ tctl get node/mynode
 kind: node
 metadata:
   expires: "2024-01-12T00:41:17.355013266Z"
   name: 116b08d2-7167-4eab-85a8-cf93f054b217
 spec:
   addr: 127.0.0.1:3022
-  hostname: foo
+  hostname: mynode
 ```
 
 1. Create the corresponding `server_info.yaml` for the node above.

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -72,7 +72,7 @@ Before you get started, you’ll need:
 1. Enter the URL for your Teleport Proxy Service host in the **Entity ID** and **Reply URL**  fields:
 
    ```code
-   https://<Var name="mytenant.teleport.sh:443" />/v1/webapi/saml/acs/ad
+   https://mytenant.teleport.sh/v1/webapi/saml/acs/ad
    ```
 
    ![Put in Entity ID and Reply URL](../../../img/azuread/azuread-7-entityandreplyurl.png)

--- a/docs/pages/zero-trust-access/sso/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/github-sso.mdx
@@ -203,8 +203,10 @@ spec.
 <details>
 <summary>Self-hosting GitHub Enterprise?</summary>
 
-For self-hosted GitHub Enterprise servers, you can specify the server
-instance endpoints with the `--endpoint-url`, `--api-endpoint-url` parameters:
+For self-hosted GitHub Enterprise servers, you can specify the server instance
+endpoints with the `--endpoint-url`, `--api-endpoint-url` parameters, replacing
+<Var name="github-enterprise-server-address"/> with your endpoint URL and 
+<Var name="api-github-enterprise-server-address"/> with your API endpoint URL:
 
 ```code
 $ tctl sso configure github \

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -43,7 +43,7 @@ Save the relevant information from your identity provider. To make following
 this guide easier, you can add the Client ID here and it will be included in the
 example commands below:
 
-Client ID: <Var name="<CLIENT-ID>" description="The Client ID for your Teleport
+Client ID: <Var name="CLIENT-ID" description="The Client ID for your Teleport
 application, provided by your IdP"/>
 
 ## OIDC Redirect URL
@@ -52,10 +52,14 @@ OIDC relies on HTTP redirects to return control back to Teleport after
 authentication is complete. The redirect URL must be selected by a Teleport
 administrator in advance.
 
-The redirect URL for OIDC authentication in Teleport is <nobr><Var
-name="mytenant.teleport.sh" description="Your Teleport Cloud tenant or Proxy
-Service address"/>`/v1/webapi/oidc/callback`</nobr>. Replace `mytenant.teleport.sh`
-with your Teleport Cloud tenant or Proxy Service address.
+The redirect URL for OIDC authentication in Teleport is <nobr> <Var
+name="mytenant.teleport.sh:443" description="Your Teleport Cloud tenant or Proxy
+Service address"/>`/v1/webapi/oidc/callback`</nobr>.  Replace <Var
+name="mytenant.teleport.sh:443" /> with your Teleport Cloud tenant or Proxy
+Service address. If you have a self-hosted cluster with multiple public
+addresses for the Teleport Proxy Service (the value of
+`proxy_service.public_addr` in the Teleport configuration file), ensure that
+this address points to the first one listed.
 
 ## OIDC connector configuration
 
@@ -72,7 +76,7 @@ connector resource file in YAML format named `oidc-connector.yaml`:
 ```code
 $ tctl sso configure oidc --name <CONNECTOR-NAME> \
   --issuer-url <PATH-TO-PROVIDER> \
-  --id <CLIENT-ID> \
+  --id <Var name="CLIENT-ID" /> \
   --secret $(cat client-secret.txt) \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,access \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,editor > oidc-connector.yaml

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -103,14 +103,27 @@ Provide the following values to their respective fields:
 
 #### General
 
-- Single sign on URL: `https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`
-- Audience URI (SP Entity ID): <nobr>`https://<cluster-url>:<port>/v1/webapi/saml/acs/okta`</nobr>
-- Name ID format `EmailAddress`
-- Application username `Okta username`
+Replace <Var name="example.teleport.sh:443" /> with your Teleport Proxy Service
+or Enterprise Cloud account domain and port (`443` by default). If you have a
+self-hosted cluster with multiple public addresses for the Teleport Proxy
+Service (the value of `proxy_service.public_addr` in the Teleport configuration
+file), ensure that this address points to the first one listed.
 
-Replace `<cluster-url>` with your Teleport Proxy Service address or Enterprise
-Cloud tenant (e.g. `mytenant.teleport.sh`). Replace `<port>` with your Proxy
-Service listening port (`443` by default).
+- Single sign on URL:
+
+  ```
+  https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
+  ```
+
+- Audience URI (SP Entity ID):
+
+  ```
+  https://<Var name="example.teleport.sh:443" />/v1/webapi/saml/acs/okta
+  ```
+
+- Name ID format `EmailAddress`
+
+- Application username `Okta username`
 
 #### Attribute Statements
 
@@ -179,7 +192,7 @@ flags for this command:
 
 ```code
 $ tctl sso configure saml --preset=okta \
---entity-descriptor <Var name="https://example.okta.com/app/000000/sso/saml/metadata"/> \
+--entity-descriptor "https://example.okta.com/app/000000/sso/saml/metadata" \
 --attributes-to-roles=groups,okta-admin,editor \
 --attributes-to-roles=groups,okta-dev,dev > okta-connector.yaml
 ```

--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -278,7 +278,7 @@ Create the resource:
 
   ```code
   # Log in to your cluster with tsh so you can run tctl commands.
-  $ tsh login --proxy=<Var name="mytenant.teleport.sh" /> --user=myuser
+  $ tsh login --proxy=example.teleport.sh --user=myuser
   $ tctl create -f cap.yaml
   ```
 


### PR DESCRIPTION
Prepare for the migration of the Vale linter for Var component usage to `remark` by editing a Var that only has a single occurrence. This linter ensures that each Var has at least two occurrences on a page so we can take advantage of the reused Var values or provide instructions on assigning a Var.