### PR TITLE
[mcp] fix "session end" not being sent sometimes

### DIFF
--- a/lib/client/mcp/reconnect.go
+++ b/lib/client/mcp/reconnect.go
@@ -155,30 +155,41 @@ func ProxyStdioConn(ctx context.Context, cfg ProxyStdioConnConfig) error {
 
 type serverConnWithAutoReconnect struct {
 	ProxyStdioConnConfig
-	parentCtx context.Context
+	closeCtx       context.Context
+	closeCtxCancel context.CancelFunc
 
 	mu                  sync.Mutex
-	serverRequestWriter mcputils.MessageWriter
+	serverMessageWriter mcputils.MessageWriter
+	serverMessageReader *mcputils.MessageReader
 	firstConnectionDone bool
 	initRequest         *mcputils.JSONRPCRequest
 	initResponse        *mcp.InitializeResult
 	initNotification    *mcputils.JSONRPCNotification
-	closeServerConn     func()
 }
 
 func newServerConnWithAutoReconnect(parentCtx context.Context, cfg ProxyStdioConnConfig) (*serverConnWithAutoReconnect, error) {
+	closeCtx, closeCtxCancel := context.WithCancel(parentCtx)
 	return &serverConnWithAutoReconnect{
 		ProxyStdioConnConfig: cfg,
-		parentCtx:            parentCtx,
+		closeCtx:             closeCtx,
+		closeCtxCancel:       closeCtxCancel,
 	}, nil
 }
 
 func (r *serverConnWithAutoReconnect) Close() error {
+	r.Logger.InfoContext(r.closeCtx, "Closing server connection")
+
 	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.closeServerConn != nil {
-		r.closeServerConn()
+	r.closeCtxCancel()
+	if r.serverMessageReader == nil {
+		r.mu.Unlock()
+		return nil
 	}
+
+	// Wait without lock.
+	wait := r.serverMessageReader.Done()
+	r.mu.Unlock()
+	<-wait
 	return nil
 }
 
@@ -210,7 +221,7 @@ func (r *serverConnWithAutoReconnect) makeServerTransport(ctx context.Context) (
 			return r.DialServer(ctx)
 		}
 		httpReaderWriter, err := mcputils.NewHTTPReaderWriter(
-			r.parentCtx,
+			r.closeCtx,
 			"http://localhost", // does not matter with the custom transport.
 			mcpclienttransport.WithHTTPBasicClient(&http.Client{
 				Transport: transport,
@@ -234,6 +245,11 @@ func (r *serverConnWithAutoReconnect) makeServerTransport(ctx context.Context) (
 }
 
 func (r *serverConnWithAutoReconnect) canRetryLocked() bool {
+	// We are closed, no retry.
+	if r.closeCtx.Err() != nil {
+		return false
+	}
+
 	// When auto-reconnect is on, always retry without exiting.
 	// When auto-reconnect is off, see if we have made the first connection yet.
 	// If not, we could retry until the first connection is established.
@@ -249,8 +265,8 @@ func (r *serverConnWithAutoReconnect) shouldExitOnWriteError() bool {
 }
 
 func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.Context) (mcputils.MessageWriter, error) {
-	if r.serverRequestWriter != nil {
-		return r.serverRequestWriter, nil
+	if r.serverMessageWriter != nil {
+		return r.serverMessageWriter, nil
 	}
 
 	if !r.canRetryLocked() {
@@ -269,9 +285,9 @@ func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.C
 			serverTransportReader.Close()
 			return nil, trace.Wrap(err)
 		}
-		r.serverRequestWriter = serverWriter
+		r.serverMessageWriter = serverWriter
 	} else {
-		r.serverRequestWriter = mcputils.NewMultiMessageWriter(
+		r.serverMessageWriter = mcputils.NewMultiMessageWriter(
 			mcputils.MessageWriterFunc(func(ctx context.Context, msg mcp.JSONRPCMessage) error {
 				r.cacheMessageLocked(ctx, msg)
 				return nil
@@ -282,7 +298,7 @@ func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.C
 	}
 
 	// This should never fail as long the correct config is passed in.
-	serverResponseReader, err := mcputils.NewMessageReader(mcputils.MessageReaderConfig{
+	r.serverMessageReader, err = mcputils.NewMessageReader(mcputils.MessageReaderConfig{
 		Transport: serverTransportReader,
 		// OnClose is called when server connection is dead or if any handler
 		// fails. Teleport Proxy automatically closes the connection when tsh
@@ -295,7 +311,7 @@ func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.C
 				r.Logger.InfoContext(ctx, "Lost server session, closing...")
 				r.ClientStdio.Close()
 			}
-			r.serverRequestWriter = nil
+			r.serverMessageWriter = nil
 			if r.onServerConnClosed != nil {
 				r.onServerConnClosed()
 			}
@@ -316,12 +332,10 @@ func (r *serverConnWithAutoReconnect) getServerRequestWriterLocked(ctx context.C
 		return nil, trace.Wrap(err)
 	}
 
-	readerCtx, readerCancel := context.WithCancel(r.parentCtx)
-	r.closeServerConn = readerCancel
-	go serverResponseReader.Run(readerCtx)
+	go r.serverMessageReader.Run(r.closeCtx)
 
 	r.Logger.InfoContext(ctx, "Started a new MCP server connection")
-	return r.serverRequestWriter, nil
+	return r.serverMessageWriter, nil
 }
 
 func (r *serverConnWithAutoReconnect) initializedLocked() bool {

--- a/lib/utils/mcputils/reader.go
+++ b/lib/utils/mcputils/reader.go
@@ -117,7 +117,8 @@ func (c *MessageReaderConfig) CheckAndSetDefaults() error {
 
 // MessageReader reads requests from provided reader.
 type MessageReader struct {
-	cfg MessageReaderConfig
+	cfg     MessageReaderConfig
+	runDone chan struct{}
 }
 
 // NewMessageReader creates a new MessageReader. Must call "Start" to
@@ -127,7 +128,8 @@ func NewMessageReader(cfg MessageReaderConfig) (*MessageReader, error) {
 		return nil, trace.Wrap(err)
 	}
 	return &MessageReader{
-		cfg: cfg,
+		cfg:     cfg,
+		runDone: make(chan struct{}),
 	}, nil
 }
 
@@ -135,15 +137,16 @@ func NewMessageReader(cfg MessageReaderConfig) (*MessageReader, error) {
 // error happens from the provided reader or any of the handler.
 func (r *MessageReader) Run(ctx context.Context) {
 	r.cfg.Logger.InfoContext(ctx, "Start processing messages", "transport", r.cfg.Transport.Type())
+	defer close(r.runDone)
 
-	finished := make(chan struct{})
+	processDone := make(chan struct{})
 	go func() {
 		r.startProcess(ctx)
-		close(finished)
+		close(processDone)
 	}()
 
 	select {
-	case <-finished:
+	case <-processDone:
 	case <-ctx.Done():
 	}
 
@@ -154,6 +157,12 @@ func (r *MessageReader) Run(ctx context.Context) {
 	if r.cfg.OnClose != nil {
 		r.cfg.OnClose()
 	}
+}
+
+// Done returns a channel for waiting until Run finishes. Useful if Run is
+// kicked off in another goroutine.
+func (r *MessageReader) Done() chan struct{} {
+	return r.runDone
 }
 
 func (r *MessageReader) startProcess(ctx context.Context) {


### PR DESCRIPTION
related:
- #56588 

changelog: Fix an issue MCP session end event is not being sent sometimes