### PR TITLE
Adding scoped authorization to scoped token CRUD

### DIFF
--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -123,9 +123,9 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// Servers and presence heartbeat
 	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", srv.WithAuth(srv.keepAliveNode))
 	srv.POST("/:version/authservers", srv.WithAuth(srv.upsertAuthServer))
-	srv.GET("/:version/authservers", srv.WithAuth(srv.getAuthServers))
+	srv.GET("/:version/authservers", srv.WithScopedAuth(srv.getAuthServers))
 	srv.POST("/:version/proxies", srv.WithAuth(srv.upsertProxy))
-	srv.GET("/:version/proxies", srv.WithAuth(srv.getProxies))
+	srv.GET("/:version/proxies", srv.WithScopedAuth(srv.getProxies))
 	srv.DELETE("/:version/proxies", srv.WithAuth(srv.deleteAllProxies))
 	srv.DELETE("/:version/proxies/:name", srv.WithAuth(srv.deleteProxy))
 	srv.POST("/:version/tunnelconnections", srv.WithAuth(srv.upsertTunnelConnection))
@@ -183,10 +183,37 @@ func (s *APIServer) WithAuth(handler HandlerWithAuthFunc) httprouter.Handle {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
 		auth := &ServerWithRoles{
 			authServer: s.AuthServer,
 			context:    *authContext,
 			alog:       s.AuthServer,
+		}
+		version := p.ByName("version")
+		if version == "" {
+			return nil, trace.BadParameter("missing version")
+		}
+		return handler(auth, w, r, p, version)
+	})
+}
+
+func (s *APIServer) WithScopedAuth(handler HandlerWithAuthFunc) httprouter.Handle {
+	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+		// HTTPS server expects auth context to be set by the auth middleware
+		scopedContext, err := s.ScopedAuthorizer.AuthorizeScoped(r.Context())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		authContext, ok := scopedContext.UnscopedContext()
+		if !ok {
+			authContext = &authz.Context{}
+		}
+
+		auth := &ServerWithRoles{
+			authServer:    s.AuthServer,
+			context:       *authContext,
+			scopedContext: scopedContext,
+			alog:          s.AuthServer,
 		}
 		version := p.ByName("version")
 		if version == "" {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5006,7 +5006,7 @@ func (g *GRPCServer) GetDomainName(ctx context.Context, req *emptypb.Empty) (*au
 func (g *GRPCServer) GetClusterCACert(
 	ctx context.Context, req *emptypb.Empty,
 ) (*authpb.GetClusterCACertResponse, error) {
-	auth, err := g.authenticate(ctx)
+	auth, err := g.scopedAuthenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -6081,9 +6081,9 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	scopedaccessv1.RegisterScopedAccessServiceServer(server, scopedAccessControl)
 
 	scopedJoining, err := scopedjoining.New(scopedjoining.Config{
-		Authorizer: cfg.Authorizer,
-		Backend:    cfg.AuthServer,
-		Logger:     logger,
+		ScopedAuthorizer: cfg.ScopedAuthorizer,
+		Backend:          cfg.AuthServer,
+		Logger:           logger,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating scoped provisioning service")

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -17,10 +17,15 @@
 package joining
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"iter"
 	"log/slog"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
@@ -28,30 +33,36 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+const defaultTokenPageSize = 100
+
 // Config contains the parameters for [New].
 type Config struct {
-	Authorizer authz.Authorizer
-	Logger     *slog.Logger
-	Backend    services.ScopedTokenService
+	ScopedAuthorizer authz.ScopedAuthorizer
+	Logger           *slog.Logger
+	Backend          services.ScopedTokenService
+	MaxPageSize      int
 }
 
 // Server is the [scopedjoiningv1.ScopedJoiningServiceServer] returned by [New].
 type Server struct {
 	scopedjoiningv1.UnsafeScopedJoiningServiceServer
 
-	authorizer authz.Authorizer
-	logger     *slog.Logger
-	backend    services.ScopedTokenService
+	authorizer  authz.ScopedAuthorizer
+	logger      *slog.Logger
+	backend     services.ScopedTokenService
+	maxPageSize uint32
 }
 
 // New returns the auth server implementation for the scoped provisioning
 // service, including the gRPC interface, authz enforcement, and business logic.
 func New(c Config) (*Server, error) {
-	if c.Authorizer == nil {
+	if c.ScopedAuthorizer == nil {
 		return nil, trace.BadParameter("missing Authorizer")
 	}
 
@@ -64,22 +75,26 @@ func New(c Config) (*Server, error) {
 	}
 
 	return &Server{
-		authorizer: c.Authorizer,
-		logger:     c.Logger,
-		backend:    c.Backend,
+		authorizer:  c.ScopedAuthorizer,
+		logger:      c.Logger,
+		backend:     c.Backend,
+		maxPageSize: cmp.Or(uint32(c.MaxPageSize), defaultTokenPageSize),
 	}, nil
 }
 
 // CreateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
 func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.CreateScopedTokenRequest) (*scopedjoiningv1.CreateScopedTokenResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to create scoped tokens", authzContext.User.GetName())
+	ruleCtx := authzContext.RuleContext()
+	if err := authzContext.CheckerContext.Decision(ctx, req.GetToken().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbCreate)
+	}); err != nil {
+		s.logger.WarnContext(ctx, "user does not have permission to create scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", req.GetToken().GetScope())
+		return nil, trace.Wrap(err)
 	}
 
 	token := req.GetToken()
@@ -104,14 +119,35 @@ func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.Cre
 
 // DeleteScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
 func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.DeleteScopedTokenRequest) (*scopedjoiningv1.DeleteScopedTokenResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to delete scoped tokens", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to delete scoped tokens", authzContext.User.GetName())
+	ruleCtx := authzContext.RuleContext()
+
+	// perform an early check for root scope delete permission to allow us to short-circuit
+	// and perform an unconditional delete. this is not strictly necessary, but allows us to
+	// have an escape hatch for deleting tokens that are so malformed that they cannot be read.
+	if err := authzContext.CheckerContext.Decision(ctx, scopes.Root, func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedRole, types.VerbDelete)
+	}); err == nil {
+		return s.backend.DeleteScopedToken(ctx, req)
+	}
+
+	// fetch the token so we can determine the resource scope
+	preAuthzRes, err := s.backend.GetScopedToken(ctx, &scopedjoiningv1.GetScopedTokenRequest{
+		Name: req.GetName(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRes.GetToken().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbDelete)
+	}); err != nil {
+		s.logger.WarnContext(ctx, "user does not have permission to delete scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", preAuthzRes.GetToken().GetScope())
+		return nil, trace.Wrap(err)
 	}
 
 	res, err := s.backend.DeleteScopedToken(ctx, req)
@@ -120,34 +156,119 @@ func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.Del
 
 // GetScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
 func (s *Server) GetScopedToken(ctx context.Context, req *scopedjoiningv1.GetScopedTokenRequest) (*scopedjoiningv1.GetScopedTokenResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to get scoped tokens", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to get scoped tokens", authzContext.User.GetName())
+	ruleCtx := authzContext.RuleContext()
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	res, err := s.backend.GetScopedToken(ctx, req)
+	preAuthzRes, err := s.backend.GetScopedToken(ctx, &scopedjoiningv1.GetScopedTokenRequest{
+		Name: req.GetName(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := authzContext.CheckerContext.Decision(ctx, preAuthzRes.GetToken().GetScope(), func(checker *services.SplitAccessChecker) error {
+		return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbRead)
+	}); err != nil {
+		s.logger.WarnContext(ctx, "user does not have permission to read scoped tokens in the requested scope", "user", authzContext.User.GetName(), "scope", preAuthzRes.GetToken().GetScope())
+		return nil, trace.Wrap(err)
+	}
+
+	res := preAuthzRes
 	return res, trace.Wrap(err)
+}
+
+func makeCursor(token *scopedjoiningv1.ScopedToken) string {
+	if token == nil {
+		return ""
+	}
+	hash := sha256.Sum256([]byte(token.GetMetadata().GetName()))
+	return base64.StdEncoding.EncodeToString(hash[:])
+}
+
+func (s *Server) scopedTokenIter(ctx context.Context, req *scopedjoiningv1.ListScopedTokensRequest) iter.Seq2[*scopedjoiningv1.ScopedToken, error] {
+	return func(yield func(token *scopedjoiningv1.ScopedToken, err error) bool) {
+		iterReq := proto.CloneOf(req)
+		iterReq.Limit = s.maxPageSize
+
+		var cursorFound bool
+		for {
+			res, err := s.backend.ListScopedTokens(ctx, iterReq)
+			if err != nil {
+				if !yield(nil, trace.Wrap(err)) {
+					return
+				}
+			}
+
+			for _, tok := range res.GetTokens() {
+				if !cursorFound && req.GetCursor() != "" && makeCursor(tok) != req.GetCursor() {
+					continue
+				}
+				cursorFound = true
+				if !yield(tok, nil) {
+					return
+				}
+			}
+
+			// make sure we stop when we reach the end
+			if res.GetCursor() == "" {
+				return
+			}
+			iterReq.Cursor = res.GetCursor()
+		}
+	}
 }
 
 // ListScopedTokens implements [scopedjoiningv1.ScopedJoiningServiceServer].
 func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.ListScopedTokensRequest) (*scopedjoiningv1.ListScopedTokensResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
+	authzContext, err := s.authorizer.AuthorizeScoped(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to list scoped tokens", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to list scoped tokens", authzContext.User.GetName())
+	ruleCtx := authzContext.RuleContext()
+	if err := authzContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbRead, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	res, err := s.backend.ListScopedTokens(ctx, req)
-	return res, trace.Wrap(err)
+	limit := int(req.GetLimit())
+	if limit == 0 {
+		limit = defaultTokenPageSize
+	}
+
+	var authorizedTokens []*scopedjoiningv1.ScopedToken
+	for token, err := range s.scopedTokenIter(ctx, req) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if err := authzContext.CheckerContext.Decision(ctx, token.GetScope(), func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CheckAccessToRules(&ruleCtx, scopedaccess.KindScopedToken, types.VerbRead, types.VerbList)
+		}); err != nil {
+			continue
+		}
+		authorizedTokens = append(authorizedTokens, token)
+
+		// stop once we've fulfilled the requested page size
+		if len(authorizedTokens) >= limit {
+			break
+		}
+	}
+
+	var lastToken *scopedjoiningv1.ScopedToken
+	if len(authorizedTokens) >= limit {
+		lastToken = authorizedTokens[len(authorizedTokens)-1]
+	}
+	return &scopedjoiningv1.ListScopedTokensResponse{
+		Tokens: authorizedTokens,
+		Cursor: makeCursor(lastToken),
+	}, nil
 }
 
 // UpdateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -19,7 +19,6 @@ package joining_test
 import (
 	"cmp"
 	"context"
-	"errors"
 	"slices"
 	"testing"
 
@@ -31,6 +30,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -38,162 +38,461 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
+func createToken(ctx context.Context, server *joining.Server, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	res, err := server.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: proto.CloneOf(token),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res.GetToken(), nil
+}
+
 func TestScopedJoiningService(t *testing.T) {
-	ctx := withAuthCtx(t.Context(), newAuthCtx(types.RoleAdmin))
+	ctx := t.Context()
+	pack := newBackendPack(t)
 
-	bk, err := memory.New(memory.Config{})
-	require.NoError(t, err)
-	svc, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
-	require.NoError(t, err)
+	t.Run("basic", func(t *testing.T) {
+		service := newServerForIdentity(t, pack, &services.AccessInfo{
+			ScopePin: &scopesv1.Pin{
+				Scope: "/staging",
+				Assignments: map[string]*scopesv1.PinnedAssignments{
+					"/staging": {
+						Roles: []string{"staging-admin"},
+					},
+				},
+			},
+		})
 
-	service, err := joining.New(joining.Config{
-		Logger:     logtest.NewLogger(),
-		Backend:    svc,
-		Authorizer: fakeAuthorizer{},
+		baseToken := &joiningv1.ScopedToken{
+			Kind:     types.KindScopedToken,
+			Version:  types.V1,
+			Scope:    "/staging",
+			Metadata: &headerv1.Metadata{},
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/staging/aa",
+				JoinMethod:    "token",
+				Roles:         []string{"Node"},
+			},
+		}
+
+		// create a token
+		token, err := createToken(ctx, service, baseToken)
+		require.NoError(t, err)
+
+		withoutNameOpts := []gocmp.Option{
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "name"),
+			protocmp.Transform(),
+		}
+		cmpOpts := []gocmp.Option{
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+			protocmp.Transform(),
+		}
+		assert.Empty(t, gocmp.Diff(baseToken, token, withoutNameOpts...))
+
+		// make sure update is no-op
+		_, err = service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{})
+		require.True(t, trace.IsNotImplemented(err))
+
+		// fail to create a token with an assigned scope that is orthogonal to its own
+		tokenWithMismatchedScope := proto.CloneOf(baseToken)
+		tokenWithMismatchedScope.Metadata.Name = "invalid-token"
+		tokenWithMismatchedScope.Spec.AssignedScope = "/prod/aa"
+		_, err = createToken(ctx, service, tokenWithMismatchedScope)
+		assert.True(t, trace.IsBadParameter(err))
+
+		// create a token with an explicit name
+		namedToken := proto.CloneOf(baseToken)
+		namedToken.Metadata.Name = "named-token"
+		namedToken, err = createToken(ctx, service, namedToken)
+		require.NoError(t, err)
+		require.NotEmpty(t, namedToken.Metadata.Name)
+
+		// fetch a token
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name: token.Metadata.Name,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, gocmp.Diff(token, fetched.GetToken(), cmpOpts...))
+
+		// delete a token
+		_, err = service.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+			Name: namedToken.Metadata.Name,
+		})
+		require.NoError(t, err)
+
+		// create some tokens to list
+		tokenStagingBB := proto.CloneOf(baseToken)
+		tokenStagingBB.Scope = "/staging/bb"
+		tokenStagingBB.Spec.AssignedScope = "/staging/bb"
+		_, err = createToken(ctx, service, tokenStagingBB)
+		require.NoError(t, err)
+
+		tokenStagingCC1 := proto.CloneOf(baseToken)
+		tokenStagingCC1.Scope = "/staging/cc"
+		tokenStagingCC1.Spec.AssignedScope = "/staging/cc"
+		tokenStagingCC1, err = createToken(ctx, service, tokenStagingCC1)
+		require.NoError(t, err)
+
+		tokenStagingCC2 := proto.CloneOf(baseToken)
+		tokenStagingCC2.Scope = "/staging/cc"
+		tokenStagingCC2.Spec.AssignedScope = "/staging/cc"
+		tokenStagingCC2, err = createToken(ctx, service, tokenStagingCC2)
+		require.NoError(t, err)
+
+		// list tokens while filtering their resource scope
+		res, err := service.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
+			ResourceScope: &scopesv1.Filter{
+				Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+				Scope: "/staging/cc",
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, res.Tokens, 2)
+		sortFn := func(left *joiningv1.ScopedToken, right *joiningv1.ScopedToken) int {
+			return cmp.Compare(left.Metadata.Name, right.Metadata.Name)
+		}
+
+		expected := []*joiningv1.ScopedToken{tokenStagingCC1, tokenStagingCC2}
+		slices.SortStableFunc(res.Tokens, sortFn)
+		slices.SortStableFunc(expected, sortFn)
+		for idx, token := range res.Tokens {
+			assert.Empty(t, gocmp.Diff(expected[idx], token, cmpOpts...))
+		}
 	})
+
+	t.Run("auth", func(t *testing.T) {
+		admin := newServerForIdentity(t, pack, &services.AccessInfo{
+			ScopePin: &scopesv1.Pin{
+				Scope: "/staging",
+				Assignments: map[string]*scopesv1.PinnedAssignments{
+					"/staging": {
+						Roles: []string{"staging-admin"},
+					},
+				},
+			},
+		})
+
+		writer := newServerForIdentity(t, pack, &services.AccessInfo{
+			ScopePin: &scopesv1.Pin{
+				Scope: "/staging/aa",
+				Assignments: map[string]*scopesv1.PinnedAssignments{
+					"/staging/aa": {
+						Roles: []string{"staging-create"},
+					},
+				},
+			},
+		})
+
+		reader := newServerForIdentity(t, pack, &services.AccessInfo{
+			ScopePin: &scopesv1.Pin{
+				Scope: "/staging/aa",
+				Assignments: map[string]*scopesv1.PinnedAssignments{
+					"/staging/aa": {
+						Roles: []string{"staging-read"},
+					},
+				},
+			},
+		})
+
+		deleter := newServerForIdentity(t, pack, &services.AccessInfo{
+			ScopePin: &scopesv1.Pin{
+				Scope: "/staging/aa",
+				Assignments: map[string]*scopesv1.PinnedAssignments{
+					"/staging/aa": {
+						Roles: []string{"staging-delete"},
+					},
+				},
+			},
+		})
+
+		baseToken := &joiningv1.ScopedToken{
+			Kind:     types.KindScopedToken,
+			Version:  types.V1,
+			Scope:    "/staging/aa",
+			Metadata: &headerv1.Metadata{},
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/staging/aa",
+				JoinMethod:    "token",
+				Roles:         []string{"Node"},
+			},
+		}
+
+		// ensure writer can create a token at an accessible scope
+		stageTokenAA, err := createToken(ctx, writer, baseToken)
+		require.NoError(t, err)
+
+		cmpOpts := []gocmp.Option{
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+			protocmp.IgnoreFields(&headerv1.Metadata{}, "name"),
+			protocmp.Transform(),
+		}
+		assert.Empty(t, gocmp.Diff(baseToken, stageTokenAA, cmpOpts...))
+
+		// ensure writer can't create a token at an orthogonal scope
+		stageTokenBB := proto.CloneOf(baseToken)
+		stageTokenBB.Scope = "/staging/bb"
+		stageTokenBB.Spec.AssignedScope = "/staging/bb"
+		_, err = createToken(ctx, writer, stageTokenBB)
+		require.True(t, trace.IsAccessDenied(err))
+
+		// ensure other identities can't create a token
+		nonWriterIdents := []*joining.Server{reader, deleter}
+		for _, ident := range nonWriterIdents {
+			_, err = createToken(ctx, ident, baseToken)
+			require.True(t, trace.IsAccessDenied(err))
+		}
+
+		// create an orthogonal token for negative testing read ops
+		stageTokenBB, err = createToken(ctx, admin, stageTokenBB)
+		require.NoError(t, err)
+
+		// ensure reader can get token at accessible scope
+		getRes, err := reader.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name: stageTokenAA.Metadata.Name,
+		})
+		require.NoError(t, err)
+		require.Empty(t, gocmp.Diff(baseToken, getRes.GetToken(), cmpOpts...))
+
+		// ensure reader can't get token at orthogonal scope
+		_, err = reader.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name: stageTokenBB.Metadata.Name,
+		})
+		require.True(t, trace.IsAccessDenied(err))
+
+		// ensure other identities can't read a token
+		nonReaderIdents := []*joining.Server{writer, deleter}
+		for _, ident := range nonReaderIdents {
+			_, err = ident.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+				Name: stageTokenAA.Metadata.Name,
+			})
+			require.True(t, trace.IsAccessDenied(err))
+		}
+
+		// ensure reader can list only accessible tokens
+		listRes, err := reader.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{})
+		require.NoError(t, err)
+		require.Len(t, listRes.GetTokens(), 1)
+
+		// ensure other identities can't list tokens
+		for _, ident := range nonReaderIdents {
+			listRes, err = ident.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{})
+			require.NoError(t, err)
+			require.Empty(t, listRes.GetTokens())
+		}
+
+		// reverse assertion order so we can confirm non-deleter identities fail before we actually
+		// delete the token
+
+		// ensure other identities can't delete a token
+		nonDeleterIdents := []*joining.Server{reader, writer}
+		for _, ident := range nonDeleterIdents {
+			_, err = ident.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+				Name: stageTokenAA.Metadata.Name,
+			})
+			require.True(t, trace.IsAccessDenied(err))
+		}
+
+		// ensure deleter can delete a token
+		_, err = deleter.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+			Name: stageTokenAA.Metadata.Name,
+		})
+		require.NoError(t, err)
+
+		// ensure deleter can't delete a token at an orthogonal scope
+		_, err = deleter.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+			Name: stageTokenBB.Metadata.Name,
+		})
+		require.True(t, trace.IsAccessDenied(err))
+	})
+}
+
+// fakeSplitAuthorizer is a mock implementation of ScopedAuthorizer that provides a hard-coded context.
+type fakeSplitAuthorizer struct {
+	ctx *authz.ScopedContext
+}
+
+func (a *fakeSplitAuthorizer) AuthorizeScoped(ctx context.Context) (*authz.ScopedContext, error) {
+	return a.ctx, nil
+}
+
+// newFakeScopedAuthorizer builds a fake split authorizer with a hard-coded context based on the provided scoped access info and reader.
+// this means that while the identity/assignments can be fake, the underlying reader must contain the expected scoped
+// roles in order for the context to be built successfully.
+func newFakeScopedAuthorizer(t *testing.T, accessInfo *services.AccessInfo, reader services.ScopedRoleReader) *fakeSplitAuthorizer {
+	t.Helper()
+
+	scopedCtx, err := services.NewScopedAccessCheckerContext(t.Context(), accessInfo, "test-cluster", reader)
 	require.NoError(t, err)
 
-	token := &joiningv1.ScopedToken{
-		Kind:    types.KindScopedToken,
-		Version: types.V1,
-		Metadata: &headerv1.Metadata{
-			Name: "testtoken",
+	return &fakeSplitAuthorizer{
+		ctx: &authz.ScopedContext{
+			User: &types.UserV2{
+				Metadata: types.Metadata{
+					Name: accessInfo.Username,
+				},
+			},
+			CheckerContext: services.NewScopedSplitAccessCheckerContext(scopedCtx),
 		},
-		Scope: "/test",
-		Spec: &joiningv1.ScopedTokenSpec{
-			AssignedScope: "/test/aa",
-			JoinMethod:    "token",
-			Roles:         []string{"Node"},
+	}
+}
+
+// newServerForIdentity builds a server with an access checker that is hard-coded to the provided access info. The backend pack
+// much be pre-seeded with the relevant scoped/unscoped roles, but assignments are drawn from the access info (as they would be
+// if the access info was being taken from a certificate).
+func newServerForIdentity(t *testing.T, bk *backendPack, accessInfo *services.AccessInfo) *joining.Server {
+	t.Helper()
+
+	authz := newFakeScopedAuthorizer(t, accessInfo, bk.service)
+	require.NotNil(t, accessInfo.ScopePin)
+
+	srv, err := joining.New(joining.Config{
+		ScopedAuthorizer: authz,
+		Backend:          bk.scopedTokenService,
+		Logger:           logtest.NewLogger(),
+	})
+	require.NoError(t, err)
+
+	return srv
+}
+
+type backendPack struct {
+	backend            backend.Backend
+	service            *local.ScopedAccessService
+	classicService     *local.AccessService
+	scopedTokenService *local.ScopedTokenService
+}
+
+func (p *backendPack) Close() {
+	p.backend.Close()
+}
+
+// newBackendPack creates a scoped access service and populates it with the provided scoped roles.
+func newBackendPack(t *testing.T) *backendPack {
+	t.Helper()
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() { backend.Close() })
+
+	service := local.NewScopedAccessService(backend)
+	classicService := local.NewAccessService(backend)
+	scopedTokenService, err := local.NewScopedTokenService(backend)
+	require.NoError(t, err)
+
+	roles := []*scopedaccessv1.ScopedRole{
+		{
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-admin",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{types.KindScopedToken},
+							Verbs:     []string{types.VerbCreate, types.VerbRead, types.VerbList, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		}, {
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-create",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/aa"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{types.KindScopedToken},
+							Verbs:     []string{types.VerbCreate},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		}, {
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-read",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/aa"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{types.KindScopedToken},
+							Verbs:     []string{types.VerbRead, types.VerbList},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		}, {
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "staging-delete",
+			},
+			Scope: "/staging",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/staging/aa"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{types.KindScopedToken},
+							Verbs:     []string{types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
+		}, {
+			Kind: scopedaccess.KindScopedRole,
+			Metadata: &headerv1.Metadata{
+				Name: "prod-admin",
+			},
+			Scope: "/prod",
+			Spec: &scopedaccessv1.ScopedRoleSpec{
+				AssignableScopes: []string{"/prod"},
+				Allow: &scopedaccessv1.ScopedRoleConditions{
+					Rules: []*scopedaccessv1.ScopedRule{
+						{
+							Resources: []string{types.KindScopedToken},
+							Verbs:     []string{types.VerbRead, types.VerbList, types.VerbCreate, types.VerbUpdate, types.VerbDelete},
+						},
+					},
+				},
+			},
+			Version: types.V1,
 		},
 	}
 
-	created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: token,
-	})
-	require.NoError(t, err)
-	cmpOpts := []gocmp.Option{
-		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
-		protocmp.Transform(),
-	}
-	assert.Empty(t, gocmp.Diff(token, created.GetToken(), cmpOpts...))
-
-	tokenWithMismatchedScope := proto.CloneOf(token)
-	tokenWithMismatchedScope.Metadata.Name = "invalid-token"
-	tokenWithMismatchedScope.Spec.AssignedScope = "/stage/aa"
-
-	// make sure update is no-op
-	_, err = service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{})
-	require.True(t, trace.IsNotImplemented(err))
-
-	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: tokenWithMismatchedScope,
-	})
-	assert.True(t, trace.IsBadParameter(err))
-
-	tokenWithoutName := proto.CloneOf(token)
-	tokenWithoutName.Metadata.Name = ""
-	createdWithoutName, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: tokenWithoutName,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, createdWithoutName.Token.GetMetadata().GetName())
-
-	// get token
-	fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
-		Name: token.Metadata.Name,
-	})
-	require.NoError(t, err)
-	assert.Empty(t, gocmp.Diff(token, fetched.GetToken(), cmpOpts...))
-
-	// delete token
-	_, err = service.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
-		Name: token.Metadata.Name,
-	})
-	require.NoError(t, err)
-
-	// create some tokens
-	token.Spec.AssignedScope = "/test/bb"
-	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: token,
-	})
-	require.NoError(t, err)
-
-	token2 := proto.CloneOf(token)
-	token2.Metadata.Name = "testtoken2"
-	token2.Scope = "/test/aa"
-	token2.Spec.AssignedScope = "/test/aa"
-	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: token2,
-	})
-	require.NoError(t, err)
-
-	token3 := proto.CloneOf(token)
-	token3.Metadata.Name = "testtoken3"
-	token3.Scope = "/test/bb"
-	token3.Spec.AssignedScope = "/test/bb"
-	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
-		Token: token3,
-	})
-	require.NoError(t, err)
-
-	res, err := service.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
-		ResourceScope: &scopesv1.Filter{
-			Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
-			Scope: "/test/aa",
-		},
-	})
-	require.NoError(t, err)
-	assert.Len(t, res.Tokens, 3)
-	sortFn := func(left *joiningv1.ScopedToken, right *joiningv1.ScopedToken) int {
-		return cmp.Compare(left.Metadata.Name, right.Metadata.Name)
-	}
-
-	expected := []*joiningv1.ScopedToken{token, tokenWithoutName, token2}
-	slices.SortStableFunc(res.Tokens, sortFn)
-	slices.SortStableFunc(expected, sortFn)
-	for idx, token := range res.Tokens {
-		assert.Empty(t, gocmp.Diff(expected[idx], token, cmpOpts...))
-	}
-}
-
-type fakeChecker struct {
-	services.AccessChecker
-	role string
-}
-
-func (f *fakeChecker) HasRole(role string) bool {
-	return role == f.role
-}
-
-type authKey struct{}
-
-func withAuthCtx(ctx context.Context, authCtx authz.Context) context.Context {
-	return context.WithValue(ctx, authKey{}, authCtx)
-}
-
-func newAuthCtx(role types.SystemRole) authz.Context {
-	return authz.Context{
-		Identity: authz.BuiltinRole{
+	for _, role := range roles {
+		_, err := service.CreateScopedRole(t.Context(), &scopedaccessv1.CreateScopedRoleRequest{
 			Role: role,
-		},
-		Checker: &fakeChecker{
-			role: string(role),
-		},
-	}
-}
-
-type fakeAuthorizer struct{}
-
-func (f fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
-	authCtx, ok := ctx.Value(authKey{}).(authz.Context)
-	if !ok {
-		return nil, errors.New("no auth context found")
+		})
+		require.NoError(t, err)
 	}
 
-	return &authCtx, nil
+	return &backendPack{
+		backend:            backend,
+		service:            service,
+		classicService:     classicService,
+		scopedTokenService: scopedTokenService,
+	}
 }

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -40,6 +40,9 @@ const (
 	// KindScopedRoleAssignment is the kind of a scoped role assignment resource.
 	KindScopedRoleAssignment = "scoped_role_assignment"
 
+	// KindScopedToken is the kind of a scoped token resource.
+	KindScopedToken = "scoped_token"
+
 	// maxAssignableScopes is the maximum number of assignable scopes that a given scoped role resource may contain. Note that
 	// unlike MaxRolesPerAssignment, this is a fairly arbitrary limit and there isn't a strong reason to keep it low other than
 	// to avoid excess resource size and to keep our options open for the future.

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -27,6 +27,9 @@ func isAllowedScopedRule(kind string, verb string) bool {
 	case KindScopedRoleAssignment:
 		// scoped role assignments can be read/written, and do not currently contain a concept of a secret.
 		return isReadWriteNoSecrets(verb)
+	case types.KindScopedToken:
+		// scoped tokens can be read/written, and contain secrets.
+		return isReadWriteWithSecrets(verb)
 	default:
 		return false
 	}
@@ -37,10 +40,25 @@ func isReadWriteNoSecrets(verb string) bool {
 	return isReadNoSecrets(verb) || isWrite(verb)
 }
 
+// isReadWriteWithSecrets returns true if the given verb conforms to the "read-write-with-secrets" category of verbs.
+func isReadWriteWithSecrets(verb string) bool {
+	return isReadWithSecrets(verb) || isWrite(verb)
+}
+
 // isReadNoSecrets returns true if the given verb conforms to the "read-no-secrets" category of verbs.
 func isReadNoSecrets(verb string) bool {
 	switch verb {
 	case types.VerbList, types.VerbReadNoSecrets:
+		return true
+	default:
+		return false
+	}
+}
+
+// isReadWithSecrets returns true if the given verb conforms to the "read-with-secrets" category of verbs.
+func isReadWithSecrets(verb string) bool {
+	switch verb {
+	case types.VerbList, types.VerbRead:
 		return true
 	default:
 		return false

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -176,6 +176,11 @@ func NewScopedSplitAccessCheckerContext(ctx *ScopedAccessCheckerContext) *SplitA
 	}
 }
 
+// Scoped
+func (c *SplitAccessCheckerContext) Scoped() *ScopedAccessCheckerContext {
+	return c.scopedContext
+}
+
 // CheckMaybeHasAccessToRules returns an error if the context definitely does not have access to the provided rules. in practice
 // this currently just serves to exit early in the event that we are dealing with an unscoped identity without appropriate
 // permissions, but it could be extended in future to perform more complex checks if needed.


### PR DESCRIPTION
This PR adds scoped access controls to the scoped token CRUD methods. It allows for managing scoped join tokens using scoped roles and scoped role assignments.

Manual testing:
Create a scoped role with the appropriate verbs selected for the `scoped_token` resource:
```
tctl create <<EOF
kind: scoped_role
metadata:
  name: example-admin
scope: /examples
spec:
  assignable_scopes:
    - /examples
  allow:
    logins: [ubuntu]
    node_labels:
      - name: '*'
        values: ['*']
    rules:
      - resources: [scoped_role, scoped_role_assignment]
        verbs: [create, list, readnosecrets, update, delete]
      - resources: [scoped_token]
        verbs: [create, list, read, update, delete]
version: v1
EOF
```

Create a scoped role assignment for a user:
```
kind: scoped_role_assignment
scope: /examples
spec:
  user: example
  assignments:
    - role: example-admin
      scope: /examples/basic
version: v1
```

Login using scoped credentials:
```
tsh login --user=example --scope=/examples/basic --proxy=teleport.example.com
```

Interact with scoped token CRUD using `tctl`:
```
tctl scoped tokens add --scope=/examples/basic --assign-scope=/examples/basic --ttl=8h --type=node
tctl scoped tokens ls
tctl scoped tokens rm
```
