### PR TITLE
Fix encrypted recording uploads in S3

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2703,7 +2703,6 @@ func (c *Client) UploadEncryptedRecording(ctx context.Context, sessionID string,
 	}
 
 	var uploadedParts []*recordingencryptionv1pb.Part
-
 	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
 	// configured for the auth service
 	var partNumber int64 = 1

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2692,11 +2692,23 @@ func (c *Client) UploadEncryptedRecording(ctx context.Context, sessionID string,
 		return trace.Wrap(err)
 	}
 
+	next, stop := iter.Pull2(parts)
+	defer stop()
+
+	part, err, ok := next()
+	if err != nil {
+		return trace.Wrap(err)
+	} else if !ok {
+		return trace.BadParameter("unexpected empty upload")
+	}
+
 	var uploadedParts []*recordingencryptionv1pb.Part
+
 	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
 	// configured for the auth service
 	var partNumber int64 = 1
-	for part, err := range parts {
+	for {
+		nextPart, err, hasNext := next()
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2705,11 +2717,18 @@ func (c *Client) UploadEncryptedRecording(ctx context.Context, sessionID string,
 			Upload:     createRes.Upload,
 			PartNumber: partNumber,
 			Part:       part,
+			IsLast:     !hasNext,
 		})
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		uploadedParts = append(uploadedParts, uploadRes.Part)
+
+		if !hasNext {
+			break
+		}
+
+		part = nextPart
 		partNumber++
 	}
 

--- a/api/gen/proto/go/teleport/recordingencryption/v1/recording_encryption_service.pb.go
+++ b/api/gen/proto/go/teleport/recordingencryption/v1/recording_encryption_service.pb.go
@@ -200,7 +200,9 @@ type UploadPartRequest struct {
 	// The ordered index applied to the part.
 	PartNumber int64 `protobuf:"varint,2,opt,name=part_number,json=partNumber,proto3" json:"part_number,omitempty"`
 	// The encrypted part of session recording data being uploaded.
-	Part          []byte `protobuf:"bytes,3,opt,name=part,proto3" json:"part,omitempty"`
+	Part []byte `protobuf:"bytes,3,opt,name=part,proto3" json:"part,omitempty"`
+	// Whether this is the last upload part in the upload.
+	IsLast        bool `protobuf:"varint,4,opt,name=is_last,json=isLast,proto3" json:"is_last,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -254,6 +256,13 @@ func (x *UploadPartRequest) GetPart() []byte {
 		return x.Part
 	}
 	return nil
+}
+
+func (x *UploadPartRequest) GetIsLast() bool {
+	if x != nil {
+		return x.IsLast
+	}
+	return false
 }
 
 // The resulting metadata about an uploaded part.
@@ -848,12 +857,13 @@ const file_teleport_recordingencryption_v1_recording_encryption_service_proto_ra
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\"W\n" +
 	"\x14CreateUploadResponse\x12?\n" +
-	"\x06upload\x18\x01 \x01(\v2'.teleport.recordingencryption.v1.UploadR\x06upload\"\x89\x01\n" +
+	"\x06upload\x18\x01 \x01(\v2'.teleport.recordingencryption.v1.UploadR\x06upload\"\xa2\x01\n" +
 	"\x11UploadPartRequest\x12?\n" +
 	"\x06upload\x18\x01 \x01(\v2'.teleport.recordingencryption.v1.UploadR\x06upload\x12\x1f\n" +
 	"\vpart_number\x18\x02 \x01(\x03R\n" +
 	"partNumber\x12\x12\n" +
-	"\x04part\x18\x03 \x01(\fR\x04part\";\n" +
+	"\x04part\x18\x03 \x01(\fR\x04part\x12\x17\n" +
+	"\ais_last\x18\x04 \x01(\bR\x06isLast\";\n" +
 	"\x04Part\x12\x1f\n" +
 	"\vpart_number\x18\x01 \x01(\x03R\n" +
 	"partNumber\x12\x12\n" +

--- a/api/proto/teleport/recordingencryption/v1/recording_encryption_service.proto
+++ b/api/proto/teleport/recordingencryption/v1/recording_encryption_service.proto
@@ -71,6 +71,8 @@ message UploadPartRequest {
   int64 part_number = 2;
   // The encrypted part of session recording data being uploaded.
   bytes part = 3;
+  // Whether this is the last upload part in the upload.
+  bool is_last = 4;
 }
 
 // The resulting metadata about an uploaded part.

--- a/lib/auth/recordingencryption/recordingencryptionv1/service.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service.go
@@ -160,16 +160,7 @@ func (s *Service) UploadPart(ctx context.Context, req *recordingencryptionv1.Upl
 	// to pad up to the minimum upload size.
 	part := req.Part
 	if !req.IsLast && len(part) < events.MinUploadPartSizeBytes {
-		paddingBytes := max(events.MinUploadPartSizeBytes-len(part), events.ProtoStreamV2PartHeaderSize)
-		paddedPart := make([]byte, paddingBytes)
-
-		paddedPartHeader := events.PartHeader{
-			ProtoVersion: events.ProtoStreamV2,
-			PaddingSize:  uint64(paddingBytes - events.ProtoStreamV2PartHeaderSize),
-			PartSize:     0,
-		}
-		copy(paddedPart, paddedPartHeader.Bytes())
-		part = append(part, paddedPart...)
+		part = events.PadUploadPart(part, events.MinUploadPartSizeBytes)
 	}
 
 	streamPart, err := s.uploader.UploadPart(ctx, upload, req.PartNumber, bytes.NewReader(part))

--- a/lib/auth/recordingencryption/recordingencryptionv1/service.go
+++ b/lib/auth/recordingencryption/recordingencryptionv1/service.go
@@ -159,8 +159,8 @@ func (s *Service) UploadPart(ctx context.Context, req *recordingencryptionv1.Upl
 	// If upload part is not at least the minimum upload part size, append an empty part
 	// to pad up to the minimum upload size.
 	part := req.Part
-	if len(part) < events.MinUploadPartSizeBytes {
-		paddingBytes := min(events.MinUploadPartSizeBytes-len(part), events.ProtoStreamV2PartHeaderSize)
+	if !req.IsLast && len(part) < events.MinUploadPartSizeBytes {
+		paddingBytes := max(events.MinUploadPartSizeBytes-len(part), events.ProtoStreamV2PartHeaderSize)
 		paddedPart := make([]byte, paddingBytes)
 
 		paddedPartHeader := events.PartHeader{

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -1087,7 +1087,11 @@ type MultipartUploader interface {
 	// ReserveUploadPart reserves an upload part. Reserve is used to identify
 	// upload errors beforehand.
 	ReserveUploadPart(ctx context.Context, upload StreamUpload, partNumber int64) error
-	// UploadPart uploads part and returns the part
+	// UploadPart uploads part and returns the part.
+	//
+	// The part must be greater than [MinUploadPartSizeBytes]. It is the responsibility
+	// of the caller to add padding if needed, or else the upload may fail depending on
+	// storage provider.
 	UploadPart(ctx context.Context, upload StreamUpload, partNumber int64, partBody io.ReadSeeker) (*StreamPart, error)
 	// ListParts returns all uploaded parts for the completed upload in sorted order
 	ListParts(ctx context.Context, upload StreamUpload) ([]StreamPart, error)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -659,17 +659,14 @@ func (l *AuditLog) UploadEncryptedRecording(ctx context.Context, sessionID strin
 	}
 
 	var streamParts []StreamPart
-
 	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
 	// configured for the auth service
 	var partNumber int64 = 1
-
 	for {
 		if err := l.UploadHandler.ReserveUploadPart(ctx, *upload, partNumber); err != nil {
 			return trace.Wrap(err, "reserving upload part")
 		}
 
-		// Before uploading the current part, try getting the next part to determine if padding is needed.
 		nextPart, err, hasNext := next()
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -520,7 +520,7 @@ func (*Handler) ReserveUploadPart(ctx context.Context, upload events.StreamUploa
 func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64, partBody io.ReadSeeker) (*events.StreamPart, error) {
 	partBlob := h.partBlob(upload, partNumber)
 
-	// our parts are just over 5 MiB (events.MinUploadPartSizeBytes) so we can
+	// our parts are just over 5 MiB [events.MinUploadPartSizeBytes] so we can
 	// upload them in one shot
 	response, err := cErr(partBlob.Upload(ctx, streaming.NopCloser(partBody), nil))
 	if err != nil {

--- a/lib/events/eventstest/generate.go
+++ b/lib/events/eventstest/generate.go
@@ -38,7 +38,7 @@ import (
 type SessionParams struct {
 	// PrintEvents sets up print events count. Ignored if PrintData is set.
 	// The size of the resulting event stream varies due to compression, but with
-	// a sufficiently large number of events results in approximately 64 Bytes per event.
+	// a sufficiently large number of events results in approximately 64 bytes per event.
 	PrintEvents int64
 	// PrintData is optional data to use for print events. Each element of the
 	// slice represents data for one print event.

--- a/lib/events/eventstest/generate.go
+++ b/lib/events/eventstest/generate.go
@@ -37,6 +37,8 @@ import (
 // for generated session
 type SessionParams struct {
 	// PrintEvents sets up print events count. Ignored if PrintData is set.
+	// The size of the resulting event stream varies due to compression, but with
+	// a sufficiently large number of events results in approximately 64 Bytes per event.
 	PrintEvents int64
 	// PrintData is optional data to use for print events. Each element of the
 	// slice represents data for one print event.

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"iter"
 	"slices"
 	"sort"
 	"sync"
@@ -35,9 +36,18 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 )
 
+// MemoryUploaderConfig optional configuration for MemoryUploader.
+type MemoryUploaderConfig struct {
+	// EventsC is used by some tests to receive signal for completed uploads.
+	EventsC chan events.UploadEvent
+	// MinimumUploadBytes sets the minimum upload part size. The uploader will
+	// add padding to smaller uploads to reach this minimum size.
+	MinimumUploadBytes int
+}
+
 // NewMemoryUploader returns a new memory uploader implementing multipart
 // upload
-func NewMemoryUploader(eventsC ...chan events.UploadEvent) *MemoryUploader {
+func NewMemoryUploader(cfg ...MemoryUploaderConfig) *MemoryUploader {
 	up := &MemoryUploader{
 		mtx:        &sync.RWMutex{},
 		uploads:    make(map[string]*MemoryUpload),
@@ -46,21 +56,22 @@ func NewMemoryUploader(eventsC ...chan events.UploadEvent) *MemoryUploader {
 		metadata:   make(map[session.ID][]byte),
 		thumbnails: make(map[session.ID][]byte),
 	}
-	if len(eventsC) != 0 {
-		up.eventsC = eventsC[0]
+	if len(cfg) != 0 {
+		up.cfg = cfg[0]
 	}
 	return up
 }
 
 // MemoryUploader uploads all bytes to memory, used in tests
 type MemoryUploader struct {
+	cfg MemoryUploaderConfig
+
 	mtx        *sync.RWMutex
 	uploads    map[string]*MemoryUpload
 	sessions   map[session.ID][]byte
 	summaries  map[session.ID][]byte
 	metadata   map[session.ID][]byte
 	thumbnails map[session.ID][]byte
-	eventsC    chan events.UploadEvent
 
 	// Clock is an optional [clockwork.Clock] to determine the time to associate
 	// with uploads and parts.
@@ -88,11 +99,11 @@ type part struct {
 }
 
 func (m *MemoryUploader) trySendEvent(event events.UploadEvent) {
-	if m.eventsC == nil {
+	if m.cfg.EventsC == nil {
 		return
 	}
 	select {
-	case m.eventsC <- event:
+	case m.cfg.EventsC <- event:
 	default:
 	}
 }
@@ -399,6 +410,73 @@ func (m *MemoryUploader) GetUploadMetadata(sid session.ID) events.UploadMetadata
 // ReserveUploadPart reserves an upload part.
 func (m *MemoryUploader) ReserveUploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64) error {
 	return nil
+}
+
+// UploadEncryptedRecording uploads encrypted recordings.
+func (m *MemoryUploader) UploadEncryptedRecording(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
+	sessID, err := session.ParseID(sessionID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	upload, err := m.CreateUpload(ctx, *sessID)
+	if err != nil {
+		return trace.Wrap(err, "creating upload")
+	}
+
+	next, stop := iter.Pull2(parts)
+	defer stop()
+
+	part, err, ok := next()
+	if err != nil {
+		return trace.Wrap(err)
+	} else if !ok {
+		return trace.BadParameter("unexpected empty upload")
+	}
+
+	var streamParts []events.StreamPart
+	// S3 requires that part numbers start at 1, so we do that by default regardless of which uploader is
+	// configured for the auth service
+	var partNumber int64 = 1
+	for {
+		if err := m.ReserveUploadPart(ctx, *upload, partNumber); err != nil {
+			return trace.Wrap(err, "reserving upload part")
+		}
+
+		nextPart, err, hasNext := next()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		// If the upload part is not at least the minimum upload part size, and this isn't
+		// the last part, append an empty part to pad up to the minimum upload size.
+		if hasNext && len(part) < m.cfg.MinimumUploadBytes {
+			paddingBytes := max(m.cfg.MinimumUploadBytes-len(part), events.ProtoStreamV2PartHeaderSize)
+			paddedPart := make([]byte, paddingBytes)
+
+			paddedPartHeader := events.PartHeader{
+				ProtoVersion: events.ProtoStreamV2,
+				PaddingSize:  uint64(paddingBytes - events.ProtoStreamV2PartHeaderSize),
+				PartSize:     0,
+			}
+			copy(paddedPart, paddedPartHeader.Bytes())
+			part = append(part, paddedPart...)
+		}
+
+		streamPart, err := m.UploadPart(ctx, *upload, partNumber, bytes.NewReader(part))
+		if err != nil {
+			return trace.Wrap(err, "uploading part")
+		}
+		streamParts = append(streamParts, *streamPart)
+
+		if !hasNext {
+			break
+		}
+
+		part = nextPart
+		partNumber++
+	}
+
+	return trace.Wrap(m.CompleteUpload(ctx, *upload, streamParts), "completing upload")
 }
 
 // MockUploader is a limited implementation of [events.MultipartUploader] that

--- a/lib/events/eventstest/uploader.go
+++ b/lib/events/eventstest/uploader.go
@@ -450,16 +450,7 @@ func (m *MemoryUploader) UploadEncryptedRecording(ctx context.Context, sessionID
 		// If the upload part is not at least the minimum upload part size, and this isn't
 		// the last part, append an empty part to pad up to the minimum upload size.
 		if hasNext && len(part) < m.cfg.MinimumUploadBytes {
-			paddingBytes := max(m.cfg.MinimumUploadBytes-len(part), events.ProtoStreamV2PartHeaderSize)
-			paddedPart := make([]byte, paddingBytes)
-
-			paddedPartHeader := events.PartHeader{
-				ProtoVersion: events.ProtoStreamV2,
-				PaddingSize:  uint64(paddingBytes - events.ProtoStreamV2PartHeaderSize),
-				PartSize:     0,
-			}
-			copy(paddedPart, paddedPartHeader.Bytes())
-			part = append(part, paddedPart...)
+			part = events.PadUploadPart(part, m.cfg.MinimumUploadBytes)
 		}
 
 		streamPart, err := m.UploadPart(ctx, *upload, partNumber, bytes.NewReader(part))

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -399,8 +399,12 @@ func (u *Uploader) uploadEncryptedRecording(ctx context.Context, sessionID strin
 
 		var buf bytes.Buffer
 		yieldNext := func() bool {
-			defer buf.Reset()
-			return yield(buf.Bytes(), nil)
+			// Copy the buffer to a new []byte so that the next
+			// iteration doesn't wipe the previous yielded bytes.
+			bytes := make([]byte, buf.Len())
+			copy(bytes, buf.Bytes())
+			buf.Reset()
+			return yield(bytes, nil)
 		}
 
 		for {

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -69,7 +69,7 @@ type UploaderConfig struct {
 	EncryptedRecordingUploader events.EncryptedRecordingUploader
 	// EncryptedRecordingUploadTargetSize is the target size used when aggregating
 	// encrypted recording parts before sending them to EncryptedRecordingUploader.
-	// encrypted uploads should slightly exceed this target size unless limited by the maximum.
+	// Encrypted uploads should slightly exceed this target size unless limited by the maximum.
 	EncryptedRecordingUploadTargetSize int
 	// EncryptedRecordingUploadTargetSize is the maximum size used when aggregating
 	// encrypted recording parts before sending them to EncryptedRecordingUploader.
@@ -413,7 +413,7 @@ func (u *Uploader) uploadEncryptedRecording(ctx context.Context, sessionID strin
 	return nil
 }
 
-// encryptedUploadAggregateIter returns an iterator that aggregates upload parts from the given reader into
+// encryptedUploadAggregateIter returns an iterator that aggregates upload parts from the given reader
 // into larger upload with size greater than targetSize, or as near targetSize as possible without exceeding
 // the maxSize.
 func encryptedUploadAggregateIter(in io.Reader, targetSize int, maxSize int) iter.Seq2[[]byte, error] {

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -53,7 +53,9 @@ func TestChaosUpload(t *testing.T) {
 	ctx := t.Context()
 
 	eventsC := make(chan events.UploadEvent, 100)
-	memUploader := eventstest.NewMemoryUploader(eventsC)
+	memUploader := eventstest.NewMemoryUploader(eventstest.MemoryUploaderConfig{
+		EventsC: eventsC,
+	})
 	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
 		Uploader:       memUploader,
 		MinUploadBytes: 1024,
@@ -121,7 +123,9 @@ func TestChaosUpload(t *testing.T) {
 	go uploader.Serve(ctx)
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir, nil)
+	fileStreamer, err := NewStreamer(StreamerConfig{
+		Dir: scanDir,
+	})
 	require.NoError(t, err)
 
 	parallelStreams := 20

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -22,9 +22,17 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"errors"
+	"io"
+	"io/fs"
+	"iter"
+	mathrand "math/rand/v2"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -41,19 +49,18 @@ import (
 
 // TestUploadOK tests async file uploads scenarios
 func TestUploadOK(t *testing.T) {
-	p := newUploaderPack(t, nil)
-	defer p.Close(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	p := newUploaderPack(ctx, t, uploaderPackConfig{})
 
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntil(1)
-
-	fileStreamer, err := NewStreamer(p.scanDir, nil)
-	require.NoError(t, err)
+	p.clock.BlockUntilContext(ctx, 1)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
 	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
 
-	emitStream(p.ctx, t, fileStreamer, inEvents)
+	p.emitEvents(ctx, t, inEvents)
 
 	// initiate the scan by advancing clock past
 	// block period
@@ -64,34 +71,33 @@ func TestUploadOK(t *testing.T) {
 	case event = <-p.memEventsC:
 		require.Equal(t, event.SessionID, sid)
 		require.NoError(t, event.Error)
-	case <-p.ctx.Done():
+	case <-ctx.Done():
 		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 	}
 
 	// read the upload and make sure the data is equal
-	outEvents := readStream(p.ctx, t, event.UploadID, p.memUploader)
+	outEvents := p.readEvents(ctx, t, event.UploadID)
 	require.Equal(t, inEvents, outEvents)
 }
 
 // TestUploadParallel verifies several parallel uploads that have to wait
 // for semaphore
 func TestUploadParallel(t *testing.T) {
-	p := newUploaderPack(t, nil)
-	defer p.Close(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	p := newUploaderPack(ctx, t, uploaderPackConfig{})
 
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntil(1)
+	p.clock.BlockUntilContext(ctx, 1)
 
 	sessions := make(map[string][]apievents.AuditEvent)
 
 	for range 5 {
-		fileStreamer, err := NewStreamer(p.scanDir, nil)
-		require.NoError(t, err)
-
 		sessionEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
 		sid := sessionEvents[0].(events.SessionMetadataGetter).GetSessionID()
 
-		emitStream(p.ctx, t, fileStreamer, sessionEvents)
+		p.emitEvents(ctx, t, sessionEvents)
 		sessions[sid] = sessionEvents
 	}
 
@@ -108,12 +114,12 @@ func TestUploadParallel(t *testing.T) {
 			require.NoError(t, event.Error)
 			sessionEvents, found = sessions[event.SessionID]
 			require.True(t, found, "session %q is not expected, possible duplicate event", event.SessionID)
-		case <-p.ctx.Done():
+		case <-ctx.Done():
 			t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 		}
 
 		// read the upload and make sure the data is equal
-		outEvents := readStream(p.ctx, t, event.UploadID, p.memUploader)
+		outEvents := p.readEvents(ctx, t, event.UploadID)
 
 		require.Equal(t, sessionEvents, outEvents)
 
@@ -150,7 +156,7 @@ func TestMovesCorruptedUploads(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, badFile.Close())
 
-	stats, err := uploader.Scan(context.Background())
+	stats, err := uploader.Scan(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, 2, stats.Scanned)
 	require.Equal(t, 2, stats.Corrupted)
@@ -165,7 +171,7 @@ func TestMovesCorruptedUploads(t *testing.T) {
 	// run a second scan to verify that:
 	// 1. the corrupted file is no longer processed
 	// 2. the file with the bad name was still flagged as corrupted
-	stats, err = uploader.Scan(context.Background())
+	stats, err = uploader.Scan(t.Context())
 	require.NoError(t, err)
 	require.Equal(t, 1, stats.Scanned)
 	require.Equal(t, 1, stats.Corrupted)
@@ -363,39 +369,40 @@ func TestUploadBackoff(t *testing.T) {
 	var terminateConnectionAt atomic.Int64
 	terminateConnectionAt.Store(700)
 
-	p := newUploaderPack(t, func(streamer events.Streamer) (events.Streamer, error) {
-		return events.NewCallbackStreamer(events.CallbackStreamerConfig{
-			Inner: streamer,
-			OnRecordEvent: func(ctx context.Context, sid session.ID, pe apievents.PreparedSessionEvent) error {
-				event := pe.GetAuditEvent()
-				terminateAt := terminateConnectionAt.Load()
-				if terminateAt > 0 && event.GetIndex() >= terminateAt {
-					t.Logf("Terminating connection at event %v", event.GetIndex())
-					return trace.ConnectionProblem(nil, "connection terminated at event index %v", terminateAt)
-				}
-				return nil
-			},
-		})
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	p := newUploaderPack(ctx, t, uploaderPackConfig{
+		wrapProtoStreamer: func(streamer events.Streamer) (events.Streamer, error) {
+			return events.NewCallbackStreamer(events.CallbackStreamerConfig{
+				Inner: streamer,
+				OnRecordEvent: func(ctx context.Context, sid session.ID, pe apievents.PreparedSessionEvent) error {
+					event := pe.GetAuditEvent()
+					terminateAt := terminateConnectionAt.Load()
+					if terminateAt > 0 && event.GetIndex() >= terminateAt {
+						t.Logf("Terminating connection at event %v", event.GetIndex())
+						return trace.ConnectionProblem(nil, "connection terminated at event index %v", terminateAt)
+					}
+					return nil
+				},
+			})
+		},
 	})
-	defer p.Close(t)
 
 	// wait until uploader blocks on the clock before creating the stream
-	p.clock.BlockUntil(1)
-
-	fileStreamer, err := NewStreamer(p.scanDir, nil)
-	require.NoError(t, err)
+	p.clock.BlockUntilContext(ctx, 1)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 4096})
 	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
 
-	stream, err := fileStreamer.CreateAuditStream(p.ctx, session.ID(sid))
+	stream, err := p.fileStreamer.CreateAuditStream(ctx, session.ID(sid))
 	require.NoError(t, err)
 
 	for _, event := range inEvents {
-		err := stream.RecordEvent(p.ctx, eventstest.PrepareEvent(event))
+		err := stream.RecordEvent(ctx, eventstest.PrepareEvent(event))
 		require.NoError(t, err)
 	}
-	err = stream.Complete(p.ctx)
+	err = stream.Complete(ctx)
 	require.NoError(t, err)
 
 	// initiate the scan by advancing clock past
@@ -418,14 +425,14 @@ func TestUploadBackoff(t *testing.T) {
 				diffs = append(diffs, event.Created.Sub(prev))
 				prev = event.Created
 			}
-		case <-p.ctx.Done():
+		case <-ctx.Done():
 			t.Fatalf("Timeout waiting for async upload %v, try `go test -v` to get more logs for details", i)
 		}
 
 		// Block until Scan has been called two times,
 		// first time after doing the scan, and second
 		// on receiving the event to <- eventsCh
-		p.clock.BlockUntil(2)
+		p.clock.BlockUntilContext(ctx, 2)
 		p.clock.Advance(p.scanPeriod*time.Duration(i+2) + time.Second)
 	}
 
@@ -438,12 +445,12 @@ func TestUploadBackoff(t *testing.T) {
 
 	// Fix the streamer, make sure the upload succeeds
 	terminateConnectionAt.Store(0)
-	p.clock.BlockUntil(2)
+	p.clock.BlockUntilContext(ctx, 2)
 	p.clock.Advance(time.Hour)
 	select {
 	case event := <-p.eventsC:
 		require.NoError(t, event.Error)
-	case <-p.ctx.Done():
+	case <-ctx.Done():
 		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 	}
 }
@@ -451,13 +458,13 @@ func TestUploadBackoff(t *testing.T) {
 // TestUploadBadSession creates a corrupted session file
 // and makes sure the uploader marks it as faulty
 func TestUploadBadSession(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
 
-	p := newUploaderPack(t, nil)
-	defer p.Close(t)
+	p := newUploaderPack(ctx, t, uploaderPackConfig{})
 
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntil(1)
+	p.clock.BlockUntilContext(ctx, 1)
 
 	sessionID := session.NewID()
 	fileName := filepath.Join(p.scanDir, string(sessionID)+tarExt)
@@ -476,7 +483,7 @@ func TestUploadBadSession(t *testing.T) {
 	case event = <-p.eventsC:
 		require.Error(t, event.Error)
 		require.True(t, isSessionError(event.Error))
-	case <-p.ctx.Done():
+	case <-ctx.Done():
 		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 	}
 
@@ -487,80 +494,335 @@ func TestUploadBadSession(t *testing.T) {
 	require.Equal(t, 0, stats.Started)
 }
 
+// TestMinimumUpload tests that the minimum upload values for files and final uploads are respected.
+func TestMinimumUpload(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	// The gzip writer ensures that upload parts exceed the minimum upload size, and imprecisely
+	// constrains the maximum size to 133% of the minimum. At small values, this is especially
+	// imprecise, so we give a full 200% of the minimum as overhead.
+	//
+	// Usually, we use 128KB for file parts and 5KB for final upload parts.
+	var minFileBytes int64 = 8192
+	var maxFileBytes int64 = 2 * minFileBytes
+	minUploadBytes := 33768
+	maxUploadBytes := 2 * minUploadBytes
+
+	p := newUploaderPack(ctx, t, uploaderPackConfig{
+		minimumFileUploadBytes: minFileBytes,
+		minimumUploadBytes:     int64(minUploadBytes),
+	})
+
+	// wait until uploader blocks on the clock
+	p.clock.BlockUntilContext(ctx, 1)
+
+	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(mathrand.IntN(5000) + 5000)})
+	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
+	stream, err := p.fileStreamer.CreateAuditStream(ctx, session.ID(sid))
+	require.NoError(t, err)
+	for _, event := range inEvents {
+		err := stream.RecordEvent(ctx, eventstest.PrepareEvent(event))
+		require.NoError(t, err)
+	}
+
+	// Before completing the file stream, which writes upload part files into a .tar, check that
+	// each file part was within specific size expectations.
+	var partFiles []fs.FileInfo
+	err = filepath.Walk(p.scanDir, func(path string, info fs.FileInfo, err error) error {
+		// skip non-part files.
+		if ext := filepath.Ext(info.Name()); ext == ".part" {
+			partFiles = append(partFiles, info)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	slices.SortFunc(partFiles, func(a fs.FileInfo, b fs.FileInfo) int {
+		aPartNumberStr, _ := strings.CutSuffix(a.Name(), ".part")
+		aPartNumber, err := strconv.Atoi(aPartNumberStr)
+		require.NoError(t, err)
+		bPartNumberStr, _ := strings.CutSuffix(b.Name(), ".part")
+		bPartNumber, err := strconv.Atoi(bPartNumberStr)
+		require.NoError(t, err)
+		return aPartNumber - bPartNumber
+	})
+
+	for i, partFile := range partFiles {
+		partSize := partFile.Size()
+		require.True(t, partSize >= minFileBytes && partSize <= maxFileBytes, "expected upload part %v to be between %v and %v bytes, but was %v bytes", i, minFileBytes, maxFileBytes, partSize)
+	}
+
+	// Complete the file stream and advance the clock to unblock the uploader scanner.
+	err = stream.Complete(ctx)
+	require.NoError(t, err)
+	p.clock.Advance(p.scanPeriod + time.Second)
+
+	var event events.UploadEvent
+	select {
+	case event = <-p.memEventsC:
+		require.Equal(t, event.SessionID, sid)
+		require.NoError(t, event.Error)
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
+	}
+
+	// read the upload and make sure the data is equal
+	outEvents := p.readEvents(ctx, t, event.UploadID)
+	require.Equal(t, inEvents, outEvents)
+
+	uploadParts, err := p.memUploader.GetParts(event.UploadID)
+	require.NoError(t, err)
+
+	// minimumProtoUploadBytes should ensure each upload part is within specific size expectations.
+	for i, part := range uploadParts {
+		if i == len(uploadParts)-1 {
+			// The last part is not required to meet the minimum size.
+			require.True(t, len(part) <= maxUploadBytes, "expected last upload part to be smaller than %v bytes, but was %v bytes", maxUploadBytes, len(part))
+		} else {
+			require.True(t, len(part) >= minUploadBytes && len(part) <= maxUploadBytes, "expected upload part %v to be between %v and %v bytes, but was %v bytes", i, minUploadBytes, maxUploadBytes, len(part))
+		}
+	}
+
+	// There should be at least 1 final upload part for every 4 file upload parts.
+	minFactor := minUploadBytes / int(minFileBytes)
+	require.True(t, len(partFiles)/minFactor <= len(uploadParts), "expected there to be 1 final upload part for every 4 transient file parts, but got %v and %v respectively", len(uploadParts), len(partFiles))
+}
+
+func TestUploadEncryptedRecording(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	var (
+		minFileBytes = 8192
+		// encrypted upload files should be aggregated by the encrypted uploader to reach the
+		// target size, without exceeding the max size.
+		encryptedTargetSize = minFileBytes * 4
+		encryptedMaxSize    = encryptedTargetSize * 2
+		// uploads from the encrypted uploader should be padded further by the final uploader to
+		// reach the minimum upload size. e.g. pad encrypted uploads of 4MB (max from GRPC) to reach
+		// S3 minimum upload of 5MB.
+		minUploadBytes = encryptedMaxSize * 2
+	)
+
+	// Create a wrapper around the encrypted uploader to ensure the caller is yielding
+	// correctly sized uploads.
+	var recollectParts [][]byte
+	encryptedUploadWrapper := wrapEncryptedUploaderFn(func(u events.EncryptedRecordingUploader) events.EncryptedRecordingUploader {
+		return encryptedUploaderFn(func(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
+			next, stop := iter.Pull2(parts)
+			defer stop()
+
+			part, err, ok := next()
+			if err != nil {
+				return trace.Wrap(err)
+			} else if !ok {
+				return trace.BadParameter("unexpected empty upload")
+			}
+
+			for {
+				recollectParts = append(recollectParts, part)
+
+				nextPart, err, hasNext := next()
+				if err != nil {
+					return trace.Wrap(err)
+				}
+
+				if !hasNext {
+					break
+				}
+
+				if hasNext {
+					require.True(t, len(part) >= encryptedTargetSize && len(part) <= encryptedMaxSize, "expected upload part to be between %v and %v bytes, but was %v bytes", encryptedTargetSize, encryptedMaxSize, len(part))
+				} else {
+					// The last part is not expected to meet the target size.
+					require.True(t, len(part) <= encryptedMaxSize, "expected last upload part to be smaller than %v bytes, but was %v bytes", encryptedMaxSize, len(part))
+				}
+
+				part = nextPart
+			}
+
+			partReIter := func(yield func([]byte, error) bool) {
+				for _, part := range recollectParts {
+					if !yield(part, nil) {
+						return
+					}
+				}
+			}
+
+			return u.UploadEncryptedRecording(ctx, sessionID, partReIter)
+		})
+	})
+
+	p := newUploaderPack(ctx, t, uploaderPackConfig{
+		minimumFileUploadBytes:             int64(minFileBytes),
+		minimumUploadBytes:                 int64(minUploadBytes),
+		encrypter:                          &fakeEncryptedIO{},
+		wrapEncryptedUploader:              encryptedUploadWrapper,
+		encryptedRecordingUploadTargetSize: encryptedTargetSize,
+		encryptedRecordingUploadMaxSize:    encryptedMaxSize,
+	})
+
+	// wait until uploader blocks on the clock
+	err := p.clock.BlockUntilContext(ctx, 1)
+	require.NoError(t, err)
+
+	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(mathrand.IntN(5000) + 5000)})
+	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
+	p.emitEvents(ctx, t, inEvents)
+
+	// initiate the scan by advancing clock past
+	// block period
+	p.clock.Advance(p.scanPeriod + time.Second)
+
+	var event events.UploadEvent
+	select {
+	case event = <-p.memEventsC:
+		require.Equal(t, event.SessionID, sid)
+		require.NoError(t, event.Error)
+	case <-ctx.Done():
+		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
+	}
+
+	// read the upload and make sure the data is equal
+	outEvents := p.readEvents(ctx, t, event.UploadID)
+	require.Equal(t, inEvents, outEvents)
+
+	uploadParts, err := p.memUploader.GetParts(event.UploadID)
+	require.NoError(t, err)
+
+	// final uploads should be above the minimum upload size.
+	for i, part := range uploadParts {
+		if i == len(uploadParts)-1 {
+			// The last part is not required to meet the minimum size. In this example, it should always be smaller.
+			require.True(t, len(part) <= minUploadBytes, "expected last upload part to be smaller than %v bytes, but was %v bytes", minUploadBytes, len(part))
+		} else {
+			require.True(t, len(part) >= minUploadBytes, "expected upload part %v to be larger than %v bytes, but was %v bytes", i, minUploadBytes, len(part))
+		}
+	}
+
+	// There should be one final upload for each upload part from the encrypted uploader.
+	require.Equal(t, len(recollectParts), len(uploadParts), "expected there to be an equal amount of final upload parts and transient upload parts, but got %v and %v respectively", len(uploadParts), len(recollectParts))
+}
+
+type uploaderPackConfig struct {
+	minimumFileUploadBytes             int64
+	minimumUploadBytes                 int64
+	wrapProtoStreamer                  wrapStreamerFn
+	encrypter                          events.EncryptionWrapper
+	wrapEncryptedUploader              wrapEncryptedUploaderFn
+	encryptedRecordingUploadTargetSize int
+	encryptedRecordingUploadMaxSize    int
+}
+
 // uploaderPack reduces boilerplate required
 // to create a test
 type uploaderPack struct {
 	scanPeriod       time.Duration
 	initialScanDelay time.Duration
 	clock            *clockwork.FakeClock
-	eventsC          chan events.UploadEvent
-	memEventsC       chan events.UploadEvent
-	memUploader      *eventstest.MemoryUploader
-	streamer         events.Streamer
-	scanDir          string
-	uploader         *Uploader
-	ctx              context.Context
-	cancel           context.CancelFunc
+	// fileStreamer streams events to upload parts on disk.
+	scanDir      string
+	fileStreamer events.Streamer
+	// uploader scans upload parts from disk and streams them through the protoStreamer.
+	eventsC  chan events.UploadEvent
+	uploader *Uploader
+	// protoStreamer streams events to upload parts in-memory (represents final audit log storage).
+	protoStreamer events.Streamer
+	memEventsC    chan events.UploadEvent
+	memUploader   *eventstest.MemoryUploader
 }
 
-func (u *uploaderPack) Close(t *testing.T) {
-	u.cancel()
-}
-
-func newUploaderPack(t *testing.T, wrapStreamer wrapStreamerFn) uploaderPack {
+func newUploaderPack(ctx context.Context, t *testing.T, cfg uploaderPackConfig) uploaderPack {
 	scanDir := t.TempDir()
 	corruptedDir := t.TempDir()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+
 	pack := uploaderPack{
 		clock:            clockwork.NewFakeClock(),
 		eventsC:          make(chan events.UploadEvent, 100),
 		memEventsC:       make(chan events.UploadEvent, 100),
-		ctx:              ctx,
-		cancel:           cancel,
 		scanDir:          scanDir,
 		scanPeriod:       10 * time.Second,
 		initialScanDelay: 10 * time.Millisecond,
 	}
-	pack.memUploader = eventstest.NewMemoryUploader(pack.memEventsC)
 
-	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
-		Uploader:       pack.memUploader,
-		MinUploadBytes: 1024,
+	pack.memUploader = eventstest.NewMemoryUploader(eventstest.MemoryUploaderConfig{
+		EventsC:            pack.memEventsC,
+		MinimumUploadBytes: int(cfg.minimumUploadBytes),
+	})
+
+	var err error
+	pack.fileStreamer, err = NewStreamer(StreamerConfig{
+		Dir:            scanDir,
+		MinUploadBytes: cfg.minimumFileUploadBytes,
+		Encrypter:      cfg.encrypter,
 	})
 	require.NoError(t, err)
-	pack.streamer = streamer
-	if wrapStreamer != nil {
-		pack.streamer, err = wrapStreamer(pack.streamer)
+
+	pack.protoStreamer, err = events.NewProtoStreamer(events.ProtoStreamerConfig{
+		Uploader:       pack.memUploader,
+		MinUploadBytes: cfg.minimumUploadBytes,
+		// Skip encrypter in proto streamer, encryption skips the proto stream flow.
+	})
+	require.NoError(t, err)
+
+	if cfg.wrapProtoStreamer != nil {
+		pack.protoStreamer, err = cfg.wrapProtoStreamer(pack.protoStreamer)
 		require.NoError(t, err)
 	}
 
-	uploader, err := NewUploader(UploaderConfig{
-		ScanDir:          pack.scanDir,
-		CorruptedDir:     corruptedDir,
-		InitialScanDelay: pack.initialScanDelay,
-		ScanPeriod:       pack.scanPeriod,
-		Streamer:         pack.streamer,
-		Clock:            pack.clock,
-		EventsC:          pack.eventsC,
-	})
+	uploaderCfg := UploaderConfig{
+		ScanDir:                            pack.scanDir,
+		CorruptedDir:                       corruptedDir,
+		InitialScanDelay:                   pack.initialScanDelay,
+		ScanPeriod:                         pack.scanPeriod,
+		Streamer:                           pack.protoStreamer,
+		Clock:                              pack.clock,
+		EventsC:                            pack.eventsC,
+		EncryptedRecordingUploadTargetSize: cfg.encryptedRecordingUploadTargetSize,
+		EncryptedRecordingUploadMaxSize:    cfg.encryptedRecordingUploadMaxSize,
+	}
+	if cfg.encrypter != nil {
+		uploaderCfg.EncryptedRecordingUploader = pack.memUploader
+		if cfg.wrapEncryptedUploader != nil {
+			uploaderCfg.EncryptedRecordingUploader = cfg.wrapEncryptedUploader(pack.memUploader)
+		}
+	}
+
+	pack.uploader, err = NewUploader(uploaderCfg)
 	require.NoError(t, err)
-	pack.uploader = uploader
-	go pack.uploader.Serve(pack.ctx)
+
+	go pack.uploader.Serve(ctx)
+
 	return pack
+}
+
+func (p *uploaderPack) emitEvents(ctx context.Context, t *testing.T, inEvents []apievents.AuditEvent) {
+	emitStream(ctx, t, p.fileStreamer, inEvents)
+}
+
+func (p *uploaderPack) readEvents(ctx context.Context, t *testing.T, uploadID string) []apievents.AuditEvent {
+	return readStream(ctx, t, uploadID, p.memUploader)
 }
 
 type wrapStreamerFn func(streamer events.Streamer) (events.Streamer, error)
 
+type wrapEncryptedUploaderFn func(u events.EncryptedRecordingUploader) events.EncryptedRecordingUploader
+
 // runResume runs resume scenario based on the test case specification
 func runResume(t *testing.T, testCase resumeTestCase) {
 	t.Logf("Running test %q.", testCase.name)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	clock := clockwork.NewFakeClock()
 	eventsC := make(chan events.UploadEvent, 100)
-	memUploader := eventstest.NewMemoryUploader(eventsC)
+	memUploader := eventstest.NewMemoryUploader(eventstest.MemoryUploaderConfig{
+		EventsC: eventsC,
+	})
 	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
 		Uploader:       memUploader,
 		MinUploadBytes: 1024,
@@ -585,11 +847,13 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 	require.NoError(t, err)
 	go uploader.Serve(ctx)
 	// wait until uploader blocks on the clock
-	clock.BlockUntil(1)
+	clock.BlockUntilContext(ctx, 1)
 
 	defer uploader.Close()
 
-	fileStreamer, err := NewStreamer(scanDir, nil)
+	fileStreamer, err := NewStreamer(StreamerConfig{
+		Dir: scanDir,
+	})
 	require.NoError(t, err)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
@@ -618,7 +882,7 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 		// Block until Scan has been called two times,
 		// first time after doing the scan, and second
 		// on receiving the event to <- eventsCh
-		clock.BlockUntil(2)
+		clock.BlockUntilContext(ctx, 2)
 		clock.Advance(scanPeriod*time.Duration(i+2) + time.Second)
 
 		// wait for upload success
@@ -646,6 +910,8 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 
 // emitStream creates and sends the session stream
 func emitStream(ctx context.Context, t *testing.T, streamer events.Streamer, inEvents []apievents.AuditEvent) {
+	t.Helper()
+
 	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
 
 	stream, err := streamer.CreateAuditStream(ctx, session.ID(sid))
@@ -669,7 +935,7 @@ func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *ev
 	var reader *events.ProtoReader
 	for i, part := range parts {
 		if i == 0 {
-			reader = events.NewProtoReader(bytes.NewReader(part), nil)
+			reader = events.NewProtoReader(bytes.NewReader(part), &fakeEncryptedIO{})
 		} else {
 			err := reader.Reset(bytes.NewReader(part))
 			require.NoError(t, err)
@@ -680,4 +946,42 @@ func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *ev
 		outEvents = append(outEvents, out...)
 	}
 	return outEvents
+}
+
+// encryptedIO is really just a reversible transform, so we fake encryption by encoding/decoding as hex
+type fakeEncryptedIO struct {
+	err error
+}
+
+type fakeEncrypter struct {
+	inner  io.WriteCloser
+	writer io.Writer
+}
+
+func (f *fakeEncrypter) Write(out []byte) (int, error) {
+	return f.writer.Write(out)
+}
+
+func (f *fakeEncrypter) Close() error {
+	return f.inner.Close()
+}
+
+func (f *fakeEncryptedIO) WithEncryption(ctx context.Context, writer io.WriteCloser) (io.WriteCloser, error) {
+	hexWriter := hex.NewEncoder(writer)
+	encrypter := &fakeEncrypter{
+		inner:  writer,
+		writer: hexWriter,
+	}
+
+	return encrypter, f.err
+}
+
+func (f *fakeEncryptedIO) WithDecryption(ctx context.Context, reader io.Reader) (io.Reader, error) {
+	return hex.NewDecoder(reader), f.err
+}
+
+type encryptedUploaderFn func(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error
+
+func (e encryptedUploaderFn) UploadEncryptedRecording(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
+	return e(ctx, sessionID, parts)
 }

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -782,14 +782,12 @@ func newUploaderPack(ctx context.Context, t *testing.T, cfg uploaderPackConfig) 
 		Streamer:                           pack.protoStreamer,
 		Clock:                              pack.clock,
 		EventsC:                            pack.eventsC,
+		EncryptedRecordingUploader:         pack.memUploader,
 		EncryptedRecordingUploadTargetSize: cfg.encryptedRecordingUploadTargetSize,
 		EncryptedRecordingUploadMaxSize:    cfg.encryptedRecordingUploadMaxSize,
 	}
-	if cfg.encrypter != nil {
-		uploaderCfg.EncryptedRecordingUploader = pack.memUploader
-		if cfg.wrapEncryptedUploader != nil {
-			uploaderCfg.EncryptedRecordingUploader = cfg.wrapEncryptedUploader(pack.memUploader)
-		}
+	if cfg.wrapEncryptedUploader != nil {
+		uploaderCfg.EncryptedRecordingUploader = cfg.wrapEncryptedUploader(pack.memUploader)
 	}
 
 	pack.uploader, err = NewUploader(uploaderCfg)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -591,8 +591,8 @@ func TestMinimumUpload(t *testing.T) {
 
 func TestUploadEncryptedRecording(t *testing.T) {
 	for _, tc := range []struct {
-		name         string
-		minFileBytes int
+		name        string
+		minFileSize int
 		// encrypted upload files should be aggregated by the encrypted uploader to reach the target size.
 		encryptedTargetSize      int
 		encryptedMaxSize         int
@@ -603,44 +603,38 @@ func TestUploadEncryptedRecording(t *testing.T) {
 		minUploadBytes int
 	}{
 		{
-			name:                "default values",
-			minFileBytes:        minUploadBytes,
-			encryptedTargetSize: events.MinUploadPartSizeBytes,
-			encryptedMaxSize:    1024 * 1024 * 4, // default GRPC message limit
-			minUploadBytes:      events.MinUploadPartSizeBytes,
-		}, {
 			name:                "target size larger than max encrypted upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4 * 2,
 			encryptedMaxSize:    8192 * 4,
 		}, {
 			name:                "target size equals max encrypted upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			encryptedMaxSize:    8192 * 4,
 		}, {
 			name:                "target size smaller than max encrypted upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			encryptedMaxSize:    8192 * 4 * 2,
 		}, {
 			name:                "target size larger than min upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4 * 2,
 			minUploadBytes:      8192 * 4,
 		}, {
 			name:                "target size equals min upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			minUploadBytes:      8192 * 4,
 		}, {
 			name:                "target size smaller than min upload size",
-			minFileBytes:        8192,
+			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			minUploadBytes:      8192 * 4 * 2,
 		}, {
 			name:                     "min file size larger than max encrypted size",
-			minFileBytes:             8192 * 4,
+			minFileSize:              8192 * 4,
 			encryptedMaxSize:         8192,
 			expectEncryptedUploadErr: true,
 		},
@@ -655,7 +649,7 @@ func TestUploadEncryptedRecording(t *testing.T) {
 			// the gzip writer is imprecise and may exceed the min file size. With a min of 8192,
 			// an extra 8192 bytes should be plenty of overhead. If this test becomes flaky, consider
 			// raising the minimum in the test cases above.
-			maxFileSize := tc.minFileBytes * 2
+			maxFileSize := tc.minFileSize * 2
 
 			// We expect encrypted uploads to exceed the target size, unless the maximum prevents it,
 			// in which case we will be short one file part.
@@ -727,7 +721,7 @@ func TestUploadEncryptedRecording(t *testing.T) {
 			})
 
 			p := newUploaderPack(ctx, t, uploaderPackConfig{
-				minimumFileUploadBytes:             int64(tc.minFileBytes),
+				minimumFileUploadBytes:             int64(tc.minFileSize),
 				minimumUploadBytes:                 int64(tc.minUploadBytes),
 				encrypter:                          &fakeEncryptedIO{},
 				wrapEncryptedUploader:              encryptedUploadWrapper,

--- a/lib/events/recorder/recorder.go
+++ b/lib/events/recorder/recorder.go
@@ -139,7 +139,10 @@ func New(cfg Config) (events.SessionPreparerRecorder, error) {
 		if cfg.Encrypter == nil {
 			cfg.Encrypter = recordingencryption.NewEncryptionWrapper(cfg.RecordingCfg)
 		}
-		fileStreamer, err := filesessions.NewStreamer(uploadDir, cfg.Encrypter)
+		fileStreamer, err := filesessions.NewStreamer(filesessions.StreamerConfig{
+			Dir:       uploadDir,
+			Encrypter: cfg.Encrypter,
+		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -352,7 +352,9 @@ func withBackoff(timeout, dur time.Duration) sessionWriterOption {
 
 func newSessionWriterTest(t *testing.T, newStreamer newStreamerFn, opts ...sessionWriterOption) *sessionWriterTest {
 	eventsCh := make(chan events.UploadEvent, 1)
-	uploader := eventstest.NewMemoryUploader(eventsCh)
+	uploader := eventstest.NewMemoryUploader(eventstest.MemoryUploaderConfig{
+		EventsC: eventsCh,
+	})
 	protoStreamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
 		Uploader: uploader,
 	})

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -68,8 +68,14 @@ const (
 	// MaxProtoMessageSizeBytes is maximum protobuf marshaled message size
 	MaxProtoMessageSizeBytes = 64 * 1024
 
-	// MinUploadPartSizeBytes is the minimum allowed part size when uploading a part to
-	// Amazon S3.
+	// MinUploadPartSizeBytes is the minimum upload part size when uploading session recordings
+	// through a [MultipartUploader]. All uploaded parts are expected to meet this minimum size.
+	// The actual minimum enforced by th external audit storage depends on the provider:
+	// - S3 (AWS):    5MiB
+	// - GCloud:      5MiB
+	// - Azure:       None
+	// - File:        None
+	// - Mem (tests): Configurable
 	MinUploadPartSizeBytes = 1024 * 1024 * 5
 
 	// ProtoStreamV1 is a version of the binary protocol

--- a/lib/events/stream_test.go
+++ b/lib/events/stream_test.go
@@ -197,7 +197,7 @@ func TestProtoStreamLargeEvent(t *testing.T) {
 	ctx := context.Background()
 
 	streamer, err := events.NewProtoStreamer(events.ProtoStreamerConfig{
-		Uploader: eventstest.NewMemoryUploader(nil),
+		Uploader: eventstest.NewMemoryUploader(),
 	})
 	require.NoError(t, err)
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -79,7 +79,6 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	grpcutils "github.com/gravitational/teleport/api/utils/grpc"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -3794,7 +3793,7 @@ func (process *TeleportProcess) initUploaderService() error {
 
 		// encrypted uploads are aggregated and uploaded directly rather than with an event stream.
 		// Since we are using the gRPC client, we must set this maximum for the aggregation step.
-		encryptedRecordingMaxUploadSize = grpcutils.MaxClientRecvMsgSize()
+		encryptedRecordingMaxUploadSize = 4 * 1024 * 1024 // 4MiB, default gRPC max msg recv size.
 	}
 
 	logger.InfoContext(process.ExitContext(), "starting upload completer service")


### PR DESCRIPTION
Changelog: Fix a bug where encrypted sessions recordings could not be uploaded to S3.

S3 buckets enforce a 5MB minimum for multipart uploads, but currently Encrypted recordings are uploaded in 128kb parts [due to technical limitations](https://github.com/gravitational/teleport/blob/master/rfd/0127-encrypted-session-recordings.md#session-recording-modes).

```
2025-10-23T18:23:34.107-07:00 WARN [UPLOAD]    Uploader scan failed, applying backoff before retrying backoff:19.704082796s error:[
ERROR REPORT:
Original Error: *smithy.OperationError operation error S3: CompleteMultipartUpload, https response error StatusCode: 400, RequestID: NB4P6J3SVNEDB64H, HostID: v/0Fn5CrKDuo1zWLsqo8P5oML4EXV3wsWZ6I/hIfUD0hxbp&#43;rL6&#43;34qUqKIN&#43;Zjnk4vf62iSvpA=, api error EntityTooSmall: Your proposed upload is smaller than the minimum allowed size
Stack Trace:
	github.com/gravitational/teleport/lib/events/s3sessions/s3stream.go:203 github.com/gravitational/teleport/lib/events/s3sessions.(*Handler).CompleteUpload
	github.com/gravitational/teleport/lib/events/auditlog.go:655 github.com/gravitational/teleport/lib/events.(*AuditLog).UploadEncryptedRecording
	github.com/gravitational/teleport/lib/events/filesessions/fileasync.go:432 github.com/gravitational/teleport/lib/events/filesessions.(*Uploader).uploadEncryptedRecording
	github.com/gravitational/teleport/lib/events/filesessions/fileasync.go:503 github.com/gravitational/teleport/lib/events/filesessions.(*Uploader).startUpload
	github.com/gravitational/teleport/lib/events/filesessions/fileasync.go:278 github.com/gravitational/teleport/lib/events/filesessions.(*Uploader).Scan
	github.com/gravitational/teleport/lib/events/filesessions/fileasync.go:239 github.com/gravitational/teleport/lib/events/filesessions.(*Uploader).Serve
	github.com/gravitational/teleport/lib/service/service.go:3648 github.com/gravitational/teleport/lib/service.(*TeleportProcess).initUploaderService.func1
	github.com/gravitational/teleport/lib/service/supervisor.go:605 github.com/gravitational/teleport/lib/service.(*LocalService).Serve
	github.com/gravitational/teleport/lib/service/supervisor.go:328 github.com/gravitational/teleport/lib/service.(*LocalSupervisor).serve.func1
	runtime/asm_amd64.s:1700 runtime.goexit
User Message: completing upload
	CompleteMultipartUpload(upload CLLKcVEllOAMbhJo4SGBBpibc2WxHJkm53CPKhNh54kwhJC2cSXvq9IGeNzYcmgrIECYuqmu8fIl3sUa9quydUTmf97o22fpYsHvxZbAG6qB6olQggGR5vBg_bzKrqXed778KMfaB02bn14gFh3GaUZGj.u.Z.iiwI4tlfzmHKY-) session(eeb355b0-69dc-4daa-b4de-ae6378f1c938)
		operation error S3: CompleteMultipartUpload, https response error StatusCode: 400, RequestID: NB4P6J3SVNEDB64H, HostID: v/0Fn5CrKDuo1zWLsqo8P5oML4EXV3wsWZ6I/hIfUD0hxbp&#43;rL6&#43;34qUqKIN&#43;Zjnk4vf62iSvpA=, api error EntityTooSmall: Your proposed upload is smaller than the minimum allowed size] filesessions/fileasync.go:242
```

This PR fixes this error by:
- Aggregating the 128kb upload parts into larger upload parts before sending the upload to Auth.
  - Auth is already agnostic to upload boundaries for both streamUploads and playback, meaning that multiple parts can be aggregated in a single upload part.
  - We aggregate up to exceed 5MB for local uploads (on Auth process) or under 4MB for gRPC client uploads (gRPC max msg recv size).
- Before Auth sends the upload part to S3, it adds padding to reach the 5MB minimum. 
  - This is only necessary for uploads with the gRPC client, limited by the 4MB max msg recv size. 
  - With the default max msg recv size size of 4MB, this will result in 1MB of padding per 5MB upload part.
  - We skip this padding on the last upload part as it is not required and could result in up to 5MB of unnecessary padding.
  - The recording playback now ignores empty upload parts, as the 1MB padding above is an individual upload part with `PartSize=0 && PaddingSize=1MB`

This is a short term fix as the 1MB of padding per upload part is not ideal. It is also tangentially related to encrypted recordings not being processed for session summaries, metadata, or thumbnails. Note that due to the lack of metadata, [this bug](https://github.com/gravitational/teleport/issues/60538) also results in encrypted recordings being unplayable in the WebUI in v18.2.3+. A more complete fix will be handled in a follow up PR.

Manual Testing (34f1f23):
- [x] encrypted recording w/ S3
  -  For each of the following configurations, I created a session recording > 5MB, played it back with `tsh play` and checked that it was the expected size in the S3 bucket.
  - [x] node recording
    - [x] node in auth process  
      - [x] async
      - [x] sync
    - [x] node in separate process (gRPC client used)
      - [x] async
        - ~~[ ] Setting `TELEPORT_UNSTABLE_GRPC_RECV_SIZE=5MB` should result in the 1MB padding being skipped, as the client will create 5MB aggregated upload parts itself.~~
      - [x] sync
  - [x] proxy recording
    - [x] proxy in auth process  
      - [x] async
      - [x] sync
    - [x] proxy in separate process (gRPC client used)
      - [x] async
        - ~~[ ] Setting `TELEPORT_UNSTABLE_GRPC_RECV_SIZE=5MB` should result in the 1MB padding being skipped, as the client will create 5MB aggregated upload parts itself.~~
      - [x] sync
- [x] non-encrypted recording
  - [x] playback w/o new padding  