### PR TITLE
Add a virtual default health check config for kube

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -776,8 +776,14 @@ var PresetRoles = []string{PresetEditorRoleName, PresetAccessRoleName, PresetAud
 
 const (
 	// PresetDefaultHealthCheckConfigName is the name of a preset
-	// default health_check_config that enables health checks for all resources.
+	// health_check_config that enables health checks for all database
+	// resources. For historical reasons, it's named "default" even though it
+	// applies to databases only.
 	PresetDefaultHealthCheckConfigName = "default"
+	// VirtualDefaultHealthCheckConfigKubeName is the name of a virtual
+	// health_check_config that enables health checks for all Kubernetes
+	// resources.
+	VirtualDefaultHealthCheckConfigKubeName = "default_kube"
 )
 
 const (

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1492,18 +1492,10 @@ func createPresetDatabaseObjectImportRule(ctx context.Context, rules services.Da
 // createPresetHealthCheckConfig creates a default preset health check config
 // resource that enables health checks on all resources.
 func createPresetHealthCheckConfig(ctx context.Context, svc services.HealthCheckConfig) error {
-	page, _, err := svc.ListHealthCheckConfigs(ctx, 0, "")
-	if err != nil {
-		return trace.Wrap(err, "failed listing available health check configs")
-	}
-	if len(page) > 0 {
-		return nil
-	}
 	preset := services.NewPresetHealthCheckConfig()
-	_, err = svc.CreateHealthCheckConfig(ctx, preset)
-	if err != nil && !trace.IsAlreadyExists(err) {
+	if _, err := svc.CreateHealthCheckConfig(ctx, preset); err != nil && !trace.IsAlreadyExists(err) {
 		return trace.Wrap(err,
-			"failed creating preset health_check_config %s",
+			"failed creating preset "+types.KindHealthCheckConfig+" %+q",
 			preset.GetMetadata().GetName(),
 		)
 	}

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -20,6 +20,7 @@ package local
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"slices"
 	"strings"
@@ -344,6 +345,10 @@ func (w *watcher) parseEvent(e backend.Event) ([]types.Event, []error) {
 		if p.match(e.Item.Key) {
 			resource, err := p.parse(e)
 			if err != nil {
+				if eo := parseEventOverrideError(nil); errors.As(err, &eo) {
+					events = append(events, eo...)
+					continue
+				}
 				errs = append(errs, trace.Wrap(err))
 				continue
 			}
@@ -403,13 +408,20 @@ func (w *watcher) Close() error {
 // resourceParser is an interface
 // for parsing resource from backend byte event stream
 type resourceParser interface {
-	// parse parses resource from the backend event
+	// parse parses resource from the backend event; if the returned error is a
+	// parseEventOverrideError then the returned resource is ignored and the
+	// events in the parseEventOverrideError will be added to the generated
+	// events instead.
 	parse(event backend.Event) (types.Resource, error)
 	// match returns true if event key matches
 	match(key backend.Key) bool
 	// prefixes returns prefixes to watch
 	prefixes() []backend.Key
 }
+
+type parseEventOverrideError []types.Event
+
+func (p parseEventOverrideError) Error() string { return "parseEventOverrideError" }
 
 // baseParser is a partial implementation of resourceParser for the most common
 // resource types (stored under a static prefix).

--- a/lib/services/local/health_check_config.go
+++ b/lib/services/local/health_check_config.go
@@ -20,13 +20,17 @@ package local
 
 import (
 	"context"
+	"iter"
+	"strings"
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
+	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
 )
@@ -58,8 +62,42 @@ func NewHealthCheckConfigService(b backend.Backend) (*HealthCheckConfigService, 
 	}, nil
 }
 
+func (*HealthCheckConfigService) hasVirtualResource(name string) bool {
+	switch name {
+	case teleport.VirtualDefaultHealthCheckConfigKubeName:
+		return true
+	default:
+		return false
+	}
+}
+
+func (*HealthCheckConfigService) getVirtualResource(name string) *healthcheckconfigv1.HealthCheckConfig {
+	switch name {
+	case teleport.VirtualDefaultHealthCheckConfigKubeName:
+		return services.VirtualDefaultHealthCheckConfigKube()
+	default:
+		return nil
+	}
+}
+
+func (*HealthCheckConfigService) rangeVirtualResources(start string) iter.Seq2[*healthcheckconfigv1.HealthCheckConfig, error] {
+	return func(yield func(*healthcheckconfigv1.HealthCheckConfig, error) bool) {
+		switch {
+		case start <= teleport.VirtualDefaultHealthCheckConfigKubeName:
+			if !yield(services.VirtualDefaultHealthCheckConfigKube(), nil) {
+				return
+			}
+			fallthrough
+		default:
+		}
+	}
+}
+
 // CreateHealthCheckConfig creates a new HealthCheckConfig resource.
 func (s *HealthCheckConfigService) CreateHealthCheckConfig(ctx context.Context, config *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	// we don't need to check if config refers to a potentially virtual resource
+	// because creating on top of a virtual resource is very convenient so it's
+	// a break from the semantics of Create that we want to allow
 	created, err := s.svc.CreateResource(ctx, config)
 	return created, trace.Wrap(err)
 }
@@ -68,6 +106,11 @@ func (s *HealthCheckConfigService) CreateHealthCheckConfig(ctx context.Context, 
 func (s *HealthCheckConfigService) GetHealthCheckConfig(ctx context.Context, name string) (*healthcheckconfigv1.HealthCheckConfig, error) {
 	item, err := s.svc.GetResource(ctx, name)
 	if err != nil {
+		if trace.IsNotFound(err) {
+			if virtualResource := s.getVirtualResource(name); virtualResource != nil {
+				return virtualResource, nil
+			}
+		}
 		return nil, trace.Wrap(err)
 	}
 	return item, nil
@@ -75,16 +118,44 @@ func (s *HealthCheckConfigService) GetHealthCheckConfig(ctx context.Context, nam
 
 // ListHealthCheckConfigs returns a paginated list of HealthCheckConfig resources.
 func (s *HealthCheckConfigService) ListHealthCheckConfigs(ctx context.Context, pageSize int, pageToken string) ([]*healthcheckconfigv1.HealthCheckConfig, string, error) {
-	items, nextKey, err := s.svc.ListResources(ctx, pageSize, pageToken)
+	items, nextPageToken, err := generic.CollectPageAndCursor(
+		iterstream.MergeStreamsWithPriority(
+			s.svc.Resources(ctx, pageToken, ""),
+			s.rangeVirtualResources(pageToken),
+			func(a, b *healthcheckconfigv1.HealthCheckConfig) int {
+				return strings.Compare(a.GetMetadata().GetName(), b.GetMetadata().GetName())
+			},
+		),
+		pageSize,
+		func(v *healthcheckconfigv1.HealthCheckConfig) string {
+			return v.GetMetadata().GetName()
+		},
+	)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
 
-	return items, nextKey, nil
+	return items, nextPageToken, nil
 }
 
 // UpdateHealthCheckConfig updates an existing HealthCheckConfig resource.
 func (s *HealthCheckConfigService) UpdateHealthCheckConfig(ctx context.Context, config *healthcheckconfigv1.HealthCheckConfig) (*healthcheckconfigv1.HealthCheckConfig, error) {
+	if virtualResource := s.getVirtualResource(config.GetMetadata().GetName()); virtualResource != nil && config.GetMetadata().GetRevision() == virtualResource.GetMetadata().GetRevision() {
+		// a (successful) conditional update on a virtual resource is a create
+		// in storage; no real storage item is going to have the same revision
+		// as the virtual resource, so this must be a conditional update on the
+		// virtual resource that we know of
+		created, err := s.svc.CreateResource(ctx, config)
+		if err != nil {
+			if trace.IsAlreadyExists(err) {
+				return nil, trace.Wrap(backend.ErrIncorrectRevision)
+			}
+			return nil, trace.Wrap(err)
+		}
+		return created, nil
+	}
+	// if this was intended to be a conditional update on a virtual resource it
+	// was not a successful one, but we can let the storage deal with it
 	updated, err := s.svc.ConditionalUpdateResource(ctx, config)
 	return updated, trace.Wrap(err)
 }
@@ -97,7 +168,13 @@ func (s *HealthCheckConfigService) UpsertHealthCheckConfig(ctx context.Context, 
 
 // DeleteHealthCheckConfig removes the specified HealthCheckConfig resource.
 func (s *HealthCheckConfigService) DeleteHealthCheckConfig(ctx context.Context, name string) error {
-	return trace.Wrap(s.svc.DeleteResource(ctx, name))
+	err := s.svc.DeleteResource(ctx, name)
+	if trace.IsNotFound(err) && s.hasVirtualResource(name) {
+		// we want to allow deleting virtual resources as a noop even if it's a
+		// little break from the standard semantics of Delete
+		return nil
+	}
+	return trace.Wrap(err)
 }
 
 // DeleteAllHealthCheckConfigs removes all HealthCheckConfig resources.
@@ -105,29 +182,43 @@ func (s *HealthCheckConfigService) DeleteAllHealthCheckConfigs(ctx context.Conte
 	return trace.Wrap(s.svc.DeleteAllResources(ctx))
 }
 
-func newHealthCheckConfigParser() *healthCheckConfigParser {
-	return &healthCheckConfigParser{
-		baseParser: newBaseParser(backend.NewKey(healthCheckConfigPrefix)),
+func newHealthCheckConfigParser() resourceParser {
+	return healthCheckConfigParser{}
+}
+
+type healthCheckConfigParser struct{}
+
+func (healthCheckConfigParser) prefixes() []backend.Key {
+	return []backend.Key{
+		backend.ExactKey(healthCheckConfigPrefix),
 	}
 }
 
-type healthCheckConfigParser struct {
-	baseParser
+func (healthCheckConfigParser) match(key backend.Key) bool {
+	return strings.HasPrefix(key.String(), backend.SeparatorString+healthCheckConfigPrefix+backend.SeparatorString)
 }
 
 func (healthCheckConfigParser) parse(event backend.Event) (types.Resource, error) {
 	switch event.Type {
 	case types.OpDelete:
-		components := event.Item.Key.Components()
-		if len(components) < 2 {
-			return nil, trace.NotFound("failed parsing %s", event.Item.Key)
+		key := event.Item.Key.String()
+		name, found := strings.CutPrefix(key, backend.SeparatorString+healthCheckConfigPrefix+backend.SeparatorString)
+		if !found {
+			return nil, trace.NotFound("failed parsing "+types.KindHealthCheckConfig+" key %+q", key)
+		}
+
+		if virtualResource := (*HealthCheckConfigService)(nil).getVirtualResource(name); virtualResource != nil {
+			return nil, parseEventOverrideError{{
+				Type:     types.OpPut,
+				Resource: types.Resource153ToLegacy(virtualResource),
+			}}
 		}
 
 		return &types.ResourceHeader{
 			Kind:    types.KindHealthCheckConfig,
 			Version: types.V1,
 			Metadata: types.Metadata{
-				Name:      components[1],
+				Name:      name,
 				Namespace: apidefaults.Namespace,
 			},
 		}, nil

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -855,15 +855,16 @@ func NewPresetMCPUserRole() types.Role {
 	return role
 }
 
-// NewPresetHealthCheckConfig returns a preset default health_check_config that
-// enables health checks for all resources.
+// NewPresetHealthCheckConfig returns a preset health_check_config enabling
+// health checks for all databases resources. It's called "default" for
+// historical reasons.
 func NewPresetHealthCheckConfig() *healthcheckconfigv1.HealthCheckConfig {
 	return &healthcheckconfigv1.HealthCheckConfig{
 		Kind:    types.KindHealthCheckConfig,
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        teleport.PresetDefaultHealthCheckConfigName,
-			Description: "Enables all health checks by default",
+			Description: "Enables health checks for all databases by default",
 			Namespace:   apidefaults.Namespace,
 			Labels: map[string]string{
 				types.TeleportInternalResourceType: types.PresetResource,
@@ -873,6 +874,32 @@ func NewPresetHealthCheckConfig() *healthcheckconfigv1.HealthCheckConfig {
 			Match: &healthcheckconfigv1.Matcher{
 				// match all databases
 				DbLabels: []*labelv1.Label{{
+					Name:   types.Wildcard,
+					Values: []string{types.Wildcard},
+				}},
+			},
+		},
+	}
+}
+
+// VirtualDefaultHealthCheckConfigKube returns a health_check_config enabling
+// health checks for all Kubernetes resources, intended to be used as a virtual
+// default resource.
+func VirtualDefaultHealthCheckConfigKube() *healthcheckconfigv1.HealthCheckConfig {
+	return &healthcheckconfigv1.HealthCheckConfig{
+		Kind:    types.KindHealthCheckConfig,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:        teleport.VirtualDefaultHealthCheckConfigKubeName,
+			Description: "Enables health checks for all Kubernetes clusters by default.",
+			// this revision MUST be changed every time we change the contents
+			// of the preset so that conditional updates can check against it
+			Revision: "d796f007-e60c-4747-8dde-f479aff6b743",
+		},
+		Spec: &healthcheckconfigv1.HealthCheckConfigSpec{
+			Match: &healthcheckconfigv1.Matcher{
+				// match all kubernetes clusters
+				KubernetesLabels: []*labelv1.Label{{
 					Name:   types.Wildcard,
 					Values: []string{types.Wildcard},
 				}},


### PR DESCRIPTION
Alternate proposal for #60544; if this ends up working out we are going to turn this approach into something directly supported by `generic.Service`/`ServiceWrapper`.