### PR TITLE
Fix GetUserOrLoginState call to always use backend instead of cache

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2667,7 +2667,12 @@ func certRequestDeviceExtensions(ext tlsca.DeviceExtensions) certRequestOption {
 
 // GetUserOrLoginState will return the given user or the login state associated with the user.
 func (a *Server) GetUserOrLoginState(ctx context.Context, username string) (services.UserState, error) {
-	return services.GetUserOrLoginState(ctx, a, username)
+	// use Services (real backend instead of cache) to make sure that the GetUserOrLoginState function
+	// return always the up-to-date user state.
+	// During Login webhooks evaluation the user state is created an upserted into backend where next Login steps
+	// fetches the state from store and relies to have the latest version.
+	// TODO(smallinsky): Get rid of sharing user state via backend and use the proper param forwarding instead.
+	return services.GetUserOrLoginState(ctx, a.Services, username)
 }
 
 func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCertRequest) (*proto.OpenSSHCert, error) {


### PR DESCRIPTION
### What

Backport https://github.com/gravitational/teleport-private/pull/2179


changelog: Fix an issue where the user login flow returns outdated permissions due to fetching a stale user login state object from cache instead of the backend. This caused users to need to log in twice for updated permissions to take effect.