### PR TITLE
Auto page size adjustment for GetUsers

### DIFF
--- a/api/utils/clientutils/resources.go
+++ b/api/utils/clientutils/resources.go
@@ -77,20 +77,8 @@ func rangeInternal[T any](ctx context.Context, params rangeParams[T]) iter.Seq2[
 		isLookingForEnd := params.end != "" && params.keyFunc != nil
 
 		for {
-			page, nextToken, err := params.pageFunc(ctx, pageSize, pageToken)
+			page, nextToken, err := Page(ctx, pageSize, pageToken, params.pageFunc)
 			if err != nil {
-				if trace.IsLimitExceeded(err) {
-					// Cut chunkSize in half if gRPC max message size is exceeded.
-					pageSize /= 2
-					// This is an extremely unlikely scenario, but better to cover it anyways.
-					if pageSize == 0 {
-						yield(*new(T), trace.Wrap(err, "resource is too large to retrieve"))
-						return
-					}
-
-					continue
-				}
-
 				yield(*new(T), trace.Wrap(err))
 				return
 			}
@@ -179,4 +167,28 @@ func CollectWithFallback[T any](ctx context.Context,
 	}
 
 	return out, nil
+}
+
+// Page is a client side utility which implements auto page size adjustment.
+func Page[T any](ctx context.Context, pageSize int, pageToken string,
+	pageFunc func(context.Context, int, string) ([]T, string, error)) ([]T, string, error) {
+	for {
+		page, nextToken, err := pageFunc(ctx, pageSize, pageToken)
+		if err != nil {
+			if trace.IsLimitExceeded(err) {
+				// Cut chunkSize in half if gRPC max message size is exceeded.
+				pageSize /= 2
+				// This is an extremely unlikely scenario, but better to cover it anyways.
+				if pageSize == 0 {
+					return nil, "", trace.Wrap(err, "resource is too large to retrieve, token: %q", pageToken)
+				}
+
+				continue
+			}
+
+			return nil, "", trace.Wrap(err)
+		}
+
+		return page, nextToken, nil
+	}
 }

--- a/lib/web/users.go
+++ b/lib/web/users.go
@@ -30,6 +30,7 @@ import (
 	userspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/users/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -79,20 +80,33 @@ func (h *Handler) listUsersHandle(w http.ResponseWriter, r *http.Request, params
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := clt.ListUsers(r.Context(), &userspb.ListUsersRequest{
-		PageSize:  limit,
-		PageToken: values.Get("startKey"),
-		Filter: &types.UserFilter{
-			SearchKeywords:  client.ParseSearchKeywords(values.Get("search"), ' '),
-			SkipSystemUsers: true,
-		},
-	})
+	users, nextToken, err := clientutils.Page(
+		r.Context(),
+		int(limit),
+		values.Get("startKey"),
+		func(ctx context.Context, pageSize int, pageToken string) ([]*types.UserV2, string, error) {
+			resp, err := clt.ListUsers(r.Context(), &userspb.ListUsersRequest{
+				PageSize:  int32(pageSize),
+				PageToken: pageToken,
+				Filter: &types.UserFilter{
+					SearchKeywords:  client.ParseSearchKeywords(values.Get("search"), ' '),
+					SkipSystemUsers: true,
+				},
+			})
+
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			return resp.Users, resp.NextPageToken, nil
+		})
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var uiUsers []ui.UserListEntry
-	for _, u := range resp.GetUsers() {
+	for _, u := range users {
 		uiuser, err := ui.NewUserListEntry(u)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -102,7 +116,7 @@ func (h *Handler) listUsersHandle(w http.ResponseWriter, r *http.Request, params
 
 	return &listUsersResponse{
 		Items:    uiUsers,
-		StartKey: resp.GetNextPageToken(),
+		StartKey: nextToken,
 	}, nil
 }
 


### PR DESCRIPTION
It is possible that the default page size will still exceed grpc
limits when user objects are large enough. This change will
use the auto page size adjustment in this case to attempt to recover
gracefully.

Fixes: #60933