### PR TITLE
tctl resource: update AccessGraphSettings

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
-	clusterconfigrec "github.com/gravitational/teleport/tool/tctl/common/clusterconfig"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobject"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
@@ -1214,23 +1213,6 @@ func (c *vnetConfigCollection) WriteText(w io.Writer, verbose bool) error {
 	t.AddRow([]string{
 		c.vnetConfig.GetSpec().GetIpv4CidrRange(),
 		strings.Join(dnsZoneSuffixes, ", "),
-	})
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type accessGraphSettings struct {
-	accessGraphSettings *clusterconfigrec.AccessGraphSettings
-}
-
-func (c *accessGraphSettings) Resources() []types.Resource {
-	return []types.Resource{c.accessGraphSettings}
-}
-
-func (c *accessGraphSettings) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"SSH Keys Scan"})
-	t.AddRow([]string{
-		c.accessGraphSettings.Spec.SecretsScanConfig,
 	})
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
-	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
 	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
@@ -72,7 +71,6 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
-	clusterconfigrec "github.com/gravitational/teleport/tool/tctl/common/clusterconfig"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobject"
 	"github.com/gravitational/teleport/tool/tctl/common/databaseobjectimportrule"
@@ -159,7 +157,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindAccessMonitoringRule:        rc.createAccessMonitoringRule,
 		types.KindCrownJewel:                  rc.createCrownJewel,
 		types.KindVnetConfig:                  rc.createVnetConfig,
-		types.KindAccessGraphSettings:         rc.upsertAccessGraphSettings,
 		types.KindPlugin:                      rc.createPlugin,
 		types.KindStaticHostUser:              rc.createStaticHostUser,
 		types.KindUserTask:                    rc.createUserTask,
@@ -180,7 +177,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindAccessMonitoringRule:        rc.updateAccessMonitoringRule,
 		types.KindCrownJewel:                  rc.updateCrownJewel,
 		types.KindVnetConfig:                  rc.updateVnetConfig,
-		types.KindAccessGraphSettings:         rc.updateAccessGraphSettings,
 		types.KindPlugin:                      rc.updatePlugin,
 		types.KindStaticHostUser:              rc.updateStaticHostUser,
 		types.KindUserTask:                    rc.updateUserTask,
@@ -2516,16 +2512,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			startKey = resp.NextKey
 		}
 		return &pluginCollection{plugins: plugins}, nil
-	case types.KindAccessGraphSettings:
-		settings, err := client.ClusterConfigClient().GetAccessGraphSettings(ctx, &clusterconfigpb.GetAccessGraphSettingsRequest{})
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		rec, err := clusterconfigrec.ProtoToResource(settings)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return &accessGraphSettings{accessGraphSettings: rec}, nil
 	case types.KindStaticHostUser:
 		hostUserClient := client.StaticHostUserClient()
 		if rc.ref.Name != "" {
@@ -2896,32 +2882,5 @@ func (rc *ResourceCommand) createPlugin(ctx context.Context, client *authclient.
 		return trace.Wrap(err)
 	}
 	fmt.Printf("plugin %q has been updated\n", item.GetName())
-	return nil
-}
-
-func (rc *ResourceCommand) upsertAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if _, err = client.ClusterConfigClient().UpsertAccessGraphSettings(ctx, &clusterconfigpb.UpsertAccessGraphSettingsRequest{AccessGraphSettings: settings}); err != nil {
-		return trace.Wrap(err)
-	}
-
-	fmt.Println("access_graph_settings has been upserted")
-	return nil
-}
-
-func (rc *ResourceCommand) updateAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if _, err = client.ClusterConfigClient().UpdateAccessGraphSettings(ctx, &clusterconfigpb.UpdateAccessGraphSettingsRequest{AccessGraphSettings: settings}); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Println("access_graph_settings has been updated")
 	return nil
 }

--- a/tool/tctl/common/resources/accessgraphsettings.go
+++ b/tool/tctl/common/resources/accessgraphsettings.go
@@ -1,0 +1,101 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	clusterconfigrec "github.com/gravitational/teleport/tool/tctl/common/clusterconfig"
+)
+
+type accessGraphSettingsCollection struct {
+	accessGraphSettings *clusterconfigrec.AccessGraphSettings
+}
+
+func (c *accessGraphSettingsCollection) Resources() []types.Resource {
+	return []types.Resource{c.accessGraphSettings}
+}
+
+func (c *accessGraphSettingsCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"SSH Keys Scan"})
+	t.AddRow([]string{
+		c.accessGraphSettings.Spec.SecretsScanConfig,
+	})
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func accessGraphSettingsHandler() Handler {
+	return Handler{
+		getHandler:    getAccessGraphSettings,
+		createHandler: upsertAccessGraphSettings,
+		updateHandler: updateAccessGraphSettings,
+		singleton:     true,
+		mfaRequired:   false,
+		description:   "Configures Access Graph settings for the cluster.",
+	}
+}
+
+func getAccessGraphSettings(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	settings, err := client.ClusterConfigClient().GetAccessGraphSettings(ctx, &clusterconfigpb.GetAccessGraphSettingsRequest{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	rec, err := clusterconfigrec.ProtoToResource(settings)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &accessGraphSettingsCollection{accessGraphSettings: rec}, nil
+}
+
+func upsertAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err = client.ClusterConfigClient().UpsertAccessGraphSettings(ctx, &clusterconfigpb.UpsertAccessGraphSettingsRequest{AccessGraphSettings: settings}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Println("access_graph_settings has been upserted")
+	return nil
+}
+
+func updateAccessGraphSettings(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	settings, err := clusterconfigrec.UnmarshalAccessGraphSettings(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err = client.ClusterConfigClient().UpdateAccessGraphSettings(ctx, &clusterconfigpb.UpdateAccessGraphSettingsRequest{AccessGraphSettings: settings}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("access_graph_settings has been updated")
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -34,6 +34,7 @@ import (
 func Handlers() map[string]Handler {
 	// When adding resources, please keep the map alphabetically ordered.
 	return map[string]Handler{
+		types.KindAccessGraphSettings:                accessGraphSettingsHandler(),
 		types.KindApp:                                appHandler(),
 		types.KindAppServer:                          appServerHandler(),
 		types.KindAuthServer:                         authHandler(),


### PR DESCRIPTION
Convert access_graph_settings to the new tctl resource handler format that was introduced in #59518