### PR TITLE
[v18] Connect: create Unix sockets in temp directory

### DIFF
--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -56,7 +56,9 @@ if (!process.defaultApp) {
 app.commandLine.appendSwitch('gtk-version', '3');
 
 if (app.requestSingleInstanceLock()) {
-  initializeApp();
+  initializeApp().catch(error =>
+    showDialogWithError('Could not initialize the app', error)
+  );
 } else {
   console.log('Attempted to open a second instance of the app, exiting.');
   // All windows will be closed immediately without asking the user,

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -222,63 +222,29 @@ async function requestGrpcServerAddresses(): Promise<GrpcServerAddresses> {
       // maximum allowed path length for Unix domain sockets.
       // Limits: macOS - 104 characters, Linux - 108 characters.
       const tempDir = await getUnixUserTempDir();
-      const [tsh, shared, tshdEvents] = await Promise.all([
-        getUnixSocketNetworkAddress(tempDir, 'tsh.socket'),
-        getUnixSocketNetworkAddress(tempDir, 'shared.socket'),
-        getUnixSocketNetworkAddress(tempDir, 'tshd_events.socket'),
-      ]);
-      return { tsh, shared, tshdEvents };
+      return {
+        tsh: getUnixSocketPath(tempDir, 'tsh.socket'),
+        shared: getUnixSocketPath(tempDir, 'shared.socket'),
+        tshdEvents: getUnixSocketPath(tempDir, 'tshd_events.socket'),
+      };
   }
 }
 
-async function getUnixSocketNetworkAddress(
-  tempDir: string,
-  socketName: string
-) {
+function getUnixSocketPath(tempDir: string, socketName: string): string {
   const socketPath = path.join(tempDir, socketName);
-  try {
-    // Try to clean up after a previous process that unexpectedly crashed.
-    await fs.promises.unlink(socketPath);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
   return `unix://${socketPath}`;
 }
 
 async function getUnixUserTempDir(): Promise<string> {
-  const appTempDir = app.getPath('temp');
+  // On macOS, the 'temp' dir is like /var/folders/y5/yqg8xz555_v7xfsr0wn6b4q80000gn/T/.
+  // That dir is per-user and secure by default.
+  // On Linux the temp dir is like /tmp, and it's accessible by anyone.
+  const tempDir = app.getPath('temp');
   const appName = app.getName();
-  // On macOS, 'temp' dir is like //var/folders/y5/yqg8xz555_v7xfsr0wn6b4q80000gn/T/.
-  // That dir is per-user and secure by default, so just create the app subdirectory.
-  if (process.platform === 'darwin') {
-    const dirPath = path.join(appTempDir, appName);
-    await fs.promises.mkdir(dirPath, { mode: 0o700, recursive: true });
-    return dirPath;
-  }
-
-  // On Linux the temp dir is like /tmp, and it's accessible by anyone,
-  // so create a user-specific subdirectory, e.g. "Teleport Connect-1000".
-  const dirPath = path.join(
-    appTempDir,
-    // UID can have at most 10 chars.
-    `${appName}-${process.getuid().toString()}`
-  );
-  await fs.promises.mkdir(dirPath, { mode: 0o700, recursive: true });
-  // The directory may already exist, validate it.
-  const stat = await fs.promises.lstat(dirPath);
-  if (!stat.isDirectory()) {
-    throw new Error(`${dirPath} is not a directory`);
-  }
-  if (stat.uid !== process.getuid()) {
-    throw new Error(`${dirPath} must be owned by the current user`);
-  }
-  // Mask to only get the permission bits.
-  const mode = stat.mode & 0o777;
-  if (mode !== 0o700) {
-    throw new Error(`${dirPath} must have permissions set to 700 (rwx------)`);
-  }
-  return dirPath;
+  // `mkdtemp` creates a temporary directory with mode 0o700,
+  // ensuring that only the current user can access it (important on Linux).
+  // TODO(gzdunek): Node.js 24 introduced mkdtempDisposable().
+  // Create a global DisposableStack to track all disposable resources
+  // and automatically clean them up when the app exits.
+  return fs.promises.mkdtemp(path.join(tempDir, `${appName}-`));
 }

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -223,9 +223,9 @@ async function requestGrpcServerAddresses(): Promise<GrpcServerAddresses> {
       // Limits: macOS - 104 characters, Linux - 108 characters.
       const tempDir = await getUnixUserTempDir();
       return {
-        tsh: getUnixSocketPath(tempDir, 'tsh.socket'),
-        shared: getUnixSocketPath(tempDir, 'shared.socket'),
-        tshdEvents: getUnixSocketPath(tempDir, 'tshd_events.socket'),
+        tsh: getUnixSocketPath(tempDir, 'tsh.sock'),
+        shared: getUnixSocketPath(tempDir, 'shared.sock'),
+        tshdEvents: getUnixSocketPath(tempDir, 'tshde.sock'),
       };
   }
 }

--- a/web/packages/teleterm/src/services/tshdEvents/index.ts
+++ b/web/packages/teleterm/src/services/tshdEvents/index.ts
@@ -64,7 +64,9 @@ export async function createTshdEventsServer(
   const { service, setupTshdEventContextBridgeService } = createService(logger);
 
   server.addService(apiService.tshdEventsServiceDefinition, service);
-
+  window.addEventListener('unload', () => {
+    server.forceShutdown();
+  });
   return { resolvedAddress, setupTshdEventContextBridgeService };
 }
 


### PR DESCRIPTION
Backport #60466 to branch/v18

changelog: Fixed a startup error `EADDRINUSE: address already in use` in Teleport Connect on macOS and Linux that could occur with long system usernames
