### PR TITLE
Add a GovCloud warning to AWS self-hosting guides

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
@@ -19,6 +19,11 @@ to customers.
 This architecture is best suited for globally distributed resources and end-users that prefer a single point of
 entry while also ensuring minimal latency when accessing connected resources.
 
+This guide assumes that your infrastructure is **not** hosted in AWS GovCloud or
+in an air-gapped AWS environment (EKS Anywhere). If it is, [contact the Teleport
+team](https://goteleport.com/contact-us) for assistance planning your
+deployment.
+
 ## Key deployment components
 
 - Deployed exclusively in the AWS ecosystem

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -17,6 +17,13 @@ and describe how to manage the resulting Teleport deployment.
 
 ## Prerequisites
 
+This guide assumes that your infrastructure is **not** hosted in AWS GovCloud or
+in an air-gapped AWS environment (EKS Anywhere). If it is, [contact the Teleport
+team](https://goteleport.com/contact-us) for assistance planning your
+deployment.
+
+This guide also requires the following:
+
 - Terraform installed on your system. Visit [Install
   Terraform](https://developer.hashicorp.com/terraform/install) for
   instructions. We will assume that you have `terraform` available on your path.

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -30,6 +30,13 @@ More details are [provided below](#reference-deployment-defaults).
 
 ## Prerequisites
 
+This guide assumes that your infrastructure is **not** hosted in AWS GovCloud or
+in an air-gapped AWS environment (EKS Anywhere). If it is, [contact the Teleport
+team](https://goteleport.com/contact-us) for assistance planning your
+deployment.
+
+This guide also requires the following:
+
 - Terraform installed on your system. Visit [Install
   Terraform](https://developer.hashicorp.com/terraform/install) for
   instructions. We will assume that you have `terraform` available on your path.

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
@@ -36,6 +36,13 @@ requires the following resources, which we show you how to create in this guide:
 
 ## Prerequisites
 
+This guide assumes that your infrastructure is **not** hosted in AWS GovCloud or
+in an air-gapped AWS environment (EKS Anywhere). If it is, [contact the Teleport
+team](https://goteleport.com/contact-us) for assistance planning your
+deployment.
+
+This guide also requires the following:
+
 (!docs/pages/includes/kubernetes-access/helm/teleport-cluster-prereqs.mdx!)
 
 ### Choose a Kubernetes namespace and Helm release name


### PR DESCRIPTION
Closes #34556

Deploying Teleport in a GovCloud environment requires that organizations accommodate certain nuances, such as the fact that Teleport AMIs are not published to GovCloud regions. This change adds a quick note to each AWS self-hosting guide that advises GovCloud users to reach out to the Teleport team.