### PR TITLE
Remove tags in IaC reference guides

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -2,10 +2,6 @@
 title: TeleportAccessList
 description: Provides a comprehensive list of fields in the TeleportAccessList resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-appsv3.mdx
@@ -2,10 +2,6 @@
 title: TeleportAppV3
 description: Provides a comprehensive list of fields in the TeleportAppV3 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateconfigsv1.mdx
@@ -2,10 +2,6 @@
 title: TeleportAutoupdateConfigV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateConfigV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -2,10 +2,6 @@
 title: TeleportAutoupdateVersionV1
 description: Provides a comprehensive list of fields in the TeleportAutoupdateVersionV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -2,10 +2,6 @@
 title: TeleportBotV1
 description: Provides a comprehensive list of fields in the TeleportBotV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-databasesv3.mdx
@@ -2,10 +2,6 @@
 title: TeleportDatabaseV3
 description: Provides a comprehensive list of fields in the TeleportDatabaseV3 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-githubconnectors.mdx
@@ -2,10 +2,6 @@
 title: TeleportGithubConnector
 description: Provides a comprehensive list of fields in the TeleportGithubConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-loginrules.mdx
@@ -2,10 +2,6 @@
 title: TeleportLoginRule
 description: Provides a comprehensive list of fields in the TeleportLoginRule resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oidcconnectors.mdx
@@ -2,10 +2,6 @@
 title: TeleportOIDCConnector
 description: Provides a comprehensive list of fields in the TeleportOIDCConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-oktaimportrules.mdx
@@ -2,10 +2,6 @@
 title: TeleportOktaImportRule
 description: Provides a comprehensive list of fields in the TeleportOktaImportRule resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -2,10 +2,6 @@
 title: TeleportOpenSSHEICEServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHEICEServerV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -2,10 +2,6 @@
 title: TeleportOpenSSHServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHServerV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -2,10 +2,6 @@
 title: TeleportProvisionToken
 description: Provides a comprehensive list of fields in the TeleportProvisionToken resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-roles.mdx
@@ -2,10 +2,6 @@
 title: TeleportRole
 description: Provides a comprehensive list of fields in the TeleportRole resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -2,10 +2,6 @@
 title: TeleportRoleV6
 description: Provides a comprehensive list of fields in the TeleportRoleV6 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -2,10 +2,6 @@
 title: TeleportRoleV7
 description: Provides a comprehensive list of fields in the TeleportRoleV7 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-rolesv8.mdx
@@ -2,10 +2,6 @@
 title: TeleportRoleV8
 description: Provides a comprehensive list of fields in the TeleportRoleV8 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-samlconnectors.mdx
@@ -2,10 +2,6 @@
 title: TeleportSAMLConnector
 description: Provides a comprehensive list of fields in the TeleportSAMLConnector resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
@@ -2,10 +2,6 @@
 title: TeleportTrustedClusterV2
 description: Provides a comprehensive list of fields in the TeleportTrustedClusterV2 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-users.mdx
@@ -2,10 +2,6 @@
 title: TeleportUser
 description: Provides a comprehensive list of fields in the TeleportUser resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
@@ -2,10 +2,6 @@
 title: TeleportWorkloadIdentityV1
 description: Provides a comprehensive list of fields in the TeleportWorkloadIdentityV1 resource available through the Teleport Kubernetes operator
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_list Terraform data-source
 sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_list_member.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_list_member Terraform data-source
 sidebar_label: access_list_member
 description: This page describes the supported values of the teleport_access_list_member data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/access_monitoring_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_monitoring_rule Terraform data-source
 sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/app.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_app Terraform data-source
 sidebar_label: app
 description: This page describes the supported values of the teleport_app data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/auth_preference.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_auth_preference Terraform data-source
 sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_autoupdate_config Terraform data-source
 sidebar_label: autoupdate_config
 description: This page describes the supported values of the teleport_autoupdate_config data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_autoupdate_version Terraform data-source
 sidebar_label: autoupdate_version
 description: This page describes the supported values of the teleport_autoupdate_version data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_maintenance_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_cluster_maintenance_config Terraform data-source
 sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/cluster_networking_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_cluster_networking_config Terraform data-source
 sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/data-sources.mdx
@@ -1,10 +1,6 @@
 ---
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/database.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_database Terraform data-source
 sidebar_label: database
 description: This page describes the supported values of the teleport_database data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/dynamic_windows_desktop.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_dynamic_windows_desktop Terraform data-source
 sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/github_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_github_connector Terraform data-source
 sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/health_check_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_health_check_config Terraform data-source
 sidebar_label: health_check_config
 description: This page describes the supported values of the teleport_health_check_config data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/installer.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_installer Terraform data-source
 sidebar_label: installer
 description: This page describes the supported values of the teleport_installer data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/login_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_login_rule Terraform data-source
 sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/oidc_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_oidc_connector Terraform data-source
 sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/okta_import_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_okta_import_rule Terraform data-source
 sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/provision_token.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_provision_token Terraform data-source
 sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/role.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_role Terraform data-source
 sidebar_label: role
 description: This page describes the supported values of the teleport_role data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/saml_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_saml_connector Terraform data-source
 sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/session_recording_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_session_recording_config Terraform data-source
 sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/static_host_user.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_static_host_user Terraform data-source
 sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_cluster.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_trusted_cluster Terraform data-source
 sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/trusted_device.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_trusted_device Terraform data-source
 sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/user.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_user Terraform data-source
 sidebar_label: user
 description: This page describes the supported values of the teleport_user data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/workload_identity.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_workload_identity Terraform data-source
 sidebar_label: workload_identity
 description: This page describes the supported values of the teleport_workload_identity data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_list Terraform resource
 sidebar_label: access_list
 description: This page describes the supported values of the teleport_access_list resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_list_member.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_list_member Terraform resource
 sidebar_label: access_list_member
 description: This page describes the supported values of the teleport_access_list_member resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/access_monitoring_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_access_monitoring_rule Terraform resource
 sidebar_label: access_monitoring_rule
 description: This page describes the supported values of the teleport_access_monitoring_rule resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/app.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_app Terraform resource
 sidebar_label: app
 description: This page describes the supported values of the teleport_app resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/auth_preference.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_auth_preference Terraform resource
 sidebar_label: auth_preference
 description: This page describes the supported values of the teleport_auth_preference resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_autoupdate_config Terraform resource
 sidebar_label: autoupdate_config
 description: This page describes the supported values of the teleport_autoupdate_config resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_autoupdate_version Terraform resource
 sidebar_label: autoupdate_version
 description: This page describes the supported values of the teleport_autoupdate_version resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/bot.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_bot Terraform resource
 sidebar_label: bot
 description: This page describes the supported values of the teleport_bot resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_maintenance_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_cluster_maintenance_config Terraform resource
 sidebar_label: cluster_maintenance_config
 description: This page describes the supported values of the teleport_cluster_maintenance_config resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/cluster_networking_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_cluster_networking_config Terraform resource
 sidebar_label: cluster_networking_config
 description: This page describes the supported values of the teleport_cluster_networking_config resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/database.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_database Terraform resource
 sidebar_label: database
 description: This page describes the supported values of the teleport_database resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/dynamic_windows_desktop.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_dynamic_windows_desktop Terraform resource
 sidebar_label: dynamic_windows_desktop
 description: This page describes the supported values of the teleport_dynamic_windows_desktop resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/github_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_github_connector Terraform resource
 sidebar_label: github_connector
 description: This page describes the supported values of the teleport_github_connector resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/health_check_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_health_check_config Terraform resource
 sidebar_label: health_check_config
 description: This page describes the supported values of the teleport_health_check_config resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_installer Terraform resource
 sidebar_label: installer
 description: This page describes the supported values of the teleport_installer resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/login_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_login_rule Terraform resource
 sidebar_label: login_rule
 description: This page describes the supported values of the teleport_login_rule resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/oidc_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_oidc_connector Terraform resource
 sidebar_label: oidc_connector
 description: This page describes the supported values of the teleport_oidc_connector resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/okta_import_rule.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_okta_import_rule Terraform resource
 sidebar_label: okta_import_rule
 description: This page describes the supported values of the teleport_okta_import_rule resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/provision_token.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_provision_token Terraform resource
 sidebar_label: provision_token
 description: This page describes the supported values of the teleport_provision_token resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/resources.mdx
@@ -1,10 +1,6 @@
 ---
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/role.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_role Terraform resource
 sidebar_label: role
 description: This page describes the supported values of the teleport_role resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/saml_connector.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_saml_connector Terraform resource
 sidebar_label: saml_connector
 description: This page describes the supported values of the teleport_saml_connector resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/server.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_server Terraform resource
 sidebar_label: server
 description: This page describes the supported values of the teleport_server resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/session_recording_config.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_session_recording_config Terraform resource
 sidebar_label: session_recording_config
 description: This page describes the supported values of the teleport_session_recording_config resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/static_host_user.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_static_host_user Terraform resource
 sidebar_label: static_host_user
 description: This page describes the supported values of the teleport_static_host_user resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_cluster.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_trusted_cluster Terraform resource
 sidebar_label: trusted_cluster
 description: This page describes the supported values of the teleport_trusted_cluster resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/trusted_device.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_trusted_device Terraform resource
 sidebar_label: trusted_device
 description: This page describes the supported values of the teleport_trusted_device resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/user.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_user Terraform resource
 sidebar_label: user
 description: This page describes the supported values of the teleport_user resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/workload_identity.mdx
@@ -2,10 +2,6 @@
 title: Reference for the teleport_workload_identity Terraform resource
 sidebar_label: workload_identity
 description: This page describes the supported values of the teleport_workload_identity resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -48,10 +48,6 @@ var crdDocTmpl string = `---
 title: {{.Title}}
 description: {{.Description}}
 tocDepth: 3
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {/*Auto-generated file. Do not edit.*/}

--- a/integrations/terraform-mwi/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform-mwi/templates/data-sources-index.mdx.tmpl
@@ -1,10 +1,6 @@
 ---
 title: "MWI Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport MWI Terraform Provider"
-tags:
-  - infrastructure-as-code
-  - reference
-  - mwi
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform-mwi/templates/data-sources.md.tmpl
+++ b/integrations/terraform-mwi/templates/data-sources.md.tmpl
@@ -2,10 +2,6 @@
 title: Reference for the {{.Name}} Terraform data-source
 sidebar_label: {{ slice .Name (len "teleportmwi_") }}
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport MWI Terraform provider.
-tags:
-  - infrastructure-as-code
-  - reference
-  - mwi
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform-mwi/templates/ephemeral-resources-index.mdx.tmpl
+++ b/integrations/terraform-mwi/templates/ephemeral-resources-index.mdx.tmpl
@@ -1,10 +1,6 @@
 ---
 title: "MWI Terraform ephemeral resources index"
 description: "Index of all the resources supported by the Teleport MWI Terraform Provider"
-tags:
-  - infrastructure-as-code
-  - reference
-  - mwi
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform-mwi/templates/ephemeral-resources.md.tmpl
+++ b/integrations/terraform-mwi/templates/ephemeral-resources.md.tmpl
@@ -2,10 +2,6 @@
 title: Reference for the {{.Name}} Terraform ephemeral resource
 sidebar_label: {{ slice .Name (len "teleportmwi_") }}
 description: This page describes the supported values of the {{.Name}} ephemeral resource of the Teleport MWI Terraform provider.
-tags:
-  - infrastructure-as-code
-  - reference
-  - mwi
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/data-sources-index.mdx.tmpl
+++ b/integrations/terraform/templates/data-sources-index.mdx.tmpl
@@ -1,10 +1,6 @@
 ---
 title: "Terraform data-sources index"
 description: "Index of all the data-sources supported by the Teleport Terraform Provider"
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/data-sources.md.tmpl
+++ b/integrations/terraform/templates/data-sources.md.tmpl
@@ -2,10 +2,6 @@
 title: Reference for the {{.Name}} Terraform data-source
 sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} data-source of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/resources-index.mdx.tmpl
+++ b/integrations/terraform/templates/resources-index.mdx.tmpl
@@ -1,10 +1,6 @@
 ---
 title: "Terraform resources index"
 description: "Index of all the datasources supported by the Teleport Terraform Provider"
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}

--- a/integrations/terraform/templates/resources.md.tmpl
+++ b/integrations/terraform/templates/resources.md.tmpl
@@ -2,10 +2,6 @@
 title: Reference for the {{.Name}} Terraform resource
 sidebar_label: {{ slice .Name (len "teleport_") }}
 description: This page describes the supported values of the {{.Name}} resource of the Teleport Terraform provider.
-tags:
- - infrastructure-as-code
- - reference
- - platform-wide
 ---
 
 {{ "{/*Auto-generated file. Do not edit.*/}" }}


### PR DESCRIPTION
Since each IaC resource reference section includes a relatively large number of guides, the `/docs/tags` pages for any tags listed in these guides feature a disproportionate number of resource reference pages. By removing tags from the resource reference docs, we can make the `/docs/tags` pages easier to navigate.

Preserve tags in index pages of resource reference sections so readers can still navigate to these parts of the docs through `/docs/tags` pages.