### PR TITLE
Clarify scheduling and grouping behavior for autoupdate_config resource

### DIFF
--- a/docs/pages/includes/reference/resources/autoupdate_config.mdx
+++ b/docs/pages/includes/reference/resources/autoupdate_config.mdx
@@ -35,7 +35,8 @@ spec:
     schedules:
       regular:
 
-        # name of each group, configured locally via "teleport-update enable --group"
+        # name of each group, configured locally via "teleport-update enable --group".
+        # Agents presenting a missing or empty group are placed in the last named group.
         - name: staging
 
           # start_hour of the update, in UTC

--- a/docs/pages/includes/reference/resources/autoupdate_config.mdx
+++ b/docs/pages/includes/reference/resources/autoupdate_config.mdx
@@ -36,7 +36,7 @@ spec:
       regular:
 
         # name of each group, configured locally via "teleport-update enable --group".
-        # Agents presenting a missing or empty group are placed in the last named group.
+        # Agents presenting a missing or empty group are placed in the last group in the list.
         - name: staging
 
           # start_hour of the update, in UTC

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -175,6 +175,11 @@ spec:
           start_hour: 16
 ```
 
+This configures a single group named "default" for all agents.
+All agents will be placed in this group, as agents with missing
+or unknown groups are always placed in the last listed group.
+Currently, only the "regular" schedule is user-configurable.
+
 For example, a Teleport user with staging and production
 environments might create a custom schedule that looks like this:
 

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -175,7 +175,7 @@ spec:
           start_hour: 16
 ```
 
-This configures a single group named "default" for all agents.
+This example configures a single group named "default" for all agents.
 All agents will be placed in this group, as agents with missing
 or unknown groups are always placed in the last listed group.
 Currently, only the "regular" schedule is user-configurable.


### PR DESCRIPTION
This PR clarifies that agents presenting a missing or invalid group are placed in the last group.
It also clarifies that only the regular schedule has configurable groups.

Goal (internal): https://github.com/gravitational/cloud/issues/14225