### PR TITLE
Clarify the meaning of `start_version` in Managed Updates docs

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -38,7 +38,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |mode|string|autoupdate_mode to use for the rollout|
 |schedule|string|schedule to use for the rollout|
-|start_version|string|start_version is the version used for new agents before their update window.|
+|start_version|string|start_version is the version used for newly installed agents before their update window.|
 |target_version|string|target_version is the version that all agents will update to during their update window.|
 
 ### spec.tools

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -39,7 +39,7 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |mode|string|autoupdate_mode to use for the rollout|
 |schedule|string|schedule to use for the rollout|
 |start_version|string|start_version is the version used for new agents before their update window.|
-|target_version|string|target_version is the version that all agents should update to during their update window.|
+|target_version|string|target_version is the version that all agents will update to during their update window.|
 
 ### spec.tools
 

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -38,8 +38,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |mode|string|autoupdate_mode to use for the rollout|
 |schedule|string|schedule to use for the rollout|
-|start_version|string|start_version is the version to update from.|
-|target_version|string|target_version is the version to update to.|
+|start_version|string|start_version is the version used for new agents before their update window.|
+|target_version|string|target_version is the version that all agents should update to during their update window.|
 
 ### spec.tools
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -44,8 +44,8 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version to update from.
-- `target_version` (String) target_version is the version to update to.
+- `start_version` (String) start_version is the version used for new agents before their update window.
+- `target_version` (String) target_version is the version that all agents should update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -45,7 +45,7 @@ Optional:
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
 - `start_version` (String) start_version is the version used for new agents before their update window.
-- `target_version` (String) target_version is the version that all agents should update to during their update window.
+- `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -44,7 +44,7 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version used for new agents before their update window.
+- `start_version` (String) start_version is the version used for newly installed agents before their update window.
 - `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -62,7 +62,7 @@ Optional:
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
 - `start_version` (String) start_version is the version used for new agents before their update window.
-- `target_version` (String) target_version is the version that all agents should update to during their update window.
+- `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -61,8 +61,8 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version to update from.
-- `target_version` (String) target_version is the version to update to.
+- `start_version` (String) start_version is the version used for new agents before their update window.
+- `target_version` (String) target_version is the version that all agents should update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -61,7 +61,7 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version used for new agents before their update window.
+- `start_version` (String) start_version is the version used for newly installed agents before their update window.
 - `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -258,8 +258,13 @@ spec:
 ```
 
 This resource is used to deploy new versions of Teleport to your agents.
-The cluster will update agents from `start_version` to `target_version`
-according to the update schedule specified in the `autoupdate_config`.
+The cluster will update agents to `target_version` according to the update
+schedule specified in the `autoupdate_config`.
+
+The `start_version` is only used to determine the version used for newly
+connected agents when their update window has not occurred yet.
+This is useful to prevent version drift within groups, but some users may
+prefer to set both version fields to the same version.
 
 Run the following command to create or update the resource:
 


### PR DESCRIPTION
This PR clarifies the use case for `start_version` in the `autoupdate_version` resource.

Goal (internal): https://github.com/gravitational/cloud/issues/14225