### PR TITLE
Add troubleshooting docs that explain how to query the target agent version

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -523,8 +523,8 @@ If the Teleport Agent has not been automatically updating for several weeks, you
 can consult the updater logs as descibed above to help troubleshoot the problem.
 
 The `teleport-update status` command provides the best UX for determining how an
-agent is being instructed to update. However, this information can also be queried
-directly from the Teleport cluster using `curl`:
+agent is being instructed to update. However, if `teleport-update is not available,
+this information can also be queried directly from the Teleport cluster using `curl`:
 
 ```code
 $ curl -s https://teleport.example.com/webapi/find | jq .auto_update

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -520,7 +520,33 @@ Teleport Agents are not updated immediately when a new version of Teleport is
 released, and agent updates can lag behind the cluster by a few days.
 
 If the Teleport Agent has not been automatically updating for several weeks, you
-can consult the updater logs to help troubleshoot the problem:
+can consult the updater logs as descibed above to help troubleshoot the problem.
+
+The `teleport-update status` command provides the best UX for determining how an
+agent is being instructed to update. However, this information can also be queried
+directly from the Teleport cluster using `curl`:
+
+```code
+$ curl -s https://teleport.example.com/webapi/find | jq .auto_update
+{
+  ...
+  "agent_version": "18.2.7",         # version that the agent should update to (also used for new agents)
+  "agent_auto_update": false,        # true if in window and the agent should update now
+  "agent_update_jitter_seconds": 60  # jitter to reduce load on the cluster and CDN
+}
+```
+
+This may be tuned for a specific agent using the `group` and `update_id` params:
+```code
+$ curl -s https://teleport.example.com/webapi/find?group=staging&update_id=$(</tmp/teleport-update.id) | jq .auto_update
+{
+  ...
+  "agent_version": "18.2.8",
+  "agent_auto_update": true,
+  "agent_update_jitter_seconds": 60
+}
+```
+
 
 ### Troubleshooting managed agent upgrades on Kubernetes
 
@@ -565,10 +591,6 @@ until the next reconciliation, you can trigger an event.
    Here, the local active version is 17.2.0. The cluster's target version is
    17.2.1, but we are not in an update window, so the agent is not immediately
    updated.
-
-```code
-$ journalctl -u teleport-update
-```
 
 1. If an agent is not automatically updated, you can invoke the updater
    manually and look at its logs:

--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -520,7 +520,7 @@ Teleport Agents are not updated immediately when a new version of Teleport is
 released, and agent updates can lag behind the cluster by a few days.
 
 If the Teleport Agent has not been automatically updating for several weeks, you
-can consult the updater logs as descibed above to help troubleshoot the problem.
+can consult the updater logs as described above to help troubleshoot the problem.
 
 The `teleport-update status` command provides the best UX for determining how an
 agent is being instructed to update. However, if `teleport-update is not available,


### PR DESCRIPTION
This PR:
- Adds a troubleshooting section to the Managed Updates v2 docs explaining how to interpret the /webapi/ping fields.
- Removes a command to show logs in the middle of an unrelated section.

Goal (internal): https://github.com/gravitational/cloud/issues/14225