### PR TITLE
ui: include --format=text for tctl tokens add instructions in discovery flows

### DIFF
--- a/web/packages/teleport/src/Apps/AddApp/Manually.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Manually.tsx
@@ -109,7 +109,7 @@ const StepsWithoutToken = ({ tshLoginCmd, host }: StepsWithoutTokenProps) => (
         Step 3
       </Text>
       {' - Generate a join token'}
-      <TextSelectCopy mt="2" text="tctl tokens add --type=app" />
+      <TextSelectCopy mt="2" text="tctl tokens add --type=app --format=text" />
     </Box>
     <Box mb="4">
       <Text bold as="span">

--- a/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryServiceDirections.tsx
+++ b/web/packages/teleport/src/Discover/Shared/ConfigureDiscoveryService/ConfigureDiscoveryServiceDirections.tsx
@@ -86,7 +86,7 @@ discovery_service:
         <TextSelectCopyMulti
           lines={[
             {
-              text: `tctl tokens add --type=discovery`,
+              text: `tctl tokens add --type=discovery --format=text`,
             },
           ]}
         />


### PR DESCRIPTION
Using the `--format=text` will only output the token text. The `tctl tokens add` commands in these contexts give the configuration and start command steps. Using this approach reduces chances of confusion since the `tctl tokens add` can output instructions that conflict with the guides.