### PR TITLE
[flaky][mcp] switch TestHTTPReaderWriter to synctest

### DIFF
--- a/lib/utils/mcputils/http_test.go
+++ b/lib/utils/mcputils/http_test.go
@@ -30,7 +30,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"testing/synctest"
-	"time"
 
 	"github.com/gravitational/trace"
 	mcpclient "github.com/mark3labs/mcp-go/client"
@@ -50,16 +49,9 @@ func TestReplaceHTTPResponse(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
 
-		// Set up a server. Use InMemoryListener for synctest.
+		// Set up a server.
 		mcpServer := mcptest.NewServerWithVersion("11.22.33")
-		listener := listenerutils.NewInMemoryListener()
-		httpServer := http.Server{
-			Handler: mcpserver.NewStreamableHTTPServer(mcpServer),
-		}
-		go httpServer.Serve(listener)
-		t.Cleanup(func() {
-			httpServer.Close()
-		})
+		listener := makeHTTPServerWithInMemoryListener(t, mcpServer)
 
 		// Set up a client with custom transport which calls "ReplaceHTTPResponse".
 		httpClientTransport := newTestReplaceHTTPResponseTransport(listener)
@@ -170,49 +162,52 @@ func (t *testReplaceHTTPResponseTransport) ProcessNotification(_ context.Context
 
 func TestHTTPReaderWriter(t *testing.T) {
 	t.Parallel()
-	ctx := t.Context()
 
-	// Set up an MCP server.
-	mcpServer := mcptest.NewServer()
-	httpServer := mcpserver.NewTestStreamableHTTPServer(mcpServer)
-	t.Cleanup(httpServer.Close)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
 
-	// Create a proxy that converts from stdio to HTTP.
-	clientStdin, writeToClient := io.Pipe()
-	readFromClient, clientStdout := io.Pipe()
-	t.Cleanup(func() {
-		assert.NoError(t, trace.NewAggregate(
-			clientStdin.Close(), writeToClient.Close(),
-			readFromClient.Close(), clientStdout.Close(),
-		))
+		// Set up an MCP server.
+		mcpServer := mcptest.NewServer()
+		listener := makeHTTPServerWithInMemoryListener(t, mcpServer)
+
+		// Create a proxy that converts from stdio to HTTP.
+		clientStdin, writeToClient := io.Pipe()
+		readFromClient, clientStdout := io.Pipe()
+		t.Cleanup(func() {
+			assert.NoError(t, trace.NewAggregate(
+				clientStdin.Close(), writeToClient.Close(),
+				readFromClient.Close(), clientStdout.Close(),
+			))
+		})
+
+		serverReaderWriter, err := NewHTTPReaderWriter(
+			ctx,
+			"http://memory/mcp",
+			mcpclienttransport.WithContinuousListening(),
+			mcpclienttransport.WithHTTPBasicClient(listener.MakeHTTPClient()),
+		)
+		require.NoError(t, err)
+		defer serverReaderWriter.Close() // Send DELETE before server is shutdown
+
+		clientTransportReader := NewStdioReader(readFromClient)
+		clientWriter := NewStdioMessageWriter(writeToClient)
+		proxyReaderWriter(t, clientTransportReader, clientWriter, serverReaderWriter, serverReaderWriter)
+
+		// Make a "high-level" stdio MCP client and test the proxy.
+		var receivedNotifications []mcp.JSONRPCNotification
+		stdioClient := mcptest.NewStdioClient(t, clientStdin, clientStdout)
+		stdioClient.OnNotification(func(notification mcp.JSONRPCNotification) {
+			receivedNotifications = append(receivedNotifications, notification)
+		})
+		mcptest.MustInitializeClient(t, stdioClient)
+		mcptest.MustCallServerTool(t, stdioClient)
+
+		// Test listening notifications from server.
+		mcpServer.SendNotificationToAllClients("notifications/test", nil)
+		synctest.Wait()
+		require.Len(t, receivedNotifications, 1)
+		require.Equal(t, "notifications/test", receivedNotifications[0].Notification.Method)
 	})
-
-	serverReaderWriter, err := NewHTTPReaderWriter(ctx, httpServer.URL, mcpclienttransport.WithContinuousListening())
-	require.NoError(t, err)
-	defer serverReaderWriter.Close() // Send DELETE before server is shutdown
-
-	clientTransportReader := NewStdioReader(readFromClient)
-	clientWriter := NewStdioMessageWriter(writeToClient)
-	proxyReaderWriter(t, clientTransportReader, clientWriter, serverReaderWriter, serverReaderWriter)
-
-	// Make a "high-level" stdio MCP client and test the proxy.
-	notificationsChan := make(chan mcp.JSONRPCNotification, 1)
-	stdioClient := mcptest.NewStdioClient(t, clientStdin, clientStdout)
-	stdioClient.OnNotification(func(notification mcp.JSONRPCNotification) {
-		notificationsChan <- notification
-	})
-	mcptest.MustInitializeClient(t, stdioClient)
-	mcptest.MustCallServerTool(t, stdioClient)
-
-	// Test listening notifications from server.
-	mcpServer.SendNotificationToAllClients("notifications/test", nil)
-	select {
-	case notification := <-notificationsChan:
-		require.NotNil(t, notification)
-		require.Equal(t, "notifications/test", notification.Notification.Method)
-	case <-time.After(time.Second):
-		require.Fail(t, "timeout waiting for notification")
-	}
 }
 
 func proxyReaderWriter(
@@ -230,4 +225,19 @@ func proxyReaderWriter(
 	require.NoError(t, err)
 	go clientMessageReader.Run(t.Context())
 	go serverMessageReader.Run(t.Context())
+}
+
+// makeHTTPServerWithInMemoryListener starts a streamable-HTTP MCP server using
+// an InMemoryListener. InMemoryListener is good to use with synctest.
+func makeHTTPServerWithInMemoryListener(t *testing.T, mcpServer *mcpserver.MCPServer) *listenerutils.InMemoryListener {
+	t.Helper()
+	listener := listenerutils.NewInMemoryListener()
+	httpServer := &http.Server{
+		Handler: mcpserver.NewStreamableHTTPServer(mcpServer),
+	}
+	go httpServer.Serve(listener)
+	t.Cleanup(func() {
+		httpServer.Close()
+	})
+	return listener
 }


### PR DESCRIPTION
related:
- #56588

https://github.com/gravitational/teleport.e/actions/runs/18837042410/job/53740308538

```
=== CONT  TestHTTPReaderWriter
    http_test.go:214: 
        	Error Trace:	/__w/teleport.e/teleport.e/lib/utils/mcputils/http_test.go:214
        	Error:      	timeout waiting for notification
        	Test:       	TestHTTPReaderWriter
2025/10/27 11:51:20 INFO Finished processing messages transport="Streamable HTTP"
2025/10/27 11:51:20 INFO Finished processing messages transport=stdio
2025/10/27 11:51:20 ERROR: Error reading from stdout: io: read/write on closed pipe
--- FAIL: TestHTTPReaderWriter (1.01s)
```
It failed because the test originally has a wait for 1 second, which is not enough for GA apprently. Instead of increasing the timeout, now switching the test to use synctest.