### PR TITLE
[teleport-update] Stabilize tsh paths when run from agent installation

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -75,7 +75,8 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
-	"github.com/gravitational/teleport/lib/autoupdate/tools"
+	autoupdateagent "github.com/gravitational/teleport/lib/autoupdate/agent"
+	autoupdatetools "github.com/gravitational/teleport/lib/autoupdate/tools"
 	"github.com/gravitational/teleport/lib/benchmark"
 	benchmarkdb "github.com/gravitational/teleport/lib/benchmark/db"
 	"github.com/gravitational/teleport/lib/client"
@@ -845,7 +846,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	}
 	// Check local update for specific proxy from configuration.
 	name := utils.TryHost(strings.TrimPrefix(strings.ToLower(proxyArg), "https://"))
-	if err := tools.CheckAndUpdateLocal(ctx, name, args); err != nil {
+	if err := autoupdatetools.CheckAndUpdateLocal(ctx, name, args); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -1467,11 +1468,13 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	}
 
 	var err error
-	cf.executablePath, err = os.Executable()
-	if err != nil {
-		return trace.Wrap(err)
+	cf.executablePath, err = autoupdateagent.StableExecutable()
+	if errors.Is(err, autoupdateagent.ErrUnstableExecutable) {
+		logger.WarnContext(ctx, "Templates may be rendered with an unstable path to the tsh executable. Please reinstall tsh with Managed Updates to prevent instability.")
+	} else if err != nil {
+		return trace.Wrap(err, "determining executable path")
 	}
-	if reExecPath := tools.GetReExecPath(); reExecPath != "" {
+	if reExecPath := autoupdatetools.GetReExecPath(); reExecPath != "" {
 		cf.executablePath = reExecPath
 	}
 
@@ -2070,7 +2073,7 @@ func onVersion(cf *CLIConf) error {
 		proxyPublicAddr = ppa
 	}
 
-	reExecFromVersion := tools.GetReExecFromVersion(cf.Context)
+	reExecFromVersion := autoupdatetools.GetReExecFromVersion(cf.Context)
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case teleport.Text, "":
@@ -2241,7 +2244,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 	// The user is not logged in and has typed in `tsh --proxy=... login`, if
 	// the running binary needs to be updated, update and re-exec.
 	if profile == nil {
-		if err := tools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+		if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -2259,7 +2262,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 
 			// The user has typed `tsh login`, if the running binary needs to
 			// be updated, update and re-exec.
-			if err := tools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
 				return trace.Wrap(err)
 			}
 
@@ -2279,7 +2282,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 
 			// The user has typed `tsh login`, if the running binary needs to
 			// be updated, update and re-exec.
-			if err := tools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
 				return trace.Wrap(err)
 			}
 
@@ -2355,7 +2358,7 @@ func onLogin(cf *CLIConf, reExecArgs ...string) (err error) {
 		default:
 			// The user is logged in and has typed in `tsh --proxy=... login`, if
 			// the running binary needs to be updated, update and re-exec.
-			if err := tools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
 				return trace.Wrap(err)
 			}
 		}
@@ -4512,7 +4515,7 @@ func wrapInitClientWithUpdateCheck(clientInitFunc ClientInitFunc, reExecArgs []s
 			return nil, trace.Wrap(err)
 		}
 		if cf.checkManagedUpdates {
-			if err := tools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
+			if err := autoupdatetools.CheckAndUpdateRemote(cf.Context, tc.WebProxyAddr, tc.InsecureSkipVerify, reExecArgs); err != nil {
 				return nil, trace.Wrap(err)
 			}
 		}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1467,15 +1467,18 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		bench.Hidden()
 	}
 
-	var err error
-	cf.executablePath, err = autoupdateagent.StableExecutable()
-	if errors.Is(err, autoupdateagent.ErrUnstableExecutable) {
-		logger.WarnContext(ctx, "Templates may be rendered with an unstable path to the tsh executable. Please reinstall tsh with Managed Updates to prevent instability.")
-	} else if err != nil {
-		return trace.Wrap(err, "determining executable path")
-	}
 	if reExecPath := autoupdatetools.GetReExecPath(); reExecPath != "" {
+		// Always prefer Client Tools Managed Updates re-exec path (~/.tsh/bin/) if set
 		cf.executablePath = reExecPath
+	} else {
+		// Otherwise, use the Agent Managed Updates stable path, if available
+		var err error
+		cf.executablePath, err = autoupdateagent.StableExecutable()
+		if errors.Is(err, autoupdateagent.ErrUnstableExecutable) {
+			logger.WarnContext(ctx, "Templates may be rendered with an unstable path to the tsh executable; reinstall tsh with Managed Updates to prevent instability")
+		} else if err != nil {
+			return trace.Wrap(err, "determining executable path")
+		}
 	}
 
 	// configs


### PR DESCRIPTION
When tsh is invoked from an Agent Managed Updates installation but is being used as a client tool, paths are not stabilized with `autoupdate/agent.StableExecutable()`. This is not an issue for most short-running re-executions of tsh in-memory, but it does break instances where tsh writes its path into a configuration file, such as in https://github.com/gravitational/teleport/issues/60600.

This PR fixes the issue by using the path from `autoupdate/agent.StableExecutable()` instead of `os.Executable()`. This function should always be safe to swap in, as it ensures tsh is being invoked from an unstable path before returning different values.

This PR is similar to https://github.com/gravitational/teleport/pull/54145, which addresses the same issue for tbot (which is updated via Agent Managed Updates).

changelog: stabilize tsh paths when run from agent installation

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/14225

Fixes https://github.com/gravitational/teleport/issues/60600