### PR TITLE
[cache_test] remove test pack timeout

### DIFF
--- a/lib/cache/app_test.go
+++ b/lib/cache/app_test.go
@@ -34,7 +34,7 @@ import (
 func TestApps(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForProxy)
+	p, err := newPack(t, ForProxy)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -305,7 +305,7 @@ func newPackForAuth(t *testing.T) *testPack {
 }
 
 func newTestPack(t *testing.T, setupConfig SetupConfigFn, opts ...packOption) *testPack {
-	pack, err := newPack(t.TempDir(), setupConfig, opts...)
+	pack, err := newPack(t, setupConfig, opts...)
 	require.NoError(t, err)
 	return pack
 }
@@ -529,9 +529,11 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 }
 
 // newPack returns a new test pack or fails the test on error
-func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) (*testPack, error) {
-	ctx := context.Background()
-	p, err := newPackWithoutCache(dir, opts...)
+func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption) (*testPack, error) {
+	t.Helper()
+
+	ctx := t.Context()
+	p, err := newPackWithoutCache(t.TempDir(), opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -590,15 +592,14 @@ func newPack(dir string, setupConfig func(c Config) Config, opts ...packOption) 
 		return nil, trace.Wrap(err)
 	}
 
-	select {
-	case event := <-p.eventsC:
-
-		if event.Type != WatcherStarted {
-			return nil, trace.CompareFailed("%q != %q %s", event.Type, WatcherStarted, event)
-		}
-	case <-time.After(time.Second):
-		return nil, trace.ConnectionProblem(nil, "wait for the watcher to start")
+	// Wait for the watcher to start. Note that we do not enforce a timeout on this, as depending on the machine
+	// the calling test runs on and CPU/scheduler contention the expected time may vary. If the watcher fails to start we will
+	// timeout due to the top level harness timeout setting instead.
+	event := <-p.eventsC
+	if event.Type != WatcherStarted {
+		return nil, trace.CompareFailed("%q != %q %s", event.Type, WatcherStarted, event)
 	}
+
 	return p, nil
 }
 
@@ -984,7 +985,7 @@ cpu: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
 BenchmarkListResourcesWithSort-8               1        2351035036 ns/op
 */
 func BenchmarkListResourcesWithSort(b *testing.B) {
-	p, err := newPack(b.TempDir(), ForAuth)
+	p, err := newPack(b, ForAuth)
 	require.NoError(b, err)
 	defer p.Close()
 
@@ -2026,7 +2027,7 @@ func TestPartialHealth(t *testing.T) {
 	ctx := context.Background()
 
 	// setup cache such that role resources wouldn't be recognized by the event source and wouldn't be cached.
-	p, err := newPack(t.TempDir(), ForApps, ignoreKinds([]types.WatchKind{{Kind: types.KindRole}}))
+	p, err := newPack(t, ForApps, ignoreKinds([]types.WatchKind{{Kind: types.KindRole}}))
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/generic_operations_test.go
+++ b/lib/cache/generic_operations_test.go
@@ -92,7 +92,7 @@ func TestGenericListerPageClipEnd(t *testing.T) {
 func TestGenericListerRangeWithFallback(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForProxy)
+	p, err := newPack(t, ForProxy)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/git_server_test.go
+++ b/lib/cache/git_server_test.go
@@ -31,7 +31,7 @@ import (
 func TestGitServers(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForAuth)
+	p, err := newPack(t, ForAuth)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/health_check_config_test.go
+++ b/lib/cache/health_check_config_test.go
@@ -47,7 +47,7 @@ func newHealthCheckConfig(t *testing.T, name string) *healthcheckconfigv1.Health
 func TestHealthCheckConfig(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForAuth)
+	p, err := newPack(t, ForAuth)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/node_test.go
+++ b/lib/cache/node_test.go
@@ -124,7 +124,7 @@ func BenchmarkGetMaxNodes(b *testing.B) {
 }
 
 func benchGetNodes(b *testing.B, nodeCount int) {
-	p, err := newPack(b.TempDir(), ForAuth)
+	p, err := newPack(b, ForAuth)
 	require.NoError(b, err)
 	defer p.Close()
 

--- a/lib/cache/plugin_static_credentials_test.go
+++ b/lib/cache/plugin_static_credentials_test.go
@@ -29,7 +29,7 @@ import (
 func TestPluginStaticCredentials(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForAuth)
+	p, err := newPack(t, ForAuth)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 

--- a/lib/cache/reverse_tunnel_test.go
+++ b/lib/cache/reverse_tunnel_test.go
@@ -29,7 +29,7 @@ import (
 func TestReverseTunnels(t *testing.T) {
 	t.Parallel()
 
-	p, err := newPack(t.TempDir(), ForProxy)
+	p, err := newPack(t, ForProxy)
 	require.NoError(t, err)
 	t.Cleanup(p.Close)
 


### PR DESCRIPTION
This timeout can make tests flaky depending on the scheduler and cpu contention. The tests cannot proceed without the test pack, so for this case simply block until ready. If for any reason the watcher fails to start the top level harness timeout will terminate it in which case we should add a dedicated test or benchmark instead.