### PR TITLE
scoped ssh access core

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -59,6 +59,7 @@ import (
 	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/scim"
+	scopedaccess "github.com/gravitational/teleport/api/client/scopes/access"
 	"github.com/gravitational/teleport/api/client/secreport"
 	statichostuserclient "github.com/gravitational/teleport/api/client/statichostuser"
 	"github.com/gravitational/teleport/api/client/userloginstate"
@@ -826,8 +827,8 @@ func (c *Client) UpsertDeviceResource(ctx context.Context, res *types.DeviceV1) 
 
 // ScopedAccessServiceClient returns an unadorned Scoped Access Service client, using the underlying
 // Auth gRPC connection.
-func (c *Client) ScopedAccessServiceClient() scopedaccessv1.ScopedAccessServiceClient {
-	return scopedaccessv1.NewScopedAccessServiceClient(c.conn)
+func (c *Client) ScopedAccessServiceClient() *scopedaccess.Client {
+	return scopedaccess.NewClient(scopedaccessv1.NewScopedAccessServiceClient(c.conn))
 }
 
 // LoginRuleClient returns an unadorned Login Rule client, using the underlying

--- a/api/client/scopes/access/client.go
+++ b/api/client/scopes/access/client.go
@@ -1,0 +1,79 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package access
+
+import (
+	"context"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+)
+
+// Client is a scoped access client that conforms to the following lib/services interfaces:
+// * services.ScopedAccess
+type Client struct {
+	grpcClient scopedaccessv1.ScopedAccessServiceClient
+}
+
+// NewClient creates a new Access List client.
+func NewClient(grpcClient scopedaccessv1.ScopedAccessServiceClient) *Client {
+	return &Client{
+		grpcClient: grpcClient,
+	}
+}
+
+// GetScopedRole gets a scoped role by name.
+func (c *Client) GetScopedRole(ctx context.Context, req *scopedaccessv1.GetScopedRoleRequest) (*scopedaccessv1.GetScopedRoleResponse, error) {
+	return c.grpcClient.GetScopedRole(ctx, req)
+}
+
+// ListScopedRoles returns a paginated list of scoped roles.
+func (c *Client) ListScopedRoles(ctx context.Context, req *scopedaccessv1.ListScopedRolesRequest) (*scopedaccessv1.ListScopedRolesResponse, error) {
+	return c.grpcClient.ListScopedRoles(ctx, req)
+}
+
+// CreateScopedRole creates a new scoped role.
+func (c *Client) CreateScopedRole(ctx context.Context, req *scopedaccessv1.CreateScopedRoleRequest) (*scopedaccessv1.CreateScopedRoleResponse, error) {
+	return c.grpcClient.CreateScopedRole(ctx, req)
+}
+
+// UpdateScopedRole updates a scoped role.
+func (c *Client) UpdateScopedRole(ctx context.Context, req *scopedaccessv1.UpdateScopedRoleRequest) (*scopedaccessv1.UpdateScopedRoleResponse, error) {
+	return c.grpcClient.UpdateScopedRole(ctx, req)
+}
+
+// DeleteScopedRole deletes a scoped role.
+func (c *Client) DeleteScopedRole(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleRequest) (*scopedaccessv1.DeleteScopedRoleResponse, error) {
+	return c.grpcClient.DeleteScopedRole(ctx, req)
+}
+
+// GetScopedRoleAssignment gets a scoped role assignment by name.
+func (c *Client) GetScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.GetScopedRoleAssignmentRequest) (*scopedaccessv1.GetScopedRoleAssignmentResponse, error) {
+	return c.grpcClient.GetScopedRoleAssignment(ctx, req)
+}
+
+// ListScopedRoleAssignments returns a paginated list of scoped role assignments.
+func (c *Client) ListScopedRoleAssignments(ctx context.Context, req *scopedaccessv1.ListScopedRoleAssignmentsRequest) (*scopedaccessv1.ListScopedRoleAssignmentsResponse, error) {
+	return c.grpcClient.ListScopedRoleAssignments(ctx, req)
+}
+
+// CreateScopedRoleAssignment creates a new scoped role assignment.
+func (c *Client) CreateScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.CreateScopedRoleAssignmentRequest) (*scopedaccessv1.CreateScopedRoleAssignmentResponse, error) {
+	return c.grpcClient.CreateScopedRoleAssignment(ctx, req)
+}
+
+// DeleteScopedRoleAssignment deletes a scoped role assignment.
+func (c *Client) DeleteScopedRoleAssignment(ctx context.Context, req *scopedaccessv1.DeleteScopedRoleAssignmentRequest) (*scopedaccessv1.DeleteScopedRoleAssignmentResponse, error) {
+	return c.grpcClient.DeleteScopedRoleAssignment(ctx, req)
+}

--- a/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
+++ b/api/gen/proto/go/teleport/scopes/access/v1/role.pb.go
@@ -22,6 +22,7 @@ package accessv1
 
 import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
@@ -188,7 +189,12 @@ func (x *ScopedRoleSpec) GetAllow() *ScopedRoleConditions {
 type ScopedRoleConditions struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Rules describe basic resource:verb permissions.
-	Rules         []*ScopedRule `protobuf:"bytes,1,rep,name=rules,proto3" json:"rules,omitempty"`
+	Rules []*ScopedRule `protobuf:"bytes,1,rep,name=rules,proto3" json:"rules,omitempty"`
+	// Logins is the list of host logins this role allows.
+	Logins []string `protobuf:"bytes,2,rep,name=logins,proto3" json:"logins,omitempty"`
+	// NodeLabels is a map of node labels (used to dynamically grant access to
+	// nodes).
+	NodeLabels    []*v11.Label `protobuf:"bytes,3,rep,name=node_labels,json=nodeLabels,proto3" json:"node_labels,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -226,6 +232,20 @@ func (*ScopedRoleConditions) Descriptor() ([]byte, []int) {
 func (x *ScopedRoleConditions) GetRules() []*ScopedRule {
 	if x != nil {
 		return x.Rules
+	}
+	return nil
+}
+
+func (x *ScopedRoleConditions) GetLogins() []string {
+	if x != nil {
+		return x.Logins
+	}
+	return nil
+}
+
+func (x *ScopedRoleConditions) GetNodeLabels() []*v11.Label {
+	if x != nil {
+		return x.NodeLabels
 	}
 	return nil
 }
@@ -290,7 +310,7 @@ var File_teleport_scopes_access_v1_role_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\n" +
-	"$teleport/scopes/access/v1/role.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\"\xe4\x01\n" +
+	"$teleport/scopes/access/v1/role.proto\x12\x19teleport.scopes.access.v1\x1a!teleport/header/v1/metadata.proto\x1a\x1dteleport/label/v1/label.proto\"\xe4\x01\n" +
 	"\n" +
 	"ScopedRole\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
@@ -301,9 +321,12 @@ const file_teleport_scopes_access_v1_role_proto_rawDesc = "" +
 	"\x04spec\x18\x06 \x01(\v2).teleport.scopes.access.v1.ScopedRoleSpecR\x04spec\"\x84\x01\n" +
 	"\x0eScopedRoleSpec\x12+\n" +
 	"\x11assignable_scopes\x18\x01 \x03(\tR\x10assignableScopes\x12E\n" +
-	"\x05allow\x18\x02 \x01(\v2/.teleport.scopes.access.v1.ScopedRoleConditionsR\x05allow\"S\n" +
+	"\x05allow\x18\x02 \x01(\v2/.teleport.scopes.access.v1.ScopedRoleConditionsR\x05allow\"\xa6\x01\n" +
 	"\x14ScopedRoleConditions\x12;\n" +
-	"\x05rules\x18\x01 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\"@\n" +
+	"\x05rules\x18\x01 \x03(\v2%.teleport.scopes.access.v1.ScopedRuleR\x05rules\x12\x16\n" +
+	"\x06logins\x18\x02 \x03(\tR\x06logins\x129\n" +
+	"\vnode_labels\x18\x03 \x03(\v2\x18.teleport.label.v1.LabelR\n" +
+	"nodeLabels\"@\n" +
 	"\n" +
 	"ScopedRule\x12\x1c\n" +
 	"\tresources\x18\x01 \x03(\tR\tresources\x12\x14\n" +
@@ -328,17 +351,19 @@ var file_teleport_scopes_access_v1_role_proto_goTypes = []any{
 	(*ScopedRoleConditions)(nil), // 2: teleport.scopes.access.v1.ScopedRoleConditions
 	(*ScopedRule)(nil),           // 3: teleport.scopes.access.v1.ScopedRule
 	(*v1.Metadata)(nil),          // 4: teleport.header.v1.Metadata
+	(*v11.Label)(nil),            // 5: teleport.label.v1.Label
 }
 var file_teleport_scopes_access_v1_role_proto_depIdxs = []int32{
 	4, // 0: teleport.scopes.access.v1.ScopedRole.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.access.v1.ScopedRole.spec:type_name -> teleport.scopes.access.v1.ScopedRoleSpec
 	2, // 2: teleport.scopes.access.v1.ScopedRoleSpec.allow:type_name -> teleport.scopes.access.v1.ScopedRoleConditions
 	3, // 3: teleport.scopes.access.v1.ScopedRoleConditions.rules:type_name -> teleport.scopes.access.v1.ScopedRule
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 4: teleport.scopes.access.v1.ScopedRoleConditions.node_labels:type_name -> teleport.label.v1.Label
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_access_v1_role_proto_init() }

--- a/api/proto/teleport/scopes/access/v1/role.proto
+++ b/api/proto/teleport/scopes/access/v1/role.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 package teleport.scopes.access.v1;
 
 import "teleport/header/v1/metadata.proto";
+import "teleport/label/v1/label.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1;accessv1";
 
@@ -56,6 +57,13 @@ message ScopedRoleSpec {
 message ScopedRoleConditions {
   // Rules describe basic resource:verb permissions.
   repeated ScopedRule rules = 1;
+
+  // Logins is the list of host logins this role allows.
+  repeated string logins = 2;
+
+  // NodeLabels is a map of node labels (used to dynamically grant access to
+  // nodes).
+  repeated teleport.label.v1.Label node_labels = 3;
 }
 
 // Rule maps resources to verbs. This is the underlying type used to describe

--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1179,6 +1179,42 @@
               "update",
               "delete"
             ]
+          },
+          {
+            "resources": [
+              "scoped_role"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
+          },
+          {
+            "resources": [
+              "scoped_role_assignment"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
+          },
+          {
+            "resources": [
+              "scoped_token"
+            ],
+            "verbs": [
+              "list",
+              "create",
+              "read",
+              "update",
+              "delete"
+            ]
           }
         ]
       },

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1426,6 +1426,13 @@ func (a *Server) ScopedAccess() services.ScopedAccess {
 	}
 }
 
+// ScopedRoleReader returns a read-only scoped role client. This is here to satisfy interfaces
+// used by agent-side logic, which only has access to the ScopedRoleReader subset of the
+// broader ScopedAccess interface.
+func (a *Server) ScopedRoleReader() services.ScopedRoleReader {
+	return a.ScopedAccessCache
+}
+
 // SetUpgradeWindowStartHourGetter sets the getter used to sync the ClusterMaintenanceConfig resource
 // with the cloud UpgradeWindowStartHour value.
 func (a *Server) SetUpgradeWindowStartHourGetter(fn func(context.Context) (int64, error)) {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1554,6 +1554,104 @@ func (a *ServerWithRoles) ListUnifiedResources(ctx context.Context, req *proto.L
 	}, nil
 }
 
+func (a *ServerWithRoles) scopedListUnifiedResources(ctx context.Context, req *proto.ListUnifiedResourcesRequest) (*proto.ListUnifiedResourcesResponse, error) {
+	// most advanced features don't work for scoped identities yet
+	switch {
+	case req.UseSearchAsRoles:
+		return nil, trace.AccessDenied("search_as_roles is not supported for scoped identities")
+	case req.UsePreviewAsRoles:
+		return nil, trace.AccessDenied("preview_as_roles is not supported for scoped identities")
+	case req.IncludeRequestable:
+		return nil, trace.AccessDenied("include_requestable is not supported for scoped identities")
+	case req.PinnedOnly:
+		return nil, trace.AccessDenied("pinned_only is not supported for scoped identities")
+	case req.IncludeLogins:
+		return nil, trace.AccessDenied("include_logins is not supported for scoped identities")
+	}
+
+	if len(req.Kinds) != 1 || req.Kinds[0] != types.KindNode {
+		return nil, trace.AccessDenied("only node kind is supported for scoped identities")
+	}
+
+	userFilter := services.MatchResourceFilter{
+		Labels:         req.Labels,
+		SearchKeywords: req.SearchKeywords,
+		Kinds:          req.Kinds,
+	}
+
+	if req.PredicateExpression != "" {
+		expression, err := services.NewResourceExpression(req.PredicateExpression)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		userFilter.PredicateExpression = expression
+	}
+
+	ruleCtx := a.scopedContext.RuleContext()
+
+	if err := a.scopedContext.CheckerContext.CheckMaybeHasAccessToRules(&ruleCtx, types.KindNode, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	unifiedResources, nextKey, err := a.authServer.UnifiedResourceCache.IterateUnifiedResources(ctx, func(resource types.ResourceWithLabels) (bool, error) {
+		// currently only nodes are supported
+		if resource.GetKind() != types.KindNode {
+			return false, nil
+		}
+
+		// Filter first and only check RBAC if there is a match to improve perf.
+		match, err := services.MatchResourceByFilters(resource, userFilter, nil)
+		if err != nil {
+			logger.WarnContext(ctx, "Unable to determine access to resource, matching with filter failed",
+				"resource_name", resource.GetName(),
+				"resource_kind", resource.GetKind(),
+				"error", err,
+			)
+			return false, nil
+		}
+		if !match {
+			return false, nil
+		}
+
+		server, ok := resource.(*types.ServerV2)
+		if !ok {
+			logger.WarnContext(ctx, "Unable to cast unified resource to server",
+				"resource_name", resource.GetName(),
+				"resource_kind", resource.GetKind(),
+			)
+			return false, nil
+		}
+
+		serverScope := scopes.Root
+		if server.Scope != "" {
+			serverScope = server.Scope
+		}
+
+		if err := a.scopedContext.CheckerContext.Decision(ctx, serverScope, func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CanAccessSSHServer(server)
+		}); err == nil {
+			return true, nil
+		} else if !trace.IsAccessDenied(err) {
+			return false, trace.Wrap(err)
+		}
+
+		return false, nil
+	}, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	paginatedResources, err := services.MakePaginatedResources(types.KindUnifiedResource, unifiedResources, nil /* requestable resources map */)
+	if err != nil {
+		return nil, trace.Wrap(err, "making paginated unified resources")
+	}
+
+	return &proto.ListUnifiedResourcesResponse{
+		NextKey:   nextKey,
+		Resources: paginatedResources,
+	}, nil
+}
+
 func (a *ServerWithRoles) filterICPermissionSets(r *proto.PaginatedResource, app types.Application, checker *unifiedResourceLister) error {
 	appV3, ok := app.(*types.AppV3)
 	if !ok {
@@ -2316,7 +2414,7 @@ func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 	}
 
 	if err := a.authorizeAction(types.KindAuthServer, types.VerbList, types.VerbRead); err != nil {
-		if !errors.Is(err, authz.ErrScopedIdentity) {
+		if !errors.Is(err, services.ErrScopedIdentity) {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -161,6 +161,9 @@ type NodeAccessPoint interface {
 
 	// accessPoint provides common access point functionality
 	accessPoint
+
+	// ScopedRoleReader returns a read-only scoped role client.
+	ScopedRoleReader() services.ScopedRoleReader
 }
 
 // ReadProxyAccessPoint is a read only API interface implemented by a certificate authority (CA) to be
@@ -363,6 +366,9 @@ type ProxyAccessPoint interface {
 
 	// accessPoint provides common access point functionality
 	accessPoint
+
+	// ScopedRoleReader returns a read-only scoped role client.
+	ScopedRoleReader() services.ScopedRoleReader
 }
 
 // ReadRelayAccessPoint is a read only API interface to be used by a Relay
@@ -472,6 +478,15 @@ type ReadRemoteProxyAccessPoint interface {
 	GetWindowsDesktopService(ctx context.Context, name string) (types.WindowsDesktopService, error)
 }
 
+// RelayAccessPoint is the top-level access point interface required by a Relay service.
+type RelayAccessPoint interface {
+	// ReadRelayAccessPoint provides methods to read data
+	ReadRelayAccessPoint
+
+	// ScopedRoleReader returns a read-only scoped role client.
+	ScopedRoleReader() services.ScopedRoleReader
+}
+
 // RemoteProxyAccessPoint is an API interface implemented by a certificate authority (CA) to be
 // used by a teleport.ComponentProxy.
 type RemoteProxyAccessPoint interface {
@@ -480,6 +495,11 @@ type RemoteProxyAccessPoint interface {
 
 	// accessPoint provides common access point functionality
 	accessPoint
+
+	// ScopedRoleReader returns a read-only scoped role client.
+	// TODO(fspmarshall/scopes): remove the need for this. this is only here to satisfy the common
+	// interface used by lib/srv components. scoped access is not support for cross-cluster operations.
+	ScopedRoleReader() services.ScopedRoleReader
 }
 
 // ReadKubernetesAccessPoint is an API interface implemented by a certificate authority (CA) to be
@@ -1426,6 +1446,12 @@ func NewNodeWrapper(base NodeAccessPoint, cache ReadNodeAccessPoint) NodeAccessP
 	}
 }
 
+func (w *NodeWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	// TODO(fspmarshall/scopes): implement caching for scoped roles
+	// on node agents.
+	return w.NoCache.ScopedRoleReader()
+}
+
 // Close closes all associated resources
 func (w *NodeWrapper) Close() error {
 	err := w.NoCache.Close()
@@ -1447,10 +1473,43 @@ func NewProxyWrapper(base ProxyAccessPoint, cache ReadProxyAccessPoint) ProxyAcc
 	}
 }
 
+func (w *ProxyWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	// TODO(fspmarshall/scopes): implement caching for scoped roles
+	// on proxies.
+	return w.NoCache.ScopedRoleReader()
+}
+
 // Close closes all associated resources
 func (w *ProxyWrapper) Close() error {
 	err := w.NoCache.Close()
 	err2 := w.ReadProxyAccessPoint.Close()
+	return trace.NewAggregate(err, err2)
+}
+
+// RelayWrapper is a wrapper around a RelayAccessPoint that manages delegation
+// of read and write operations between a cached and non-cached access point.
+type RelayWrapper struct {
+	ReadRelayAccessPoint
+	NoCache RelayAccessPoint
+}
+
+// NewRelayWrapper creates a new RelayWrapper from the provided cache and upstream.
+func NewRelayWrapper(base RelayAccessPoint, cache ReadRelayAccessPoint) RelayAccessPoint {
+	return &RelayWrapper{
+		NoCache:              base,
+		ReadRelayAccessPoint: cache,
+	}
+}
+
+// ScopedRoleReader returns the scoped role reader from the non-cached access point.
+func (w *RelayWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	return w.NoCache.ScopedRoleReader()
+}
+
+// Close closes all associated resources
+func (w *RelayWrapper) Close() error {
+	err := w.NoCache.Close()
+	err2 := w.ReadRelayAccessPoint.Close()
 	return trace.NewAggregate(err, err2)
 }
 
@@ -1466,6 +1525,10 @@ func NewRemoteProxyWrapper(base RemoteProxyAccessPoint, cache ReadRemoteProxyAcc
 		accessPoint:                base,
 		ReadRemoteProxyAccessPoint: cache,
 	}
+}
+
+func (w *RemoteProxyWrapper) ScopedRoleReader() services.ScopedRoleReader {
+	return w.NoCache.ScopedRoleReader()
 }
 
 // Close closes all associated resources

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -679,6 +679,12 @@ func (c *Client) SetStaticTokens(st types.StaticTokens) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// ScopedRoleReader returns a read-only scoped role client. Having this method lets us reduce the surface
+// are of the scoped access API available in agent access points to only what is necessary.
+func (c *Client) ScopedRoleReader() services.ScopedRoleReader {
+	return c.APIClient.ScopedAccessServiceClient()
+}
+
 // UpsertUserNotificationState creates or updates a user notification state which records whether the user has clicked on or dismissed a notification.
 func (c *Client) UpsertUserNotificationState(ctx context.Context, username string, uns *notificationsv1.UserNotificationState) (*notificationsv1.UserNotificationState, error) {
 	return c.APIClient.UpsertUserNotificationState(ctx, &notificationsv1.UpsertUserNotificationStateRequest{
@@ -1910,4 +1916,8 @@ type ClientI interface {
 	// SummarizerServiceClient returns a client for the session recording
 	// summarizer service.
 	SummarizerServiceClient() summarizerv1.SummarizerServiceClient
+
+	// ScopedRoleReader returns a read-only scoped role client. Having this method lets us reduce the surface
+	// are of the scoped access API available in agent access points to only what is necessary.
+	ScopedRoleReader() services.ScopedRoleReader
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -898,7 +898,7 @@ func (g *GRPCServer) GetInstances(filter *types.InstanceFilter, stream authpb.Au
 func (g *GRPCServer) GetClusterAlerts(ctx context.Context, query *types.GetClusterAlertsRequest) (*authpb.GetClusterAlertsResponse, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
-		if errors.Is(err, authz.ErrScopedIdentity) {
+		if errors.Is(err, services.ErrScopedIdentity) {
 			// NOTE: scoped alerts do not currently exist. a lot of client logic wants to incidentally load cluster alerts
 			// as part of other operations. ordinarily we just return an access denied when a scoped identity is used to
 			// call an API that doesn't support scoping yet, but doing so here would complicate client logic a lot. it is
@@ -4734,7 +4734,7 @@ func isScopePinnedLocalUserCredential(ctx context.Context) bool {
 func (g *GRPCServer) CreateAuthenticateChallenge(ctx context.Context, req *authpb.CreateAuthenticateChallengeRequest) (*authpb.MFAAuthenticateChallenge, error) {
 	actx, err := g.authenticate(ctx)
 	if err != nil {
-		if errors.Is(err, authz.ErrScopedIdentity) && isScopePinnedLocalUserCredential(ctx) && req.MFARequiredCheck != nil {
+		if errors.Is(err, services.ErrScopedIdentity) && isScopePinnedLocalUserCredential(ctx) && req.MFARequiredCheck != nil {
 			if _, ok := req.MFARequiredCheck.Target.(*authpb.IsMFARequiredRequest_AdminAction); ok {
 				// NOTE: scopes don't currently have a concept of admin action MFA. a lot of client logic wants to do a preemtive
 				// check to see if MFA is required. ordinarily we just return an access denied when a scoped identity is used to
@@ -4801,10 +4801,26 @@ func (g *GRPCServer) GenerateCertAuthorityCRL(ctx context.Context, req *authpb.C
 func (g *GRPCServer) ListUnifiedResources(ctx context.Context, req *authpb.ListUnifiedResourcesRequest) (*authpb.ListUnifiedResourcesResponse, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
+		if errors.Is(err, services.ErrScopedIdentity) {
+			return g.scopedListUnifiedResources(ctx, req)
+		}
 		return nil, trace.Wrap(err)
 	}
 
 	return auth.ListUnifiedResources(ctx, req)
+}
+
+// scopedListUnifiedResources handles ListUnifiedResources requests for scoped identities. eventually we want to do away with
+// this in favor of fully porting over the ListUnifiedResources API to support scopes natively. for the time being, we use
+// this method to specifically make it possible to use 'tsh ls' with scoped credentials. usecases other than that are not
+// guaranteed to work properly at this time.
+func (g *GRPCServer) scopedListUnifiedResources(ctx context.Context, req *authpb.ListUnifiedResourcesRequest) (*authpb.ListUnifiedResourcesResponse, error) {
+	auth, err := g.scopedAuthenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return auth.scopedListUnifiedResources(ctx, req)
 }
 
 // ListResources retrieves a paginated list of resources.

--- a/lib/scopes/access/access.go
+++ b/lib/scopes/access/access.go
@@ -18,6 +18,7 @@ package access
 
 import (
 	"iter"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
@@ -147,6 +148,37 @@ func StrongValidateRole(role *scopedaccessv1.ScopedRole) error {
 				}
 			}
 		}
+	}
+
+	// verify that logins are well-formed
+	for _, login := range role.GetSpec().GetAllow().GetLogins() {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// logins. we likely will support substitution in the future, but its best to disallow
+		// it until that has landed.
+		if strings.ContainsAny(login, "{}^$*") {
+			return trace.BadParameter("scoped role %q has invalid login %q", role.GetMetadata().GetName(), login)
+		}
+	}
+
+	// verify that node labels are well-formed
+	for _, label := range role.GetSpec().GetAllow().GetNodeLabels() {
+		// we currently don't support any form of wildcard/regex/substitution in scoped role
+		// node labels. we likely will support such things in the future, but its best to disallow
+		// them until that has landed.
+
+		if strings.ContainsAny(label.GetName(), "{}^$") {
+			return trace.BadParameter("scoped role %q has invalid node label name %q", role.GetMetadata().GetName(), label.GetName())
+		}
+		for _, value := range label.GetValues() {
+			if strings.ContainsAny(value, "{}^$") {
+				return trace.BadParameter("scoped role %q has invalid node label value %q for label %q", role.GetMetadata().GetName(), value, label.GetName())
+			}
+		}
+	}
+
+	// verify that scoped role converts to a valid unscoped role
+	if _, err := ScopedRoleToRole(role, role.GetScope()); err != nil {
+		return trace.BadParameter("scoped role %q is malformed: %v", role.GetMetadata().GetName(), err)
 	}
 
 	return nil

--- a/lib/scopes/access/compat_test.go
+++ b/lib/scopes/access/compat_test.go
@@ -23,8 +23,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 )
 
 // TestEmptyRoleConverts verifies that a scoped role that is empty except for
@@ -46,6 +48,84 @@ func TestEmptyRoleConverts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, role)
 	require.Equal(t, "test@/foo/bar", role.GetName())
+}
+
+// TestSSHConversion verifies the various SSH-related scoped role rule conversion scenarios.
+func TestSSHConversion(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name       string
+		conditions *scopedaccessv1.ScopedRoleConditions
+		expect     types.RoleConditions
+	}{
+		{
+			name:       "empty conditions",
+			conditions: &scopedaccessv1.ScopedRoleConditions{},
+			expect:     types.RoleConditions{},
+		},
+		{
+			name: "sparse",
+			conditions: &scopedaccessv1.ScopedRoleConditions{
+				Logins: []string{"root"},
+				NodeLabels: []*labelv1.Label{
+					{
+						Name:   "team",
+						Values: []string{"red"},
+					},
+				},
+			},
+			expect: types.RoleConditions{
+				Logins: []string{"root"},
+				NodeLabels: types.Labels{
+					"team": apiutils.Strings{"red"},
+				},
+			},
+		},
+		{
+			name: "full",
+			conditions: &scopedaccessv1.ScopedRoleConditions{
+				Logins: []string{"root", "admin"},
+				NodeLabels: []*labelv1.Label{
+					{
+						Name:   "env",
+						Values: []string{"prod", "staging"},
+					},
+					{
+						Name:   "team",
+						Values: []string{"blue"},
+					},
+				},
+			},
+			expect: types.RoleConditions{
+				Logins: []string{"root", "admin"},
+				NodeLabels: types.Labels{
+					"env":  apiutils.Strings{"prod", "staging"},
+					"team": apiutils.Strings{"blue"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			role, err := ScopedRoleToRole(&scopedaccessv1.ScopedRole{
+				Kind: KindScopedRole,
+				Metadata: &headerv1.Metadata{
+					Name: "test",
+				},
+				Scope: "/foo",
+				Spec: &scopedaccessv1.ScopedRoleSpec{
+					AssignableScopes: []string{"/foo/bar"},
+					Allow:            tt.conditions,
+				},
+				Version: types.V1,
+			}, "/foo/bar")
+			require.NoError(t, err)
+			tt.expect.Namespaces = []string{"default"}
+			require.Empty(t, cmp.Diff(tt.expect, role.GetRoleConditions(types.Allow)))
+		})
+	}
 }
 
 // TestRulesConversion verifies various scoped role rule conversion scenarios.

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -105,13 +105,21 @@ func (process *TeleportProcess) runRelayService() error {
 	}
 	defer lockWatcher.Close()
 
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName:   conn.clusterName,
-		AccessPoint:   accessPoint,
-		LockWatcher:   lockWatcher,
-		Logger:        sublogger("authorizer"),
-		PermitCaching: process.Config.CachePolicy.Enabled,
-	})
+	authorizerOpts := authz.AuthorizerOpts{
+		ClusterName:      conn.clusterName,
+		AccessPoint:      accessPoint,
+		ScopedRoleReader: accessPoint.ScopedRoleReader(),
+		LockWatcher:      lockWatcher,
+		Logger:           sublogger("authorizer"),
+		PermitCaching:    process.Config.CachePolicy.Enabled,
+	}
+
+	authorizer, err := authz.NewAuthorizer(authorizerOpts)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	scopedAuthorizer, err := authz.NewScopedAuthorizer(authorizerOpts)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -278,6 +286,7 @@ func (process *TeleportProcess) runRelayService() error {
 				ClusterName: conn.clusterName,
 			},
 			Authorizer:        authorizer,
+			ScopedAuthorizer:  scopedAuthorizer,
 			GetAuthPreference: accessPoint.GetAuthPreference,
 		})
 		if err != nil {
@@ -329,7 +338,7 @@ func (process *TeleportProcess) runRelayService() error {
 		FIPS:   process.Config.FIPS,
 		Logger: sublogger("transport_service"),
 		Dialer: relayRouter,
-		SignerFn: func(*authz.Context, string) agentless.SignerCreator {
+		SignerFn: func(*authz.ScopedContext, string) agentless.SignerCreator {
 			return func(context.Context, agentless.LocalAccessPoint, agentless.CertGenerator) (ssh.Signer, error) {
 				// the behavior of relayRouter is such that we should never
 				// attempt to connect to an agentless server

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3162,7 +3162,7 @@ func (process *TeleportProcess) newLocalCacheForProxy(clt authclient.ClientI, ca
 	return authclient.NewProxyWrapper(clt, cache), nil
 }
 
-func (process *TeleportProcess) newLocalCacheForRelay(clt authclient.ClientI, cacheName []string) (authclient.ReadRelayAccessPoint, error) {
+func (process *TeleportProcess) newLocalCacheForRelay(clt authclient.ClientI, cacheName []string) (authclient.RelayAccessPoint, error) {
 	// if caching is disabled, return access point
 	if !process.Config.CachePolicy.Enabled {
 		return clt, nil
@@ -3173,7 +3173,7 @@ func (process *TeleportProcess) newLocalCacheForRelay(clt authclient.ClientI, ca
 		return nil, trace.Wrap(err)
 	}
 
-	return cache, nil
+	return authclient.NewRelayWrapper(clt, cache), nil
 }
 
 // newLocalCacheForRemoteProxy returns new instance of access point configured for a remote proxy.
@@ -5617,13 +5617,21 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName:   clusterName,
-		AccessPoint:   accessPoint,
-		LockWatcher:   lockWatcher,
-		Logger:        process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
-		PermitCaching: process.Config.CachePolicy.Enabled,
-	})
+	authorizerOpts := authz.AuthorizerOpts{
+		ClusterName:      clusterName,
+		AccessPoint:      accessPoint,
+		ScopedRoleReader: accessPoint.ScopedRoleReader(),
+		LockWatcher:      lockWatcher,
+		Logger:           process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentReverseTunnelServer, process.id)),
+		PermitCaching:    process.Config.CachePolicy.Enabled,
+	}
+
+	authorizer, err := authz.NewAuthorizer(authorizerOpts)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	scopedAuthorizer, err := authz.NewScopedAuthorizer(authorizerOpts)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -5663,6 +5671,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		TransportCredentials: credentials.NewTLS(sshGRPCTLSConfig),
 		UserGetter:           authMiddleware,
 		Authorizer:           authorizer,
+		ScopedAuthorizer:     scopedAuthorizer,
 		GetAuthPreference:    accessPoint.GetAuthPreference,
 	})
 	if err != nil {
@@ -5698,8 +5707,15 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		FIPS:   cfg.FIPS,
 		Logger: process.logger.With(teleport.ComponentKey, "transport"),
 		Dialer: proxyRouter,
-		SignerFn: func(authzCtx *authz.Context, clusterName string) agentless.SignerCreator {
-			return agentless.SignerFromAuthzContext(authzCtx, accessPoint, clusterName)
+		SignerFn: func(authzCtx *authz.ScopedContext, clusterName string) agentless.SignerCreator {
+			if unscopedCtx, ok := authzCtx.UnscopedContext(); ok {
+				return agentless.SignerFromAuthzContext(unscopedCtx, accessPoint, clusterName)
+			}
+
+			return func(ctx context.Context, localAccessPoint agentless.LocalAccessPoint, certGen agentless.CertGenerator) (ssh.Signer, error) {
+				// TODO(fspamarshall/scopes): implement agentless transport signer for scoped identities
+				return nil, trace.NotImplemented("agentless transport signer is not implemented for scoped identities")
+			}
 		},
 		ConnectionMonitor: connMonitor,
 		LocalAddr:         listeners.sshGRPC.Addr(),

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -344,7 +344,7 @@ type accessChecker struct {
 //     full RoleSet
 func NewAccessChecker(info *AccessInfo, localCluster string, access RoleGetter) (AccessChecker, error) {
 	if info.ScopePin != nil {
-		return nil, trace.BadParameter("cannot create unscoped AccessChecker based on scoped identity")
+		return nil, trace.Errorf("cannot create standard access checker: %w", ErrScopedIdentity)
 	}
 	roleSet, err := FetchRoles(info.Roles, access, info.Traits)
 	if err != nil {

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/modules"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/utils/set"
 )
 
@@ -223,6 +224,9 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindInferenceSecret, RW()),
 					types.NewRule(types.KindInferencePolicy, RW()),
 					types.NewRule(types.KindClientIPRestriction, RW()),
+					types.NewRule(scopedaccess.KindScopedRole, RW()),
+					types.NewRule(scopedaccess.KindScopedRoleAssignment, RW()),
+					types.NewRule(types.KindScopedToken, RW()),
 				},
 			},
 		},

--- a/lib/services/scoped.go
+++ b/lib/services/scoped.go
@@ -21,8 +21,16 @@ package services
 import (
 	"context"
 
+	scopedaccessclient "github.com/gravitational/teleport/api/client/scopes/access"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 )
+
+// ScopedAccessClientGetter provides a method to get a scoped access service client. This interface works directly with
+// the API client, but sub-components should prefer to use more specific interfaces where possible.
+type ScopedAccessClientGetter interface {
+	// ScopedAccessServiceClient returns a client for the scoped access service.
+	ScopedAccessServiceClient() *scopedaccessclient.Client
+}
 
 // ScopedAccess provides an API for managing scoped access-control resources.
 type ScopedAccess interface {

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -26,11 +26,14 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
+	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/sshca"
 )
 
 // CommonAccessChecker defines the common methods that are identical across both scoped and unscoped access checkers.
@@ -46,6 +49,19 @@ type CommonAccessChecker interface {
 	PermitX11Forwarding() bool
 	LockingMode(defaultMode constants.LockingMode) constants.LockingMode
 	CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error
+	HostSudoers(types.Server) ([]string, error)
+	EnhancedRecordingSet() map[string]bool
+	HostUsers(types.Server) (*decisionpb.HostUsersInfo, error)
+	CheckAgentForward(login string) error
+	MaxConnections() int64
+	MaxSessions() int64
+	CanCopyFiles() bool
+	SSHPortForwardMode() decisionpb.SSHPortForwardMode
+	AdjustClientIdleTimeout(timeout time.Duration) time.Duration
+	AdjustDisconnectExpiredCert(disconnect bool) bool
+	SessionRecordingMode(service constants.SessionRecordingService) constants.SessionRecordingMode
+	CheckAccessToSSHServer(target types.Server, state AccessState, osUser string) error
+	CanAccessSSHServer(target types.Server) error
 }
 
 // ScopedAccessCheckerSubset defines the methods that are specific to scoped access checkers.
@@ -125,6 +141,27 @@ func (c *accessCheckerShim) CheckAccessToRules(ctx RuleContext, resource string,
 // verbs and does not support namespaces.
 func (c *accessCheckerShim) CheckMaybeHasAccessToRules(ctx RuleContext, resource string, verbs ...string) error {
 	return checkMaybeHasAccessToRulesImpl(c.AccessChecker, ctx, resource, verbs...)
+}
+
+// CheckAccessToSSHServer checks access to an SSH server with optional role matchers. Note that this function
+// is a thin wrapper around the standard [AccessChecker.CheckAccess] method. The purpose of this method is to
+// provide a more constrained access-checking API since the majority of access-checkable resources are not
+// supported by scopes yet.
+func (c *accessCheckerShim) CheckAccessToSSHServer(target types.Server, state AccessState, osUser string) error {
+	return c.AccessChecker.CheckAccess(
+		target,
+		state,
+		NewLoginMatcher(osUser),
+	)
+}
+
+// CanAccessSSHServer is a helper method that checkes whether access to the specified SSH server is possible.
+// This method is used to determine read access to SSH servers, and does not take into account elements like
+// MFA state or os login. This helper is based on the behavior of auth.resourceChecker.CanAccess. The purpose
+// of this method is to provide a more constrained access-checking API since the majority of access-checkable
+// resources are not supported by scopes yet.
+func (c *accessCheckerShim) CanAccessSSHServer(target types.Server) error {
+	return c.AccessChecker.CheckAccess(target, AccessState{MFAVerified: true})
 }
 
 func checkAccessToRulesImpl(checker AccessChecker, ctx RuleContext, resource string, verbs ...string) error {
@@ -271,4 +308,34 @@ func (c *SplitAccessCheckerContext) decision(ctx context.Context, checkers strea
 	}
 
 	return trace.AccessDenied("access denied (decision)")
+}
+
+func (c *SplitAccessCheckerContext) AccessStateFromSSHIdentity(ctx context.Context, ident *sshca.Identity, authPrefGetter AuthPreferenceGetter) (AccessState, error) {
+	if c.scopedContext == nil {
+		// in unscoped state, defer to regular access state building
+		return AccessStateFromSSHIdentity(ctx, ident, c.unscopedChecker, authPrefGetter)
+	}
+
+	authPref, err := authPrefGetter.GetAuthPreference(ctx)
+	if err != nil {
+		return AccessState{}, trace.Wrap(err)
+	}
+
+	if authPref.GetRequireMFAType().IsSessionMFARequired() {
+		// TODO(fspmarshall/scopes): implement scoped MFA
+		// NOTE: this will require additional refactoring of relevant access-checking logic. currently, we often
+		// check MFA requirements *before* we determine access to the underlying resource, but a scoped MFA model
+		// will need to first determine the scope of access *before* we can determine whether MFA is required for that scope.
+		return AccessState{}, trace.AccessDenied("cannot perform scoped access when cluster-level MFA is required (scoped MFA is not implemented)")
+	}
+
+	return AccessState{
+		// MFA state is hard-coded here because scoped roles do not support MFA yet, and the above check should reject
+		// cases where cluster-level config would obligate MFA.
+		MFARequired:              MFARequiredNever,
+		MFAVerified:              false,
+		EnableDeviceVerification: true,
+		DeviceVerified:           dtauthz.IsSSHDeviceVerified(ident),
+		IsBot:                    ident.IsBot(),
+	}, nil
 }

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -97,6 +97,9 @@ type AccessPoint interface {
 	// Semaphores provides semaphore operations
 	types.Semaphores
 
+	// ScopedRoleReader returns a read-only scoped role client.
+	ScopedRoleReader() services.ScopedRoleReader
+
 	// GetClusterName returns cluster name
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 
@@ -766,7 +769,10 @@ func (c *ServerContext) CheckSFTPAllowed(registry *SessionRegistry) error {
 	}
 
 	// ensure moderated session policies allow starting an unattended session
-	policySets := c.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+	var policySets []*types.SessionTrackerPolicySet
+	if c.Identity.UnstableSessionJoiningAccessChecker != nil {
+		policySets = c.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+	}
 	checker := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, c.Identity.TeleportUser)
 	canStart, _, err := checker.FulfilledFor(nil)
 	if err != nil {

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -629,7 +629,10 @@ func (s *Server) Serve() {
 	if s.targetServer.IsOpenSSHNode() {
 		// OpenSSH nodes don't support moderated sessions, send an error to
 		// the user and gracefully fail if the user is attempting to create one.
-		policySets := s.identityContext.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+		var policySets []*types.SessionTrackerPolicySet
+		if s.identityContext.UnstableSessionJoiningAccessChecker != nil {
+			policySets = s.identityContext.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+		}
 		evaluator := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, s.identityContext.TeleportUser)
 		if evaluator.IsModerated() {
 			s.rejectChannel(chans, "Moderated sessions cannot be created for OpenSSH nodes")

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -171,6 +171,7 @@ func newMockServer(t *testing.T) *mockServer {
 
 type mockServer struct {
 	*eventstest.MockRecorderEmitter
+	info      types.Server
 	datadir   string
 	auth      *auth.Server
 	component string
@@ -233,8 +234,18 @@ func (m *mockServer) GetClock() clockwork.Clock {
 	return clockwork.NewRealClock()
 }
 
+// setInfo overrides the default result of [mockServer.GetInfo]. Necessary in order to
+// correctly test the behavior of local node rbac that expects specific server attributes.
+func (m *mockServer) setInfo(server types.Server) {
+	m.info = server
+}
+
 // GetInfo returns a services.Server that represents this server.
 func (m *mockServer) GetInfo() types.Server {
+	if m.info != nil {
+		return m.info
+	}
+
 	hostname, err := os.Hostname()
 	if err != nil {
 		hostname = "localhost"

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -853,7 +853,11 @@ func newSession(ctx context.Context, r *SessionRegistry, scx *ServerContext, ch 
 		rsess.TerminalParams.H = int(winsize.Height)
 	}
 
-	policySets := scx.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+	var policySets []*types.SessionTrackerPolicySet
+	if scx.Identity.UnstableSessionJoiningAccessChecker != nil {
+		policySets = scx.Identity.UnstableSessionJoiningAccessChecker.SessionPolicySets()
+	}
+
 	access := moderation.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, scx.Identity.TeleportUser)
 	sess := &session{
 		logger: slog.With(
@@ -1896,9 +1900,14 @@ func (s *session) checkIfFileTransferApproved(req *FileTransferRequest) (bool, e
 			continue
 		}
 
+		var roles []types.Role
+		if party.ctx.Identity.UnstableSessionJoiningAccessChecker != nil {
+			roles = party.ctx.Identity.UnstableSessionJoiningAccessChecker.Roles()
+		}
+
 		participants = append(participants, moderation.SessionAccessContext{
 			Username: party.ctx.Identity.TeleportUser,
-			Roles:    party.ctx.Identity.UnstableSessionJoiningAccessChecker.Roles(),
+			Roles:    roles,
 			Mode:     party.mode,
 		})
 	}
@@ -2081,9 +2090,14 @@ func (s *session) checkIfStartUnderLock() (bool, moderation.PolicyOptions, error
 			continue
 		}
 
+		var roles []types.Role
+		if party.ctx.Identity.UnstableSessionJoiningAccessChecker != nil {
+			roles = party.ctx.Identity.UnstableSessionJoiningAccessChecker.Roles()
+		}
+
 		participants = append(participants, moderation.SessionAccessContext{
 			Username: party.ctx.Identity.TeleportUser,
-			Roles:    party.ctx.Identity.UnstableSessionJoiningAccessChecker.Roles(),
+			Roles:    roles,
 			Mode:     party.mode,
 		})
 	}
@@ -2216,9 +2230,14 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 
 func (s *session) join(ch ssh.Channel, scx *ServerContext, mode types.SessionParticipantMode) error {
 	if scx.Identity.TeleportUser != s.initiator.user || scx.Identity.OriginClusterName != s.initiator.cluster {
+		var roles []types.Role
+		if scx.Identity.UnstableSessionJoiningAccessChecker != nil {
+			roles = scx.Identity.UnstableSessionJoiningAccessChecker.Roles()
+		}
+
 		accessContext := moderation.SessionAccessContext{
 			Username: scx.Identity.TeleportUser,
-			Roles:    scx.Identity.UnstableSessionJoiningAccessChecker.Roles(),
+			Roles:    roles,
 		}
 
 		modes := s.access.CanJoin(accessContext)

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -242,7 +242,7 @@ func newServer(t *testing.T, cfg ServerConfig) testPack {
 	}
 }
 
-func fakeSigner(authzCtx *authz.Context, clusterName string) agentless.SignerCreator {
+func fakeSigner(authzCtx *authz.ScopedContext, clusterName string) agentless.SignerCreator {
 	return func(_ context.Context, _ agentless.LocalAccessPoint, _ agentless.CertGenerator) (ssh.Signer, error) {
 		return nil, nil
 	}
@@ -512,13 +512,13 @@ func TestService_ProxySSH_Errors(t *testing.T) {
 				ConnectionMonitor: fakeMonitor{},
 				Logger:            logtest.NewLogger(),
 				LocalAddr:         utils.MustParseAddr("127.0.0.1:4242"),
-				authzContextFn: func(info credentials.AuthInfo) (*authz.Context, error) {
+				authzContextFn: func(info credentials.AuthInfo) (*authz.ScopedContext, error) {
 					checker, err := test.checkerFn(info)
 					if err != nil {
 						return nil, trace.Wrap(err)
 					}
 
-					return &authz.Context{Checker: checker}, nil
+					return authz.ScopedContextFromUnscopedContext(&authz.Context{Checker: checker}), nil
 				},
 			})
 
@@ -588,8 +588,8 @@ func TestService_ProxySSH(t *testing.T) {
 				}, nil
 			}
 		},
-		authzContextFn: func(info credentials.AuthInfo) (*authz.Context, error) {
-			return &authz.Context{Checker: fakeChecker{}}, nil
+		authzContextFn: func(info credentials.AuthInfo) (*authz.ScopedContext, error) {
+			return authz.ScopedContextFromUnscopedContext(&authz.Context{Checker: fakeChecker{}}), nil
 		},
 	})
 
@@ -820,13 +820,13 @@ func TestService_ProxyWindowsDesktopSession(t *testing.T) {
 				ConnectionMonitor: fakeMonitor{},
 				Logger:            logtest.NewLogger(),
 				LocalAddr:         utils.MustParseAddr("127.0.0.1:4243"),
-				authzContextFn: func(info credentials.AuthInfo) (*authz.Context, error) {
+				authzContextFn: func(info credentials.AuthInfo) (*authz.ScopedContext, error) {
 					checker, err := test.checkerFn(info)
 					if err != nil {
 						return nil, trace.Wrap(err)
 					}
 
-					return &authz.Context{Checker: checker}, nil
+					return authz.ScopedContextFromUnscopedContext(&authz.Context{Checker: checker}), nil
 				},
 			})
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7007,7 +7007,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 					require.Contains(t, returnedTrace.Error, expectedTrace.Error)
 				}
 
-				require.True(t, foundTrace, "expected trace %v was not found", expectedTrace)
+				require.True(t, foundTrace, "expected trace '%v' was not found, got '%v'", expectedTrace, connectionDiagnostic.Traces)
 			}
 			require.Equal(t, expectedFailedTraces, gotFailedTraces)
 		})
@@ -8591,11 +8591,17 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		}
 	}()
 
-	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
-		ClusterName: clustername,
-		AccessPoint: authServer.Auth(),
-		LockWatcher: proxyLockWatcher,
-	})
+	authorizerOpts := authz.AuthorizerOpts{
+		ClusterName:      clustername,
+		AccessPoint:      authServer.Auth(),
+		ScopedRoleReader: authServer.Auth().ScopedRoleReader(),
+		LockWatcher:      proxyLockWatcher,
+	}
+
+	authorizer, err := authz.NewAuthorizer(authorizerOpts)
+	require.NoError(t, err)
+
+	scopedAuthorizer, err := authz.NewScopedAuthorizer(authorizerOpts)
 	require.NoError(t, err)
 
 	tlscfg, err := authServer.Identity.TLSConfig(utils.DefaultCipherSuites())
@@ -8624,7 +8630,8 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		UserGetter: &authz.Middleware{
 			ClusterName: authServer.ClusterName(),
 		},
-		Authorizer: authorizer,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: scopedAuthorizer,
 	})
 	require.NoError(t, err)
 
@@ -8650,8 +8657,15 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		FIPS:   false,
 		Logger: logtest.NewLogger(),
 		Dialer: router,
-		SignerFn: func(authzCtx *authz.Context, clusterName string) agentless.SignerCreator {
-			return agentless.SignerFromAuthzContext(authzCtx, client, clusterName)
+		SignerFn: func(authzCtx *authz.ScopedContext, clusterName string) agentless.SignerCreator {
+			if unscopedCtx, ok := authzCtx.UnscopedContext(); ok {
+				return agentless.SignerFromAuthzContext(unscopedCtx, client, clusterName)
+			}
+
+			return func(ctx context.Context, localAccessPoint agentless.LocalAccessPoint, certGen agentless.CertGenerator) (ssh.Signer, error) {
+				// TODO(fspamarshall/scopes): implement agentless transport signer for scoped identities
+				return nil, trace.NotImplemented("agentless transport signer is not implemented for scoped identities")
+			}
 		},
 		ConnectionMonitor: connMonitor,
 		LocalAddr:         proxyListener.Addr(),

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1145,18 +1145,19 @@ func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
 }
 
 func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"Scope", "Name", "Assigns"}
+	headers := []string{"Scope", "Name", "User", "Assigns"}
 	var rows [][]string
 
 	for _, item := range c.items {
 		var assigns []string
 		for _, subAssignment := range item.GetSpec().GetAssignments() {
-			assigns = append(assigns, fmt.Sprintf("%s@%s", subAssignment.GetRole(), subAssignment.GetScope()))
+			assigns = append(assigns, fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope()))
 		}
 
 		rows = append(rows, []string{
 			item.GetScope(),
 			item.GetMetadata().GetName(),
+			item.GetSpec().GetUser(),
 			strings.Join(assigns, ", "),
 		})
 	}


### PR DESCRIPTION
This PR implements core functionality for scoped SSH access.  Two new scoped role fields, `spec.allow.logins` and `spec.allow.node_labels`, have been added and  SSH agent access-control logic has been updated to be compatible with scoped identities.

This is a very bare-bones MVP of scoped SSH access, and has a number of notable limitations/issues:
- This work does not currently integrate with the scoped agent joining/identity work that is being done concurrently.  For the time being, agent scope must be set explicitly via env var (e.g. `export TELEPORT_UNSTABLE_AGENT_SCOPE=/staging/west`).  Node listing access checks similarly are not integrated with scoped ssh resource work yet.  `tsh ls` behavior can be tested by setting `TELEPORT_UNSTABLE_SERVER_RESOURCE_SCOPE`.
- No ssh access parameters/controls are supported beyond labels/logins.  This includes all of the common `options` block controls like agent forwarding, X11 forwarding, etc.  Additionally, logins do not support trait interpolation, meaning that roles must specify static logins rather than using the common `{{internal.logins}}` expansion pattern.
- Routing/dialing logic has not been updated to be scope-aware yet, meaning that conflicting hostnames in orthogonal scopes can still result in an ambiguous host error.
- Caching of scoped roles has not been implemented yet for proxies or agents, meaning that ssh access with a scoped identity will have noticeably worse initial session establishment latency, especially in geographically distributed access scenarios.  Latency *during* the ssh session is unaffected.
- There is a known bug in scoped SSH certificate generation that causes logins to not be applied to a cert unless the cert is pinned to the exact scope where the logins are assigned, or a child of that scope.  (e.g. if you are granted the login `ec2-user` by a role assigned at `/staging/west`, you have to pin to `/staging/west` or `/staging/west/some-child`  in order for that login to be usable).  This differs from the intended behavior, where privileges granted in a child scope are usable when pinned to a parent scope (for access of resources within the child scope).
- Scoped access for openssh nodes is not yet supported.

This change also represents the first active divergence from classic role syntax.  Classic roles used some unmarshaling and proto plugin magic to allow node labels to be expressed as a mapping with string keys and dynamic values that could be either of type `string` or `[]string`.  Scoped roles adhere to our updated resource conventions and stick to a canonical `protojson` representation.  As such, node labels are now represented as a sequence of objects of the form `{ name string, values []string }`.

A classic node label selector of the form:

```yaml
node_labels:
  foo: bar
  bin: [baz, bat]
```

Must now be represented as:

```yaml
node_labels:
  - name: foo
    values: [bar]
  - name: bin
    values: [baz, bat]
```

This new format is consistent with other modern teleport label selectors such as those used by `crownjewels`, `userprovisioning`, `healthcheckconfig`, etc.

#### Example Usage

- Set `TELEPORT_UNSTABLE_SCOPES=yes` on all teleport instances (agent and control-plane).

- Set `TELEPORT_UNSTABLE_AGENT_SCOPE=/staging/west` on the teleport node instance.

- Set `TELEPORT_UNSTABLE_SERVER_RESOURCE_SCOPE=/staging/west` on the teleport auth server.

- Create and assign the following scoped role and scoped role assignment, replacing `alice` and `ec2-user`  with your teleport username and intended login respectively:
```yaml
kind: scoped_role
metadata:
  labels:
    key: val
  name: staging-west-access
scope: /staging/west
spec:
  allow:
    logins:
    - ec2-user
    node_labels:
      - name: '*'
        values: ['*']
  assignable_scopes:
  - /staging/west
version: v1
---
kind: scoped_role_assignment
scope: /staging/west
spec:
  assignments:
  - role: staging-west-access
    scope: /staging/west
  user: alice
version: v1
```

- Run `tsh login --scope=/staging/west --user=<username>`.  The post-login status printout should include:

```
  Scoped Roles:
    /staging/west: staging-west-access
```

- Run `tsh ls`. Output should include all matching nodes (due to global nature of the node resource env var).

- Run `tsh ssh <username>@<host>` targeting your `/staging/west` node.

- Note that while "pinned" to a scope, your teleport credentials will not be usable for most commands/APIs.  You will need to log out and back in without the `--scope` flag in order to resume normal operations.

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).