### PR TITLE
Docs: add AWS IAM Roles Anywhere CA entry to CA Rotation docs

### DIFF
--- a/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
@@ -86,6 +86,7 @@ during the migration.
 |[`saml_idp`](#saml_idp)|The Teleport SAML IdP.|
 |[`spiffe`](#spiffe)|Workload Identity (SPIFFE) clients.|
 |[`oidc_idp`](#oidc_idp)|The Teleport OIDC IdP integration.|
+|[`awsra`](#awsra)|The Teleport AWS IAM Roles Anywhere integration.|
 
 ### `host`
 
@@ -356,6 +357,19 @@ the `/.well-known/openid-configuration` path of the Web UI and reading the
 $ curl https://example.teleport.sh/.well-known/openid-configuration | jq '.jwks_uri'
 "https://example.teleport.sh/.well-known-jwks-oidc"
 ```
+
+### `awsra`
+
+The `awsra` CA signs X.509 certificates which are sent to AWS in exchange for AWS temporary sessions.
+AWS must be configured to trust the `awsra` CA by adding it as Trust Anchor.
+This integration allows for AWS CLI and Console access.
+
+After starting the rotation, you will need to add the new CA to the same AWS IAM Roles Anywhere Trust Anchor.
+
+During this period, AWS will trust both the old and the new CA.
+All new sessions will use the new CA.
+
+After the rotation is complete, make sure to remove the old CA from the AWS IAM Roles Anywhere Trust Anchor.
 
 ## Step 2/4. Start a manual rotation
 

--- a/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
@@ -361,15 +361,15 @@ $ curl https://example.teleport.sh/.well-known/openid-configuration | jq '.jwks_
 ### `awsra`
 
 The `awsra` CA signs X.509 certificates which are sent to AWS in exchange for AWS temporary sessions.
-AWS must be configured to trust the `awsra` CA by adding it as Trust Anchor.
+AWS must be configured to trust the `awsra` CA by adding it as trust anchor.
 This integration allows for AWS CLI and Console access.
 
-After starting the rotation, you will need to add the new CA to the same AWS IAM Roles Anywhere Trust Anchor.
+After starting the rotation, you will need to add the new CA to the same AWS IAM Roles Anywhere trust anchor.
 
 During this period, AWS will trust both the old and the new CA.
 All new sessions will use the new CA.
 
-After the rotation is complete, make sure to remove the old CA from the AWS IAM Roles Anywhere Trust Anchor.
+After the rotation is complete, make sure to remove the old CA from the AWS IAM Roles Anywhere trust anchor.
 
 ## Step 2/4. Start a manual rotation
 


### PR DESCRIPTION
Add AWS IAM Roles Anywhere entry to CA Rotation docs.