### PR TITLE
[mcp][poc] k8s auto-discovery

### DIFF
--- a/api/types/matchers_kube.go
+++ b/api/types/matchers_kube.go
@@ -27,12 +27,15 @@ import (
 const (
 	// KubernetesMatchersApp is app matcher type for Kubernetes services
 	KubernetesMatchersApp = "app"
+	// KubernetesMatchersMCP is the MCP matcher type for Kubernetes services
+	KubernetesMatchersMCP = "mcp"
 )
 
 // SupportedKubernetesMatchers is a list of Kubernetes matchers supported by
 // Teleport discovery service
 var SupportedKubernetesMatchers = []string{
 	KubernetesMatchersApp,
+	KubernetesMatchersMCP,
 }
 
 // CheckAndSetDefaults that the matcher is correct and adds default values.
@@ -45,7 +48,7 @@ func (m *KubernetesMatcher) CheckAndSetDefaults() error {
 	}
 
 	if len(m.Types) == 0 {
-		m.Types = []string{KubernetesMatchersApp}
+		m.Types = []string{KubernetesMatchersApp, KubernetesMatchersMCP}
 	}
 
 	if len(m.Namespaces) == 0 {

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -210,6 +210,20 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 	return nil, trace.BadParameter("unsupported app server resource version %q", h.Version)
 }
 
+// TODO(greedy52)
+func NewMCPServerFromKubeService(service corev1.Service, clusterName, protocol string, port corev1.ServicePort) (types.Application, error) {
+	app, err := NewApplicationFromKubeService(service, clusterName, protocol, port)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	uri := "mcp+" + app.GetURI()
+	if service.GetAnnotations()[types.DiscoveryPathLabel] == "" {
+		uri += "/mcp"
+	}
+	app.SetURI(uri)
+	return app, nil
+}
+
 // NewApplicationFromKubeService creates application resources from kubernetes service.
 // It transforms service fields and annotations into appropriate Teleport app fields.
 // Service labels are copied to app labels.

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -41,6 +42,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -300,8 +302,15 @@ kubernetes matchers are present.`)
 	if c.KubernetesClient == nil && len(c.Matchers.Kubernetes) > 0 {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
-			return trace.Wrap(err,
-				"the Kubernetes App Discovery requires a Teleport Kube Agent running on a Kubernetes cluster")
+			// TODO(greedy52) just for quick local debugging, remove before review.
+			if os.Getenv("LOCAL_MINIKUBE") != "" {
+				cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{}).ClientConfig()
+			}
+
+			if err != nil {
+				return trace.Wrap(err,
+					"the Kubernetes App Discovery requires a Teleport Kube Agent running on a Kubernetes cluster")
+			}
 		}
 		kubeClient, err := kubernetes.NewForConfig(cfg)
 		if err != nil {
@@ -684,10 +693,10 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 	}
 
 	for _, matcher := range matchers {
-		if !slices.Contains(matcher.Types, types.KubernetesMatchersApp) {
+		if !slices.Contains(matcher.Types, types.KubernetesMatchersApp) &&
+			!slices.Contains(matcher.Types, types.KubernetesMatchersMCP) {
 			continue
 		}
-
 		fetcher, err := fetchers.NewKubeAppsFetcher(fetchers.KubeAppsFetcherConfig{
 			KubernetesClient: kubeClient,
 			FilterLabels:     matcher.Labels,
@@ -695,6 +704,7 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 			Logger:           s.Log,
 			ClusterName:      s.DiscoveryGroup,
 			ProtocolChecker:  s.Config.protocolChecker,
+			MatcherTypes:     matcher.Types,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
related:
- #56586 

setup:

<details>
  <summary>`kubectl apply -n mcp -f notion.yaml`</summary>

```yaml
notion.yaml 
apiVersion: apps/v1
kind: Deployment
metadata:
  name: notion-mcp
  labels:
    app: notion-mcp
spec:
  replicas: 1
  selector:
    matchLabels:
      app: notion-mcp
  template:
    metadata:
      labels:
        app: notion-mcp
    spec:
      containers:
        - name: server
          image: node:20-alpine
          imagePullPolicy: IfNotPresent
          env:
            - name: NOTION_TOKEN
              valueFrom:
                secretKeyRef:
                  name: notion-credentials
                  key: NOTION_TOKEN
            - name: AUTH_TOKEN
              valueFrom:
                secretKeyRef:
                  name: notion-credentials
                  key: AUTH_TOKEN
          command: ["sh","-lc"]
          args:
            - >
              npx -y @notionhq/notion-mcp-server
              --transport http
              --port 80
              --auth-token "$AUTH_TOKEN"
          ports:
            - name: http
              containerPort: 80
          resources:
            requests:
              cpu: "100m"
              memory: "128Mi"
            limits:
              cpu: "500m"
              memory: "512Mi"
---
apiVersion: v1
kind: Service
metadata:
  name: notion-mcp
  labels:
    app: notion-mcp
  annotations:
    teleport.dev/discovery-type: "mcp"
    env: "dev"
spec:
  type: ClusterIP
  selector:
    app: notion-mcp
  ports:
    - name: http
      port: 80
      targetPort: http

```
</details>


<details>
  <summary>`Teleport discovery service`</summary>

```yaml
discovery_service:
  enabled: "yes"
  discovery_group: minikube
  kubernetes:
  - types: ["mcp"]
    namespaces: [ "mcp"]
    labels:
      "*": "*"
```
</details>