### PR TITLE
Managed Updates docs: clarify that inventory output may take several minutes to update

### DIFF
--- a/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
+++ b/docs/pages/upgrading/agent-managed-updates/agent-managed-updates.mdx
@@ -316,6 +316,9 @@ Server ID                            Hostname      Services Version Upgrader
 Agents enrolled into Managed Updates v2 can be queried with the
 `--upgrader=binary` flag.
 
+Note that it may take several minutes for newly upgraded agents to be reflected
+in the inventory output.
+
 ### Enrolling unmanaged agents
 
 1. For each agent ID returned by the `tctl inventory ls` command, copy the ID


### PR DESCRIPTION
This PR clarifies that the inventory output may be outdated when finding unmanaged agents.

Several users have reported confusion when checking the inventory after immediately migrating an agent to Managed Updates.

Goal (internal): https://github.com/gravitational/cloud/issues/14225