### PR TITLE
docs: add video to MWI docs page

### DIFF
--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -11,7 +11,6 @@ import LandingHero, { LandingHeroProps } from '@site/src/components/Pages/Landin
 import Integrations, { IntegrationsProps } from "@site/src/components/Pages/Homepage/Integrations";
 import UseCasesList, { UseCasesListProps } from "@site/src/components/Pages/Landing/UseCasesList";
 
-import mwiImg from '@version/docs/img/machine-id/mwi-hero.png';
 import bookOpenSvg from "@site/src/components/Icon/teleport-svg/book-open.svg";
 import identificationBadgeSvg from "@site/src/components/Icon/teleport-svg/identification-badge.svg";
 import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.svg";
@@ -38,7 +37,7 @@ import teleportSvg from "@site/src/components/Icon/teleport-svg/teleport.svg";
 
 <LandingHero
   title="Machine & Workload Identity"
-  image={mwiImg}
+  youtubeVideoId="ZDWRt105tBg"
 >
 
 Use Teleport to replace long-lived secrets with identity-based authentication for your machines and workloads.


### PR DESCRIPTION
MWI docs homepage has a static hero image. This PR is to replace this with a YT video.