### PR TITLE
Fix MongoDB connection leak

### DIFF
--- a/integration/db/db_integration_test.go
+++ b/integration/db/db_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
@@ -357,9 +358,8 @@ func (p *DatabasePack) testMongoRootCluster(t *testing.T) {
 // testMongoConnectionCount tests if mongo service releases
 // resource after a mongo client disconnect.
 func (p *DatabasePack) testMongoConnectionCount(t *testing.T) {
-	connectMongoClient := func(t *testing.T) (serverConnectionCount int32) {
-		// Connect to the database service in root cluster.
-		client, err := mongodb.MakeTestClient(context.Background(), common.TestClientConfig{
+	makeClient := func(t *testing.T, dbUser string) (*mongo.Client, error) {
+		return mongodb.MakeTestClient(t.Context(), common.TestClientConfig{
 			AuthClient: p.Root.Cluster.GetSiteAPI(p.Root.Cluster.Secrets.SiteName),
 			AuthServer: p.Root.Cluster.Process.GetAuthServer(),
 			Address:    p.Root.Cluster.Web,
@@ -368,27 +368,31 @@ func (p *DatabasePack) testMongoConnectionCount(t *testing.T) {
 			RouteToDatabase: tlsca.RouteToDatabase{
 				ServiceName: p.Root.MongoService.Name,
 				Protocol:    p.Root.MongoService.Protocol,
-				Username:    "admin",
+				Username:    dbUser,
 			},
 		})
+	}
+
+	connectMongoClient := func(t *testing.T, dbUser string) (serverConnectionCount int32) {
+		client, err := makeClient(t, dbUser)
 		require.NoError(t, err)
 
 		// Execute a query.
-		_, err = client.Database("test").Collection("test").Find(context.Background(), bson.M{})
+		_, err = client.Database("test").Collection("test").Find(t.Context(), bson.M{})
 		require.NoError(t, err)
 
 		// Get a server connection count before disconnect.
 		serverConnectionCount = p.Root.mongo.GetActiveConnectionsCount()
 
 		// Disconnect.
-		err = client.Disconnect(context.Background())
+		err = client.Disconnect(t.Context())
 		require.NoError(t, err)
 
 		return serverConnectionCount
 	}
 
 	// Get connection count while the first client is connected.
-	initialConnectionCount := connectMongoClient(t)
+	initialConnectionCount := connectMongoClient(t, "admin")
 
 	// Check if active connections count is not growing over time when new
 	// clients connect to the mongo server.
@@ -396,22 +400,41 @@ func (p *DatabasePack) testMongoConnectionCount(t *testing.T) {
 	for range clientCount {
 		// Note that connection count per client fluctuates between 6 and 9.
 		// Use InDelta to avoid flaky test.
-		require.InDelta(t, initialConnectionCount, connectMongoClient(t), 3)
+		got := connectMongoClient(t, "admin")
+		require.InDelta(t, initialConnectionCount, got, 3)
 	}
+
+	client, err := makeClient(t, "nonexistent")
+	if !assert.Error(t, err) {
+		require.NoError(t, client.Disconnect(t.Context()))
+		return
+	}
+	require.ErrorContains(t, err, "does not exist")
 
 	// Wait until the server reports no more connections. This usually happens
 	// really quick but wait a little longer just in case.
-	waitUntilNoConnections := func() bool {
-		return p.Root.mongo.GetActiveConnectionsCount() == 0
-	}
-	require.Eventually(t, waitUntilNoConnections, 5*time.Second, 100*time.Millisecond)
+	var activeConns int32
+	require.Eventually(t, func() bool {
+		conns := p.Root.mongo.GetActiveConnectionsCount()
+		if conns != activeConns {
+			t.Logf("active connections to MongoDB changed from %d to %d", activeConns, conns)
+			activeConns = conns
+		}
+		return activeConns == 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	start := time.Now()
+	require.Never(t, func() bool {
+		return p.Root.mongo.GetActiveConnectionsCount() > 0
+	}, time.Second*5, time.Millisecond*100, "no connections should be left open. Found after %v", time.Since(start))
 }
 
 // testMongoLeafCluster tests a scenario where a user connects
 // to a Mongo database running in a leaf cluster.
 func (p *DatabasePack) testMongoLeafCluster(t *testing.T) {
+	ctx := t.Context()
 	// Connect to the database service in root cluster.
-	client, err := mongodb.MakeTestClient(context.Background(), common.TestClientConfig{
+	client, err := mongodb.MakeTestClient(ctx, common.TestClientConfig{
 		AuthClient: p.Root.Cluster.GetSiteAPI(p.Root.Cluster.Secrets.SiteName),
 		AuthServer: p.Root.Cluster.Process.GetAuthServer(),
 		Address:    p.Root.Cluster.Web, // Connecting via root cluster.
@@ -426,11 +449,11 @@ func (p *DatabasePack) testMongoLeafCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	// Execute a query.
-	_, err = client.Database("test").Collection("test").Find(context.Background(), bson.M{})
+	_, err = client.Database("test").Collection("test").Find(ctx, bson.M{})
 	require.NoError(t, err)
 
 	// Disconnect.
-	err = client.Disconnect(context.Background())
+	err = client.Disconnect(ctx)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Changelog: Fixed MongoDB topology monitoring connection leak in the Teleport Database Service.

This fixes a topology monitoring connection leak.
The leak was triggered by an error during server selection or the initial auth handshake with the MongoDB server.

I decided to pull this out of the connection pool PR draft since the actual code change to fix the bug is only a few lines and has nothing to do with reducing user<->db agent connection amplification.