### PR TITLE
Remove TabItem with a duplicate label

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -310,6 +310,9 @@ $ tsh --proxy=proxy.example.com --auth=local --user=admin login
 
 # Log in using GitHub as an SSO provider, assuming the GitHub connector is called "github"
 $ tsh --proxy=proxy.example.com --auth=github login
+
+# Don't open the system default browser when logging in
+$ tsh login --proxy=work.example.com --browser=none
 ```
 
 </TabItem>
@@ -333,14 +336,6 @@ system's default browser. If you wish to suppress this behavior, you can use the
 `--browser=none` flag:
 
 <Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-```code
-# Don't open the system default browser when logging in
-$ tsh login --proxy=work.example.com --browser=none
-```
-
-</TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code


### PR DESCRIPTION
Fix a `Tabs` component in the `tsh` guide that has two `TabItem`s with duplicate labels.