### PR TITLE
expose TeleportProcess metrics registry

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1078,14 +1078,17 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}()
 
+	// Note: testing what happens if I still use the same config for everything
 	// Use the custom metrics registry if specified, else create a new one.
 	// We must create the registry in NewTeleport, as opposed to ApplyConfig(),
 	// because some tests are running multiple Teleport instances from the same
 	// config.
 	metricsRegistry := cfg.MetricsRegistry
-	if metricsRegistry == nil {
-		metricsRegistry = prometheus.NewRegistry()
-	}
+	/*
+		if metricsRegistry == nil {
+			metricsRegistry = prometheus.NewRegistry()
+		}
+	*/
 
 	// If FIPS mode was requested make sure binary is build against BoringCrypto.
 	if cfg.FIPS {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -714,7 +714,7 @@ type TeleportProcess struct {
 	// conflicts.
 	//
 	// Both the metricsRegistry and the default global registry are gathered by
-	// Telepeort's metric service.
+	// Teleport's metric service.
 	metricsRegistry *prometheus.Registry
 
 	// state is the process state machine tracking if the process is healthy or not.
@@ -987,6 +987,12 @@ func (process *TeleportProcess) getIdentity(role types.SystemRole) (i *state.Ide
 	return i, nil
 }
 
+// MetricsRegistry returns the process-scoped metrics registry.
+// New metrics must register against this and not the global prometheus registry.
+func (process *TeleportProcess) MetricsRegistry() prometheus.Registerer {
+	return process.metricsRegistry
+}
+
 // Process is a interface for processes
 type Process interface {
 	// Closer closes all resources used by the process
@@ -1078,17 +1084,14 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}()
 
-	// Note: testing what happens if I still use the same config for everything
 	// Use the custom metrics registry if specified, else create a new one.
 	// We must create the registry in NewTeleport, as opposed to ApplyConfig(),
 	// because some tests are running multiple Teleport instances from the same
 	// config.
 	metricsRegistry := cfg.MetricsRegistry
-	/*
-		if metricsRegistry == nil {
-			metricsRegistry = prometheus.NewRegistry()
-		}
-	*/
+	if metricsRegistry == nil {
+		metricsRegistry = prometheus.NewRegistry()
+	}
 
 	// If FIPS mode was requested make sure binary is build against BoringCrypto.
 	if cfg.FIPS {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1084,7 +1084,6 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}()
 
-	// Use the custom metrics registry if specified, else create a new one.
 	// We must create the registry in NewTeleport, as opposed to the config,
 	// because some tests are running multiple Teleport instances from the same
 	// config and reusing the same registry causes them to fail.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1085,13 +1085,10 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 	}()
 
 	// Use the custom metrics registry if specified, else create a new one.
-	// We must create the registry in NewTeleport, as opposed to ApplyConfig(),
+	// We must create the registry in NewTeleport, as opposed to the config,
 	// because some tests are running multiple Teleport instances from the same
-	// config.
-	metricsRegistry := cfg.MetricsRegistry
-	if metricsRegistry == nil {
-		metricsRegistry = prometheus.NewRegistry()
-	}
+	// config and reusing the same registry causes them to fail.
+	metricsRegistry := prometheus.NewRegistry()
 
 	// If FIPS mode was requested make sure binary is build against BoringCrypto.
 	if cfg.FIPS {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -265,10 +265,9 @@ type Config struct {
 	// protocol.
 	DatabaseREPLRegistry dbrepl.REPLRegistry
 
-	// MetricsRegistry is the prometheus metrics registry used by the Teleport process to register its metrics.
-	// As of today, not every Teleport metric is registered against this registry. Some Teleport services
-	// and Teleport dependencies are using the global registry.
-	// Both the MetricsRegistry and the default global registry are gathered by Teleport's metric service.
+	// MetricsRegistry is the test-only metrics registry configuration.
+	// This MUST NOT be used to access the process metrics registry, only to set it.
+	// You must use [service.TeleportProcess.MetricsRegistry()].
 	MetricsRegistry *prometheus.Registry
 
 	// token is either the token needed to join the auth server, or a path pointing to a file
@@ -739,10 +738,6 @@ func applyDefaults(cfg *Config) {
 
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
-	}
-
-	if cfg.MetricsRegistry == nil {
-		cfg.MetricsRegistry = prometheus.NewRegistry()
 	}
 
 	if cfg.LoggerLevel == nil {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -741,6 +741,10 @@ func applyDefaults(cfg *Config) {
 		cfg.Logger = slog.Default()
 	}
 
+	if cfg.MetricsRegistry == nil {
+		cfg.MetricsRegistry = prometheus.NewRegistry()
+	}
+
 	if cfg.LoggerLevel == nil {
 		cfg.LoggerLevel = new(slog.LevelVar)
 	}

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -33,7 +33,6 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
@@ -264,11 +263,6 @@ type Config struct {
 	// DatabaseREPLRegistry is used to retrieve datatabase REPL given the
 	// protocol.
 	DatabaseREPLRegistry dbrepl.REPLRegistry
-
-	// MetricsRegistry is the test-only metrics registry configuration.
-	// This MUST NOT be used to access the process metrics registry, only to set it.
-	// You must use [service.TeleportProcess.MetricsRegistry()].
-	MetricsRegistry *prometheus.Registry
 
 	// token is either the token needed to join the auth server, or a path pointing to a file
 	// that contains the token


### PR DESCRIPTION
I just shot myself with my own footgun: I tried to use the MetricsRegsitry from the service config in `e`, which was nil and caused a panic.

This PR indicates that the config registry must only be used in tests, and adds a `process.MetricsRegistry()` function to access the process metrics registry.

We cannot set the registry back into the config because several tests use same config to start several Teleport processes, and this causes metrics registration conflicts all over the place.