### PR TITLE
Bump Node.js to 22.21

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -6,7 +6,7 @@ GOLANG_VERSION ?= go1.25.3
 GOLANGCI_LINT_VERSION ?= v2.4.0
 
 # NOTE: Remember to update engines.node in package.json to match the major version.
-NODE_VERSION ?= 22.14.0
+NODE_VERSION ?= 22.21.0
 
 WASM_OPT_VERSION ?= 0.116.1
 LIBBPF_VERSION ?= 1.2.2


### PR DESCRIPTION
Just keeping the version up to date.

The tag build passed https://github.com/gravitational/teleport.e/actions/runs/18846532438