### PR TITLE
[v16] Update the shared-workflows ref in doc-tests.yaml

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2 
+          ref: 6f388765b8ce993721502083c74cb9af1fc5658f 
 
       - name: Install Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Include the bug fix introduced by gravitational/shared-workflows#402, which accommodates the different ways the GitHub API can represent the renaming of a file.