### PR TITLE
MWI: Fix flaky test in SPIFFE Workload APIs

### DIFF
--- a/lib/tbot/services/workloadidentity/workload_api_test.go
+++ b/lib/tbot/services/workloadidentity/workload_api_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/workloadidentity"
+	"github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -138,6 +139,11 @@ func TestBotWorkloadIdentityAPI(t *testing.T) {
 						Name: workloadIdentity.GetMetadata().GetName(),
 					},
 					Listen: listenAddr.String(),
+					Attestors: workloadattest.Config{
+						Unix: workloadattest.UnixAttestorConfig{
+							BinaryHashMaxSizeBytes: workloadattest.TestBinaryHashMaxBytes,
+						},
+					},
 				},
 				trustBundleCache,
 				crlCache,

--- a/lib/tbot/workloadidentity/workloadattest/unix.go
+++ b/lib/tbot/workloadidentity/workloadattest/unix.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/shirou/gopsutil/v4/process"
@@ -34,6 +35,18 @@ import (
 
 // DefaultBinaryHashMaxBytes is default value for BinaryHashMaxSizeBytes.
 const DefaultBinaryHashMaxBytes = 1 << 30 // 1GiB
+
+// TestBinaryHashMaxBytes is a more suitable value for BinaryHashMaxSizeBytes
+// in tests. Reading `/proc/<pid>/exe` relies on inode stability, and in GitHub
+// Actions we've observed read stalls likely caused by overlayfs or debugfs.
+const TestBinaryHashMaxBytes = 1 << 12 // 4KiB
+
+// BinaryHashReadTimeout is the maximum amount of time we will wait to read
+// a process's executable to calculate its checksum. In normal circumstances
+// we should never reach this timeout, but reading `/proc/<pid>/exe` depends
+// on inode stability, so it's possible to encounter read stalls if there is
+// a network or overlay filesystem involved.
+const BinaryHashReadTimeout = 15 * time.Second
 
 // UnixAttestorConfig holds the configuration for the Unix workload attestor.
 type UnixAttestorConfig struct {
@@ -156,13 +169,35 @@ func (a *UnixAttestor) Attest(ctx context.Context, pid int) (*workloadidentityv1
 	}
 	defer func() { _ = exe.Close() }()
 
-	hash := sha256.New()
-	if _, err := copyAtMost(hash, exe, a.cfg.BinaryHashMaxSizeBytes); err != nil {
-		a.log.ErrorContext(ctx, "Failed to hash workload executable", "error", err)
-		return att, nil
+	// Read the workload executable to calculate a checksum. We do this in a
+	// goroutine in case of read stalls (e.g. due to the executable being on
+	// a network or overlay filesystem). If this happens, the goroutine will
+	// terminate when we close the file descriptor (see defer statement above).
+	type sumResult struct {
+		sum string
+		err error
 	}
-	sum := hex.EncodeToString(hash.Sum(nil))
-	att.BinaryHash = &sum
+	resCh := make(chan sumResult, 1)
+	go func() {
+		hash := sha256.New()
+		if _, err := copyAtMost(hash, exe, a.cfg.BinaryHashMaxSizeBytes); err == nil {
+			resCh <- sumResult{sum: hex.EncodeToString(hash.Sum(nil))}
+		} else {
+			resCh <- sumResult{err: err}
+		}
+	}()
+
+	select {
+	case res := <-resCh:
+		if res.err == nil {
+			att.BinaryHash = &res.sum
+		} else {
+			a.log.ErrorContext(ctx, "Failed to hash workload executable", "error", err)
+		}
+	case <-time.After(BinaryHashReadTimeout):
+		a.log.ErrorContext(ctx, "Timeout reading workload executable. If this happens frequently, it could be due to the workload executable being on a network or overlay filesystem, you may also consider lowering `attestors.unix.binary_hash_max_size_bytes`.")
+	case <-ctx.Done():
+	}
 
 	return att, nil
 }


### PR DESCRIPTION
The `workload-identity-api` and `spiffe-workload-api` tests frequently fail the Flake Detector by timing out after 10 minutes.

On taking a look at the logs, the following stacktrace stood out to me:

```
2025-10-28T12:42:46.4097768Z goroutine 9965029 [runnable]:
2025-10-28T12:42:46.4097973Z internal/poll.(*FD).Read(0xc0333a8cc0, {0xc029ff0000, 0x8000, 0x8000})

...

github.com/gravitational/teleport/lib/tbot/workloadidentity/workloadattest.copyAtMost({0x7fe928bbdbf0, 0xc09d285900}, {0x1ade5660, 0xc011dfecf0}, 0x40000000)
2025-10-28T12:42:46.4100772Z 	/__w/teleport/teleport/lib/tbot/workloadidentity/workloadattest/unix.go:178 +0x8f
```

Which is the codepath that reads a workload's executable using the `/proc/<pid>/exe` symlink in order to attest its SHA256 checksum. This symlink is special in that it points to an *inode* rather than a regular path, so that if you replace the executable (e.g. during a rolling deploy) it will still point to the *original* file.

My current theory is that the combination of overlayfs, debugfs, and any other layers of indirection in our GitHub Actions environment break inode stability causing reads to stall indefinitely. Lowering `binary_hash_max_size_bytes` and therefore the number of reads we perform seems to fix this!

I think it's unlikely we would see this in a real production deployment (due to the odd filesystem shenanigans required), but as it's not impossible, I've added a 15 second timeout to the read.
