### PR TITLE
[v17] Fix slack plugin crashing if access lists feature is not supported

### DIFF
--- a/integrations/access/accesslist/app.go
+++ b/integrations/access/accesslist/app.go
@@ -130,6 +130,12 @@ func (a *App) run(ctx context.Context) error {
 		select {
 		case <-timer.Chan():
 			if err := a.remindIfNecessary(ctx); err != nil {
+				// if the call returns NotImplemented, gracefully end the access list app,
+				// as we may be communicating with an OSS server, which does not support access lists.
+				if trace.IsNotImplemented(err) {
+					log.Warnf("Slack plugin is connected to an auth server that does not support access lists. Access list reminders will be disabled")
+					return nil
+				}
 				return trace.Wrap(err)
 			}
 			timer.Reset(jitter(reminderInterval))
@@ -156,7 +162,7 @@ func (a *App) remindIfNecessary(ctx context.Context) error {
 		accessLists, nextToken, err = a.apiClient.ListAccessLists(ctx, 0 /* default page size */, nextToken)
 		if err != nil {
 			if trace.IsNotImplemented(err) {
-				log.Errorf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
+				log.Warnf("access list endpoint is not implemented on this auth server, so the access list app is ceasing to run.")
 				return trace.Wrap(err)
 			} else if trace.IsAccessDenied(err) {
 				log.Warnf("Slack bot does not have permissions to list access lists. Please add access_list read and list permissions " +

--- a/integrations/access/accesslist/app_test.go
+++ b/integrations/access/accesslist/app_test.go
@@ -358,6 +358,54 @@ func TestAccessListReminders_BadClient(t *testing.T) {
 	}
 }
 
+// TestAccessListReminders_NotImplemented does not return error (crash) if ListAccessLists is not supported.
+func TestAccessListReminders_NotImplemented(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	server := newTestAuth(t)
+	as := server.Auth()
+	t.Cleanup(func() {
+		require.NoError(t, as.Close())
+	})
+
+	// Use this mock client so that we can force ListAccessLists to return an error.
+	// The error we force is NotImplemented, which should not cause the app to crash.
+	client := &mockClient{
+		Client: as,
+	}
+	client.On("ListAccessLists", mock.Anything, mock.Anything, mock.Anything).Return(([]*accesslist.AccessList)(nil), "", trace.NotImplemented("error"))
+
+	bot := &mockMessagingBot{
+		recipients: map[string]*common.Recipient{
+			"owner1": {Name: "owner1"},
+			"owner2": {Name: "owner2"},
+		},
+	}
+	app := common.NewApp(&mockPluginConfig{client: client, bot: bot}, "test-plugin")
+	app.Clock = clock
+	ctx := context.Background()
+
+	go func() {
+		app.Run(ctx)
+	}()
+
+	ready, err := app.WaitReady(ctx)
+	require.NoError(t, err)
+	require.True(t, ready)
+
+	clock.BlockUntil(1)
+	clock.Advance(3 * time.Hour)
+
+	// ensure ListAccessLists was called only once, and app returns no error on termination
+	app.Terminate()
+	<-app.Done()
+	require.NoError(t, app.Err())
+
+	client.AssertNumberOfCalls(t, "ListAccessLists", 1)
+}
+
 func advanceAndLookForRecipients(t *testing.T,
 	bot *mockMessagingBot,
 	alSvc services.AccessLists,


### PR DESCRIPTION
Backport #60486 to branch/v17

changelog: Slack access plugin no longer crashes in the event access list is unsupported