### PR TITLE
[v18] Remove `KindInstaller` from the `ForProxy` cache

### DIFF
--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -257,7 +257,6 @@ func ForProxy(cfg Config) Config {
 		{Kind: types.KindWindowsDesktop},
 		{Kind: types.KindDynamicWindowsDesktop},
 		{Kind: types.KindKubeServer},
-		{Kind: types.KindInstaller},
 		{Kind: types.KindKubernetesCluster},
 		{Kind: types.KindSAMLIdPServiceProvider},
 		{Kind: types.KindUserGroup},

--- a/lib/cache/installer_test.go
+++ b/lib/cache/installer_test.go
@@ -26,7 +26,7 @@ import (
 func TestInstallers(t *testing.T) {
 	t.Parallel()
 
-	p := newTestPack(t, ForProxy)
+	p := newTestPack(t, ForAuth)
 	t.Cleanup(p.Close)
 
 	testResources(t, p, testFuncs[types.Installer]{


### PR DESCRIPTION
Backport #60487 to branch/v18