### PR TITLE
docs: Azure Machine ID tbot deployment guide: add output verification steps

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure.mdx
@@ -137,19 +137,20 @@ instance successfully joined the cluster and is issuing credentials.
 Run the following command on the Azure VM:
 
 ```code
-$ sudo tbot status
+$ tsh --proxy example.teleport.sh:443 -i /opt/machine-id/identity status
 ```
 
 If tbot is running correctly, you’ll see output similar to:
 
 ```code
-
-BOT STATUS
-Joined via: azure
-Auth server: example.teleport.sh:443
-Last renewal: 2025-03-10T15:05:22Z
-Next renewal: 2025-03-10T16:05:22Z
-Certificate destination: /var/lib/tbot/destinations/default
+> Profile URL:        https://example.teleport.sh:443
+  Logged in as:       bot-example
+  Cluster:            example.teleport.sh
+  Roles:              access, auditor, breakglass
+  Logins:             root, ubuntu, ec2-user, breakglass, mmcallister, device-admin, device-enroll, editor
+  Kubernetes:         disabled
+  Valid until:        2025-11-20 22:02:39 -0800 PST [valid for 12h0m0s]
+  Extensions:         bot-instance-id@goteleport.com, bot-name@goteleport.com, disallow-reissue, impersonator, login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy
 ```
 
 To further confirm that credentials are valid, list the generated identity files:
@@ -164,13 +165,13 @@ your workloads can use to authenticate through Teleport.
 If you’re using Workload Identity or SPIFFE, you can also run `spiffe-inspect` and see similar output:
 
 ```code
-$ tbot spiffe-inspect
+$ tbot spiffe-inspect --path=PATH
 
 INFO [TBOT] Inspecting SPIFFE Workload API Endpoint unix:///opt/machine-id/workload.sock
 INFO [TBOT] Received X.509 SVID context from Workload API bundles_count:1 svids_count:1
 SVIDS
 - spiffe://example.teleport.sh/svc/foo
-  - Expiry: 2025-03-20 10:55:52 +0000 UTC
+  - Expiry: 2025-11-20 18:05:10 -0800 PST
 Trust Bundles
 - example.teleport.sh
 ```

--- a/docs/pages/machine-workload-identity/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure.mdx
@@ -146,8 +146,8 @@ If tbot is running correctly, you’ll see output similar to:
 > Profile URL:        https://example.teleport.sh:443
   Logged in as:       bot-example
   Cluster:            example.teleport.sh
-  Roles:              access, auditor, breakglass
-  Logins:             root, ubuntu, ec2-user, breakglass, mmcallister, device-admin, device-enroll, editor
+  Roles:              access, auditor, read
+  Logins:             root, ubuntu, ec2-user, device-admin, device-enroll, editor
   Kubernetes:         disabled
   Valid until:        2025-11-20 22:02:39 -0800 PST [valid for 12h0m0s]
   Extensions:         bot-instance-id@goteleport.com, bot-name@goteleport.com, disallow-reissue, impersonator, login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

--- a/docs/pages/machine-workload-identity/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure.mdx
@@ -37,7 +37,7 @@ occur without the use of a long-lived secret.
 - An Azure VM you wish to install Machine & Workload Identity onto with the
   managed identity configured as a user-assigned managed identity.
 
-## Step 1/5. Install `tbot`
+## Step 1/6. Install `tbot`
 
 **This step is completed on the Azure VM.**
 
@@ -48,13 +48,13 @@ Download and install the appropriate Teleport package for your platform:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 2/5. Create a Bot
+## Step 2/6. Create a Bot
 
 **This step is completed on your local machine.**
 
 (!docs/pages/includes/machine-id/create-a-bot.mdx!)
 
-## Step 3/5. Create a join token
+## Step 3/6. Create a join token
 
 **This step is completed on your local machine.**
 
@@ -95,7 +95,7 @@ Use `tctl` to apply this file:
 $ tctl create -f bot-token.yaml
 ```
 
-## Step 4/5. Configure `tbot`
+## Step 4/6. Configure `tbot`
 
 **This step is completed on the Azure VM.**
 
@@ -125,7 +125,7 @@ Replace:
 
 (!docs/pages/includes/machine-id/daemon-or-oneshot.mdx!)
 
-## Step 5/5. Configure services
+## Step 5/6. Configure services
 
 (!docs/pages/includes/machine-id/configure-services.mdx!)
 

--- a/docs/pages/machine-workload-identity/deployment/azure.mdx
+++ b/docs/pages/machine-workload-identity/deployment/azure.mdx
@@ -129,6 +129,55 @@ Replace:
 
 (!docs/pages/includes/machine-id/configure-services.mdx!)
 
+## Step 6/6. Verify that tbot is running correctly
+
+nce the configuration file and services are in place, verify that your tbot
+instance successfully joined the cluster and is issuing credentials.
+
+Run the following command on the Azure VM:
+
+```code
+$ sudo tbot status
+```
+
+If tbot is running correctly, you’ll see output similar to:
+
+```code
+
+BOT STATUS
+Joined via: azure
+Auth server: example.teleport.sh:443
+Last renewal: 2025-03-10T15:05:22Z
+Next renewal: 2025-03-10T16:05:22Z
+Certificate destination: /var/lib/tbot/destinations/default
+```
+
+To further confirm that credentials are valid, list the generated identity files:
+
+```code
+$ ls /var/lib/tbot/destinations/default
+```
+
+You should see key and certificate files (`key`, `cert`, and `ca.pem`) that
+your workloads can use to authenticate through Teleport.
+
+If you’re using Workload Identity or SPIFFE, you can also run `spiffe-inspect` and see similar output:
+
+```code
+$ tbot spiffe-inspect
+
+INFO [TBOT] Inspecting SPIFFE Workload API Endpoint unix:///opt/machine-id/workload.sock
+INFO [TBOT] Received X.509 SVID context from Workload API bundles_count:1 svids_count:1
+SVIDS
+- spiffe://example.teleport.sh/svc/foo
+  - Expiry: 2025-03-20 10:55:52 +0000 UTC
+Trust Bundles
+- example.teleport.sh
+```
+
+This confirms that your bot successfully authenticated using Azure managed
+identity and can issue short-lived credentials for your workloads.
+
 ## Next steps
 
 - Follow the [access guides](../access-guides/access-guides.mdx) to finish configuring `tbot` for


### PR DESCRIPTION
This is to address a quarterly Doc's goal to ensure that all Machine-ID deployment guides include examples for output to confirm the previous steps have been successful 