### PR TITLE
Web: hide access graph preview error if attempting again

### DIFF
--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -57,13 +57,15 @@ export function PolicyPlaceholder({
   roleDiffProps?: RoleDiffProps;
 }) {
   const theme = useTheme();
+  const waitingForSync =
+    roleDiffProps?.roleDiffState === RoleDiffState.WaitingForSync;
   const loading =
     roleDiffProps?.roleDiffState === RoleDiffState.LoadingSettings ||
-    roleDiffProps?.roleDiffState === RoleDiffState.WaitingForSync;
+    waitingForSync;
 
   return (
     <Box maxWidth={promoImageWidth + 2 * 2} minWidth={300}>
-      {roleDiffProps?.roleDiffErrorMessage && (
+      {roleDiffProps?.roleDiffErrorMessage && !waitingForSync && (
         <Alert>{roleDiffProps.roleDiffErrorMessage}</Alert>
       )}
       <H1 mb={2}>{FeatureName.IdentitySecurity} saves you from mistakes.</H1>


### PR DESCRIPTION
This just hides error messages while re-attempting to preview access graph. [useAsync](https://github.com/gravitational/teleport/blob/ada75723a719b8b4bd5b5e08e94922716fe33c96/web/packages/shared/hooks/useAsync.ts#L99) preserves error messages even on re-attempts.