### PR TITLE
test: add `require.Eventually` to fix flaky `TestPortForwardProxy_run_connsClosed`

### DIFF
--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -454,7 +454,9 @@ func TestPortForwardProxy_run_connsClosed(t *testing.T) {
 		}
 	}, 5*time.Second, 100*time.Millisecond, "streams werent properly removed from targetConn")
 
-	require.True(t, sourceConn.streamsClosed(), "sourceConn streams not closed")
+	require.Eventually(t, func() bool {
+		return sourceConn.streamsClosed()
+	}, 5*time.Second, 100*time.Millisecond, "sourceConn streams not closed")
 	require.True(t, targetConn.streamsClosed(), "targetConn streams not closed")
 }
 


### PR DESCRIPTION
#### Which issue(s) does the PR fix:
Fixes [#60157](https://github.com/gravitational/teleport/issues/60157)
### Problem
The test `TestPortForwardProxy_run_connsClosed` is flaky due to a race condition between two goroutines competing for the `f.mu` lock on the `fakeSPDYConnection` (`sourceConn`):
1. After `h.run()` returns, the main test function calls `sourceConn.streamsClosed()` to check if the streams are cleaned up.
2. Inside `h.run()`, a new goroutine `h.monitorStreamPair(p)` triggers `removeStreamPair()`, which calls `sourceConn.RemoveStreams()` to acquire the lock to clean the streams.

The test failed when the main test function acquires the lock to check that the streams are cleaned up before calling `sourceConn.RemoveStreams()`.

### Solution
Replace `require.True()` with `require.Eventually`.
This solution works because `require.Eventually` will give `RemoveStreams()` enough time to clean up the sourceConn by calling sourceConn.streamsClosed() every 100ms within 5 seconds.

### Verification
The test now correctly and consistently passes on my local machine after running it 10000 times using a loop to simulate the flaky behavior within 7 seconds. 
```bash
go test -v -race ./lib/kube/proxy -run ^TestPortForwardProxy_run_connsClosed$ -count=10000
```