### PR TITLE
Fix Kubernetes load balancing GOAWAY errors by buffering request body

### DIFF
--- a/lib/httplib/reverseproxy/reverse_proxy.go
+++ b/lib/httplib/reverseproxy/reverse_proxy.go
@@ -257,6 +257,7 @@ func (r *roundTripperWithLogger) RoundTrip(req *http.Request) (*http.Response, e
 			slog.Any("url", logutils.StringerAttr(req.URL)),
 			slog.Int("code", rsp.StatusCode),
 			slog.Duration("duration", time.Now().UTC().Sub(start)),
+			slog.String("response_proto", rsp.Proto),
 			slog.Group("tls",
 				"version", req.TLS.Version,
 				"resume", req.TLS.DidResume,
@@ -270,6 +271,7 @@ func (r *roundTripperWithLogger) RoundTrip(req *http.Request) (*http.Response, e
 			"url", logutils.StringerAttr(req.URL),
 			"code", rsp.StatusCode,
 			"duration", time.Now().UTC().Sub(start),
+			"response_proto", rsp.Proto,
 		)
 	}
 

--- a/lib/kube/proxy/transport_retryable.go
+++ b/lib/kube/proxy/transport_retryable.go
@@ -1,0 +1,350 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	// envRetryBufferTotal is the environment variable for RetryBufferTotal.
+	envRetryBufferTotal = "TELEPORT_UNSTABLE_KUBE_RETRY_BUFFER_TOTAL"
+	// envRetryBufferPerRequest is the environment variable for RetryBufferPerRequest.
+	envRetryBufferPerRequest = "TELEPORT_UNSTABLE_KUBE_RETRY_BUFFER_PER_REQ"
+	// defaultRetryBufferTotal is the 500 MiB default value for RetryBufferTotal.
+	defaultRetryBufferTotal = int64(500 * 1024 * 1024)
+	// defaultRetryBufferPerRequest is the 50 MiB default value for RetryBufferPerRequest.
+	defaultRetryBufferPerRequest = int64(50 * 1024 * 1024)
+)
+
+// retryableTransport wraps an http.RoundTripper to enable automatic retry
+// on HTTP/2 GOAWAY frames by buffering request bodies in memory.
+//
+// Kubernetes API servers send GOAWAY on HTTP/2 connections to redistribute
+// load across replicas. Go's http2.Transport automatically retries if
+// req.GetBody is set.
+//
+// A global semaphore limits total buffered memory to 500 MiB across all
+// concurrent requests, preventing OOM. Individual requests have a maximum
+// body size of 50 MiB. Requests are blocked if required memory cannot be
+// acquired from the semaphore. These limits are tunable with environment
+// variables.
+//
+// Requests that are not retried are:
+// 1. HTTP/1.1 protocol upgrades (exec/attach/portforward), which won't
+// receive an HTTP/2.0 GOAWAY.
+// 2. Requests with unknown body sizes, used with chunked encoding,
+// cannot safely acquire the semaphore.
+type retryableTransport struct {
+	inner               http.RoundTripper
+	log                 *slog.Logger
+	semaphore           *semaphore.Weighted
+	maxBufferPerRequest int64
+}
+
+// newRetryableTransport enables automatic retry during HTTP/2 GOAWAY
+// load balancing.
+//
+// Intended to wrap transports created via newH2Transport() or equivalent
+// HTTP/2-configured transports. Wrapping non-HTTP/2 transports would add
+// unnecessary buffering.
+func newRetryableTransport(inner http.RoundTripper, log *slog.Logger, semaphore *semaphore.Weighted, maxBufferPerRequest int64) *retryableTransport {
+	return &retryableTransport{
+		inner:               inner,
+		log:                 log,
+		semaphore:           semaphore,
+		maxBufferPerRequest: maxBufferPerRequest,
+	}
+}
+
+// RoundTrip implements http.RoundTripper and makes requests retryable.
+func (rt *retryableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Detect HTTP/1.1 protocol upgrades that won't receive HTTP/2 GOAWAY.
+	if rt.isUpgrade(req) {
+		// Perform roundtrip, no retry necessary.
+		return rt.inner.RoundTrip(req)
+	}
+
+	if req.Body == nil || req.Body == http.NoBody || req.GetBody != nil {
+		// Perform roundtrip, retry available.
+		return rt.inner.RoundTrip(req)
+	}
+
+	// Buffer body to make retryable.
+	releaseSemaphore := rt.makeRetryable(req)
+
+	// Release semaphore after roundtrip completes.
+	defer releaseSemaphore()
+
+	// Perform roundtrip, retry available.
+	return rt.inner.RoundTrip(req)
+}
+
+// makeRetryable buffers the request body to enable retry on HTTP/2 GOAWAY.
+func (rt *retryableTransport) makeRetryable(req *http.Request) func() {
+	// Chunked request are not retried due to unknown size.
+	if req.ContentLength < 0 {
+		rt.log.DebugContext(req.Context(),
+			"Skipping retry buffer due to unknown content length, request will not be retryable on GOAWAY",
+			"method", req.Method,
+			"path", req.URL.Path,
+		)
+		return func() {}
+	}
+
+	// Skip zero-length bodies.
+	if req.ContentLength == 0 {
+		return func() {}
+	}
+
+	// Request body is too large to retry.
+	// Allows balanced use of memory budget across requests.
+	if req.ContentLength > rt.maxBufferPerRequest {
+		rt.log.InfoContext(req.Context(),
+			"Request body too large for retry buffer, request will not be retryable on GOAWAY",
+			"size", req.ContentLength,
+			"limit", rt.maxBufferPerRequest,
+			"method", req.Method,
+			"path", req.URL.Path,
+		)
+		return func() {}
+	}
+
+	// Acquire memory, blocks if unavailable.
+	if err := rt.semaphore.Acquire(req.Context(), req.ContentLength); err != nil {
+		if !errors.Is(err, context.Canceled) {
+			rt.log.DebugContext(req.Context(),
+				"Unable to acquire retry buffer, request will not be retryable on GOAWAY",
+				"size", req.ContentLength,
+				"error", err,
+			)
+		}
+		return func() {}
+	}
+
+	rb := newRetryBuffer(
+		req.Body,
+		rt.semaphore,
+		req.ContentLength,
+	)
+	req.Body = rb
+	req.GetBody = func() (io.ReadCloser, error) {
+		return rb.getBody()
+	}
+
+	releaseSemaphore := func() {
+		if err := rb.Close(); err != nil {
+			rt.log.DebugContext(req.Context(),
+				"Unable to close request body",
+				"size", req.ContentLength,
+				"method", req.Method,
+				"path", req.URL.Path,
+				"error", err,
+			)
+		}
+		// Note: Semaphore is not released here. It will be released by the
+		// finalizer when rb is garbage collected, ensuring accurate memory
+		// accounting. The buffer remains allocated until garbage is collected.
+	}
+	return releaseSemaphore
+}
+
+// isUpgrade detects HTTP/1.1 protocol upgrades (WebSocket, SPDY) that won't
+// receive HTTP/2 GOAWAY frames.
+//
+// We cannot check req.Proto to detect HTTP/2 because modifyRequest() sets it
+// to "HTTP/1.1" for all outgoing requests. Instead, we rely on the fact that
+// all transports wrapped by retryableTransport are created via newH2Transport(),
+// which configures HTTP/2. Requests without Upgrade headers will use HTTP/2 and
+// may receive GOAWAY.
+func (rt *retryableTransport) isUpgrade(req *http.Request) bool {
+	return req.Header.Get("Connection") == "Upgrade" ||
+		req.Header.Get("Upgrade") != "" ||
+		req.Header.Get("X-Stream-Protocol-Version") != ""
+}
+
+// CloseIdleConnections closes idle connections in the inner transport.
+func (rt *retryableTransport) CloseIdleConnections() {
+	if ci, ok := rt.inner.(interface{ CloseIdleConnections() }); ok {
+		ci.CloseIdleConnections()
+	}
+}
+
+// retryBuffer incrementally reads from a source, incrementally writes
+// to a buffer, and gracefully completes reading during any early call to Close.
+type retryBuffer struct {
+	src           io.ReadCloser
+	buf           *bytes.Buffer
+	mu            sync.Mutex
+	cond          sync.Cond
+	readErr       error
+	semaphore     *semaphore.Weighted
+	semaphoreSize int64
+}
+
+func newRetryBuffer(source io.ReadCloser, semaphore *semaphore.Weighted, memSize int64) *retryBuffer {
+	type limitedReadCloser struct {
+		*io.LimitedReader
+		io.Closer
+	}
+	rb := &retryBuffer{
+		// Limit reading in case actual body size is
+		// greater than presented ContentLength.
+		src: &limitedReadCloser{
+			LimitedReader: &io.LimitedReader{R: source, N: memSize},
+			Closer:        source,
+		},
+		buf:           bytes.NewBuffer(make([]byte, 0, memSize)),
+		semaphore:     semaphore,
+		semaphoreSize: memSize,
+	}
+	rb.cond.L = &rb.mu
+
+	// Release semaphore when buffer is garbage collected.
+	if semaphore != nil {
+		runtime.SetFinalizer(rb, func(rb *retryBuffer) {
+			rb.releaseSemaphore()
+		})
+	}
+
+	return rb
+}
+
+// releaseSemaphore is release only once.
+func (rb *retryBuffer) releaseSemaphore() {
+	if rb.semaphore != nil {
+		rb.semaphore.Release(rb.semaphoreSize)
+	}
+}
+
+func (rb *retryBuffer) Read(p []byte) (int, error) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	if rb.src == nil {
+		return 0, io.EOF
+	}
+
+	n, err := rb.src.Read(p)
+	if n > 0 {
+		rb.buf.Write(p[:n])
+	}
+	if err != nil && !errors.Is(err, io.EOF) && rb.readErr == nil {
+		rb.readErr = err
+		rb.cond.Broadcast()
+	}
+	return n, err
+}
+
+// Close completes buffering by reading any remaining data,
+// ensuring getBody() always has the complete buffer.
+func (rb *retryBuffer) Close() error {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	// Close is idempotent.
+	if rb.src == nil {
+		return nil
+	}
+
+	// If the connection closed in the middle of sending
+	// due to a GOAWAY, read remaining data for a retry attempt.
+	remaining, readErr := io.ReadAll(rb.src)
+	if readErr != nil && !errors.Is(readErr, io.EOF) && rb.readErr == nil {
+		rb.readErr = readErr
+	}
+	if len(remaining) > 0 {
+		rb.buf.Write(remaining)
+	}
+
+	// Close source and mark as done.
+	err := rb.src.Close()
+	rb.src = nil
+	rb.cond.Broadcast()
+
+	return err
+}
+
+// getBody waits for any reading to complete
+// before returning the buffered body.
+func (rb *retryBuffer) getBody() (io.ReadCloser, error) {
+	rb.mu.Lock()
+	defer rb.mu.Unlock()
+
+	// Wait for any remaining reading in Close to complete.
+	for rb.src != nil {
+		rb.cond.Wait()
+	}
+
+	// Return if there was any read error.
+	if rb.readErr != nil {
+		return nil, rb.readErr
+	}
+
+	return io.NopCloser(bytes.NewReader(rb.buf.Bytes())), nil
+}
+
+// GetRetryBufferTotal returns RetryBufferTotal and RetryBufferPerRequest
+// from an environment variable or default.
+func GetRetryBufferValues() (int64, int64, error) {
+	// Parse RetryBufferTotal.
+	retryBufferTotal := defaultRetryBufferTotal
+	if env := os.Getenv(envRetryBufferTotal); env != "" {
+		if val, err := strconv.ParseInt(env, 10, 64); err != nil {
+			return 0, 0, trace.WrapWithMessage(err, "unable to parse env var %s, got %q", defaultRetryBufferTotal, env)
+		} else {
+			// Allow RetryBufferTotal to be zero or negative.
+			// Zero or negative indicates RetryBuffer is disabled.
+			retryBufferTotal = val
+		}
+	}
+
+	// Parse RetryBufferPerRequest.
+	retryBufferPerRequest := defaultRetryBufferPerRequest
+	if env := os.Getenv(envRetryBufferPerRequest); env != "" {
+		if val, err := strconv.ParseInt(env, 10, 64); err != nil {
+			return 0, 0, trace.WrapWithMessage(err, "unable to parse env var %s, got %q", envRetryBufferPerRequest, env)
+		} else if val > 0 {
+			retryBufferPerRequest = val
+		}
+	}
+
+	// Check bounds.
+	if retryBufferTotal > 0 && retryBufferPerRequest > retryBufferTotal {
+		return 0, 0, trace.BadParameter(
+			"retry buffer per-request size (%d bytes) cannot exceed total buffer size (%d bytes)",
+			retryBufferPerRequest,
+			retryBufferTotal,
+		)
+	}
+
+	return retryBufferTotal, retryBufferPerRequest, nil
+}

--- a/lib/kube/proxy/transport_retryable_test.go
+++ b/lib/kube/proxy/transport_retryable_test.go
@@ -1,0 +1,846 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+)
+
+const (
+	testTotalLimit      = 50 * 1024
+	testPerRequestLimit = 10 * 1024
+	testSmallBody       = 16
+	testMediumBody      = 64
+	testLargeBody       = 8 * 1024
+)
+
+// TestRetryableTransport_GetBody validates retry mechanism buffer
+// completeness after partial reads, which simulates a GOAWAY mid-send.
+func TestRetryableTransport_GetBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		bodySize        int
+		partialRead     bool
+		expectRetryable bool
+	}{
+		{
+			name:            "full_read_medium",
+			bodySize:        testMediumBody,
+			partialRead:     false,
+			expectRetryable: true,
+		},
+		{
+			name:            "partial_read_medium",
+			bodySize:        testMediumBody,
+			partialRead:     true,
+			expectRetryable: true,
+		},
+		{
+			name:            "full_read_large",
+			bodySize:        testLargeBody,
+			partialRead:     false,
+			expectRetryable: true,
+		},
+		{
+			name:            "partial_read_large",
+			bodySize:        testLargeBody,
+			partialRead:     true,
+			expectRetryable: true,
+		},
+		{
+			name:            "exactly_at_limit",
+			bodySize:        testPerRequestLimit,
+			partialRead:     false,
+			expectRetryable: true,
+		},
+		{
+			name:            "over_limit_not_retryable",
+			bodySize:        testPerRequestLimit + 1,
+			partialRead:     false,
+			expectRetryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			originalBody := bytes.Repeat([]byte("x"), tt.bodySize)
+			rt := newRetryableTransport(
+				&mockTransport{},
+				slog.New(slog.DiscardHandler),
+				semaphore.NewWeighted(testTotalLimit),
+				testPerRequestLimit,
+			)
+
+			req, err := http.NewRequest("POST", "http://test",
+				io.NopCloser(bytes.NewReader(originalBody)))
+			require.NoError(t, err)
+			req.ContentLength = int64(tt.bodySize)
+
+			cleanup := rt.makeRetryable(req)
+			defer cleanup()
+
+			if tt.expectRetryable {
+				require.NotNil(t, req.GetBody, "GetBody must be set for retryable request")
+
+				if tt.partialRead {
+					// Simulate a GOAWAY mid-send: read half, then close it.
+					partial := make([]byte, tt.bodySize/2)
+					n, err := req.Body.Read(partial)
+					require.NoError(t, err)
+					require.Equal(t, tt.bodySize/2, n)
+				} else {
+					// Normal case reads everything.
+					_, err := io.ReadAll(req.Body)
+					require.NoError(t, err)
+				}
+
+				// Close completes buffering and reads any remaining data.
+				require.NoError(t, req.Body.Close())
+
+				// GetBody returns a complete buffer for retry.
+				retryBody, err := req.GetBody()
+				require.NoError(t, err)
+				retryData, err := io.ReadAll(retryBody)
+				require.NoError(t, err)
+				require.Equal(t, originalBody, retryData, "GetBody must return complete buffer")
+				require.NoError(t, retryBody.Close())
+
+				// Verify idempotent.
+				retryBody2, err := req.GetBody()
+				require.NoError(t, err)
+				retryData2, err := io.ReadAll(retryBody2)
+				require.NoError(t, err)
+				require.Equal(t, originalBody, retryData2, "GetBody must be idempotent")
+				require.NoError(t, retryBody2.Close())
+			} else {
+				// When the body is too large buffering is skipped.
+				require.Nil(t, req.GetBody, "GetBody should be nil for oversized body")
+			}
+		})
+	}
+}
+
+// TestRetryableTransport_SemaphoreAcquiredNotReleasedEarly verifies that
+// the semaphore is acquired during buffering and NOT released by cleanup().
+// The semaphore will be released by a finalizer when the buffer is GC'd,
+// but we cannot reliably test finalizer timing in unit tests.
+func TestRetryableTransport_SemaphoreAcquiredNotReleasedEarly(t *testing.T) {
+	t.Parallel()
+
+	sem := semaphore.NewWeighted(testMediumBody)
+	rt := newRetryableTransport(
+		&mockTransport{},
+		slog.New(slog.DiscardHandler),
+		sem,
+		testPerRequestLimit,
+	)
+
+	body := bytes.Repeat([]byte("x"), testMediumBody)
+	req, err := http.NewRequest("POST", "http://test",
+		io.NopCloser(bytes.NewReader(body)))
+	require.NoError(t, err)
+	req.ContentLength = testMediumBody
+
+	// Acquire semaphore.
+	cleanup := rt.makeRetryable(req)
+	require.False(t, sem.TryAcquire(1), "semaphore should be acquired")
+
+	// Read.
+	io.ReadAll(req.Body)
+	require.NoError(t, req.Body.Close())
+	require.False(t, sem.TryAcquire(1), "semaphore still held during use")
+
+	// Cleanup is not releasing memory..
+	cleanup()
+	require.False(t, sem.TryAcquire(1),
+		"semaphore is not released during cleanup")
+}
+
+// TestRetryableTransport_SemaphoreIsolation validates test isolation
+func TestRetryableTransport_SemaphoreIsolation(t *testing.T) {
+	t.Parallel()
+
+	sem1 := semaphore.NewWeighted(testMediumBody)
+	sem2 := semaphore.NewWeighted(testMediumBody)
+
+	rt1 := newRetryableTransport(&mockTransport{}, slog.New(slog.DiscardHandler), sem1, testPerRequestLimit)
+	rt2 := newRetryableTransport(&mockTransport{}, slog.New(slog.DiscardHandler), sem2, testPerRequestLimit)
+
+	// Exhaust rt1
+	body1 := bytes.Repeat([]byte("x"), testMediumBody)
+	req1, err := http.NewRequest("POST", "http://test", io.NopCloser(bytes.NewReader(body1)))
+	require.NoError(t, err)
+	req1.ContentLength = testMediumBody
+	cleanup1 := rt1.makeRetryable(req1)
+	defer cleanup1()
+
+	require.False(t, sem1.TryAcquire(1), "rt1 semaphore exhausted")
+	require.True(t, sem2.TryAcquire(testMediumBody), "rt2 semaphore available")
+	sem2.Release(testMediumBody)
+
+	// rt2 can still buffer
+	body2 := bytes.Repeat([]byte("y"), testMediumBody)
+	req2, err := http.NewRequest("POST", "http://test", io.NopCloser(bytes.NewReader(body2)))
+	require.NoError(t, err)
+	req2.ContentLength = testMediumBody
+	cleanup2 := rt2.makeRetryable(req2)
+	defer cleanup2()
+
+	require.NotNil(t, req2.GetBody, "rt2 should buffer despite rt1 exhaustion")
+}
+
+// TestRetryableTransport_SemaphoreContextCanceled validates context cancellation
+// during semaphore acquire.
+func TestRetryableTransport_SemaphoreContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	sem := semaphore.NewWeighted(testMediumBody)
+	rt := newRetryableTransport(
+		&mockTransport{},
+		slog.New(slog.DiscardHandler),
+		sem,
+		testPerRequestLimit,
+	)
+
+	// Exhaust semaphore
+	require.True(t, sem.TryAcquire(testMediumBody))
+	defer sem.Release(testMediumBody)
+
+	// Create request with pre-canceled context
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	body := bytes.Repeat([]byte("x"), testMediumBody)
+	req, err := http.NewRequestWithContext(ctx, "POST", "http://test",
+		io.NopCloser(bytes.NewReader(body)))
+	require.NoError(t, err)
+	req.ContentLength = testMediumBody
+
+	cleanup := rt.makeRetryable(req)
+	defer cleanup()
+
+	require.Nil(t, req.GetBody, "should skip buffering on context cancel")
+}
+
+// TestRetryableTransport_ZeroCopyPaths validates that requests which don't
+// require retry skip buffering and avoid unnecessary memory use.
+func TestRetryableTransport_ZeroCopyPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		setupReq       func() *http.Request
+		expectBuffered bool
+	}{
+		{
+			name: "nil_body",
+			setupReq: func() *http.Request {
+				req, err := http.NewRequest("GET", "http://test", nil)
+				require.NoError(t, err)
+				return req
+			},
+			expectBuffered: false,
+		},
+		{
+			name: "getbody_already_set",
+			setupReq: func() *http.Request {
+				body := bytes.NewReader([]byte("test"))
+				req, err := http.NewRequest("POST", "http://test", body)
+				require.NoError(t, err)
+				req.ContentLength = 4
+				req.GetBody = func() (io.ReadCloser, error) {
+					return io.NopCloser(bytes.NewReader([]byte("test"))), nil
+				}
+				return req
+			},
+			expectBuffered: false,
+		},
+		{
+			name: "upgrade_request",
+			setupReq: func() *http.Request {
+				body := bytes.NewReader([]byte("test"))
+				req, err := http.NewRequest("POST", "http://test", body)
+				require.NoError(t, err)
+				req.Header.Set("Connection", "Upgrade")
+				req.ContentLength = 4
+				return req
+			},
+			expectBuffered: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := newRetryableTransport(
+				&mockTransport{},
+				slog.New(slog.DiscardHandler),
+				semaphore.NewWeighted(1024),
+				1024,
+			)
+
+			req := tt.setupReq()
+			originalBody := req.Body
+
+			resp, err := rt.RoundTrip(req)
+			require.NoError(t, err)
+			if resp != nil {
+				require.NoError(t, resp.Body.Close())
+			}
+
+			if tt.expectBuffered {
+				require.NotEqual(t, originalBody, req.Body, "body should be wrapped")
+			} else {
+				require.Equal(t, originalBody, req.Body, "body should not be wrapped")
+			}
+		})
+	}
+}
+
+// TestRetryableTransport_SkipConditions validates requests that skip buffering.
+func TestRetryableTransport_SkipConditions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		contentLength  int64
+		expectBuffered bool
+	}{
+		{
+			"chunked_encoding",
+			-1,
+			false,
+		},
+		{
+			"zero_length",
+			0,
+			false,
+		},
+		{
+			"too_large",
+			testPerRequestLimit + 1,
+			false,
+		},
+		{
+			"exactly_at_limit",
+			testPerRequestLimit,
+			true,
+		},
+		{
+			"under_limit",
+			testPerRequestLimit - 1,
+			true,
+		},
+		{
+			"normal_size",
+			testSmallBody,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := newRetryableTransport(
+				&mockTransport{},
+				slog.New(slog.DiscardHandler),
+				semaphore.NewWeighted(testTotalLimit),
+				testPerRequestLimit,
+			)
+
+			body := bytes.Repeat([]byte("x"), testSmallBody)
+			req, err := http.NewRequest("POST", "http://test",
+				io.NopCloser(bytes.NewReader(body)))
+			require.NoError(t, err)
+			req.ContentLength = tt.contentLength
+
+			cleanup := rt.makeRetryable(req)
+			defer cleanup()
+
+			if tt.expectBuffered {
+				require.NotNil(t, req.GetBody, tt.name)
+			} else {
+				require.Nil(t, req.GetBody, tt.name)
+			}
+		})
+	}
+}
+
+// TestRetryableTransport_IsUpgrade validates protocol upgrade detection.
+func TestRetryableTransport_IsUpgrade(t *testing.T) {
+	t.Parallel()
+
+	rt := &retryableTransport{}
+
+	tests := []struct {
+		name      string
+		path      string
+		headers   map[string]string
+		isUpgrade bool
+	}{
+		{
+			name: "websocket",
+			headers: map[string]string{
+				"Upgrade":    "websocket",
+				"Connection": "Upgrade",
+			},
+			isUpgrade: true,
+		},
+		{
+			name: "spdy",
+			headers: map[string]string{
+				"Upgrade":    "SPDY/3.1",
+				"Connection": "Upgrade",
+			},
+			isUpgrade: true,
+		},
+		{
+			name: "x_stream_protocol",
+			headers: map[string]string{
+				"X-Stream-Protocol-Version": "v4.channel.k8s.io",
+			},
+			isUpgrade: true,
+		},
+		{
+			name:      "normal_request",
+			path:      "/api/v1/pods",
+			headers:   map[string]string{},
+			isUpgrade: false,
+		},
+		{
+			name:      "watch_not_upgrade",
+			path:      "/api/v1/pods?watch=true",
+			headers:   map[string]string{},
+			isUpgrade: false,
+		},
+		{
+			name:      "log_streaming_not_upgrade",
+			path:      "/api/v1/namespaces/default/pods/mypod/log?follow=true",
+			headers:   map[string]string{},
+			isUpgrade: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req, err := http.NewRequest("GET", "http://test"+tt.path, nil)
+			require.NoError(t, err)
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+			require.Equal(t, tt.isUpgrade, rt.isUpgrade(req))
+		})
+	}
+}
+
+// TestRetryableTransport_ErrorPropagation validates error handling.
+func TestRetryableTransport_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupBody func() io.ReadCloser
+		expectErr string
+	}{
+		{
+			name: "read_error",
+			setupBody: func() io.ReadCloser {
+				return io.NopCloser(&failingReader{
+					data:    bytes.Repeat([]byte("x"), testSmallBody),
+					failAt:  testSmallBody / 2,
+					failErr: errors.New("read error"),
+				})
+			},
+			expectErr: "read error",
+		},
+		{
+			name: "close_error_does_not_fail_getbody",
+			setupBody: func() io.ReadCloser {
+				return &errorCloser{
+					Reader:   bytes.NewReader(bytes.Repeat([]byte("x"), testSmallBody)),
+					closeErr: errors.New("close error"),
+				}
+			},
+			expectErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := newRetryableTransport(
+				&mockTransport{},
+				slog.New(slog.DiscardHandler),
+				semaphore.NewWeighted(testTotalLimit),
+				testPerRequestLimit,
+			)
+
+			req, err := http.NewRequest("POST", "http://test", tt.setupBody())
+			require.NoError(t, err)
+			req.ContentLength = testSmallBody
+
+			cleanup := rt.makeRetryable(req)
+			defer cleanup()
+
+			io.Copy(io.Discard, req.Body)
+			req.Body.Close()
+
+			body, err := req.GetBody()
+			if tt.expectErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErr)
+			} else {
+				require.NoError(t, err)
+				_, err := io.ReadAll(body)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestRetryBuffer_ConcurrentGetBody validates thread safety.
+func TestRetryBuffer_ConcurrentGetBody(t *testing.T) {
+	t.Parallel()
+
+	rb := newRetryBuffer(
+		io.NopCloser(bytes.NewReader([]byte("test"))),
+		nil,
+		4,
+	)
+
+	// Prime buffer
+	io.ReadAll(rb)
+	rb.Close()
+
+	// Multiple goroutines call GetBody concurrently
+	const N = 10
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for range N {
+		go func() {
+			defer wg.Done()
+			body, err := rb.getBody()
+			require.NoError(t, err)
+			data, err := io.ReadAll(body)
+			require.NoError(t, err)
+			require.Equal(t, []byte("test"), data)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestRetryBuffer_EnforcesLimit validates that the retryBuffer
+// doesn't read beyond the limit if the ContentLength is inaccurate.
+func TestRetryBuffer_EnforcesLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		sourceSize    int
+		contentLength int64
+		expectLen     int
+	}{
+		{
+			name:          "source_larger_than_content_length",
+			sourceSize:    200,
+			contentLength: 100,
+			expectLen:     100,
+		},
+		{
+			name:          "source_equals_content_length",
+			sourceSize:    100,
+			contentLength: 100,
+			expectLen:     100,
+		},
+		{
+			name:          "source_smaller_than_content_length",
+			sourceSize:    50,
+			contentLength: 100,
+			expectLen:     50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			source := io.NopCloser(bytes.NewReader(bytes.Repeat([]byte("x"), tt.sourceSize)))
+			rb := newRetryBuffer(source, nil, tt.contentLength)
+
+			// Read all
+			data, err := io.ReadAll(rb)
+			require.NoError(t, err)
+			require.Len(t, data, tt.expectLen)
+
+			// Close and get body
+			rb.Close()
+			body, err := rb.getBody()
+			require.NoError(t, err)
+
+			replay, err := io.ReadAll(body)
+			require.NoError(t, err)
+			require.Len(t, replay, tt.expectLen)
+		})
+	}
+}
+
+// TestRetryBuffer_CloseIdempotent validates Close can be called multiple times.
+func TestRetryBuffer_CloseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	rb := newRetryBuffer(
+		io.NopCloser(bytes.NewReader([]byte("test"))),
+		nil,
+		4,
+	)
+
+	require.NoError(t, rb.Close())
+	require.NoError(t, rb.Close())
+	require.NoError(t, rb.Close())
+
+	body, err := rb.getBody()
+	require.NoError(t, err)
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, []byte("test"), data)
+}
+
+func TestRetryBuffer_CompletesBufferingInClose(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("ABCDEFGHIJ")
+	rb := newRetryBuffer(io.NopCloser(bytes.NewReader(data)), nil, 10)
+
+	// Read partial
+	buf := make([]byte, 5)
+	n, err := rb.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+	require.Equal(t, []byte("ABCDE"), buf)
+
+	// Close completes buffering
+	require.NoError(t, rb.Close())
+
+	// GetBody returns complete buffer
+	body, err := rb.getBody()
+	require.NoError(t, err)
+	all, err := io.ReadAll(body)
+	require.NoError(t, err)
+	require.Equal(t, data, all)
+}
+
+func TestRetryBuffer_GetValues(t *testing.T) {
+	tests := []struct {
+		name              string
+		envTotal          string
+		envPerRequest     string
+		expectTotal       int64
+		expectPerRequest  int64
+		expectErrContains string
+	}{
+		{
+			name:             "defaults_when_no_env",
+			envTotal:         "",
+			envPerRequest:    "",
+			expectTotal:      defaultRetryBufferTotal,
+			expectPerRequest: defaultRetryBufferPerRequest,
+		},
+		{
+			name:             "custom_values_valid",
+			envTotal:         "1048576",
+			envPerRequest:    "524288",
+			expectTotal:      1048576,
+			expectPerRequest: 524288,
+		},
+		{
+			name:             "zero_total_disables_retry",
+			envTotal:         "0",
+			envPerRequest:    "1024",
+			expectTotal:      0,
+			expectPerRequest: 1024,
+		},
+		{
+			name:             "negative_total_disables_retry",
+			envTotal:         "-1",
+			envPerRequest:    "1024",
+			expectTotal:      -1,
+			expectPerRequest: 1024,
+		},
+		{
+			name:              "small_total_with_default_per_request_exceeds",
+			envTotal:          "1048576", // 1 MiB
+			envPerRequest:     "",        // Defaults to 50 MiB
+			expectErrContains: "per-request size (52428800 bytes) cannot exceed total buffer size (1048576 bytes)",
+		},
+		{
+			name:              "small_total_explicit_zero_per_request_exceeds",
+			envTotal:          "1048576", // 1 MiB
+			envPerRequest:     "0",       // Defaults to 50 MiB
+			expectErrContains: "per-request size (52428800 bytes) cannot exceed total buffer size (1048576 bytes)",
+		},
+		{
+			name:              "small_total_explicit_negative_per_request_exceeds",
+			envTotal:          "1048576", // 1 MiB
+			envPerRequest:     "-1",      // Defaults to 50 MiB
+			expectErrContains: "per-request size (52428800 bytes) cannot exceed total buffer size (1048576 bytes)",
+		},
+		{
+			name:              "invalid_total_returns_error",
+			envTotal:          "not-a-number",
+			envPerRequest:     "1024",
+			expectErrContains: "unable to parse env var",
+		},
+		{
+			name:              "invalid_per_request_returns_error",
+			envTotal:          "1048576",
+			envPerRequest:     "not-a-number",
+			expectErrContains: "unable to parse env var",
+		},
+		{
+			name:              "per_request_exceeds_total",
+			envTotal:          "1024",
+			envPerRequest:     "2048",
+			expectErrContains: "per-request size (2048 bytes) cannot exceed total buffer size (1024 bytes)",
+		},
+		{
+			name:             "per_request_equals_total",
+			envTotal:         "1024",
+			envPerRequest:    "1024",
+			expectTotal:      1024,
+			expectPerRequest: 1024,
+		},
+		{
+			name:             "very_large_values",
+			envTotal:         "10737418240", // 10 GiB
+			envPerRequest:    "1073741824",  // 1 GiB
+			expectTotal:      10737418240,
+			expectPerRequest: 1073741824,
+		},
+		{
+			name:              "only_small_total_set_errors",
+			envTotal:          "2097152", // 2 MiB < 50 MiB default
+			envPerRequest:     "",
+			expectErrContains: "per-request size (52428800 bytes) cannot exceed total buffer size (2097152 bytes)",
+		},
+		{
+			name:             "only_large_total_set_succeeds",
+			envTotal:         "524288000", // 500 MiB > 50 MiB default
+			envPerRequest:    "",
+			expectTotal:      524288000,
+			expectPerRequest: defaultRetryBufferPerRequest,
+		},
+		{
+			name:             "only_per_request_set",
+			envTotal:         "",
+			envPerRequest:    "2097152",
+			expectTotal:      defaultRetryBufferTotal,
+			expectPerRequest: 2097152,
+		},
+		{
+			name:             "both_unset_uses_defaults",
+			envTotal:         "",
+			envPerRequest:    "",
+			expectTotal:      defaultRetryBufferTotal,
+			expectPerRequest: defaultRetryBufferPerRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envTotal != "" {
+				t.Setenv(envRetryBufferTotal, tt.envTotal)
+			}
+			if tt.envPerRequest != "" {
+				t.Setenv(envRetryBufferPerRequest, tt.envPerRequest)
+			}
+
+			total, perRequest, err := GetRetryBufferValues()
+			if tt.expectErrContains != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectErrContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expectTotal, total, "total mismatch")
+			require.Equal(t, tt.expectPerRequest, perRequest, "per-request mismatch")
+		})
+	}
+}
+
+// Test helpers
+
+type mockTransport struct {
+	fn func(*http.Request) (*http.Response, error)
+}
+
+func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.fn != nil {
+		return m.fn(req)
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}, nil
+}
+
+type failingReader struct {
+	data    []byte
+	pos     int
+	failAt  int
+	failErr error
+}
+
+func (f *failingReader) Read(p []byte) (int, error) {
+	if f.pos >= f.failAt {
+		return 0, f.failErr
+	}
+	n := copy(p, f.data[f.pos:])
+	f.pos += n
+	if f.pos >= f.failAt {
+		return n, f.failErr
+	}
+	return n, nil
+}
+
+type errorCloser struct {
+	io.Reader
+	closeErr error
+}
+
+func (e *errorCloser) Close() error {
+	return e.closeErr
+}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -221,6 +221,12 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		return trace.Wrap(err)
 	}
 
+	// Get retry buffer configuration values.
+	retryBufferTotal, retryBufferPerRequest, err := kubeproxy.GetRetryBufferValues()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	var publicAddr string
 	if len(cfg.Kube.PublicAddrs) > 0 {
 		publicAddr = cfg.Kube.PublicAddrs[0].String()
@@ -246,6 +252,8 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
 			ClusterFeatures:               process.GetClusterFeatures,
+			RetryBufferTotal:              retryBufferTotal,
+			RetryBufferPerRequest:         retryBufferPerRequest,
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,


### PR DESCRIPTION
Kubernetes API servers send HTTP/2 GOAWAY errors to redistribute load across replicas for up to 2% of requests. Setting the request's `GetBody` function enables automatic retries.

For HTTP/2 requests, `GetBody` is set, and request bodies are incrementally buffered and accumulated as reads occur. In the case of GOAWAY errors occurring mid-send, body buffering is completed before closing. HTTP/1.1 protocol upgrades are not buffered, since they wouldn't receive HTTP/2 GOAWAY errors.

A weighted semaphore limits total concurrent buffering to prevent OOM. The default global memory limit is 500 MiB, and is adjusted with an environment variable. Each request body size is limited to a default of 50 MiB, and may be adjusted with an environment variable. 

In this PR:
- Added `retryableTransport` and `retryBuffer` enabling incremental request body buffering
- Added a weighted semaphore limiting total concurrent buffer size to 500 MiB by default
- Added a per-request buffer size limit with a 50 MiB default
- Added tunable parameters `RetryBufferTotal` and `RetryBufferPerRequest`
- Added environment variable `TELEPORT_UNSTABLE_KUBE_RETRY_BUFFER_TOTAL`
- Added environment variable `TELEPORT_UNSTABLE_KUBE_RETRY_BUFFER_PER_REQ`
- Added unit tests

Fixes:
- #57766

---
Changelog: Fixed intermittent connection errors when accessing Kubernetes clusters, particularly EKS 1.27+

---
### Manual Testing

A `test-load-balance` app was written to reproduce the load balancing `GOAWAY` errors with Kubernetes.

Three manual tests were run and compared.
1. Test run 1 ran directly to Kubernetes without Teleport. Load balancing `GOAWAY` errors were seen.
2. Test run 2 ran through Teleport without the bug fix. Load balancing `GOAWAY` errors were seen.
3. Test run 3 ran through Teleport with the bug fix applied. No load balancing `GOAWAY` errors were seen.

#### Test Runs

| Test Configuration  | Total Ops | Failed | GOAWAY | Error Rate |
|---------------------|-----------|--------|--------|------------|
| Direct K8s          | 1000      | 5      | 5      | 0.50%      |
| Teleport (no fix)   | 1000      | 6      | 6      | 0.60%      |
| Teleport (with fix) | 1000      | 0      | 0      | 0.00%      |



#### Latency Comparison

| Metric | Baseline | Without Fix | With Fix | Delta |
|--------|----------|-------------|----------|-------|
| p50    | 199.87ms | 199.81ms    | 199.78ms | -0.0% |
| p95    | 202.43ms | 203.07ms    | 202.77ms | -0.1% |
| p99    | 208.68ms | 206.76ms    | 205.99ms | -0.4% |

<details>
<summary>Test app</summary>

A `test-load-balance` app exercises Kubernetes operations to display load balancing `goaway-chance` errors. It records statistics for display and test comparison.

```go
package main

import (
	"bytes"
	"context"
	"encoding/json"
	"flag"
	"fmt"
	"net/http"
	"os"
	"path/filepath"
	"sort"
	"strings"
	"sync"
	"sync/atomic"
	"time"

	v1 "k8s.io/api/core/v1"
	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
	"k8s.io/client-go/kubernetes"
	"k8s.io/client-go/tools/clientcmd"
)

// TestResult captures load test metrics for GOAWAY error detection
type TestResult struct {
	TestName        string        `json:"test_name"`
	StartTime       time.Time     `json:"start_time"`
	EndTime         time.Time     `json:"end_time"`
	Duration        time.Duration `json:"duration"`
	TotalOperations int           `json:"total_operations"`
	SuccessfulOps   int           `json:"successful_ops"`
	FailedOps       int           `json:"failed_ops"`
	GoawayErrors    int           `json:"goaway_errors"`
	ErrorRate       float64       `json:"error_rate"`
	GoawayRate      float64       `json:"goaway_rate"`
	Workers         int           `json:"workers"`
	OpsPerWorker    int           `json:"ops_per_worker"`
	KubeContext     string        `json:"kube_context"`
	KubeVersion     string        `json:"kube_version"`
	APIServer       string        `json:"api_server"`
	LatencyP50      time.Duration `json:"latency_p50"`
	LatencyP95      time.Duration `json:"latency_p95"`
	LatencyP99      time.Duration `json:"latency_p99"`
	SampleErrors    []string      `json:"sample_errors,omitempty"`
}

func main() {
	if len(os.Args) < 2 {
		os.Args = append(os.Args, "run") // Default to 'run' command
	}

	switch os.Args[1] {
	case "run":
		runTest()
	case "compare":
		compareResults()
	case "help", "-h", "--help":
		printHelp()
	default:
		// Treat unknown command as 'run' with that arg as flag
		os.Args = append([]string{os.Args[0], "run"}, os.Args[1:]...)
		runTest()
	}
}

func printHelp() {
	fmt.Println(`test-load-balance - Kubernetes GOAWAY load testing tool

USAGE:
  test-load-balance run [flags]        Run a load test
  test-load-balance compare [flags]    Compare test results

RUN FLAGS:
  -name <string>           Test name (default: "test")
  -workers <int>           Concurrent workers (default: 20)
  -ops <int>              Operations per worker (default: 50)
  -namespace <string>      Kubernetes namespace (default: "teleport-test")
  -kubeconfig <string>     Path to kubeconfig
  -no-retry               Disable retry (exposes GOAWAY errors)
  -output <file.json>      Save results to JSON file
  -quiet                   Minimal output (progress only)

COMPARE FLAGS:
  -files <file1,file2,...> Comma-separated JSON result files
  -markdown                Output as markdown
  -summary                 Output summary table only

EXAMPLES:
  # Run test and save results
  test-load-balance run -name "baseline" -workers 10 -ops 100 -output baseline.json

  # Compare multiple results
  test-load-balance compare -files baseline.json,without-fix.json,with-fix.json -markdown

  # Generate summary table
  test-load-balance compare -files *.json -summary`)
}

func runTest() {
	fs := flag.NewFlagSet("run", flag.ExitOnError)
	var (
		workers      = fs.Int("workers", 20, "Number of concurrent workers")
		opsPerWorker = fs.Int("ops", 50, "Operations per worker")
		namespace    = fs.String("namespace", "teleport-test", "Kubernetes namespace")
		testName     = fs.String("name", "test", "Test run name")
		kubeconfig   = fs.String("kubeconfig", "", "Path to kubeconfig (default: $HOME/.kube/config)")
		noRetry      = fs.Bool("no-retry", false, "Disable automatic retry (exposes GOAWAY errors)")
		outputFile   = fs.String("output", "", "Save results to JSON file")
		quiet        = fs.Bool("quiet", false, "Minimal output")
	)
	fs.Parse(os.Args[2:])

	if *kubeconfig == "" {
		*kubeconfig = filepath.Join(os.Getenv("HOME"), ".kube", "config")
	}

	// Load kubeconfig
	config, err := clientcmd.LoadFromFile(*kubeconfig)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error loading kubeconfig: %v\n", err)
		os.Exit(1)
	}

	restConfig, err := clientcmd.NewDefaultClientConfig(*config, &clientcmd.ConfigOverrides{}).ClientConfig()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error creating client config: %v\n", err)
		os.Exit(1)
	}

	// Increase QPS to avoid rate limiting
	restConfig.QPS = 100
	restConfig.Burst = 200

	// Disable retry if requested
	if *noRetry {
		restConfig.Wrap(func(rt http.RoundTripper) http.RoundTripper {
			return &noRetryTransport{inner: rt}
		})
	}

	clientset, err := kubernetes.NewForConfig(restConfig)
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error creating clientset: %v\n", err)
		os.Exit(1)
	}

	// Get server version
	versionInfo, err := clientset.Discovery().ServerVersion()
	if err != nil {
		fmt.Fprintf(os.Stderr, "Error getting server version: %v\n", err)
		os.Exit(1)
	}

	currentContext := config.CurrentContext

	result := TestResult{
		TestName:        *testName,
		StartTime:       time.Now(),
		Workers:         *workers,
		OpsPerWorker:    *opsPerWorker,
		TotalOperations: *workers * *opsPerWorker,
		KubeContext:     currentContext,
		KubeVersion:     versionInfo.String(),
		APIServer:       restConfig.Host,
		SampleErrors:    make([]string, 0),
	}

	if !*quiet {
		fmt.Printf("=== Kubernetes GOAWAY Load Test ===\n")
		fmt.Printf("Test Name:     %s\n", result.TestName)
		fmt.Printf("Context:       %s\n", result.KubeContext)
		fmt.Printf("API Server:    %s\n", result.APIServer)
		fmt.Printf("K8s Version:   %s\n", result.KubeVersion)
		fmt.Printf("Namespace:     %s\n", *namespace)
		fmt.Printf("Workers:       %d\n", result.Workers)
		fmt.Printf("Ops/Worker:    %d\n", result.OpsPerWorker)
		fmt.Printf("Total Ops:     %d\n", result.TotalOperations)
		fmt.Printf("Retry Mode:    %s\n", map[bool]string{
			true:  "DISABLED (exposes GOAWAY)",
			false: "ENABLED (hides GOAWAY)",
		}[*noRetry])
		if *outputFile != "" {
			fmt.Printf("Output File:   %s\n", *outputFile)
		}
		fmt.Printf("Started:       %s\n\n", result.StartTime.Format(time.RFC3339))
	}

	// Counters and latency tracking
	var (
		successCount atomic.Int64
		errorCount   atomic.Int64
		goawayCount  atomic.Int64
		errorsMu     sync.Mutex
		latencies    []time.Duration
		latenciesMu  sync.Mutex
	)

	// Worker function
	worker := func(workerID int) {
		ctx := context.Background()
		for i := 0; i < *opsPerWorker; i++ {
			opStart := time.Now()
			cmName := fmt.Sprintf("test-cm-w%d-i%d-%d", workerID, i, time.Now().UnixNano())

			// Create ConfigMap with 1KB data
			cm := &v1.ConfigMap{
				ObjectMeta: metav1.ObjectMeta{
					Name:      cmName,
					Namespace: *namespace,
				},
				Data: map[string]string{
					"worker":    fmt.Sprintf("%d", workerID),
					"iteration": fmt.Sprintf("%d", i),
					"data":      string(bytes.Repeat([]byte("x"), 1024)),
				},
			}

			_, err := clientset.CoreV1().ConfigMaps(*namespace).Create(ctx, cm, metav1.CreateOptions{})
			if err != nil {
				errorCount.Add(1)
				if isGoawayError(err) {
					goawayCount.Add(1)
					errorsMu.Lock()
					if len(result.SampleErrors) < 10 {
						result.SampleErrors = append(result.SampleErrors, err.Error())
					}
					errorsMu.Unlock()
				}
				continue
			}

			// Delete ConfigMap
			err = clientset.CoreV1().ConfigMaps(*namespace).Delete(ctx, cmName, metav1.DeleteOptions{})
			if err != nil {
				errorCount.Add(1)
				if isGoawayError(err) {
					goawayCount.Add(1)
				}
			} else {
				successCount.Add(1)
				// Record latency only for successful operations
				opLatency := time.Since(opStart)
				latenciesMu.Lock()
				latencies = append(latencies, opLatency)
				latenciesMu.Unlock()
			}

			// Progress indicator
			if !*quiet && (successCount.Load()+errorCount.Load())%100 == 0 {
				fmt.Printf("Progress: %d/%d (errors: %d, GOAWAY: %d)\n",
					successCount.Load()+errorCount.Load(),
					result.TotalOperations,
					errorCount.Load(),
					goawayCount.Load())
			}
		}
	}

	// Run workers
	var wg sync.WaitGroup
	for w := 0; w < *workers; w++ {
		wg.Add(1)
		go func(id int) {
			defer wg.Done()
			worker(id)
		}(w)
	}
	wg.Wait()

	// Calculate latency percentiles
	if len(latencies) > 0 {
		sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
		result.LatencyP50 = latencies[len(latencies)*50/100]
		result.LatencyP95 = latencies[len(latencies)*95/100]
		result.LatencyP99 = latencies[len(latencies)*99/100]
	}

	// Finalize results
	result.EndTime = time.Now()
	result.Duration = result.EndTime.Sub(result.StartTime)
	result.SuccessfulOps = int(successCount.Load())
	result.FailedOps = int(errorCount.Load())
	result.GoawayErrors = int(goawayCount.Load())
	result.ErrorRate = float64(result.FailedOps) / float64(result.TotalOperations) * 100
	result.GoawayRate = float64(result.GoawayErrors) / float64(result.TotalOperations) * 100

	// Display results
	if !*quiet {
		fmt.Printf("\n=== Results ===\n")
		fmt.Printf("Completed:        %s\n", result.EndTime.Format(time.RFC3339))
		fmt.Printf("Duration:         %s\n", result.Duration)
		fmt.Printf("Total Operations: %d\n", result.TotalOperations)
		fmt.Printf("Successful:       %d\n", result.SuccessfulOps)
		fmt.Printf("Failed:           %d\n", result.FailedOps)
		fmt.Printf("GOAWAY Errors:    %d\n", result.GoawayErrors)
		fmt.Printf("Error Rate:       %.2f%%\n", result.ErrorRate)
		fmt.Printf("GOAWAY Rate:      %.2f%%\n", result.GoawayRate)

		if len(latencies) > 0 {
			fmt.Printf("\nLatency Percentiles:\n")
			fmt.Printf("  p50: %s\n", formatDuration(result.LatencyP50))
			fmt.Printf("  p95: %s\n", formatDuration(result.LatencyP95))
			fmt.Printf("  p99: %s\n", formatDuration(result.LatencyP99))
		}

		if len(result.SampleErrors) > 0 {
			fmt.Printf("\nSample Errors:\n")
			for i, err := range result.SampleErrors {
				fmt.Printf("  %d. %s\n", i+1, err)
			}
		}
	}

	// Save to JSON if requested
	if *outputFile != "" {
		if err := saveJSON(&result, *outputFile); err != nil {
			fmt.Fprintf(os.Stderr, "Error saving JSON: %v\n", err)
			os.Exit(1)
		}
		if !*quiet {
			fmt.Printf("\nResults saved to: %s\n", *outputFile)
		}
	}

	// Exit with error if operations failed
	if result.FailedOps > 0 {
		os.Exit(1)
	}
}

func compareResults() {
	fs := flag.NewFlagSet("compare", flag.ExitOnError)
	var (
		filesStr = fs.String("files", "", "Comma-separated list of JSON result files")
		markdown = fs.Bool("markdown", false, "Output as markdown")
		summary  = fs.Bool("summary", false, "Output summary table only")
	)
	fs.Parse(os.Args[2:])

	if *filesStr == "" {
		fmt.Fprintf(os.Stderr, "Error: -files flag is required\n")
		os.Exit(1)
	}

	// Parse file list
	files := strings.Split(*filesStr, ",")
	for i, f := range files {
		files[i] = strings.TrimSpace(f)
	}

	// Load all results
	results := make([]*TestResult, 0, len(files))
	for _, file := range files {
		result, err := loadJSON(file)
		if err != nil {
			fmt.Fprintf(os.Stderr, "Error loading %s: %v\n", file, err)
			os.Exit(1)
		}
		results = append(results, result)
	}

	if *markdown {
		generateMarkdown(results, *summary)
	} else {
		generateTextComparison(results)
	}
}

func generateMarkdown(results []*TestResult, summaryOnly bool) {
	// Summary table
	fmt.Println("| Test Configuration | Total Ops | Failed | GOAWAY | Error Rate | p50 | p95 | p99 |")
	fmt.Println("|-------------------|-----------|--------|--------|------------|-----|-----|-----|")
	for _, r := range results {
		fmt.Printf("| %s | %d | %d | %d | %.2f%% | %s | %s | %s |\n",
			r.TestName,
			r.TotalOperations,
			r.FailedOps,
			r.GoawayErrors,
			r.ErrorRate,
			formatDuration(r.LatencyP50),
			formatDuration(r.LatencyP95),
			formatDuration(r.LatencyP99))
	}

	if summaryOnly {
		return
	}

	// Key findings
	fmt.Println()
	fmt.Println("## Key Findings")
	fmt.Println()

	// Find baseline, without-fix, with-fix
	var baseline, withoutFix, withFix *TestResult
	for _, r := range results {
		name := strings.ToLower(r.TestName)
		if strings.Contains(name, "baseline") || strings.Contains(name, "direct") {
			baseline = r
		} else if strings.Contains(name, "without") || strings.Contains(name, "no fix") {
			withoutFix = r
		} else if strings.Contains(name, "with") {
			withFix = r
		}
	}

	// Generate findings
	if withoutFix != nil && withFix != nil {
		errorReduction := withoutFix.FailedOps - withFix.FailedOps
		fmt.Printf("1. **Problem Reproduced**: %d GOAWAY errors (%.2f%% rate)\n",
			withoutFix.GoawayErrors, withoutFix.GoawayRate)
		fmt.Printf("2. **Fix Validated**: Error rate reduced from %.2f%% to %.2f%%\n",
			withoutFix.ErrorRate, withFix.ErrorRate)
		fmt.Printf("3. **Error Elimination**: %d errors eliminated (100%% improvement)\n",
			errorReduction)

		if withoutFix.LatencyP99 > 0 && withFix.LatencyP99 > 0 {
			latencyDelta := float64(withFix.LatencyP99-withoutFix.LatencyP99) * 100 / float64(withoutFix.LatencyP99)
			fmt.Printf("4. **Latency Impact**: p99 increased by %.1f%% (%s)\n",
				latencyDelta,
				formatDuration(withFix.LatencyP99-withoutFix.LatencyP99))
		}
		fmt.Printf("5. **Consistency**: Tested with %d total operations\n",
			withFix.TotalOperations)
	}

	// Latency comparison
	if baseline != nil && withoutFix != nil && withFix != nil {
		fmt.Println()
		fmt.Println("### Latency Comparison")
		fmt.Println()
		fmt.Println("| Metric | Baseline | Without Fix | With Fix | Delta |")
		fmt.Println("|--------|----------|-------------|----------|-------|")

		for _, metric := range []struct {
			name string
			fn   func(*TestResult) time.Duration
		}{
			{"p50", func(r *TestResult) time.Duration { return r.LatencyP50 }},
			{"p95", func(r *TestResult) time.Duration { return r.LatencyP95 }},
			{"p99", func(r *TestResult) time.Duration { return r.LatencyP99 }},
		} {
			baseVal := metric.fn(baseline)
			withoutVal := metric.fn(withoutFix)
			withVal := metric.fn(withFix)
			delta := float64(withVal-withoutVal) * 100 / float64(withoutVal)

			fmt.Printf("| %s | %s | %s | %s | %+.1f%% |\n",
				metric.name,
				formatDuration(baseVal),
				formatDuration(withoutVal),
				formatDuration(withVal),
				delta)
		}
	}
}

func generateTextComparison(results []*TestResult) {
	fmt.Println("=== Test Comparison ===")
	fmt.Println()

	for _, r := range results {
		fmt.Printf("Test: %s\n", r.TestName)
		fmt.Printf("  Total Operations: %d\n", r.TotalOperations)
		fmt.Printf("  Failed:           %d\n", r.FailedOps)
		fmt.Printf("  GOAWAY Errors:    %d\n", r.GoawayErrors)
		fmt.Printf("  Error Rate:       %.2f%%\n", r.ErrorRate)
		fmt.Printf("  Latency p50:      %s\n", formatDuration(r.LatencyP50))
		fmt.Printf("  Latency p95:      %s\n", formatDuration(r.LatencyP95))
		fmt.Printf("  Latency p99:      %s\n", formatDuration(r.LatencyP99))
		fmt.Println()
	}
}

func saveJSON(result *TestResult, filename string) error {
	data, err := json.MarshalIndent(result, "", "  ")
	if err != nil {
		return err
	}
	return os.WriteFile(filename, data, 0644)
}

func loadJSON(filename string) (*TestResult, error) {
	data, err := os.ReadFile(filename)
	if err != nil {
		return nil, err
	}
	var result TestResult
	if err := json.Unmarshal(data, &result); err != nil {
		return nil, err
	}
	return &result, nil
}

// noRetryTransport wraps a RoundTripper and clears GetBody to prevent
// automatic retry on GOAWAY, exposing the raw error.
type noRetryTransport struct {
	inner http.RoundTripper
}

func (t *noRetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
	req.GetBody = nil
	return t.inner.RoundTrip(req)
}

func isGoawayError(err error) bool {
	if err == nil {
		return false
	}
	errStr := err.Error()
	return strings.Contains(errStr, "cannot retry") ||
		strings.Contains(errStr, "GOAWAY") ||
		strings.Contains(errStr, "graceful shutdown") ||
		strings.Contains(errStr, "http2: server sent GOAWAY") ||
		strings.Contains(errStr, "http2: Transport") ||
		strings.Contains(errStr, "Request.Body was written")
}

func formatDuration(d time.Duration) string {
	if d == 0 {
		return "N/A"
	}
	if d < time.Millisecond {
		return fmt.Sprintf("%.0fµs", float64(d.Microseconds()))
	}
	if d < time.Second {
		return fmt.Sprintf("%.2fms", float64(d.Microseconds())/1000.0)
	}
	return fmt.Sprintf("%.2fs", d.Seconds())
}
```

</details>

<details>
<summary>Kind config</summary>

A `kind` configuration file sets the load balancing `goaway-chance` to the maximum of 2%. The actual chance per request is randomized with the 2% being the maximum probability.

```yaml
# kind.yaml
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
name: load-balance
nodes:
  - role: control-plane
    kubeadmConfigPatches:
      - |
        kind: ClusterConfiguration
        apiServer:
          extraArgs:
            goaway-chance: "0.02"
            v: "4"
```

</details>


<details>
<summary>Teleport config</summary>

The Teleport config file used during testing.

```yaml
# teleport.yaml
version: v3
teleport:
  log:
    severity: DEBUG
  nodename: teleport
  diag_addr: "127.0.0.1:3000"

auth_service:
  enabled: true
  cluster_name: "teleport-laptop"
  listen_addr: 0.0.0.0:3025

proxy_service:
  enabled: true
  listen_addr: 0.0.0.0:3023
  web_listen_addr: 0.0.0.0:3080
  public_addr: localhost:3080
  kube_listen_addr: 0.0.0.0:3026
  kube_public_addr: localhost:3026
  https_keypairs:
    - cert_file: /Users/rana.ian/src/wrk/cfg/crt/_wildcard.teleport-laptop+4.pem
      key_file: /Users/rana.ian/src/wrk/cfg/crt/_wildcard.teleport-laptop+4-key.pem

ssh_service:
  enabled: false

kubernetes_service:
  enabled: true
  listen_addr: localhost:3027
  kubeconfig_file: /Users/rana.ian/.kube/config
```

</details>


<details>
<summary>Teleport role config</summary>

A Teleport role config file granting Kubernetes administrator permissions which enable the test app to run.

```yaml
# teleport-role-kube.yaml
kind: role
version: v8
metadata:
  name: kube-admin
spec:
  allow:
    # Match all Kubernetes clusters
    kubernetes_labels:
      "*": "*"

    # Map to Kubernetes RBAC
    kubernetes_groups:
      - system:masters   # K8s built-in admin group

    kubernetes_users:
      - rana.ian

    # What resources can be accessed at the Teleport level
    kubernetes_resources:
      - kind: "*"
        api_group: "*"
        namespace: "*"
        name: "*"
        verbs: ["*"]
      - kind: namespaces
        name: "*"
        verbs: ["*"]
```

</details>


<details>
<summary>Manual Testing</summary>

Environment: `Macos, Kind, Kubernetes v1.34.0`

### 1. Kind setup

The intent is to setup a local Kubernetes cluster with the load balancing option `--goaway-chance=0.02` turned on.

- [x] A new Kubernetes cluster was created using `kind` and the `kind.yaml` configuration file.

```zsh
> kind create cluster --config ~/src/wrk/cfg/kind.yaml
Creating cluster "load-balance" ...
 ✓ Ensuring node image (kindest/node:v1.34.0) 🖼
 ✓ Preparing nodes 📦
 ✓ Writing configuration 📜
 ✓ Starting control-plane 🕹️
 ✓ Installing CNI 🔌
 ✓ Installing StorageClass 💾
Set kubectl context to "kind-load-balance"
```

- [x] Validated that Kubernetes is running with the `--goaway-chance=0.02` flag.
```zsh
> docker exec load-balance-control-plane \
  ps aux | grep kube-apiserver | grep goaway-chance
root         552 10.6  3.2 1443096 263676 ?      Ssl  20:17   0:03 kube-apiserver --advertise-address=172.19.0.2 --allow-privileged=true --authorization-mode=Node,RBAC --client-ca-file=/etc/kubernetes/pki/ca.crt --enable-admission-plugins=NodeRestriction --enable-bootstrap-token-auth=true --etcd-cafile=/etc/kubernetes/pki/etcd/ca.crt --etcd-certfile=/etc/kubernetes/pki/apiserver-etcd-client.crt --etcd-keyfile=/etc/kubernetes/pki/apiserver-etcd-client.key --etcd-servers=https://127.0.0.1:2379 --goaway-chance=0.02 --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt --kubelet-client-key=/etc/kubernetes/pki/apiserver-kubelet-client.key --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname --proxy-client-cert-file=/etc/kubernetes/pki/front-proxy-client.crt --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key --requestheader-allowed-names=front-proxy-client --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt --requestheader-extra-headers-prefix=X-Remote-Extra- --requestheader-group-headers=X-Remote-Group --requestheader-username-headers=X-Remote-User --runtime-config= --secure-port=6443 --service-account-issuer=https://kubernetes.default.svc.cluster.local --service-account-key-file=/etc/kubernetes/pki/sa.pub --service-account-signing-key-file=/etc/kubernetes/pki/sa.key --service-cluster-ip-range=10.96.0.0/16 --tls-cert-file=/etc/kubernetes/pki/apiserver.crt --tls-private-key-file=/etc/kubernetes/pki/apiserver.key --v=4
```

- [x] Exercised a Kubernetes operation for smoke testing.
```zsh
> kubectl create namespace teleport-test
namespace/teleport-test created
```

### 2. Test run (no Teleport)

The intent is to see load balancing errors with the `test-load-balance` app and Kubernetes. This forms a baseline understanding that we can see `GOAWAY` load balancing errors without Teleport.

- [x] Ran the `test-load-balance` app. Load balancing `GOAWAY` errors are seen.
```zsh
> ./test-load-balance run -name "Direct K8s" -workers 10 -ops 100 -no-retry -output baseline.json
=== Kubernetes GOAWAY Load Test ===
Test Name:     Direct K8s
Context:       kind-load-balance
API Server:    https://127.0.0.1:63755
K8s Version:   v1.34.0
Namespace:     teleport-test
Workers:       10
Ops/Worker:    100
Total Ops:     1000
Retry Mode:    DISABLED (exposes GOAWAY)
Output File:   baseline.json
Started:       2025-11-02T12:20:29-08:00

Progress: 100/1000 (errors: 5, GOAWAY: 5)
Progress: 200/1000 (errors: 5, GOAWAY: 5)
Progress: 300/1000 (errors: 5, GOAWAY: 5)
Progress: 400/1000 (errors: 5, GOAWAY: 5)
Progress: 500/1000 (errors: 5, GOAWAY: 5)
Progress: 600/1000 (errors: 5, GOAWAY: 5)
Progress: 700/1000 (errors: 5, GOAWAY: 5)
Progress: 800/1000 (errors: 5, GOAWAY: 5)
Progress: 900/1000 (errors: 5, GOAWAY: 5)
Progress: 1000/1000 (errors: 5, GOAWAY: 5)

=== Results ===
Completed:        2025-11-02T12:20:47-08:00
Duration:         17.956518208s
Total Operations: 1000
Successful:       995
Failed:           5
GOAWAY Errors:    5
Error Rate:       0.50%
GOAWAY Rate:      0.50%

Latency Percentiles:
  p50: 199.87ms
  p95: 202.43ms
  p99: 208.68ms

Sample Errors:
  1. Post "https://127.0.0.1:63755/api/v1/namespaces/teleport-test/configmaps": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
  2. Post "https://127.0.0.1:63755/api/v1/namespaces/teleport-test/configmaps": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
  3. Post "https://127.0.0.1:63755/api/v1/namespaces/teleport-test/configmaps": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

### 3. Test run (Teleport, no fix)

The intent is to see load balancing errors through Teleport, without the bug fix. We'll compare this test run with a run with the bug fix.

- [x] Teleport backend database was deleted.
```zsh
sudo rm -rf /var/lib/teleport
sudo mkdir -p -m0700 /var/lib/teleport
sudo chown $USER /var/lib/teleport
```

- [x] Teleport was built and run with the latest `master` branch. No bug fix present.
```zsh
> git switch master
Already on 'master'
Your branch is up to date with 'origin/master'.

> make clean && make full
```

- [x] Teleport started with the `teleport.yaml` config file, and is configured with `auth + proxy + kube agent`.

- [x] Looking at the Teleport terminal output, Kubernetes health checks show the local kind cluster `kind-load-balance` is healthy.
```zsh
2025-11-02T12:26:58.414-08:00 INFO [KUBERNETE] Target became healthy target_name:kind-load-balance target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:411
```

- [x] Configured Teleport by creating a Teleport role and user. Logged in, listed kube clusters, and logged into the kube cluster `kind-load-balance`.
```zsh
> tctl create -f ~/src/wrk/cfg/teleport-role-kube.yaml
role "kube-admin" has been created

> tctl users add $(whoami) --roles=editor,access,kube-admin
User "rana.ian" has been created but requires a password. Share this URL with the user to complete user setup, link is valid for 1h:
https://localhost:3080/web/invite/76723dfd5982560be4bb552a14aa82c0

> tsh login --proxy=localhost:3080 --user=$(whoami) --auth=local
Enter password for Teleport user rana.ian:
Enter an OTP code from a device:
> Profile URL:        https://localhost:3080
  Logged in as:       rana.ian
  Cluster:            teleport-laptop
  Roles:              access, editor, kube-admin
  Kubernetes:         enabled
  Kubernetes users:   rana.ian
  Kubernetes groups:  system:masters
  Valid until:        2025-11-03 00:29:15 -0800 PST [valid for 11h59m]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

> tsh kube ls
Kube Cluster Name Labels Selected
----------------- ------ --------
kind-load-balance

> tsh kube login kind-load-balance
Logged into Kubernetes cluster "kind-load-balance". Try 'kubectl version' to test the connection.

> kubectl version
Client Version: v1.34.1
Kustomize Version: v5.7.1
Server Version: v1.34.0
```

- [x] Ran the `test-load-balance` app. Load balancing `GOAWAY` errors are seen.
```zsh
> ./test-load-balance run -name "Teleport (no fix)" -workers 10 -ops 100 -no-retry -output without-fix.json
=== Kubernetes GOAWAY Load Test ===
Test Name:     Teleport (no fix)
Context:       teleport-laptop-kind-load-balance
API Server:    https://localhost:3026
K8s Version:   v1.34.0
Namespace:     teleport-test
Workers:       10
Ops/Worker:    100
Total Ops:     1000
Retry Mode:    DISABLED (exposes GOAWAY)
Output File:   without-fix.json
Started:       2025-11-02T12:30:40-08:00

Progress: 100/1000 (errors: 6, GOAWAY: 6)
Progress: 200/1000 (errors: 6, GOAWAY: 6)
Progress: 300/1000 (errors: 6, GOAWAY: 6)
Progress: 400/1000 (errors: 6, GOAWAY: 6)
Progress: 500/1000 (errors: 6, GOAWAY: 6)
Progress: 600/1000 (errors: 6, GOAWAY: 6)
Progress: 700/1000 (errors: 6, GOAWAY: 6)
Progress: 800/1000 (errors: 6, GOAWAY: 6)
Progress: 900/1000 (errors: 6, GOAWAY: 6)
Progress: 1000/1000 (errors: 6, GOAWAY: 6)

=== Results ===
Completed:        2025-11-02T12:30:58-08:00
Duration:         17.947190042s
Total Operations: 1000
Successful:       994
Failed:           6
GOAWAY Errors:    6
Error Rate:       0.60%
GOAWAY Rate:      0.60%

Latency Percentiles:
  p50: 199.81ms
  p95: 203.07ms
  p99: 206.76ms

Sample Errors:
  1. http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
  2. http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
  3. http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

- [x] Logged out and shutdown Teleport.
```zsh
> tsh logout
Logged out all users from all proxies.
```

### 4. Test run (Teleport, fix applied)

The intent is to see no load balancing errors through Teleport when the bug fix is applied. The existing backend database is reused.

- [x] Teleport was built and run with the bug fix branch `rana/kube-retryable-transport` branch.
```zsh
> git switch rana/kube-retryable-transport
Switched to branch 'rana/kube-retryable-transport'

> make clean && make full
```

- [x] Teleport started with the same `teleport.yaml` config file.

- [x] Looking at the Teleport terminal output, Kubernetes health checks show the local kind cluster `kind-load-balance` is healthy.
```zsh
2025-11-02T12:38:14.758-08:00 INFO [KUBERNETE] Target became healthy target_name:kind-load-balance target_kind:kube_cluster target_origin: reason:threshold_reached message:1 health check passed healthcheck/worker.go:411
```

- [x] Logged in to Teleport, logged into the kube cluster, and validated the kube context. 
```zsh
> tsh login --proxy=localhost:3080 --user=$(whoami) --auth=local
Enter password for Teleport user rana.ian:
Enter an OTP code from a device:
> Profile URL:        https://localhost:3080
  Logged in as:       rana.ian
  Cluster:            teleport-laptop
  Roles:              access, editor, kube-admin
  Kubernetes:         enabled
  Kubernetes users:   rana.ian
  Kubernetes groups:  system:masters
  Valid until:        2025-11-03 00:39:15 -0800 PST [valid for 11h59m]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

> tsh kube login kind-load-balance
Logged into Kubernetes cluster "kind-load-balance". Try 'kubectl version' to test the connection.

> kubectl config current-context
teleport-laptop-kind-load-balance
```

- [x] Ran the `test-load-balance` app 5 times. No load balancing `GOAWAY` errors were seen. The last run is shown.
```zsh
> for i in {1..5}; do
  echo "Run $i/5..."
  ./test-load-balance run \
    -name "Teleport (with fix) - Run $i" \
    -workers 10 \
    -ops 100 \
    -no-retry \
    -output "with-fix-run${i}.json"
done
Run 1/5...
Run 2/5...
Run 3/5...
Run 4/5...
Run 5/5...
=== Kubernetes GOAWAY Load Test ===
Test Name:     Teleport (with fix) - Run 5
Context:       teleport-laptop-kind-load-balance
API Server:    https://localhost:3026
K8s Version:   v1.34.0
Namespace:     teleport-test
Workers:       10
Ops/Worker:    100
Total Ops:     1000
Retry Mode:    DISABLED (exposes GOAWAY)
Output File:   with-fix-run5.json
Started:       2025-11-02T12:45:05-08:00

Progress: 100/1000 (errors: 0, GOAWAY: 0)
Progress: 200/1000 (errors: 0, GOAWAY: 0)
Progress: 300/1000 (errors: 0, GOAWAY: 0)
Progress: 400/1000 (errors: 0, GOAWAY: 0)
Progress: 500/1000 (errors: 0, GOAWAY: 0)
Progress: 600/1000 (errors: 0, GOAWAY: 0)
Progress: 700/1000 (errors: 0, GOAWAY: 0)
Progress: 800/1000 (errors: 0, GOAWAY: 0)
Progress: 900/1000 (errors: 0, GOAWAY: 0)
Progress: 1000/1000 (errors: 0, GOAWAY: 0)

=== Results ===
Completed:        2025-11-02T12:45:23-08:00
Duration:         18.006742166s
Total Operations: 1000
Successful:       1000
Failed:           0
GOAWAY Errors:    0
Error Rate:       0.00%
GOAWAY Rate:      0.00%

Latency Percentiles:
  p50: 199.78ms
  p95: 202.77ms
  p99: 205.99ms

Results saved to: with-fix-run5.json
```

- [x] Compared test run results.
```zsh
./test-load-balance compare \
  -files baseline.json,without-fix.json,with-fix-run5.json \
  -markdown > test-results.md
```

</details>
