### PR TITLE
Increase the size of the SSO MFA popup

### DIFF
--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -356,8 +356,8 @@ const auth = {
     abortController?: AbortController
   ) {
     // try to center the screen
-    const width = 1045;
-    const height = 550;
+    const width = 1024;
+    const height = 768;
     const left = (screen.width - width) / 2;
     const top = (screen.height - height) / 2;
 


### PR DESCRIPTION
Changelog: The browser window for SSO MFA is slightly taller in order to accommodate larger elements like QR codes.