### PR TITLE
Add markdown fenced codeblocks to cspell ignores

### DIFF
--- a/rfd/cspell.json
+++ b/rfd/cspell.json
@@ -1,6 +1,16 @@
 {
   "version": "0.2",
   "language": "en",
+  "patterns": [
+    {
+      "name": "mdFencedCode",
+      "pattern": "(```|~~~)[\\s\\S]*?\\1"
+    },
+    {
+      "name": "inlineCode",
+      "pattern": "`[^`\\n]+`"
+    }
+  ],
   "words": [
     "AAAX",
     "aabbcc",
@@ -1028,5 +1038,11 @@
     "zdvik",
     "Zilla",
     "ZLMR"
+  ],
+  "overrides": [
+    {
+      "filename": "**/*.md",
+      "ignoreRegExpList": ["mdFencedCode", "inlineCode"]
+    }
   ]
 }


### PR DESCRIPTION
## Context
The RFD spellcheck runs over the full text of every RFD, including code, so design docs full of identifiers (proto/Go type names, fields, CLI flags) constantly trip it and each token has to be hand-added to the ~1k-word allowlist. This excludes fenced and inline code from the check via two *.md-scoped cspell patterns, so prose is still checked while the allowlist goes back to covering only real non-dictionary English.  
