### PR TITLE
fix: keep instance host ID when healing identity

### DIFF
--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -66,12 +66,13 @@ func Join(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	if trace.IsNotImplemented(err) || errors.As(err, new(*connectionError)) {
 		// Fall back to joining via legacy service.
 		slog.InfoContext(ctx, "Falling back to joining via the legacy join service", "error", err)
-		// Non-bots must generate their own host UUID when joining via legacy service.
-		if params.ID.Role != types.RoleBot {
+		// Non-bots must provide their own host UUID when joining via legacy service.
+		if params.ID.HostUUID == "" && params.ID.Role != types.RoleBot {
 			hostID, err := hostid.Generate(ctx, params.JoinMethod)
 			if err != nil {
 				return nil, trace.Wrap(err, "generating host ID")
 			}
+			slog.InfoContext(ctx, "Generated host UUID for legacy join attempt", "host_uuid", hostID)
 			params.ID.HostUUID = hostID
 		}
 		result, err := LegacyJoin(ctx, params)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -391,6 +391,12 @@ func (process *TeleportProcess) healInstanceIdentity(currentIdentity *state.Iden
 	if lostRoles := currentSystemRoles.Clone().Subtract(newSystemRoles); len(lostRoles) > 0 {
 		return nil, trace.Errorf("new Instance identity is missing the following system roles from the current identity (this is a bug): %v", lostRoles.Elements())
 	}
+	// Sanity check the host ID didn't change.
+	if currentIdentity.ID.HostID() != newIdentity.ID.HostID() {
+		return nil, trace.Errorf("new Instance host ID %s does not match current host ID %s (this is a bug)",
+			newIdentity.ID.HostID(),
+			currentIdentity.ID.HostID())
+	}
 
 	gainedSystemRoles := newSystemRoles.Clone().Subtract(currentSystemRoles)
 	if len(gainedSystemRoles) == 0 {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1042,6 +1042,7 @@ func TestInstanceSelfRepair(t *testing.T) {
 
 	// Create and start a process with only the Proxy service enabled using the proxy-only token.
 	process := newStartedProcess(proxyToken.GetName(), false)
+
 	// Sanity check the Instance identity looks as expected with only the Proxy system role.
 	connector, err := process.WaitForConnector(InstanceIdentityEvent, logger)
 	require.NoError(t, err)
@@ -1049,7 +1050,9 @@ func TestInstanceSelfRepair(t *testing.T) {
 	id := connector.clientState.Load().identity
 	require.Equal(t, types.RoleInstance, id.ID.Role)
 	require.Equal(t, []string{types.RoleProxy.String()}, id.SystemRoles)
-	// Close the process.
+	originalHostID := id.ID.HostID()
+
+	// Close the original process.
 	require.NoError(t, process.Close())
 	require.NoError(t, process.Wait())
 
@@ -1057,6 +1060,7 @@ func TestInstanceSelfRepair(t *testing.T) {
 	// the previous Instance and Proxy certs, but enable the SSH service and
 	// provide the token that allows only role Node.
 	process = newStartedProcess(sshToken.GetName(), true)
+
 	// Get the new Instance identity and make sure it includes both the Proxy
 	// and Node system roles.
 	instanceConnector, err := process.WaitForConnector(InstanceIdentityEvent, logger)
@@ -1065,21 +1069,24 @@ func TestInstanceSelfRepair(t *testing.T) {
 	instanceID := instanceConnector.clientState.Load().identity
 	require.Equal(t, types.RoleInstance, instanceID.ID.Role)
 	assert.ElementsMatch(t, []string{types.RoleProxy.String(), types.RoleNode.String()}, instanceID.SystemRoles)
+	// Make sure the host ID has not changed.
+	assert.Equal(t, instanceID.ID.HostID(), originalHostID)
+
 	// Make sure the SSH identity becomes available.
 	sshConnector, err := process.WaitForConnector(SSHIdentityEvent, logger)
 	require.NoError(t, err)
 	require.NotNil(t, sshConnector)
 	sshID := sshConnector.clientState.Load().identity
 	require.Equal(t, types.RoleNode, sshID.ID.Role)
+	// Make sure the host ID matches the original instance host ID.
+	assert.Equal(t, sshID.ID.HostID(), originalHostID)
+	// Make sure the SSH cert has all expected principals.
+	expectSSHPrincipals := expectedSSHPrincipals(sshID.ID.HostID(), hostName, clusterName)
+	require.ElementsMatch(t, expectSSHPrincipals, sshID.Cert.ValidPrincipals)
+
 	// Close the process to clean up.
 	require.NoError(t, process.Close())
 	require.NoError(t, process.Wait())
-
-	nodeConnector, err := process.WaitForConnector(SSHIdentityEvent, logger)
-	require.NoError(t, err)
-	nodeID := nodeConnector.clientState.Load().identity
-	expectSSHPrincipals := expectedSSHPrincipals(nodeID.ID.HostID(), hostName, clusterName)
-	require.ElementsMatch(t, expectSSHPrincipals, nodeID.Cert.ValidPrincipals)
 }
 
 func TestSSHPrincipals(t *testing.T) {


### PR DESCRIPTION
There is currently a bug on master (unreleased) where a node can end up fetching and persisting a new Instance identity with a different host ID to its original host ID, which breaks things like the inventory control stream, and requires the instance state to be wiped in order to resolve.

The bug hits when:
- the node has already successfully joined a cluster
- an additional teleport service (app, db, etc) is added to the node config with a join token that supports this role
- the node is restarted
- the node attempts to rejoin via the new join service to get a new instance cert with the new system role
- the new join service does not yet support this join method
- the logic falls back to joining via the legacy join service and generates a new host UUID

At the final step it was unconditionally generating a new host UUID. The fix is to avoid generating a new host UUID if the node already has one.