### PR TITLE
[v17] Adds Conditional Update support for Access Lists with members

### DIFF
--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -148,7 +148,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 	for {
 		var accessLists []*accesslist.AccessList
 		var err error
-		accessLists, nextToken, err = a.Services.AccessLists.ListAccessLists(ctx, 0 /* default page size */, nextToken)
+		accessLists, nextToken, err = a.Services.AccessListsInternal.ListAccessLists(ctx, 0 /* default page size */, nextToken)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -530,7 +530,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		UserTasks:                       cfg.UserTasks,
 		DiscoveryConfigs:                cfg.DiscoveryConfigs,
 		Okta:                            cfg.Okta,
-		AccessLists:                     cfg.AccessLists,
+		AccessListsInternal:             cfg.AccessLists,
 		DatabaseObjectImportRules:       cfg.DatabaseObjectImportRules,
 		DatabaseObjects:                 cfg.DatabaseObjects,
 		SecReports:                      cfg.SecReports,
@@ -778,7 +778,7 @@ type Services struct {
 	services.UserTasks
 	services.DiscoveryConfigs
 	services.Okta
-	services.AccessLists
+	services.AccessListsInternal
 	services.DatabaseObjectImportRules
 	services.DatabaseObjects
 	services.UserLoginStates
@@ -5425,7 +5425,7 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if req.GetDryRun() {
 		// NOTE: Some dry-run options are set in [services.ValidateAccessRequestForUser].
 		_, promotions := a.generateAccessRequestPromotions(ctx, req)
-		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessLists, promotions)
+		updateAccessRequestWithAdditionalReviewers(ctx, req, a.AccessListsInternal, promotions)
 		// Return before creating the request if this is a dry run.
 		return req, nil
 	}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -520,7 +520,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		Unstarted:    p.Unstarted,
 
 		Access:                  p.AuthServer.Services.Access,
-		AccessLists:             p.AuthServer.Services.AccessLists,
+		AccessLists:             p.AuthServer.Services.AccessListsInternal,
 		AccessMonitoringRules:   p.AuthServer.Services.AccessMonitoringRules,
 		AppSession:              p.AuthServer.Services.Identity,
 		Applications:            p.AuthServer.Services.Applications,

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -276,7 +276,7 @@ type InitConfig struct {
 	Okta services.Okta
 
 	// AccessLists is a service that manages access list resources.
-	AccessLists services.AccessLists
+	AccessLists services.AccessListsInternal
 
 	// DatabaseObjectImportRule is a service that manages database object import rules.
 	DatabaseObjectImportRules services.DatabaseObjectImportRules

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2689,7 +2689,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.Registerer = process.metricsRegistry
 
 	cfg.Access = services.Access
-	cfg.AccessLists = services.AccessLists
+	cfg.AccessLists = services.AccessListsInternal
 	cfg.AccessMonitoringRules = services.AccessMonitoringRules
 	cfg.AppSession = services.Identity
 	cfg.Applications = services.Applications

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -77,6 +77,16 @@ type AccessLists interface {
 	AccessRequestPromote(ctx context.Context, req *accesslistv1.AccessRequestPromoteRequest) (*accesslistv1.AccessRequestPromoteResponse, error)
 }
 
+// AccessListsInternal extends the public AccessList interface with internal-only
+// methods.
+type AccessListsInternal interface {
+	AccessLists
+
+	// UpdateAccessListAndOverwriteMembers conditionally updates the access list,
+	// overwriting the list's members if successful.
+	UpdateAccessListAndOverwriteMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
+}
+
 // MarshalAccessList marshals the access list resource to JSON.
 func MarshalAccessList(accessList *accesslist.AccessList, opts ...MarshalOption) ([]byte, error) {
 	if err := accessList.CheckAndSetDefaults(); err != nil {

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -668,9 +668,29 @@ func (a *AccessListService) DeleteAllAccessListMembers(ctx context.Context) erro
 	return trace.Wrap(a.memberService.DeleteAllResources(ctx))
 }
 
-// UpsertAccessListWithMembers creates or updates an access list resource and its members.
-func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+type writeFn func(context.Context, *accesslist.AccessList) (*accesslist.AccessList, error)
+
+func (a *AccessListService) selectWriteFn(op opType) (writeFn, error) {
+	switch op {
+	case opTypeUpdate:
+		return a.service.ConditionalUpdateResource, nil
+
+	case opTypeUpsert:
+		return a.service.UpsertResource, nil
+	}
+
+	return nil, trace.BadParameter("Unknown Access List write operation: %d", op)
+}
+
+// writeAccessListWithMembers holds all of the common logic for updating and
+// upserting an access list and it's collection of members.
+func (a *AccessListService) writeAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember, op opType) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
 	if err := accessList.CheckAndSetDefaults(); err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	writeFn, err := a.selectWriteFn(op)
+	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
@@ -682,9 +702,20 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 
 	validateAccessList := func() error {
 		existingAccessList, err := a.service.GetResource(ctx, accessList.GetName())
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
+		if err != nil {
+			// a not found error is totally legal for an upsert operation, but
+			// fatal for an update.
+			if op == opTypeUpdate || !trace.IsNotFound(err) {
+				return trace.Wrap(err)
+			}
 		}
+
+		if op == opTypeUpdate {
+			if accessList.Metadata.Revision != existingAccessList.Metadata.Revision {
+				return trace.CompareFailed("access list revision does not match. it may have been concurrently modified")
+			}
+		}
+
 		preserveAccessListFields(existingAccessList, accessList)
 
 		if err := accesslists.ValidateAccessListWithMembers(ctx, accessList, membersIn, &accessListAndMembersGetter{a.service, a.memberService}); err != nil {
@@ -788,9 +819,9 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 		return nil
 	}
 
-	updateAccessList := func() error {
+	writeAccessList := func() error {
 		var err error
-		accessList, err = a.service.UpsertResource(ctx, accessList)
+		accessList, err = writeFn(ctx, accessList)
 		return trace.Wrap(err)
 	}
 
@@ -804,7 +835,7 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 		actions = append(actions, func() error { return a.VerifyAccessListCreateLimit(ctx, accessList.GetName()) })
 	}
 
-	actions = append(actions, validateAccessList, reconcileMembers, updateAccessList, reconcileOwners)
+	actions = append(actions, validateAccessList, reconcileMembers, writeAccessList, reconcileOwners)
 
 	if err := a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
 		return a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
@@ -820,6 +851,26 @@ func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, acc
 	}
 
 	return accessList, membersIn, nil
+}
+
+// UpsertAccessListWithMembers creates or updates an access list resource and its members.
+func (a *AccessListService) UpsertAccessListWithMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+	upsertedACL, upsertedMembers, err := a.writeAccessListWithMembers(ctx, accessList, membersIn, opTypeUpsert)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return upsertedACL, upsertedMembers, nil
+}
+
+// UpdateAccessListAndOverwriteMembers does a conditional update on an AccessList and
+// all its members. For the purposes of this update, the Access List's member
+// records  are covered under the enclosing Access List's revision.
+func (a *AccessListService) UpdateAccessListAndOverwriteMembers(ctx context.Context, accessList *accesslist.AccessList, membersIn []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error) {
+	updatedACL, udatedMembers, err := a.writeAccessListWithMembers(ctx, accessList, membersIn, opTypeUpdate)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return updatedACL, udatedMembers, nil
 }
 
 func (a *AccessListService) AccessRequestPromote(_ context.Context, _ *accesslistv1.AccessRequestPromoteRequest) (*accesslistv1.AccessRequestPromoteResponse, error) {

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -37,11 +37,14 @@ import (
 	"github.com/gravitational/teleport/api/types/common"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.
@@ -421,7 +424,129 @@ func TestAccessListDedupeOwnersBackwardsCompat(t *testing.T) {
 	require.Len(t, accessList.Spec.Owners, 2)
 }
 
-func TestAccessListUpsertWithMembers(t *testing.T) {
+func deleteAllAccessLists(t *testing.T, service *AccessListService) func() {
+	return func() {
+		require.NoError(t, service.DeleteAllAccessLists(context.Background()))
+	}
+}
+
+// getAccessListMembers fetches the current list of members for the given access
+// list, sorted by name
+func getAccessListMembers(t *testing.T, service *AccessListService, listName string) []*accesslist.AccessListMember {
+	getPage := func(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+		return service.ListAccessListMembers(ctx, listName, pageSize, pageToken)
+	}
+	members, err := stream.Collect(clientutils.Resources(t.Context(), getPage))
+	require.NoError(t, err)
+	return members
+}
+
+type writeAccessListWithMembersFn func(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
+
+func testAddAndRemoveAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
+	t.Run("add and remove members", func(t *testing.T) {
+		const listName = "test-add-members-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
+		ctx := t.Context()
+
+		toAccessListMember := func(name string) *accesslist.AccessListMember {
+			return newAccessListMember(t, listName, name)
+		}
+
+		cmpOpts := []cmp.Option{
+			cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+			cmpopts.EquateEmpty(),
+		}
+
+		// GIVEN an existing Access List
+		acl, err := service.UpsertAccessList(ctx, newAccessList(t, listName, clock))
+		require.NoError(t, err)
+
+		var expectedMemberNames []string
+		for _, memberName := range []string{"alice", "bob", "carol", "dave"} {
+			expectedMemberNames = append(expectedMemberNames, memberName)
+			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+
+			// WHEN I update the Access List to have one or more users,
+			// EXPECT that the operation succeeds and all member are present
+			// in both the returned member list and in the backend service
+			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+
+			backendMembers := getAccessListMembers(t, service, listName)
+			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+		}
+
+		for len(expectedMemberNames) > 0 {
+			expectedMemberNames = expectedMemberNames[1:]
+			members := sliceutils.Map(expectedMemberNames, toAccessListMember)
+
+			// WHEN I update the Access List to remove a user, EXPECT that
+			// the operation succeeds and that only the expected members
+			// are present in the returned member list and in the backend
+			// service
+			updatedACL, updatedMembers, err := fnUnderTest(ctx, acl, members)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(acl, updatedACL, cmpOpts...))
+			require.Empty(t, cmp.Diff(members, updatedMembers, cmpOpts...))
+
+			backendMembers := getAccessListMembers(t, service, listName)
+			require.Empty(t, cmp.Diff(members, backendMembers, cmpOpts...))
+		}
+	})
+}
+
+func testSetEmptyAccessListMembers(t *testing.T, service *AccessListService, clock clockwork.Clock, fnUnderTest writeAccessListWithMembersFn) {
+	t.Run("setting empty member list deletes members", func(t *testing.T) {
+		ctx := t.Context()
+
+		emptyLists := []struct {
+			name  string
+			value []*accesslist.AccessListMember
+		}{
+			{
+				name:  "nil",
+				value: nil,
+			},
+			{
+				name:  "zero-length",
+				value: []*accesslist.AccessListMember{},
+			},
+		}
+
+		for _, emptyList := range emptyLists {
+			t.Run(emptyList.name, func(t *testing.T) {
+				t.Cleanup(deleteAllAccessLists(t, service))
+				listName := "test-set-empty-members-list" + emptyList.name
+
+				// GIVEN an access list with several members...
+				acl, _, err := service.UpsertAccessListWithMembers(ctx,
+					newAccessList(t, listName, clock),
+					[]*accesslist.AccessListMember{
+						newAccessListMember(t, listName, "alice"),
+						newAccessListMember(t, listName, "bob"),
+						newAccessListMember(t, listName, "carol"),
+						newAccessListMember(t, listName, "dave"),
+					})
+				require.NoError(t, err)
+				require.Len(t, getAccessListMembers(t, service, listName), 4)
+
+				// WHEN I update it with an empty member list
+				_, members, err := fnUnderTest(ctx, acl, emptyList.value)
+				require.NoError(t, err)
+
+				// EXPECT that both the returned member list and the member
+				// collection from the backend are empty
+				require.Empty(t, members)
+				require.Empty(t, getAccessListMembers(t, service, listName))
+			})
+		}
+	})
+}
+
+func TestUpsertAccessListWithMembers(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
@@ -433,65 +558,197 @@ func TestAccessListUpsertWithMembers(t *testing.T) {
 
 	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
-	// Create a couple access lists.
-	accessList1 := newAccessList(t, "accessList1", clock)
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		cmpopts.EquateEmpty(),
+	}
+
+	t.Run("create empty", func(t *testing.T) {
+		emptyLists := []struct {
+			name  string
+			value []*accesslist.AccessListMember
+		}{
+			{
+				name:  "nil",
+				value: nil,
+			},
+			{
+				name:  "zero-length",
+				value: []*accesslist.AccessListMember{},
+			},
+		}
+		for _, empty := range emptyLists {
+			t.Run(empty.name, func(t *testing.T) {
+				t.Cleanup(deleteAllAccessLists(t, service))
+				listName := "test-create-acl-list-" + empty.name
+
+				acl := newAccessList(t, listName, clock)
+				createdACL, createdMembers, err := service.UpsertAccessListWithMembers(ctx, acl, empty.value)
+				require.NoError(t, err)
+				require.Empty(t, createdMembers)
+				require.Empty(t, cmp.Diff(createdACL, acl, cmpOpts...))
+			})
+		}
+	})
+
+	t.Run("create with members", func(t *testing.T) {
+		const listName = "test-create-with-members-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		acl := newAccessList(t, listName, clock)
+		members := []*accesslist.AccessListMember{newAccessListMember(t, listName, "alice")}
+		createdACL, createdMembers, err := service.UpsertAccessListWithMembers(ctx, acl, members)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(acl, createdACL, cmpOpts...))
+		require.Empty(t, cmp.Diff(members, createdMembers, cmpOpts...))
+		require.Empty(t, cmp.Diff(members, getAccessListMembers(t, service, listName), cmpOpts...))
+	})
+
+	testAddAndRemoveAccessListMembers(t, service, clock, service.UpsertAccessListWithMembers)
+
+	testSetEmptyAccessListMembers(t, service, clock, service.UpsertAccessListWithMembers)
+
+	t.Run("colliding updates", func(t *testing.T) {
+		const listName = "test-colliding-updates-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		// GIVEN an existing Access List...
+		originalACL, _, err := service.UpsertAccessListWithMembers(ctx,
+			newAccessList(t, listName, clock),
+			[]*accesslist.AccessListMember{
+				newAccessListMember(t, listName, "alice"),
+				newAccessListMember(t, listName, "bob"),
+				newAccessListMember(t, listName, "carol"),
+				newAccessListMember(t, listName, "dave"),
+			})
+		require.NoError(t, err)
+
+		// GIVEN an updated version of the original access list, which
+		// will have a new version string...
+		update := originalACL.CloneResource().(*accesslist.AccessList)
+		update.Spec.Title = "updated list once"
+		_, err = service.UpsertAccessList(ctx, update)
+		require.NoError(t, err)
+
+		// WHEN I submit an updated Access List based on the original Access List revision
+		secondUpdate := originalACL.CloneResource().(*accesslist.AccessList)
+		secondUpdate.Spec.Title = "overridden update"
+		updatedMembers := []*accesslist.AccessListMember{
+			newAccessListMember(t, listName, "erica"),
+			newAccessListMember(t, listName, "fred"),
+			newAccessListMember(t, listName, "giselle"),
+			newAccessListMember(t, listName, "hector"),
+		}
+		finalACL, finalMembers, updateErr := service.UpsertAccessListWithMembers(ctx, secondUpdate, updatedMembers)
+
+		// EXPECT an upsert to succeed
+		require.NoError(t, updateErr)
+
+		// EXPECT the returned Access List and member list to match the
+		// requested update
+		require.Empty(t, cmp.Diff(finalACL, secondUpdate, cmpOpts...))
+		require.Empty(t, cmp.Diff(finalMembers, updatedMembers, cmpOpts...))
+
+		// EXPECT the actual backend records to match the updated values
+		backendACL, err := service.GetAccessList(ctx, listName)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(backendACL, secondUpdate, cmpOpts...))
+		require.Empty(t, cmp.Diff(getAccessListMembers(t, service, listName), updatedMembers))
+	})
+}
+
+func TestUpdateAccessListAndOverwriteMembers(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	mem, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service := newAccessListService(t, mem, clock, true /* igsEnabled */)
 
 	cmpOpts := []cmp.Option{
 		cmpopts.IgnoreFields(header.Metadata{}, "Revision"),
+		cmpopts.EquateEmpty(),
 	}
 
-	t.Run("create access list", func(t *testing.T) {
-		// Create both access lists.
-		accessList, _, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{})
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(accessList1, accessList, cmpOpts...))
+	t.Run("update non-existing", func(t *testing.T) {
+		const listName = "test-update-acl-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
+
+		acl := newAccessList(t, listName, clock)
+		_, _, err := service.UpdateAccessListAndOverwriteMembers(ctx, acl, []*accesslist.AccessListMember{})
+
+		var NotFound *trace.NotFoundError
+		require.ErrorAs(t, err, &NotFound)
 	})
 
-	accessList1Member1 := newAccessListMember(t, accessList1.GetName(), "alice")
+	t.Run("update non-existing with members", func(t *testing.T) {
+		const listName = "test-update-with-members-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
 
-	t.Run("add member to the access list", func(t *testing.T) {
-		// Add access list members.
-		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{accessList1Member1})
-		require.NoError(t, err)
-		// Assert that access list is returned.
-		require.Empty(t, cmp.Diff(updatedAccessList, updatedAccessList, cmpOpts...))
-		// Assert that the member is returned.
-		require.Len(t, updatedMembers, 1)
-		require.Empty(t, cmp.Diff(updatedMembers[0], accessList1Member1, cmpOpts...))
+		acl := newAccessList(t, listName, clock)
+		members := []*accesslist.AccessListMember{newAccessListMember(t, listName, "alice")}
+		_, _, err := service.UpdateAccessListAndOverwriteMembers(ctx, acl, members)
 
-		listMembers, err := service.GetAccessListMember(ctx, accessList1.GetName(), accessList1Member1.GetName())
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(listMembers, accessList1Member1, cmpOpts...))
+		var NotFound *trace.NotFoundError
+		require.ErrorAs(t, err, &NotFound)
 	})
 
-	accessList1Member2 := newAccessListMember(t, accessList1.GetName(), "bob")
+	testAddAndRemoveAccessListMembers(t, service, clock, service.UpdateAccessListAndOverwriteMembers)
 
-	t.Run("add another member to the access list", func(t *testing.T) {
-		// Add access list members.
-		updatedAccessList, updatedMembers, err := service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{accessList1Member1, accessList1Member2})
-		require.NoError(t, err)
-		// Assert that access list is returned.
-		require.Empty(t, cmp.Diff(updatedAccessList, updatedAccessList, cmpOpts...))
-		// Assert that the member is returned.
-		require.Len(t, updatedMembers, 2)
-		require.Empty(t, cmp.Diff(updatedMembers, []*accesslist.AccessListMember{accessList1Member1, accessList1Member2}, cmpOpts...))
+	testSetEmptyAccessListMembers(t, service, clock, service.UpdateAccessListAndOverwriteMembers)
 
-		listMembers, err := service.GetAccessListMember(ctx, accessList1.GetName(), accessList1Member1.GetName())
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(listMembers, accessList1Member1, cmpOpts...))
+	t.Run("colliding updates", func(t *testing.T) {
+		const listName = "test-colliding-updates-list"
+		t.Cleanup(deleteAllAccessLists(t, service))
 
-		listMembers, err = service.GetAccessListMember(ctx, accessList1.GetName(), accessList1Member2.GetName())
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(listMembers, accessList1Member2, cmpOpts...))
-	})
-
-	t.Run("empty members removes all members", func(t *testing.T) {
-		_, _, err = service.UpsertAccessListWithMembers(ctx, accessList1, []*accesslist.AccessListMember{})
+		// GIVEN an existing Access List (note that we're deliberately
+		// using UpsertAccessListWithMembers because this is part of the
+		// test setup rather than the test action itself.)
+		originalACL, originalMembers, err := service.UpsertAccessListWithMembers(ctx,
+			newAccessList(t, listName, clock),
+			[]*accesslist.AccessListMember{
+				newAccessListMember(t, listName, "alice"),
+				newAccessListMember(t, listName, "bob"),
+				newAccessListMember(t, listName, "carol"),
+				newAccessListMember(t, listName, "dave"),
+			})
 		require.NoError(t, err)
 
-		members, _, err := service.ListAccessListMembers(ctx, accessList1.GetName(), 0 /* default size*/, "")
+		// GIVEN an updated version of the original access list, which
+		// will have a new version string...
+		update := originalACL.CloneResource().(*accesslist.AccessList)
+		update.Spec.Title = "updated list once"
+
+		updatedACL, err := service.UpsertAccessList(ctx, update)
 		require.NoError(t, err)
-		require.Empty(t, members)
+
+		// WHEN I try to submit an updated Access List based on the original
+		// Access List revision
+		secondUpdate := originalACL.CloneResource().(*accesslist.AccessList)
+		secondUpdate.Spec.Title = "overridden update"
+		updatedMembers := []*accesslist.AccessListMember{
+			newAccessListMember(t, listName, "erica"),
+			newAccessListMember(t, listName, "fred"),
+			newAccessListMember(t, listName, "giselle"),
+			newAccessListMember(t, listName, "hector"),
+		}
+		_, _, err = service.UpdateAccessListAndOverwriteMembers(ctx, secondUpdate, updatedMembers)
+
+		// EXPECT a conditional update to fail
+		var cmpFailedErr *trace.CompareFailedError
+		require.ErrorAs(t, err, &cmpFailedErr)
+
+		// EXPECT that the backend Access List record has not been changed
+		backendACL, err := service.GetAccessList(ctx, listName)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(backendACL, updatedACL, cmpOpts...))
+
+		// EXPECT that the member list has not been changed
+		require.Empty(t, cmp.Diff(getAccessListMembers(t, service, listName), originalMembers, cmpOpts...))
 	})
 }
 


### PR DESCRIPTION
Prior to this patch, we could only do an unconditional update of an
Access List and its members at the same time, meaning that the result
of multiple updates depends only on who wrote the access list last.

This patch adds `UpdateAccessListWithMembers()` to perform a conditional
update of an Access List and its members at the same time.

Addresses: gravitational/teleport.e#7385
Backports: #60309
Co-authored-by: Pawel Kopiczko <pawel.kopiczko@goteleport.com>
