### PR TITLE
Reduce MongoDB connections from agent

### DIFF
--- a/lib/srv/db/mongodb/connect.go
+++ b/lib/srv/db/mongodb/connect.go
@@ -21,10 +21,14 @@ package mongodb
 import (
 	"context"
 	"crypto/tls"
+	"iter"
+	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 
 	"github.com/gravitational/trace"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -38,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/endpoints"
+	"github.com/gravitational/teleport/lib/srv/db/mongodb/protocol"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -56,10 +61,22 @@ const (
 // When connecting to a replica set, returns connection to the server selected
 // based on the read preference connection string option. This allows users to
 // configure database access to always connect to a secondary for example.
-func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (driver.Connection, func(), error) {
+func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*serverConnection, error) {
+	deployment, err := depCache.load(ctx, sessionCtx, e.connectDeployment)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	conn, err := deployment.connect(ctx)
+	if err != nil {
+		return nil, trace.NewAggregate(err, deployment.close(ctx))
+	}
+	return conn, nil
+}
+
+func (e *Engine) connectDeployment(ctx context.Context, sessionCtx *common.Session) (*deployment, error) {
 	options, selector, err := e.getTopologyOptions(ctx, sessionCtx)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	// Using driver's "topology" package allows to retain low-level control
 	// over server connections (reading/writing wire messages) but at the
@@ -67,46 +84,18 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (drive
 	// in a replica set.
 	top, err := topology.New(options)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	if err := top.Connect(); err != nil {
 		e.Log.DebugContext(e.Context, "Failed to connect topology", "error", err)
-		return nil, nil, trace.Wrap(err)
-	}
-	conn, err := e.selectServerConn(ctx, top, selector)
-	if err != nil {
-		if err := top.Disconnect(ctx); err != nil {
-			e.Log.WarnContext(e.Context, "Failed to close topology", "error", err)
-		}
-		return nil, nil, trace.Wrap(err)
-	}
-
-	closeFn := func() {
-		if err := top.Disconnect(ctx); err != nil {
-			e.Log.WarnContext(e.Context, "Failed to close topology", "error", err)
-		}
-		if err := conn.Close(); err != nil {
-			e.Log.ErrorContext(e.Context, "Failed to close server connection.", "error", err)
-		}
-	}
-	return conn, closeFn, nil
-}
-
-func (e *Engine) selectServerConn(ctx context.Context, top *topology.Topology, selector description.ServerSelector) (driver.Connection, error) {
-	e.Log.DebugContext(e.Context, "Selecting server from topology", "topology", top)
-	server, err := top.SelectServer(ctx, selector)
-	if err != nil {
-		e.Log.DebugContext(e.Context, "failed to select server", "error", err)
 		return nil, trace.Wrap(err)
 	}
-
-	e.Log.DebugContext(e.Context, "Connecting to server", "server", server)
-	conn, err := server.Connection(ctx)
-	if err != nil {
-		e.Log.DebugContext(e.Context, "failed to connect to server", "error", err)
-		return nil, trace.Wrap(err)
-	}
-	return conn, nil
+	return &deployment{
+		top:              top,
+		selector:         selector,
+		log:              e.Log,
+		messagesReceived: common.GetMessagesFromServerMetric(sessionCtx.Database),
+	}, nil
 }
 
 // getTopologyOptions constructs topology options for connecting to a MongoDB server.
@@ -304,4 +293,124 @@ func (h *handshaker) FinishHandshake(context.Context, driver.Connection) error {
 func x509Username(sessionCtx *common.Session) string {
 	// MongoDB uses full certificate Subject field as a username.
 	return "CN=" + sessionCtx.DatabaseUser
+}
+
+type serverConnection struct {
+	connection driver.Connection
+	deployment *deployment
+}
+
+type replyIterator iter.Seq2[protocol.Message, error]
+
+func (c *serverConnection) roundTrip(ctx context.Context, clientMessage protocol.Message, maxMessageSize uint32) replyIterator {
+	return func(yield func(protocol.Message, error) bool) {
+		if err := c.writeMessage(ctx, clientMessage); err != nil {
+			yield(nil, err)
+			return
+		}
+		// Some client messages will not receive a reply.
+		if clientMessage.MoreToCome(nil) {
+			return
+		}
+		for {
+			// Otherwise read the server's reply...
+			serverMessage, err := c.readMessage(ctx, maxMessageSize)
+			if !yield(serverMessage, err) || err != nil {
+				return
+			}
+			// Stop reading if server indicated it has nothing more to send.
+			if !serverMessage.MoreToCome(clientMessage) {
+				return
+			}
+		}
+	}
+}
+
+func (c *serverConnection) readMessage(ctx context.Context, maxMessageSize uint32) (protocol.Message, error) {
+	msg, err := protocol.ReadServerMessage(ctx, c.connection, maxMessageSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c.deployment.messagesReceived.Inc()
+	return msg, nil
+}
+
+func (c *serverConnection) writeMessage(ctx context.Context, clientMessage protocol.Message) error {
+	return trace.Wrap(c.connection.WriteWireMessage(ctx, clientMessage.GetBytes()))
+}
+
+func (c *serverConnection) close(ctx context.Context) error {
+	var errs []error
+	if err := c.deployment.close(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	if expirer, ok := c.connection.(driver.Expirable); ok {
+		// expire the connection to evict it from the driver connection pool
+		if err := expirer.Expire(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if err := c.connection.Close(); err != nil {
+		errs = append(errs, err)
+	}
+	return trace.NewAggregate(errs...)
+}
+
+type clientConnection struct {
+	net.Conn
+	messagesReceived prometheus.Counter
+}
+
+func (c *clientConnection) readMessage(maxMessageSize uint32) (protocol.Message, error) {
+	msg, err := protocol.ReadMessage(c, maxMessageSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	c.messagesReceived.Inc()
+	return msg, trace.Wrap(err)
+}
+
+func (c *clientConnection) writeMessage(message protocol.Message) error {
+	_, err := c.Write(message.GetBytes())
+	return trace.Wrap(err)
+}
+
+// deployment wraps [topology.Topology] and [description.ServerSelector].
+// It is used to select and connect to a server in the topology.
+type deployment struct {
+	top      *topology.Topology
+	selector description.ServerSelector
+
+	onClose          func(ctx context.Context, log *slog.Logger) error
+	log              *slog.Logger
+	messagesReceived prometheus.Counter
+}
+
+// connect selects a server, connects to it, and returns the connection.
+func (d *deployment) connect(ctx context.Context) (*serverConnection, error) {
+	d.log.DebugContext(ctx, "Selecting server from topology", "topology", d.top)
+	server, err := d.top.SelectServer(ctx, d.selector)
+	if err != nil {
+		d.log.DebugContext(ctx, "Failed to select server from topology", "error", err)
+		return nil, trace.Wrap(err)
+	}
+
+	d.log.DebugContext(ctx, "Connecting to server", "server", server)
+	conn, err := server.Connection(ctx)
+	if err != nil {
+		d.log.DebugContext(ctx, "Failed to connect to server", "error", err)
+		return nil, trace.Wrap(err)
+	}
+	serverConn := &serverConnection{
+		connection: conn,
+		deployment: d,
+	}
+	return serverConn, nil
+}
+
+func (d *deployment) close(ctx context.Context) error {
+	if d.onClose != nil {
+		return trace.Wrap(d.onClose(ctx, d.log))
+	}
+	return nil
 }

--- a/lib/srv/db/mongodb/connection_cache.go
+++ b/lib/srv/db/mongodb/connection_cache.go
@@ -1,0 +1,139 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+var (
+	// depCache is a singleton connection cache.
+	depCache deploymentCache
+)
+
+// deploymentCache is used to cache topology connection pools and share them
+// for client connections from the same client session.
+// The reason this was added is that MongoDB clients establish multiple
+// connections to Teleport and the agent's MongoDB driver also establishes
+// multiple connections to the upstream database server, which amplifies the
+// number of connections established, so we avoid connection amplification by
+// sharing connections.
+type deploymentCache struct {
+	cache utils.SyncMap[sessionKey, *sharedDeployment]
+}
+
+// sessionKey is the key used to determine if two connections belong to
+// the same session, which we share to reduce the number of connections to the
+// database server.
+type sessionKey struct {
+	username            string
+	dbUser              string
+	dbName              string
+	dbRoles             string
+	dbServerName        string
+	teleportDBURI       string
+	teleportClusterName string
+}
+
+func newSessionKey(sctx *common.Session) sessionKey {
+	return sessionKey{
+		username:            sctx.Identity.Username,
+		dbUser:              sctx.DatabaseUser,
+		dbName:              sctx.DatabaseName,
+		dbRoles:             strings.Join(sctx.DatabaseRoles, ","),
+		dbServerName:        sctx.Database.GetName(),
+		teleportDBURI:       sctx.Database.GetURI(),
+		teleportClusterName: sctx.ClusterName,
+	}
+}
+
+// sharedDeployment is a reference counted [deployment].
+type sharedDeployment struct {
+	deployment *deployment
+	// count is the shared session count. After the last client closes their
+	// session, count will be negative and the session will be deleted from
+	// the cache. It is not safe to read or write to this field without holding
+	// the cache lock.
+	count int
+}
+
+// load looks for a [deployment] in the cache and if one does not exist it calls
+// the given connect func to establish and cache a new deployment.
+func (c *deploymentCache) load(
+	ctx context.Context,
+	sessionCtx *common.Session,
+	connectFn func(ctx context.Context, sessionCtx *common.Session) (*deployment, error),
+) (*deployment, error) {
+	key := newSessionKey(sessionCtx)
+	var (
+		dep        *deployment
+		connectErr error
+	)
+	c.cache.Write(func(deployments map[sessionKey]*sharedDeployment) {
+		if item, ok := deployments[key]; ok {
+			item.count++
+			dep = item.deployment
+			return
+		}
+		dep, connectErr = connectFn(ctx, sessionCtx)
+		if connectErr != nil {
+			return
+		}
+		dep.onClose = func(ctx context.Context, log *slog.Logger) error {
+			return trace.Wrap(c.release(ctx, log, key))
+		}
+		deployments[key] = &sharedDeployment{deployment: dep, count: 1}
+	})
+	return dep, trace.Wrap(connectErr)
+}
+
+// release returns a shared deployment to the cache and returns true if it was
+// evicted from the cache as a result.
+func (c *deploymentCache) release(ctx context.Context, log *slog.Logger, key sessionKey) error {
+	var evict bool
+	var item *sharedDeployment
+	c.cache.Write(func(deployments map[sessionKey]*sharedDeployment) {
+		var ok bool
+		item, ok = deployments[key]
+		if !ok {
+			return
+		}
+		item.count--
+		evict = item.count < 1
+		if evict {
+			delete(deployments, key)
+		}
+	})
+	if evict && item != nil {
+		log.DebugContext(ctx, "Evicted deployment from cache, disconnecting topology",
+			"topology", item.deployment.top,
+		)
+		if err := item.deployment.top.Disconnect(ctx); err != nil {
+			return trace.Wrap(err, "failed to disconnect topology")
+		}
+	}
+	return nil
+}

--- a/lib/srv/db/mongodb/engine.go
+++ b/lib/srv/db/mongodb/engine.go
@@ -23,10 +23,8 @@ import (
 	"net"
 
 	"github.com/gravitational/trace"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/description"
-	"go.mongodb.org/mongo-driver/x/mongo/driver"
 
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -53,7 +51,7 @@ type Engine struct {
 	// EngineConfig is the common database engine configuration.
 	common.EngineConfig
 	// clientConn is an incoming client connection.
-	clientConn net.Conn
+	clientConn *clientConnection
 	// maxMessageSize is the max message size.
 	maxMessageSize uint32
 	// serverConnected specifies whether server connection has been created.
@@ -61,8 +59,11 @@ type Engine struct {
 }
 
 // InitializeConnection initializes the client connection.
-func (e *Engine) InitializeConnection(clientConn net.Conn, _ *common.Session) error {
-	e.clientConn = clientConn
+func (e *Engine) InitializeConnection(clientConn net.Conn, sessionCtx *common.Session) error {
+	e.clientConn = &clientConnection{
+		Conn:             clientConn,
+		messagesReceived: common.GetMessagesFromClientMetric(sessionCtx.Database),
+	}
 	return nil
 }
 
@@ -97,13 +98,12 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 			e.Log.ErrorContext(ctx, "Failed to deactivate the user.", "error", err)
 		}
 	}()
-	// Establish connection to the MongoDB server.
-	serverConn, closeFn, err := e.connect(ctx, sessionCtx)
+	serverConn, err := e.connect(ctx, sessionCtx)
 	if err != nil {
 		cancelAutoUserLease()
 		return trace.Wrap(err, "error connecting to the database")
 	}
-	defer closeFn()
+	defer serverConn.close(ctx)
 
 	// Release the auto-users semaphore now that we've successfully connected.
 	cancelAutoUserLease()
@@ -114,16 +114,13 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	e.serverConnected = true
 	observe()
 
-	msgFromClient := common.GetMessagesFromClientMetric(sessionCtx.Database)
-	msgFromServer := common.GetMessagesFromServerMetric(sessionCtx.Database)
-
 	// Start reading client messages and sending them to server.
 	for {
-		clientMessage, err := protocol.ReadMessage(e.clientConn, e.maxMessageSize)
+		clientMessage, err := e.clientConn.readMessage(e.maxMessageSize)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		err = e.handleClientMessage(ctx, sessionCtx, clientMessage, e.clientConn, serverConn, msgFromClient, msgFromServer)
+		err = e.handleClientMessage(ctx, sessionCtx, clientMessage, serverConn)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -140,49 +137,25 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 //     after sending message to the server and wait for next client message.
 //  4. Server can also send multiple messages in a row in which case we exhaust
 //     them before returning to listen for next client message.
-func (e *Engine) handleClientMessage(ctx context.Context, sessionCtx *common.Session, clientMessage protocol.Message, clientConn net.Conn, serverConn driver.Connection, msgFromClient prometheus.Counter, msgFromServer prometheus.Counter) error {
-	msgFromClient.Inc()
-
+func (e *Engine) handleClientMessage(ctx context.Context, sessionCtx *common.Session, clientMessage protocol.Message, serverConn *serverConnection) error {
 	// First check the client command against user's role and log in the audit.
 	err := e.authorizeClientMessage(sessionCtx, clientMessage)
 	if err != nil {
-		return protocol.ReplyError(clientConn, clientMessage, err)
+		return protocol.ReplyError(e.clientConn, clientMessage, err)
 	}
 	// If RBAC is ok, pass the message to the server.
-	err = serverConn.WriteWireMessage(ctx, clientMessage.GetBytes())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// Some client messages will not receive a reply.
-	if clientMessage.MoreToCome(nil) {
-		return nil
-	}
-	// Otherwise read the server's reply...
-	serverMessage, err := protocol.ReadServerMessage(ctx, serverConn, e.maxMessageSize)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	msgFromServer.Inc()
-
-	// Intercept handshake server response to proper configure the engine.
-	if protocol.IsHandshake(clientMessage) {
-		e.processHandshakeResponse(ctx, serverMessage)
-	}
-
-	// ... and pass it back to the client.
-	_, err = clientConn.Write(serverMessage.GetBytes())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	// Keep reading if server indicated it has more to send.
-	for serverMessage.MoreToCome(clientMessage) {
-		serverMessage, err = protocol.ReadServerMessage(ctx, serverConn, e.maxMessageSize)
+	var processedHandshake bool
+	isHandshake := protocol.IsHandshake(clientMessage)
+	for serverMessage, err := range serverConn.roundTrip(ctx, clientMessage, e.maxMessageSize) {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		msgFromServer.Inc()
-		_, err = clientConn.Write(serverMessage.GetBytes())
-		if err != nil {
+		if isHandshake && !processedHandshake {
+			e.processHandshakeResponse(ctx, serverMessage)
+			processedHandshake = true
+		}
+		// ... and pass it back to the client.
+		if err := e.clientConn.writeMessage(serverMessage); err != nil {
 			return trace.Wrap(err)
 		}
 	}


### PR DESCRIPTION
Changelog:  To reduce the number of connections established to MongoDB servers, Teleport Database Service instances will now cache connection pools to MongoDB servers and reuse the connections when handling connections from the same Teleport client.