### PR TITLE
feat: Allow instances to be selectable from bot details

### DIFF
--- a/web/packages/teleport/src/Bots/Details/BotDetails.story.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.story.tsx
@@ -20,6 +20,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory } from 'history';
 import { MemoryRouter, Route, Router } from 'react-router';
+import { action } from 'storybook/internal/actions';
 
 import Box from 'design/Box';
 
@@ -134,10 +135,13 @@ export const HappyWithEmpty: Story = {
           tokens: [],
         }),
         mfaAuthnChallengeSuccess(),
-        listBotInstancesSuccess({
-          bot_instances: [],
-          next_page_token: '',
-        }),
+        listBotInstancesSuccess(
+          {
+            bot_instances: [],
+            next_page_token: '',
+          },
+          'v1'
+        ),
         successGetRoles({
           startKey: '',
           items: Array.from({ length: 10 }, (_, k) => k).map(r => ({
@@ -172,21 +176,24 @@ export const HappyWithTypical: Story = {
           tokens: ['kubernetes'],
         }),
         mfaAuthnChallengeSuccess(),
-        listBotInstancesSuccess({
-          bot_instances: [
-            {
-              bot_name: 'bot-1',
-              instance_id: '6570dbf1-3530-4e13-a8c7-497bb9927994',
-              active_at_latest: new Date().toISOString(),
-              host_name_latest:
-                'my-svc.my-namespace.svc.cluster-domain.example',
-              join_method_latest: 'kubernetes',
-              os_latest: 'linux',
-              version_latest: '18.1.0',
-            },
-          ],
-          next_page_token: '',
-        }),
+        listBotInstancesSuccess(
+          {
+            bot_instances: [
+              {
+                bot_name: 'bot-1',
+                instance_id: '6570dbf1-3530-4e13-a8c7-497bb9927994',
+                active_at_latest: new Date().toISOString(),
+                host_name_latest:
+                  'my-svc.my-namespace.svc.cluster-domain.example',
+                join_method_latest: 'kubernetes',
+                os_latest: 'linux',
+                version_latest: '18.1.0',
+              },
+            ],
+            next_page_token: '',
+          },
+          'v1'
+        ),
         successGetRoles({
           startKey: '',
           items: Array.from({ length: 10 }, (_, k) => k).map(r => ({
@@ -238,22 +245,25 @@ export const HappyWithLongValues: Story = {
           ],
         }),
         mfaAuthnChallengeSuccess(),
-        listBotInstancesSuccess({
-          bot_instances: [
-            {
-              bot_name: '',
-              instance_id:
-                '04241a2a66b904241a2a66b904241a2a66b904241a2a66b904241a2a66b9',
-              host_name_latest:
-                'hotnamehotnamehotnamehotnamehotnamehotnamehotnamehotnamehotname',
-              active_at_latest: '2025-01-01T00:00:00Z',
-              join_method_latest: 'github',
-              os_latest: 'linux',
-              version_latest: '17.2.6-04241a2',
-            },
-          ],
-          next_page_token: '',
-        }),
+        listBotInstancesSuccess(
+          {
+            bot_instances: [
+              {
+                bot_name: '',
+                instance_id:
+                  '04241a2a66b904241a2a66b904241a2a66b904241a2a66b904241a2a66b9',
+                host_name_latest:
+                  'hotnamehotnamehotnamehotnamehotnamehotnamehotnamehotnamehotname',
+                active_at_latest: '2025-01-01T00:00:00Z',
+                join_method_latest: 'github',
+                os_latest: 'linux',
+                version_latest: '17.2.6-04241a2',
+              },
+            ],
+            next_page_token: '',
+          },
+          'v1'
+        ),
         successGetRoles({
           startKey: '',
           items: ['access', 'editor', 'terraform-provider'].map(r => ({
@@ -582,6 +592,7 @@ function Wrapper(props?: {
   const history = createMemoryHistory({
     initialEntries: ['/web/bot/ansible-worker'],
   });
+  history.push = action('history.push');
 
   const customAcl = makeAcl({
     bots: {

--- a/web/packages/teleport/src/Bots/Details/BotDetails.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.tsx
@@ -56,6 +56,7 @@ import { ResourceLockIndicator } from 'teleport/lib/locks/ResourceLockIndicator'
 import { ResourceUnlockDialog } from 'teleport/lib/locks/ResourceUnlockDialog';
 import { useResourceLock } from 'teleport/lib/locks/useResourceLock';
 import { isAdminActionRequiresMfaError } from 'teleport/services/api/api';
+import { BotInstanceSummary } from 'teleport/services/bot/types';
 import useTeleport from 'teleport/useTeleport';
 
 import { DeleteDialog } from '../Delete/DeleteDialog';
@@ -138,6 +139,17 @@ export function BotDetails() {
   const handleDeleteComplete = () => {
     setShowDeleteConfirmation(false);
     history.replace(cfg.getBotsRoute());
+  };
+
+  const handleInstanceSelected = (instance: BotInstanceSummary) => {
+    const path = cfg.getBotInstancesRoute({
+      selectedItemId: `${instance.bot_name}/${instance.instance_id}`,
+      isAdvancedQuery: true,
+      query: `spec.bot_name == "${instance.bot_name}"`,
+      sortField: 'active_at_latest',
+      sortDir: 'DESC',
+    });
+    history.push(path);
   };
 
   return (
@@ -314,7 +326,10 @@ export function BotDetails() {
             />
           </ColumnContainer>
           <ColumnContainer maxWidth={400}>
-            <InstancesPanel botName={params.botName} />
+            <InstancesPanel
+              botName={params.botName}
+              onItemSelected={handleInstanceSelected}
+            />
           </ColumnContainer>
 
           {isEditing ? (

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.story.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.story.tsx
@@ -18,6 +18,7 @@
 
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { action } from 'storybook/internal/actions';
 import styled from 'styled-components';
 
 import { CardTile } from 'design/CardTile/CardTile';
@@ -47,51 +48,54 @@ type Story = StoryObj<typeof meta>;
 
 export default meta;
 
-export const listBotInstancesSuccessHandler = listBotInstancesSuccess({
-  bot_instances: [
-    {
-      bot_name: 'ansible-worker',
-      instance_id: crypto.randomUUID(),
-      active_at_latest: '2025-07-22T10:54:00Z',
-      host_name_latest: 'my-svc.my-namespace.svc.cluster-domain.example',
-      join_method_latest: 'github',
-      os_latest: 'linux',
-      version_latest: '4.4.0',
-    },
-    {
-      bot_name: 'ansible-worker',
-      instance_id: crypto.randomUUID(),
-      active_at_latest: '2025-07-22T10:54:00Z',
-      host_name_latest: 'win-123a',
-      join_method_latest: 'tpm',
-      os_latest: 'windows',
-      version_latest: '4.3.18+ab12hd',
-    },
-    {
-      bot_name: 'ansible-worker',
-      instance_id: crypto.randomUUID(),
-      active_at_latest: '2025-07-22T10:54:00Z',
-      host_name_latest: 'mac-007',
-      join_method_latest: 'kubernetes',
-      os_latest: 'darwin',
-      version_latest: '3.9.99',
-    },
-    {
-      bot_name: 'ansible-worker',
-      instance_id: crypto.randomUUID(),
-      active_at_latest: '2025-07-22T10:54:00Z',
-      host_name_latest: 'aws:g49dh27dhjm3',
-      join_method_latest: 'ec2',
-      os_latest: 'linux',
-      version_latest: '1.3.2',
-    },
-    {
-      bot_name: 'ansible-worker',
-      instance_id: crypto.randomUUID(),
-    },
-  ],
-  next_page_token: '',
-});
+export const listBotInstancesSuccessHandler = listBotInstancesSuccess(
+  {
+    bot_instances: [
+      {
+        bot_name: 'ansible-worker',
+        instance_id: crypto.randomUUID(),
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'my-svc.my-namespace.svc.cluster-domain.example',
+        join_method_latest: 'github',
+        os_latest: 'linux',
+        version_latest: '4.4.0',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: crypto.randomUUID(),
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'win-123a',
+        join_method_latest: 'tpm',
+        os_latest: 'windows',
+        version_latest: '4.3.18+ab12hd',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: crypto.randomUUID(),
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'mac-007',
+        join_method_latest: 'kubernetes',
+        os_latest: 'darwin',
+        version_latest: '3.9.99',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: crypto.randomUUID(),
+        active_at_latest: '2025-07-22T10:54:00Z',
+        host_name_latest: 'aws:g49dh27dhjm3',
+        join_method_latest: 'ec2',
+        os_latest: 'linux',
+        version_latest: '1.3.2',
+      },
+      {
+        bot_name: 'ansible-worker',
+        instance_id: crypto.randomUUID(),
+      },
+    ],
+    next_page_token: '',
+  },
+  'v1'
+);
 
 export const Happy: Story = {
   parameters: {
@@ -142,7 +146,10 @@ function Wrapper(props: { hasBotInstanceListPermission?: boolean }) {
       <TeleportProviderBasic teleportCtx={ctx}>
         <Container>
           <InnerContainer>
-            <InstancesPanel botName="ansible-worker" />
+            <InstancesPanel
+              botName="ansible-worker"
+              onItemSelected={action('onItemSelected')}
+            />
           </InnerContainer>
         </Container>
       </TeleportProviderBasic>

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
@@ -57,7 +57,7 @@ afterAll(() => server.close());
 describe('InstancesPanel', () => {
   it('should show a fetch error state', async () => {
     withFetchError();
-    render(<InstancesPanel botName="test-bot" />, {
+    render(<InstancesPanel botName="test-bot" onItemSelected={jest.fn()} />, {
       wrapper: makeWrapper(),
     });
     await waitForLoading();
@@ -67,7 +67,7 @@ describe('InstancesPanel', () => {
 
   it('should show a no permissions state', async () => {
     withFetchError();
-    render(<InstancesPanel botName="test-bot" />, {
+    render(<InstancesPanel botName="test-bot" onItemSelected={jest.fn()} />, {
       wrapper: makeWrapper({
         customAcl: makeAcl({
           botInstances: {
@@ -88,7 +88,7 @@ describe('InstancesPanel', () => {
   it('renders instance items', async () => {
     withFetchSuccess();
 
-    render(<InstancesPanel botName="test-bot" />, {
+    render(<InstancesPanel botName="test-bot" onItemSelected={jest.fn()} />, {
       wrapper: makeWrapper(),
     });
     await waitForLoading();

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.tsx
@@ -29,13 +29,17 @@ import { Indicator } from 'design/Indicator/Indicator';
 import Text from 'design/Text';
 
 import { listBotInstances } from 'teleport/services/bot/bot';
+import { BotInstanceSummary } from 'teleport/services/bot/types';
 import useTeleport from 'teleport/useTeleport';
 
 import { Instance } from './Instance';
 import { PanelTitleText } from './Panel';
 
-export function InstancesPanel(props: { botName: string }) {
-  const { botName } = props;
+export function InstancesPanel(props: {
+  botName: string;
+  onItemSelected: (instance: BotInstanceSummary) => void;
+}) {
+  const { botName, onItemSelected } = props;
 
   const [sortField] = useState('active_at_latest');
   const [sortDir, setSortDir] = useState<'ASC' | 'DESC'>('DESC');
@@ -83,6 +87,10 @@ export function InstancesPanel(props: { botName: string }) {
   useEffect(() => {
     contentRef.current?.scrollTo({ top: 0, behavior: 'instant' });
   }, [sortField, sortDir]);
+
+  const makeOnSelectedCallback = (instance: BotInstanceSummary) => () => {
+    onItemSelected(instance);
+  };
 
   return (
     <Container>
@@ -138,6 +146,8 @@ export function InstancesPanel(props: { botName: string }) {
                         method: instance.join_method_latest,
                         os: instance.os_latest,
                       }}
+                      isSelectable
+                      onSelected={makeOnSelectedCallback(instance)}
                     />
                   </React.Fragment>
                 ))

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -846,8 +846,36 @@ const cfg = {
     return generatePath(cfg.routes.bot, { botName });
   },
 
-  getBotInstancesRoute() {
-    return generatePath(cfg.routes.botInstances);
+  getBotInstancesRoute(
+    options?: Partial<{
+      query: string;
+      isAdvancedQuery: boolean;
+      sortField: string;
+      sortDir: 'ASC' | 'DESC';
+      selectedItemId: string;
+      activeTab: 'info' | 'health' | 'yaml';
+    }>
+  ) {
+    const search = new URLSearchParams(location.search);
+    if (options?.query) {
+      search.set('query', options.query);
+    }
+    if (options?.isAdvancedQuery) {
+      search.set('is_advanced', '1');
+    }
+    if (options?.sortField) {
+      search.set('sort_field', options.sortField);
+    }
+    if (options?.sortDir) {
+      search.set('sort_dir', options.sortDir);
+    }
+    if (options?.selectedItemId) {
+      search.set('selected', options.selectedItemId);
+    }
+    if (options?.activeTab) {
+      search.set('tab', options.activeTab);
+    }
+    return generatePath(`${cfg.routes.botInstances}?${search.toString()}`);
   },
 
   getWorkloadIdentitiesRoute() {


### PR DESCRIPTION
## Summary
This change makes items in the Active Instances section of the Bot Details page clickable. On click, the user is navigated to the Bot Instances page with the selected instance item selected. In addition, the Bot Instances page is filtered to show instance items for the appropriate bot (using a Teleport predicate language query), and sorted to be consistent with the instances list on the Bot Details page.

## Changes
- Deeplink to the Bot Instance page when an instance items is selected
- Fix a few network mocks in stories

## Demo

https://github.com/user-attachments/assets/f0e630ca-b9eb-4162-abc8-6279dba51ca5

## Reviewer notes
Here's a script to insert a bunch of bot instances to make testing easier; 
[bot_instances.sql](https://github.com/user-attachments/files/23206765/bot_instances.sql)

```
$ sqlite3 <your cluster's data dir>/backend/sqlite.db
sqlite> .read bot_instances.sql
```
**Be sure to restart your cluster afterwards - the cache will not be notified of the changes.**

Then, create a bot with the name "abscido" - some of the instances created use this bot name. Easiest way is to use the [GitHub Actions wizard in the web UI](https://cluster.local:3000/web/bots/new/github-actions).

Delete **all** instances afterwards to tidy up, if you like;

```sql
delete from kv where key like '/bot_instance/%';
```