### PR TITLE
tctl resource: `database object`

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 	accessmonitoringrulesv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	crownjewelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/crownjewel/v1"
-	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
@@ -53,7 +52,6 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
-	"github.com/gravitational/teleport/tool/tctl/common/databaseobject"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
 	"github.com/gravitational/teleport/tool/tctl/common/oktaassignment"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
@@ -923,32 +921,6 @@ func (c *samlIdPServiceProviderCollection) WriteText(w io.Writer, verbose bool) 
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type databaseObjectCollection struct {
-	objects []*dbobjectv1.DatabaseObject
-}
-
-func (c *databaseObjectCollection) Resources() []types.Resource {
-	resources := make([]types.Resource, len(c.objects))
-	for i, b := range c.objects {
-		resources[i] = databaseobject.ProtoToResource(b)
-	}
-	return resources
-}
-
-func (c *databaseObjectCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name", "Kind", "DB Service", "Protocol"})
-	for _, b := range c.objects {
-		t.AddRow([]string{
-			b.GetMetadata().GetName(),
-			fmt.Sprintf("%v", b.GetSpec().GetObjectKind()),
-			fmt.Sprintf("%v", b.GetSpec().GetDatabaseServiceName()),
-			fmt.Sprintf("%v", b.GetSpec().GetProtocol()),
-		})
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -29,10 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api"
-	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
-	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
 	"github.com/gravitational/teleport/tool/common"
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
@@ -250,41 +248,6 @@ func testDatabaseServerCollection_writeText(t *testing.T) {
 			)
 			return table.AsBuffer().String()
 		},
-	}
-	test.run(t)
-}
-
-func TestDatabaseObjectCollection_writeText(t *testing.T) {
-	mkObj := func(name string) *dbobjectv1.DatabaseObject {
-		r, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
-			Name:                name,
-			Protocol:            "postgres",
-			DatabaseServiceName: "pg",
-			ObjectKind:          "table",
-		})
-		require.NoError(t, err)
-		return r
-	}
-
-	items := []*dbobjectv1.DatabaseObject{
-		mkObj("object_1"),
-		mkObj("object_2"),
-		mkObj("object_3"),
-	}
-
-	table := asciitable.MakeTable(
-		[]string{"Name", "Kind", "DB Service", "Protocol"},
-		[]string{"object_1", "table", "pg", "postgres"},
-		[]string{"object_2", "table", "pg", "postgres"},
-		[]string{"object_3", "table", "pg", "postgres"},
-	)
-
-	formatted := table.AsBuffer().String()
-
-	test := writeTextTest{
-		collection:          &databaseObjectCollection{items},
-		wantVerboseTable:    func() string { return formatted },
-		wantNonVerboseTable: func() string { return formatted },
 	}
 	test.run(t)
 }

--- a/tool/tctl/common/resources/database_object.go
+++ b/tool/tctl/common/resources/database_object.go
@@ -1,0 +1,147 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/tool/tctl/common/databaseobject"
+)
+
+type databaseObjectCollection struct {
+	objects []*dbobjectv1.DatabaseObject
+}
+
+func (c *databaseObjectCollection) Resources() []types.Resource {
+	resources := make([]types.Resource, len(c.objects))
+	for i, b := range c.objects {
+		resources[i] = databaseobject.ProtoToResource(b)
+	}
+	return resources
+}
+
+func (c *databaseObjectCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Kind", "DB Service", "Protocol"})
+	for _, b := range c.objects {
+		t.AddRow([]string{
+			b.GetMetadata().GetName(),
+			fmt.Sprintf("%v", b.GetSpec().GetObjectKind()),
+			fmt.Sprintf("%v", b.GetSpec().GetDatabaseServiceName()),
+			fmt.Sprintf("%v", b.GetSpec().GetProtocol()),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func databaseObjectHandler() Handler {
+	return Handler{
+		getHandler:    getDatabaseObject,
+		createHandler: createDatabaseObject,
+		updateHandler: updateDatabaseObject,
+		deleteHandler: deleteDatabaseObject,
+		singleton:     false,
+		mfaRequired:   false,
+		description:   "Representation of a database object that can be imported into Teleport.",
+	}
+}
+
+func getDatabaseObject(ctx context.Context, client *authclient.Client, ref services.Ref, _ GetOpts) (Collection, error) {
+	remote := client.DatabaseObjectClient()
+	if ref.Name != "" {
+		object, err := remote.GetDatabaseObject(ctx, &dbobjectv1.GetDatabaseObjectRequest{Name: ref.Name})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &databaseObjectCollection{objects: []*dbobjectv1.DatabaseObject{object}}, nil
+	}
+
+	objects, err := stream.Collect(clientutils.Resources(ctx,
+		func(ctx context.Context, limit int, token string) ([]*dbobjectv1.DatabaseObject, string, error) {
+			resp, err := remote.ListDatabaseObjects(ctx, &dbobjectv1.ListDatabaseObjectsRequest{
+				PageSize:  int32(limit),
+				PageToken: token,
+			})
+
+			return resp.GetObjects(), resp.GetNextPageToken(), trace.Wrap(err)
+		}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &databaseObjectCollection{objects: objects}, nil
+}
+
+func createDatabaseObject(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	object, err := databaseobject.UnmarshalJSON(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if opts.Force {
+		_, err = client.DatabaseObjectClient().UpsertDatabaseObject(ctx, &dbobjectv1.UpsertDatabaseObjectRequest{
+			Object: object,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("database object %q has been created\n", object.GetMetadata().GetName())
+		return nil
+	}
+	_, err = client.DatabaseObjectClient().CreateDatabaseObject(ctx, &dbobjectv1.CreateDatabaseObjectRequest{
+		Object: object,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("database object %q has been created\n", object.GetMetadata().GetName())
+	return nil
+}
+
+func updateDatabaseObject(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	object, err := databaseobject.UnmarshalJSON(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.DatabaseObjectClient().UpdateDatabaseObject(ctx, &dbobjectv1.UpdateDatabaseObjectRequest{
+		Object: object,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("database object %q has been updated\n", object.GetMetadata().GetName())
+	return nil
+}
+
+func deleteDatabaseObject(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if _, err := client.DatabaseObjectClient().DeleteDatabaseObject(ctx, &dbobjectv1.DeleteDatabaseObjectRequest{Name: ref.Name}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("database object %q has been deleted\n", ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resources/database_object_import_rule_test.go
+++ b/tool/tctl/common/resources/database_object_import_rule_test.go
@@ -27,33 +27,35 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 )
 
-func TestDatabaseImportRuleCollection_writeText(t *testing.T) {
-	mkRule := func(name string, priority int) *dbobjectimportrulev1.DatabaseObjectImportRule {
-		r, err := databaseobjectimportrule.NewDatabaseObjectImportRule(name, &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
-			Priority: int32(priority),
-			DatabaseLabels: label.FromMap(map[string][]string{
-				"foo":   {"bar"},
-				"beast": {"dragon", "phoenix"},
-			}),
-			Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{
-				{
-					Match: &dbobjectimportrulev1.DatabaseObjectImportMatch{
-						TableNames: []string{"dummy"},
-					},
-					AddLabels: map[string]string{
-						"dummy_table": "true",
-						"another":     "label"},
-				},
-			},
-		})
-		require.NoError(t, err)
-		return r
-	}
+func makeDatabaseObjectImportRule(t *testing.T, name string, priority int) *dbobjectimportrulev1.DatabaseObjectImportRule {
+	t.Helper()
 
+	r, err := databaseobjectimportrule.NewDatabaseObjectImportRule(name, &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
+		Priority: int32(priority),
+		DatabaseLabels: label.FromMap(map[string][]string{
+			"foo":   {"bar"},
+			"beast": {"dragon", "phoenix"},
+		}),
+		Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{
+			{
+				Match: &dbobjectimportrulev1.DatabaseObjectImportMatch{
+					TableNames: []string{"dummy"},
+				},
+				AddLabels: map[string]string{
+					"dummy_table": "true",
+					"another":     "label"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return r
+}
+
+func TestDatabaseImportRuleCollection_writeText(t *testing.T) {
 	rules := []*dbobjectimportrulev1.DatabaseObjectImportRule{
-		mkRule("rule_1", 11),
-		mkRule("rule_2", 22),
-		mkRule("rule_3", 33),
+		makeDatabaseObjectImportRule(t, "rule_1", 11),
+		makeDatabaseObjectImportRule(t, "rule_2", 22),
+		makeDatabaseObjectImportRule(t, "rule_3", 33),
 	}
 
 	table := asciitable.MakeTable(

--- a/tool/tctl/common/resources/database_object_test.go
+++ b/tool/tctl/common/resources/database_object_test.go
@@ -26,22 +26,23 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
 )
 
-func TestDatabaseObjectCollection_writeText(t *testing.T) {
-	mkObj := func(name string) *dbobjectv1.DatabaseObject {
-		r, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
-			Name:                name,
-			Protocol:            "postgres",
-			DatabaseServiceName: "pg",
-			ObjectKind:          "table",
-		})
-		require.NoError(t, err)
-		return r
-	}
+func makeDatabaseObject(t *testing.T, name string) *dbobjectv1.DatabaseObject {
+	t.Helper()
+	r, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
+		Name:                name,
+		Protocol:            "postgres",
+		DatabaseServiceName: "pg",
+		ObjectKind:          "table",
+	})
+	require.NoError(t, err)
+	return r
+}
 
+func TestDatabaseObjectCollection_writeText(t *testing.T) {
 	items := []*dbobjectv1.DatabaseObject{
-		mkObj("object_1"),
-		mkObj("object_2"),
-		mkObj("object_3"),
+		makeDatabaseObject(t, "object_1"),
+		makeDatabaseObject(t, "object_2"),
+		makeDatabaseObject(t, "object_3"),
 	}
 
 	table := asciitable.MakeTable(

--- a/tool/tctl/common/resources/database_object_test.go
+++ b/tool/tctl/common/resources/database_object_test.go
@@ -1,0 +1,57 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	dbobjectv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobject/v1"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/srv/db/common/databaseobject"
+)
+
+func TestDatabaseObjectCollection_writeText(t *testing.T) {
+	mkObj := func(name string) *dbobjectv1.DatabaseObject {
+		r, err := databaseobject.NewDatabaseObject(name, &dbobjectv1.DatabaseObjectSpec{
+			Name:                name,
+			Protocol:            "postgres",
+			DatabaseServiceName: "pg",
+			ObjectKind:          "table",
+		})
+		require.NoError(t, err)
+		return r
+	}
+
+	items := []*dbobjectv1.DatabaseObject{
+		mkObj("object_1"),
+		mkObj("object_2"),
+		mkObj("object_3"),
+	}
+
+	table := asciitable.MakeTable(
+		[]string{"Name", "Kind", "DB Service", "Protocol"},
+		[]string{"object_1", "table", "pg", "postgres"},
+		[]string{"object_2", "table", "pg", "postgres"},
+		[]string{"object_3", "table", "pg", "postgres"},
+	)
+
+	formatted := table.AsBuffer().String()
+
+	collectionFormatTest(t, &databaseObjectCollection{items}, formatted, formatted)
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -46,6 +46,7 @@ func Handlers() map[string]Handler {
 		types.KindBot:                                botHandler(),
 		types.KindBotInstance:                        botInstanceHandler(),
 		types.KindDatabase:                           databaseHandler(),
+		types.KindDatabaseObject:                     databaseObjectHandler(),
 		types.KindDatabaseObjectImportRule:           databaseObjectImportRuleHandler(),
 		types.KindDiscoveryConfig:                    discoveryConfigHandler(),
 		types.KindGitServer:                          gitServerHandler(),

--- a/tool/tctl/common/resources/resource_test.go
+++ b/tool/tctl/common/resources/resource_test.go
@@ -26,11 +26,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/label"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/common/databaseobjectimportrule"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 	"github.com/gravitational/teleport/tool/teleport/testenv"
@@ -88,27 +85,20 @@ func TestHandlers(t *testing.T) {
 			checkMFARequired: require.False,
 		},
 		{
+			kind: types.KindDatabaseObject,
+			makeResource: func(t *testing.T, name string) types.Resource {
+				t.Helper()
+				resource := makeDatabaseObject(t, name)
+				return types.ProtoResource153ToLegacy(resource)
+			},
+			checkMFARequired: require.False,
+			updateResource:   updateResourceWithLabels,
+		},
+		{
 			kind: types.KindDatabaseObjectImportRule,
 			makeResource: func(t *testing.T, name string) types.Resource {
 				t.Helper()
-				resource, err := databaseobjectimportrule.NewDatabaseObjectImportRule(name, &dbobjectimportrulev1.DatabaseObjectImportRuleSpec{
-					Priority: 123,
-					DatabaseLabels: label.FromMap(map[string][]string{
-						"foo":   {"bar"},
-						"beast": {"dragon", "phoenix"},
-					}),
-					Mappings: []*dbobjectimportrulev1.DatabaseObjectImportRuleMapping{
-						{
-							Match: &dbobjectimportrulev1.DatabaseObjectImportMatch{
-								TableNames: []string{"dummy"},
-							},
-							AddLabels: map[string]string{
-								"dummy_table": "true",
-								"another":     "label"},
-						},
-					},
-				})
-				require.NoError(t, err)
+				resource := makeDatabaseObjectImportRule(t, name, 100)
 				return types.ProtoResource153ToLegacy(resource)
 			},
 			checkMFARequired: require.False,


### PR DESCRIPTION
Convert `db_object` to the new tctl resource handler format.

Updates https://github.com/gravitational/teleport/issues/60370