### PR TITLE
gha(docs-test): setup node v22

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -83,7 +83,6 @@ jobs:
         run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
 
       - name: Install Node.js
-        id: setup-node
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
@@ -92,7 +91,6 @@ jobs:
 
       - name: Install docs site dependencies
         working-directory: docs
-        if: ${{ steps.setup-node.outputs.cache-hit != 'true' }}
         # Prevent occasional `yarn install` executions that run indefinitely
         timeout-minutes: 10
         run: yarn install

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -86,6 +86,7 @@ jobs:
         with:
           node-version: 22
           cache: 'yarn'
+          cache-dependency-path: '${{ github.workspace }}/docs/yarn.lock'
 
       - name: Install docs site dependencies
         working-directory: docs

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -81,19 +81,11 @@ jobs:
           TOKEN: ${{ steps.generate_token.outputs.token }}
           REVIEWERS: ${{ secrets.reviewers }}
         run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
-      # Cache node_modules. Unlike the example in the actions/cache repo, this
-      # caches the node_modules directory instead of the yarn cache. This is
-      # because yarn needs to build fresh packages even when it copies files
-      # from the yarn cache into node_modules.
-      # See:
-      # https://github.com/actions/cache/blob/main/examples.md#node---yarn
-      - uses: actions/cache@v4
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          path: '${{ github.workspace }}/docs/node_modules'
-          key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}/docs/yarn.lock', github.workspace)) }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: 22
+          cache: 'yarn'
 
       - name: Install docs site dependencies
         working-directory: docs

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -72,9 +72,10 @@ jobs:
           ref: 6f388765b8ce993721502083c74cb9af1fc5658f 
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
           go-version: 'stable'
+          cache-dependency-path: shared-workflows/bot/go.sum
 
       - name: Ensure docs changes include redirects
         env:

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -82,7 +82,9 @@ jobs:
           REVIEWERS: ${{ secrets.reviewers }}
         run: cd shared-workflows/bot && go run main.go -workflow=docpaths -token="${TOKEN}" -teleport-path="${GITHUB_WORKSPACE}/teleport" -reviewers="${REVIEWERS}"
 
-      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+      - name: Install Node.js
+        id: setup-node
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: 22
           cache: 'yarn'
@@ -90,7 +92,7 @@ jobs:
 
       - name: Install docs site dependencies
         working-directory: docs
-        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.setup-node.outputs.cache-hit != 'true' }}
         # Prevent occasional `yarn install` executions that run indefinitely
         timeout-minutes: 10
         run: yarn install

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -86,9 +86,10 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: 22
+          # node-version: 22
           cache: 'yarn'
           cache-dependency-path: '${{ github.workspace }}/docs/yarn.lock'
+          node-version-file: '${{ github.workspace }}/docs/package.json'
 
       - name: Install docs site dependencies
         working-directory: docs

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -86,10 +86,9 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          # node-version: 22
+          node-version: 22
           cache: 'yarn'
           cache-dependency-path: '${{ github.workspace }}/docs/yarn.lock'
-          node-version-file: '${{ github.workspace }}/docs/package.json'
 
       - name: Install docs site dependencies
         working-directory: docs

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -93,7 +93,7 @@ jobs:
         working-directory: docs
         # Prevent occasional `yarn install` executions that run indefinitely
         timeout-minutes: 10
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
       - name: Prepare docs site configuration
         working-directory: docs


### PR DESCRIPTION
Use `setup-node` action to install node v22 and use it for dependency caching.

Ride-along: update `setup-go` action and fix caching.

Related to:
- https://github.com/gravitational/docs-website/pull/437
- https://github.com/gravitational/docs-website/pull/438