### PR TITLE
Allow the usage of AWS-RunShellScript in discovery bootstrapping commands

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -985,6 +985,10 @@ func buildSSMDocumentCreators(ctx context.Context, config ConfiguratorConfig, ta
 		if !slices.Contains(matcher.Types, types.AWSMatcherEC2) {
 			continue
 		}
+		// If using the pre-defined AWS-RunShellScript document, skip SSM document creation.
+		if matcher.SSM.DocumentName == types.AWSSSMDocumentRunShellScript {
+			continue
+		}
 		for _, region := range matcher.Regions {
 			var ssmClient ssmClient
 			if !config.Flags.Manual {

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
@@ -108,13 +108,24 @@ func TestEC2SSMIAMConfigReqDefaults(t *testing.T) {
 			errCheck: badParameterCheck,
 		},
 		{
-			name: "missing ssm document",
+			name: "missing ssm document is not an issue because users might want to use a pre-defined one",
 			req: func() EC2SSMIAMConfigureRequest {
 				req := baseReq()
 				req.SSMDocumentName = ""
 				return req
 			},
-			errCheck: badParameterCheck,
+			errCheck: require.NoError,
+			expected: EC2SSMIAMConfigureRequest{
+				Region:                      "us-east-1",
+				IntegrationRole:             "integrationrole",
+				IntegrationRoleEC2SSMPolicy: "EC2DiscoverWithSSM",
+				SSMDocumentName:             "",
+				ProxyPublicURL:              "https://proxy.example.com",
+				ClusterName:                 "my-cluster",
+				IntegrationName:             "my-integration",
+				AccountID:                   "123456789012",
+				AutoConfirm:                 true,
+			},
 		},
 		{
 			name: "missing proxy url",

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -678,10 +678,9 @@ func (h *Handler) awsOIDCConfigureEC2SSMIAM(w http.ResponseWriter, r *http.Reque
 		return nil, trace.Wrap(err, "invalid awsAccountID")
 	}
 
+	// SSM Document is not required, since the user might want to use a pre-defined one. Eg, AWS-RunShellScript.
 	ssmDocumentName := queryParams.Get("ssmDocument")
-	if ssmDocumentName == "" {
-		return nil, trace.BadParameter("missing ssmDocument query param")
-	}
+
 	// PublicProxyAddr() might return tenant.teleport.sh
 	// However, the expected format for --proxy-public-url includes the protocol `https://`
 	proxyPublicURL := h.PublicProxyAddr()

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -512,7 +512,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEC2SSMCmd := integrationConfigureCmd.Command("ec2-ssm-iam", "Adds required IAM permissions and SSM Document to enable EC2 Auto Discover using SSM.")
 	integrationConfEC2SSMCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.RoleName)
 	integrationConfEC2SSMCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.Region)
-	integrationConfEC2SSMCmd.Flag("ssm-document-name", "The AWS SSM Document name to create that will be used to install teleport.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.SSMDocumentName)
+	integrationConfEC2SSMCmd.Flag("ssm-document-name", "The AWS SSM Document name to create that will be used to install teleport.").StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.SSMDocumentName)
 	integrationConfEC2SSMCmd.Flag("proxy-public-url", "Proxy Public URL (eg https://mytenant.teleport.sh).").StringVar(&ccf.
 		IntegrationConfEC2SSMIAMArguments.ProxyPublicURL)
 	integrationConfEC2SSMCmd.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.IntegrationConfEC2SSMIAMArguments.ClusterName)


### PR DESCRIPTION
EC2 server auto discovery used to require a custom SSM Document.
After https://github.com/gravitational/teleport/pull/60224, this is no longer the case.

We are now able to use the AWS-RunShellScript pre-defined document.
This document is present in all the AWS Account and Regions.

We have two bootstrap commands for the EC2 Server Discovery:
- one used from the web ui (discover wizard)
- another one called using `teleport discovery bootstrap` as described in the docs https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided/#step-57-bootstrap-the-discovery-service-aws-configuration

This PR ensures that creating an SSM Document is optional and if the SSM Document name is `AWS-RunShellScript`, then the SSM Document creation step is skipped.