### PR TITLE
[v17] Update docs frontmatter fields

### DIFF
--- a/docs/pages/enroll-resources/application-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Application Access Guides
 description: Guides for configuring Teleport application access.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
@@ -1,7 +1,7 @@
 ---
 title: Application Access JWT Authentication
 description: Guides for using Teleport application access JWT authentication.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/auto-discovery/reference/aws-iam.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/reference/aws-iam.mdx
@@ -1,7 +1,6 @@
 ---
 title: Discovery Service AWS IAM Reference
 description: AWS IAM permissions for the Teleport Discovery Service.
-tocDepth: 3
 tags:
  - reference
  - zero-trust

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server Auto-Discovery for Amazon EC2
 description: How to configure Teleport to automatically enroll EC2 instances.
-labels:
+tags:
  - how-to
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx
@@ -1,7 +1,6 @@
 ---
 title: Database Access with AWS RDS Proxy for Microsoft SQL Server
 description: How to configure Teleport database access with AWS RDS Proxy for Microsoft SQL Server
-labels:
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx
@@ -1,6 +1,5 @@
 ---
 title: Database Access with AWS RDS and Aurora
-h1: Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB
 description: How to configure Teleport database access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/database-access/guides/guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using the Teleport Database Service
 description: Guides to possibilities for running the Teleport Database Service.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -2,7 +2,6 @@
 title: Configure access for Active Directory manually
 description: Explains how to manually connect Teleport to an Active Directory domain.
 videoBanner: YvMqgcq0MTQ
-tocDepth: 3
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/register-clusters/register-clusters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Registering Kubernetes Clusters with Teleport
 description: How to manually add a Kubernetes cluster to Teleport after creating it.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -1,7 +1,6 @@
 ---
 title: Configure SSH with the Linux Auditing System
 description: How to configure Teleport SSH with auditd (Linux Auditing System).
-h1: Linux Auditing System (auditd)
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -1,7 +1,6 @@
 ---
 title: Enhanced Session Recording for SSH with BPF
 description: How to record your SSH session commands using BPF.
-h1: Enhanced Session Recording with BPF
 videoBanner: 8uO5H-iYw5A
 tags:
  - how-to

--- a/docs/pages/enroll-resources/server-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Server Access Guides
 description: Teleport server access guides.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/jetbrains-sftp.mdx
@@ -1,7 +1,6 @@
 ---
 title: JetBrains SFTP
 description: How to use a JetBrains IDE to manipulate files on a remote host with Teleport
-h1: SFTP with JetBrains IDE
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -1,7 +1,6 @@
 ---
 title: Configure SSH with Pluggable Authentication Modules
 description: How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
-h1: Pluggable Authentication Modules (PAM)
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/enroll-resources/server-access/guides/vscode.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/vscode.mdx
@@ -1,7 +1,6 @@
 ---
 title: Visual Studio Code
 description: How to use Visual Studio Code's Remote Development plugin with Teleport
-h1: Remote Development With Visual Studio Code
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
+++ b/docs/pages/enroll-resources/server-access/openssh/openssh.mdx
@@ -1,7 +1,7 @@
 ---
 title: OpenSSH Guides
 description: Teleport Agentless OpenSSH integration guides.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport FAQ
 description: Frequently Asked Questions About Using Teleport
-h1: Teleport FAQ
 tags:
   - faq
   - platform-wide

--- a/docs/pages/get-started/access.mdx
+++ b/docs/pages/get-started/access.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step 3 - Set Up Access Controls"
 description: "Configure identity-based access controls in your Teleport cluster."
-tocDepth: 2
+toc_max_heading_level: 2
 tags:
   - get-started
 ---

--- a/docs/pages/get-started/audit.mdx
+++ b/docs/pages/get-started/audit.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step 4 - Monitor Audit Logs"
 description: "Explore audit logging features in your Teleport cluster."
-tocDepth: 2
+toc_max_heading_level: 2
 tags:
   - get-started
 ---

--- a/docs/pages/get-started/connect.mdx
+++ b/docs/pages/get-started/connect.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step 2 - Connect Infrastructure"
 description: "Enroll the resources you want to protect with your Teleport cluster."
-tocDepth: 2
+toc_max_heading_level: 2
 tags:
   - get-started
 ---

--- a/docs/pages/get-started/deploy-cloud.mdx
+++ b/docs/pages/get-started/deploy-cloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Step 1 - Sign up for Teleport Enterprise Cloud"
 description: "Sign up for Teleport Enterprise Cloud and deploy your hosted cluster."
-tocDepth: 2
+toc_max_heading_level: 2
 tags:
   - get-started
   - platform-wide

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Step 1 - Deploy Teleport Community Edition"
 description: "Deploy a self-hosted Teleport Community Edition cluster using the Linux demo."
-tocDepth: 3
 tags:
   - get-started
   - platform-wide

--- a/docs/pages/get-started/get-started.mdx
+++ b/docs/pages/get-started/get-started.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Get Started with Teleport"
 description: "Learn how to deploy a cluster, connect infrastructure, set up access controls, and review audit logs."
-tocDepth: 3
 template: no-toc
 tags:
   - get-started

--- a/docs/pages/identity-governance/access-lists/access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/access-lists.mdx
@@ -1,7 +1,7 @@
 ---
 title: Access Lists
 description: Use Access Lists in Teleport
-layout: tocless-doc
+template: "no-toc"
 sidebar_position: 3
 tags:
  - identity-governance

--- a/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
+++ b/docs/pages/identity-governance/access-request-plugins/access-request-plugins.mdx
@@ -1,7 +1,7 @@
 ---
 title: Just-in-Time Access Request Plugins
 description: "Use Teleport's Access Request plugins to least-privilege access without sacrificing productivity."
-layout: tocless-doc
+template: "no-toc"
 sidebar_position: 2
 tags:
  - conceptual

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -1,7 +1,6 @@
 ---
 title: Configure Access Requests
 description: Describes the options available for configuring just-in-time access to roles and resources in your Teleport cluster.
-tocDepth: 3
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/identity-governance/access-requests/access-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/access-requests.mdx
@@ -1,7 +1,7 @@
 ---
 title: Just-in-Time Access Requests
 description: Use just-in-time Access Requests to request elevated privileges.
-layout: tocless-doc
+template: "no-toc"
 sidebar_position: 1
 tags:
  - conceptual

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -1,7 +1,6 @@
 ---
 title: Resource Access Requests
 description: Teleport allows users to request access to specific resources from the CLI or UI. Requests can be escalated via ChatOps or anywhere else via our flexible Authorization Workflow API.
-tocDepth: 3
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/identity-governance/access-requests/role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/role-requests.mdx
@@ -1,7 +1,6 @@
 ---
 title: Role Access Requests
 description: Use Just-in-time Access Requests to request new roles with elevated privileges.
-h1: Teleport Role Access Requests
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/identity-governance/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/advanced-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Advanced Identity Center Options
 description: Describes advanced Identity Center use cases.
-labels:
+tags:
  - conceptual
  - identity-governance
 ---

--- a/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -1,7 +1,6 @@
 ---
 title: Migrating AWS IAM Identity Center from Okta to Teleport
 description: Explains how to migrate an Identity Center instance from Okta control to Teleport control.
-tocDepth: 3
 tags:
  - how-to
  - identity-governance
@@ -479,3 +478,4 @@ $ tctl plugins delete aws-identity-center
   [JIT Access Requests](../access-requests/access-requests.mdx) and 
   [Access Lists](../access-lists/access-lists.mdx).
 - See how to [use Teleport-managed account assignments with the AWS command-line tools](./using-aws-cli.mdx). 
+

--- a/docs/pages/identity-governance/device-trust/device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/device-trust.mdx
@@ -1,7 +1,7 @@
 ---
 title: Device Trust
 description: Teleport Device Trust Concepts
-layout: tocless-doc
+template: "no-toc"
 videoBanner: gBQyj_X1LVw
 sidebar_position: 5
 tags:

--- a/docs/pages/identity-governance/entra-id/faq.mdx
+++ b/docs/pages/identity-governance/entra-id/faq.mdx
@@ -2,7 +2,6 @@
 title: Entra ID Integration FAQ
 description: Frequently asked questions on the Teleport Entra ID integration.
 sidebar_position: 3
-labels:
 tags:
  - identity-governance
 ---

--- a/docs/pages/identity-governance/identity-gov-use-cases.mdx
+++ b/docs/pages/identity-governance/identity-gov-use-cases.mdx
@@ -1,7 +1,7 @@
 ---
 title: Identity Governance in Action
 description: Common use cases with Teleport Identity Governance
-labels:
+tags:
  - identity-governance
 ---
 

--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -1,7 +1,6 @@
 ---
 title: SAML IdP Attribute Mapping
 description: How to map user attributes to custom SAML response
-h1: SAML Attribute Mapping
 tags:
  - conceptual
  - identity-governance

--- a/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/identity-governance/idps/saml-gcp-workforce-identity-federation.mdx
@@ -1,7 +1,6 @@
 ---
-title: Access GCP Web Console and API with federated authentication
+title: GCP Workforce Identity Federation with Teleport SAML IdP
 description: Manage Google Cloud Platform (GCP) web console access with Teleport SAML IdP.
-h1: GCP Workforce Identity Federation with Teleport SAML IdP
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/identity-governance/idps/saml-guide.mdx
+++ b/docs/pages/identity-governance/idps/saml-guide.mdx
@@ -1,7 +1,6 @@
 ---
 title: Using Teleport as a SAML identity provider
 description: How to configure and use Teleport as a SAML identity provider.
-h1: Teleport as a SAML identity provider
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/identity-security/teleport-policy.mdx
+++ b/docs/pages/identity-security/teleport-policy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Teleport Identity Security
 description: A reference for Access Graph with Identity Security.
-labels:
+tags:
  - conceptual
  - identity-security
 ---

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,8 +1,6 @@
 ---
-h1: Introduction to Teleport
 title: "The Teleport Infrastructure Identity Platform"
 description: Read an overview of the Teleport Access Platform. Learn how to implement Zero Trust Security across all your infrastructure for enhanced protection and streamlined access control.
-tocDepth: 3
 template: "landing-page"
 ---
 

--- a/docs/pages/installation/installation.mdx
+++ b/docs/pages/installation/installation.mdx
@@ -1,9 +1,7 @@
 ---
 title: Installing Teleport
 description: How to install Teleport and Teleport's client tools on your platform, including binaries and instructions for Docker and Helm.
-h1: Installation
 videoBanner: fjk29wqXm1A
-tocDepth: 3
 tags:
 - reference
 - platform-wide

--- a/docs/pages/ips.mdx
+++ b/docs/pages/ips.mdx
@@ -1,7 +1,6 @@
 ---
 title: Public IP Address Allowlist
 description: Restrict outbound network connections from your infrastructure to cloud-hosted Teleport Enterprise.
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/ai-agents-mwi.mdx
@@ -1,7 +1,7 @@
 ---
 title: AI Agents with Machine & Workload Identity
 description: Managing AI Agents with Machine & Workload Identity
-labels:
+tags:
  - conceptual
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
+++ b/docs/pages/machine-workload-identity/hybrid-multi-mwi.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hybrid & Multi-Cloud with Machine & Workload Identity
 description: Managing hybrid and multi-cloud systems with Machine & Workload Identity
-labels:
+tags:
  - conceptual
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/iac-mwi.mdx
+++ b/docs/pages/machine-workload-identity/iac-mwi.mdx
@@ -1,7 +1,7 @@
 ---
 title: Infrastructure-as-Code with Machine & Workload Identity
 description: Configuring IaC with Machine & Workload Identity
-labels:
+tags:
  - conceptual
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/access-guides.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/access-guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Access your Infrastructure with Machine ID
 description: How to use Machine ID to enable secure access to Teleport resources.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/access-guides/argocd.mdx
@@ -1,7 +1,7 @@
 ---
 title: Machine ID with Argo CD
 description: How to use Machine ID to enable Argo CD to connect to external Kubernetes clusters
-labels:
+tags:
  - how-to
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/deployment.mdx
@@ -1,7 +1,6 @@
 ---
 title: Deploy tbot
 description: Explains how to deploy tbot on your platform and join it to your Teleport cluster.
-tocDepth: 3
 tags:
  - conceptual
  - mwi

--- a/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes-oidc.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/deployment/kubernetes-oidc.mdx
@@ -1,7 +1,7 @@
 ---
 title: Deploying tbot on Kubernetes with OIDC
 description: How to install and configure Machine ID on Kubernetes with OIDC
-labels:
+tags:
  - how-to
  - mwi
 ---

--- a/docs/pages/machine-workload-identity/machine-id/introduction.mdx
+++ b/docs/pages/machine-workload-identity/machine-id/introduction.mdx
@@ -2,7 +2,6 @@
 title: Introduction to Machine ID
 description: Teleport Machine ID introduction, demo and resources.
 videoBanner: QWd0eqIa9mA
-tocDepth: 3
 tags:
  - conceptual
  - mwi

--- a/docs/pages/machine-workload-identity/workload-mwi.mdx
+++ b/docs/pages/machine-workload-identity/workload-mwi.mdx
@@ -1,7 +1,7 @@
 ---
 title: Service to Service mTLS with Machine & Workload Identity
 description: Managing Service to Service mTLS with Machine & Workload Identity
-labels:
+tags:
  - conceptual
  - mwi
 ---

--- a/docs/pages/model-context-preview.mdx
+++ b/docs/pages/model-context-preview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Secure Agentic AI with Teleport Zero Trust Access"
 description: "Access control and audit between LLMs and data sources or MCP servers."
-h1: Secure Agentic AI with Teleport Zero Trust Access
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/reference/access-controls/login-rules.mdx
+++ b/docs/pages/reference/access-controls/login-rules.mdx
@@ -1,7 +1,6 @@
 ---
 title: Login Rules Reference 
 description: Reference documentation for Login Rules
-tocDepth: 3
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -1,7 +1,6 @@
 ---
 title: Access Controls Reference
 description: Explains the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
-tocDepth: 3
 tags:
  - reference
  - zero-trust

--- a/docs/pages/reference/agent-services/agent-services.mdx
+++ b/docs/pages/reference/agent-services/agent-services.mdx
@@ -1,6 +1,5 @@
 ---
-title: Agent Services
-h1: Agent Service References
+title: Agent Service References
 description: Includes guides to use while using the SSH Service, Database Service, and other Teleport Agent services.
 tags:
  - zero-trust

--- a/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
@@ -1,7 +1,7 @@
 ---
 title: Desktop Access Reference
 description: Comprehensive guides to configuring and auditing desktop access.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/reference/architecture/agents.mdx
+++ b/docs/pages/reference/architecture/agents.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Agent Architecture
 description: Describes the architecture that enables Teleport to securely proxy client traffic to infrastructure resources. 
-tocDepth: 3
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Authentication
 description: This chapter explains how Teleport uses certificate authorities to authenticate users and services.
-h1: Teleport Authentication with Certificates
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Authorization
 description: This chapter explains how Teleport authorizes users and roles.
-h1: Teleport Authorization
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Proxy Service
 description: Architecture of Teleport's identity-aware proxy service
-h1: Teleport Identity-Aware Proxy Service
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/reference/cli/cli.mdx
+++ b/docs/pages/reference/cli/cli.mdx
@@ -1,6 +1,5 @@
 ---
-title: Command-Line Tools
-h1: CLI References
+title: Command-Line Tool References
 description: Detailed guide and reference documentation for Teleport's command line interface (CLI) tools.
 tags:
  - reference

--- a/docs/pages/reference/cloud-faq.mdx
+++ b/docs/pages/reference/cloud-faq.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Enterprise Cloud FAQ
 description: Teleport cloud frequently asked questions.
-tocDepth: 3
 tags:
   - faq
   - platform-wide

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -1,9 +1,7 @@
 ---
-title: Teleport Configuration
-h1: Teleport Configuration Reference
+title: Teleport Configuration Reference
 description: The detailed guide and reference documentation for configuring Teleport for SSH and Kubernetes access.
 keywords: [config, file, reference, yaml, etc]
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -1,8 +1,7 @@
 ---
-title: Helm Charts
-h1: Helm Chart References
+title: Helm Chart References
 description: Comprehensive lists of configuration values in Teleport's Helm charts
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/reference/join-methods.mdx
+++ b/docs/pages/reference/join-methods.mdx
@@ -1,9 +1,7 @@
 ---
 title: Join Methods and Tokens
-h1: Join Methods and Token Reference
 description: Describes the different ways to configure a Teleport to join a cluster.
 keywords: [join, joining, token]
-tocDepth: 3
 tags:
  - conceptual
  - reference

--- a/docs/pages/reference/machine-id/configuration.mdx
+++ b/docs/pages/reference/machine-id/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Machine ID Configuration Reference
 description: Configuration reference for Teleport Machine ID.
-tocDepth: 4
+toc_max_heading_level: 4
 tags:
  - reference
  - mwi

--- a/docs/pages/reference/monitoring/monitoring.mdx
+++ b/docs/pages/reference/monitoring/monitoring.mdx
@@ -1,6 +1,5 @@
 ---
-title: Teleport Monitoring
-h1: Teleport Monitoring References
+title: Teleport Monitoring References
 description: Provides comprehensive guides to monitoring data available from Teleport.
 tags:
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-accesslists.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportAccessList
 description: Provides a comprehensive list of fields in the TeleportAccessList resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-botsv1.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-botsv1.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportBotV1
 description: Provides a comprehensive list of fields in the TeleportBotV1 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-githubconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-githubconnectors.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportGithubConnector
 description: Provides a comprehensive list of fields in the TeleportGithubConnector resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-loginrules.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-loginrules.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportLoginRule
 description: Provides a comprehensive list of fields in the TeleportLoginRule resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-oidcconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-oidcconnectors.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportOIDCConnector
 description: Provides a comprehensive list of fields in the TeleportOIDCConnector resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-oktaimportrules.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-oktaimportrules.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportOktaImportRule
 description: Provides a comprehensive list of fields in the TeleportOktaImportRule resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-openssheiceserversv2.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportOpenSSHEICEServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHEICEServerV2 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-opensshserversv2.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-opensshserversv2.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportOpenSSHServerV2
 description: Provides a comprehensive list of fields in the TeleportOpenSSHServerV2 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-provisiontokens.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-provisiontokens.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportProvisionToken
 description: Provides a comprehensive list of fields in the TeleportProvisionToken resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-roles.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-roles.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportRole
 description: Provides a comprehensive list of fields in the TeleportRole resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv6.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv6.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportRoleV6
 description: Provides a comprehensive list of fields in the TeleportRoleV6 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv7.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-rolesv7.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportRoleV7
 description: Provides a comprehensive list of fields in the TeleportRoleV7 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-samlconnectors.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-samlconnectors.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportSAMLConnector
 description: Provides a comprehensive list of fields in the TeleportSAMLConnector resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-trustedclustersv2.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportTrustedClusterV2
 description: Provides a comprehensive list of fields in the TeleportTrustedClusterV2 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-users.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-users.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportUser
 description: Provides a comprehensive list of fields in the TeleportUser resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
+++ b/docs/pages/reference/operator-resources/resources-teleport-dev-workloadidentitiesv1.mdx
@@ -1,7 +1,6 @@
 ---
 title: TeleportWorkloadIdentityV1
 description: Provides a comprehensive list of fields in the TeleportWorkloadIdentityV1 resource available through the Teleport Kubernetes operator
-tocDepth: 3
 tags:
  - reference
  - platform-wide

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -1,6 +1,5 @@
 ---
 title: Teleport Resources
-h1: Teleport Resource Reference
 description: Reference documentation for Teleport resources
 tags:
  - reference

--- a/docs/pages/reference/signals.mdx
+++ b/docs/pages/reference/signals.mdx
@@ -1,6 +1,5 @@
 ---
 title: Teleport Signals
-h1: Teleport Signals Reference
 description: "Signals you can send to a running teleport process."
 tags:
  - reference

--- a/docs/pages/reference/signature-algorithms.mdx
+++ b/docs/pages/reference/signature-algorithms.mdx
@@ -1,6 +1,5 @@
 ---
 title: Signature Algorithms
-h1: Signature Algorithms Reference
 description: "Signature algorithms used in Teleport."
 tags:
  - conceptual

--- a/docs/pages/reference/user-types.mdx
+++ b/docs/pages/reference/user-types.mdx
@@ -2,7 +2,6 @@
 title: User Types
 description: Describes the different types of Teleport users and their properties.
 keywords: [user,idp,sso]
-tocDepth: 3
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/upgrading/upgrading-manual.mdx
+++ b/docs/pages/upgrading/upgrading-manual.mdx
@@ -1,7 +1,6 @@
 ---
 title: Manual Upgrades
 description: Provides detailed information on upgrading Teleport without Managed Updates.
-tocDepth: 3
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -1,7 +1,6 @@
 ---
 title: Usage Reporting and Billing
 description: Provides a detailed breakdown of Teleport usage reporting and billing.
-tocDepth: 3
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/zero-trust-access/access-controls/access-controls.mdx
+++ b/docs/pages/zero-trust-access/access-controls/access-controls.mdx
@@ -1,8 +1,8 @@
 ---
 title: Access Controls
 description: How to provide role-based access control (RBAC) for servers, databases, Kubernetes clusters, and other resources in your infrastructure
-layout: tocless-doc
-labels:
+template: no-toc
+tags:
  - zero-trust
 ---
 

--- a/docs/pages/zero-trust-access/access-controls/getting-started.mdx
+++ b/docs/pages/zero-trust-access/access-controls/getting-started.mdx
@@ -1,7 +1,7 @@
 ---
 title: Getting Started With Access Controls
 description: Get started using Access Controls.
-labels:
+tags:
  - get-started
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/dual-authz.mdx
@@ -2,7 +2,7 @@
 title: Dual Authorization
 description: Dual Authorization for SSH and Kubernetes.
 videoBanner: b_iqJm_o15I
-labels:
+tags:
  - how-to
  - identity-governance
 ---

--- a/docs/pages/zero-trust-access/access-controls/guides/guides.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/guides.mdx
@@ -1,8 +1,8 @@
 ---
 title: Cluster Access and RBAC
 description: How to configure access to specific resources in your infrastructure or your Teleport cluster as a whole.
-layout: tocless-doc
-labels:
+template: no-toc
+tags:
  - zero-trust
 ---
 

--- a/docs/pages/zero-trust-access/access-controls/login-rules/login-rules.mdx
+++ b/docs/pages/zero-trust-access/access-controls/login-rules/login-rules.mdx
@@ -1,7 +1,7 @@
 ---
 title: Login Rules 
 description: Transform User Traits with Login Rules
-layout: tocless-doc
+template: "no-toc"
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/api/api.mdx
+++ b/docs/pages/zero-trust-access/api/api.mdx
@@ -1,7 +1,7 @@
 ---
 title: Using the Teleport API
 description: Guides to writing a client application for the Teleport gRPC API, which makes it possible to programmatically manage dynamic resources.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
@@ -1,7 +1,6 @@
 ---
 title: SOC 2 compliance for SSH, Kubernetes, and Databases
 description: How to configure SOC 2-compliant access to SSH, Kubernetes, databases, desktops, and web apps
-h1: SOC 2 Compliance for SSH, Kubernetes, Databases, Desktops, and Web Apps
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/aws-kms.mdx
@@ -1,7 +1,6 @@
 ---
-title: AWS KMS
+title: Store Teleport Private Keys in AWS KMS
 description: Configure Teleport to store CA private keys in the AWS Key Management Service
-h1: Store Teleport Private Keys in AWS KMS
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -1,8 +1,6 @@
 ---
 title: Teleport High Availability mode on AWS
 description: How to configure Teleport in High Availability mode for AWS deployments.
-h1: Running Teleport Enterprise in High Availability mode on AWS
-tocDepth: 3
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Single-Instance Deployment on AWS
 description: How to quickly configure Teleport on a single instance for testing in AWS.
-tocDepth: 3
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/deployments.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/deployments.mdx
@@ -1,7 +1,7 @@
 ---
 title: Reference Deployment Guides
 description: Teleport Installation and Configuration Reference Deployment Guides.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/gcp-kms.mdx
@@ -1,7 +1,6 @@
 ---
-title: Google Cloud KMS
+title: Store Teleport Private Keys in Google Cloud KMS
 description: Configure Teleport to store CA private keys in the Google Cloud Key Management Service
-h1: Store Teleport Private Keys in Google Cloud KMS
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/helm-deployments.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/helm-deployments.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guides for running Teleport using Helm
 description: How to install and configure Teleport in Kubernetes using Helm
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/high-availability.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Deploying a High Availability Teleport Cluster"
 description: "Deploying a High Availability Teleport Cluster"
-tocDepth: 3
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/zero-trust-access/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/hsm.mdx
@@ -1,7 +1,6 @@
 ---
 title: HSM Support
 description: How to configure Hardware Security Modules to manage your Teleport CA private keys
-h1: Teleport HSM Support
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
@@ -1,8 +1,6 @@
 ---
 title: Infrastructure as Code
-h1: Manage Teleport Resources with Infrastructure as Code
 description: An introduction to Teleport's dynamic resources, which make it possible to apply settings to remote clusters using infrastructure as code.
-tocDepth: 3
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Managing Resources with Infrastructure as Code"
 description: Provides instructions on managing specific dynamic resources with tctl and the Teleport Terraform provider and Kubernetes operator.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - zero-trust
 ---

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/enroll-resources.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Part 1: Enroll Infrastructure with Terraform"
-h1: "Terraform Starter: Enroll Infrastructure"
 description: Explains how to deploy a pool of Teleport Agents so you can apply dynamic resources to enroll your infrastructure with Teleport.
 tags:
  - zero-trust

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-starter/rbac.mdx
@@ -1,6 +1,5 @@
 ---
 title: "Part 2: Configure Teleport RBAC with Terraform"
-h1: "Terraform Starter: Configure RBAC"
 description: Explains how to manage Teleport roles and authentication connectors with Terraform so you can implement the principle of least privilege in your infrastructure.
 tags:
  - get-started

--- a/docs/pages/zero-trust-access/management/admin/admin.mdx
+++ b/docs/pages/zero-trust-access/management/admin/admin.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cluster Administration Guides
 description: Teleport Cluster Administration Guides.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/management/diagnostics/metrics.mdx
+++ b/docs/pages/zero-trust-access/management/diagnostics/metrics.mdx
@@ -1,7 +1,6 @@
 ---
 title: Key Metrics for Self-Hosted Clusters
 description: Describes important metrics to monitor if you are self-hosting Teleport.
-tocDepth: 3
 tags:
  - conceptual
  - platform-wide

--- a/docs/pages/zero-trust-access/management/guides/awsoidc-integration-rds.mdx
+++ b/docs/pages/zero-trust-access/management/guides/awsoidc-integration-rds.mdx
@@ -1,7 +1,6 @@
 ---
 title: AWS RDS Enrollment Wizard
 description: Enroll AWS RDS databases with your Teleport cluster using an enrollment wizard.
-tocDepth: 3
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/management/guides/datadog.mdx
+++ b/docs/pages/zero-trust-access/management/guides/datadog.mdx
@@ -1,7 +1,6 @@
 ---
 title: Datadog Integration
 description: How to export Teleport metrics and logs to Datadog
-h1: Export Teleport metrics and logs to Datadog
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/management/guides/ec2-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/ec2-tags.mdx
@@ -1,7 +1,6 @@
 ---
 title: EC2 Tags as Teleport Node Labels
 description: How to set up Teleport Node labels based on EC2 tags
-h1: Sync EC2 Tags and Teleport Node Labels
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/management/guides/gcp-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/gcp-tags.mdx
@@ -1,7 +1,6 @@
 ---
 title: GCP Tags and Labels as Teleport Agent Labels
 description: How to set up Teleport Agent labels based on GCP tags and labels
-h1: Sync GCP Tags/Labels and Teleport Agent labels
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/management/guides/guides.mdx
+++ b/docs/pages/zero-trust-access/management/guides/guides.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrations
 description: Miscellaneous guides for integrating Teleport with third-party tools.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/management/guides/oracle-tags.mdx
+++ b/docs/pages/zero-trust-access/management/guides/oracle-tags.mdx
@@ -1,7 +1,6 @@
 ---
 title: Oracle Cloud Tags as Teleport Agent Labels
 description: How to set up Teleport Agent labels based on Oracle Cloud tags
-h1: Sync Oracle Cloud tags and Teleport Agent labels
 tags:
  - conceptual
  - zero-trust

--- a/docs/pages/zero-trust-access/management/management.mdx
+++ b/docs/pages/zero-trust-access/management/management.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cluster Management
 description: "Guides for performing day-two operations on your Teleport cluster."
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/operations/ca-rotation.mdx
@@ -1,7 +1,6 @@
 ---
 title: Certificate Authority Rotation
 description: Describes how to rotate Teleport's certificate authorities.
-tocDepth: 3
 tags:
  - how-to
  - platform-wide

--- a/docs/pages/zero-trust-access/management/operations/operations.mdx
+++ b/docs/pages/zero-trust-access/management/operations/operations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Operations
 description: Teleport Operations - Scaling and High-Availability.
-layout: tocless-doc
+template: "no-toc"
 tags:
  - platform-wide
 ---

--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -1,7 +1,6 @@
 ---
 title: SSO with Active Directory Federation Services
 description: How to configure Teleport access with Active Directory Federation Services
-h1: Single Sign-On with Active Directory Federation Services
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -1,7 +1,6 @@
 ---
 title: Authentication With GitLab as an SSO provider
 description: How to configure Teleport access using GitLab for SSO
-h1: Teleport SSO Authentication with GitLab
 tags:
  - how-to
  - zero-trust

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -1,7 +1,6 @@
 ---
 title: Teleport Authentication with OneLogin as an SSO Provider
 description: How to configure Teleport access using OneLogin as an SSO provider
-h1: Teleport Authentication with OneLogin
 tags:
  - how-to
  - zero-trust

--- a/integrations/operator/crdgen/format.go
+++ b/integrations/operator/crdgen/format.go
@@ -47,7 +47,6 @@ func formatAsCRD(crd apiextv1.CustomResourceDefinition, groupName, pluralName st
 var crdDocTmpl string = `---
 title: {{.Title}}
 description: {{.Description}}
-tocDepth: 3
 tags:
  - reference
  - platform-wide


### PR DESCRIPTION
Backports #60637

Remove deprecated frontmatter fields and, if required, replace them with their equivalents in the new, Docusaurus-powered docs engine.

- `h1`: This specified the title displayed on a page on the legacy docs site, but Docusaurus does not include this functionality. Replace `title` with the value of `h1` if it is more descriptive, and delete `h1`.
- `layout`: Replace with `template`.
- Replace `tocDepth` with the Docusaurus-native `toc_max_heading_level` unless `toc_max_heading_level` is at its default of 3, in which case remove it.
- Replace `labels` with `tags`. We had rolled out the `labels` field to implement custom tagging logic, but ended up using the Docusaurus-native tagging functionality instead.