### PR TITLE
MWI Docs: Provide shortened sidebar labels for key content

### DIFF
--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -1,6 +1,7 @@
 ---
 title: Machine and Workload Identity Getting Started Guide
 description: Getting started with Teleport Machine and Workload Identity
+sidebar_label: Getting Started
 videoBanner: YzVK2tr6u-U
 tags:
  - get-started

--- a/docs/pages/machine-workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/introduction.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Introduction to Machine & Workload Identity"
 description: "Replace static secrets with secure, short-lived identities for machines and workloads."
+sidebar_label: "Introduction"
 tags:
  - mwi
  - infrastructure-identity


### PR DESCRIPTION
Today, the sidebar labels for these two pieces of content are very long and repeat the phrase "Machine & Workload Identity" which is already stated as the title of the subsection. This makes it very hard to glance at all the items under the sidebar and immediately spot which content you are looking for.

This PR provides shortened, to-the-point, sidebar labels.

Before:

<img width="297" height="154" alt="image" src="https://github.com/user-attachments/assets/13b8e63c-ebe1-4fe8-ba12-05a38d60209c" />

After:

<img width="297" height="120" alt="image" src="https://github.com/user-attachments/assets/f5c98567-b21d-45af-aeb0-d125979c4a35" />
