### PR TITLE
Node autodiscover command: add support for HTTP_PROXY

### DIFF
--- a/lib/utils/packagemanager/apt.go
+++ b/lib/utils/packagemanager/apt.go
@@ -96,7 +96,7 @@ func NewAPT(cfg *APTConfig) (*APT, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	httpClient, err := defaults.HTTPClient()
+	httpClient, err := defaults.HTTPClient(defaults.UseProxyFromEnvironment())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -146,7 +146,8 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 
 	switch p.TeleportCommandPrefix {
 	case PrefixSUDO:
-		p.TeleportCommandPrefix = p.binSudo
+		// add -E to preserve environment variables set before executing the script.
+		p.TeleportCommandPrefix = p.binSudo + " -E"
 	case "":
 	default:
 		return trace.BadParameter("invalid command prefix %q, only %v are supported", p.TeleportCommandPrefix, allowedCommandPrefix)

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -273,7 +273,7 @@ func TestOneOffScript(t *testing.T) {
 		unameMock.Expect("-s").AndWriteToStdout("Linux")
 		unameMock.Expect("-m").AndWriteToStdout("x86_64")
 		mktempMock.Expect("-d", "-p", homeDir).AndWriteToStdout(testWorkingDir)
-		sudoMock.Expect(teleportMock.Path, "version").AndWriteToStdout(teleportVersionOutput)
+		sudoMock.Expect("-E", teleportMock.Path, "version").AndWriteToStdout(teleportVersionOutput)
 
 		err = os.WriteFile(scriptLocation, []byte(script), 0700)
 		require.NoError(t, err)


### PR DESCRIPTION
When discovering nodes, we have to install and configure teleport in the target VM.

This is accomplished by running `teleport install autodiscover-node` command in the target VM.

For systems that require an HTTP PROXY, users must expose the HTTP_PROXY env var before executing the teleport command.

This PR fixes two things:
- env vars were not exposed from the current environment because we use sudo but didn't set the `-E` flag, so the `teleport install` command received no env var
- the default HTTP Client used for fetching the APT GPG key was not loading the HTTP Proxy env vars.


This was discovered during the testing of https://github.com/gravitational/teleport/pull/60635