### PR TITLE
[v18] Adding scoped join tokens for SSH nodes

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -95,6 +95,7 @@ import (
 	resourceusagepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/resourceusage/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	secreportsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/secreports/v1"
 	stableunixusersv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/stableunixusers/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
@@ -134,6 +135,7 @@ type AuthServiceClient struct {
 	userpreferencespb.UserPreferencesServiceClient
 	notificationsv1pb.NotificationServiceClient
 	recordingencryptionv1pb.RecordingEncryptionServiceClient
+	joiningv1.ScopedJoiningServiceClient
 }
 
 // Client is a gRPC Client that connects to a Teleport Auth server either
@@ -547,6 +549,7 @@ func (c *Client) dialGRPC(ctx context.Context, addr string) error {
 		UserPreferencesServiceClient:     userpreferencespb.NewUserPreferencesServiceClient(c.conn),
 		NotificationServiceClient:        notificationsv1pb.NewNotificationServiceClient(c.conn),
 		RecordingEncryptionServiceClient: recordingencryptionv1pb.NewRecordingEncryptionServiceClient(c.conn),
+		ScopedJoiningServiceClient:       joiningv1.NewScopedJoiningServiceClient(c.conn),
 	}
 	c.JoinServiceClient = NewJoinServiceClient(proto.NewJoinServiceClient(c.conn))
 
@@ -5860,4 +5863,26 @@ func (c *Client) DeleteHealthCheckConfig(ctx context.Context, name string) error
 		},
 	)
 	return trace.Wrap(err)
+}
+
+// ListScopedTokens fetches pages of scoped tokens.
+func (c *Client) ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error) {
+	res, err := c.grpc.ListScopedTokens(ctx, req)
+	return res, trace.Wrap(err)
+}
+
+// DeleteScopedToken deletes an existing scoped token.
+func (c *Client) DeleteScopedToken(ctx context.Context, name string) error {
+	_, err := c.grpc.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+		Name: name,
+	})
+	return trace.Wrap(err)
+}
+
+// CreateScopedToken creates a new scoped token.
+func (c *Client) CreateScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	return res.GetToken(), trace.Wrap(err)
 }

--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_identity.pb.go
@@ -289,7 +289,9 @@ type SSHIdentity struct {
 	JoinToken string `protobuf:"bytes,34,opt,name=join_token,json=joinToken,proto3" json:"join_token,omitempty"`
 	// ScopePin is an optional pin that ties the certificate to a specific scope and set of scoped roles. When
 	// set, the Roles field must not be set.
-	ScopePin      *v11.Pin `protobuf:"bytes,35,opt,name=scope_pin,json=scopePin,proto3" json:"scope_pin,omitempty"`
+	ScopePin *v11.Pin `protobuf:"bytes,35,opt,name=scope_pin,json=scopePin,proto3" json:"scope_pin,omitempty"`
+	// The scope associated with a host identity.
+	AgentScope    string `protobuf:"bytes,36,opt,name=agent_scope,json=agentScope,proto3" json:"agent_scope,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -569,6 +571,13 @@ func (x *SSHIdentity) GetScopePin() *v11.Pin {
 	return nil
 }
 
+func (x *SSHIdentity) GetAgentScope() string {
+	if x != nil {
+		return x.AgentScope
+	}
+	return ""
+}
+
 // CertExtension represents a key/value for a certificate extension. This type must
 // be kept up to date with types.CertExtension.
 type CertExtension struct {
@@ -654,7 +663,7 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"-teleport/decision/v1alpha1/ssh_identity.proto\x12\x1ateleport.decision.v1alpha1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a-teleport/decision/v1alpha1/tls_identity.proto\x1a\x1fteleport/scopes/v1/scopes.proto\x1a\x1dteleport/trait/v1/trait.proto\"X\n" +
 	"\fSSHAuthority\x12!\n" +
 	"\fcluster_name\x18\x01 \x01(\tR\vclusterName\x12%\n" +
-	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\xef\v\n" +
+	"\x0eauthority_type\x18\x02 \x01(\tR\rauthorityType\"\x90\f\n" +
 	"\vSSHIdentity\x12\x1f\n" +
 	"\vvalid_after\x18\x01 \x01(\x04R\n" +
 	"validAfter\x12!\n" +
@@ -698,7 +707,9 @@ const file_teleport_decision_v1alpha1_ssh_identity_proto_rawDesc = "" +
 	"\x0fgithub_username\x18! \x01(\tR\x0egithubUsername\x12\x1d\n" +
 	"\n" +
 	"join_token\x18\" \x01(\tR\tjoinToken\x124\n" +
-	"\tscope_pin\x18# \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\"\xbf\x01\n" +
+	"\tscope_pin\x18# \x01(\v2\x17.teleport.scopes.v1.PinR\bscopePin\x12\x1f\n" +
+	"\vagent_scope\x18$ \x01(\tR\n" +
+	"agentScope\"\xbf\x01\n" +
 	"\rCertExtension\x12A\n" +
 	"\x04type\x18\x01 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionTypeR\x04type\x12A\n" +
 	"\x04mode\x18\x02 \x01(\x0e2-.teleport.decision.v1alpha1.CertExtensionModeR\x04mode\x12\x12\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
@@ -131,14 +131,18 @@ func (x *GetScopedTokenResponse) GetToken() *ScopedToken {
 // ListScopedTokensRequest is the request to list scoped tokens.
 type ListScopedTokensRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// ResourceScope filters tokens by their resource scope if specified.
+	// Filter tokens by their resource scope.
 	ResourceScope *v1.Filter `protobuf:"bytes,1,opt,name=resource_scope,json=resourceScope,proto3" json:"resource_scope,omitempty"`
-	// AssignedScope filters tokens by their assigned scope if specified.
+	// Filter tokens by their assigned scope.
 	AssignedScope *v1.Filter `protobuf:"bytes,2,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
-	// Cursor is the pagination cursor.
+	// The pagination cursor.
 	Cursor string `protobuf:"bytes,3,opt,name=cursor,proto3" json:"cursor,omitempty"`
-	// Limit is the maximum number of results to return.
-	Limit         uint32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
+	// The maximum number of results to return.
+	Limit uint32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
+	// Filter tokens that apply at least one of the provided roles.
+	Roles []string `protobuf:"bytes,5,rep,name=roles,proto3" json:"roles,omitempty"`
+	// Filter tokens that match all provided labels.
+	Labels        map[string]string `protobuf:"bytes,6,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -199,6 +203,20 @@ func (x *ListScopedTokensRequest) GetLimit() uint32 {
 		return x.Limit
 	}
 	return 0
+}
+
+func (x *ListScopedTokensRequest) GetRoles() []string {
+	if x != nil {
+		return x.Roles
+	}
+	return nil
+}
+
+func (x *ListScopedTokensRequest) GetLabels() map[string]string {
+	if x != nil {
+		return x.Labels
+	}
+	return nil
 }
 
 // ListScopedTokensResponse is the response to list scoped tokens.
@@ -540,12 +558,17 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x15GetScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"W\n" +
 	"\x16GetScopedTokenResponse\x12=\n" +
-	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\xcd\x01\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\xf7\x02\n" +
 	"\x17ListScopedTokensRequest\x12A\n" +
 	"\x0eresource_scope\x18\x01 \x01(\v2\x1a.teleport.scopes.v1.FilterR\rresourceScope\x12A\n" +
 	"\x0eassigned_scope\x18\x02 \x01(\v2\x1a.teleport.scopes.v1.FilterR\rassignedScope\x12\x16\n" +
 	"\x06cursor\x18\x03 \x01(\tR\x06cursor\x12\x14\n" +
-	"\x05limit\x18\x04 \x01(\rR\x05limit\"s\n" +
+	"\x05limit\x18\x04 \x01(\rR\x05limit\x12\x14\n" +
+	"\x05roles\x18\x05 \x03(\tR\x05roles\x12W\n" +
+	"\x06labels\x18\x06 \x03(\v2?.teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntryR\x06labels\x1a9\n" +
+	"\vLabelsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"s\n" +
 	"\x18ListScopedTokensResponse\x12?\n" +
 	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokens\x12\x16\n" +
 	"\x06cursor\x18\x02 \x01(\tR\x06cursor\"Y\n" +
@@ -580,7 +603,7 @@ func file_teleport_scopes_joining_v1_service_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_service_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_joining_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_teleport_scopes_joining_v1_service_proto_goTypes = []any{
 	(*GetScopedTokenRequest)(nil),     // 0: teleport.scopes.joining.v1.GetScopedTokenRequest
 	(*GetScopedTokenResponse)(nil),    // 1: teleport.scopes.joining.v1.GetScopedTokenResponse
@@ -592,33 +615,35 @@ var file_teleport_scopes_joining_v1_service_proto_goTypes = []any{
 	(*UpdateScopedTokenResponse)(nil), // 7: teleport.scopes.joining.v1.UpdateScopedTokenResponse
 	(*DeleteScopedTokenRequest)(nil),  // 8: teleport.scopes.joining.v1.DeleteScopedTokenRequest
 	(*DeleteScopedTokenResponse)(nil), // 9: teleport.scopes.joining.v1.DeleteScopedTokenResponse
-	(*ScopedToken)(nil),               // 10: teleport.scopes.joining.v1.ScopedToken
-	(*v1.Filter)(nil),                 // 11: teleport.scopes.v1.Filter
+	nil,                               // 10: teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
+	(*ScopedToken)(nil),               // 11: teleport.scopes.joining.v1.ScopedToken
+	(*v1.Filter)(nil),                 // 12: teleport.scopes.v1.Filter
 }
 var file_teleport_scopes_joining_v1_service_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.joining.v1.GetScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 1: teleport.scopes.joining.v1.ListScopedTokensRequest.resource_scope:type_name -> teleport.scopes.v1.Filter
-	11, // 2: teleport.scopes.joining.v1.ListScopedTokensRequest.assigned_scope:type_name -> teleport.scopes.v1.Filter
-	10, // 3: teleport.scopes.joining.v1.ListScopedTokensResponse.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	10, // 4: teleport.scopes.joining.v1.CreateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	10, // 5: teleport.scopes.joining.v1.CreateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	10, // 6: teleport.scopes.joining.v1.UpdateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	10, // 7: teleport.scopes.joining.v1.UpdateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	0,  // 8: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:input_type -> teleport.scopes.joining.v1.GetScopedTokenRequest
-	2,  // 9: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:input_type -> teleport.scopes.joining.v1.ListScopedTokensRequest
-	4,  // 10: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:input_type -> teleport.scopes.joining.v1.CreateScopedTokenRequest
-	6,  // 11: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:input_type -> teleport.scopes.joining.v1.UpdateScopedTokenRequest
-	8,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:input_type -> teleport.scopes.joining.v1.DeleteScopedTokenRequest
-	1,  // 13: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:output_type -> teleport.scopes.joining.v1.GetScopedTokenResponse
-	3,  // 14: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:output_type -> teleport.scopes.joining.v1.ListScopedTokensResponse
-	5,  // 15: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:output_type -> teleport.scopes.joining.v1.CreateScopedTokenResponse
-	7,  // 16: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:output_type -> teleport.scopes.joining.v1.UpdateScopedTokenResponse
-	9,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:output_type -> teleport.scopes.joining.v1.DeleteScopedTokenResponse
-	13, // [13:18] is the sub-list for method output_type
-	8,  // [8:13] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	11, // 0: teleport.scopes.joining.v1.GetScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	12, // 1: teleport.scopes.joining.v1.ListScopedTokensRequest.resource_scope:type_name -> teleport.scopes.v1.Filter
+	12, // 2: teleport.scopes.joining.v1.ListScopedTokensRequest.assigned_scope:type_name -> teleport.scopes.v1.Filter
+	10, // 3: teleport.scopes.joining.v1.ListScopedTokensRequest.labels:type_name -> teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
+	11, // 4: teleport.scopes.joining.v1.ListScopedTokensResponse.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 5: teleport.scopes.joining.v1.CreateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 6: teleport.scopes.joining.v1.CreateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 7: teleport.scopes.joining.v1.UpdateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 8: teleport.scopes.joining.v1.UpdateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	0,  // 9: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:input_type -> teleport.scopes.joining.v1.GetScopedTokenRequest
+	2,  // 10: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:input_type -> teleport.scopes.joining.v1.ListScopedTokensRequest
+	4,  // 11: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:input_type -> teleport.scopes.joining.v1.CreateScopedTokenRequest
+	6,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:input_type -> teleport.scopes.joining.v1.UpdateScopedTokenRequest
+	8,  // 13: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:input_type -> teleport.scopes.joining.v1.DeleteScopedTokenRequest
+	1,  // 14: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:output_type -> teleport.scopes.joining.v1.GetScopedTokenResponse
+	3,  // 15: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:output_type -> teleport.scopes.joining.v1.ListScopedTokensResponse
+	5,  // 16: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:output_type -> teleport.scopes.joining.v1.CreateScopedTokenResponse
+	7,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:output_type -> teleport.scopes.joining.v1.UpdateScopedTokenResponse
+	9,  // 18: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:output_type -> teleport.scopes.joining.v1.DeleteScopedTokenResponse
+	14, // [14:19] is the sub-list for method output_type
+	9,  // [9:14] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_service_proto_init() }
@@ -633,7 +658,7 @@ func file_teleport_scopes_joining_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_service_proto_rawDesc), len(file_teleport_scopes_joining_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -133,8 +133,15 @@ func (x *ScopedToken) GetSpec() *ScopedTokenSpec {
 // ScopedTokenSpec is the specification of a scoped token.
 type ScopedTokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// AssignedScope is the scope to which this token is assigned.
+	// The scope to which this token is assigned.
 	AssignedScope string `protobuf:"bytes,1,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
+	// The list of roles associated with the token. They will be converted
+	// to metadata in the SSH and X509 certificates issued to the user of the
+	// token.
+	Roles []string `protobuf:"bytes,2,rep,name=roles,proto3" json:"roles,omitempty"`
+	// The joining method required in order to use this token.
+	// Supported joining methods for scoped tokens only include 'token'.
+	JoinMethod    string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -176,6 +183,20 @@ func (x *ScopedTokenSpec) GetAssignedScope() string {
 	return ""
 }
 
+func (x *ScopedTokenSpec) GetRoles() []string {
+	if x != nil {
+		return x.Roles
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetJoinMethod() string {
+	if x != nil {
+		return x.JoinMethod
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -187,9 +208,12 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
-	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"8\n" +
+	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"o\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
-	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScopeBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
+	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
+	"\vjoin_method\x18\x03 \x01(\tR\n" +
+	"joinMethodBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once

--- a/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
+++ b/api/proto/teleport/decision/v1alpha1/ssh_identity.proto
@@ -164,6 +164,9 @@ message SSHIdentity {
   // ScopePin is an optional pin that ties the certificate to a specific scope and set of scoped roles. When
   // set, the Roles field must not be set.
   teleport.scopes.v1.Pin scope_pin = 35;
+
+  // The scope associated with a host identity.
+  string agent_scope = 36;
 }
 
 // CertExtensionMode specifies the type of extension to use in the cert. This type

--- a/api/proto/teleport/scopes/joining/v1/service.proto
+++ b/api/proto/teleport/scopes/joining/v1/service.proto
@@ -53,17 +53,23 @@ message GetScopedTokenResponse {
 
 // ListScopedTokensRequest is the request to list scoped tokens.
 message ListScopedTokensRequest {
-  // ResourceScope filters tokens by their resource scope if specified.
+  // Filter tokens by their resource scope.
   teleport.scopes.v1.Filter resource_scope = 1;
 
-  // AssignedScope filters tokens by their assigned scope if specified.
+  // Filter tokens by their assigned scope.
   teleport.scopes.v1.Filter assigned_scope = 2;
 
-  // Cursor is the pagination cursor.
+  // The pagination cursor.
   string cursor = 3;
 
-  // Limit is the maximum number of results to return.
+  // The maximum number of results to return.
   uint32 limit = 4;
+
+  // Filter tokens that apply at least one of the provided roles.
+  repeated string roles = 5;
+
+  // Filter tokens that match all provided labels.
+  map<string, string> labels = 6;
 }
 
 // ListScopedTokensResponse is the response to list scoped tokens.

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -46,8 +46,15 @@ message ScopedToken {
 
 // ScopedTokenSpec is the specification of a scoped token.
 message ScopedTokenSpec {
-  // AssignedScope is the scope to which this token is assigned.
+  // The scope to which this token is assigned.
   string assigned_scope = 1;
 
-  // TODO(fspmarshall): port relevant token features to scoped tokens.
+  // The list of roles associated with the token. They will be converted
+  // to metadata in the SSH and X509 certificates issued to the user of the
+  // token.
+  repeated string roles = 2;
+
+  // The joining method required in order to use this token.
+  // Supported joining methods for scoped tokens only include 'token'.
+  string join_method = 3;
 }

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -286,6 +286,9 @@ const (
 	// KindToken is a provisioning token resource
 	KindToken = "token"
 
+	// KindScopedToken is a provisioning token resource
+	KindScopedToken = "scoped_token"
+
 	// KindCertAuthority is a certificate authority resource
 	KindCertAuthority = "cert_authority"
 

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -178,6 +178,11 @@ type ProvisionToken interface {
 	// join methods where the name is secret. This should be used when logging
 	// the token name.
 	GetSafeName() string
+
+	// GetAssignedScope always returns an empty string because a [ProvisionToken] is always
+	// unscoped
+	GetAssignedScope() string
+
 	// Clone creates a copy of the token.
 	Clone() ProvisionToken
 }
@@ -650,6 +655,12 @@ func (p *ProvisionTokenV2) GetSafeName() string {
 	name = name[hiddenBefore:]
 	name = strings.Repeat("*", hiddenBefore) + name
 	return name
+}
+
+// GetAssignedScope always returns an empty string because a [ProvisionTokenV2] is always
+// unscoped
+func (p *ProvisionTokenV2) GetAssignedScope() string {
+	return ""
 }
 
 // String returns the human readable representation of a provisioning token.

--- a/constants.go
+++ b/constants.go
@@ -464,9 +464,14 @@ const (
 )
 
 const (
-	// CertExtensionScopePin is used to pin a certificate to a specific scope and
-	// set of scoped roles.
+	// CertExtensionScopePin is used to pin a user certificate to a specific scope and
+	// set of scoped roles. This constrains a user's access to resources based on both
+	// the scoping rules and scoped roles defined.
 	CertExtensionScopePin = "scope-pin@goteleport.com"
+	// CertExtensionAgentScope is used to pin an agent/host certificate to a specific scope.
+	// This constrains other identities' access to the agent itself as well as the agent's
+	// access to other resources based on scoping rules.
+	CertExtensionAgentScope = "agent-scope@goteleport.com"
 	// CertExtensionPermitX11Forwarding allows X11 forwarding for certificate
 	CertExtensionPermitX11Forwarding = "permit-X11-forwarding"
 	// CertExtensionPermitAgentForwarding allows agent forwarding for certificate

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -263,7 +263,7 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 			Role:         types.RoleNode,
 			PublicSSHKey: sshPublicKey,
 			PublicTLSKey: tlsPublicKey,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -660,7 +660,8 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 	if !a.hasBuiltinRole(req.Role) && req.Role != types.RoleInstance {
 		return nil, trace.AccessDenied("roles do not match: %v and %v", existingRoles, req.Role)
 	}
-	return a.authServer.GenerateHostCerts(ctx, req)
+	identity := a.context.Identity.GetIdentity()
+	return a.authServer.GenerateHostCerts(ctx, req, identity.AgentScope)
 }
 
 // checkAdditionalSystemRoles verifies additional system roles in host cert request.

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -7296,6 +7296,66 @@ func TestGenerateHostCert(t *testing.T) {
 	}
 }
 
+// newScopedTestServerForHost creates a self-cleaning `ServerWithRoles`, configured
+// for a given host
+func newScopedTestServerForHost(t *testing.T, srv *authtest.AuthServer, hostID, scope string, role types.SystemRole) *auth.ServerWithRoles {
+	authzContext := authz.ContextWithUser(t.Context(), authtest.TestScopedHost(srv.ClusterName, hostID, scope, role).I)
+	ctxIdentity, err := srv.Authorizer.Authorize(authzContext)
+	require.NoError(t, err)
+
+	authWithRole := auth.NewServerWithRoles(
+		srv.AuthServer,
+		srv.AuditLog,
+		*ctxIdentity,
+	)
+
+	t.Cleanup(func() { authWithRole.Close() })
+
+	return authWithRole
+}
+
+func TestGenerateHostCertsScoped(t *testing.T) {
+	ctx := context.Background()
+	srv := newTestTLSServer(t)
+
+	scope := "/aa/bb"
+	hostID := "testhost"
+	roles := types.SystemRoles{types.RoleNode}
+
+	s := newScopedTestServerForHost(t, srv.AuthServer, hostID, scope, types.RoleNode)
+
+	_, sshPub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	tlsKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+	tlsPubPEM, err := keys.MarshalPublicKey(tlsKey.Public())
+	require.NoError(t, err)
+
+	certs, err := s.GenerateHostCerts(ctx, &proto.HostCertsRequest{
+		PublicTLSKey: tlsPubPEM,
+		PublicSSHKey: sshPub,
+		HostID:       hostID,
+		Role:         types.RoleInstance,
+		SystemRoles:  roles,
+	})
+	require.NoError(t, err)
+
+	// ensure scope encoded in TLS cert matches the auth identity
+	tlsCert, err := tlsca.ParseCertificatePEM(certs.TLS)
+	require.NoError(t, err)
+
+	tlsIdent, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
+	require.NoError(t, err)
+	require.Equal(t, scope, tlsIdent.AgentScope)
+
+	// ensure scope encoded in SSH cert matches the auth identity
+	sshCert, err := sshutils.ParseCertificate(certs.SSH)
+	require.NoError(t, err)
+	sshIdent, err := sshca.DecodeIdentity(sshCert)
+	require.NoError(t, err)
+	require.Equal(t, scope, sshIdent.AgentScope)
+}
+
 // TestLocalServiceRolesHavePermissionsForUploaderService verifies that all of Teleport's
 // builtin roles have permissions to execute the calls required by the uploader service.
 // This is because only one uploader service runs per Teleport process, and it will use

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -700,7 +700,7 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 				PublicTLSKey: tlsPublicKeyPEM,
 				PublicSSHKey: sshPublicKeyPEM,
 				SystemRoles:  id.AdditionalSystemRoles,
-			})
+			}, "")
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -713,7 +713,7 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 				Role:         id.Role,
 				PublicTLSKey: tlsPublicKeyPEM,
 				PublicSSHKey: sshPublicKeyPEM,
-			})
+			}, "")
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -1048,6 +1048,24 @@ func TestBuiltin(role types.SystemRole) TestIdentity {
 	}
 }
 
+// TestScopedHost returns TestIdentity for a scoped host
+func TestScopedHost(clusterName, hostID, scope string, role types.SystemRole) TestIdentity {
+	username := hostID
+	if clusterName != "" {
+		username = utils.HostFQDN(hostID, clusterName)
+	}
+	return TestIdentity{
+		I: authz.BuiltinRole{
+			Role:                  types.RoleInstance,
+			Username:              username,
+			AdditionalSystemRoles: types.SystemRoles{role},
+			Identity: tlsca.Identity{
+				AgentScope: scope,
+			},
+		},
+	}
+}
+
 // TestServerID returns a TestIdentity for a node with the passed in serverID.
 func TestServerID(role types.SystemRole, serverID string) TestIdentity {
 	return TestIdentity{
@@ -1325,7 +1343,7 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 			Role:         role,
 			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
 			PublicTLSKey: tlsPubKey,
-		})
+		}, "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6082,6 +6082,8 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 
 	scopedJoining, err := scopedjoining.New(scopedjoining.Config{
 		Authorizer: cfg.Authorizer,
+		Backend:    cfg.AuthServer,
+		Logger:     logger,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "creating scoped provisioning service")
@@ -6144,10 +6146,11 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	authpb.RegisterJoinServiceServer(server, legacyJoinServiceServer)
 
 	joinv1.RegisterJoinServiceServer(server, join.NewServer(&join.ServerConfig{
-		Authorizer:       cfg.Authorizer,
-		AuthService:      cfg.AuthServer,
-		FIPS:             cfg.AuthServer.fips,
-		OracleHTTPClient: cfg.OracleHTTPClient,
+		Authorizer:         cfg.Authorizer,
+		AuthService:        cfg.AuthServer,
+		FIPS:               cfg.AuthServer.fips,
+		OracleHTTPClient:   cfg.OracleHTTPClient,
+		ScopedTokenService: cfg.AuthServer.Services,
 	}))
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -417,6 +417,9 @@ type InitConfig struct {
 
 	// ScopedAccess is a service that manages scoped access resources.
 	ScopedAccess services.ScopedAccess
+
+	// ScopedTokenService is a service that manages scoped join token resources.
+	ScopedTokenService services.ScopedTokenService
 }
 
 // Init instantiates and configures an instance of AuthServer
@@ -1587,7 +1590,7 @@ func GenerateIdentity(a *Server, id state.IdentityID, additionalPrincipals, dnsN
 			DNSNames:             dnsNames,
 			PublicSSHKey:         ssh.MarshalAuthorizedKey(sshPub),
 			PublicTLSKey:         tlsPub,
-		})
+		}, "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -70,7 +70,7 @@ func LocalRegister(id state.IdentityID, authServer *Server, additionalPrincipals
 			PublicSSHKey:         ssh.MarshalAuthorizedKey(sshPub),
 			PublicTLSKey:         tlsPub,
 			SystemRoles:          systemRoles,
-		})
+		}, "")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/scopes/joining/service.go
+++ b/lib/auth/scopes/joining/service.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package provisioning
+package joining
 
 import (
 	"context"
@@ -23,15 +23,20 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedjoiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // Config contains the parameters for [New].
 type Config struct {
 	Authorizer authz.Authorizer
 	Logger     *slog.Logger
+	Backend    services.ScopedTokenService
 }
 
 // Server is the [scopedjoiningv1.ScopedJoiningServiceServer] returned by [New].
@@ -40,6 +45,7 @@ type Server struct {
 
 	authorizer authz.Authorizer
 	logger     *slog.Logger
+	backend    services.ScopedTokenService
 }
 
 // New returns the auth server implementation for the scoped provisioning
@@ -48,6 +54,11 @@ func New(c Config) (*Server, error) {
 	if c.Authorizer == nil {
 		return nil, trace.BadParameter("missing Authorizer")
 	}
+
+	if c.Backend == nil {
+		return nil, trace.BadParameter("missing Backend")
+	}
+
 	if c.Logger == nil {
 		c.Logger = slog.With(teleport.ComponentKey, "scopes")
 	}
@@ -55,6 +66,7 @@ func New(c Config) (*Server, error) {
 	return &Server{
 		authorizer: c.Authorizer,
 		logger:     c.Logger,
+		backend:    c.Backend,
 	}, nil
 }
 
@@ -70,7 +82,24 @@ func (s *Server) CreateScopedToken(ctx context.Context, req *scopedjoiningv1.Cre
 		return nil, trace.AccessDenied("user %q does not have permission to create scoped tokens", authzContext.User.GetName())
 	}
 
-	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).CreateScopedToken(ctx, req)
+	token := req.GetToken()
+	if token.GetMetadata().GetName() == "" {
+		if token.Metadata == nil {
+			token.Metadata = &headerv1.Metadata{}
+		}
+		name, err := utils.CryptoRandomHex(defaults.TokenLenBytes)
+		if err != nil {
+			return nil, trace.Wrap(err, "generating token value")
+		}
+		token.Metadata.Name = name
+	}
+
+	if token.GetSpec() != nil && token.GetSpec().GetJoinMethod() == "" {
+		token.Spec.JoinMethod = string(types.JoinMethodToken)
+	}
+
+	res, err := s.backend.CreateScopedToken(ctx, req)
+	return res, trace.Wrap(err)
 }
 
 // DeleteScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
@@ -85,7 +114,8 @@ func (s *Server) DeleteScopedToken(ctx context.Context, req *scopedjoiningv1.Del
 		return nil, trace.AccessDenied("user %q does not have permission to delete scoped tokens", authzContext.User.GetName())
 	}
 
-	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).DeleteScopedToken(ctx, req)
+	res, err := s.backend.DeleteScopedToken(ctx, req)
+	return res, trace.Wrap(err)
 }
 
 // GetScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
@@ -100,7 +130,8 @@ func (s *Server) GetScopedToken(ctx context.Context, req *scopedjoiningv1.GetSco
 		return nil, trace.AccessDenied("user %q does not have permission to get scoped tokens", authzContext.User.GetName())
 	}
 
-	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).GetScopedToken(ctx, req)
+	res, err := s.backend.GetScopedToken(ctx, req)
+	return res, trace.Wrap(err)
 }
 
 // ListScopedTokens implements [scopedjoiningv1.ScopedJoiningServiceServer].
@@ -115,20 +146,11 @@ func (s *Server) ListScopedTokens(ctx context.Context, req *scopedjoiningv1.List
 		return nil, trace.AccessDenied("user %q does not have permission to list scoped tokens", authzContext.User.GetName())
 	}
 
-	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).ListScopedTokens(ctx, req)
+	res, err := s.backend.ListScopedTokens(ctx, req)
+	return res, trace.Wrap(err)
 }
 
 // UpdateScopedToken implements [scopedjoiningv1.ScopedJoiningServiceServer].
 func (s *Server) UpdateScopedToken(ctx context.Context, req *scopedjoiningv1.UpdateScopedTokenRequest) (*scopedjoiningv1.UpdateScopedTokenResponse, error) {
-	authzContext, err := s.authorizer.Authorize(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if !authz.HasBuiltinRole(*authzContext, string(types.RoleAdmin)) {
-		s.logger.WarnContext(ctx, "user does not have permission to update scoped tokens", "user", authzContext.User.GetName())
-		return nil, trace.AccessDenied("user %q does not have permission to update scoped tokens", authzContext.User.GetName())
-	}
-
-	return (scopedjoiningv1.UnimplementedScopedJoiningServiceServer{}).UpdateScopedToken(ctx, req)
+	return nil, trace.NotImplemented("scoped tokens must be recreated, they cannot be updated")
 }

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -1,0 +1,199 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joining_test
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"slices"
+	"testing"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/scopes/joining"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestScopedJoiningService(t *testing.T) {
+	ctx := withAuthCtx(t.Context(), newAuthCtx(types.RoleAdmin))
+
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	svc, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	require.NoError(t, err)
+
+	service, err := joining.New(joining.Config{
+		Logger:     logtest.NewLogger(),
+		Backend:    svc,
+		Authorizer: fakeAuthorizer{},
+	})
+	require.NoError(t, err)
+
+	token := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "testtoken",
+		},
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test/aa",
+			JoinMethod:    "token",
+			Roles:         []string{"Node"},
+		},
+	}
+
+	created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	require.NoError(t, err)
+	cmpOpts := []gocmp.Option{
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
+	}
+	assert.Empty(t, gocmp.Diff(token, created.GetToken(), cmpOpts...))
+
+	tokenWithMismatchedScope := proto.CloneOf(token)
+	tokenWithMismatchedScope.Metadata.Name = "invalid-token"
+	tokenWithMismatchedScope.Spec.AssignedScope = "/stage/aa"
+
+	// make sure update is no-op
+	_, err = service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{})
+	require.True(t, trace.IsNotImplemented(err))
+
+	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: tokenWithMismatchedScope,
+	})
+	assert.True(t, trace.IsBadParameter(err))
+
+	tokenWithoutName := proto.CloneOf(token)
+	tokenWithoutName.Metadata.Name = ""
+	createdWithoutName, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: tokenWithoutName,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, createdWithoutName.Token.GetMetadata().GetName())
+
+	// get token
+	fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name: token.Metadata.Name,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, gocmp.Diff(token, fetched.GetToken(), cmpOpts...))
+
+	// delete token
+	_, err = service.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+		Name: token.Metadata.Name,
+	})
+	require.NoError(t, err)
+
+	// create some tokens
+	token.Spec.AssignedScope = "/test/bb"
+	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	require.NoError(t, err)
+
+	token2 := proto.CloneOf(token)
+	token2.Metadata.Name = "testtoken2"
+	token2.Scope = "/test/aa"
+	token2.Spec.AssignedScope = "/test/aa"
+	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token2,
+	})
+	require.NoError(t, err)
+
+	token3 := proto.CloneOf(token)
+	token3.Metadata.Name = "testtoken3"
+	token3.Scope = "/test/bb"
+	token3.Spec.AssignedScope = "/test/bb"
+	_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token3,
+	})
+	require.NoError(t, err)
+
+	res, err := service.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
+		ResourceScope: &scopesv1.Filter{
+			Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+			Scope: "/test/aa",
+		},
+	})
+	require.NoError(t, err)
+	assert.Len(t, res.Tokens, 3)
+	sortFn := func(left *joiningv1.ScopedToken, right *joiningv1.ScopedToken) int {
+		return cmp.Compare(left.Metadata.Name, right.Metadata.Name)
+	}
+
+	expected := []*joiningv1.ScopedToken{token, tokenWithoutName, token2}
+	slices.SortStableFunc(res.Tokens, sortFn)
+	slices.SortStableFunc(expected, sortFn)
+	for idx, token := range res.Tokens {
+		assert.Empty(t, gocmp.Diff(expected[idx], token, cmpOpts...))
+	}
+}
+
+type fakeChecker struct {
+	services.AccessChecker
+	role string
+}
+
+func (f *fakeChecker) HasRole(role string) bool {
+	return role == f.role
+}
+
+type authKey struct{}
+
+func withAuthCtx(ctx context.Context, authCtx authz.Context) context.Context {
+	return context.WithValue(ctx, authKey{}, authCtx)
+}
+
+func newAuthCtx(role types.SystemRole) authz.Context {
+	return authz.Context{
+		Identity: authz.BuiltinRole{
+			Role: role,
+		},
+		Checker: &fakeChecker{
+			role: string(role),
+		},
+	}
+}
+
+type fakeAuthorizer struct{}
+
+func (f fakeAuthorizer) Authorize(ctx context.Context) (*authz.Context, error) {
+	authCtx, ok := ctx.Value(authKey{}).(authz.Context)
+	if !ok {
+		return nil, errors.New("no auth context found")
+	}
+
+	return &authCtx, nil
+}

--- a/lib/auth/state/identity.go
+++ b/lib/auth/state/identity.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -61,7 +62,7 @@ func (id *IdentityID) String() string {
 
 // Identity is collection of certificates and signers that represent server identity
 type Identity struct {
-	// ID specifies server unique ID, name and role
+	// ID specifies server unique ID, name, role, and scope
 	ID IdentityID
 	// KeyBytes is a PEM encoded private key
 	KeyBytes []byte
@@ -84,6 +85,8 @@ type Identity struct {
 	ClusterName string
 	// SystemRoles is a list of additional system roles.
 	SystemRoles []string
+	// AgentScope is the scope an identity is constrained to.
+	AgentScope string
 }
 
 // HasSystemRole checks if this identity encompasses the supplied system role.
@@ -337,6 +340,7 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 		return nil, trace.BadParameter("missing cert extension %v", utils.CertExtensionAuthority)
 	}
 
+	agentScope := cert.Permissions.Extensions[teleport.CertExtensionAgentScope]
 	return &Identity{
 		ID:          IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
 		ClusterName: clusterName,
@@ -344,5 +348,6 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 		CertBytes:   certBytes,
 		KeySigner:   certSigner,
 		Cert:        cert,
+		AgentScope:  agentScope,
 	}, nil
 }

--- a/lib/decision/ssh_identity.go
+++ b/lib/decision/ssh_identity.go
@@ -67,6 +67,7 @@ func SSHIdentityToSSHCA(id *decisionpb.SSHIdentity) *sshca.Identity {
 		DeviceCredentialID:      id.DeviceCredentialId,
 		GitHubUserID:            id.GithubUserId,
 		GitHubUsername:          id.GithubUsername,
+		AgentScope:              id.AgentScope,
 	}
 }
 
@@ -111,6 +112,7 @@ func SSHIdentityFromSSHCA(id *sshca.Identity) *decisionpb.SSHIdentity {
 		GithubUserId:            id.GitHubUserID,
 		GithubUsername:          id.GitHubUsername,
 		JoinToken:               id.JoinToken,
+		AgentScope:              id.AgentScope,
 	}
 }
 

--- a/lib/decision/ssh_identity_test.go
+++ b/lib/decision/ssh_identity_test.go
@@ -88,6 +88,7 @@ func TestSSHIdentityConversion(t *testing.T) {
 		DeviceCredentialID:     "cred",
 		GitHubUserID:           "github",
 		GitHubUsername:         "ghuser",
+		AgentScope:             "/foo",
 	}
 
 	ignores := []string{

--- a/lib/join/boundkeypair/boundkeypair.go
+++ b/lib/join/boundkeypair/boundkeypair.go
@@ -40,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	libsshutils "github.com/gravitational/teleport/lib/sshutils"
@@ -529,7 +530,7 @@ type JoinParams struct {
 	// Diag is the join attempt diagnostic.
 	Diag *diagnostic.Diagnostic
 	// ProvisionToken is the provision token used for the join attempt.
-	ProvisionToken types.ProvisionToken
+	ProvisionToken provision.Token
 	// ClientInit is the ClientInit message sent by the joining client.
 	ClientInit *messages.ClientInit
 	// BoundKeypairInit is the BoundKeypairInit message sent by the joining client.

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/services"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 	"github.com/gravitational/teleport/lib/utils/aws/stsutils"
@@ -157,7 +158,7 @@ func parseAndVerifyIID(iidBytes []byte) (*imds.InstanceIdentityDocument, error) 
 	return &iid, nil
 }
 
-func checkPendingTime(iid *imds.InstanceIdentityDocument, provisionToken types.ProvisionToken, clock clockwork.Clock) error {
+func checkPendingTime(iid *imds.InstanceIdentityDocument, provisionToken provision.Token, clock clockwork.Clock) error {
 	timeSinceInstanceStart := clock.Since(iid.PendingTime)
 	// Sanity check IID is not from the future. Allow 1 minute of clock drift.
 	if timeSinceInstanceStart < -1*time.Minute {
@@ -342,7 +343,7 @@ func tryToDetectIdentityReuse(ctx context.Context, params *CheckEC2RequestParams
 // CheckEC2RequestParams holds parameters for checking an EC2-method join request.
 type CheckEC2RequestParams struct {
 	// ProvisionToken is the provision token being used.
-	ProvisionToken types.ProvisionToken
+	ProvisionToken provision.Token
 	// Role is the system role being requested.
 	Role types.SystemRole
 	// Document is a signed EC2 Instance Identity Document.

--- a/lib/join/githubactions/githubactions.go
+++ b/lib/join/githubactions/githubactions.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gravitational/teleport"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
@@ -154,7 +155,7 @@ type GithubIDTokenJWKSValidator func(
 ) (*IDTokenClaims, error)
 
 type CheckGithubIDTokenParams struct {
-	ProvisionToken types.ProvisionToken
+	ProvisionToken provision.Token
 	IDToken        []byte
 	Clock          clockwork.Clock
 	Validator      GithubIDTokenValidator

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/join/iam"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/aws"
 )
@@ -265,7 +266,7 @@ type CheckIAMRequestParams struct {
 	// Challenge is the challenge that was sent to the client.
 	Challenge string
 	// ProvisionToken is the provision token being used.
-	ProvisionToken types.ProvisionToken
+	ProvisionToken provision.Token
 	// STSIdentityRequest is the signed sts:GetCallerIdentity request sent by
 	// the client in response to the challenge.
 	STSIdentityRequest []byte

--- a/lib/join/internal/authz/authz.go
+++ b/lib/join/internal/authz/authz.go
@@ -39,4 +39,6 @@ type Context struct {
 	BotGeneration uint64
 	// BotInstanceID is an authenticated Bot ID.
 	BotInstanceID string
+	// Scope is the assigned scope of the authenticated client.
+	Scope string
 }

--- a/lib/join/join_test.go
+++ b/lib/join/join_test.go
@@ -32,10 +32,13 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport/api/constants"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	joinv1proto "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -52,7 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
 
-// TestJoin tests the full cycle of proxy and node joining via the join service.
+// TestJoinToken tests the full cycle of proxy and node joining via the join service.
 //
 // It first sets up a fake auth service running the gRPC join service.
 //
@@ -62,7 +65,7 @@ import (
 //
 // Finally, it tests various scenarios where a node attempts to join by
 // connecting to the proxy's gRPC join service.
-func TestJoin(t *testing.T) {
+func TestJoinToken(t *testing.T) {
 	t.Parallel()
 
 	token1, err := types.NewProvisionTokenFromSpec("token1", time.Now().Add(time.Minute), types.ProvisionTokenSpecV2{
@@ -84,9 +87,44 @@ func TestJoin(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	scopedToken1 := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Scope:   "/aa",
+		Metadata: &headerv1.Metadata{
+			Name: "scoped1",
+		},
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/aa/bb",
+			Roles:         []string{types.RoleNode.String()},
+			JoinMethod:    string(types.JoinMethodToken),
+		},
+	}
+	scopedToken2 := proto.CloneOf(scopedToken1)
+	scopedToken2.Metadata.Name = "scoped2"
+	scopedToken2.Spec.AssignedScope = "/aa/cc"
+
+	scopedToken3 := proto.CloneOf(scopedToken1)
+	scopedToken3.Metadata.Name = "scoped3"
+
 	authService := newFakeAuthService(t)
 	require.NoError(t, authService.Auth().UpsertToken(t.Context(), token1))
 	require.NoError(t, authService.Auth().UpsertToken(t.Context(), token2))
+
+	_, err = authService.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+		Token: scopedToken1,
+	})
+	require.NoError(t, err)
+
+	_, err = authService.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+		Token: scopedToken2,
+	})
+	require.NoError(t, err)
+
+	_, err = authService.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+		Token: scopedToken3,
+	})
+	require.NoError(t, err)
 
 	proxy := newFakeProxy(authService)
 	proxy.join(t)
@@ -173,6 +211,89 @@ func TestJoin(t *testing.T) {
 			func(s string) bool { return s == types.RoleInstance.String() },
 		)
 		require.ElementsMatch(t, expectedSystemRoles, newIdentity.SystemRoles)
+	})
+
+	t.Run("join and rejoin with scoped token", func(t *testing.T) {
+		// Node initially joins by connecting to the proxy's gRPC service.
+		identity, err := joinViaProxy(
+			t.Context(),
+			scopedToken1.GetMetadata().GetName(),
+			proxyListener.Addr(),
+		)
+		require.NoError(t, err)
+		// Make sure the result contains a host ID and expected certificate roles.
+		require.NotEmpty(t, identity.ID.HostUUID)
+		require.Equal(t, types.RoleInstance, identity.ID.Role)
+		expectedSystemRoles := slices.DeleteFunc(
+			scopedToken1.GetSpec().GetRoles(),
+			func(s string) bool { return s == types.RoleInstance.String() },
+		)
+		require.ElementsMatch(t, expectedSystemRoles, identity.SystemRoles)
+
+		require.Equal(t, scopedToken1.GetSpec().GetAssignedScope(), identity.AgentScope)
+		// Build an auth client with the new identity.
+		tlsConfig, err := identity.TLSConfig(nil /*cipherSuites*/)
+		require.NoError(t, err)
+		authClient, err := authService.TLS.NewClientWithCert(tlsConfig.Certificates[0])
+		require.NoError(t, err)
+
+		// Node can rejoin with a different token assigning the same scope
+		// by dialing the auth service with an auth client authenticated with
+		// its original credentials.
+		//
+		// It should get back its original host ID and the combined roles of
+		// its original certificate and the new token.
+		newIdentity, err := rejoinViaAuthClient(
+			t.Context(),
+			scopedToken3.GetMetadata().GetName(),
+			authClient,
+		)
+		require.NoError(t, err)
+		require.Equal(t, identity.AgentScope, newIdentity.AgentScope)
+		require.Equal(t, identity.ID.HostUUID, newIdentity.ID.HostUUID)
+		require.Equal(t, identity.ID.NodeName, newIdentity.ID.NodeName)
+		require.Equal(t, identity.ID.Role, newIdentity.ID.Role)
+		expectedSystemRoles = slices.DeleteFunc(
+			apiutils.Deduplicate(slices.Concat(
+				scopedToken1.GetSpec().GetRoles(),
+				scopedToken3.GetSpec().GetRoles(),
+			)),
+			func(s string) bool { return s == types.RoleInstance.String() },
+		)
+		require.ElementsMatch(t, expectedSystemRoles, newIdentity.SystemRoles)
+	})
+
+	t.Run("join and rejoin with mismatched scoped tokens", func(t *testing.T) {
+		// Node initially joins by connecting to the proxy's gRPC service.
+		identity, err := joinViaProxy(
+			t.Context(),
+			scopedToken1.GetMetadata().GetName(),
+			proxyListener.Addr(),
+		)
+		require.NoError(t, err)
+		// Make sure the result contains a host ID and expected certificate roles.
+		require.NotEmpty(t, identity.ID.HostUUID)
+		require.Equal(t, types.RoleInstance, identity.ID.Role)
+		expectedSystemRoles := slices.DeleteFunc(
+			scopedToken1.GetSpec().GetRoles(),
+			func(s string) bool { return s == types.RoleInstance.String() },
+		)
+		require.ElementsMatch(t, expectedSystemRoles, identity.SystemRoles)
+
+		require.Equal(t, scopedToken1.GetSpec().GetAssignedScope(), identity.AgentScope)
+		// Build an auth client with the new identity.
+		tlsConfig, err := identity.TLSConfig(nil /*cipherSuites*/)
+		require.NoError(t, err)
+		authClient, err := authService.TLS.NewClientWithCert(tlsConfig.Certificates[0])
+		require.NoError(t, err)
+
+		// Node cannot rejoin with a different token assigning a different scope.
+		_, err = rejoinViaAuthClient(
+			t.Context(),
+			scopedToken2.GetMetadata().GetName(),
+			authClient,
+		)
+		require.Error(t, err)
 	})
 
 	t.Run("join and rejoin with bad token", func(t *testing.T) {

--- a/lib/join/oraclejoin/oracle.go
+++ b/lib/join/oraclejoin/oracle.go
@@ -36,9 +36,9 @@ import (
 	"github.com/oracle/oci-go-sdk/v65/common"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -50,7 +50,7 @@ type CheckChallengeSolutionParams struct {
 	// Solution is the client's full solution to the challenge.
 	Solution *messages.OracleChallengeSolution
 	// ProvisionToken is the token being used for the request.
-	ProvisionToken types.ProvisionToken
+	ProvisionToken provision.Token
 	// RootCACache caches Oracle root CAs per region.
 	RootCACache *RootCACache
 	// HTTPClient (optional) is an HTTP client that will be used to send

--- a/lib/join/oraclejoin/rules.go
+++ b/lib/join/oraclejoin/rules.go
@@ -22,11 +22,12 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // CheckOracleAllowRules checks that a the oracle rules in a provision token
 // allow an OCI instance with the given claims to join the cluster.
-func CheckOracleAllowRules(claims *Claims, token types.ProvisionToken) error {
+func CheckOracleAllowRules(claims *Claims, token provision.Token) error {
 	ptv2, ok := token.(*types.ProvisionTokenV2)
 	if !ok {
 		return trace.Errorf("Oracle join method only supports ProvisionTokenV2")

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -1,0 +1,49 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package provision
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// A Token is used in the join service to facilitate provisioning.
+type Token interface {
+	// GetName returns the name of the token.
+	GetName() string
+	// GetSafeName returns the name of the token, sanitized appropriately for
+	// join methods where the name is secret. This should be used when logging
+	// the token name.
+	GetSafeName() string
+	// GetJoinMethod returns joining method that must be used with this token.
+	GetJoinMethod() types.JoinMethod
+	// GetRoles returns a list of teleport roles that will be granted to the
+	// resources provisioned with this token.
+	GetRoles() types.SystemRoles
+	// Expiry returns the token's expiration time.
+	Expiry() time.Time
+	// GetBotName returns the BotName field which must be set for joining bots.
+	GetBotName() string
+	// GetAssignedScope returns the scope that will be assigned to provisioned resources
+	// provisioned using the wrapped [joiningv1.ScopedToken].
+	GetAssignedScope() string
+	// GetAllowRules returns the list of allow rules.
+	GetAllowRules() []*types.TokenRule
+	// GetAWSIIDTTL returns the TTL of EC2 IIDs
+	GetAWSIIDTTL() types.Duration
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -51,6 +52,8 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
@@ -64,8 +67,8 @@ var log = logutils.NewPackageLogger(teleport.ComponentKey, "join")
 // JoinServer to implement joining.
 type AuthService interface {
 	ValidateToken(ctx context.Context, tokenName string) (types.ProvisionToken, error)
-	GenerateHostCertsForJoin(ctx context.Context, provisionToken types.ProvisionToken, req *HostCertsParams) (*proto.Certs, error)
-	GenerateBotCertsForJoin(ctx context.Context, provisionToken types.ProvisionToken, req *BotCertsParams) (*proto.Certs, string, error)
+	GenerateHostCertsForJoin(ctx context.Context, token provision.Token, req *HostCertsParams) (*proto.Certs, error)
+	GenerateBotCertsForJoin(ctx context.Context, token provision.Token, req *BotCertsParams) (*proto.Certs, string, error)
 	EmitAuditEvent(ctx context.Context, e apievents.AuditEvent) error
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
 	GetReadOnlyAuthPreference(context.Context) (readonly.AuthPreference, error)
@@ -86,10 +89,11 @@ type AuthService interface {
 
 // ServerConfig holds configuration parameters for [Server].
 type ServerConfig struct {
-	AuthService      AuthService
-	Authorizer       authz.Authorizer
-	FIPS             bool
-	OracleHTTPClient utils.HTTPDoClient
+	AuthService        AuthService
+	Authorizer         authz.Authorizer
+	FIPS               bool
+	OracleHTTPClient   utils.HTTPDoClient
+	ScopedTokenService services.ScopedTokenService
 }
 
 // Server implements cluster joining for nodes and bots.
@@ -104,6 +108,69 @@ func NewServer(cfg *ServerConfig) *Server {
 		cfg:               cfg,
 		oracleRootCACache: oraclejoin.NewRootCACache(),
 	}
+}
+
+// getProvisionToken attempts to resolve a name to a [provision.Token] by first attempting to
+// fetch a [joiningv1.ScopedToken] and then falling back to a [types.ProvisionTokenV2] if a
+// scoped token can not be found.
+func (s *Server) getProvisionToken(ctx context.Context, name string) (provision.Token, error) {
+	var scoped provision.Token
+	var scopedErr error
+
+	var classic provision.Token
+	var classicErr error
+
+	wg := &sync.WaitGroup{}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tok, err := s.cfg.ScopedTokenService.UseScopedToken(ctx, name)
+		if err != nil {
+			scopedErr = err
+			return
+		}
+
+		scoped, scopedErr = joining.NewToken(tok)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Fetch the provision token and validate that it is not expired.
+		classic, classicErr = s.cfg.AuthService.ValidateToken(ctx, name)
+	}()
+	wg.Wait()
+
+	// we explicitly disallow a join if the provided token name returns both a scoped and classic provision token
+	if scoped != nil && classic != nil {
+		return nil, trace.AccessDenied("joining with an ambiguous token name is not permitted")
+	}
+
+	if scoped != nil {
+		return scoped, nil
+	}
+
+	if classic != nil {
+		return classic, nil
+	}
+
+	// if both errors are [trace.NotFoundError], just return a single err
+	if trace.IsNotFound(scopedErr) && trace.IsNotFound(classicErr) {
+		return nil, trace.NotFound("token expired or not found")
+	}
+
+	// prefer reporting errors other than [trace.NotFoundError]
+	if trace.IsNotFound(scopedErr) {
+		return nil, trace.Wrap(classicErr)
+	}
+
+	if trace.IsNotFound(classicErr) {
+		return nil, trace.Wrap(scopedErr)
+	}
+
+	// return both errors as an aggregate if we couldn't reasonably return one
+	return nil, trace.NewAggregate(scopedErr, classicErr)
 }
 
 // Join implements cluster joining for nodes and bots.
@@ -152,30 +219,34 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 		return trace.Wrap(err)
 	}
 
-	// Fetch the provision token and validate that it is not expired.
-	provisionToken, err := s.cfg.AuthService.ValidateToken(ctx, clientInit.TokenName)
+	token, err := s.getProvisionToken(ctx, clientInit.TokenName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	// Set any diagnostic info we can get from the token.
 	diag.Set(func(i *diagnostic.Info) {
-		i.SafeTokenName = provisionToken.GetSafeName()
-		i.TokenJoinMethod = string(configuredJoinMethod(provisionToken))
-		i.TokenExpires = provisionToken.Expiry()
-		i.BotName = provisionToken.GetBotName()
+		i.SafeTokenName = token.GetSafeName()
+		i.TokenJoinMethod = string(configuredJoinMethod(token))
+		i.TokenExpires = token.Expiry()
+		i.BotName = token.GetBotName()
 	})
 
 	// Validate that the requested join method matches the join method
 	// configured on the token, or that the client did not specify a specific
 	// join method and allow the server to choose it from the token.
-	joinMethod, err := checkJoinMethod(provisionToken, clientInit.JoinMethod)
+	joinMethod, err := checkJoinMethod(token, clientInit.JoinMethod)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// Assert that the provision token allows the requested system role.
-	if err := ProvisionTokenAllowsRole(provisionToken, types.SystemRole(clientInit.SystemRole)); err != nil {
+	if err := TokenAllowsRole(token, types.SystemRole(clientInit.SystemRole)); err != nil {
 		return trace.Wrap(err)
+	}
+
+	if authCtx.IsInstance && authCtx.Scope != token.GetAssignedScope() {
+		return trace.BadParameter("tried to re-join instance from scope %q into %q", authCtx.Scope, token.GetAssignedScope())
 	}
 
 	authPref, err := s.cfg.AuthService.GetAuthPreference(ctx)
@@ -194,7 +265,7 @@ func (s *Server) Join(stream messages.ServerStream) (err error) {
 	}
 
 	// Call out to the handler for the specific join method.
-	result, err := s.handleJoinMethod(stream, authCtx, clientInit, provisionToken, joinMethod)
+	result, err := s.handleJoinMethod(stream, authCtx, clientInit, token, joinMethod)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -207,24 +278,24 @@ func (s *Server) handleJoinMethod(
 	stream messages.ServerStream,
 	authCtx *joinauthz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 	joinMethod types.JoinMethod,
 ) (messages.Response, error) {
 	switch joinMethod {
 	case types.JoinMethodToken:
-		return s.handleTokenJoin(stream, authCtx, clientInit, provisionToken)
+		return s.handleTokenJoin(stream, authCtx, clientInit, token)
 	case types.JoinMethodBoundKeypair:
-		return s.handleBoundKeypairJoin(stream, authCtx, clientInit, provisionToken)
+		return s.handleBoundKeypairJoin(stream, authCtx, clientInit, token)
 	case types.JoinMethodIAM:
-		return s.handleIAMJoin(stream, authCtx, clientInit, provisionToken)
+		return s.handleIAMJoin(stream, authCtx, clientInit, token)
 	case types.JoinMethodEC2:
-		return s.handleEC2Join(stream, authCtx, clientInit, provisionToken)
+		return s.handleEC2Join(stream, authCtx, clientInit, token)
 	case types.JoinMethodEnv0:
-		return s.handleOIDCJoin(stream, authCtx, clientInit, provisionToken, s.validateEnv0Token)
+		return s.handleOIDCJoin(stream, authCtx, clientInit, token, s.validateEnv0Token)
 	case types.JoinMethodOracle:
-		return s.handleOracleJoin(stream, authCtx, clientInit, provisionToken)
+		return s.handleOracleJoin(stream, authCtx, clientInit, token)
 	case types.JoinMethodGitHub:
-		return s.handleOIDCJoin(stream, authCtx, clientInit, provisionToken, s.validateGithubToken)
+		return s.handleOIDCJoin(stream, authCtx, clientInit, token, s.validateGithubToken)
 	default:
 		// TODO(nklaassen): implement checks for all join methods.
 		return nil, trace.NotImplemented("join method %s is not yet implemented by the new join service", joinMethod)
@@ -301,11 +372,12 @@ func (s *Server) authenticate(ctx context.Context, diag *diagnostic.Diagnostic, 
 		HostID:        hostID,
 		BotInstanceID: botInstanceID,
 		BotGeneration: botGeneration,
+		Scope:         id.AgentScope,
 	}, nil
 }
 
-func checkJoinMethod(provisionToken types.ProvisionToken, requestedJoinMethod *string) (types.JoinMethod, error) {
-	tokenJoinMethod := configuredJoinMethod(provisionToken)
+func checkJoinMethod(token provision.Token, requestedJoinMethod *string) (types.JoinMethod, error) {
+	tokenJoinMethod := configuredJoinMethod(token)
 	if requestedJoinMethod == nil {
 		// Auto join method mode, the client didn't specify so use whatever is on the token.
 		return tokenJoinMethod, nil
@@ -318,14 +390,14 @@ func checkJoinMethod(provisionToken types.ProvisionToken, requestedJoinMethod *s
 	return tokenJoinMethod, nil
 }
 
-// ProvisionTokenAllowsRole asserts that the given provision token allows the
+// TokenAllowsRole asserts that the given provision token allows the
 // requested role, or else it returns an error.
-func ProvisionTokenAllowsRole(provisionToken types.ProvisionToken, role types.SystemRole) error {
+func TokenAllowsRole(token provision.Token, role types.SystemRole) error {
 	// Instance certs can be requested if the provision token allows at least
 	// one local service role (e.g. proxy, node, etc).
 	if role == types.RoleInstance {
 		hasLocalServiceRole := false
-		for _, role := range provisionToken.GetRoles() {
+		for _, role := range token.GetRoles() {
 			if role.IsLocalService() {
 				hasLocalServiceRole = true
 				break
@@ -337,7 +409,7 @@ func ProvisionTokenAllowsRole(provisionToken types.ProvisionToken, role types.Sy
 	}
 
 	// Make sure the caller is requesting a role allowed by the token.
-	if !provisionToken.GetRoles().Include(role) && role != types.RoleInstance {
+	if !token.GetRoles().Include(role) && role != types.RoleInstance {
 		return trace.BadParameter("can not join the cluster, the token does not allow role %s", role)
 	}
 
@@ -350,15 +422,15 @@ func (s *Server) makeResult(
 	authCtx *joinauthz.Context,
 	clientInit *messages.ClientInit,
 	clientParams *messages.ClientParams,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 	rawClaims any,
 	attrs *workloadidentityv1pb.JoinAttrs,
 ) (messages.Response, error) {
 	switch types.SystemRole(clientInit.SystemRole) {
 	case types.RoleInstance:
-		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, provisionToken, rawClaims)
+		return s.makeHostResult(ctx, diag, authCtx, clientParams.HostParams, token, rawClaims)
 	case types.RoleBot:
-		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, provisionToken, rawClaims, attrs)
+		result, _, err := s.makeBotResult(ctx, diag, authCtx, clientParams.BotParams, token, rawClaims, attrs)
 		return result, trace.Wrap(err)
 	default:
 		return nil, trace.NotImplemented("new join service only supports Instance and Bot system roles, client requested %s", clientInit.SystemRole)
@@ -370,14 +442,14 @@ func (s *Server) makeHostResult(
 	diag *diagnostic.Diagnostic,
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 	rawClaims any,
 ) (*messages.HostResult, error) {
-	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(provisionToken), rawClaims)
+	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(token), token.GetAssignedScope(), rawClaims)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := s.cfg.AuthService.GenerateHostCertsForJoin(ctx, provisionToken, certsParams)
+	certs, err := s.cfg.AuthService.GenerateHostCertsForJoin(ctx, token, certsParams)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -399,6 +471,7 @@ func makeHostCertsParams(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	joinMethod types.JoinMethod,
+	scope string,
 	rawClaims any,
 ) (*HostCertsParams, error) {
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.
@@ -456,7 +529,7 @@ func (s *Server) makeBotResult(
 	diag *diagnostic.Diagnostic,
 	authCtx *joinauthz.Context,
 	botParams *messages.BotParams,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 	rawClaims any,
 	attrs *workloadidentityv1pb.JoinAttrs,
 ) (*messages.BotResult, string, error) {
@@ -464,7 +537,7 @@ func (s *Server) makeBotResult(
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	certs, botInstanceID, err := s.cfg.AuthService.GenerateBotCertsForJoin(ctx, provisionToken, certsParams)
+	certs, botInstanceID, err := s.cfg.AuthService.GenerateBotCertsForJoin(ctx, token, certsParams)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -650,7 +723,7 @@ func makeAuditEvent(info diagnostic.Info, attributesStruct *apievents.Struct) ap
 	}
 }
 
-func configuredJoinMethod(token types.ProvisionToken) types.JoinMethod {
+func configuredJoinMethod(token provision.Token) types.JoinMethod {
 	method := token.GetJoinMethod()
 	if method == types.JoinMethodUnspecified {
 		return types.JoinMethodToken

--- a/lib/join/server_boundkeypair.go
+++ b/lib/join/server_boundkeypair.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // handleBoundKeypairJoin handles join attempts for the bound keypair join
@@ -58,7 +59,7 @@ func (s *Server) handleBoundKeypairJoin(
 	stream messages.ServerStream,
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 ) (*messages.BotResult, error) {
 	ctx := stream.Context()
 	diag := stream.Diagnostic()
@@ -67,6 +68,13 @@ func (s *Server) handleBoundKeypairJoin(
 	if clientInit.SystemRole != types.RoleBot.String() {
 		return nil, trace.BadParameter("bound keypair joining is only supported for bots")
 	}
+
+	// Scoped tokens currently validate against being created with the bot role, but just in case
+	// we'll check and return a more helpful error message if one happens to make it through.
+	if token.GetAssignedScope() != "" {
+		return nil, trace.BadParameter("bound keypair joining is not supported by scoped tokens")
+	}
+
 	boundKeypairInit, err := messages.RecvRequest[*messages.BoundKeypairInit](stream)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -97,7 +105,7 @@ func (s *Server) handleBoundKeypairJoin(
 			return nil, "", trace.Wrap(err)
 		}
 		botCertsParams.PreviousBotInstanceID = previousBotInstanceID
-		protoCerts, botInstanceID, err := s.cfg.AuthService.GenerateBotCertsForJoin(ctx, provisionToken, botCertsParams)
+		protoCerts, botInstanceID, err := s.cfg.AuthService.GenerateBotCertsForJoin(ctx, token, botCertsParams)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
 		}
@@ -111,7 +119,7 @@ func (s *Server) handleBoundKeypairJoin(
 		AuthService:          s.cfg.AuthService,
 		AuthCtx:              authCtx,
 		Diag:                 diag,
-		ProvisionToken:       provisionToken,
+		ProvisionToken:       token,
 		ClientInit:           clientInit,
 		BoundKeypairInit:     boundKeypairInit,
 		IssueChallenge:       issueChallenge,
@@ -183,7 +191,7 @@ func AdaptRegisterUsingBoundKeypairMethod(
 	}
 
 	// Assert that the provision token allows the requested system role.
-	if err := ProvisionTokenAllowsRole(provisionToken, req.JoinRequest.Role); err != nil {
+	if err := TokenAllowsRole(provisionToken, req.JoinRequest.Role); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/join/server_ec2.go
+++ b/lib/join/server_ec2.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/ec2join"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // handleEC2Join handles join attempts for the IAM join method.
@@ -41,7 +42,7 @@ func (s *Server) handleEC2Join(
 	stream messages.ServerStream,
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	provisionToken provision.Token,
 ) (messages.Response, error) {
 	// Receive the EC2Init message from the client.
 	ec2Init, err := messages.RecvRequest[*messages.EC2Init](stream)

--- a/lib/join/server_env0.go
+++ b/lib/join/server_env0.go
@@ -24,6 +24,7 @@ import (
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/env0"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 type Env0TokenValidator interface {
@@ -37,7 +38,7 @@ type Env0TokenValidator interface {
 // suitable for use in `handleOIDCJoin`
 func (s *Server) validateEnv0Token(
 	ctx context.Context,
-	provisionToken types.ProvisionToken,
+	provisionToken provision.Token,
 	idToken []byte,
 ) (any, *workloadidentityv1.JoinAttrs, error) {
 	verifiedIdentity, err := s.cfg.AuthService.GetEnv0IDTokenValidator().ValidateToken(ctx, idToken)

--- a/lib/join/server_github.go
+++ b/lib/join/server_github.go
@@ -24,13 +24,13 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/githubactions"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 func (a *Server) validateGithubToken(
 	ctx context.Context,
-	pt types.ProvisionToken,
+	pt provision.Token,
 	idToken []byte,
 ) (any, *workloadidentityv1.JoinAttrs, error) {
 	claims, err := githubactions.CheckGithubIDToken(ctx, &githubactions.CheckGithubIDTokenParams{

--- a/lib/join/server_oidc.go
+++ b/lib/join/server_oidc.go
@@ -24,17 +24,17 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // oidcTokenValidator is a function type that validates an OIDC token and checks that
 // it matches an allow rule configured in the provision token.
 type oidcTokenValidator func(
 	ctx context.Context,
-	provisionToken types.ProvisionToken,
+	provisionToken provision.Token,
 	idToken []byte,
 ) (rawClaims any, joinAttrs *workloadidentityv1.JoinAttrs, err error)
 
@@ -43,7 +43,7 @@ func (s *Server) handleOIDCJoin(
 	stream messages.ServerStream,
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	provisionToken provision.Token,
 	validator oidcTokenValidator,
 ) (messages.Response, error) {
 	// Receive the OIDCInit message from the client.

--- a/lib/join/server_oracle.go
+++ b/lib/join/server_oracle.go
@@ -22,12 +22,12 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // handleOracleJoin handles join attempts for the Oracle join method.
@@ -48,7 +48,7 @@ func (s *Server) handleOracleJoin(
 	stream messages.ServerStream,
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	provisionToken provision.Token,
 ) (messages.Response, error) {
 	// Receive the OracleInit message from the client.
 	oracleInit, err := messages.RecvRequest[*messages.OracleInit](stream)

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -19,9 +19,9 @@ package join
 import (
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
 )
 
 // handleTokenJoin handles join attempts for the token join method.
@@ -29,7 +29,7 @@ func (s *Server) handleTokenJoin(
 	stream messages.ServerStream,
 	authCtx *authz.Context,
 	clientInit *messages.ClientInit,
-	provisionToken types.ProvisionToken,
+	token provision.Token,
 ) (messages.Response, error) {
 	// Receive the TokenInit message from the client.
 	tokenInit, err := messages.RecvRequest[*messages.TokenInit](stream)
@@ -47,7 +47,7 @@ func (s *Server) handleTokenJoin(
 		authCtx,
 		clientInit,
 		&tokenInit.ClientParams,
-		provisionToken,
+		token,
 		nil, /*rawClaims*/
 		nil, /*attrs*/
 	)

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -1,0 +1,265 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joining
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes"
+)
+
+var rolesSupportingScopes = types.SystemRoles{
+	types.RoleNode,
+}
+
+var joinMethodsSupportingScopes = map[string]struct{}{
+	string(types.JoinMethodToken): {},
+}
+
+// StrongValidateToken checks if the scoped token is well-formed according to
+// all scoped token rules. This function *must* be used to validate any scoped
+// token being created from scratch. When validating existing scoped token
+// resources, this function should be avoided in favor of the
+// [WeakValidateToken] function.
+func StrongValidateToken(token *joiningv1.ScopedToken) error {
+	if expected, actual := types.KindScopedToken, token.GetKind(); expected != actual {
+		return trace.BadParameter("expected kind %v, got %q", expected, actual)
+	}
+	if expected, actual := types.V1, token.GetVersion(); expected != actual {
+		return trace.BadParameter("expected version %v, got %q", expected, actual)
+	}
+	if expected, actual := "", token.GetSubKind(); expected != actual {
+		return trace.BadParameter("expected sub_kind %v, got %q", expected, actual)
+	}
+	if name := token.GetMetadata().GetName(); name == "" {
+		return trace.BadParameter("missing name")
+	}
+
+	if token.GetScope() == "" {
+		return trace.BadParameter("scoped token must have a scope assigned")
+	}
+
+	spec := token.GetSpec()
+	if spec == nil {
+		return trace.BadParameter("spec must not be nil")
+	}
+
+	if err := scopes.StrongValidate(token.GetScope()); err != nil {
+		return trace.Wrap(err, "validating scoped token resource scope")
+	}
+
+	if err := scopes.StrongValidate(spec.AssignedScope); err != nil {
+		return trace.Wrap(err, "validating scoped token assigned scope")
+	}
+
+	if !scopes.ResourceScope(spec.AssignedScope).IsSubjectToPolicyScope(token.GetScope()) {
+		return trace.BadParameter("scoped token assigned scope must be descendant of its resource scope")
+	}
+
+	if _, ok := joinMethodsSupportingScopes[spec.JoinMethod]; !ok {
+		return trace.BadParameter("join method %q does not support scoping", spec.JoinMethod)
+	}
+
+	if len(spec.Roles) == 0 {
+		return trace.BadParameter("scoped token must have at least one role")
+	}
+
+	roles, err := types.NewTeleportRoles(spec.Roles)
+	if err != nil {
+		return trace.Wrap(err, "validating scoped token roles")
+	}
+
+	for _, role := range roles {
+		if !rolesSupportingScopes.Include(role) {
+			return trace.BadParameter("role %q does not support scoping", role)
+		}
+	}
+
+	return nil
+}
+
+// WeakValidateToken performs a weak form of validation on a scoped token. This
+// function is intended to catch bugs/incompatibilites that might have resulted
+// in a scoped token too malformed for us to safely reason about (e.g. due to
+// significant version drift). Use this function to validate scoped tokens
+// propagated from the control plane. Prefer using [StrongValidateToken] when
+// building a new scoped token from scratch.
+func WeakValidateToken(token *joiningv1.ScopedToken) error {
+	if token == nil {
+		return trace.BadParameter("missing scoped token")
+	}
+
+	if err := scopes.WeakValidate(token.GetScope()); err != nil {
+		return trace.Wrap(err, "validating scoped token resource scope")
+	}
+
+	if err := scopes.WeakValidate(token.GetSpec().GetAssignedScope()); err != nil {
+		return trace.Wrap(err, "validating scoped token assigned scope")
+	}
+
+	if len(token.GetSpec().GetRoles()) == 0 {
+		return trace.BadParameter("scoped token must have at least one role")
+	}
+
+	if _, ok := joinMethodsSupportingScopes[token.GetSpec().GetJoinMethod()]; !ok {
+		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
+	}
+
+	return nil
+}
+
+// ValidateTokenForUse checks if a given scoped token can be used for
+// provisioning.
+func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
+	if err := WeakValidateToken(token); err != nil {
+		return trace.Wrap(err)
+	}
+
+	ttl := token.GetMetadata().GetExpires()
+	if ttl == nil || ttl.AsTime().IsZero() {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	if ttl.AsTime().Before(now) {
+		return trace.LimitExceeded("scoped token is expired")
+	}
+
+	return nil
+}
+
+// Token wraps a [joiningv1.ScopedToken] such that it can be used to provision
+// resources.
+type Token struct {
+	scoped     *joiningv1.ScopedToken
+	joinMethod types.JoinMethod
+	roles      types.SystemRoles
+}
+
+// NewToken returns the wrapped version of the given [joiningv1.ScopedToken].
+// It will return an error if the configured join method is not a valid
+// [types.JoinMethod] or if any of the configured roles are not a valid
+// [types.SystemRole]. The validated join method and roles are cached on the
+// [Scoped] wrapper itself so they can be read without repeating validation.
+func NewToken(token *joiningv1.ScopedToken) (*Token, error) {
+	joinMethod := types.JoinMethod(token.GetSpec().GetJoinMethod())
+	if err := types.ValidateJoinMethod(joinMethod); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	roles, err := types.NewTeleportRoles(token.GetSpec().GetRoles())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Token{scoped: token, joinMethod: joinMethod, roles: roles}, nil
+}
+
+// GetName returns the name of a [joiningv1.ScopedToken].
+func (t *Token) GetName() string {
+	if t == nil {
+		return ""
+	}
+
+	return t.scoped.GetMetadata().GetName()
+}
+
+// GetJoinMethod returns the cached [types.JoinMethod] generated when the
+// [joiningv1.ScopedToken] was wrapped.
+func (t *Token) GetJoinMethod() types.JoinMethod {
+	if t == nil {
+		return types.JoinMethodUnspecified
+	}
+
+	return t.joinMethod
+}
+
+// GetRoles returns the cached [types.SystemRoles] generated when the
+// [joiningv1.ScopedToken] was wrapped.
+func (t *Token) GetRoles() types.SystemRoles {
+	if t == nil {
+		return nil
+	}
+	return t.roles
+}
+
+// GetSafeName returns the name of the scoped token, sanitized appropriately
+// for join methods where the name is secret. This should be used when logging
+// the token name.
+func (t *Token) GetSafeName() string {
+	return GetSafeScopedTokenName(t.scoped)
+}
+
+// GetSafeScopedTokenName returns the name of the scoped token, sanitized
+// appropriately for join methods where the name is secret. This should be used
+// when logging the token name.
+func GetSafeScopedTokenName(token *joiningv1.ScopedToken) string {
+	name := token.GetMetadata().GetName()
+	if types.JoinMethod(token.GetSpec().GetJoinMethod()) != types.JoinMethodToken {
+		return name
+	}
+
+	// If the token name is short, we just blank the whole thing.
+	if len(name) < 16 {
+		return strings.Repeat("*", len(name))
+	}
+
+	// If the token name is longer, we can show the last 25% of it to help
+	// the operator identify it.
+	hiddenBefore := int(0.75 * float64(len(name)))
+	name = name[hiddenBefore:]
+	name = strings.Repeat("*", hiddenBefore) + name
+	return name
+}
+
+// Expiry returns the [time.Time] representing when the wrapped
+// [joiningv1.ScopedToken] will expire.
+func (t *Token) Expiry() time.Time {
+	expiry := t.scoped.GetMetadata().GetExpires()
+	if expiry == nil {
+		return time.Time{}
+	}
+
+	return expiry.AsTime()
+}
+
+// GetBotName returns an empty string because scoped tokens do not currently
+// support configuring a bot name.
+func (t *Token) GetBotName() string {
+	return ""
+}
+
+// GetAssignedScope returns the scope that will be assigned to resources
+// provisioned using the wrapped [joiningv1.ScopedToken].
+func (t *Token) GetAssignedScope() string {
+	return t.scoped.GetSpec().GetAssignedScope()
+}
+
+// GetAllowRules returns the list of allow rules.
+func (t *Token) GetAllowRules() []*types.TokenRule {
+	return nil
+}
+
+// GetAWSIIDTTL returns the TTL of EC2 IIDs
+func (t *Token) GetAWSIIDTTL() types.Duration {
+	return types.NewDuration(0)
+}

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -1,0 +1,340 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joining_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+)
+
+func TestValidateScopedToken(t *testing.T) {
+	cases := []struct {
+		name              string
+		token             *joiningv1.ScopedToken
+		expectedStrongErr string
+		expectedWeakErr   string
+	}{
+		{
+			name: "invalid kind",
+			token: &joiningv1.ScopedToken{
+				Version: types.V1,
+				Scope:   "/aa",
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: fmt.Sprintf("expected kind %v, got %q", types.KindScopedToken, ""),
+		},
+		{
+			name: "invalid version",
+			token: &joiningv1.ScopedToken{
+				Kind:  types.KindScopedToken,
+				Scope: "/aa",
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: fmt.Sprintf("expected version %v, got %q", types.V1, ""),
+		},
+		{
+			name: "invalid subkind",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Version: types.V1,
+				Scope:   "/aa",
+				SubKind: "subkind",
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: fmt.Sprintf("expected sub_kind %v, got %q", "", "subkind"),
+		},
+		{
+			name: "missing name",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Version: types.V1,
+				Scope:   "/aa",
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "missing name",
+		},
+		{
+			name: "missing spec",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Version: types.V1,
+				Scope:   "/aa",
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+			},
+			expectedStrongErr: "spec must not be nil",
+			expectedWeakErr:   "validating scoped token assigned scope",
+		},
+		{
+			name: "missing scope",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "scoped token must have a scope assigned",
+			expectedWeakErr:   "validating scoped token resource scope",
+		},
+		{
+			name: "non-absolute scope",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token resource scope",
+		},
+		{
+			name: "scope with invalid characters",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb}",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token resource scope",
+			expectedWeakErr:   "validating scoped token resource scope",
+		},
+		{
+			name: "missing assigned scope",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:      []string{types.RoleNode.String()},
+					JoinMethod: string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token assigned scope",
+			expectedWeakErr:   "validating scoped token assigned scope",
+		},
+		{
+			name: "non-absolute assigned scope",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "aa/bb",
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token assigned scope",
+		},
+		{
+			name: "assigned scope with invalid character",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "aa/bb}",
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token assigned scope",
+			expectedWeakErr:   "validating scoped token assigned scope",
+		},
+		{
+			name: "assigned scope is not descendant of token scope",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/bb/aa",
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "scoped token assigned scope must be descendant of its resource scope",
+		},
+		{
+			name: "invalid join method",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodUnspecified),
+				},
+			},
+			expectedStrongErr: fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
+			expectedWeakErr:   fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
+		},
+		{
+			name: "missing roles",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "scoped token must have at least one role",
+			expectedWeakErr:   "scoped token must have at least one role",
+		},
+		{
+			name: "invalid roles",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{"random_role"},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "validating scoped token roles",
+		},
+		{
+			name: "unsupported roles",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: fmt.Sprintf("role %q does not support scoping", types.RoleInstance),
+		},
+		{
+			name: "valid scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := joining.StrongValidateToken(c.token)
+			if c.expectedStrongErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, c.expectedStrongErr)
+			}
+
+			err = joining.WeakValidateToken(c.token)
+			if c.expectedWeakErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, c.expectedWeakErr)
+			}
+		})
+	}
+}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -443,6 +443,17 @@ func (process *TeleportProcess) getCertAuthority(conn *Connector, id types.CertA
 	return conn.Client.GetCertAuthority(ctx, id, loadPrivateKeys)
 }
 
+// localReRegister wraps an [*auth.Server] and removes the scope parameter from the signature of
+// [auth.Server.GenerateHostCerts]
+type localReRegister struct {
+	*auth.Server
+}
+
+// GenerateHostCerts allows for generating host certs without providing a scope.
+func (l localReRegister) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequest) (*proto.Certs, error) {
+	return l.Server.GenerateHostCerts(ctx, req, "")
+}
+
 // reRegister receives new identity credentials for proxy, node and auth.
 // In case if auth servers, the role is 'TeleportAdmin' and instead of using
 // TLS client this method uses the local auth server.
@@ -458,7 +469,7 @@ func (process *TeleportProcess) reRegister(conn *Connector, additionalPrincipals
 	var clt auth.ReRegisterClient = conn.Client
 	var remoteAddr string
 	if srv := process.getLocalAuth(); srv != nil {
-		clt = srv
+		clt = localReRegister{srv}
 		// auth server typically extracts remote addr from conn. since we're using the local auth
 		// directly we must supply a reasonable remote addr value. preferably the advertise IP, but
 		// otherwise localhost. this behavior must be kept consistent with the equivalent behavior

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -272,6 +272,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newRotatedKeyParser()
 		case types.KindRelayServer:
 			parser = newRelayServerParser()
+		case types.KindScopedToken:
+			parser = newScopedTokenParser()
 		default:
 			if watch.AllowPartialSuccess {
 				continue

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -1,0 +1,248 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const (
+	scopedTokenPrefix = "scoped_token"
+)
+
+// ScopedTokenService exposes backend functionality for working with scoped token resources.
+type ScopedTokenService struct {
+	svc *generic.ServiceWrapper[*joiningv1.ScopedToken]
+}
+
+// NewScopedTokenService creates a new ScopedTokenService.
+func NewScopedTokenService(b backend.Backend) (*ScopedTokenService, error) {
+	const pageLimit = 100
+	svc, err := generic.NewServiceWrapper(generic.ServiceConfig[*joiningv1.ScopedToken]{
+		Backend:       b,
+		PageLimit:     pageLimit,
+		ResourceKind:  types.KindScopedToken,
+		BackendPrefix: backend.NewKey(scopedTokenPrefix),
+		MarshalFunc:   services.MarshalProtoResource[*joiningv1.ScopedToken],
+		UnmarshalFunc: services.UnmarshalProtoResource[*joiningv1.ScopedToken],
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ScopedTokenService{
+		svc: svc,
+	}, nil
+}
+
+// CreateScopedToken adds a scoped token to the auth server.
+func (s *ScopedTokenService) CreateScopedToken(ctx context.Context, req *joiningv1.CreateScopedTokenRequest) (*joiningv1.CreateScopedTokenResponse, error) {
+	if err := joining.StrongValidateToken(req.GetToken()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	created, err := s.svc.CreateResource(ctx, req.GetToken())
+	return &joiningv1.CreateScopedTokenResponse{
+		Token: created,
+	}, trace.Wrap(err)
+}
+
+// GetScopedToken finds and returns a scoped token by name.
+func (s *ScopedTokenService) GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.GetScopedTokenResponse, error) {
+	token, err := s.svc.GetResource(ctx, req.GetName())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := joining.WeakValidateToken(token); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &joiningv1.GetScopedTokenResponse{Token: token}, nil
+}
+
+// UseScopedToken fetches a scoped join token by unique name and checks if it
+// can be used for provisioning. Expired tokens will be deleted.
+func (s *ScopedTokenService) UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error) {
+	token, err := s.svc.GetResource(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := joining.ValidateTokenForUse(token); err != nil {
+		if trace.IsLimitExceeded(err) {
+			if err := s.svc.DeleteResource(ctx, name); err != nil {
+				return nil, trace.LimitExceeded("cleaning up expired token: %v", err)
+			}
+		}
+		return nil, trace.Wrap(err)
+	}
+	return token, nil
+}
+
+func evalScopeFilter(filter *scopesv1.Filter, scope string) bool {
+	if filter == nil {
+		return true
+	}
+
+	switch filter.Mode {
+	case scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE:
+		return scopes.ResourceScope(scope).IsSubjectToPolicyScope(filter.Scope)
+	case scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE:
+		return scopes.PolicyScope(scope).AppliesToResourceScope(filter.Scope)
+	}
+
+	return true
+}
+
+// ListScopedTokens retrieves a paginated list of scoped join tokens.
+func (s *ScopedTokenService) ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error) {
+	// we only want to return filters if at least one of the filters
+	// has been defined, otherwise we should return nil so that the
+	// backend can choose to perform a simple list operation instead
+	// of a list with filter
+	switch {
+	case req.ResourceScope != nil:
+	case req.AssignedScope != nil:
+	case len(req.Roles) > 0:
+	case len(req.Labels) > 0:
+	default:
+		tokens, cursor, err := s.svc.ListResources(ctx, int(req.GetLimit()), req.GetCursor())
+
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &joiningv1.ListScopedTokensResponse{
+			Tokens: tokens,
+			Cursor: cursor,
+		}, nil
+	}
+
+	if req.GetAssignedScope().GetScope() != "" {
+		if err := scopes.WeakValidate(req.GetAssignedScope().GetScope()); err != nil {
+			return nil, trace.BadParameter("invalid scope for assigned filter: %s", req.GetAssignedScope().GetScope())
+		}
+
+	}
+
+	if req.GetResourceScope().GetScope() != "" {
+		if err := scopes.WeakValidate(req.GetResourceScope().GetScope()); err != nil {
+			return nil, trace.BadParameter("invalid scope for resource filter: %s", req.GetResourceScope().GetScope())
+		}
+	}
+
+	filterRoles, err := types.NewTeleportRoles(req.GetRoles())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	filterFn := func(token *joiningv1.ScopedToken) bool {
+		if len(req.GetRoles()) > 0 {
+			roles, err := types.NewTeleportRoles(token.Spec.Roles)
+			if err != nil {
+				return false
+			}
+
+			if !filterRoles.IncludeAny(roles...) {
+				return false
+			}
+		}
+
+		if !evalScopeFilter(req.GetAssignedScope(), token.Spec.AssignedScope) {
+			return false
+		}
+
+		if !evalScopeFilter(req.GetResourceScope(), token.Scope) {
+			return false
+		}
+
+		for k, v := range req.GetLabels() {
+			if token.GetMetadata().GetLabels()[k] != v {
+				return false
+			}
+		}
+
+		if err := joining.WeakValidateToken(token); err != nil {
+			return false
+		}
+
+		return true
+	}
+
+	tokens, cursor, err := s.svc.ListResourcesWithFilter(ctx, int(req.GetLimit()), req.GetCursor(), filterFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &joiningv1.ListScopedTokensResponse{
+		Tokens: tokens,
+		Cursor: cursor,
+	}, nil
+}
+
+// DeleteScopedToken deletes a scoped token by name.
+func (s *ScopedTokenService) DeleteScopedToken(ctx context.Context, req *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error) {
+	return nil, trace.Wrap(s.svc.DeleteResource(ctx, req.GetName()))
+}
+
+type scopedTokenParser struct {
+	baseParser
+}
+
+func newScopedTokenParser() *scopedTokenParser {
+	return &scopedTokenParser{
+		baseParser: newBaseParser(backend.NewKey(scopedTokenPrefix)),
+	}
+}
+
+func (p *scopedTokenParser) parse(event backend.Event) (types.Resource, error) {
+	switch event.Type {
+	case types.OpPut:
+		scopedToken, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](
+			event.Item.Value,
+			services.WithExpires(event.Item.Expires),
+			services.WithRevision(event.Item.Revision),
+		)
+		if err != nil {
+			return nil, trace.Wrap(err, "unmarshaling resource from event")
+		}
+		return types.Resource153ToLegacy(scopedToken), nil
+	case types.OpDelete:
+		name := event.Item.Key.TrimPrefix(backend.NewKey(scopedTokenPrefix)).String()
+		if name == "" {
+			return nil, trace.NotFound("failed parsing %v", event.Item.Key)
+		}
+		return &types.ResourceHeader{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Metadata: types.Metadata{
+				Name: name,
+			},
+		}, nil
+	default:
+		return nil, trace.BadParameter("event %v is not supported", event.Type)
+	}
+}

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -1,0 +1,350 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package local_test
+
+import (
+	"cmp"
+	"slices"
+	"testing"
+	"time"
+
+	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+func TestScopedTokenService(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	clock.Advance(-30 * time.Hour)
+	bk, err := memory.New(memory.Config{
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	// service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	service, err := local.NewScopedTokenService(bk)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	token := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "testtoken",
+		},
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test/one",
+			JoinMethod:    "token",
+			Roles:         []string{types.RoleNode.String()},
+		},
+	}
+
+	created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	require.NoError(t, err)
+	cmpOpts := []gocmp.Option{
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
+	}
+	assert.Empty(t, gocmp.Diff(token, created.Token, cmpOpts...))
+
+	fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name: token.Metadata.Name,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, gocmp.Diff(created.Token, fetched.Token, cmpOpts...))
+
+	_, err = service.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+		Name: fetched.Token.Metadata.Name,
+	})
+	require.NoError(t, err)
+	_, err = service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name: fetched.Token.Metadata.Name,
+	})
+	require.True(t, trace.IsNotFound(err))
+
+	expiredToken := proto.CloneOf(token)
+	expiredToken.Metadata.Name = "expiredtoken"
+	expiredToken.Metadata.Expires = timestamppb.New(time.Now().UTC().Add(-25 * time.Hour))
+
+	activeToken := proto.CloneOf(token)
+	activeToken.Metadata.Name = "activetoken"
+	activeToken.Metadata.Expires = timestamppb.New(time.Now().UTC().Add(25 * time.Hour))
+
+	expiredRes, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: expiredToken,
+	})
+	require.NoError(t, err)
+
+	activeRes, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: activeToken,
+	})
+	require.NoError(t, err)
+
+	// expired tokens should error and delete the token
+	expiredToken, err = service.UseScopedToken(ctx, expiredRes.Token.Metadata.Name)
+	require.True(t, trace.IsLimitExceeded(err))
+	require.Nil(t, expiredToken)
+
+	_, err = service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name: expiredRes.Token.Metadata.Name,
+	})
+	require.True(t, trace.IsNotFound(err))
+
+	// active tokens should function like a get
+	activeToken, err = service.UseScopedToken(ctx, activeToken.Metadata.Name)
+	require.NoError(t, err)
+	assert.Empty(t, gocmp.Diff(activeToken, activeRes.Token, cmpOpts...))
+
+	fetchedActive, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name: activeRes.Token.Metadata.Name,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, gocmp.Diff(activeRes.Token, fetchedActive.Token, cmpOpts...))
+}
+
+func TestScopedTokenList(t *testing.T) {
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	test := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "test",
+		},
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test",
+			JoinMethod:    "token",
+			Roles: []string{
+				types.RoleNode.String(),
+			},
+		},
+	}
+
+	test1 := proto.CloneOf(test)
+	test1.Metadata.Name = "test1"
+	test1.Scope = "/test/aa"
+	test1.Spec.AssignedScope = test1.Scope
+
+	test2 := proto.CloneOf(test)
+	test2.Metadata.Name = "test2"
+	test2.Scope = "/test/bb"
+	test2.Spec.AssignedScope = test2.Scope
+	test2.Metadata.Labels = map[string]string{
+		"hello": "world",
+	}
+
+	test3 := proto.CloneOf(test)
+	test3.Metadata.Name = "test3"
+	test3.Scope = "/test/aa/bb"
+	test3.Spec.AssignedScope = test3.Scope
+
+	test4 := proto.CloneOf(test)
+	test4.Metadata.Name = "test4"
+	test4.Spec.AssignedScope = "/test/aa"
+	test4.Scope = "/test/aa"
+	test4.Spec.AssignedScope = test4.Scope
+
+	stage := proto.CloneOf(test)
+	stage.Metadata.Name = "stage"
+	stage.Scope = "/stage"
+	stage.Spec.AssignedScope = stage.Scope
+
+	stage1 := proto.CloneOf(stage)
+	stage1.Metadata.Name = "stage1"
+	stage1.Spec.AssignedScope = "/stage/aa"
+
+	stage2 := proto.CloneOf(stage)
+	stage2.Metadata.Name = "stage2"
+	stage2.Scope = "/stage/aa"
+	stage2.Spec.AssignedScope = "/stage/aa"
+
+	allTokens := []*joiningv1.ScopedToken{test, test1, test2, test3, test4, stage, stage1, stage2}
+	for _, token := range allTokens {
+		_, err = service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+	}
+
+	sortFn := func(left *joiningv1.ScopedToken, right *joiningv1.ScopedToken) int {
+		return cmp.Compare(left.Metadata.Name, right.Metadata.Name)
+	}
+	cases := []struct {
+		name     string
+		req      *joiningv1.ListScopedTokensRequest
+		expected []*joiningv1.ScopedToken
+	}{
+		{
+			name:     "all tokens (no filters)",
+			req:      &joiningv1.ListScopedTokensRequest{},
+			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4, stage, stage1, stage2},
+		},
+		{
+			name: "tokens assigning scope descendant of /test",
+			req: &joiningv1.ListScopedTokensRequest{
+				AssignedScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4},
+		},
+		{
+			name: "tokens assigning scope descendant of /test/aa",
+			req: &joiningv1.ListScopedTokensRequest{
+				AssignedScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test/aa",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test1, test3, test4},
+		},
+		{
+			name: "tokens assigning scope ancestor to /test/bb",
+			req: &joiningv1.ListScopedTokensRequest{
+				AssignedScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/test/bb",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test, test2},
+		},
+		{
+			name: "tokens descendants of /test",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4},
+		},
+		{
+			name: "tokens descendants of /test/aa",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test/aa",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test1, test3, test4},
+		},
+		{
+			name: "tokens ancestor to /test/bb",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
+					Scope: "/test/bb",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test, test2},
+		},
+		{
+			name: "tokens descendant of /stage assigning /stage/aa",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/stage",
+				},
+				AssignedScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/stage/aa",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{stage1, stage2},
+		},
+		{
+			name: "tokens descendant of /stage/aa assigning /stage/aa",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/stage/aa",
+				},
+				AssignedScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/stage/aa",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{stage2},
+		},
+		{
+			name: "tokens in /test scope applying auth role",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test",
+				},
+				Roles: []string{types.RoleAuth.String()},
+			},
+			expected: []*joiningv1.ScopedToken{},
+		},
+		{
+			name: "tokens in /test scope filtered by label",
+			req: &joiningv1.ListScopedTokensRequest{
+				ResourceScope: &scopesv1.Filter{
+					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
+					Scope: "/test",
+				},
+				Roles: []string{types.RoleNode.String()},
+				Labels: map[string]string{
+					"hello": "world",
+				},
+			},
+			expected: []*joiningv1.ScopedToken{test2},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := proto.CloneOf(c.req)
+			req.Limit = 10
+			res, err := service.ListScopedTokens(ctx, req)
+			require.NoError(t, err)
+
+			slices.SortStableFunc(c.expected, sortFn)
+			slices.SortStableFunc(res.GetTokens(), sortFn)
+			require.Len(t, res.GetTokens(), len(c.expected))
+			for i, token := range res.GetTokens() {
+				cmpOpts := []gocmp.Option{
+					protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+					protocmp.Transform(),
+				}
+				assert.Empty(t, gocmp.Diff(c.expected[i], token, cmpOpts...))
+			}
+		})
+	}
+}

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -1,0 +1,43 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+)
+
+// ScopedTokenService handles CRUD operations for the ScopedToken resource.
+type ScopedTokenService interface {
+	// CreateScopedToken creates a scoped join token.
+	CreateScopedToken(ctx context.Context, req *joiningv1.CreateScopedTokenRequest) (*joiningv1.CreateScopedTokenResponse, error)
+
+	// GetScopedToken fetches a scoped join token by unique name
+	GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.GetScopedTokenResponse, error)
+
+	// UseScopedToken fetches a scoped join token by unique name and checks if it can
+	// be used for provisioning. If the token is expired, [UseScopedToken] should also
+	// delete it from the backend.
+	UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
+	// ListScopedTokens retrieves a paginated list of scoped join tokens
+	ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error)
+
+	// DeleteScopedToken deletes a named scoped join token. Imlementations must guarantee that
+	// this returns trace.NotFound error if the token doesn't exist
+	DeleteScopedToken(ctx context.Context, req *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error)
+}

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2407,7 +2407,7 @@ func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 			DNSNames:             []string{hostname},
 			PublicSSHKey:         pub,
 			PublicTLSKey:         tlsPub,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -3277,7 +3277,7 @@ func newSigner(t testing.TB, ctx context.Context, testServer *authtest.Server) s
 			Role:         types.RoleNode,
 			PublicSSHKey: pub,
 			PublicTLSKey: tlsPub,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -144,6 +144,8 @@ type Identity struct {
 	// GitHubUsername indicates the GitHub username identified by the GitHub
 	// connector.
 	GitHubUsername string
+	// AgentScope is the scope this identity belongs to.
+	AgentScope string
 }
 
 // Encode encodes the identity into an ssh certificate. Note that the returned certificate is incomplete
@@ -185,6 +187,10 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 
 	if i.ClusterName != "" {
 		cert.Permissions.Extensions[utils.CertExtensionAuthority] = i.ClusterName
+	}
+
+	if i.AgentScope != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionAgentScope] = i.AgentScope
 	}
 
 	// --- user extensions ---
@@ -411,6 +417,7 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		ident.ScopePin = &pin
 	}
 
+	ident.AgentScope = takeValue(teleport.CertExtensionAgentScope)
 	ident.PermitX11Forwarding = takeBool(teleport.CertExtensionPermitX11Forwarding)
 	ident.PermitAgentForwarding = takeBool(teleport.CertExtensionPermitAgentForwarding)
 	ident.PermitPortForwarding = takeBool(teleport.CertExtensionPermitPortForwarding)

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -90,6 +90,7 @@ func TestIdentityConversion(t *testing.T) {
 		DeviceCredentialID:     "cred",
 		GitHubUserID:           "github",
 		GitHubUsername:         "ghuser",
+		AgentScope:             "/foo",
 	}
 
 	ignores := []string{

--- a/lib/sshca/sshca.go
+++ b/lib/sshca/sshca.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
 )
 
 // Authority implements minimal key-management facility for generating OpenSSH
@@ -77,6 +78,11 @@ func (r *HostCertificateRequest) Check() error {
 	}
 	if err := r.Identity.SystemRole.Check(); err != nil {
 		return trace.Wrap(err)
+	}
+	if r.Identity.AgentScope != "" {
+		if err := scopes.StrongValidate(r.Identity.AgentScope); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return nil

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -331,7 +331,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 			Role:         types.RoleNode,
 			PublicSSHKey: pub,
 			PublicTLSKey: tlsPub,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -633,7 +633,7 @@ func (s *WebSuite) addNode(t *testing.T, uuid string, hostname string, address s
 			Role:         types.RoleNode,
 			PublicSSHKey: pub,
 			PublicTLSKey: tlsPub,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -8334,7 +8334,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 			Role:         types.RoleNode,
 			PublicSSHKey: pub,
 			PublicTLSKey: tlsPub,
-		})
+		}, "")
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)

--- a/tool/tctl/common/cmds.go
+++ b/tool/tctl/common/cmds.go
@@ -73,5 +73,6 @@ func Commands() []CLICommand {
 		&stableunixusers.Command{},
 		&decision.Command{},
 		&BoundKeypairCommand{},
+		&ScopedCommand{},
 	}
 }

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -120,6 +120,16 @@ func runTokensCommand(t *testing.T, client *authclient.Client, args []string) (*
 	return &stdoutBuff, runCommand(t, client, command, args)
 }
 
+func runScopedCommand(t *testing.T, client *authclient.Client, args []string) (*bytes.Buffer, error) {
+	var stdoutBuff bytes.Buffer
+	command := &ScopedCommand{
+		Stdout: &stdoutBuff,
+	}
+
+	args = append([]string{"scoped"}, args...)
+	return &stdoutBuff, runCommand(t, client, command, args)
+}
+
 func runUserCommand(t *testing.T, client *authclient.Client, args []string) error {
 	command := &UserCommand{}
 	args = append([]string{"users"}, args...)

--- a/tool/tctl/common/scoped_command.go
+++ b/tool/tctl/common/scoped_command.go
@@ -1,0 +1,60 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"io"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+)
+
+// ScopedCommand implements scoped variants of tctl command groups, such as
+// `tctl scoped tokens`.
+type ScopedCommand struct {
+	config *servicecfg.Config
+	tokens *ScopedTokensCommand
+	Stdout io.Writer
+}
+
+// Initialize allows ScopedCommand to plug itself into the CLI parser
+func (c *ScopedCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
+	c.config = config
+	scoped := app.Command("scoped", "Run a subcommand using scoped auth")
+
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+
+	c.tokens = &ScopedTokensCommand{
+		Stdout: c.Stdout,
+	}
+
+	c.tokens.Initialize(scoped, config)
+}
+
+// TryRun takes the CLI command as an argument (like "scoped tokens") and executes it.
+func (c *ScopedCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	return c.tokens.TryRun(ctx, cmd, clientFunc)
+}

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -1,0 +1,310 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
+	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
+)
+
+// ScopedTokensCommand implements `tctl scoped tokens` group of commands
+type ScopedTokensCommand struct {
+	config *servicecfg.Config
+
+	withSecrets bool
+
+	// format is the output format, e.g. text or json
+	format string
+
+	// tokenType is the type of token. For example, "node".
+	tokenType string
+
+	// Value is the value of the token. Can be used to either act on a
+	// token (for example, delete a token) or used to create a token with a
+	// specific value.
+	value string
+
+	// assignedScope allows for filtering tokens by the scope they assign
+	assignedScope string
+
+	// tokenScope allows for filtering tokens by the scope they belong to
+	tokenScope string
+
+	// ttl is how long the token will live for.
+	ttl time.Duration
+
+	// tokenAdd is used to add a token.
+	tokenAdd *kingpin.CmdClause
+
+	// tokenDel is used to delete a token.
+	tokenDel *kingpin.CmdClause
+
+	// tokenList is used to view all tokens that Teleport knows about.
+	tokenList *kingpin.CmdClause
+
+	// Stdout allows to switch the standard output source. Used in tests.
+	Stdout io.Writer
+}
+
+// Initialize allows TokenCommand to plug itself into the CLI parser
+func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *servicecfg.Config) {
+	c.config = config
+
+	tokens := scopedCmd.Command("tokens", "List or revoke scoped invitation tokens")
+
+	formats := []string{teleport.Text, teleport.JSON, teleport.YAML}
+
+	// tctl scoped tokens add ..."
+	c.tokenAdd = tokens.Command("add", "Create a scoped invitation token.")
+	c.tokenAdd.Flag("type", "Type(s) of token to add, e.g. --type=node").Required().StringVar(&c.tokenType)
+	c.tokenAdd.Flag("value", "Override the default random generated token with a specified value").StringVar(&c.value)
+	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v minutes",
+		int(defaults.ProvisioningTokenTTL/time.Minute))).
+		Default(fmt.Sprintf("%v", defaults.ProvisioningTokenTTL)).
+		DurationVar(&c.ttl)
+	c.tokenAdd.Flag("format", "Output format, 'text', 'json', or 'yaml'").EnumVar(&c.format, formats...)
+	c.tokenAdd.Flag("assign-scope", "Scope that should be applied to resources provisioned by this token").StringVar(&c.assignedScope)
+	c.tokenAdd.Flag("scope", "Scope assigned to the token itself").StringVar(&c.tokenScope)
+
+	// "tctl scoped tokens rm ..."
+	c.tokenDel = tokens.Command("rm", "Delete/revoke a scoped invitation token.").Alias("del")
+	c.tokenDel.Arg("token", "Token to delete").StringVar(&c.value)
+
+	// "tctl scoped tokens ls"
+	c.tokenList = tokens.Command("ls", "List invitation tokens.")
+	c.tokenList.Flag("format", "Output format, 'text', 'json' or 'yaml'").EnumVar(&c.format, formats...)
+	c.tokenList.Flag("with-secrets", "Do not redact join tokens").BoolVar(&c.withSecrets)
+
+	if c.Stdout == nil {
+		c.Stdout = os.Stdout
+	}
+}
+
+// TryRun attempts to run subcommands like like "scoped tokens ls".
+func (c *ScopedTokensCommand) TryRun(ctx context.Context, cmd string, clientFunc commonclient.InitFunc) (match bool, err error) {
+	var commandFunc func(ctx context.Context, client *authclient.Client) error
+	switch cmd {
+	case c.tokenAdd.FullCommand():
+		commandFunc = c.Add
+	case c.tokenDel.FullCommand():
+		commandFunc = c.Del
+	case c.tokenList.FullCommand():
+		commandFunc = c.List
+	default:
+		return false, nil
+	}
+	client, closeFn, err := clientFunc(ctx)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	err = commandFunc(ctx, client)
+	closeFn(ctx)
+
+	return true, trace.Wrap(err)
+}
+
+// Add is called to execute "scoped tokens add ..." command.
+func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client) error {
+	// Parse string to see if it's a type of role that Teleport supports.
+	roles, err := types.ParseTeleportRoles(c.tokenType)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// If it's Kube, then enable App and Discovery roles automatically so users
+	// don't have problems with running Kubernetes App Discovery by default.
+	if len(roles) == 1 && roles[0] == types.RoleKube {
+		roles = append(roles, types.RoleApp, types.RoleDiscovery)
+	}
+
+	tokenName := c.value
+
+	expires := time.Now().UTC().Add(c.ttl)
+	tok := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:    tokenName,
+			Expires: timestamppb.New(expires),
+		},
+		Scope: c.tokenScope,
+		Spec: &joiningv1.ScopedTokenSpec{
+			Roles:         roles.StringSlice(),
+			AssignedScope: c.assignedScope,
+		},
+	}
+
+	tok, err = client.CreateScopedToken(ctx, tok)
+	if err != nil {
+		if trace.IsAlreadyExists(err) {
+			return trace.AlreadyExists(
+				"failed to create scoped token (%q already exists), please use another name",
+				tokenName,
+			)
+		}
+		return trace.Wrap(err, "creating scoped token")
+	}
+
+	tokenName = tok.GetMetadata().GetName()
+	// Print token information formatted with JSON, YAML, or just print the raw token.
+	switch c.format {
+	case teleport.JSON, teleport.YAML:
+		expires := time.Now().Add(c.ttl)
+		tokenInfo := map[string]any{
+			"token":        tokenName,
+			"roles":        roles,
+			"scope":        tok.GetScope(),
+			"assign_scope": tok.GetSpec().GetAssignedScope(),
+			"expires":      expires,
+		}
+
+		var (
+			data []byte
+			err  error
+		)
+		if c.format == teleport.JSON {
+			data, err = json.MarshalIndent(tokenInfo, "", " ")
+		} else {
+			data, err = yaml.Marshal(tokenInfo)
+		}
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Fprint(c.Stdout, string(data))
+
+		return nil
+	case teleport.Text:
+		fmt.Fprintln(c.Stdout, tokenName)
+		return nil
+	}
+
+	return trace.Wrap(showJoinInstructions(ctx, joinInstructionsInput{
+		out:       c.Stdout,
+		ttl:       c.ttl,
+		roles:     roles,
+		tokenName: tokenName,
+		client:    client,
+	}))
+}
+
+// Del is called to execute "scoped tokens del ..." command.
+func (c *ScopedTokensCommand) Del(ctx context.Context, client *authclient.Client) error {
+	if c.value == "" {
+		return trace.BadParameter("Need an argument: token")
+	}
+	if err := client.DeleteScopedToken(ctx, c.value); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Fprintf(c.Stdout, "Token %s has been deleted\n", c.value)
+	return nil
+}
+
+// List is called to execute "tokens ls" command.
+func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Client) error {
+	tokens, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*joiningv1.ScopedToken, string, error) {
+		res, err := client.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
+			Limit:  uint32(pageSize),
+			Cursor: pageKey,
+		})
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		return res.GetTokens(), res.GetCursor(), nil
+	}))
+	if err != nil {
+		return trace.Wrap(err, "listing scoped tokens")
+	}
+
+	if len(tokens) == 0 && c.format == teleport.Text {
+		fmt.Fprintln(c.Stdout, "No active tokens found.")
+		return nil
+	}
+
+	// Sort by expire time.
+	slices.SortStableFunc(tokens, func(left, right *joiningv1.ScopedToken) int {
+		return left.GetMetadata().GetExpires().AsTime().Compare(right.GetMetadata().GetExpires().AsTime())
+	})
+
+	nameFunc := func(tok *joiningv1.ScopedToken) string {
+		if c.withSecrets {
+			return tok.GetMetadata().GetName()
+		}
+		return joining.GetSafeScopedTokenName(tok)
+	}
+	switch c.format {
+	case teleport.JSON:
+		err := utils.WriteJSONArray(c.Stdout, tokens)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal tokens")
+		}
+	case teleport.YAML:
+		err := utils.WriteYAML(c.Stdout, tokens)
+		if err != nil {
+			return trace.Wrap(err, "failed to marshal tokens")
+		}
+	case teleport.Text:
+		for _, token := range tokens {
+			fmt.Fprintln(c.Stdout, nameFunc(token))
+		}
+	default:
+		tokensView := func() string {
+			table := asciitable.MakeTable([]string{"Token", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
+			now := time.Now()
+			for _, t := range tokens {
+				expiry := "never"
+				expiresAt := t.GetMetadata().GetExpires().AsTime()
+				if !expiresAt.IsZero() && expiresAt.Unix() != 0 {
+					exptime := expiresAt.Format(time.RFC822)
+					expdur := expiresAt.Sub(now).Round(time.Second)
+					expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
+				}
+				table.AddRow([]string{nameFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), printMetadataLabels(t.GetMetadata().Labels), expiry})
+			}
+			return table.AsBuffer().String()
+		}
+		fmt.Fprint(c.Stdout, tokensView())
+	}
+	return nil
+}

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -1,0 +1,125 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
+)
+
+type listedScopedToken struct {
+	Kind     string
+	Version  string
+	Metadata struct {
+		Name    string
+		Expires timestamppb.Timestamp
+		ID      uint
+	}
+	Spec struct {
+		Roles      []string
+		JoinMethod string
+	}
+}
+
+func TestScopedTokens(t *testing.T) {
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Apps: config.Apps{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+
+	process := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(process)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	scopeFlags := []string{"--scope=/aa", "--assign-scope=/aa/bb"}
+	// Test all output formats of "tokens add".
+	buf, err := runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node"}, scopeFlags...))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(buf.String(), "The invite token:"))
+
+	buf, err = runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node", "--format", teleport.Text}, scopeFlags...))
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(buf.String(), "\n"))
+
+	buf, err = runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node", "--format", teleport.JSON}, scopeFlags...))
+	require.NoError(t, err)
+	out := mustDecodeJSON[addedToken](t, buf)
+
+	require.Len(t, out.Roles, 1)
+	require.Equal(t, types.KindNode, strings.ToLower(out.Roles[0]))
+
+	buf, err = runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node", "--format", teleport.YAML}, scopeFlags...))
+	require.NoError(t, err)
+	out = mustDecodeYAML[addedToken](t, buf)
+
+	require.Len(t, out.Roles, 1)
+	require.Equal(t, types.KindNode, strings.ToLower(out.Roles[0]))
+
+	// Test all output formats of "tokens ls".
+	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(buf.String(), "Token "))
+	require.Equal(t, 6, strings.Count(buf.String(), "\n")) // account for header lines
+
+	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})
+	require.NoError(t, err)
+	require.Equal(t, 4, strings.Count(buf.String(), "\n"))
+
+	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.JSON})
+	require.NoError(t, err)
+	jsonOut := mustDecodeJSON[[]listedScopedToken](t, buf)
+	require.Len(t, jsonOut, 4)
+
+	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.YAML})
+	require.NoError(t, err)
+	yamlOut := []listedScopedToken{}
+	mustDecodeYAMLDocuments(t, buf, &yamlOut)
+	require.Len(t, yamlOut, 4)
+	require.Equal(t, jsonOut, yamlOut)
+}


### PR DESCRIPTION
This PR backports the following PRs into branch/v18:

- #59609
- #60035
- #60362

changelog: Added support for creating and managing scoped tokens using `tctl scoped tokens add/ls/rm`. SSH nodes can now join a cluster within a particular scope by joining with a scoped token.