### PR TITLE
docs: adding video to ZTA docs homepage

### DIFF
--- a/docs/pages/zero-trust-access/zero-trust-access.mdx
+++ b/docs/pages/zero-trust-access/zero-trust-access.mdx
@@ -8,7 +8,6 @@ import LandingHero, { LandingHeroProps } from '@site/src/components/Pages/Landin
 import Resources, { ResourcesProps } from "@site/src/components/Pages/Homepage/Resources";
 import UseCasesList, { UseCasesListProps } from "@site/src/components/Pages/Landing/UseCasesList";
 
-import zeroTrustAccessImg from '@version/docs/img/zero-trust-access/zta-hero.png';
 import applicationSvg from "@site/src/components/Icon/teleport-svg/application.svg";
 import linuxServersSvg from "@site/src/components/Icon/teleport-svg/linux-servers.svg";
 import databaseSvg from "@site/src/components/Icon/teleport-svg/database-access.svg";
@@ -20,7 +19,7 @@ import mcpAndAiSvg from "@site/src/components/Icon/teleport-svg/mcp-and-ai.svg";
 
 <LandingHero
   title="Teleport Zero Trust Access"
-  image={zeroTrustAccessImg}
+  youtubeVideoId="Vf9W6EjENcg"
 >
   Easy access to all your infrastructure, on a foundation of cryptographic identity and zero trust.
 


### PR DESCRIPTION
This PR exchanges the hero image in the ZTA docs homepage (`/zero-trust-access/`) with a YouTube video.