### PR TITLE
docs: updated MCP docs page with new design

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -1,30 +1,89 @@
 ---
 title: MCP Servers
-description: Guides to protecting MCP servers with Teleport
+description: Protect MCP servers with Teleport's access controls and auditing capabilities 
+template: doc-page
 tags:
  - mcp
  - zero-trust
 ---
 
-Teleport can provide secure connections to your MCP (Model Context Protocol)
-servers while improving both access control and visibility.
+import DocHero from "@site/src/components/Pages/Landing/DocHero";
+import UseCasesList from "@site/src/components/Pages/Landing/UseCasesList";
 
-![Architecture diagram for enrolling MCP servers with Teleport](../../../img/mcp-access/architecture.svg)
+import userCheckSvg from "@site/src/components/Icon/svg/user-check.svg";
+import questionSvg from "@site/src/components/Icon/svg/question2.svg";
 
+<DocHero
+  title="Enroll your first MCP server"
+  youtubeVideoId="JdiNX4pIUaU"
+  ctaLinks={[
+    {
+      title: "Get started with MCP servers",
+      href: "./getting-started/",
+      variant: "secondary",
+      arrow: true,
+    },
+  ]}
+  links={[
+    {
+      title: "MCP access controls",
+      description: "Use Teleport's role-based access control (RBAC) system to set up granular permissions for authenticating to MCP servers connected to Teleport.",
+      href: "./rbac/",
+      icon: userCheckSvg,
+    },
+    {
+      title: "Troubleshooting",
+      description: "Understand common issues that you might encounter in managing access to MCP servers with Teleport and how to work around or resolve them.",
+      href: "./troubleshooting/",
+      icon: questionSvg,
+    },
+  ]}
+>
+{/* vale messaging.protocol-products = NO */}
+Connect an MCP server with the Teleport Application Service, configure and assign a role granting MCP permissions, and connect and query the server with the Teleport CLI or your AI platform of choice.
+</DocHero>
 
-## Getting started
-- [Quick-start with Demo MCP Server](./getting-started.mdx): Provides instructions to set up a Teleport Service and enable secure access to a demo MCP server.
-
-## Guides
-- [MCP Access with Streamable-HTTP MCP Server](./streamable-http.mdx): Set up a Teleport Service and enable secure access to a MCP server with streamable-HTTP transport.
-- [MCP Access with Stdio MCP Server](./stdio.mdx): Set up a Teleport Service and enable secure access to a MCP server with stdio transport.
-- [MCP Access with SSE MCP Server](./sse.mdx): Set up a Teleport Service and enable secure access to a MCP server with SSE transport.
-- [Configure MCP clients](../../connect-your-client/model-context-protocol/mcp-access.mdx): How to configure MCP clients such as Claude Desktop to access MCP servers.
-
-## Configuration & management
-- [MCP Access Controls](./rbac.mdx): Role-Based Access Control (RBAC) for Teleport MCP access.
-- [JWT Authentication to MCP server](./jwt.mdx): Use Teleport JWT to authenticate your MCP servers.
-- [Dynamic Registration](./dynamic-registration.mdx): Register/unregister MCP servers without restarting Teleport.
-
-## Troubleshooting & support
-- [Troubleshooting MCP Access](./troubleshooting.mdx): Describes common issues and solutions for access to MCP servers.
+<UseCasesList
+  title="MCP server access"
+  description="Connect to and query MCP servers with the AI platform of your choice"
+  desktopColumnsCount={2}
+  variant="doc"
+  useCases={[
+    {
+      title: "Enroll a streamable-HTTP MCP server",
+      description: "Enroll an MCP server with streamable-HTTP transport into your Teleport cluster and connect to it through Teleport.",
+      href: "./streamable-http/",
+    },  
+    {
+      title: "Enroll an stdio MCP server",
+      description: "Enroll an MCP server with stdio transport into your Teleport cluster and connect to it through Teleport.",
+      href: "./stdio/",
+    },  
+    {
+      title: "Enroll an SSE MCP server",
+      description: "Enroll an MCP server with SSE (Server-Sent Events) transport into your Teleport cluster and connect to it through Teleport.",
+      href: "./sse/",
+    },  
+    {
+      title: "JWT authentication to MCP server",
+      description: "Authenticate Teleport to an MCP server with JWTs signed by Teleport's CA, carrying user identity, roles, and traits.",
+      href: "./jwt/",
+    },  
+    {
+      title: "Dynamic MCP server registration",
+      description: "Register MCP servers (or update existing ones) without having to update the static configuration files read by Teleport Application Service instances.",
+      href: "./dynamic-registration/",
+    },
+    {
+      title: "Access databases over MCP",
+      description: "Configure fine-grained access to a Teleport-protected database for MCP clients such as Claude Desktop or Cursor.",
+      href: "../../connect-your-client/model-context-protocol/database-access/",
+    },  
+    {
+      title: "Configure MCP clients",
+      description: "Configure MCP clients such as Claude Desktop or Cursor to access MCP servers.",
+      href: "../../connect-your-client/model-context-protocol/mcp-access/",
+    },
+  ]}
+/>
+{/* vale messaging.protocol-products = YES */}


### PR DESCRIPTION
This PR updates the MCP Servers page with the new design as received from Figma - https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=3844-849&p=f&t=bhCQOgwHFMHi6Pst-0