### PR TITLE
Add optional gRPC client-side load balancer for agents

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -498,6 +498,13 @@ func dialerConnect(ctx context.Context, params connectParams) (*Client, error) {
 	return clt, nil
 }
 
+var serviceConfig = `{
+	"loadBalancingConfig": [{"teleport_pick_healthy":{}}],
+	"healthCheckConfig": {
+		"serviceName": ""
+	}
+}`
+
 // dialGRPC dials a connection between server and client.
 func (c *Client) dialGRPC(ctx context.Context, addr string) error {
 	dialContext, cancel := context.WithTimeout(ctx, c.c.DialTimeout)
@@ -511,6 +518,7 @@ func (c *Client) dialGRPC(ctx context.Context, addr string) error {
 	dialOpts = append(dialOpts, grpc.WithContextDialer(c.grpcDialer()))
 	dialOpts = append(dialOpts,
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithDefaultServiceConfig(serviceConfig),
 		grpc.WithChainUnaryInterceptor(
 			metadata.UnaryClientInterceptor,
 			interceptors.GRPCClientUnaryErrorInterceptor,

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -168,7 +168,9 @@ func (t *teleportPickHealthyBalancer) UpdateClientConnState(state balancer.Clien
 		return errors.New("balancer closed")
 	}
 
+	t.mu.Lock()
 	t.resolvedState = state.ResolverState
+	t.mu.Unlock()
 
 	state.ResolverState = pickfirstleaf.EnableHealthListener(state.ResolverState)
 
@@ -317,11 +319,12 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 
 			t.tlb.pending = &wb
 
+			resolvedState := t.tlb.resolvedState
+
 			t.tlb.mu.Unlock()
 
-			// TODO(dustin.specker): do we need to enable health listener here?
 			pflb.UpdateClientConnState(balancer.ClientConnState{
-				ResolverState: pickfirstleaf.EnableHealthListener(t.tlb.resolvedState),
+				ResolverState: pickfirstleaf.EnableHealthListener(resolvedState),
 			})
 		} else if state.ConnectivityState == connectivity.Ready && t.tlb.pending != nil {
 			t.log.InfoContext(context.Background(), "original balancer became healthy, closing pending balancer")
@@ -374,11 +377,12 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 
 			t.tlb.pending = &wb
 
+			resolvedState := t.tlb.resolvedState
+
 			t.tlb.mu.Unlock()
 
-			// TODO(dustin.specker): do we need to enable health listener here?
 			pflb.UpdateClientConnState(balancer.ClientConnState{
-				ResolverState: pickfirstleaf.EnableHealthListener(t.tlb.resolvedState),
+				ResolverState: pickfirstleaf.EnableHealthListener(resolvedState),
 			})
 		default:
 			t.tlb.mu.Unlock()

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -94,16 +94,19 @@ func (teleportPickHealthyBuilder) Name() string {
 // This is where teleportPickHealthyBalancer comes into play. By creating a new pick_first_leaf load balancer, each resolved
 // aaddress/endpoint is tried again. This provides the opportunity for the load balancer to forward the request to another server.
 type teleportPickHealthyBalancer struct {
+	// cc and opts are used for creating new pick_first_leaf load balancers
+	// cc and opts are never written once configured in [teleportPickHealthyBuilder.Build]
 	cc   balancer.ClientConn
 	opts balancer.BuildOptions
-	log  *slog.Logger
 
-	current *wrappedBalancer
-	pending *wrappedBalancer
+	log *slog.Logger
 
-	resolvedState resolver.State
-
+	// mu lock should be held before accessing resolvedState or current/pending balancers
 	mu sync.Mutex
+	// resolvedState is used when creating new pick_first_leaf_balancers
+	resolvedState resolver.State
+	current       *wrappedBalancer
+	pending       *wrappedBalancer
 }
 
 // Close closes the current and pending underlying pick_first_leaf balancers.

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -309,6 +309,9 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 		return
 	}
 
+	// always pass UpdateState to ClientConn if the current or pending balancer experiences a state change
+	defer t.tlb.cc.UpdateState(state)
+
 	switch t {
 	case t.tlb.current:
 		if state.ConnectivityState == connectivity.TransientFailure {
@@ -379,6 +382,4 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 		t.log.InfoContext(context.Background(), "UpdateState called for invalid balancer")
 		t.tlb.mu.Unlock()
 	}
-
-	t.tlb.cc.UpdateState(state)
 }

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -378,8 +378,5 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 		default:
 			t.tlb.mu.Unlock()
 		}
-	default:
-		t.log.InfoContext(context.Background(), "UpdateState called for invalid balancer")
-		t.tlb.mu.Unlock()
 	}
 }

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -355,14 +355,14 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 		case connectivity.Ready:
 			t.log.InfoContext(context.Background(), "Pending balancer is ready, migrating to new balancer")
 
-			current := t.tlb.current
+			oldCurrent := t.tlb.current
 
 			t.tlb.current = t.tlb.pending
 			t.tlb.pending = nil
 
 			t.tlb.mu.Unlock()
 
-			current.Close()
+			oldCurrent.Close()
 		case connectivity.TransientFailure:
 			t.log.InfoContext(context.Background(), "Pending balancer is unhealthy, recreating new balancer")
 

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -47,7 +47,7 @@ type teleportPickHealthyBuilder struct{}
 
 // Build creates a [teleportPickHealthyBalancer] with an underlying pick_first_leaf balancer.
 func (teleportPickHealthyBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
-	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 
 	b := teleportPickHealthyBalancer{
 		cc:   cc,

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package client
 
 import (

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -325,7 +325,7 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 	switch t {
 	case t.tlb.current:
 		if state.ConnectivityState == connectivity.TransientFailure {
-			t.log.InfoContext(context.Background(), "creating new balancer")
+			t.log.InfoContext(context.Background(), "Current balancer is unhealthy, creating pending balancer")
 			wb := newWrappedBalancer(t.tlb)
 
 			t.tlb.pending = wb
@@ -338,7 +338,7 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 				ResolverState: pickfirstleaf.EnableHealthListener(resolvedState),
 			})
 		} else if state.ConnectivityState == connectivity.Ready && t.tlb.pending != nil {
-			t.log.InfoContext(context.Background(), "original balancer became healthy, closing pending balancer")
+			t.log.InfoContext(context.Background(), "Current balancer became healthy, closing pending balancer")
 
 			pending := t.tlb.pending
 
@@ -353,7 +353,7 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 	case t.tlb.pending:
 		switch state.ConnectivityState {
 		case connectivity.Ready:
-			t.log.InfoContext(context.Background(), "new balancer is ready, migrating to new balancer")
+			t.log.InfoContext(context.Background(), "Pending balancer is ready, migrating to new balancer")
 
 			current := t.tlb.current
 
@@ -364,7 +364,7 @@ func (t *wrappedBalancer) UpdateState(state balancer.State) {
 
 			current.Close()
 		case connectivity.TransientFailure:
-			t.log.InfoContext(context.Background(), "new balancer is unhealthy, recreating new balancer")
+			t.log.InfoContext(context.Background(), "Pending balancer is unhealthy, recreating new balancer")
 
 			t.tlb.pending.Close()
 

--- a/api/client/teleport_pick_healthy.go
+++ b/api/client/teleport_pick_healthy.go
@@ -1,0 +1,379 @@
+package client
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	"google.golang.org/grpc/balancer/pickfirst/pickfirstleaf"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/resolver"
+)
+
+const (
+	// Name is used by gRPC client service configuration to select this load balancer.
+	Name = "teleport_pick_healthy"
+)
+
+func init() {
+	balancer.Register(teleportPickHealthyBuilder{})
+}
+
+// teleportPickHealthyBuilder is used by gRPC clients to build a [teleportPickHealthyBalancer]
+type teleportPickHealthyBuilder struct{}
+
+// Build creates a [teleportPickHealthyBalancer] with an underlying pick_first_leaf balancer.
+func (teleportPickHealthyBuilder) Build(cc balancer.ClientConn, opts balancer.BuildOptions) balancer.Balancer {
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	b := teleportPickHealthyBalancer{
+		cc:   cc,
+		opts: opts,
+		log:  log,
+	}
+
+	wb := wrappedBalancer{
+		ClientConn: cc,
+		log:        log,
+
+		tlb:      &b,
+		subConns: make(map[balancer.SubConn]bool, 0),
+	}
+
+	pflb := balancer.Get(pickfirstleaf.Name).Build(&wb, opts)
+
+	wb.Balancer = pflb
+
+	b.current = &wb
+
+	return &b
+}
+
+// Name returns the name of the load balancer that will be produced by this builder.
+func (teleportPickHealthyBuilder) Name() string {
+	return Name
+}
+
+// teleportPickHealthyBalancer balances client traffic using underlying pick_first_leaf balancers.
+//
+// teleportPickHealthyBalancer creates a pick_first_leaf balancer and enables health checking. When
+// the balancer's state reports a transient failure (failing health check) then teleportPickHealthyBalancer will
+// create a new pick_first_leaf balancer. Once the new pick_first_leaf balancer's [balancer.SubConn] becomes healthy
+// then teleportPickHealthyBalancer will use the new balancer for new RPCs. It'll then close the previous pick_first_leaf
+// balancer, which gracefully shuts down waiting for all current RPCs to complete before completely shutting down its
+// subconnection.
+//
+// The pick_first_leaf load balancer iterates through resolved addresses/endpoints until it is able to successfully connect
+// to one. The pick_first_leaf load balancer assumes that each address/endpoint ties to one server. This falls apart when
+// the resolved address/endpoint is actually a load balancer. The pick_first_leaf will not try to establish a new connection
+// to the same address/endpoint when health check fails because it assumes there is only 1 server for that address/endpoint and
+// its unhealthy.
+// This is where teleportPickHealthyBalancer comes into play. By creating a new pick_first_leaf load balancer, each resolved
+// aaddress/endpoint is tried again. This provides the opportunity for the load balancer to forward the request to another server.
+type teleportPickHealthyBalancer struct {
+	cc   balancer.ClientConn
+	opts balancer.BuildOptions
+	log  *slog.Logger
+
+	current *wrappedBalancer
+	pending *wrappedBalancer
+
+	resolvedState resolver.State
+
+	mu sync.Mutex
+}
+
+// Close closes the current and pending underlying pick_first_leaf balancers.
+func (t *teleportPickHealthyBalancer) Close() {
+	t.mu.Lock()
+
+	current := t.current
+	pending := t.pending
+
+	t.current = nil
+	t.pending = nil
+
+	t.mu.Unlock()
+
+	if current != nil {
+		current.Close()
+	}
+
+	if pending != nil {
+		pending.Close()
+	}
+}
+
+// ExitIdle invokes ExitIdle on the most recently created load balancer.
+func (t *teleportPickHealthyBalancer) ExitIdle() {
+	bal := t.newestBalancer()
+
+	if bal == nil {
+		return
+	}
+
+	bal.ExitIdle()
+}
+
+// ResolverError invokes ResolverError for the newest load balancer.
+//
+// There is no point in invoking ResolverError for older load balancers
+// since they've already completed resolving.
+func (t *teleportPickHealthyBalancer) ResolverError(err error) {
+	bal := t.newestBalancer()
+
+	if bal == nil {
+		t.cc.UpdateState(balancer.State{
+			ConnectivityState: connectivity.TransientFailure,
+			Picker:            base.NewErrPicker(err),
+		})
+
+		return
+	}
+
+	bal.ResolverError(err)
+}
+
+// UpdateClientConnState is responsible for enabling health checking for the underlying pick_first_leaf load balancers.
+func (t *teleportPickHealthyBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
+	bal := t.newestBalancer()
+
+	if bal == nil {
+		return errors.New("balancer closed")
+	}
+
+	t.resolvedState = state.ResolverState
+
+	state.ResolverState = pickfirstleaf.EnableHealthListener(state.ResolverState)
+
+	return bal.UpdateClientConnState(state)
+}
+
+// UpdateSubConnState forwards the state update to the corresponding balancer controlling the provided [balancer.SubConn].
+func (t *teleportPickHealthyBalancer) UpdateSubConnState(sc balancer.SubConn, scs balancer.SubConnState) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	var bal *wrappedBalancer
+
+	if t.current != nil && t.current.subConns[sc] {
+		bal = t.current
+	} else if t.pending != nil && t.pending.subConns[sc] {
+		bal = t.pending
+	}
+
+	if bal == nil {
+		return
+	}
+
+	if scs.ConnectivityState == connectivity.Shutdown {
+		delete(bal.subConns, sc)
+	}
+
+	// Do not invoke bal.UpdateSubConnState since the pick_first_leaf does not expect UpdateSubConnState to be invoked,
+	// since it uses state listeners instead. Invoking will only emit error logs from the pick_first_leaf load balancer.
+}
+
+// newestBalancer returns the pending load balancer if existing, otherwise the current load balancer is returned.
+func (t *teleportPickHealthyBalancer) newestBalancer() balancer.Balancer {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.pending != nil {
+		return t.pending
+	}
+
+	return t.current
+}
+
+// wrappedBalancer is responsible for wrapping a [balancer.Balancer] and [balancer.SubConn]
+type wrappedBalancer struct {
+	balancer.ClientConn
+	balancer.Balancer
+	log *slog.Logger
+
+	tlb *teleportPickHealthyBalancer
+
+	subConns map[balancer.SubConn]bool
+}
+
+// Close will shutdown all registered subconnections.
+//
+// This is a graceful shutdown, so any active RPCs are waited on before shutting down the subconnection entirely.
+func (t *wrappedBalancer) Close() {
+	if t == nil {
+		return
+	}
+
+	for sc := range t.subConns {
+		sc.Shutdown()
+	}
+}
+
+// NewSubConn registers created [balancer.SubConn] by the balancer, so that [teleportPickHealthyBalancer] can know which
+// balancer created the subconnection for forwarding events to.
+//
+// This also registers a health listener so that [teleportPickHealthyBalancer] can know when the new subconnection has reached
+// a ready state.
+func (t *wrappedBalancer) NewSubConn(addrs []resolver.Address, opts balancer.NewSubConnOptions) (balancer.SubConn, error) {
+	t.tlb.mu.Lock()
+
+	if t != t.tlb.current && t != t.tlb.pending {
+		t.tlb.mu.Unlock()
+		return nil, errors.New("balancer that called NewSubConn is closed")
+	}
+
+	t.tlb.mu.Unlock()
+
+	origListener := opts.StateListener
+
+	var sc balancer.SubConn
+
+	opts.StateListener = func(state balancer.SubConnState) {
+		t.tlb.UpdateSubConnState(sc, state)
+
+		if origListener != nil {
+			origListener(state)
+		}
+	}
+
+	sc, err := t.tlb.cc.NewSubConn(addrs, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	t.subConns[sc] = true
+
+	return sc, nil
+}
+
+// ResolveNow only invokes ResolveNow if the balancer is the newest load balancer.
+func (t *wrappedBalancer) ResolveNow(opts resolver.ResolveNowOptions) {
+	if t != t.tlb.newestBalancer() {
+		return
+	}
+
+	t.tlb.cc.ResolveNow(opts)
+}
+
+// RemoveSubConn shuts down the provided [balancer.SubConn]
+func (t *wrappedBalancer) RemoveSubConn(sc balancer.SubConn) {
+	sc.Shutdown()
+}
+
+// UpdateAddresses invokes UpdateAddresses if the balancer is not a stale balancer.
+func (t *wrappedBalancer) UpdateAddresses(sc balancer.SubConn, addrs []resolver.Address) {
+	t.tlb.mu.Lock()
+	if t != t.tlb.current && t != t.tlb.pending {
+		t.tlb.mu.Unlock()
+		return
+	}
+
+	t.tlb.mu.Unlock()
+
+	t.tlb.cc.UpdateAddresses(sc, addrs)
+}
+
+// UpdateState handles creating new pick_first_leaf balancers in the case one becomes unhealthy.
+func (t *wrappedBalancer) UpdateState(state balancer.State) {
+	// TODO(dustin.specker): refactor to remove nesting and simply unlocking mutex
+	t.tlb.mu.Lock()
+
+	if t != t.tlb.current && t != t.tlb.pending {
+		t.tlb.mu.Unlock()
+		return
+	}
+
+	if t == t.tlb.current {
+		if state.ConnectivityState == connectivity.TransientFailure {
+			t.log.Info("creating new balancer")
+			wb := wrappedBalancer{
+				ClientConn: t.tlb.cc,
+				log:        t.log,
+
+				tlb:      t.tlb,
+				subConns: make(map[balancer.SubConn]bool, 0),
+			}
+
+			pflb := balancer.Get(pickfirstleaf.Name).Build(&wb, t.tlb.opts)
+
+			wb.Balancer = pflb
+
+			t.tlb.pending = &wb
+
+			t.tlb.mu.Unlock()
+
+			// TODO(dustin.specker): do we need to enable health listener here?
+			pflb.UpdateClientConnState(balancer.ClientConnState{
+				ResolverState: pickfirstleaf.EnableHealthListener(t.tlb.resolvedState),
+			})
+		} else if state.ConnectivityState == connectivity.Ready && t.tlb.pending != nil {
+			t.log.Info("original balancer became healthy, closing pending balancer")
+
+			pending := t.tlb.pending
+
+			t.tlb.pending = nil
+
+			t.tlb.mu.Unlock()
+
+			pending.Close()
+		} else {
+			t.tlb.mu.Unlock()
+		}
+	} else if t == t.tlb.pending {
+		if state.ConnectivityState == connectivity.Ready {
+			t.log.Info("new balancer is ready, migrating to new balancer")
+
+			current := t.tlb.current
+
+			t.tlb.current = t.tlb.pending
+			t.tlb.pending = nil
+
+			t.tlb.mu.Unlock()
+
+			current.Close()
+		} else if state.ConnectivityState == connectivity.TransientFailure {
+			t.log.Info("new balancer is unhealthy, recreating new balancer")
+
+			t.tlb.pending.Close()
+
+			t.tlb.mu.Unlock()
+
+			time.Sleep(1 * time.Second)
+
+			t.tlb.mu.Lock()
+
+			wb := wrappedBalancer{
+				ClientConn: t.tlb.cc,
+				log:        t.log,
+
+				tlb:      t.tlb,
+				subConns: make(map[balancer.SubConn]bool, 0),
+			}
+
+			pflb := balancer.Get(pickfirstleaf.Name).Build(&wb, t.tlb.opts)
+
+			wb.Balancer = pflb
+
+			t.tlb.pending = &wb
+
+			t.tlb.mu.Unlock()
+
+			// TODO(dustin.specker): do we need to enable health listener here?
+			pflb.UpdateClientConnState(balancer.ClientConnState{
+				ResolverState: pickfirstleaf.EnableHealthListener(t.tlb.resolvedState),
+			})
+		} else {
+			t.tlb.mu.Unlock()
+		}
+	} else {
+		t.log.Info("UpdateState called for invalid balancer")
+		t.tlb.mu.Unlock()
+	}
+
+	t.tlb.cc.UpdateState(state)
+}

--- a/api/client/teleport_resolver.go
+++ b/api/client/teleport_resolver.go
@@ -1,0 +1,173 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gravitational/teleport/api/client/webclient"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// teleportResolverBuilder is responsible for building a wrapped DNS resolver that polls the provided
+// PingURL to determine what the service configuration should be.
+//
+// teleportResolverBuilder is intentionally not registered as a [resolver.Builder] so that gRPC clients
+// must explicitly opt in to using a wrapped DNS resolver.
+type teleportResolverBuilder struct {
+	PingURL string
+}
+
+// Build returns a wrapped DNS resolver that polls the configured PingURL to determine what the
+// service configuration should be.
+func (r teleportResolverBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	dnsBuilder := resolver.Get("dns")
+	if dnsBuilder == nil {
+		return nil, errors.New("unable to get dns resolver")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wr := wrappedResolver{
+		ClientConn: cc,
+
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	dnsResolver, err := dnsBuilder.Build(target, &wr, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	wr.Resolver = dnsResolver
+
+	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	go func() {
+		for {
+			select {
+			case <-time.After(30 * time.Second):
+				serviceConfig, err := poll(wr.ctx, wr.ClientConn, r.PingURL)
+				if err != nil {
+					log.Error("error polling", slog.String("err", err.Error()))
+					continue
+				}
+
+				wr.mu.Lock()
+				state := wr.resolvedState
+				wr.mu.Unlock()
+				state.ServiceConfig = serviceConfig
+
+				wr.UpdateState(state)
+			case <-wr.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return &wr, nil
+}
+
+// Scheme is set to dns so that gRPC clients including this Resolver may then use for wrapped the DNS resolver.
+func (teleportResolverBuilder) Scheme() string {
+	return "dns"
+}
+
+// wrappedResolver wraps an underlying [resolver.Resolver] and [resolver.ClientConn] to intercept calls to UpdateState and Close.
+type wrappedResolver struct {
+	resolver.Resolver
+	resolver.ClientConn
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	// mu guards access to resolvedState
+	// other fields are set when a new wrappedResolver is created and only read
+	// from after that point.
+	mu            sync.Mutex
+	resolvedState resolver.State
+}
+
+func poll(ctx context.Context, cc resolver.ClientConn, findURL string) (*serviceconfig.ParseResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, findURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GET request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error making GET request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("GET request failed with status [%d] %s", resp.StatusCode, resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response: %w", err)
+	}
+
+	var pingResponse webclient.PingResponse
+	if err := json.Unmarshal(body, &pingResponse); err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON response: %w", err)
+	}
+
+	if pingResponse.GRPCClientLoadBalancerPolicy == nil {
+		return nil, nil
+	}
+
+	serviceConfig, err := json.Marshal(pingResponse.GRPCClientLoadBalancerPolicy)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling service config: %w", err)
+	}
+
+	return cc.ParseServiceConfig(string(serviceConfig)), nil
+}
+
+// Close cancels polling and closes the underlying resolver.
+func (w *wrappedResolver) Close() {
+	w.cancel()
+
+	w.Resolver.Close()
+}
+
+// UpdateState intercepts calls to save resolved state so changes to service configuration
+// can use the last resolved addresses.
+func (w *wrappedResolver) UpdateState(state resolver.State) error {
+	w.mu.Lock()
+	w.resolvedState = state
+	w.mu.Unlock()
+
+	return w.ClientConn.UpdateState(state)
+}

--- a/api/client/teleport_resolver.go
+++ b/api/client/teleport_resolver.go
@@ -30,9 +30,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport/api/client/webclient"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
+
+	"github.com/gravitational/teleport/api/client/webclient"
 )
 
 // teleportResolverBuilder is responsible for building a wrapped DNS resolver that polls the provided
@@ -75,7 +76,7 @@ func (r teleportResolverBuilder) Build(target resolver.Target, cc resolver.Clien
 			case <-time.After(30 * time.Second):
 				serviceConfig, err := poll(wr.ctx, wr.ClientConn, r.PingURL)
 				if err != nil {
-					log.Error("error polling", slog.String("err", err.Error()))
+					log.ErrorContext(wr.ctx, "error polling", slog.String("err", err.Error()))
 					continue
 				}
 
@@ -149,7 +150,7 @@ func poll(ctx context.Context, cc resolver.ClientConn, findURL string) (*service
 
 	serviceConfig, err := json.Marshal(pingResponse.GRPCClientLoadBalancerPolicy)
 	if err != nil {
-		return nil, fmt.Errorf("error marshalling service config: %w", err)
+		return nil, fmt.Errorf("error marshaling service config: %w", err)
 	}
 
 	return cc.ParseServiceConfig(string(serviceConfig)), nil

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -427,7 +427,7 @@ type PingResponse struct {
 	// ClusterName contains the name of the Teleport cluster.
 	ClusterName string `json:"cluster_name"`
 
-	GRPCClientLoadBalancerPolicy GRPCClientLoadBalancerPolicy `json:"grpc_client_load_balancer_policy"`
+	GRPCClientLoadBalancerPolicy *GRPCClientLoadBalancerPolicy `json:"grpc_client_load_balancer_policy,omitempty"`
 
 	// reserved: license_warnings ([]string)
 	// AutomaticUpgrades describes whether agents should automatically upgrade.

--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -400,6 +400,17 @@ type MotD struct {
 	Text string
 }
 
+type LoadBalancingConfig struct{}
+
+type HealthCheckConfig struct {
+	ServiceName string `json:"serviceName"`
+}
+
+type GRPCClientLoadBalancerPolicy struct {
+	LoadBalancingConfig []map[string]LoadBalancingConfig `json:"loadBalancingConfig"`
+	HealthCheckConfig   HealthCheckConfig                `json:"healthCheckConfig"`
+}
+
 // PingResponse contains data about the Teleport server like supported
 // authentication types, server version, etc.
 type PingResponse struct {
@@ -415,6 +426,8 @@ type PingResponse struct {
 	AutoUpdate AutoUpdateSettings `json:"auto_update"`
 	// ClusterName contains the name of the Teleport cluster.
 	ClusterName string `json:"cluster_name"`
+
+	GRPCClientLoadBalancerPolicy GRPCClientLoadBalancerPolicy `json:"grpc_client_load_balancer_policy"`
 
 	// reserved: license_warnings ([]string)
 	// AutomaticUpgrades describes whether agents should automatically upgrade.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -40,9 +40,7 @@ import (
 	"google.golang.org/grpc/codes"
 	_ "google.golang.org/grpc/encoding/gzip" // gzip compressor for gRPC.
 	"google.golang.org/grpc/health"
-	_ "google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -217,7 +215,7 @@ type GRPCServer struct {
 	createAuditStreamSemaphore chan struct{}
 }
 
-func (g *GRPCServer) SetServingStatus(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+func (g *GRPCServer) SetServingStatus(service string, servingStatus healthgrpc.HealthCheckResponse_ServingStatus) {
 	// add nil check
 	g.healthcheck.SetServingStatus(service, servingStatus)
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -39,6 +39,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	_ "google.golang.org/grpc/encoding/gzip" // gzip compressor for gRPC.
+	"google.golang.org/grpc/health"
+	_ "google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
@@ -5792,6 +5795,8 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 	}
 
 	authpb.RegisterAuthServiceServer(server, authServer)
+	healthcheck := health.NewServer()
+	healthgrpc.RegisterHealthServer(server, healthcheck)
 	collectortracepb.RegisterTraceServiceServer(server, authServer)
 	auditlogpb.RegisterAuditLogServiceServer(server, authServer)
 

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -38,6 +38,7 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/peer"
 
 	"github.com/gravitational/teleport"
@@ -252,6 +253,11 @@ func NewTLSServer(ctx context.Context, cfg TLSServerConfig) (*TLSServer, error) 
 	}
 
 	return server, nil
+}
+
+func (t *TLSServer) SetServingStatus(service string, servingStatus healthpb.HealthCheckResponse_ServingStatus) {
+	// add nil check
+	t.grpcServer.SetServingStatus(service, servingStatus)
 }
 
 // Close closes TLS server non-gracefully - terminates in flight connections

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2749,6 +2749,7 @@ func (process *TeleportProcess) initAuthService() error {
 		for {
 			select {
 			case e := <-eventCh:
+				// TODO: only invoke SetServingStatus if status has actually changed
 				switch e.Name {
 				case TeleportDegradedEvent:
 					logger.InfoContext(process.ExitContext(), "setting health status to not serving")

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -62,6 +62,7 @@ import (
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -2735,6 +2736,33 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	process.RegisterFunc("grpc.health", func() error {
+		// Start loop to monitor for events that are used to update Teleport state.
+		ctx, cancel := context.WithCancel(process.GracefulExitContext())
+		defer cancel()
+
+		eventCh := make(chan Event, 1024)
+		process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
+		process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
+
+		for {
+			select {
+			case e := <-eventCh:
+				switch e.Name {
+				case TeleportDegradedEvent:
+					logger.InfoContext(process.ExitContext(), "setting health status to not serving")
+					tlsServer.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+				case TeleportOKEvent:
+					logger.InfoContext(process.ExitContext(), "setting health status to serving")
+					tlsServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+				}
+			case <-ctx.Done():
+				logger.DebugContext(process.ExitContext(), "Teleport is exiting, returning.")
+				return nil
+			}
+		}
+	})
 
 	process.RegisterCriticalFunc("auth.tls", func() error {
 		logger.InfoContext(process.ExitContext(), "Auth service is starting.", "version", teleport.Version, "git_ref", teleport.Gitref, "listen_address", authAddr)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1658,9 +1658,9 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 	group := r.URL.Query().Get(webclient.AgentUpdateGroupParameter)
 	updaterID := r.URL.Query().Get(webclient.AgentUpdateIDParameter)
 
-	var gRPCClientLoadBalancerPolicy webclient.GRPCClientLoadBalancerPolicy
+	var gRPCClientLoadBalancerPolicy *webclient.GRPCClientLoadBalancerPolicy
 	if os.Getenv("TELEPORT_UNSTABLE_GRPC_CLIENT_LB_POLICY") != "" {
-		gRPCClientLoadBalancerPolicy = webclient.GRPCClientLoadBalancerPolicy{
+		gRPCClientLoadBalancerPolicy = &webclient.GRPCClientLoadBalancerPolicy{
 			HealthCheckConfig: webclient.HealthCheckConfig{
 				ServiceName: "",
 			},

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1668,6 +1668,16 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 		AutoUpdate:        h.automaticUpdateSettings184(r.Context(), group, updaterID),
 		Edition:           modules.GetModules().BuildType(),
 		FIPS:              modules.IsBoringBinary(),
+		GRPCClientLoadBalancerPolicy: webclient.GRPCClientLoadBalancerPolicy{
+			HealthCheckConfig: webclient.HealthCheckConfig{
+				ServiceName: "",
+			},
+			LoadBalancingConfig: []map[string]webclient.LoadBalancingConfig{
+				{
+					"teleport_pick_healthy": webclient.LoadBalancingConfig{},
+				},
+			},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
This pull request adds a new optional load balancer for gRPC clients running in agents. This load balancer will attempt to reconnect when an auth server reports an unhealthy serving status.

The auth server now implements gRPC health serving status (TODO ADD LINK). gRPC clients may watch this response. This load balancer will attempt to create a new connection to the auth server's address in hopes of connecting to a healthy auth server.

This load balancer is ideal for when a resolved address is a load balancer with multiple servers running behind it. grpc-go's existing load balancers assume that each resolved address/endpoint is tied directly to a single server. This is not the case when a resolved address/endpoint is actually a load balancer. This new load balancer works around this by instantiating a new pick_first_leaf load balancer whenever the existing pick_first_leaf load balancer experiences a transient failure (failing health check from a gRPC server).

---

Important notes

- creating a new load balancer does not impact existing active RPCs (so existing streaming RPCs continue even if health check is failing, as long as the server hasn't disconnected)
- this implementation allows new RPCs to work on "unhealthy" connections while a new pending connection is being made
- closing a load balancer waits for active RPCs to complete before the underlying subconnection is completely shut down (so existing streaming RPCs are left intact)