### PR TITLE
tbot: remove legacy --proxy flag

### DIFF
--- a/lib/tbot/cli/proxy.go
+++ b/lib/tbot/cli/proxy.go
@@ -18,10 +18,6 @@
 
 package cli
 
-import (
-	"context"
-)
-
 // ProxyCommand supports `tbot proxy`
 type ProxyCommand struct {
 	*genericExecutorHandler[ProxyCommand]
@@ -29,11 +25,6 @@ type ProxyCommand struct {
 	DestinationDir string
 	Cluster        string
 	ProxyServer    string
-
-	// LegacyProxy is the legacy --proxy flag.
-	// TODO(timothyb89): DELETE IN 17.0.0
-	// TODO(timothyb89): Or maybe remove in this PR.
-	LegacyProxyFlag string
 
 	ProxyRemaining *[]string
 }
@@ -43,20 +34,7 @@ func NewProxyCommand(app KingpinClause, action func(*ProxyCommand) error) *Proxy
 	cmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
 
 	c := &ProxyCommand{}
-	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, func(c *ProxyCommand) error {
-		// Prepend an action to handle --proxy deprecation.
-		if c.LegacyProxyFlag != "" {
-			c.ProxyServer = c.LegacyProxyFlag
-			log.WarnContext(context.TODO(), "The --proxy flag is deprecated and will be removed in v17.0.0. Use --proxy-server instead")
-		}
-
-		return nil
-	}, action)
-
-	// We're migrating from --proxy to --proxy-server so this flag is hidden
-	// but still supported.
-	// TODO(strideynet): DELETE IN 17.0.0
-	cmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Hidden().StringVar(&c.LegacyProxyFlag)
+	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
 	cmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Envar(ProxyServerEnvVar).StringVar(&c.ProxyServer)
 	cmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&c.DestinationDir)


### PR DESCRIPTION
This flag was replaced with --proxy-server back in Teleport 16. We kept the original flag around (but hidden) for compatibility reasons, but it's been long enough that we can probably remove it now.

Changelog: The legacy `--proxy` flag has been removed from `tbot`.  Users should prefer `--proxy-server` or `--auth-server` instead.