### PR TITLE
access_monitoring_rule: evaluate rules using UserLoginState

### DIFF
--- a/integrations/access/accessmonitoring/access_monitoring_rules.go
+++ b/integrations/access/accessmonitoring/access_monitoring_rules.go
@@ -147,17 +147,21 @@ func (amrh *RuleHandler) HandleAccessMonitoringRule(ctx context.Context, event t
 // RecipientsFromAccessMonitoringRules returns the recipients that result from the Access Monitoring Rules being applied to the given Access Request.
 func (amrh *RuleHandler) RecipientsFromAccessMonitoringRules(ctx context.Context, req types.AccessRequest) *common.RecipientSet {
 	log := logger.Get(ctx)
+	recipientSet := common.NewRecipientSet()
+
 	rawRecipients, err := amrh.recipients(ctx, req)
 	if err != nil {
 		log.WarnContext(ctx, "Failed to create expression env", "error", err)
-		return nil
+		return &recipientSet
 	}
 
-	recipientSet := common.NewRecipientSet()
 	for _, rawRecipient := range rawRecipients {
 		rec, err := amrh.fetchRecipientCallback(ctx, rawRecipient)
 		if err != nil {
-			log.WarnContext(ctx, "Failed to fetch plugin recipients based on Access monitoring rule recipients", "error", err)
+			log.WarnContext(ctx, "Failed to fetch plugin recipients based on Access monitoring rule recipients",
+				"recipient", rawRecipient,
+				"error", err,
+			)
 			continue
 		}
 		recipientSet.Add(*rec)

--- a/integrations/access/accessrequest/app.go
+++ b/integrations/access/accessrequest/app.go
@@ -548,16 +548,15 @@ func (a *App) getLoginsByRole(ctx context.Context, req types.AccessRequest) (map
 	log := logger.Get(ctx)
 	loginsByRole := make(map[string][]string, len(req.GetRoles()))
 
-	const withSecretsFalse = false
 	var userTraits trait.Traits
-	user, err := a.apiClient.GetUser(ctx, req.GetUser(), withSecretsFalse)
+	userState, err := services.GetUserOrLoginState(ctx, a.apiClient, req.GetUser())
 	switch {
 	case trace.IsAccessDenied(err):
 		log.WarnContext(ctx, `Missing permissions to read user.traits, please use the preset "access-plugin" role`, "error", err)
 	case err != nil:
 		return nil, trace.Wrap(err)
 	default:
-		userTraits = user.GetTraits()
+		userTraits = userState.GetTraits()
 	}
 
 	roles, err := getRoles(ctx, a.apiClient, req.GetRoles(), userTraits)

--- a/integrations/access/accessrequest/app_test.go
+++ b/integrations/access/accessrequest/app_test.go
@@ -25,10 +25,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 )
 
@@ -53,6 +55,15 @@ func (m *mockTeleportClient) GetUser(ctx context.Context, name string, withSecre
 	return args.Get(0).(types.User), args.Error(1)
 }
 
+func (m *mockTeleportClient) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+	args := m.Called(ctx, name)
+	userLoginState, ok := args.Get(0).(*userloginstate.UserLoginState)
+	if ok {
+		return userLoginState, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 type mockMessagingBot struct {
 	mock.Mock
 	MessagingBot
@@ -63,9 +74,54 @@ func (m *mockMessagingBot) FetchOncallUsers(ctx context.Context, req types.Acces
 	return args.Get(0).([]string), args.Error(1)
 }
 
+func TestGetLoginsByRoleWithUserLoginState(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	t.Cleanup(cancel)
+
+	teleportClient := &mockTeleportClient{}
+
+	teleportClient.On("GetRole", mock.Anything, "admin").
+		Return(&types.RoleV6{
+			Metadata: types.Metadata{Name: "admin"},
+			Spec: types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Logins: []string{"root", "foo", "bar", "{{internal.logins}}"},
+				},
+			},
+		}, nil)
+
+	teleportClient.On("GetUserLoginState", mock.Anything, mock.Anything).
+		Return(&userloginstate.UserLoginState{
+			Spec: userloginstate.Spec{
+				Traits: map[string][]string{
+					"logins": {"buz"},
+				},
+			},
+		}, nil)
+
+	app := App{
+		apiClient: teleportClient,
+	}
+	loginsByRole, err := app.getLoginsByRole(ctx, &types.AccessRequestV3{
+		Spec: types.AccessRequestSpecV3{
+			User:  "admin",
+			Roles: []string{"admin"},
+		},
+	})
+	require.NoError(t, err)
+
+	expected := map[string][]string{
+		"admin": {"root", "foo", "bar", "buz"},
+	}
+	require.Equal(t, expected, loginsByRole)
+}
+
 func TestGetLoginsByRole(t *testing.T) {
 	teleportClient := &mockTeleportClient{}
+	teleportClient.On("GetUserLoginState", mock.Anything, mock.Anything).
+		Return(nil, trace.AccessDenied("test error"))
 	teleportClient.On("GetRole", mock.Anything, "admin").Return(&types.RoleV6{
+		Metadata: types.Metadata{Name: "admin"},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
 				Logins: []string{"root", "foo", "bar", "{{internal.logins}}"},
@@ -73,6 +129,7 @@ func TestGetLoginsByRole(t *testing.T) {
 		},
 	}, (error)(nil))
 	teleportClient.On("GetRole", mock.Anything, "foo").Return(&types.RoleV6{
+		Metadata: types.Metadata{Name: "foo"},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
 				Logins: []string{"foo"},
@@ -80,6 +137,7 @@ func TestGetLoginsByRole(t *testing.T) {
 		},
 	}, (error)(nil))
 	teleportClient.On("GetRole", mock.Anything, "dev").Return(&types.RoleV6{
+		Metadata: types.Metadata{Name: "dev"},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
 				Logins: []string{},
@@ -87,6 +145,7 @@ func TestGetLoginsByRole(t *testing.T) {
 		},
 	}, (error)(nil))
 	teleportClient.On("GetUser", mock.Anything, "admin", mock.Anything).Return(&types.UserV2{
+		Metadata: types.Metadata{Name: "admin"},
 		Spec: types.UserSpecV2{
 			Traits: map[string][]string{
 				"logins": {"buz"},

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/accesslist"
 	"github.com/gravitational/teleport/api/client/accessmonitoringrules"
+	"github.com/gravitational/teleport/api/client/userloginstate"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
@@ -60,11 +61,13 @@ func (c BaseConfig) GetRecipients() RawRecipientsMap {
 
 type accessListClient = *accesslist.Client
 type accessMonitoringRulesClient = *accessmonitoringrules.Client
+type userLoginStateClient = *userloginstate.Client
 
 type wrappedClient struct {
 	*client.Client
 	accessListClient
 	accessMonitoringRulesClient
+	userLoginStateClient
 }
 
 // wrapAPIClient will wrap the API client such that it conforms to the Teleport plugin client interface.
@@ -73,6 +76,7 @@ func wrapAPIClient(clt *client.Client) teleport.Client {
 		Client:                      clt,
 		accessListClient:            clt.AccessListClient(),
 		accessMonitoringRulesClient: clt.AccessMonitoringRulesClient(),
+		userLoginStateClient:        clt.UserLoginStateClient(),
 	}
 }
 

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -24,9 +24,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client"
-	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	"github.com/gravitational/teleport/api/client/accesslist"
+	"github.com/gravitational/teleport/api/client/accessmonitoringrules"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/access/common/teleport"
 	"github.com/gravitational/teleport/integrations/lib"
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -56,27 +56,23 @@ func (c BaseConfig) GetRecipients() RawRecipientsMap {
 	return c.Recipients
 }
 
+// client type alias are used to embed the types in the wrappedClient
+
+type accessListClient = *accesslist.Client
+type accessMonitoringRulesClient = *accessmonitoringrules.Client
+
 type wrappedClient struct {
 	*client.Client
-}
-
-func (w *wrappedClient) ListAccessLists(ctx context.Context, pageSize int, pageToken string) ([]*accesslist.AccessList, string, error) {
-	return w.Client.AccessListClient().ListAccessLists(ctx, pageSize, pageToken)
-}
-
-func (w *wrappedClient) GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error) {
-	return w.Client.AccessListClient().GetAccessListOwners(ctx, accessListName)
-}
-
-// ListAccessMonitoringRulesWithFilter lists current access monitoring rules.
-func (w *wrappedClient) ListAccessMonitoringRulesWithFilter(ctx context.Context, req *accessmonitoringrulesv1.ListAccessMonitoringRulesWithFilterRequest) ([]*accessmonitoringrulesv1.AccessMonitoringRule, string, error) {
-	return w.Client.AccessMonitoringRulesClient().ListAccessMonitoringRulesWithFilter(ctx, req)
+	accessListClient
+	accessMonitoringRulesClient
 }
 
 // wrapAPIClient will wrap the API client such that it conforms to the Teleport plugin client interface.
 func wrapAPIClient(clt *client.Client) teleport.Client {
 	return &wrappedClient{
-		Client: clt,
+		Client:                      clt,
+		accessListClient:            clt.AccessListClient(),
+		accessMonitoringRulesClient: clt.AccessMonitoringRulesClient(),
 	}
 }
 

--- a/integrations/access/common/teleport/client.go
+++ b/integrations/access/common/teleport/client.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/integrations/lib/plugindata"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // Client aggregates the parts of Teleport API client interface
@@ -43,5 +44,5 @@ type Client interface {
 	ListAccessLists(context.Context, int, string) ([]*accesslist.AccessList, string, error)
 	ListAccessMonitoringRulesWithFilter(ctx context.Context, req *accessmonitoringrulesv1.ListAccessMonitoringRulesWithFilterRequest) ([]*accessmonitoringrulesv1.AccessMonitoringRule, string, error)
 	GetAccessListOwners(ctx context.Context, accessListName string) ([]*accesslist.Owner, error)
-	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
+	services.UserOrLoginStateGetter
 }

--- a/lib/accessmonitoring/access_monitoring_rule.go
+++ b/lib/accessmonitoring/access_monitoring_rule.go
@@ -25,7 +25,7 @@ import (
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 )
 
-// EvaluateRules evalutes the rules againast the request environemnt and
+// EvaluateRules evalutes the rules againast the request environment and
 // returns the list of rules that match the conditions.
 func EvaluateRules(
 	ctx context.Context,

--- a/lib/accessmonitoring/access_monitoring_rule.go
+++ b/lib/accessmonitoring/access_monitoring_rule.go
@@ -41,7 +41,7 @@ func EvaluateRules(
 		schedule := rule.GetSpec().GetSchedules()
 		isInSchedules, err := InSchedules(schedule, env.CreationTime)
 		if err != nil {
-			log.WarnContext(ctx, "Failed to evaluate access monitoring rule", "error", err)
+			log.WarnContext(ctx, "Failed to evaluate access monitoring rule schedules", "error", err)
 			continue
 		}
 		if len(schedule) != 0 && !isInSchedules {
@@ -52,7 +52,7 @@ func EvaluateRules(
 		// Check if environment matches rule conditions.
 		conditionMatch, err := EvaluateCondition(rule.GetSpec().GetCondition(), env)
 		if err != nil {
-			log.WarnContext(ctx, "Failed to evaluate access monitoring rule", "error", err)
+			log.WarnContext(ctx, "Failed to evaluate access monitoring rule condition", "error", err)
 			continue
 		}
 		if conditionMatch {

--- a/lib/accessmonitoring/access_monitoring_rule.go
+++ b/lib/accessmonitoring/access_monitoring_rule.go
@@ -1,0 +1,63 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessmonitoring
+
+import (
+	"context"
+	"log/slog"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+)
+
+// EvaluateRules evalutes the rules againast the request environemnt and
+// returns the list of rules that match the conditions.
+func EvaluateRules(
+	ctx context.Context,
+	log *slog.Logger,
+	env AccessRequestExpressionEnv,
+	rules []*accessmonitoringrulesv1.AccessMonitoringRule,
+) []*accessmonitoringrulesv1.AccessMonitoringRule {
+	var matchingRules []*accessmonitoringrulesv1.AccessMonitoringRule
+	for _, rule := range rules {
+		log = log.With("rule", rule.GetMetadata().GetName())
+
+		// Check if creation time is within rule schedules.
+		schedule := rule.GetSpec().GetSchedules()
+		isInSchedules, err := InSchedules(schedule, env.CreationTime)
+		if err != nil {
+			log.WarnContext(ctx, "Failed to evaluate access monitoring rule", "error", err)
+			continue
+		}
+		if len(schedule) != 0 && !isInSchedules {
+			log.DebugContext(ctx, "Access request does not satisfy schedule condition")
+			continue
+		}
+
+		// Check if environment matches rule conditions.
+		conditionMatch, err := EvaluateCondition(rule.GetSpec().GetCondition(), env)
+		if err != nil {
+			log.WarnContext(ctx, "Failed to evaluate access monitoring rule", "error", err)
+			continue
+		}
+		if conditionMatch {
+			matchingRules = append(matchingRules, rule)
+		}
+	}
+	return matchingRules
+}

--- a/lib/accessmonitoring/access_monitoring_rule_test.go
+++ b/lib/accessmonitoring/access_monitoring_rule_test.go
@@ -1,0 +1,128 @@
+/*
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessmonitoring
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// TestEvaluateRules verifies proper rules validation.
+func TestEvaluateRules(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	t.Cleanup(cancel)
+
+	tests := []struct {
+		description string
+		env         AccessRequestExpressionEnv
+		rules       []*accessmonitoringrulesv1.AccessMonitoringRule
+		expected    []string
+	}{
+		{
+			description: "condition and schedule match 1 rule",
+			env: AccessRequestExpressionEnv{
+				CreationTime: time.Date(2025, time.August, 11, 14, 30, 0, 0, time.UTC),
+			},
+			rules: []*accessmonitoringrulesv1.AccessMonitoringRule{
+				makeRule("test-rule", "true", time.Monday, "14:00", "15:00"),
+			},
+			expected: []string{"test-rule"},
+		},
+		{
+			description: "condition and schedule match multiple rules",
+			env: AccessRequestExpressionEnv{
+				CreationTime: time.Date(2025, time.August, 11, 14, 30, 0, 0, time.UTC),
+			},
+			rules: []*accessmonitoringrulesv1.AccessMonitoringRule{
+				makeRule("test-rule-1", "true", time.Monday, "14:00", "15:00"),
+				makeRule("test-rule-2", "true", time.Monday, "14:00", "15:00"),
+			},
+			expected: []string{"test-rule-1", "test-rule-2"},
+		},
+		{
+			description: "condition does not match",
+			env: AccessRequestExpressionEnv{
+				CreationTime: time.Date(2025, time.August, 11, 14, 30, 0, 0, time.UTC),
+			},
+			rules: []*accessmonitoringrulesv1.AccessMonitoringRule{
+				makeRule("test-rule-1", "false", time.Monday, "14:00", "15:00"),
+			},
+			expected: []string{},
+		},
+		{
+			description: "schedule does not match",
+			env: AccessRequestExpressionEnv{
+				CreationTime: time.Date(2025, time.August, 11, 15, 30, 0, 0, time.UTC),
+			},
+			rules: []*accessmonitoringrulesv1.AccessMonitoringRule{
+				makeRule("test-rule-1", "true", time.Monday, "14:00", "15:00"),
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			t.Parallel()
+
+			rules := EvaluateRules(ctx, logtest.NewLogger(), test.env, test.rules)
+			require.Len(t, rules, len(test.expected))
+			for _, rule := range rules {
+				require.Contains(t, test.expected, rule.Metadata.GetName())
+			}
+		})
+	}
+}
+
+func makeRule(
+	name, condition string,
+	weekday time.Weekday,
+	start, end string,
+) *accessmonitoringrulesv1.AccessMonitoringRule {
+	return &accessmonitoringrulesv1.AccessMonitoringRule{
+		Kind:    types.KindAccessMonitoringRule,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+		Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+			Subjects:  []string{types.KindAccessRequest},
+			Condition: condition,
+			Schedules: map[string]*accessmonitoringrulesv1.Schedule{
+				"default": {
+					Time: &accessmonitoringrulesv1.TimeSchedule{
+						Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{{
+							Weekday: weekday.String(),
+							Start:   start,
+							End:     end,
+						}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/lib/accessmonitoring/request_mapping.go
+++ b/lib/accessmonitoring/request_mapping.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/lib/expression"
 	"github.com/gravitational/teleport/lib/utils/typical"
 )
@@ -41,7 +42,27 @@ type AccessRequestExpressionEnv struct {
 
 	// UserTraits includes arbitrary user traits dynamically provided by the
 	// access monitoring rule handler.
-	UserTraits map[string][]string
+	UserTraits trait.Traits
+}
+
+// NewAccessRequestExpressionEnv constructs an AccessRequestExpressionEnv from
+// the provided request and additional fields.
+func NewAccessRequestExpressionEnv(
+	req types.AccessRequest,
+	userTraits trait.Traits,
+	requestedResources []types.ResourceWithLabels,
+) AccessRequestExpressionEnv {
+	return AccessRequestExpressionEnv{
+		Roles:              req.GetRoles(),
+		RequestedResources: requestedResources,
+		SuggestedReviewers: req.GetSuggestedReviewers(),
+		Annotations:        req.GetSystemAnnotations(),
+		User:               req.GetUser(),
+		RequestReason:      req.GetRequestReason(),
+		CreationTime:       req.GetCreationTime(),
+		Expiry:             req.Expiry(),
+		UserTraits:         userTraits,
+	}
 }
 
 type accessRequestExpression typical.Expression[AccessRequestExpressionEnv, any]

--- a/lib/accessmonitoring/review/review.go
+++ b/lib/accessmonitoring/review/review.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/accessrequest"
-
 	"github.com/gravitational/teleport/api/client"
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -508,6 +508,8 @@ func TestHandleAccessRequest(t *testing.T) {
 			setupMock: func(m *mockClient) {
 				m.On("GetUserLoginState", mock.Anything, "non-existent-user").
 					Return(nil, trace.NotFound("user not found"))
+				m.On("GetUser", mock.Anything, "non-existent-user", false).
+					Return(nil, trace.NotFound("user not found"))
 			},
 			assertErr: func(t require.TestingT, err error, _ ...any) {
 				require.ErrorContains(t, err, "user not found")
@@ -645,6 +647,15 @@ func (m *mockClient) ListAccessMonitoringRulesWithFilter(ctx context.Context, re
 		return rules, args.String(1), args.Error(2)
 	}
 	return nil, args.String(1), args.Error(2)
+}
+
+func (m *mockClient) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
+	args := m.Called(ctx, name, withSecrets)
+	user, ok := args.Get(0).(types.User)
+	if ok {
+		return user, args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *mockClient) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {

--- a/lib/accessmonitoring/review/review_test.go
+++ b/lib/accessmonitoring/review/review_test.go
@@ -34,6 +34,9 @@ import (
 	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/lib/accessmonitoring"
 )
 
@@ -149,7 +152,6 @@ func TestConflictingRules(t *testing.T) {
 	t.Cleanup(cancel)
 
 	testReqID := uuid.New().String()
-	withSecretsFalse := false
 	requesterUserName := "requester"
 	approvedRule := newApprovedRule("approved-rule", "true")
 	deniedRule := newDeniedRule("denied-rule", "true")
@@ -161,12 +163,15 @@ func TestConflictingRules(t *testing.T) {
 		deniedRule,
 	})
 
-	requester, err := types.NewUser(requesterUserName)
+	userLoginState, err := userloginstate.New(
+		header.Metadata{Name: requesterUserName},
+		userloginstate.Spec{},
+	)
 	require.NoError(t, err)
 
 	client := &mockClient{}
-	client.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-		Return(requester, nil)
+	client.On("GetUserLoginState", mock.Anything, requesterUserName).
+		Return(userLoginState, nil)
 
 	review, err := newAccessReview(
 		requesterUserName,
@@ -204,10 +209,12 @@ func TestScheduleRequest(t *testing.T) {
 
 	testReqID := uuid.New().String()
 	testRuleName := "test-rule"
-	withSecretsFalse := false
 	requesterUserName := "requester"
 
-	requester, err := types.NewUser(requesterUserName)
+	userLoginState, err := userloginstate.New(
+		header.Metadata{Name: requesterUserName},
+		userloginstate.Spec{},
+	)
 	require.NoError(t, err)
 
 	testRule := newApprovedRule(
@@ -240,8 +247,8 @@ func TestScheduleRequest(t *testing.T) {
 		{
 			description: "test within schedule",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-					Return(requester, nil)
+				m.On("GetUserLoginState", mock.Anything, requesterUserName).
+					Return(userLoginState, nil)
 
 				review, err := newAccessReview(
 					requesterUserName,
@@ -262,8 +269,8 @@ func TestScheduleRequest(t *testing.T) {
 		{
 			description: "test outside schedule",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-					Return(requester, nil)
+				m.On("GetUserLoginState", mock.Anything, requesterUserName).
+					Return(userLoginState, nil)
 
 				m.AssertNotCalled(t, "SubmitAccessReview")
 			},
@@ -311,10 +318,12 @@ func TestResourceRequest(t *testing.T) {
 
 	testReqID := uuid.New().String()
 	testRuleName := "test-rule"
-	withSecretsFalse := false
 	requesterUserName := "requester"
 
-	requester, err := types.NewUser(requesterUserName)
+	userLoginState, err := userloginstate.New(
+		header.Metadata{Name: requesterUserName},
+		userloginstate.Spec{},
+	)
 	require.NoError(t, err)
 
 	testRule := newApprovedRule(
@@ -332,8 +341,8 @@ func TestResourceRequest(t *testing.T) {
 		{
 			description: "test 0 requested resources",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-					Return(requester, nil)
+				m.On("GetUserLoginState", mock.Anything, requesterUserName).
+					Return(userLoginState, nil)
 
 				m.On("ListResources", mock.Anything, mock.Anything).
 					Return(&types.ListResourcesResponse{
@@ -348,8 +357,8 @@ func TestResourceRequest(t *testing.T) {
 		{
 			description: "test !matching resource labels",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-					Return(requester, nil)
+				m.On("GetUserLoginState", mock.Anything, requesterUserName).
+					Return(userLoginState, nil)
 
 				m.On("ListResources", mock.Anything, mock.Anything).
 					Return(&types.ListResourcesResponse{
@@ -370,8 +379,8 @@ func TestResourceRequest(t *testing.T) {
 		{
 			description: "test matching resource labels",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, requesterUserName, withSecretsFalse).
-					Return(requester, nil)
+				m.On("GetUserLoginState", mock.Anything, requesterUserName).
+					Return(userLoginState, nil)
 
 				m.On("ListResources", mock.Anything, mock.Anything).
 					Return(&types.ListResourcesResponse{
@@ -453,8 +462,6 @@ func TestHandleAccessRequest(t *testing.T) {
 		approvedUserTraitVal = "approved-trait-value"
 		approvedRole         = "approved-role"
 		testRuleName         = "test-rule"
-
-		withSecretsFalse = false
 	)
 
 	testReqID := uuid.New().String()
@@ -469,15 +476,22 @@ func TestHandleAccessRequest(t *testing.T) {
 			approvedRole, approvedUserTraitKey, approvedUserTraitVal))
 	cache.Put([]*accessmonitoringrulesv1.AccessMonitoringRule{rule})
 
-	// Setup approved user
-	approvedUser, err := types.NewUser(approvedUserName)
+	// Setup approved user login state
+	approvedUserLoginState, err := userloginstate.New(
+		header.Metadata{Name: approvedUserName},
+		userloginstate.Spec{
+			Traits: trait.Traits{
+				approvedUserTraitKey: {approvedUserTraitVal},
+			},
+		},
+	)
 	require.NoError(t, err)
-	approvedUser.SetTraits(map[string][]string{
-		approvedUserTraitKey: {approvedUserTraitVal},
-	})
 
-	// Setup unapproved user
-	unapprovedUser, err := types.NewUser(unapprovedUserName)
+	// Setup unapproved user login state
+	unapprovedUserLoginState, err := userloginstate.New(
+		header.Metadata{Name: unapprovedUserName},
+		userloginstate.Spec{},
+	)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -492,7 +506,7 @@ func TestHandleAccessRequest(t *testing.T) {
 			requester:     "non-existent-user",
 			requestedRole: "non-existent-role",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, "non-existent-user", withSecretsFalse).
+				m.On("GetUserLoginState", mock.Anything, "non-existent-user").
 					Return(nil, trace.NotFound("user not found"))
 			},
 			assertErr: func(t require.TestingT, err error, _ ...any) {
@@ -504,8 +518,8 @@ func TestHandleAccessRequest(t *testing.T) {
 			requester:     approvedUserName,
 			requestedRole: "unapproved-role",
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, approvedUserName, withSecretsFalse).
-					Return(approvedUser, nil)
+				m.On("GetUserLoginState", mock.Anything, approvedUserName).
+					Return(approvedUserLoginState, nil)
 
 				m.AssertNotCalled(t, "SubmitAccessReview",
 					"user is not automatically approved for this role")
@@ -517,8 +531,8 @@ func TestHandleAccessRequest(t *testing.T) {
 			requester:     unapprovedUserName,
 			requestedRole: approvedRole,
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, unapprovedUserName, withSecretsFalse).
-					Return(unapprovedUser, nil)
+				m.On("GetUserLoginState", mock.Anything, unapprovedUserName).
+					Return(unapprovedUserLoginState, nil)
 
 				m.AssertNotCalled(t, "SubmitAccessReview",
 					"user is not automatically approved for this role")
@@ -530,8 +544,8 @@ func TestHandleAccessRequest(t *testing.T) {
 			requester:     approvedUserName,
 			requestedRole: approvedRole,
 			setupMock: func(m *mockClient) {
-				m.On("GetUser", mock.Anything, approvedUserName, withSecretsFalse).
-					Return(approvedUser, nil)
+				m.On("GetUserLoginState", mock.Anything, approvedUserName).
+					Return(approvedUserLoginState, nil)
 
 				review, err := newAccessReview(
 					approvedUserName,
@@ -606,6 +620,7 @@ func newReviewRule(name, condition, decision string) *accessmonitoringrulesv1.Ac
 // mockClient is a mock implementation of the Teleport API client.
 type mockClient struct {
 	mock.Mock
+	Client
 }
 
 func (m *mockClient) SubmitAccessReview(ctx context.Context, review types.AccessReviewSubmission) (types.AccessRequest, error) {
@@ -632,11 +647,11 @@ func (m *mockClient) ListAccessMonitoringRulesWithFilter(ctx context.Context, re
 	return nil, args.String(1), args.Error(2)
 }
 
-func (m *mockClient) GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error) {
-	args := m.Called(ctx, name, withSecrets)
-	user, ok := args.Get(0).(types.User)
+func (m *mockClient) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+	args := m.Called(ctx, name)
+	userLoginState, ok := args.Get(0).(*userloginstate.UserLoginState)
 	if ok {
-		return user, args.Error(1)
+		return userLoginState, args.Error(1)
 	}
 	return nil, args.Error(1)
 }

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -621,6 +621,7 @@ func NewPresetAccessPluginRole() types.Role {
 					types.NewRule(types.KindAccessList, RO()),
 					types.NewRule(types.KindRole, RO()),
 					types.NewRule(types.KindUser, RO()),
+					types.NewRule(types.KindUserLoginState, RO()),
 				},
 				ReviewRequests: &types.AccessReviewConditions{
 					PreviewAsRoles: []string{

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -804,6 +804,7 @@ func TestAddRoleDefaults(t *testing.T) {
 							types.NewRule(types.KindAccessList, RO()),
 							types.NewRule(types.KindRole, RO()),
 							types.NewRule(types.KindUser, RO()),
+							types.NewRule(types.KindUserLoginState, RO()),
 						},
 					},
 				},

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -105,7 +105,7 @@ type UserOrLoginStateGetter interface {
 // GetUserOrLoginState will return the given user or the login state associated with the user.
 func GetUserOrLoginState(ctx context.Context, getter UserOrLoginStateGetter, username string) (UserState, error) {
 	uls, err := getter.GetUserLoginState(ctx, username)
-	if err != nil && !trace.IsNotFound(err) {
+	if err != nil && !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
PR is split into two commits since there are a lot of refactoring changes:
- https://github.com/gravitational/teleport/pull/60782/commits/07893eaa2c3bc7c9d23dc38c5bb47bd09c1faa3d: Includes refactoring changes
- https://github.com/gravitational/teleport/pull/60782/commits/53c08ba495e3297ae13e6fb39338ccb711d52340: Includes migration to `UserLoginState`

Changelog: Fixed an issue causing Access Automation Rules to evaluate incorrectly when users are granted traits via Access Lists

## Issue

### Expected Behavior:
access_monitoring_rules conditions should evaluate properly when users are granted traits from Teleport Access Lists.

### Current Behavior:
access_monitoring_rules conditions are not evaluated correctly when users are granted traits from Teleport Access Lists. During evaluation, Teleport references the original user resource to retrieve the user traits. These traits do not include those granted from Access Lists.

To ensure access_monitoring_rules are evaluated properly, we should use UserLoginState during evaluation.