### PR TITLE
fix: Bot instance health status dot inconsistency

### DIFF
--- a/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
@@ -123,7 +123,7 @@ const ItemContainer = styled(Flex)`
   gap: ${({ theme }) => theme.space[3]}px;
 `;
 
-const HealthStatusDot = styled.div<{
+export const HealthStatusDot = styled.div<{
   $status: BotInstanceServiceHealthStatus | undefined;
 }>`
   width: ${({ theme }) => theme.space[3] - theme.space[1]}px;

--- a/web/packages/teleport/src/BotInstances/Details/InfoTab.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/InfoTab.tsx
@@ -38,6 +38,8 @@ import {
   GetBotInstanceResponseJoinAttrs,
 } from 'teleport/services/bot/types';
 
+import { HealthStatusDot } from './HealthTab';
+
 export function InfoTab(props: {
   data: GetBotInstanceResponse;
   onGoToServicesClick: () => void;
@@ -249,25 +251,6 @@ const HealthLabelText = styled(Text).attrs({
   typography: 'body3',
 })`
   white-space: nowrap;
-`;
-
-const HealthStatusDot = styled.div<{
-  $status: BotInstanceServiceHealthStatus | undefined;
-}>`
-  width: ${props => props.theme.space[3] - props.theme.space[1]}px;
-  height: ${props => props.theme.space[3] - props.theme.space[1]}px;
-  border-radius: 999px;
-  background-color: ${({ theme, $status }) =>
-    $status ===
-    BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_HEALTHY
-      ? theme.colors.interactive.solid.success.default
-      : $status ===
-          BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_UNHEALTHY
-        ? theme.colors.interactive.solid.danger.default
-        : $status ===
-            BotInstanceServiceHealthStatus.BOT_INSTANCE_HEALTH_STATUS_UNSPECIFIED
-          ? theme.colors.interactive.solid.alert.default
-          : theme.colors.interactive.tonal.neutral[1]};
 `;
 
 const AccentCountText = styled(Text)`


### PR DESCRIPTION
## Summary
This change fixes a cosmetic inconsistency between the health status dot on the Bot Instance overview tab and the services tab. Services with an `unspecified` health status were coloured grey (same as for `initialising`) instead of being amber.

## Changes
- Unify the health status dot implementation between overview and services tabs

## Screenshot
<img width="1219" height="949" alt="image" src="https://github.com/user-attachments/assets/115e23fd-6404-436b-aa14-4eeffa67fd92" />
