### PR TITLE
[v18] Bump Node.js to 22.21

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -7,7 +7,7 @@ GOLANG_VERSION ?= go1.24.9
 GOLANGCI_LINT_VERSION ?= v2.1.5
 
 # NOTE: Remember to update engines.node in package.json to match the major version.
-NODE_VERSION ?= 22.14.0
+NODE_VERSION ?= 22.21.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.81.0


### PR DESCRIPTION
Backport #60655 to branch/v18