### PR TITLE
Standardize Device Trust capitalization in UI

### DIFF
--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -802,7 +802,7 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 		if err := s.watchWebSessionsOnce(ctx, linear.Reset); err != nil && !errors.Is(err, context.Canceled) {
 			const msg = "" +
 				"sessionCache: WebSession watcher aborted, re-connecting. " +
-				"This may have an impact in device trust web sessions."
+				"This may have an impact on Device Trust web sessions."
 			s.log.WarnContext(ctx, msg, "error", err)
 		}
 	}

--- a/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
+++ b/web/packages/teleport/src/DeviceTrust/EmptyList.tsx
@@ -90,7 +90,7 @@ export const EmptyList = ({
       <Box mb={3}>
         <H1 mb={3}>What are Trusted Devices?</H1>
         <Text css={{ maxWidth }}>
-          Device trust reduces the attack surface by enforcing that only
+          Device Trust reduces the attack surface by enforcing that only
           trusted, registered devices can access your Teleport cluster.
         </Text>
       </Box>
@@ -116,7 +116,7 @@ export const EmptyList = ({
             isSliding={!!intervalId}
             onClick={() => handleOnClick(2)}
             title="Tie audit events to the user AND machine accessing the system."
-            description="Device trust maps the device identity to every audit log event, so you always know which device was used for each action."
+            description="Device Trust maps the device identity to every audit log event, so you always know which device was used for each action."
           />
           <DetailsTab
             active={currIndex === 3}

--- a/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
+++ b/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
@@ -30,7 +30,7 @@ const DeviceTrustText = ({ kind }: { kind: DeviceTrustStatusKind }) => {
   if (kind === 'authorized') {
     return (
       <StatusText color="success.active">
-        Session authorized with device trust.
+        Session authorized with Device Trust.
       </StatusText>
     );
   }

--- a/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.tsx
@@ -149,7 +149,7 @@ export function DocumentAuthorizeWebSession(props: {
             </Alert>
           )}
           <Text>
-            Would you like to authorize a device trust web session for{' '}
+            Would you like to authorize a Device Trust web session for{' '}
             <b>{clusterName}</b>?
             <br />
             The session will automatically open in a new browser tab.

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
@@ -39,7 +39,7 @@ test.each([
     }),
     expect: async () => {
       expect(
-        await screen.findByText(/Access secured with device trust/)
+        await screen.findByText(/access secured with device trust/i)
       ).toBeVisible();
     },
   },
@@ -63,7 +63,7 @@ test.each([
     }),
     expect: async () => {
       expect(
-        screen.queryByText(/Access secured with device trust/)
+        screen.queryByText(/access secured with device trust/i)
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(/Full access requires a trusted device/)

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -141,7 +141,7 @@ function DeviceTrustMessage(props: { status: DeviceTrustStatus }) {
       message = (
         <>
           <ShieldCheck color="success.main" size="small" mb="2px" />
-          <P3>Access secured with device trust.</P3>
+          <P3>Access secured with Device Trust.</P3>
         </>
       );
       break;


### PR DESCRIPTION
* ent counterpart: https://github.com/gravitational/teleport.e/pull/7494

We had some places in the UI where capitalization wasn't consistent, e.g., we said "device trust" in one state and "Device Trust" in another.

https://github.com/gravitational/teleport/blob/d0111b9408b505074739794c446b9806cdf06ee4/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx#L29-L43

This PR standardizes it to "Device Trust".