### PR TITLE
Fix the recording player for legacy recordings

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
@@ -54,7 +54,7 @@ export interface RecordingPlayerProps<
   TEndEventType extends TEventType = TEventType,
 > {
   duration: number;
-  onTimeChange: (time: number) => void;
+  onTimeChange?: (time: number) => void;
   onToggleSidebar?: () => void;
   onToggleTimeline?: () => void;
   onToggleFullscreen?: () => void;
@@ -104,13 +104,13 @@ export function RecordingPlayer<
     });
 
     stream.on('time', time => {
-      if (!controlsRef.current || !eventInfoRef.current) {
-        return;
+      if (controlsRef.current) {
+        controlsRef.current.setTime(time);
       }
-
-      controlsRef.current.setTime(time);
-      onTimeChange(time);
-      eventInfoRef.current.setTime(time);
+      onTimeChange?.(time);
+      if (eventInfoRef.current) {
+        eventInfoRef.current.setTime(time);
+      }
     });
 
     stream.loadInitial();
@@ -177,11 +177,13 @@ export function RecordingPlayer<
         overflow="hidden"
         position="relative"
       >
-        <CurrentEventInfo
-          events={events}
-          onSeek={handleSeek}
-          ref={eventInfoRef}
-        />
+        {events && (
+          <CurrentEventInfo
+            events={events}
+            onSeek={handleSeek}
+            ref={eventInfoRef}
+          />
+        )}
 
         {showPlayButton && (
           <PlayButton onClick={handlePlay}>


### PR DESCRIPTION
This allows playing terminal session recordings without metadata on the current generation of the player. Previously, the player was unable to work without an `onTimeChange` handler, which was only set is timeline was available (and that, by extension, was only available in case if metadata was present). I also changed it to render `CurrentEventInfo` conditionally, as this is only relevant if we have events (which are part of metadata). Otherwise, it ended up dereferencing an `undefined` value. Last but not least, the change in `stream.on('time')` handler makes it possible to properly propagate the time changes to the player controls even if there's no event info panel, which is crucial for updating the progress bar.

Fixes https://github.com/gravitational/teleport/issues/60538

Changelog: Fixed the session recording player that was unable to play SSH sessions captured prior to v18.1.6