### PR TITLE
[v18] Migrate lib/player tests to testing/synctest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -959,7 +959,7 @@ test-go-unit: rdpclient
 test-go-unit: FLAGS ?= -race -shuffle on
 test-go-unit: SUBJECT ?= $(shell go list ./... | grep -vE 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
-	$(CGOFLAG) GOEXPERIMENT=synctest go test -cover -json -tags "enablesynctest $(PAM_TAG) $(RDPCLIENT_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG) $(ADDTAGS)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+	$(CGOFLAG) GOEXPERIMENT=synctest go test -cover -json -tags "enablesynctest $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG) $(VNETDAEMON_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
 		| gotestsum --raw-command -- cat
 


### PR DESCRIPTION
These tests have been flaky because clockwork's BlockUntil functionality isn't capable of blocking until the code is waiting on a timer.

The synctest package introduced in Go 1.24 doesn't suffer from this limitation and allows us to reliably wait for the code to be blocked on the timer's channel.

This package is experimental only available to the compiler when the GOEXPERIMENT=synctest environment variable is set. For this reason, the tests are hidden behind a build flag to prevent `go test` invocations from failing for devs who haven't set the env var. The makefile does set the variable, so `make test-go` _will_ execute the test (both locally and in CI).

Closes #43559
Closes #40842
Backports #53744