### PR TITLE
Add PutBatch method that can be implemented by backends

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -400,3 +400,57 @@ func NewLease(item Item) *Lease {
 		Revision: item.Revision,
 	}
 }
+
+// BatchPutter is an optional interface that backends can implement
+// to support batched PutBatch operations for improved performance when writing
+// multiple items at once.
+type BatchPutter interface {
+	// PutBatch upserts multiple items into the backend in a single call, in a way
+	// that is equivalent to a loop around multiple invocations of [backend.Put],
+	// but with the potential to be more efficient or faster, depending on the
+	// implementation. Returns a revision item for each item in the same order.
+	// Revisions are not guaranteed to be different nor they are guaranteed to be
+	// the same between items of the same batch. If an error is returned, it's
+	// possible for some of the items to have been persisted to the storage. The
+	// order in which items are internally persisted is an implementation detail.
+	PutBatch(context.Context, []Item) ([]string, error)
+}
+
+// PutBatch is an implementation of PutBatch that by default calls Put for each item.
+// Backends can overwrite this behavior providing optimized PutBatch implementation.
+//
+// WARNING: Make sure that items have unique keys when calling PutBatch.
+func PutBatch(ctx context.Context, bk Backend, items []Item) ([]string, error) {
+	if v, hasDuplicate := hasDuplicateKeys(items); hasDuplicate {
+		return nil, trace.BadParameter("duplicate key detected in PutBatch: %q", v)
+	}
+	// Many Backend implementations rely on unique keys for correct operation.
+	// Where it is up to the caller to ensure this to remove duplication keys
+	// Just in case we will fallback to single Put calls if duplicates are detected.
+	if v, ok := bk.(BatchPutter); ok {
+		revs, err := v.PutBatch(ctx, items)
+		return revs, trace.Wrap(err)
+	}
+
+	revisions := make([]string, 0, len(items))
+	for _, item := range items {
+		rev, err := bk.Put(ctx, item)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		revisions = append(revisions, rev.Revision)
+	}
+	return revisions, nil
+}
+
+func hasDuplicateKeys(items Items) (string, bool) {
+	seen := make(map[string]struct{})
+	for _, ca := range items {
+		keyStr := ca.Key.String()
+		if _, ok := seen[keyStr]; ok {
+			return keyStr, true
+		}
+		seen[keyStr] = struct{}{}
+	}
+	return "", false
+}

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -120,6 +120,17 @@ func (s *Sanitizer) Put(ctx context.Context, i Item) (*Lease, error) {
 	return s.backend.Put(ctx, i)
 }
 
+// PutBatch puts multiple values into backend.
+func (s *Sanitizer) PutBatch(ctx context.Context, items []Item) ([]string, error) {
+	for _, item := range items {
+		if !IsKeySafe(item.Key) {
+			return nil, trace.BadParameter(errorMessage, item.Key)
+		}
+	}
+	out, err := PutBatch(ctx, s.backend, items)
+	return out, trace.Wrap(err)
+}
+
 // Update updates value in the backend
 func (s *Sanitizer) Update(ctx context.Context, i Item) (*Lease, error) {
 	if !IsKeySafe(i.Key) {

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -113,6 +113,11 @@ func (s *Wrapper) CompareAndSwap(ctx context.Context, expected Item, replaceWith
 	return s.backend.CompareAndSwap(ctx, expected, replaceWith)
 }
 
+// PutBatch puts multiple values into backend.
+func (s *Wrapper) PutBatch(ctx context.Context, items []Item) ([]string, error) {
+	return PutBatch(ctx, s.backend, items)
+}
+
 // Delete deletes item by key
 func (s *Wrapper) Delete(ctx context.Context, key Key) error {
 	return s.backend.Delete(ctx, key)


### PR DESCRIPTION
### What

Add Scaffolding  that allows backend to implement `PutBatch` per database behavior. 

This allows backend to implement PutBatch method - see https://github.com/gravitational/teleport.e/pull/7506 as example implementation 