### PR TITLE
[v18] Fix the recording player for legacy recordings

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
@@ -54,7 +54,7 @@ export interface RecordingPlayerProps<
   TEndEventType extends TEventType = TEventType,
 > {
   duration: number;
-  onTimeChange: (time: number) => void;
+  onTimeChange?: (time: number) => void;
   onToggleSidebar?: () => void;
   onToggleTimeline?: () => void;
   onToggleFullscreen?: () => void;
@@ -104,13 +104,13 @@ export function RecordingPlayer<
     });
 
     stream.on('time', time => {
-      if (!controlsRef.current || !eventInfoRef.current) {
-        return;
+      if (controlsRef.current) {
+        controlsRef.current.setTime(time);
       }
-
-      controlsRef.current.setTime(time);
-      onTimeChange(time);
-      eventInfoRef.current.setTime(time);
+      onTimeChange?.(time);
+      if (eventInfoRef.current) {
+        eventInfoRef.current.setTime(time);
+      }
     });
 
     stream.loadInitial();
@@ -177,11 +177,13 @@ export function RecordingPlayer<
         overflow="hidden"
         position="relative"
       >
-        <CurrentEventInfo
-          events={events}
-          onSeek={handleSeek}
-          ref={eventInfoRef}
-        />
+        {events && (
+          <CurrentEventInfo
+            events={events}
+            onSeek={handleSeek}
+            ref={eventInfoRef}
+          />
+        )}
 
         {showPlayButton && (
           <PlayButton onClick={handlePlay}>


### PR DESCRIPTION
Backport #60794 to branch/v18

changelog: Fixed the session recording player that was unable to play SSH sessions captured prior to v18.1.6
