### PR TITLE
[v16] Fix duplicate tab labels in the tsh guide

### DIFF
--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -487,6 +487,17 @@ $ ssh -o ForwardAgent=yes user@node
 $ ssh -o AddKeysToAgent=yes user@node
 ```
 
+By default, the Teleport Proxy Service listens on port `3080`.
+
+If a Teleport Proxy Service instance is configured to listen on non-default
+ports, they must be specified via `--proxy` flag as shown:
+
+```code
+$ tsh --proxy=proxy.example.com:5000 <subcommand>
+```
+
+This `tsh` command will use port `5000` of the Proxy Service.
+
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
@@ -505,24 +516,6 @@ $ ssh -o AddKeysToAgent=yes user@node
 ```
 
 </TabItem>
-
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-### Proxy ports
-
-By default, the Teleport Proxy Service listens on port `3080`.
-
-If a Teleport Proxy Service instance is configured to listen on non-default
-ports, they must be specified via `--proxy` flag as shown:
-
-```code
-$ tsh --proxy=proxy.example.com:5000 <subcommand>
-```
-
-This `tsh` command will use port `5000` of the Proxy Service.
-
-</TabItem>
-
 </Tabs>
 
 ### Port forwarding


### PR DESCRIPTION
Backports #60803

One `Tabs` component in the `tsh` user guide includes two tab items for the label "Self-Hosted". Merge the content in the two tab items.

Note that this was fixed in #58442 on `master` and `branch/v18`. This change fixes the duplicate label without backporting all of #58442.