### PR TITLE
Use gotestsum when running integrations tests

### DIFF
--- a/integrations/Makefile
+++ b/integrations/Makefile
@@ -3,11 +3,11 @@ test: test-access test-lib test-event-handler test-terraform-provider test-terra
 
 .PHONY: test-access
 test-access:
-	go test -v ./access/...
+	gotestsum ./access/...
 
 .PHONY: test-lib
 test-lib:
-	go test ./lib/...
+	gotestsum ./lib/...
 
 .PHONY: test-event-handler
 test-event-handler:

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -96,7 +96,7 @@ install: build
 
 .PHONY: test
 test:
-	go test -coverprofile=cover.out
+	gotestsum 
 
 .PHONY: configure
 configure: build

--- a/integrations/kube-agent-updater/Makefile
+++ b/integrations/kube-agent-updater/Makefile
@@ -10,7 +10,7 @@ ARCH ?= $(shell go env GOARCH)
 
 .PHONY: test
 test: pkg/img/cosign_fixtures_test.go
-	go test ./...
+	gotestsum ./...
 
 .PHONY: docker-build
 docker-build: ## Build docker image

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -176,7 +176,7 @@ debug-dump-request:
 test: generate $(ENVTEST) ## Run tests.
 test: export KUBEBUILDER_ASSETS=$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
 test:
-	go test ./...
+	gotestsum ./...
 
 .PHONY: echo-kubebuilder-assets
 echo-kubebuilder-assets:

--- a/integrations/terraform-mwi/Makefile
+++ b/integrations/terraform-mwi/Makefile
@@ -58,7 +58,7 @@ endif
 
 PHONY: test
 test:
-	go test -v -timeout=120s -parallel=10 ./...
+	gotestsum -- -v -timeout=120s -parallel=10
 
 PHONY: testacc
 testacc:

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -197,7 +197,7 @@ ifeq ($(shell expr $(CURRENT_ULIMIT) \< 1024), 1)
 	@echo "ulimit -n is too low ($(CURRENT_ULIMIT)), please set ulimit -n 1024"
 	@exit -1
 endif
-	go test ./testlib -v $(TEST_ARGS)
+	gotestsum  -- ./testlib -v $(TEST_ARGS)
 
 .PHONY: test-full
 test-full: TEST_ARGS=--tags enterprisetests


### PR DESCRIPTION
Consolidating all of our tests to use gotestum provides consistency. This is helpful both for developers when examining logs but also for tools that consume the logs, i.e. the flaky test reporting script.