### PR TITLE
Dashboard Mode Init Test

### DIFF
--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -1367,7 +1367,7 @@ func TestDashboardMode(t *testing.T) {
 	})
 
 	conf := setupConfig(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	authServer, err := auth.Init(ctx, conf)
 	require.NoError(t, err)
 	t.Cleanup(func() {


### PR DESCRIPTION
Adds `TestDashboardMode` to verify that preset roles and users are correctly skipped during auth server initialization in dashboard deployments.