### PR TITLE
Add support for `tsh logout --proxy` to work without `--user` flag when only one identity exists

### DIFF
--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -29,7 +29,7 @@ const (
 	// sessionKeyDir is a sub-directory where session keys are stored
 	sessionKeyDir = "keys"
 	// sshDirSuffix is the suffix of a sub-directory where SSH certificates are stored.
-	SshDirSuffix = "-ssh"
+	SSHDirSuffix = "-ssh"
 	// fileNameKnownHosts is a file where known hosts are stored.
 	fileNameKnownHosts = "known_hosts"
 	// FileExtTLSCertLegacy is the legacy suffix/extension of a file where a TLS cert is stored.
@@ -257,7 +257,7 @@ func TLSCAsPathCluster(baseDir, proxy, cluster string) string {
 //
 // <baseDir>/keys/<proxy>/<username>-ssh
 func SSHDir(baseDir, proxy, username string) string {
-	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+SshDirSuffix)
+	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+SSHDirSuffix)
 }
 
 // PPKFilePath returns the path to the user's PuTTY PPK-formatted keypair

--- a/api/utils/keypaths/keypaths.go
+++ b/api/utils/keypaths/keypaths.go
@@ -29,7 +29,7 @@ const (
 	// sessionKeyDir is a sub-directory where session keys are stored
 	sessionKeyDir = "keys"
 	// sshDirSuffix is the suffix of a sub-directory where SSH certificates are stored.
-	sshDirSuffix = "-ssh"
+	SshDirSuffix = "-ssh"
 	// fileNameKnownHosts is a file where known hosts are stored.
 	fileNameKnownHosts = "known_hosts"
 	// FileExtTLSCertLegacy is the legacy suffix/extension of a file where a TLS cert is stored.
@@ -257,7 +257,7 @@ func TLSCAsPathCluster(baseDir, proxy, cluster string) string {
 //
 // <baseDir>/keys/<proxy>/<username>-ssh
 func SSHDir(baseDir, proxy, username string) string {
-	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+sshDirSuffix)
+	return filepath.Join(ProxyKeyDir(baseDir, proxy), username+SshDirSuffix)
 }
 
 // PPKFilePath returns the path to the user's PuTTY PPK-formatted keypair

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -25,9 +25,11 @@ import (
 	"fmt"
 	iofs "io/fs"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -625,8 +627,8 @@ func (fs *FSKeyStore) GetIdentities(proxyHost string) ([]string, error) {
 	for _, file := range files {
 		// we seek the files corresponding to user SSH certificates, which are
 		// stored in [user]-ssh subdirectory. These are generated on successful logins.
-		if file.IsDir() && strings.HasSuffix(file.Name(), keypaths.SshDirSuffix) {
-			username := strings.TrimSuffix(file.Name(), keypaths.SshDirSuffix)
+		if file.IsDir() && strings.HasSuffix(file.Name(), keypaths.SSHDirSuffix) {
+			username := strings.TrimSuffix(file.Name(), keypaths.SSHDirSuffix)
 			identities = append(identities, username)
 		}
 	}
@@ -983,10 +985,5 @@ func (ms *MemKeyStore) GetSSHCertificates(proxyHost, username string) ([]*ssh.Ce
 // GetIdentities returns the usernames associated to signed user certificates
 // for the given proxy in the keystore.
 func (ms *MemKeyStore) GetIdentities(proxyHost string) ([]string, error) {
-	var identities []string
-
-	for username := range ms.keyRings[proxyHost] {
-		identities = append(identities, username)
-	}
-	return identities, nil
+	return slices.Collect(maps.Keys(ms.keyRings[proxyHost])), nil
 }

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -89,6 +89,10 @@ type KeyStore interface {
 	// GetSSHCertificates gets all certificates signed for the given user and proxy,
 	// including certificates for trusted clusters.
 	GetSSHCertificates(proxyHost, username string) ([]*ssh.Certificate, error)
+
+	// GetIdentities returns the usernames associated to signed user certificates
+	// for the given proxy in the keystore.
+	GetIdentities(proxyHost string) ([]string, error)
 }
 
 // FSKeyStore is an on-disk implementation of the KeyStore interface.
@@ -111,6 +115,11 @@ func NewFSKeyStore(dirPath string) *FSKeyStore {
 		log:    slog.With(teleport.ComponentKey, teleport.ComponentKeyStore),
 		KeyDir: dirPath,
 	}
+}
+
+// proxyKeyDir returns the path to the given proxy's keys directory.
+func (fs *FSKeyStore) proxyKeyDir(proxy string) string {
+	return keypaths.ProxyKeyDir(fs.KeyDir, proxy)
 }
 
 // userSSHKeyPath returns the SSH private key path for the given KeyRingIndex.
@@ -603,6 +612,27 @@ func (fs *FSKeyStore) GetSSHCertificates(proxyHost, username string) ([]*ssh.Cer
 	return sshCerts, nil
 }
 
+// GetIdentities returns the usernames associated to signed user certificates
+// for the given proxy in the keystore.
+func (fs *FSKeyStore) GetIdentities(proxyHost string) ([]string, error) {
+	proxyDir := fs.proxyKeyDir(proxyHost)
+	files, err := os.ReadDir(proxyDir)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
+	var identities []string
+	for _, file := range files {
+		// we seek the files corresponding to user SSH certificates, which are
+		// stored in [user]-ssh subdirectory. These are generated on successful logins.
+		if file.IsDir() && strings.HasSuffix(file.Name(), keypaths.SshDirSuffix) {
+			username := strings.TrimSuffix(file.Name(), keypaths.SshDirSuffix)
+			identities = append(identities, username)
+		}
+	}
+	return identities, nil
+}
+
 func getCredentialsByName(credentialDir string, opts ...keys.ParsePrivateKeyOpt) (map[string]TLSCredential, error) {
 	files, err := os.ReadDir(credentialDir)
 	if err != nil {
@@ -948,4 +978,15 @@ func (ms *MemKeyStore) GetSSHCertificates(proxyHost, username string) ([]*ssh.Ce
 	}
 
 	return sshCerts, nil
+}
+
+// GetIdentities returns the usernames associated to signed user certificates
+// for the given proxy in the keystore.
+func (ms *MemKeyStore) GetIdentities(proxyHost string) ([]string, error) {
+	var identities []string
+
+	for username := range ms.keyRings[proxyHost] {
+		identities = append(identities, username)
+	}
+	return identities, nil
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2576,8 +2576,6 @@ func onLogout(cf *CLIConf) error {
 		}
 
 		switch {
-		// If username is not set, clients can still logout if there is only one identity
-		// for this proxy.
 		case cf.Username != "":
 			tc, err := makeClient(cf)
 			if err != nil {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2565,62 +2565,65 @@ func onLogout(cf *CLIConf) error {
 				return trace.Wrap(err)
 			}
 
+			if len(usernames) == 0 {
+				fmt.Fprintf(cf.Stdout(), "All users logged out.\n")
+				return nil
+			}
+
 			logger.DebugContext(cf.Context, "No --user flag provided, but identities found for proxy",
 				"proxy_host", proxyHost,
 				"users", usernames)
 
-			if len(usernames) == 1 {
-				cf.Username = usernames[0]
+			if len(usernames) > 1 {
+				fmt.Fprintf(cf.Stdout(), "Specify --user to log out a specific user from %q or remove the --proxy flag to log out all users from all proxies.\n", proxyHost)
+				return nil
+			}
+
+			cf.Username = usernames[0]
+		}
+
+		tc, err := makeClient(cf)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		// Load profile for the requested proxy/user.
+		profile, err := tc.ProfileStatus()
+		if err != nil && !trace.IsNotFound(err) && !trace.IsCompareFailed(err) {
+			return trace.Wrap(err)
+		}
+
+		// Log out user from the databases.
+		if profile != nil {
+			for _, db := range profile.Databases {
+				logger.DebugContext(cf.Context, "Logging user out of database",
+					"user", profile.Name,
+					"database", db,
+				)
+				err = dbprofile.Delete(tc, db)
+				if err != nil {
+					return trace.Wrap(err)
+				}
 			}
 		}
 
-		switch {
-		case cf.Username != "":
-			tc, err := makeClient(cf)
-			if err != nil {
-				return trace.Wrap(err)
+		// Remove keys for this user from disk and running agent.
+		err = tc.Logout()
+		if err != nil {
+			if trace.IsNotFound(err) {
+				fmt.Fprintf(cf.Stdout(), "User %v already logged out from %v.\n", cf.Username, proxyHost)
+				return trace.Wrap(&common.ExitCodeError{Code: 1})
 			}
-			// Load profile for the requested proxy/user.
-			profile, err := tc.ProfileStatus()
-			if err != nil && !trace.IsNotFound(err) && !trace.IsCompareFailed(err) {
-				return trace.Wrap(err)
-			}
-
-			// Log out user from the databases.
-			if profile != nil {
-				for _, db := range profile.Databases {
-					logger.DebugContext(cf.Context, "Logging user out of database",
-						"user", profile.Name,
-						"database", db,
-					)
-					err = dbprofile.Delete(tc, db)
-					if err != nil {
-						return trace.Wrap(err)
-					}
-				}
-			}
-
-			// Remove keys for this user from disk and running agent.
-			err = tc.Logout()
-			if err != nil {
-				if trace.IsNotFound(err) {
-					fmt.Fprintf(cf.Stdout(), "User %v already logged out from %v.\n", cf.Username, proxyHost)
-					return trace.Wrap(&common.ExitCodeError{Code: 1})
-				}
-				return trace.Wrap(err)
-			}
-
-			// Remove Teleport related entries from kubeconfig.
-			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
-			err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			fmt.Fprintf(cf.Stdout(), "Logged out %v from %v.\n", cf.Username, proxyHost)
-		case cf.Username == "":
-			fmt.Fprintf(cf.Stdout(), "Specify --user to log out a specific user from %q or remove the --proxy flag to log out all users from all proxies.\n", proxyHost)
+			return trace.Wrap(err)
 		}
+
+		// Remove Teleport related entries from kubeconfig.
+		logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
+		err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		fmt.Fprintf(cf.Stdout(), "Logged out %v from %v.\n", cf.Username, proxyHost)
 	// Remove all keys.
 	case proxyHost == "" && cf.Username == "":
 		tc, err := makeClient(cf)
@@ -2675,7 +2678,7 @@ func onLogout(cf *CLIConf) error {
 			return trace.Wrap(tc.SAMLSingleLogout(ctx, sloURL))
 		})
 		if err != nil {
-			fmt.Fprintf(cf.Stdout(), "We were unable to log you out of your SAML identity provider: %v", err)
+			fmt.Fprintf(cf.Stdout(), "We were unable to log you out of your SAML identity provider: %v\n", err)
 		}
 
 		// Remove all keys from disk and the running agent.

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2567,7 +2567,7 @@ func onLogout(cf *CLIConf) error {
 		}
 		if cf.Username == "" {
 			logger.DebugContext(cf.Context, "No --user flag provided, but identities found for proxy",
-				"proxyHost", proxyHost,
+				"proxy_host", proxyHost,
 				"users", usernames)
 
 			if len(usernames) == 1 {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2556,16 +2556,15 @@ func onLogout(cf *CLIConf) error {
 	switch {
 	// Proxy and username for key to remove.
 	case proxyHost != "":
-
 		// In the event --user flag is not supplied, and there is only one identity,
 		// we can simply log out the single identity.
-		// Extract the list of identities (usernames) currently in keystore.
-		clientStore := cf.getClientStore()
-		usernames, err := clientStore.GetIdentities(proxyHost)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		if cf.Username == "" {
+			clientStore := cf.getClientStore()
+			usernames, err := clientStore.GetIdentities(proxyHost)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
 			logger.DebugContext(cf.Context, "No --user flag provided, but identities found for proxy",
 				"proxy_host", proxyHost,
 				"users", usernames)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -101,7 +101,6 @@ import (
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 	"github.com/gravitational/teleport/tool/common"
-	"github.com/gravitational/teleport/tool/teleport/testenv"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
@@ -7777,7 +7776,7 @@ func TestLogoutOneIdentity(t *testing.T) {
 	require.NoError(t, err)
 	alice.SetRoles([]string{"access"})
 
-	rootServer, err := testenv.NewTeleportProcess(
+	rootServer, err := testserver.NewTeleportProcess(
 		t.TempDir(),
 		testserver.WithBootstrap(connector, alice))
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #58495

changelog: Added support for `tsh logout --proxy` (or `TELEPORT_PROXY` set) to work without `--user` flag when one identity exists

<details><summary>Manual Tests</summary>
<p>

Test: When proxy is specified with either `--proxy` or `TELEPORT_PROXY` env var set, and only one user identity exists for that proxy, `tsh logout` logs the user out. Identity is defined as user certificate present in the current session.

- [x]  `--proxy` is set, `--user` is not given
    - [x]  When one identity is logged into the proxy, verify `tsh logout` logs the user out
    - [x]  When multiple identities are logged into the proxy, verify `tsh logout` specifies the user to include `--user` flag
- [x]  `TELEPORT_PROXY` is set, `--proxy` is not given, `--user` is not given
    - [x]  When one identity is logged into the proxy, verify `tsh logout` logs the user out
    - [x]  When multiple identities are logged into the proxy, verify `tsh logout` specifies the user to include `--user` flag

</p>
</details> 