### PR TITLE
Add support in process for additional metrics gatherers

### DIFF
--- a/lib/metrics/gatherers.go
+++ b/lib/metrics/gatherers.go
@@ -1,0 +1,58 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// SyncGatherers wraps a [prometheus.Gatherers] so it can be accessed
+// in a thread-safe fashion. Gatherer can be added with AddGatherer.
+type SyncGatherers struct {
+	mutex     sync.Mutex
+	gatherers prometheus.Gatherers
+}
+
+// NewSyncGatherers returns a thread-safe [prometheus.Gatherers].
+func NewSyncGatherers(gatherers ...prometheus.Gatherer) *SyncGatherers {
+	return &SyncGatherers{
+		gatherers: gatherers,
+	}
+}
+
+// AddGatherer adds a gatherer to the SyncGatherers slice.
+func (s *SyncGatherers) AddGatherer(g prometheus.Gatherer) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.gatherers = append(s.gatherers, g)
+}
+
+// Gather implements [prometheus.Gatherer].
+func (s *SyncGatherers) Gather() ([]*dto.MetricFamily, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.gatherers == nil {
+		return nil, nil
+	}
+	return s.gatherers.Gather()
+}

--- a/lib/service/diagnostic.go
+++ b/lib/service/diagnostic.go
@@ -68,7 +68,7 @@ func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerCon
 // in-process one.
 func (process *TeleportProcess) newMetricsHandler() http.Handler {
 	metricsHandler := promhttp.InstrumentMetricHandler(
-		process.metricsRegistry, promhttp.HandlerFor(&process.metricsGatherers, promhttp.HandlerOpts{
+		process.metricsRegistry, promhttp.HandlerFor(process, promhttp.HandlerOpts{
 			// Errors can happen if metrics are registered with identical names in both the local and the global registry.
 			// In this case, we log the error but continue collecting metrics. The first collected metric will win
 			// (the one from the local metrics registry takes precedence).

--- a/lib/service/diagnostic.go
+++ b/lib/service/diagnostic.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/gravitational/teleport"
@@ -68,15 +67,8 @@ func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerCon
 // newMetricsHandler creates a new metrics handler serving metrics both from the global prometheus registry and the
 // in-process one.
 func (process *TeleportProcess) newMetricsHandler() http.Handler {
-	// We gather metrics both from the in-process registry (preferred metrics registration method)
-	// and the global registry (used by some Teleport services and many dependencies).
-	gatherers := prometheus.Gatherers{
-		process.metricsRegistry,
-		prometheus.DefaultGatherer,
-	}
-
 	metricsHandler := promhttp.InstrumentMetricHandler(
-		process.metricsRegistry, promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{
+		process.metricsRegistry, promhttp.HandlerFor(&process.metricsGatherers, promhttp.HandlerOpts{
 			// Errors can happen if metrics are registered with identical names in both the local and the global registry.
 			// In this case, we log the error but continue collecting metrics. The first collected metric will win
 			// (the one from the local metrics registry takes precedence).


### PR DESCRIPTION
Before this change, we were gathering from 2 metrics gatherers:
- the process registry
- the global registry

There are cases where we must add and remove metrics (e.g. plugins). We could throw them into the global registry but:
- this would pollute the global registry and cause duplicates/conflicts in tests
- this would conflate all metrics from the same plugin kind. We support several instances of the same hosted plugin and we might want to keep distinct metrics.

This change makes the gatherers a list, and add a function so teleport.e can add its own gatherer. A teleport.e PR using this mechanism will follow.