### PR TITLE
cache oracle instance root CAs

### DIFF
--- a/lib/join/oraclejoin/join_test.go
+++ b/lib/join/oraclejoin/join_test.go
@@ -416,6 +416,8 @@ func TestInstanceKeyAlgorithms(t *testing.T) {
 		return assert.ErrorAs(t, err, new(*trace.AccessDeniedError), msgAndArgs...)
 	}
 
+	rootCACache := oraclejoin.NewRootCACache()
+
 	for _, tc := range []struct {
 		desc         string
 		instanceKey  crypto.Signer
@@ -475,6 +477,7 @@ func TestInstanceKeyAlgorithms(t *testing.T) {
 				Solution:       solution,
 				ProvisionToken: token,
 				HTTPClient:     fakeOracleAPIClient,
+				RootCACache:    rootCACache,
 			}
 
 			_, err = oraclejoin.CheckChallengeSolution(t.Context(), params)
@@ -604,6 +607,7 @@ func (f *fakeOracleAPI) handleRootCACertificates(w http.ResponseWriter, r *http.
 	}
 	resp := rootCAResp{
 		Certificates: []string{f.rootCABase64},
+		RefreshIn:    time.Now().Add(time.Hour).Format(time.RFC3339),
 	}
 	json.NewEncoder(w).Encode(resp)
 }

--- a/lib/join/oraclejoin/rootcacache.go
+++ b/lib/join/oraclejoin/rootcacache.go
@@ -1,0 +1,112 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package oraclejoin
+
+import (
+	"context"
+	"crypto/x509"
+	"sync"
+	"time"
+)
+
+// RootCACache caches Oracle instance root CAs for each region. It is inspired
+// by lib/utils.FnCache which is designed for caching backend reads, but this
+// cache makes a couple different choices:
+//   - Each cache entry expiry is determined by the response we get from the
+//     Oracle API and unknown before making the request.
+//   - Error results are always retried at the next request.
+//   - There is no regularly scheduled cleanup, expired entries will be cleaned
+//     up on the next get. This cache will not be large, max 1 entry per OCI region.
+type RootCACache struct {
+	entries map[string]*rootCACacheEntry
+	mu      sync.Mutex
+}
+
+// NewRootCACache returns a new RootCACache, ready to use.
+func NewRootCACache() *RootCACache {
+	return &RootCACache{
+		entries: make(map[string]*rootCACacheEntry),
+	}
+}
+
+type getRootCAPoolFn func() (*x509.CertPool, time.Time, error)
+
+// get is the only method consumers of RootCACache should call. Given a key
+// (which should be the region of the root CA) and a getRootCAPoolFn, it will
+// return a cached root CA pool if one is present and not expired, else it will
+// call loadFn to request the root CA pool.
+func (c *RootCACache) get(ctx context.Context, key string, loadFn getRootCAPoolFn) (*x509.CertPool, error) {
+	entry := c.getEntry(key, loadFn)
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-entry.loaded:
+		return entry.caPool, entry.err
+	}
+}
+
+func (c *RootCACache) getEntry(key string, loadFn getRootCAPoolFn) *rootCACacheEntry {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+
+	c.removeExpiredLocked(now)
+
+	if entry, ok := c.entries[key]; ok {
+		// There is an existing cache entry, return it. If the entry is expired
+		// or stores an error it would have been removed in removeExpiredLocked
+		// above.
+		return entry
+	}
+
+	// Create a new cache entry to store and return.
+	entry := &rootCACacheEntry{
+		loaded: make(chan struct{}),
+	}
+	c.entries[key] = entry
+	go func() {
+		entry.caPool, entry.expires, entry.err = loadFn()
+		close(entry.loaded)
+	}()
+
+	return entry
+}
+
+func (c *RootCACache) removeExpiredLocked(now time.Time) {
+	for key, entry := range c.entries {
+		select {
+		case <-entry.loaded:
+			if entry.expires.Before(now) || entry.err != nil {
+				delete(c.entries, key)
+			}
+		default:
+			// entry is still being loaded.
+			continue
+		}
+	}
+}
+
+type rootCACacheEntry struct {
+	// loaded will be closed when the entry is ready. It also acts as a memory barrier:
+	// the below fields must only be written before loaded is closed, and must
+	// only be read after it is closed.
+	loaded  chan struct{}
+	caPool  *x509.CertPool
+	expires time.Time
+	err     error
+}

--- a/lib/join/oraclejoin/rootcacache_test.go
+++ b/lib/join/oraclejoin/rootcacache_test.go
@@ -1,0 +1,108 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package oraclejoin
+
+import (
+	"crypto/x509"
+	"errors"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootCACache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, testRootCACache)
+}
+
+func testRootCACache(t *testing.T) {
+	cache := NewRootCACache()
+
+	caPool := x509.NewCertPool()
+	const caTTL = 5 * time.Minute
+
+	var loadCount atomic.Int32
+	loadFn := func() (*x509.CertPool, time.Time, error) {
+		loadCount.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		expires := time.Now().Add(caTTL)
+		return caPool, expires, nil
+	}
+
+	// Getting the same key many times only results in 1 load.
+	for range 10 {
+		pool, err := cache.get(t.Context(), "test", loadFn)
+		require.Equal(t, caPool, pool)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), loadCount.Load())
+
+	// Waiting until the entry expires then getting the same key again a number
+	// of times results in 1 additional load.
+	time.Sleep(caTTL + time.Minute)
+	for range 10 {
+		_, err := cache.get(t.Context(), "test", loadFn)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(2), loadCount.Load())
+
+	// Getting 10 different keys multiple times results in 10 total loads.
+	loadCount.Store(0)
+	for range 10 {
+		for i := range 10 {
+			_, err := cache.get(t.Context(), strconv.Itoa(i), loadFn)
+			require.NoError(t, err)
+		}
+	}
+	require.Equal(t, int32(10), loadCount.Load())
+
+	// Wait until all current entries expire, then do 1 more load, expired
+	// entries should be cleaned up.
+	time.Sleep(caTTL + time.Minute)
+	_, err := cache.get(t.Context(), "test", loadFn)
+	require.NoError(t, err)
+	require.Len(t, cache.entries, 1)
+
+	// Error values should not be cached.
+	_, err = cache.get(t.Context(), "testerror", func() (*x509.CertPool, time.Time, error) {
+		return nil, time.Time{}, errors.New("test error")
+	})
+	require.Error(t, err)
+	// An immediate re-fetch does not get the error.
+	_, err = cache.get(t.Context(), "testerror", loadFn)
+	require.NoError(t, err)
+
+	// Even with many concurrent calls the value will only be loaded once.
+	loadCount.Store(0)
+	var wg sync.WaitGroup
+	wg.Add(100)
+	for range 100 {
+		go func() {
+			_, err := cache.get(t.Context(), "concurrent", loadFn)
+			assert.NoError(t, err)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int32(1), loadCount.Load())
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/oraclejoin"
 	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
@@ -94,13 +95,15 @@ type ServerConfig struct {
 
 // Server implements cluster joining for nodes and bots.
 type Server struct {
-	cfg *ServerConfig
+	cfg               *ServerConfig
+	oracleRootCACache *oraclejoin.RootCACache
 }
 
 // NewServer returns a new [Server] instance.
 func NewServer(cfg *ServerConfig) *Server {
 	return &Server{
-		cfg: cfg,
+		cfg:               cfg,
+		oracleRootCACache: oraclejoin.NewRootCACache(),
 	}
 }
 

--- a/lib/join/server_oracle.go
+++ b/lib/join/server_oracle.go
@@ -80,6 +80,7 @@ func (s *Server) handleOracleJoin(
 		Solution:       solution,
 		ProvisionToken: provisionToken,
 		HTTPClient:     s.cfg.OracleHTTPClient,
+		RootCACache:    s.oracleRootCACache,
 	})
 	// CheckOracleRequest may return claims even when returning an error, which
 	// may aid in debugging.


### PR DESCRIPTION
This PR builds on https://github.com/gravitational/teleport/pull/60601 to cache Oracle instance root CAs per region instead of fetching them from Oracle on each request. See [RFD 231](https://github.com/gravitational/teleport/pull/60609).