### PR TITLE
[v16] Standardize Device Trust capitalization in UI

### DIFF
--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -788,7 +788,7 @@ func (s *sessionCache) watchWebSessions(ctx context.Context) {
 		if err := s.watchWebSessionsOnce(ctx, linear.Reset); err != nil && !errors.Is(err, context.Canceled) {
 			const msg = "" +
 				"sessionCache: WebSession watcher aborted, re-connecting. " +
-				"This may have an impact in device trust web sessions."
+				"This may have an impact on Device Trust web sessions."
 			s.log.WithError(err).Warn(msg)
 		}
 	}

--- a/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
+++ b/web/packages/shared/components/AuthorizeDeviceWeb/AuthorizeDeviceWeb.tsx
@@ -137,7 +137,7 @@ export const DeviceTrustConnectPassthrough = ({
               `}
               to={processRedirectUri(redirectUri)}
             >
-              continue without device trust{' '}
+              continue without Device Trust{' '}
             </Link>
             but you will not be able to connect to resources that require Device
             Trust.

--- a/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
+++ b/web/packages/teleport/src/TopBar/DeviceTrustStatus.tsx
@@ -30,7 +30,7 @@ const DeviceTrustText = ({ kind }: { kind: DeviceTrustStatusKind }) => {
   if (kind === 'authorized') {
     return (
       <StatusText color="success.active">
-        Session authorized with device trust.
+        Session authorized with Device Trust.
       </StatusText>
     );
   }

--- a/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAuthorizeWebSession/DocumentAuthorizeWebSession.tsx
@@ -146,7 +146,7 @@ export function DocumentAuthorizeWebSession(props: {
             </Alert>
           )}
           <Text>
-            Would you like to authorize a device trust web session for{' '}
+            Would you like to authorize a Device Trust web session for{' '}
             <b>{clusterName}</b>?
             <br />
             The session will automatically open in a new browser tab.

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.test.tsx
@@ -40,7 +40,7 @@ test.each([
     }),
     expect: async () => {
       expect(
-        await screen.findByText(/Access secured with device trust/)
+        await screen.findByText(/access secured with device trust/i)
       ).toBeVisible();
     },
   },
@@ -64,7 +64,7 @@ test.each([
     }),
     expect: async () => {
       expect(
-        screen.queryByText(/Access secured with device trust/)
+        screen.queryByText(/access secured with device trust/i)
       ).not.toBeInTheDocument();
       expect(
         screen.queryByText(/Full access requires a trusted device/)

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -91,7 +91,7 @@ function DeviceTrustMessage(props: { status: DeviceTrustStatus }) {
       message = (
         <>
           <ShieldCheck color="success.main" size="small" mb="2px" />
-          <P3>Access secured with device trust.</P3>
+          <P3>Access secured with Device Trust.</P3>
         </>
       );
       break;


### PR DESCRIPTION
Backport #60791

UI files were shuffled around in gravitational/teleport.e#6218 (some things from OSS were moved to ent and vice versa). This wasn't backported to v16, that's why the v16 backport changes a different set of files.