### PR TITLE
docs: clean up API authorization code block highlighting

### DIFF
--- a/docs/pages/reference/architecture/api-architecture.mdx
+++ b/docs/pages/reference/architecture/api-architecture.mdx
@@ -31,9 +31,11 @@ action on the `role` resource. You should create a user and role with the minimu
 
 (!docs/pages/includes/permission-warning.mdx!)
 
+Copy and paste the below and run on the Teleport Auth Service:
+
 ```code
-# Copy and Paste the below and run on the Teleport Auth server.
-cat > api-role.yaml <<EOF
+# Create role configuration
+$ cat > api-role.yaml <<EOF
 kind: role
 metadata:
   name: api-role
@@ -48,9 +50,9 @@ spec:
 version: v5
 EOF
 # Create role
-tctl create -f api-role.yaml
+$ tctl create -f api-role.yaml
 # Add user and login via web proxy
-tctl users add api-user --roles=api-role
+$ tctl users add api-user --roles=api-role
 ```
 
 See our [roles](../access-controls/roles.mdx) documentation for more details


### PR DESCRIPTION
This code block in the API architecture doc was missing the `$` before the commands which [muted the text ](https://goteleport.com/docs/reference/architecture/api-architecture/#authorization)in the entire block. 

This commit adds the `$` before the commands. 

It also moves the text to "Copy and paste the below..." above, and out of, the code block which is a better place for it. Also adds a comment to "Create role configuration" above the first code command to complement the subsequent two comments.