### PR TITLE
[mcp][discover] add unguided link for sse and streamable-http transport

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources/resources.tsx
@@ -225,6 +225,16 @@ export const KUBERNETES: SelectResourceSpec[] = [
 
 export const MCP_SERVERS: SelectResourceSpec[] = [
   {
+    id: DiscoverGuideId.MCPServerStreamableHTTPTransport,
+    name: 'MCP Server with streamable-HTTP transport',
+    kind: ResourceKind.MCP,
+    keywords: [...mcpKeywords, 'streamable', 'http'],
+    icon: 'mcp',
+    event: DiscoverEventResource.MCPStreamableHTTP,
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/mcp-access/streamable-http/',
+  },
+  {
     id: DiscoverGuideId.MCPServerStdioTransport,
     name: 'MCP Server with stdio transport',
     kind: ResourceKind.MCP,
@@ -233,6 +243,16 @@ export const MCP_SERVERS: SelectResourceSpec[] = [
     event: DiscoverEventResource.MCPStdio,
     unguidedLink:
       'https://goteleport.com/docs/enroll-resources/mcp-access/stdio/',
+  },
+  {
+    id: DiscoverGuideId.MCPServerSSETransport,
+    name: 'MCP Server with the legacy SSE transport',
+    kind: ResourceKind.MCP,
+    keywords: [...mcpKeywords, 'sse'],
+    icon: 'mcp',
+    event: DiscoverEventResource.MCPSSE,
+    unguidedLink:
+      'https://goteleport.com/docs/enroll-resources/mcp-access/sse/',
   },
 ];
 

--- a/web/packages/teleport/src/services/userEvent/types.ts
+++ b/web/packages/teleport/src/services/userEvent/types.ts
@@ -230,6 +230,8 @@ export enum DiscoverEventResource {
   SamlApplication = 'DISCOVER_RESOURCE_SAML_APPLICATION',
 
   MCPStdio = 'DISCOVER_RESOURCE_MCP_STDIO',
+  MCPSSE = 'DISCOVER_RESOURCE_MCP_SSE',
+  MCPStreamableHTTP = 'DISCOVER_RESOURCE_MCP_STREAMABLE_HTTP',
 }
 
 export enum DiscoverEventStatus {

--- a/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
+++ b/web/packages/teleport/src/services/userPreferences/discoverPreference.ts
@@ -47,6 +47,8 @@ export enum DiscoverGuideId {
 
   // MCP Servers:
   MCPServerStdioTransport = 'mcp-stdio',
+  MCPServerSSETransport = 'mcp-sse',
+  MCPServerStreamableHTTPTransport = 'mcp-streamable-http',
 
   // Windows Desktops:
   WindowsDesktopsActiveDirectory = 'windows-desktops-active-directory',


### PR DESCRIPTION
related
- #56588
- #58880

<img width="1003" height="260" alt="Screenshot 2025-10-31 at 1 00 46 PM" src="https://github.com/user-attachments/assets/2115b036-1338-4a94-9fa9-714adc387523" />

event type already added in previous PR:
https://github.com/gravitational/teleport/blob/805bbc5015cd1596ee98b55f900521639da25b93/api/proto/teleport/usageevents/v1/usageevents.proto#L151-L153