### PR TITLE
docs: update Oracle join docs for permissionless join method

### DIFF
--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -17,8 +17,17 @@ The Oracle join method is available to any Teleport process running on an
 OCI Compute instance.
 
 Under the hood, services prove that they are running in your OCI tenant by
-sending a presigned self-authentication request to the OCI API for the Auth
-Service to execute.
+sending their signed OCI instance identity certificate to the Auth Service,
+along with a cryptographic signature proving ownership of the instance's
+private key.
+The Auth Service verifies the instance identity certificate was signed by
+Oracle's root CAs and that the signature is valid.
+The certificate verifies the instance's tenancy, compartment, and instance ID
+and matches them against rules configured in an Oracle joining token.
+
+Instances running a version older than Teleport v18.4.0 do not send the
+instance identity certificate, instead they send a presigned
+self-authentication request to the OCI API for the Auth Service to execute.
 
 ## Prerequisites
 
@@ -34,7 +43,9 @@ allow services from your OCI tenants to join your Teleport cluster.
 
 Create the following `token.yaml` file with an `oracle.allow` rule specifying
 the Oracle tenant(s), compartment(s), and region(s) in which your OCI
-Compute instances will run:
+Compute instances will run.
+In Teleport v18.4.0 or higher you can also specify exact compute instance OCIDs
+that will be allowed.
 
 (!docs/pages/includes/provision-token/oracle-spec.mdx!)
 
@@ -46,8 +57,14 @@ $ tctl create token.yaml
 
 ## Step 2/5. Configure permissions
 
-Every OCI Compute instance needs permission to authenticate itself with the
-Oracle Cloud API so the presigned request can succeed.
+On Teleport versions older than v18.4.0, every OCI compute instance needs IAM
+permissions to authenticate itself with the Oracle Cloud API.
+Newer Teleport versions do not require any permissions.
+The permissions are only required if either the Auth Service or the joining
+instance is running a Teleport version older than v18.4.0.
+
+<details>
+<summary>Configuring OCI IAM Permissions</summary>
 
 ### Create a dynamic group
 
@@ -83,6 +100,8 @@ Allow dynamic-group '<Var name="identity-domain" />'/'join-teleport' to inspect 
 ```
 
 ![Create policy](../../../img/oracle/oracle-join-policy@2x.png)
+
+</details>
 
 ## Step 3/5. Install Teleport
 

--- a/docs/pages/includes/provision-token/oracle-spec.mdx
+++ b/docs/pages/includes/provision-token/oracle-spec.mdx
@@ -16,12 +16,16 @@ spec:
   oracle:
     allow:
       # OCID of the tenancy to allow instances to join from. Required.
-      - tenancy: "ocid1.tenancy.oc1..<unique ID>"
+      - tenancy: "ocid1.tenancy.oc1..<unique_ID>"
         # (Optional) OCIDs of compartments to allow instances to join from. Only the direct parent
         # compartment applies; i.e. nested compartments are not taken into account.
         # If empty, instances can join from any compartment in the tenancy.
-        parent_compartments: ["ocid1.compartment.oc1...<unique_ID>"]
+        parent_compartments: ["ocid1.compartment.oc1..<unique_ID>"]
         # (Optional) Regions to allow instances to join from. Both full names ("us-phoenix-1")
         # and abbreviations ("phx") are allowed. If empty, instances can join from any region.
         regions: ["example-region"]
+        # (Optional) OCIDs of specific compute instances that should be allowed to join.
+        # If empty, any instance matching the other fields is allowed.
+        # The instances field is supported in Teleport v18.4.0+.
+        instances: ["ocid1.instance.oc1.<region>.<unique_ID>"]
 ```


### PR DESCRIPTION
This PR updates the oracle joining docs to reflect the changes made as a result of [RFD 231](https://github.com/gravitational/teleport/pull/60609). The only user-facing change is that the OCI IAM permissions are no longer necessary.

I also added mention of the new `instances` field that can be specified in oracle join tokens, to restrict joining to specific instances by ID.