### PR TITLE
Use access point for the watcher in the relay node watcher

### DIFF
--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -131,7 +131,7 @@ func (process *TeleportProcess) runRelayService() error {
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component:    teleport.ComponentRelay,
 			Logger:       sublogger("node_watcher"),
-			Client:       conn.Client,
+			Client:       accessPoint,
 			MaxStaleness: time.Minute,
 		},
 		NodesGetter: accessPoint,


### PR DESCRIPTION
This PR makes it so that the node watcher used by the Relay service uses the event stream from the local access point (i.e. the "cache") rather than opening stream through its connector to auth.