### PR TITLE
fix: deflake connection problem detection during joining

### DIFF
--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -24,11 +24,9 @@ import (
 	"errors"
 	"log/slog"
 	"os"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
-	"google.golang.org/grpc/status"
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
@@ -213,9 +211,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	defer cancel()
 	stream, err := client.Join(ctx)
 	if err != nil {
-		// Connection errors are usually delayed until the first request is
-		// attempted, wrap with a connectionError here to allow a fallback to
-		// the legacy join method.
+		// Connection errors may manifest when initiating the RPC.
 		return nil, &connectionError{trace.Wrap(err, "initiating join stream")}
 	}
 	defer stream.CloseSend()
@@ -227,13 +223,20 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 		TokenName:  params.Token,
 		SystemRole: params.ID.Role.String(),
 	}); err != nil {
-		return nil, trace.Wrap(err)
+		// Failing to send the first message on the stream is always a connection error.
+		return nil, &connectionError{trace.Wrap(err, "sending ClientInit message")}
 	}
 
 	// Receive the ServerInit message.
 	serverInit, err := messages.RecvResponse[*messages.ServerInit](stream)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		err = trace.Wrap(err, "receiving ServerInit message")
+		if !trace.IsAccessDenied(err) && !trace.IsBadParameter(err) {
+			// Any unrecognized error reading the first response on the stream
+			// is likely to be a connection error.
+			err = &connectionError{err}
+		}
+		return nil, err
 	}
 
 	// Generate keys based on the signature algorithm suite from the ServerInit message.
@@ -450,14 +453,7 @@ func (e *connectionError) Unwrap() error {
 
 func isConnectionError(err error) bool {
 	var ce *connectionError
-	if errors.As(err, &ce) {
-		return true
-	}
-	// It's possible to hit a gRPC status error like this when reading the
-	// first response from the stream if connecting in insecure mode to a proxy
-	// address provided as an auth address.
-	statusErr, ok := status.FromError(err)
-	return ok && strings.Contains(statusErr.Message(), "unexpected HTTP status code")
+	return errors.As(err, &ce)
 }
 
 // LegacyJoinError is returned when the join attempt failed while attempting to


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/60796

When joining a cluster and it's unknown if the address is a proxy or auth server, we try both. Since tests use a random port we always try to connect as if it's an auth server first, and fall back to connecting as if it's a proxy.
https://github.com/gravitational/teleport/pull/60673 made an attempt to return legitimate join failures immediately instead of falling back, but as the flaky tests have shown, it was not detecting some connection errors that require a fallback, specifically when the first write on the gRPC stream returns an error. It's basically only possible to hit this error when connecting in insecure mode to a proxy address with tls disabled on a non-default proxy port, as some of our tests do.

With this change, anything that could possibly be a connection error is returned as such, so that all fallbacks will be tried. This includes any error creating the gRPC client, any error initiating the gRPC stream, any error sending the first message on the stream, and any error that is not AccessDenied or BadParameter when receiving the first message from the stream.