### PR TITLE
[v17] Use gotestsum when running integrations tests

### DIFF
--- a/integrations/Makefile
+++ b/integrations/Makefile
@@ -3,11 +3,11 @@ test: test-access test-lib test-event-handler test-terraform-provider test-terra
 
 .PHONY: test-access
 test-access:
-	go test -v ./access/...
+	gotestsum ./access/...
 
 .PHONY: test-lib
 test-lib:
-	go test ./lib/...
+	gotestsum ./lib/...
 
 .PHONY: test-event-handler
 test-event-handler:

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -96,7 +96,7 @@ install: build
 
 .PHONY: test
 test:
-	go test -coverprofile=cover.out
+	gotestsum 
 
 .PHONY: configure
 configure: build

--- a/integrations/kube-agent-updater/Makefile
+++ b/integrations/kube-agent-updater/Makefile
@@ -10,7 +10,7 @@ ARCH ?= $(shell go env GOARCH)
 
 .PHONY: test
 test: pkg/img/cosign_fixtures_test.go
-	go test ./...
+	gotestsum ./...
 
 .PHONY: docker-build
 docker-build: ## Build docker image

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -142,7 +142,7 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet $(ENVTEST) crdgen-test ## Run tests.
 test: export KUBEBUILDER_ASSETS=$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)
 test:
-	go test ./... -coverprofile cover.out
+	gotestsum ./...
 
 .PHONY: echo-kubebuilder-assets
 echo-kubebuilder-assets:

--- a/integrations/terraform-mwi/Makefile
+++ b/integrations/terraform-mwi/Makefile
@@ -58,7 +58,7 @@ endif
 
 PHONY: test
 test:
-	go test -v -cover -timeout=120s -parallel=10 ./...
+	gotestsum -- -v -timeout=120s -parallel=10
 
 PHONY: testacc
 testacc:

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -175,7 +175,7 @@ ifeq ($(shell expr $(CURRENT_ULIMIT) \< 1024), 1)
 	@echo "ulimit -n is too low ($(CURRENT_ULIMIT)), please set ulimit -n 1024"
 	@exit -1
 endif
-	go test ./testlib -v $(TEST_ARGS)
+	gotestsum  -- ./testlib -v $(TEST_ARGS)
 
 .PHONY: test-full
 test-full: TEST_ARGS=--tags enterprisetests


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/60834 to branch/v17