### PR TITLE
[v17] Fix session recording truncation

### DIFF
--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -145,6 +145,11 @@ func (h *Handler) CompleteUpload(ctx context.Context, upload events.StreamUpload
 		return trace.Wrap(err)
 	}
 
+	// If there are no parts to complete, move to cleanup
+	if len(parts) == 0 {
+		return h.cleanupUpload(ctx, upload)
+	}
+
 	// Parts must be sorted in PartNumber order.
 	sort.Slice(parts, func(i, j int) bool {
 		return parts[i].Number < parts[j].Number
@@ -235,6 +240,22 @@ Loop:
 	if err != nil {
 		h.logger.ErrorContext(ctx, "Failed to remove upload", "upload_id", upload.ID)
 	}
+	return nil
+}
+
+func (h *Handler) cleanupUpload(ctx context.Context, upload events.StreamUpload) error {
+	uploadKey := h.path(upload.SessionID)
+	log := h.logger.With(
+		"upload", upload.ID,
+		"session", upload.SessionID,
+		"key", uploadKey,
+	)
+	log.DebugContext(ctx, "Aborting upload")
+	if err := os.RemoveAll(h.uploadRootPath(upload)); err != nil {
+		h.logger.ErrorContext(ctx, "Failed to remove upload", "upload_id", upload.ID)
+	}
+
+	log.InfoContext(ctx, "Aborted upload")
 	return nil
 }
 

--- a/lib/events/filesessions/filestream_test.go
+++ b/lib/events/filesessions/filestream_test.go
@@ -126,14 +126,6 @@ func TestCompleteUpload(t *testing.T) {
 				createPart(t, handler, upload, int64(5), []byte("withreservation"))
 			},
 		},
-		{
-			desc:            "OnlyReservation",
-			expectedContent: []byte{},
-			partsFunc: func(t *testing.T, handler *Handler, upload *events.StreamUpload) {
-				createPart(t, handler, upload, int64(1), []byte{})
-				createPart(t, handler, upload, int64(2), []byte{})
-			},
-		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			handler, err := NewHandler(Config{
@@ -168,4 +160,48 @@ func TestCompleteUpload(t *testing.T) {
 			require.True(t, os.IsNotExist(err))
 		})
 	}
+}
+
+func TestCleanupEmptyUpload(t *testing.T) {
+	ctx := t.Context()
+
+	handler, err := NewHandler(Config{
+		Directory: t.TempDir(),
+	})
+	require.NoError(t, err)
+
+	sessionID := session.NewID()
+
+	// Create a completed upload.
+	upload, err := handler.CreateUpload(ctx, sessionID)
+	require.NoError(t, err)
+
+	err = handler.ReserveUploadPart(ctx, *upload, 1)
+	require.NoError(t, err)
+
+	content := []byte("hello world")
+	part, err := handler.UploadPart(ctx, *upload, 1, bytes.NewReader(content))
+	require.NoError(t, err)
+
+	err = handler.CompleteUpload(ctx, *upload, []events.StreamPart{*part})
+	require.NoError(t, err)
+
+	// Create an empty upload with the same session ID and try to complete it.
+	emptyUpload, err := handler.CreateUpload(ctx, sessionID)
+	require.NoError(t, err)
+
+	err = handler.CompleteUpload(ctx, *emptyUpload, []events.StreamPart{})
+	require.NoError(t, err)
+
+	// The empty upload should be cleaned up without impacting the original completed upload.
+	uploadPath := handler.path(upload.SessionID)
+	f, err := os.Open(uploadPath)
+	require.NoError(t, err)
+
+	gotContent, err := io.ReadAll(f)
+	require.NoError(t, err)
+	require.Equal(t, content, gotContent)
+
+	require.NoDirExists(t, handler.uploadRootPath(*upload))
+	require.NoDirExists(t, handler.uploadRootPath(*emptyUpload))
 }


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/60891 to branch/v17

changelog: fix an issue which could lead to session recordings saved on disk being truncated.