### PR TITLE
[v18] kube: register metrics api resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -266,6 +266,7 @@ require (
 	k8s.io/component-base v0.33.3
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/kubectl v0.33.3
+	k8s.io/metrics v0.33.3
 	k8s.io/utils v0.0.0-20241210054802-24370beab758
 	sigs.k8s.io/controller-runtime v0.20.4
 	sigs.k8s.io/controller-tools v0.17.1
@@ -601,7 +602,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	k8s.io/component-helpers v0.33.3 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/metrics v0.33.3 // indirect
 	mvdan.cc/sh/v3 v3.7.0 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -522,6 +522,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/kubectl v0.33.3 // indirect
+	k8s.io/metrics v0.33.3 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	mvdan.cc/sh/v3 v3.7.0 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -1762,6 +1762,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.33.3 h1:r/phHvH1iU7gO/l7tTjQk2K01ER7/OAJi8uFHHyWSac=
 k8s.io/kubectl v0.33.3/go.mod h1:euj2bG56L6kUGOE/ckZbCoudPwuj4Kud7BR0GzyNiT0=
+k8s.io/metrics v0.33.3 h1:9CcqBz15JZfISqwca33gdHS8I6XfsK1vA8WUdEnG70g=
+k8s.io/metrics v0.33.3/go.mod h1:Aw+cdg4AYHw0HvUY+lCyq40FOO84awrqvJRTw0cmXDs=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -522,6 +522,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
 	k8s.io/kubectl v0.33.3 // indirect
+	k8s.io/metrics v0.33.3 // indirect
 	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	mvdan.cc/sh/v3 v3.7.0 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -2112,6 +2112,8 @@ k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff h1:/usPimJzUKKu+m+TE36gUy
 k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff/go.mod h1:5jIi+8yX4RIb8wk3XwBo5Pq2ccx4FP10ohkbSKCZoK8=
 k8s.io/kubectl v0.33.3 h1:r/phHvH1iU7gO/l7tTjQk2K01ER7/OAJi8uFHHyWSac=
 k8s.io/kubectl v0.33.3/go.mod h1:euj2bG56L6kUGOE/ckZbCoudPwuj4Kud7BR0GzyNiT0=
+k8s.io/metrics v0.33.3 h1:9CcqBz15JZfISqwca33gdHS8I6XfsK1vA8WUdEnG70g=
+k8s.io/metrics v0.33.3/go.mod h1:Aw+cdg4AYHw0HvUY+lCyq40FOO84awrqvJRTw0cmXDs=
 k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
 k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=

--- a/lib/kube/proxy/scheme.go
+++ b/lib/kube/proxy/scheme.go
@@ -38,6 +38,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/metrics/pkg/apis/metrics"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
 const (
@@ -69,6 +71,15 @@ func init() {
 func registerDefaultKubeTypes(s *runtime.Scheme) error {
 	// Register external types for Scheme
 	metav1.AddToGroupVersion(s, schema.GroupVersion{Group: "", Version: "v1"})
+
+	if err := metrics.AddToScheme(s); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := metricsv1beta1.AddToScheme(s); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := metav1.AddMetaToScheme(s); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/kube/proxy/scheme_test.go
+++ b/lib/kube/proxy/scheme_test.go
@@ -22,9 +22,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/metrics/pkg/apis/metrics"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
@@ -60,4 +65,77 @@ func (c *clientSet) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.AP
 	return nil, []*metav1.APIResourceList{
 		&fakeAPIResource,
 	}, nil
+}
+
+func TestRegisterDefaultKubeTypes(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := registerDefaultKubeTypes(scheme)
+	require.NoError(t, err)
+
+	// Check that some known types are registered
+	tests := []struct {
+		gvk          schema.GroupVersionKind
+		expectedType runtime.Object
+	}{
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"},
+			expectedType: &corev1.Pod{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"},
+			expectedType: &corev1.PodList{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "PodMetrics"},
+			expectedType: &metricsv1beta1.PodMetrics{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "metrics.k8s.io", Version: "v1beta1", Kind: "NodeMetrics"},
+			expectedType: &metricsv1beta1.NodeMetrics{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "metrics.k8s.io", Version: runtime.APIVersionInternal, Kind: "PodMetrics"},
+			expectedType: &metrics.PodMetrics{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "metrics.k8s.io", Version: runtime.APIVersionInternal, Kind: "NodeMetrics"},
+			expectedType: &metrics.NodeMetrics{},
+		},
+
+		// --- metav1 types ---
+		{
+			gvk:          schema.GroupVersionKind{Group: "meta.k8s.io", Version: "v1", Kind: "PartialObjectMetadata"},
+			expectedType: &metav1.PartialObjectMetadata{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "meta.k8s.io", Version: "v1", Kind: "PartialObjectMetadataList"},
+			expectedType: &metav1.PartialObjectMetadataList{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Status"},
+			expectedType: &metav1.Status{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "APIVersions"},
+			expectedType: &metav1.APIVersions{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "APIGroupList"},
+			expectedType: &metav1.APIGroupList{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "APIGroup"},
+			expectedType: &metav1.APIGroup{},
+		},
+		{
+			gvk:          schema.GroupVersionKind{Group: "", Version: "v1", Kind: "APIResourceList"},
+			expectedType: &metav1.APIResourceList{},
+		},
+	}
+
+	for _, testCase := range tests {
+		newType, err := scheme.New(testCase.gvk)
+		require.NoError(t, err, "expected type %v to be registered", testCase.gvk)
+		require.IsType(t, testCase.expectedType, newType, "expected type %v to be of type %T", testCase.gvk, testCase.expectedType)
+	}
 }


### PR DESCRIPTION
Backport of #60683 to branch/v18

Changelog: Fixed Kubernetes metrics API unmarshaling errors causing kubectl top commands to fail in certain scenarios.