### PR TITLE
[v17] Fix wrong typing in `GenericWatcher` and `services/readonly`

### DIFF
--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -55,6 +55,8 @@ type AuthPreference interface {
 	Clone() types.AuthPreference
 }
 
+var _ AuthPreference = types.AuthPreference(nil)
+
 type sealedAuthPreference struct {
 	AuthPreference
 }
@@ -78,6 +80,8 @@ type ClusterNetworkingConfig interface {
 	Clone() types.ClusterNetworkingConfig
 }
 
+var _ ClusterNetworkingConfig = types.ClusterNetworkingConfig(nil)
+
 type sealedClusterNetworkingConfig struct {
 	ClusterNetworkingConfig
 }
@@ -99,6 +103,8 @@ type SessionRecordingConfig interface {
 	GetProxyChecksHostKeys() bool
 	Clone() types.SessionRecordingConfig
 }
+
+var _ SessionRecordingConfig = types.SessionRecordingConfig(nil)
 
 type sealedSessionRecordingConfig struct {
 	SessionRecordingConfig
@@ -122,7 +128,7 @@ type AccessGraphSettings interface {
 }
 
 type sealedAccessGraphSettings struct {
-	*clusterconfigpb.AccessGraphSettings
+	settings *clusterconfigpb.AccessGraphSettings
 }
 
 // sealAccessGraphSettings returns a read-only version of the SessionRecordingConfig.
@@ -135,11 +141,11 @@ func sealAccessGraphSettings(c *clusterconfigpb.AccessGraphSettings) AccessGraph
 }
 
 func (a sealedAccessGraphSettings) SecretsScanConfig() clusterconfigpb.AccessGraphSecretsScanConfig {
-	return a.GetSpec().GetSecretsScanConfig()
+	return a.settings.GetSpec().GetSecretsScanConfig()
 }
 
 func (a sealedAccessGraphSettings) Clone() *clusterconfigpb.AccessGraphSettings {
-	return protobuf.Clone(a.AccessGraphSettings).(*clusterconfigpb.AccessGraphSettings)
+	return protobuf.CloneOf(a.settings)
 }
 
 // Resource is a read only variant of [types.Resource].
@@ -160,12 +166,16 @@ type Resource interface {
 	GetRevision() string
 }
 
+var _ Resource = types.Resource(nil)
+
 // ResourceWithOrigin is a read only variant of [types.ResourceWithOrigin].
 type ResourceWithOrigin interface {
 	Resource
 	// Origin returns the origin value of the resource.
 	Origin() string
 }
+
+var _ ResourceWithOrigin = types.ResourceWithOrigin(nil)
 
 // ResourceWithLabels is a read only variant of [types.ResourceWithLabels].
 type ResourceWithLabels interface {
@@ -180,6 +190,8 @@ type ResourceWithLabels interface {
 	// and tries to match against the list of search values.
 	MatchSearch(searchValues []string) bool
 }
+
+var _ ResourceWithLabels = types.ResourceWithLabels(nil)
 
 // Application is a read only variant of [types.Application].
 type Application interface {
@@ -230,6 +242,8 @@ type Application interface {
 	GetCORS() *types.CORSPolicy
 }
 
+var _ Application = types.Application(nil)
+
 // KubeServer is a read only variant of [types.KubeServer].
 type KubeServer interface {
 	// ResourceWithLabels provides common resource methods.
@@ -255,6 +269,8 @@ type KubeServer interface {
 	// GetProxyIDs returns a list of proxy ids this service is connected to.
 	GetProxyIDs() []string
 }
+
+var _ KubeServer = types.KubeServer(nil)
 
 // KubeCluster is a read only variant of [types.KubeCluster].
 type KubeCluster interface {
@@ -292,6 +308,8 @@ type KubeCluster interface {
 	// isn't running on a cloud provider.
 	GetCloud() string
 }
+
+var _ KubeCluster = types.KubeCluster(nil)
 
 // Database is a read only variant of [types.Database].
 type Database interface {
@@ -381,6 +399,8 @@ type Database interface {
 	IsUsernameCaseInsensitive() bool
 }
 
+var _ Database = types.Database(nil)
+
 // Server is a read only variant of [types.Server].
 type Server interface {
 	// ResourceWithLabels provides common resource headers
@@ -440,6 +460,8 @@ type Server interface {
 	GetGitHub() *types.GitHubServerMetadata
 }
 
+var _ Server = types.Server(nil)
+
 // DynamicWindowsDesktop represents a Windows desktop host that is automatically discovered by Windows Desktop Service.
 type DynamicWindowsDesktop interface {
 	// ResourceWithLabels provides common resource methods.
@@ -458,3 +480,5 @@ type DynamicWindowsDesktop interface {
 	// Copy returns a copy of this dynamic Windows desktop
 	Copy() *types.DynamicWindowsDesktopV1
 }
+
+var _ DynamicWindowsDesktop = types.DynamicWindowsDesktop(nil)

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -400,17 +400,21 @@ func NewProxyWatcher(ctx context.Context, cfg ProxyWatcherConfig) (*GenericWatch
 		cfg.ProxyDiffer = func(old, new types.Server) bool { return true }
 	}
 
+	proxyGetter := cfg.ProxyGetter
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.Server, readonly.Server]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindProxy,
 		ResourceKey:           types.Server.GetName,
 		ResourceGetter: func(ctx context.Context) ([]types.Server, error) {
-			return cfg.ProxyGetter.GetProxies()
+			return proxyGetter.GetProxies()
 		},
 		ResourcesC:                          cfg.ProxiesC,
 		ResourceDiffer:                      cfg.ProxyDiffer,
 		RequireResourcesForInitialBroadcast: true,
 		CloneFunc:                           types.Server.DeepCopy,
+		ReadOnlyFunc: func(resource types.Server) readonly.Server {
+			return resource
+		},
 	})
 	return w, trace.Wrap(err)
 }
@@ -435,12 +439,13 @@ func NewDatabaseWatcher(ctx context.Context, cfg DatabaseWatcherConfig) (*Generi
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindDatabase,
 		ResourceKey:           types.Database.GetName,
-		ResourceGetter: func(ctx context.Context) ([]types.Database, error) {
-			return cfg.DatabaseGetter.GetDatabases(ctx)
-		},
-		ResourcesC: cfg.DatabasesC,
+		ResourceGetter:        cfg.DatabaseGetter.GetDatabases,
+		ResourcesC:            cfg.DatabasesC,
 		CloneFunc: func(resource types.Database) types.Database {
 			return resource.Copy()
+		},
+		ReadOnlyFunc: func(resource types.Database) readonly.Database {
+			return resource
 		},
 	})
 	return w, trace.Wrap(err)
@@ -466,12 +471,13 @@ func NewAppWatcher(ctx context.Context, cfg AppWatcherConfig) (*GenericWatcher[t
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindApp,
 		ResourceKey:           types.Application.GetName,
-		ResourceGetter: func(ctx context.Context) ([]types.Application, error) {
-			return cfg.AppGetter.GetApps(ctx)
-		},
-		ResourcesC: cfg.AppsC,
+		ResourceGetter:        cfg.AppGetter.GetApps,
+		ResourcesC:            cfg.AppsC,
 		CloneFunc: func(resource types.Application) types.Application {
 			return resource.Copy()
+		},
+		ReadOnlyFunc: func(resource types.Application) readonly.Application {
+			return resource
 		},
 	})
 
@@ -495,14 +501,15 @@ func NewKubeServerWatcher(ctx context.Context, cfg KubeServerWatcherConfig) (*Ge
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.KubeServer, readonly.KubeServer]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindKubeServer,
-		ResourceGetter: func(ctx context.Context) ([]types.KubeServer, error) {
-			return cfg.KubernetesServerGetter.GetKubernetesServers(ctx)
-		},
+		ResourceGetter:        cfg.KubernetesServerGetter.GetKubernetesServers,
 		ResourceKey: func(resource types.KubeServer) string {
 			return resource.GetHostID() + resource.GetName()
 		},
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.KubeServer.Copy,
+		ReadOnlyFunc: func(resource types.KubeServer) readonly.KubeServer {
+			return resource
+		},
 	})
 	return w, trace.Wrap(err)
 }
@@ -523,20 +530,24 @@ func NewKubeClusterWatcher(ctx context.Context, cfg KubeClusterWatcherConfig) (*
 		return nil, trace.BadParameter("KubernetesClusterGetter must be provided")
 	}
 
+	getter := cfg.KubernetesClusterGetter
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.KubeCluster, readonly.KubeCluster]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindKubernetesCluster,
 		ResourceGetter: func(ctx context.Context) ([]types.KubeCluster, error) {
 			return clientutils.CollectWithFallback(
 				ctx,
-				cfg.KubernetesClusterGetter.ListKubernetesClusters,
-				cfg.KubernetesClusterGetter.GetKubernetesClusters,
+				getter.ListKubernetesClusters,
+				getter.GetKubernetesClusters,
 			)
 		},
 		ResourceKey: types.KubeCluster.GetName,
 		ResourcesC:  cfg.KubeClustersC,
 		CloneFunc: func(resource types.KubeCluster) types.KubeCluster {
 			return resource.Copy()
+		},
+		ReadOnlyFunc: func(resource types.KubeCluster) readonly.KubeCluster {
+			return resource
 		},
 	})
 	return w, trace.Wrap(err)
@@ -561,7 +572,7 @@ func NewDynamicWindowsDesktopWatcher(ctx context.Context, cfg DynamicWindowsDesk
 	if cfg.DynamicWindowsDesktopGetter == nil {
 		return nil, trace.BadParameter("DynamicWindowsDesktopGetter must be provided")
 	}
-
+	getter := cfg.DynamicWindowsDesktopGetter
 	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.DynamicWindowsDesktop, readonly.DynamicWindowsDesktop]{
 		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
 		ResourceKind:          types.KindDynamicWindowsDesktop,
@@ -569,7 +580,7 @@ func NewDynamicWindowsDesktopWatcher(ctx context.Context, cfg DynamicWindowsDesk
 			var desktops []types.DynamicWindowsDesktop
 			next := ""
 			for {
-				d, token, err := cfg.DynamicWindowsDesktopGetter.ListDynamicWindowsDesktops(ctx, defaults.MaxIterationLimit, next)
+				d, token, err := getter.ListDynamicWindowsDesktops(ctx, defaults.MaxIterationLimit, next)
 				if err != nil {
 					return nil, err
 				}
@@ -585,6 +596,9 @@ func NewDynamicWindowsDesktopWatcher(ctx context.Context, cfg DynamicWindowsDesk
 		ResourcesC:  cfg.DynamicWindowsDesktopsC,
 		CloneFunc: func(resource types.DynamicWindowsDesktop) types.DynamicWindowsDesktop {
 			return resource.Copy()
+		},
+		ReadOnlyFunc: func(resource types.DynamicWindowsDesktop) readonly.DynamicWindowsDesktop {
+			return resource
 		},
 	})
 	return w, trace.Wrap(err)
@@ -608,6 +622,11 @@ type GenericWatcherConfig[T any, R any] struct {
 	// or [GenericWatcher.CurrentResourcesWithFilter] will be cloned by this
 	// mechanism before being provided to callers.
 	CloneFunc func(resource T) T
+	// ReadOnlyFunc returns the read-only view of a resource. Ideally this will
+	// be a type conversion (but we can't statically express that as constraints
+	// on T and R) but it's also possible to wrapper the original resource.
+	// Making the read-only view should be much cheaper than CloneFunc.
+	ReadOnlyFunc func(resource T) R
 	ResourceWatcherConfig
 	// ResourceKind specifies the kind of resource the watcher is monitoring.
 	ResourceKind string
@@ -637,6 +656,13 @@ func (cfg *GenericWatcherConfig[T, R]) CheckAndSetDefaults() error {
 
 	if cfg.ResourceKey == nil {
 		return trace.BadParameter("ResourceKey not provided to generic resource watcher")
+	}
+
+	if cfg.CloneFunc == nil {
+		return trace.BadParameter("CloneFunc not provided to generic resource watcher")
+	}
+	if cfg.ReadOnlyFunc == nil {
+		return trace.BadParameter("ReadOnlyFunc not provided to generic resource watcher")
 	}
 
 	if cfg.ResourceDiffer == nil {
@@ -713,13 +739,9 @@ func (g *GenericWatcher[T, R]) CurrentResourcesWithFilter(ctx context.Context, f
 	g.rw.RLock()
 	defer g.rw.RUnlock()
 
-	r := func(a any) R {
-		return a.(R)
-	}
-
 	var out []T
 	for _, resource := range g.current {
-		if filter(r(resource)) {
+		if filter(g.ReadOnlyFunc(resource)) {
 			out = append(out, g.CloneFunc(resource))
 		}
 	}
@@ -727,7 +749,8 @@ func (g *GenericWatcher[T, R]) CurrentResourcesWithFilter(ctx context.Context, f
 	return out, nil
 }
 
-// genericCollector accompanies resourceWatcher when monitoring proxies.
+// genericCollector accompanies resourceWatcher when monitoring proxies. T is
+// the resource type, R is a read-only view over T.
 type genericCollector[T any, R any] struct {
 	GenericWatcherConfig[T, R]
 	// current holds a map of the currently known resources (keyed by server name,
@@ -1385,6 +1408,9 @@ func NewNodeWatcher(ctx context.Context, cfg NodeWatcherConfig) (*GenericWatcher
 		ResourceKey:            types.Server.GetName,
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.Server.DeepCopy,
+		ReadOnlyFunc: func(resource types.Server) readonly.Server {
+			return resource
+		},
 	})
 	return w, trace.Wrap(err)
 }
@@ -1748,6 +1774,9 @@ func NewGitServerWatcher(ctx context.Context, cfg GitServerWatcherConfig) (*Gene
 		ResourceKey:            types.Server.GetName,
 		DisableUpdateBroadcast: !cfg.EnableUpdateBroadcast,
 		CloneFunc:              types.Server.DeepCopy,
+		ReadOnlyFunc: func(resource types.Server) readonly.Server {
+			return resource
+		},
 	})
 	return w, trace.Wrap(err)
 }


### PR DESCRIPTION
Backport #60943 to branch/v17