### PR TITLE
Ensure we don't generate an invalid CRL distribution point

### DIFF
--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -302,7 +302,7 @@ func crlContainerDN(domain string, caType types.CertAuthType) string {
 func CRLCN(issuerCN string, issuerSKID []byte) string {
 	name := issuerCN
 	if len(issuerSKID) > 0 {
-		id := base32.HexEncoding.EncodeToString(issuerSKID)
+		id := base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(issuerSKID)
 		name = id + "_" + name
 	}
 	// The limit on the CN attribute should be 64 characters, but in practice

--- a/lib/winpki/windows_test.go
+++ b/lib/winpki/windows_test.go
@@ -71,6 +71,14 @@ func TestCRLDN(t *testing.T) {
 			crlDN:       "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPV8DQ_example.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
+			name:        "user CA with SKID requiring padding",
+			clusterName: "example.com",
+			caType:      types.UserCA,
+			// This test makes sure we don't corrupt the DN with base32 padding in the even the SKID is not exactly 20 bytes long.
+			issuerSKID: []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f},
+			crlDN:      "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPU_example.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+		},
+		{
 			name:        "long CN truncated",
 			clusterName: "reallylongclustername.goteleport.com",
 			caType:      types.UserCA,


### PR DESCRIPTION
The CRL distribution point for Windows desktop and database certs includes the base32 encoded SKID of the issuer. We need to perform the base32 encoding _without_ padding in order to avoid corrupting the DN with extra '=' characters.

In practice, this hasn't been a problem since the SKID is always 20 bytes in length (so no padding is necessary), but nothing guarantees this won't change in the future.

Special thanks to @espadolini for the find.