### PR TITLE
Update link to self-signed etcd certs in CoreOS docs

### DIFF
--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -145,7 +145,7 @@ teleport:
      # Required path to TLS client certificate and key files to connect to etcd.
      #
      # To create these, follow
-     # https://coreos.com/os/docs/latest/generate-self-signed-certificates.html
+     # https://github.com/coreos/docs/blob/master/os/generate-self-signed-certificates.md
      # or use the etcd-provided script
      # https://github.com/etcd-io/etcd/tree/master/hack/tls-setup.
      tls_cert_file: /var/lib/teleport/etcd-cert.pem


### PR DESCRIPTION
The old link no longer works. This was caught by Tiago during an S1. He also sent me the correct link to the archived docs. There's no other links to coreos.com in our docs.

[Zendesk ticket](https://gravitational.zendesk.com/agent/tickets/15772)