### PR TITLE
[v17] Update Connect gateway docs to mention background mode 

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -165,7 +165,9 @@ Teleport Connect can run in the background (via the menu bar or system tray),
 so you can continue using VNet and connections to databases, Kubernetes clusters,
 and apps without keeping the main window open.
 
-See [the `runInBackground` configuration option](#configuration).
+The first time you close the window, the app will ask you whether to run in background mode
+or quit when closing the window.
+To change this behavior later, see [the `runInBackground` configuration option](#configuration).
 
 ## Connecting to an SSH server
 
@@ -239,8 +241,11 @@ A new tab will open with a new connection established between your device and th
 
 Alternatively, you can look for the database in the search bar and press `Enter` to connect to it.
 
-This connection will remain active until you click the Close Connection button or close Teleport
-Connect. The port number will persist between app restarts—you can set up your favorite client
+The connection is active while Teleport Connect is running.
+If [the background mode](#background-mode) is on, it remains active even after you close the window.
+To end the connection, click Close Connection or quit the app.
+
+The port number will persist between app restarts—you can set up your client
 without worrying about the port suddenly changing.
 
 ### With a GUI client
@@ -329,8 +334,11 @@ press `Enter` to set up a connection to it.
 
 A new tab will open with a new connection established between your device and the application.
 
-This connection will remain active until you click the Close Connection button or close Teleport
-Connect. The port number will persist between app restarts—you can set up your favorite client
+The connection is active while Teleport Connect is running.
+If [the background mode](#background-mode) is on, it remains active even after you close the window.
+To end the connection, click Close Connection or quit the app.
+
+The port number will persist between app restarts—you can set up your client
 without worrying about the port suddenly changing.
 
 The application connection tab shows an example command that can be used to query the application.
@@ -417,10 +425,12 @@ completely remove it. Manually logging out of the cluster will remove the agent 
 
 ![Connect My Computer status](../../img/use-teleport/connect-my-computer-status@2x.png)
 
-Your computer will be shared while Teleport Connect is open. To stop sharing, close Teleport Connect
-or stop the agent through the Connect My Computer tab. Sharing will resume on app restart, unless
-you stop the agent before exiting. The agent stops immediately if Teleport Connect unexpectedly
-crashes.
+Your computer will be shared while Teleport Connect is running.
+If [the background mode](#background-mode) is on, it remains shared even after you close the window.
+To stop sharing, quit the app or stop the agent through the Connect My Computer tab.
+
+Sharing will resume on app restart, unless you stop the agent before exiting.
+The agent stops immediately if Teleport Connect unexpectedly crashes.
 
 ### Agent maintenance
 


### PR DESCRIPTION
Backport #60939 to branch/v17

Manual backport because there's no MCP in v17.