### PR TITLE
tctl resource: convert accesslist handler

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -41,7 +41,6 @@ import (
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/label"
 	"github.com/gravitational/teleport/api/types/secreports"
@@ -1061,32 +1060,6 @@ func (c *serverInfoCollection) WriteText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Labels"})
 	for _, si := range c.serverInfos {
 		t.AddRow([]string{si.GetName(), printMetadataLabels(si.GetNewLabels())})
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type accessListCollection struct {
-	accessLists []*accesslist.AccessList
-}
-
-func (c *accessListCollection) Resources() []types.Resource {
-	r := make([]types.Resource, len(c.accessLists))
-	for i, resource := range c.accessLists {
-		r[i] = resource
-	}
-	return r
-}
-
-func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
-	for _, al := range c.accessLists {
-		t.AddRow([]string{
-			al.GetName(),
-			al.Spec.Title,
-			al.Spec.Audit.Recurrence.Frequency.String(),
-			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
-		})
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -54,7 +54,6 @@ import (
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/api/utils/clientutils"
@@ -141,7 +140,6 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindIntegration:                 rc.createIntegration,
 		types.KindWindowsDesktop:              rc.createWindowsDesktop,
 		types.KindDynamicWindowsDesktop:       rc.createDynamicWindowsDesktop,
-		types.KindAccessList:                  rc.createAccessList,
 		types.KindAuditQuery:                  rc.createAuditQuery,
 		types.KindSecurityReport:              rc.createSecurityReport,
 		types.KindServerInfo:                  rc.createServerInfo,
@@ -1195,30 +1193,6 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authcl
 	return nil
 }
 
-func (rc *ResourceCommand) createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	accessList, err := services.UnmarshalAccessList(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	_, err = client.AccessListClient().GetAccessList(ctx, accessList.GetName())
-	if err != nil && !trace.IsNotFound(err) {
-		return trace.Wrap(err)
-	}
-	exists := (err == nil)
-
-	if exists && !rc.IsForced() {
-		return trace.AlreadyExists("Access list %q already exists", accessList.GetName())
-	}
-
-	if _, err := client.AccessListClient().UpsertAccessList(ctx, accessList); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("Access list %q has been %s\n", accessList.GetName(), UpsertVerb(exists, rc.IsForced()))
-
-	return nil
-}
-
 func (rc *ResourceCommand) createServerInfo(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	si, err := services.UnmarshalServerInfo(raw.Raw, services.DisallowUnknown())
 	if err != nil {
@@ -1553,11 +1527,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("User group %q has been deleted\n", rc.ref.Name)
-	case types.KindAccessList:
-		if err := client.AccessListClient().DeleteAccessList(ctx, rc.ref.Name); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("Access list %q has been deleted\n", rc.ref.Name)
 	case types.KindAuditQuery:
 		if err := client.SecReportsClient().DeleteSecurityAuditQuery(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)
@@ -2301,17 +2270,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &serverInfoCollection{serverInfos: serverInfos}, nil
-	case types.KindAccessList:
-		if rc.ref.Name != "" {
-			resource, err := client.AccessListClient().GetAccessList(ctx, rc.ref.Name)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return &accessListCollection{accessLists: []*accesslist.AccessList{resource}}, nil
-		}
-		accessLists, err := client.AccessListClient().GetAccessLists(ctx)
-
-		return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
 	case types.KindVnetConfig:
 		vnetConfig, err := client.VnetConfigServiceClient().GetVnetConfig(ctx, &vnet.GetVnetConfigRequest{})
 		if err != nil {

--- a/tool/tctl/common/resources/accesslist.go
+++ b/tool/tctl/common/resources/accesslist.go
@@ -1,0 +1,131 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type accessListCollection struct {
+	accessLists []*accesslist.AccessList
+}
+
+func (c *accessListCollection) Resources() []types.Resource {
+	r := make([]types.Resource, len(c.accessLists))
+	for i, resource := range c.accessLists {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *accessListCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Title", "Review Frequency", "Next Audit Date"})
+	for _, al := range c.accessLists {
+		t.AddRow([]string{
+			al.GetName(),
+			al.Spec.Title,
+			al.Spec.Audit.Recurrence.Frequency.String(),
+			al.Spec.Audit.NextAuditDate.Format(time.RFC822),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func accessListHandler() Handler {
+	return Handler{
+		getHandler:    getAccessList,
+		createHandler: createAccessList,
+		deleteHandler: deleteAccessList,
+		singleton:     false,
+		mfaRequired:   true,
+		description:   "Used to grant roles or traits to users or other lists. Part of Identity Governance.",
+	}
+}
+
+// getAccessList implements `tctl get accesslist/my-list` command.
+func getAccessList(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		resource, err := client.AccessListClient().GetAccessList(ctx, ref.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &accessListCollection{accessLists: []*accesslist.AccessList{resource}}, nil
+	}
+
+	accessLists, err := stream.Collect(
+		clientutils.Resources(ctx, func(ctx context.Context, size int, token string) ([]*accesslist.AccessList, string, error) {
+			return client.AccessListClient().ListAccessListsV2(ctx,
+				&accesslistv1.ListAccessListsV2Request{
+					PageSize:  int32(size),
+					PageToken: token,
+				})
+		}),
+	)
+
+	return &accessListCollection{accessLists: accessLists}, trace.Wrap(err)
+
+}
+
+// createAccessList implements `tctl create accesslist/my-list` command.
+func createAccessList(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	accessList, err := services.UnmarshalAccessList(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = client.AccessListClient().GetAccessList(ctx, accessList.GetName())
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+	exists := (err == nil)
+
+	if exists && !opts.Force {
+		return trace.AlreadyExists("Access list %q already exists", accessList.GetName())
+	}
+
+	if _, err := client.AccessListClient().UpsertAccessList(ctx, accessList); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Access list %q has been %s\n", accessList.GetName(), upsertVerb(exists, opts.Force))
+
+	return nil
+
+}
+
+// deleteAccessList implements `tctl rm accesslist/my-list` command.
+func deleteAccessList(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.AccessListClient().DeleteAccessList(ctx, ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Access list %q has been deleted\n", ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -35,6 +35,7 @@ func Handlers() map[string]Handler {
 	// When adding resources, please keep the map alphabetically ordered.
 	return map[string]Handler{
 		types.KindAccessGraphSettings:                accessGraphSettingsHandler(),
+		types.KindAccessList:                         accessListHandler(),
 		types.KindAccessRequest:                      accessRequestHandler(),
 		types.KindApp:                                appHandler(),
 		types.KindAppServer:                          appServerHandler(),


### PR DESCRIPTION
Convert `accesslist` to the new tctl resource handler format that was introduced in https://github.com/gravitational/teleport/pull/59518

Also makes `tctl get accesslists` use the paginated API.

Part of: https://github.com/gravitational/teleport/issues/60370