### PR TITLE
Remove extra skeleton component from Audit page

### DIFF
--- a/web/packages/teleport/src/Audit/Audit.tsx
+++ b/web/packages/teleport/src/Audit/Audit.tsx
@@ -21,6 +21,7 @@ import styled from 'styled-components';
 
 import { Box, ButtonSecondary, Flex } from 'design';
 import { Danger } from 'design/Alert';
+import { SearchPanel } from 'shared/components/Search';
 import { useInfiniteScroll } from 'shared/hooks';
 
 import { ExternalAuditStorageCta } from '@gravitational/teleport/src/components/ExternalAuditStorageCta';
@@ -113,20 +114,25 @@ export function Audit(props: State) {
         />
       )}
       {errorMessage && <Danger>{errorMessage}</Danger>}
-      {isLoading && events.length === 0 && (
-        <Box mt={2}>
-          <EventListSkeleton />
-        </Box>
-      )}
       <Box mt={2}>
-        <EventList
-          events={events}
-          search={search}
-          setSearch={setSearch}
-          sort={sort}
-          setSort={setSort}
+        <SearchPanel
+          updateSearch={setSearch}
+          updateQuery={null}
+          hideAdvancedSearch={true}
+          filter={{ search }}
         />
-        {isFetchingNextPage && <EventListSkeleton />}
+        {!isLoading && (
+          <EventList
+            events={events}
+            search={search}
+            setSearch={setSearch}
+            sort={sort}
+            setSort={setSort}
+          />
+        )}
+        {((isLoading && events.length === 0) || isFetchingNextPage) && (
+          <EventListSkeleton />
+        )}
         <div ref={setTrigger} />
         {isError && events.length > 0 && !isLoading && (
           <Box mt={2} textAlign="center">

--- a/web/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -20,7 +20,6 @@ import { useState } from 'react';
 
 import { ButtonBorder, Flex } from 'design';
 import Table, { Cell } from 'design/DataTable';
-import { SearchPanel } from 'shared/components/Search';
 
 import { Event } from 'teleport/services/audit';
 
@@ -30,16 +29,10 @@ import renderTypeCell from './EventTypeCell';
 import { ViewInPolicyButton } from './ViewInPolicyButton';
 
 export default function EventList(props: Props) {
-  const { events = [], search, setSearch, sort, setSort } = props;
+  const { events = [], sort, setSort } = props;
   const [detailsToShow, setDetailsToShow] = useState<Event>();
   return (
     <>
-      <SearchPanel
-        updateSearch={setSearch}
-        updateQuery={null}
-        hideAdvancedSearch={true}
-        filter={{ search }}
-      />
       <Table
         data={events}
         columns={[


### PR DESCRIPTION
Some vestigial testing elements got in during a merge/conflict. This removes the extra skeleton, and cleans up where the search panel is so it can be seen while the page is loading for the first time. I found it while backporting to v18. I will include this in the v18 backport as well