### PR TITLE
Improve dynamic desktop reconciler

### DIFF
--- a/lib/services/reconciler.go
+++ b/lib/services/reconciler.go
@@ -223,7 +223,7 @@ func (r *GenericReconciler[K, T]) Reconcile(ctx context.Context) error {
 }
 
 // processRegisteredResource checks the specified registered resource against the
-// new list of resources.
+// new list of resources, deleting the resource if should no longer exist.
 func (r *GenericReconciler[K, T]) processRegisteredResource(ctx context.Context, newResources map[K]T, key K, registered T) error {
 	// See if this registered resource is still present among "new" resources.
 	if _, ok := newResources[key]; ok {
@@ -268,7 +268,10 @@ func (r *GenericReconciler[K, T]) processRegisteredResource(ctx context.Context,
 }
 
 // processNewResource checks the provided new resource against currently
-// registered resources.
+// registered resources. It may:
+// - create a new resource if one does not already exist
+// - update an existing resource
+// - delete a resource that no longer matches the reconciler's label matchers
 func (r *GenericReconciler[K, T]) processNewResource(ctx context.Context, currentResources map[K]T, key K, newT T) error {
 	// First see if the resource is already registered and if not, whether it
 	// matches the selector labels and should be registered.

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -33,8 +33,10 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
@@ -409,6 +411,35 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(
 	return desktop, nil
 }
 
+// dynamicDesktops returns the WindowsDesktop resources that were registered
+// by _this_ desktop service.
+func (s *WindowsService) dynamicDesktops(ctx context.Context) map[string]types.WindowsDesktop {
+	result := make(map[string]types.WindowsDesktop)
+
+	for desktop, err := range clientutils.Resources(ctx,
+		func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktop, string, error) {
+			// We're looking for desktops that were both:
+			// 1. Registered with our HostUUID.
+			// 2. Dynamically registered
+			resp, err := s.cfg.AccessPoint.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: s.cfg.Heartbeat.HostUUID},
+				Labels:               map[string]string{types.OriginLabel: types.OriginDynamic},
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+
+			return resp.Desktops, resp.NextKey, nil
+		}) {
+		if err != nil {
+			return result
+		}
+		result[desktop.GetName()] = desktop
+	}
+
+	return result
+}
+
 // startDynamicReconciler starts resource watcher and reconciler that registers/unregisters Windows desktops
 // according to the up-to-date list of dynamic Windows desktop resources. The reconciler runs until the
 // provided context expires.
@@ -428,6 +459,7 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 			ResourceWatcherConfig: services.ResourceWatcherConfig{
 				Component: teleport.ComponentWindowsDesktop,
 				Client:    s.cfg.AccessPoint,
+				Logger:    s.cfg.Logger,
 			},
 		})
 		if err != nil {
@@ -438,14 +470,14 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 		defer watcher.Close()
 		defer s.cfg.Logger.DebugContext(ctx, "DynamicWindowsDesktop resource watcher done.")
 
-		currentResources := make(map[string]types.WindowsDesktop)
 		var newResources map[string]types.WindowsDesktop
 
 		reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
+			Logger: s.cfg.Logger,
 			Matcher: func(desktop types.WindowsDesktop) bool {
 				return services.MatchResourceLabels(s.cfg.ResourceMatchers, desktop.GetAllLabels())
 			},
-			GetCurrentResources: func() map[string]types.WindowsDesktop { return currentResources },
+			GetCurrentResources: func() map[string]types.WindowsDesktop { return s.dynamicDesktops(ctx) },
 			GetNewResources:     func() map[string]types.WindowsDesktop { return newResources },
 			OnCreate:            s.upsertDesktop,
 			OnUpdate:            s.updateDesktop,
@@ -459,45 +491,43 @@ func (s *WindowsService) startDynamicReconciler(ctx context.Context) error {
 		// If we got here, the reconciler is running.
 		errCh <- nil
 
-		tickDuration := 5 * time.Minute
-		expiryDuration := tickDuration + 2*time.Minute
-
-		tick := s.cfg.Clock.NewTicker(tickDuration)
-		defer tick.Stop()
-
 		for {
 			select {
 			case desktops := <-watcher.ResourcesC:
 				start := s.cfg.Clock.Now()
 				newResources = make(map[string]types.WindowsDesktop)
 				for _, dynamicDesktop := range desktops {
+					// TODO: the reconciler's default comparison func is going to mark new resources
+					// different just because the expiry timestamp differs.
 					desktop, err := s.toWindowsDesktop(dynamicDesktop)
 					if err != nil {
 						s.cfg.Logger.WarnContext(ctx, "Can't create desktop resource", "error", err)
 						continue
 					}
-					desktop.SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+					// TODO: use a longer expiry here once the desktop agent deletes desktops on shtudown
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
+					s.cfg.Logger.DebugContext(ctx, "reconciler discovered new resource from watcher", "name", dynamicDesktop.GetName())
 					newResources[dynamicDesktop.GetName()] = desktop
 				}
 				if err := reconciler.Reconcile(ctx); err != nil {
 					s.cfg.Logger.WarnContext(ctx, "Reconciliation failed, will retry", "error", err)
 					continue
 				}
-				currentResources = newResources
+
 				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
-			case <-tick.Chan():
-				start := s.cfg.Clock.Now()
-				newResources = make(map[string]types.WindowsDesktop)
-				for k, v := range currentResources {
-					newResources[k] = v.Copy()
-					newResources[k].SetExpiry(s.cfg.Clock.Now().Add(expiryDuration))
+			case <-s.cfg.Clock.After(retryutils.SeventhJitter(apidefaults.ServerAnnounceTTL / 2)):
+				// We currently use a relatively short expiration period so that desktops associated with
+				// an agent that terminates will expire shortly after the agent stops heartbeating them.
+				//
+				// As a result, we must also run the reconciler periodically to "renew" the desktop
+				// heartbeat and prevent it from expiring while the agent is healthy.
+				for _, desktop := range newResources {
+					desktop.SetExpiry(s.cfg.Clock.Now().Add(apidefaults.ServerAnnounceTTL))
 				}
 				if err := reconciler.Reconcile(ctx); err != nil {
 					s.cfg.Logger.WarnContext(ctx, "Reconciliation failed, will retry", "error", err)
 					continue
 				}
-				currentResources = newResources
-				s.cfg.Logger.DebugContext(ctx, "completed dynamic desktop reconciliation", "duration", s.cfg.Clock.Since(start), "count", len(newResources))
 			case <-watcher.Done():
 				return
 			case <-ctx.Done():

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -175,27 +176,22 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, authServer.Close())
-	})
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
 
 	tlsServer, err := authServer.NewTestTLSServer()
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, tlsServer.Close())
-	})
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
 
 	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, "test-host-id"))
 	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, client.Close())
-	})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	for _, testCase := range []struct {
@@ -253,6 +249,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 			}
 
 			require.NoError(t, s.startDynamicReconciler(t.Context()))
+
 			t.Cleanup(func() {
 				require.NoError(t, authServer.AuthServer.DeleteAllWindowsDesktops(ctx))
 				var key string
@@ -269,6 +266,7 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 				}
 			})
 
+			// Create a dynamic desktop and then check whether a corresponding desktop resource was created.
 			desktop, err := types.NewDynamicWindowsDesktopV1("test", testCase.labels, types.DynamicWindowsDesktopSpecV1{
 				Addr: "addr",
 			})
@@ -288,6 +286,8 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 				}
 			}, 5*time.Second, 50*time.Millisecond)
 
+			// Make an update to the dynamic desktop and ensure it is reflected
+			// in the corresponding desktop resource.
 			desktop.Spec.Addr = "addr2"
 			_, err = dynamicWindowsClient.UpsertDynamicWindowsDesktop(ctx, desktop)
 			require.NoError(t, err)
@@ -302,6 +302,8 @@ func TestDynamicWindowsDiscovery(t *testing.T) {
 				}
 			}, 5*time.Second, 50*time.Millisecond)
 
+			// Delete the dynamic desktop and ensure that the corresponding desktop
+			// resource is also removed.
 			require.NoError(t, dynamicWindowsClient.DeleteDynamicWindowsDesktop(ctx, "test"))
 
 			require.EventuallyWithT(t, func(t *assert.CollectT) {
@@ -317,6 +319,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -331,7 +334,7 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 
 	dynamicWindowsClient := client.DynamicDesktopClient()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	clock := clockwork.NewFakeClock()
@@ -367,6 +370,8 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Create the dynamic desktop and verify that a corresponding desktop
+	// resource is created.
 	_, err = dynamicWindowsClient.CreateDynamicWindowsDesktop(ctx, desktop)
 	require.NoError(t, err)
 
@@ -377,6 +382,8 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
 
+	// Delete the desktop resource, advance the clock, and verify that
+	// the reconciler re-created the desktop resource.
 	err = client.DeleteWindowsDesktop(ctx, s.cfg.Heartbeat.HostUUID, "test")
 	require.NoError(t, err)
 
@@ -392,6 +399,25 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
+
+	// Ensure that the reconciler is advancing the expiry.
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, 1)
+
+	start := desktops[0].GetMetadata().Expires
+	require.NotNil(t, start)
+
+	clock.Advance(5 * time.Minute)
+	clock.BlockUntilContext(t.Context(), 1)
+
+	desktops, err = client.GetWindowsDesktops(ctx, types.WindowsDesktopFilter{})
+	require.NoError(t, err)
+	require.Len(t, desktops, 1)
+
+	end := desktops[0].GetMetadata().Expires
+	require.NotNil(t, start)
+	require.Equal(t, start.Add(5*time.Minute), *end)
 }
 
 func TestCurrentDesktops(t *testing.T) {
@@ -399,6 +425,7 @@ func TestCurrentDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
@@ -502,6 +529,7 @@ func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
 	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 		ClusterName: "test",
 		Dir:         t.TempDir(),
+		AuditLog:    &eventstest.MockAuditLog{Emitter: new(eventstest.MockRecorderEmitter)},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authServer.Close()) })


### PR DESCRIPTION
This fixes an edge case where the dynamic desktop reconciler could try to delete desktop resources that don't actually exist.

We worked around this error by making `trace.NotFound` a non-error in #59884, but with these changes that deletion would never be attempted.

Manual test plan:
- [x] existing dynamic desktop unit tests continue to pass
- [x] verify dynamic desktop general behavior with existing test plan steps
- [x] Check logs for delete failures.
  - Configure a WDS to match dynamic desktops with the `foo: bar` label.
  - Create 2 dynamic desktop entries - one that matches `foo: bar` and one that doesn't.
  - Wait for the one matching desktop to show up.
  - Wait for one additional reconciliation, verify no `Failed to delete resource` reconciler logs are emitted.
 - [x] Repeat the above steps with an agent from master (without this PR) and verify that you _do_ see the failed to delete message (for the non-matching dynamic desktop).