### PR TITLE
Improve resource name validation for AWS Roles Anywhere and AWS OIDC generate command

### DIFF
--- a/api/utils/aws/identifiers.go
+++ b/api/utils/aws/identifiers.go
@@ -206,7 +206,7 @@ var (
 	// See https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_CreateTrustAnchor.html#API_CreateTrustAnchor_RequestBody
 	matchRolesAnywhereTrustAnchorName = baseResourceNameMatcher
 
-	// matchRolesAnywhereProfileName is a regex that matches against AWS IAM Roles Anywhere Trust Anchor Names.
+	// matchRolesAnywhereProfileName is a regex that matches against AWS IAM Roles Anywhere Profile Names.
 	// See https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_CreateProfile.html#API_CreateProfile_RequestBody
 	matchRolesAnywhereProfileName = baseResourceNameMatcher
 

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -256,7 +256,7 @@ func (s *Service) CreateIntegration(ctx context.Context, req *integrationpb.Crea
 			return nil, trace.Wrap(err)
 		}
 	case types.IntegrationSubKindAWSOIDC, types.IntegrationSubKindAWSRolesAnywhere:
-		if err := awscommon.ValidIntegratioName(req.Integration.GetName()); err != nil {
+		if err := awscommon.ValidIntegrationName(req.Integration.GetName()); err != nil {
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/integrations/awscommon/validations.go
+++ b/lib/integrations/awscommon/validations.go
@@ -23,8 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-// ValidIntegratioName validates the integration name.
-func ValidIntegratioName(name string) error {
+// ValidIntegrationName validates the integration name.
+func ValidIntegrationName(name string) error {
 	// AWS OIDC and Roles Anywhere Integrations can be used as source of credentials to access AWS Web/CLI.
 	// For OIDC, this creates a new AppServer whose endpoint is <integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.
 	// For Roles Anywhere, this creates a AppServers for each Roles Anywhere Profile whose endpoint is <profileName>-<integrationName>.<proxyURL>, which can fail if integrationName is not a valid DNS Label.

--- a/lib/web/integrations_awsra.go
+++ b/lib/web/integrations_awsra.go
@@ -156,7 +156,7 @@ func (h *Handler) validateAWSRolesAnywhereIntegration(w http.ResponseWriter, r *
 	}
 
 	// validate integration name.
-	if err := awscommon.ValidIntegratioName(integrationName); err != nil {
+	if err := awscommon.ValidIntegrationName(integrationName); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -107,40 +107,6 @@ const requiredConfirmedPassword =
  */
 const DNS1035_LABEL_REGEX = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
 const DNS1035_LABEL_MAX_LENGTH = 63;
-const isIntegrationNameValid = (integrationName: string) => {
-  return (
-    integrationName &&
-    integrationName.length <= DNS1035_LABEL_MAX_LENGTH &&
-    integrationName.match(DNS1035_LABEL_REGEX)
-  );
-};
-
-/**
- * IAM_ROLE_NAME_REGEX uses the same regex matcher used in the backend:
- * https://github.com/gravitational/teleport/blob/master/api/utils/aws/identifiers.go#L178
- *
- * The regex checks for alphanumerics and select few characters.
- */
-const IAM_ROLE_NAME_REGEX = /^[\w+=,.@-]+$/;
-const IAM_ROLE_NAME_MAX_LENGTH = 64;
-const isIamRoleNameValid = (roleName: string) => {
-  return (
-    roleName &&
-    roleName.length <= IAM_ROLE_NAME_MAX_LENGTH &&
-    roleName.match(IAM_ROLE_NAME_REGEX)
-  );
-};
-
-/**
- * ROLES_ANYWHERE_NAME_REGEX uses the same regex matcher used in the backend:
- * https://github.com/gravitational/teleport/blob/master/api/utils/aws/identifiers.go#L213
- */
-const ROLES_ANYWHERE_NAME_REGEX = /^[ a-zA-Z0-9-_]{1,255}$/;
-const ROLES_ANYWHERE_NAME_MAX_LENGTH = 255;
-const isRaResourceNameValid = (resourceName: string) => {
-  return resourceName && resourceName.match(ROLES_ANYWHERE_NAME_REGEX);
-};
-
 /**
  * @param name validIntegrationName verifies if the given value is a
  * valid Integration name.
@@ -153,7 +119,7 @@ const validIntegrationName = (name: string): ValidationResult => {
     };
   }
 
-  if (!isIntegrationNameValid(name)) {
+  if (!name.match(DNS1035_LABEL_REGEX)) {
     return {
       valid: false,
       message: 'Name must be a lower case valid DNS subdomain',
@@ -166,6 +132,14 @@ const validIntegrationName = (name: string): ValidationResult => {
 };
 
 /**
+ * IAM_ROLE_NAME_REGEX uses the same regex matcher used in the backend:
+ * https://github.com/gravitational/teleport/blob/8d946146999260578f1a1b250aa87a6008343bab/api/utils/aws/identifiers.go#L178
+ *
+ * The regex checks for alphanumerics and select few characters.
+ */
+const IAM_ROLE_NAME_REGEX = /^[\w+=,.@-]+$/;
+const IAM_ROLE_NAME_MAX_LENGTH = 64;
+/**
  * @param name validAwsIAMRoleName verifies if the given value is a
  * valid AWS IAM role name.
  */
@@ -177,7 +151,7 @@ const validAwsIAMRoleName = (name: string): ValidationResult => {
     };
   }
 
-  if (!isIamRoleNameValid(name)) {
+  if (!name.match(IAM_ROLE_NAME_REGEX)) {
     return {
       valid: false,
       message: 'Name can only contain characters @ = , . + - and alphanumerics',
@@ -189,6 +163,12 @@ const validAwsIAMRoleName = (name: string): ValidationResult => {
   };
 };
 
+/**
+ * ROLES_ANYWHERE_NAME_REGEX uses the same regex matcher used in the backend:
+ * https://github.com/gravitational/teleport/blob/8d946146999260578f1a1b250aa87a6008343bab/api/utils/aws/identifiers.go#L213
+ */
+const ROLES_ANYWHERE_NAME_REGEX = /^[ a-zA-Z0-9-_]{1,255}$/;
+const ROLES_ANYWHERE_NAME_MAX_LENGTH = 255;
 /**
  * @param name validAwsRaResourceName verifies if the given value is a
  * valid AWS Roles Anywhere resource name.
@@ -202,7 +182,15 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
     };
   }
 
-  if (!isRaResourceNameValid(name)) {
+  // Since [space] is allowed in regex matcher, we don't want leading/trailing whitespaces.
+  if (name !== name.trim()) {
+    return {
+      valid: false,
+      message: 'Name contains leading/trailing whitespace characters',
+    };
+  }
+
+  if (!name.match(ROLES_ANYWHERE_NAME_REGEX)) {
     return {
       valid: false,
       message: 'Name can only contain characters [space] - _ and alphanumerics',
@@ -313,6 +301,14 @@ const requiredRoleArn: Rule = roleArn => () => {
   return {
     valid: true,
   };
+};
+
+const isIamRoleNameValid = (roleName: string) => {
+  return (
+    roleName &&
+    roleName.length <= IAM_ROLE_NAME_MAX_LENGTH &&
+    roleName.match(IAM_ROLE_NAME_REGEX)
+  );
 };
 
 export interface EmailValidationResult extends ValidationResult {

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -533,7 +533,6 @@ export {
   requiredAll,
   requiredMatchingRoleNameAndRoleArn,
   validAwsIAMRoleName,
-  validAwsRaResourceName,
   requiredPort,
   arrayOf,
   precomputed,

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -23,6 +23,7 @@
  * The regex checks for alphanumerics and select few characters.
  */
 const IAM_ROLE_NAME_REGEX = /^[\w+=,.@-]+$/;
+const ROLES_ANYWHERE_NAME_REGEX = /^[ a-zA-Z0-9-_]{1,255}$/;
 
 /**
  * The result of validating a field.
@@ -107,9 +108,15 @@ const requiredConfirmedPassword =
     };
   };
 
-const isIamRoleNameValid = roleName => {
+const isIamRoleNameValid = (roleName: string) => {
   return (
     roleName && roleName.length <= 64 && roleName.match(IAM_ROLE_NAME_REGEX)
+  );
+};
+
+const isRaResourceNameValid = (resourceName: string) => {
+  return (
+    resourceName && resourceName.match(ROLES_ANYWHERE_NAME_REGEX)
   );
 };
 
@@ -137,6 +144,25 @@ const validAwsIAMRoleName = (name: string): ValidationResult => {
   };
 };
 
+const validAwsRaResourceName = (name: string): ValidationResult => {
+  if (name.length > 255) {
+    return {
+      valid: false,
+      message: 'name should be <= 255 characters',
+    };
+  }
+
+  if (!isRaResourceNameValid(name)) {
+    return {
+      valid: false,
+      message: 'name can only contain characters [space] - _ and alphanumerics',
+    };
+  }
+  return {
+    valid: true,
+  };
+};
+
 /**
  * requiredIamRoleName is a required field and checks for a
  * value which should also be a valid AWS IAM role name.
@@ -152,6 +178,24 @@ const requiredIamRoleName: Rule = name => (): ValidationResult => {
   }
 
   return validAwsIAMRoleName(name);
+};
+
+/**
+ * requiredRaResourceName is a required field and checks for a
+ * value which should also be a valid AWS IAM Roles Anywhere resource name.
+ * This includes AWS IAM Roles Anywhere Trust Anchor names and Profile names.
+ * @param name is a Roles Anywhere resource name.
+ * @returns ValidationResult
+ */
+const requiredRaResourceName: Rule = name => (): ValidationResult => {
+  if (!name) {
+    return {
+      valid: false,
+      message: 'Name is required',
+    };
+  }
+
+  return validAwsRaResourceName(name);
 };
 
 /**
@@ -402,11 +446,13 @@ export {
   requiredField,
   requiredRoleArn,
   requiredIamRoleName,
+  requiredRaResourceName,
   requiredEmailLike,
   requiredMaxLength,
   requiredAll,
   requiredMatchingRoleNameAndRoleArn,
   validAwsIAMRoleName,
+  validAwsRaResourceName,
   requiredPort,
   arrayOf,
   precomputed,

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -115,9 +115,7 @@ const isIamRoleNameValid = (roleName: string) => {
 };
 
 const isRaResourceNameValid = (resourceName: string) => {
-  return (
-    resourceName && resourceName.match(ROLES_ANYWHERE_NAME_REGEX)
-  );
+  return resourceName && resourceName.match(ROLES_ANYWHERE_NAME_REGEX);
 };
 
 /**
@@ -128,14 +126,14 @@ const validAwsIAMRoleName = (name: string): ValidationResult => {
   if (name.length > 64) {
     return {
       valid: false,
-      message: 'name should be <= 64 characters',
+      message: 'Name should be <= 64 characters',
     };
   }
 
   if (!isIamRoleNameValid(name)) {
     return {
       valid: false,
-      message: 'name can only contain characters @ = , . + - and alphanumerics',
+      message: 'Name can only contain characters @ = , . + - and alphanumerics',
     };
   }
 
@@ -148,14 +146,14 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
   if (name.length > 255) {
     return {
       valid: false,
-      message: 'name should be <= 255 characters',
+      message: 'Name should be <= 255 characters',
     };
   }
 
   if (!isRaResourceNameValid(name)) {
     return {
       valid: false,
-      message: 'name can only contain characters [space] - _ and alphanumerics',
+      message: 'Name can only contain characters [space] - _ and alphanumerics',
     };
   }
   return {
@@ -165,7 +163,7 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
 
 /**
  * requiredIamRoleName is a required field and checks for a
- * value which should also be a valid AWS IAM role name.
+ * value which should also be a valid AWS IAM Role name.
  * @param name is a role name.
  * @returns ValidationResult
  */
@@ -173,7 +171,7 @@ const requiredIamRoleName: Rule = name => (): ValidationResult => {
   if (!name) {
     return {
       valid: false,
-      message: 'IAM role name required',
+      message: 'IAM Role name is required',
     };
   }
 
@@ -181,17 +179,33 @@ const requiredIamRoleName: Rule = name => (): ValidationResult => {
 };
 
 /**
- * requiredRaResourceName is a required field and checks for a
- * value which should also be a valid AWS IAM Roles Anywhere resource name.
- * This includes AWS IAM Roles Anywhere Trust Anchor names and Profile names.
- * @param name is a Roles Anywhere resource name.
+ * requiredIamTrustAnchorName is a required field and checks for a
+ * value which should also be a valid AWS IAM Roles Anywhere Trust Anchor name.
+ * @param name is a trust anchor name.
  * @returns ValidationResult
  */
-const requiredRaResourceName: Rule = name => (): ValidationResult => {
+const requiredIamTrustAnchorName: Rule = name => (): ValidationResult => {
   if (!name) {
     return {
       valid: false,
-      message: 'Name is required',
+      message: 'IAM Trust Anchor name is required',
+    };
+  }
+
+  return validAwsRaResourceName(name);
+};
+
+/**
+ * requiredIamProfileName is a required field and checks for a
+ * value which should also be a valid AWS IAM Roles Anywhere Profile name.
+ * @param name is a profile name.
+ * @returns ValidationResult
+ */
+const requiredIamProfileName: Rule = name => (): ValidationResult => {
+  if (!name) {
+    return {
+      valid: false,
+      message: 'IAM Profile name is required',
     };
   }
 
@@ -446,7 +460,8 @@ export {
   requiredField,
   requiredRoleArn,
   requiredIamRoleName,
-  requiredRaResourceName,
+  requiredIamTrustAnchorName,
+  requiredIamProfileName,
   requiredEmailLike,
   requiredMaxLength,
   requiredAll,

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
@@ -121,7 +121,7 @@ test('flows through roles anywhere IAM setup', async () => {
     }
   );
   fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
-  expect(screen.getAllByText(/name can only contain characters/i)).toHaveLength(
+  expect(screen.getAllByText(/Name can only contain characters/i)).toHaveLength(
     3
   );
 

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
@@ -83,10 +83,10 @@ test('flows through roles anywhere IAM setup', async () => {
   ).toBeDisabled();
 
   fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
-  expect(screen.getByText('Name is required')).toBeInTheDocument();
+  expect(screen.getByText('Integration name is required')).toBeInTheDocument();
 
   fireEvent.change(screen.getByLabelText('Integration Name'), {
-    target: { value: 'some-integration-name' },
+    target: { value: 'invalid(((***' },
   });
 
   fireEvent.click(
@@ -121,10 +121,16 @@ test('flows through roles anywhere IAM setup', async () => {
     }
   );
   fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
+  expect(
+    screen.getByText('Name must be a lower case valid DNS subdomain')
+  ).toBeInTheDocument();
   expect(screen.getAllByText(/Name can only contain characters/i)).toHaveLength(
     3
   );
 
+  fireEvent.change(screen.getByLabelText('Integration Name'), {
+    target: { value: 'some-integration-name' },
+  });
   fireEvent.change(
     screen.getByLabelText('IAM Roles Anywhere Trust Anchor Name'),
     {

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
@@ -82,9 +82,69 @@ test('flows through roles anywhere IAM setup', async () => {
     screen.getByRole('button', { name: 'Next: Configure Access' })
   ).toBeDisabled();
 
+  fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
+  expect(screen.getByText('Name is required')).toBeInTheDocument();
+
   fireEvent.change(screen.getByLabelText('Integration Name'), {
     target: { value: 'some-integration-name' },
   });
+
+  fireEvent.click(
+    screen.getByRole('button', {
+      name: 'Optionally edit resource names that will be created in AWS',
+    })
+  );
+  expect(
+    screen.getByText('Edit resource names that will be created in AWS')
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText('IAM Roles Anywhere Trust Anchor Name')
+  ).toBeInTheDocument();
+  fireEvent.change(
+    screen.getByLabelText('IAM Roles Anywhere Trust Anchor Name'),
+    {
+      target: { value: 'invalid(((***' },
+    }
+  );
+  fireEvent.change(
+    screen.getByLabelText('IAM Role Name (used for profile synchronization)'),
+    {
+      target: { value: 'invalid(((***' },
+    }
+  );
+  fireEvent.change(
+    screen.getByLabelText(
+      'IAM Roles Anywhere Profile Name (used for profile synchronization)'
+    ),
+    {
+      target: { value: 'invalid(((***' },
+    }
+  );
+  fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
+  expect(screen.getAllByText(/name can only contain characters/i)).toHaveLength(
+    3
+  );
+
+  fireEvent.change(
+    screen.getByLabelText('IAM Roles Anywhere Trust Anchor Name'),
+    {
+      target: { value: 'teleport-aws-roles-anywhere-trust-anchor' },
+    }
+  );
+  fireEvent.change(
+    screen.getByLabelText('IAM Role Name (used for profile synchronization)'),
+    {
+      target: { value: 'teleport-aws-roles-anywhere-role' },
+    }
+  );
+  fireEvent.change(
+    screen.getByLabelText(
+      'IAM Roles Anywhere Profile Name (used for profile synchronization)'
+    ),
+    {
+      target: { value: 'teleport-aws-roles-anywhere-profile' },
+    }
+  );
   fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
 
   await waitFor(() =>

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
@@ -42,7 +42,12 @@ import { FieldTextArea } from 'shared/components/FieldTextArea';
 import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import Validation, { Validator } from 'shared/components/Validation';
-import { requiredField, requiredIamRoleName, requiredRaResourceName } from 'shared/components/Validation/rules';
+import {
+  requiredField,
+  requiredIamProfileName,
+  requiredIamRoleName,
+  requiredIamTrustAnchorName,
+} from 'shared/components/Validation/rules';
 
 import { FeatureBox } from 'teleport/components/Layout';
 import cfg from 'teleport/config';
@@ -283,7 +288,7 @@ export function IamIntegration() {
                   <FieldInput
                     label="IAM Roles Anywhere Trust Anchor Name"
                     placeholder=""
-                    rule={requiredRaResourceName}
+                    rule={requiredIamTrustAnchorName}
                     value={formState.trustAnchorName}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({
@@ -307,7 +312,7 @@ export function IamIntegration() {
                   <FieldInput
                     label="IAM Roles Anywhere Profile Name (used for profile synchronization)"
                     placeholder=""
-                    rule={requiredRaResourceName}
+                    rule={requiredIamProfileName}
                     value={formState.syncProfileName}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
@@ -42,7 +42,7 @@ import { FieldTextArea } from 'shared/components/FieldTextArea';
 import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import Validation, { Validator } from 'shared/components/Validation';
-import { requiredField } from 'shared/components/Validation/rules';
+import { requiredField, requiredIamRoleName, requiredRaResourceName } from 'shared/components/Validation/rules';
 
 import { FeatureBox } from 'teleport/components/Layout';
 import cfg from 'teleport/config';
@@ -283,6 +283,7 @@ export function IamIntegration() {
                   <FieldInput
                     label="IAM Roles Anywhere Trust Anchor Name"
                     placeholder=""
+                    rule={requiredRaResourceName}
                     value={formState.trustAnchorName}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({
@@ -294,6 +295,7 @@ export function IamIntegration() {
                   <FieldInput
                     label="IAM Role Name (used for profile synchronization)"
                     placeholder=""
+                    rule={requiredIamRoleName}
                     value={formState.syncRoleName}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({
@@ -305,6 +307,7 @@ export function IamIntegration() {
                   <FieldInput
                     label="IAM Roles Anywhere Profile Name (used for profile synchronization)"
                     placeholder=""
+                    rule={requiredRaResourceName}
                     value={formState.syncProfileName}
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
@@ -43,10 +43,10 @@ import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide';
 import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import Validation, { Validator } from 'shared/components/Validation';
 import {
-  requiredField,
   requiredIamProfileName,
   requiredIamRoleName,
   requiredIamTrustAnchorName,
+  requiredIntegrationName,
 } from 'shared/components/Validation/rules';
 
 import { FeatureBox } from 'teleport/components/Layout';
@@ -270,7 +270,7 @@ export function IamIntegration() {
                 <FieldInput
                   label="Integration Name"
                   placeholder="teleport-aws-prod"
-                  rule={requiredField('Name is required')}
+                  rule={requiredIntegrationName}
                   value={formState.integrationName}
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     return setFormState(prev => ({

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.tsx
@@ -275,7 +275,7 @@ export function IamIntegration() {
                   onChange={(e: ChangeEvent<HTMLInputElement>) => {
                     return setFormState(prev => ({
                       ...prev,
-                      integrationName: e.target.value,
+                      integrationName: e.target.value.trim(),
                     }));
                   }}
                 />
@@ -305,7 +305,7 @@ export function IamIntegration() {
                     onChange={(e: ChangeEvent<HTMLInputElement>) => {
                       return setFormState(prev => ({
                         ...prev,
-                        syncRoleName: e.target.value,
+                        syncRoleName: e.target.value.trim(),
                       }));
                     }}
                   />

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/AwsOidc.tsx
@@ -23,7 +23,10 @@ import { Box, ButtonPrimary, ButtonSecondary, Flex, Link, Text } from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import Validation from 'shared/components/Validation';
-import { requiredIamRoleName } from 'shared/components/Validation/rules';
+import {
+  requiredIamRoleName,
+  requiredIntegrationName,
+} from 'shared/components/Validation/rules';
 
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
 import cfg from 'teleport/config';
@@ -112,13 +115,14 @@ export function AwsOidc() {
               <Box width="600px">
                 <FieldInput
                   autoFocus={true}
+                  rule={requiredIntegrationName}
                   value={integrationConfig.name}
                   label="Give this AWS integration a name"
                   placeholder="Integration Name"
                   onChange={e =>
                     setIntegrationConfig({
                       ...integrationConfig,
-                      name: e.target.value,
+                      name: e.target.value.trim(),
                     })
                   }
                   disabled={!!scriptUrl}
@@ -131,7 +135,7 @@ export function AwsOidc() {
                   onChange={e =>
                     setIntegrationConfig({
                       ...integrationConfig,
-                      roleName: e.target.value,
+                      roleName: e.target.value.trim(),
                     })
                   }
                   disabled={!!scriptUrl}


### PR DESCRIPTION
Fixes #60387

changelog: Resource names are now properly validated for AWS Roles Anywhere integration `Generate Command`

<details><summary>Manual Tests</summary>
<p>

- [x]  Integration name validation
    - [x]  Verify non-empty and no leading/trailing whitespaces
    - [x]  Verify ≤ 63 characters
    - [x]  Verify valid lowercase DNS subdomain string (DNS1035 label)
- [x]  Trust Anchor name validation
    - [x]  Verify non-empty and no leading/trailing whitespaces
    - [x]  Verify ≤ 255 characters
    - [x]  Verify valid regex match ^[ a-zA-Z0-9-_]{1,255}$
- [x]  Role name validation
    - [x]  Verify non-empty and no leading/trailing whitespaces
    - [x]  Verify ≤ 64 characters
    - [x]  Verify valid regex match ^[\w+=,.@-]+$
- [x]  Profile name validation
    - [x]  Verify non-empty and no leading/trailing whitespaces
    - [x]  Verify ≤ 255 characters
    - [x]  Verify valid regex match ^[ a-zA-Z0-9-_]{1,255}$
 
</p>
</details> 

<details><summary>Examples</summary>
<p>

<img width="576" height="639" alt="Screenshot 2025-11-12 at 12 09 23 PM" src="https://github.com/user-attachments/assets/ab059ba6-1369-4f63-ad92-0fd34923db46" />
<img width="578" height="644" alt="Screenshot 2025-11-12 at 12 10 06 PM" src="https://github.com/user-attachments/assets/2c4c73c2-ad38-4dd9-bdac-25299ab1de06" />
<img width="576" height="635" alt="Screenshot 2025-11-12 at 12 12 15 PM" src="https://github.com/user-attachments/assets/0a5c777d-b1cc-4bdd-9828-1b06334c2ee2" />
<img width="526" height="296" alt="Screenshot 2025-11-12 at 12 12 49 PM" src="https://github.com/user-attachments/assets/ebd73397-3d2a-48b9-97d0-ed88c8e4935e" />

</p>
</details> 