### PR TITLE
proto / docs: Update proto comments to match modified docs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -68,8 +68,8 @@ jobs:
               # rendered doc changes
               - 'docs/pages/admin-guides/**'
               - 'docs/pages/enroll-resources/**'
-              - 'docs/pages/reference/operator-resources/**'
-              - 'docs/pages/reference/terraform-provider/**'
+              - 'docs/pages/reference/infrastructure-as-code/operator-resources/**'
+              - 'docs/pages/reference/infrastructure-as-code/terraform-provider/**'
               - 'examples/chart/teleport-cluster/charts/teleport-operator/operator-crds'
             has_ui:
               - '.github/workflows/lint.yaml'

--- a/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
+++ b/api/gen/proto/go/teleport/autoupdate/v1/autoupdate.pb.go
@@ -736,9 +736,9 @@ func (x *AutoUpdateVersionSpecTools) GetTargetVersion() string {
 // AutoUpdateVersionSpecAgents is the spec for the autoupdate version.
 type AutoUpdateVersionSpecAgents struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// start_version is the version to update from.
+	// start_version is the version used for newly installed agents before their update window.
 	StartVersion string `protobuf:"bytes,1,opt,name=start_version,json=startVersion,proto3" json:"start_version,omitempty"`
-	// target_version is the version to update to.
+	// target_version is the version that all agents will update to during their update window.
 	TargetVersion string `protobuf:"bytes,2,opt,name=target_version,json=targetVersion,proto3" json:"target_version,omitempty"`
 	// schedule to use for the rollout
 	Schedule string `protobuf:"bytes,3,opt,name=schedule,proto3" json:"schedule,omitempty"`
@@ -898,9 +898,9 @@ func (x *AutoUpdateAgentRollout) GetStatus() *AutoUpdateAgentRolloutStatus {
 // AutoUpdateVersionSpecAgents.
 type AutoUpdateAgentRolloutSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// start_version is the version to update from.
+	// start_version is the version used for newly installed agents before their update window.
 	StartVersion string `protobuf:"bytes,1,opt,name=start_version,json=startVersion,proto3" json:"start_version,omitempty"`
-	// target_version is the version to update to.
+	// target_version is the version that all agents will update to during their update window.
 	TargetVersion string `protobuf:"bytes,2,opt,name=target_version,json=targetVersion,proto3" json:"target_version,omitempty"`
 	// schedule to use for the rollout. Supported values are "regular" and "immediate".
 	// - "regular" follows the regular group schedule

--- a/api/proto/teleport/autoupdate/v1/autoupdate.proto
+++ b/api/proto/teleport/autoupdate/v1/autoupdate.proto
@@ -117,9 +117,9 @@ message AutoUpdateVersionSpecTools {
 
 // AutoUpdateVersionSpecAgents is the spec for the autoupdate version.
 message AutoUpdateVersionSpecAgents {
-  // start_version is the version to update from.
+  // start_version is the version used for newly installed agents before their update window.
   string start_version = 1;
-  // target_version is the version to update to.
+  // target_version is the version that all agents will update to during their update window.
   string target_version = 2;
   // schedule to use for the rollout
   string schedule = 3;
@@ -143,9 +143,9 @@ message AutoUpdateAgentRollout {
 // This is built by merging the user-provided AutoUpdateConfigSpecAgents and the operator-provided
 // AutoUpdateVersionSpecAgents.
 message AutoUpdateAgentRolloutSpec {
-  // start_version is the version to update from.
+  // start_version is the version used for newly installed agents before their update window.
   string start_version = 1;
-  // target_version is the version to update to.
+  // target_version is the version that all agents will update to during their update window.
   string target_version = 2;
   // schedule to use for the rollout. Supported values are "regular" and "immediate".
   // - "regular" follows the regular group schedule

--- a/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
+++ b/docs/pages/reference/infrastructure-as-code/operator-resources/resources-teleport-dev-autoupdateversionsv1.mdx
@@ -38,8 +38,8 @@ resource, which you can apply after installing the Teleport Kubernetes operator.
 |---|---|---|
 |mode|string|autoupdate_mode to use for the rollout|
 |schedule|string|schedule to use for the rollout|
-|start_version|string|start_version is the version to update from.|
-|target_version|string|target_version is the version to update to.|
+|start_version|string|start_version is the version used for newly installed agents before their update window.|
+|target_version|string|target_version is the version that all agents will update to during their update window.|
 
 ### spec.tools
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/autoupdate_version.mdx
@@ -44,8 +44,8 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version to update from.
-- `target_version` (String) target_version is the version to update to.
+- `start_version` (String) start_version is the version used for newly installed agents before their update window.
+- `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/autoupdate_version.mdx
@@ -61,8 +61,8 @@ Optional:
 
 - `mode` (String) autoupdate_mode to use for the rollout
 - `schedule` (String) schedule to use for the rollout
-- `start_version` (String) start_version is the version to update from.
-- `target_version` (String) target_version is the version to update to.
+- `start_version` (String) start_version is the version used for newly installed agents before their update window.
+- `target_version` (String) target_version is the version that all agents will update to during their update window.
 
 
 ### Nested Schema for `spec.tools`

--- a/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateversionsv1.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/operator-crds/resources.teleport.dev_autoupdateversionsv1.yaml
@@ -45,10 +45,12 @@ spec:
                     description: schedule to use for the rollout
                     type: string
                   start_version:
-                    description: start_version is the version to update from.
+                    description: start_version is the version used for newly installed
+                      agents before their update window.
                     type: string
                   target_version:
-                    description: target_version is the version to update to.
+                    description: target_version is the version that all agents will
+                      update to during their update window.
                     type: string
                 type: object
               tools:

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateversionsv1.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_autoupdateversionsv1.yaml
@@ -45,10 +45,12 @@ spec:
                     description: schedule to use for the rollout
                     type: string
                   start_version:
-                    description: start_version is the version to update from.
+                    description: start_version is the version used for newly installed
+                      agents before their update window.
                     type: string
                   target_version:
-                    description: target_version is the version to update to.
+                    description: target_version is the version that all agents will
+                      update to during their update window.
                     type: string
                 type: object
               tools:

--- a/integrations/terraform/tfschema/autoupdate/v1/autoupdate_terraform.go
+++ b/integrations/terraform/tfschema/autoupdate/v1/autoupdate_terraform.go
@@ -234,12 +234,12 @@ func GenSchemaAutoUpdateVersion(ctx context.Context) (github_com_hashicorp_terra
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"start_version": {
-							Description: "start_version is the version to update from.",
+							Description: "start_version is the version used for newly installed agents before their update window.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},
 						"target_version": {
-							Description: "target_version is the version to update to.",
+							Description: "target_version is the version that all agents will update to during their update window.",
 							Optional:    true,
 							Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 						},


### PR DESCRIPTION
Update `autoupdate.proto` doc comments to match changes manually made to
the docs. The docs are auto-generated from the proto comments, so those
manual changes are being reverted when running the autogen tools, and
the lint job checking this is failing.

Also update the lint job to update the changed paths for the docs - this
would have prevented the manual change to the docs from being merged in
the first place, but the paths were out of date.

Update generated files running:

    make grpc/host
    make -C integrations/operator crd
    make -C integrations/terraform docs

Fixes: https://github.com/gravitational/teleport/pull/60599
Fixes: https://github.com/gravitational/teleport/pull/58248
