### PR TITLE
docs: correct terraform teleport_provision_token in kube oidc join

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
@@ -201,7 +201,7 @@ spec:
 Create the file `token.tf` with the following content:
 
 ```hcl
-resource "teleport_token" "<Var name="kube-cluster-name"/>" {
+resource "teleport_provision_token" "<Var name="kube-cluster-name"/>" {
   version = "v2"
   metadata = {
     name = "<Var name="kube-cluster-name"/>-oidc"


### PR DESCRIPTION
`teleport_provision_token` is the correct name of the terraform resource.