### PR TITLE
Desktop Access: Gracefully Handle Invalid Smartcard Commands

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -338,24 +338,27 @@ impl ScardBackend {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: TransmitCall,
     ) -> PduResult<()> {
-        let cmd =
-            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer).map_err(|err| {
-                pdu_other_err!(
-                    "",
-                    source:SmartcardBackendError(format!(
-                        "failed to parse smartcard command {:?}: {:?}",
-                        &call.send_buffer, err
-                    ))
-                )
-            })?;
+        let cmd = CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer);
 
-        let card = self.contexts.get_card(&call.handle)?;
-        let resp = card.handle(cmd)?;
+        match cmd {
+            Ok(cmd) => {
+                let card = self.contexts.get_card(&call.handle)?;
+                let resp = card.handle(cmd)?;
 
-        self.send_device_control_response(
-            req,
-            TransmitReturn::new(ReturnCode::Success, None, resp.encode()),
-        )
+                self.send_device_control_response(
+                    req,
+                    TransmitReturn::new(ReturnCode::Success, None, resp.encode()),
+                )?;
+            }
+            Err(err) => {
+                warn!("error parsing smart card command: {:?} - {:?}", call, err);
+                self.send_device_control_response(
+                    req,
+                    TransmitReturn::new(ReturnCode::InvalidValue, None, Vec::new()),
+                )?;
+            }
+        }
+        Ok(())
     }
 
     fn handle_status(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<()> {


### PR DESCRIPTION
This PR fixes a PDU error encountered by a customer when opening a proprietary application. Similar to issues seen with other applications that utilize hardware security keys (such as KeepassXC), opening this application appears to cause some RDPDR traffic to our virtualized smart card and reader.

In this particular case, the Windows host was sending PTS (Protocol Type Selection) messages to our virtual smart card, which is perceived as an invalid command by the [iso7816 crate](https://docs.rs/iso7816/0.2.0/iso7816/) that we use for parsing these commands. It seems that we shouldn't be receiving these commands anyhow, as our virtual smart card explicitly advertises itself as using a specific, non-negotiable communication protocol.

The fix is to simply return a smart card error to the Windows host, rather than return with a PDU error (which is fatal to the connection). A dev build with this patch was sent to the customer who reported stable RDP connections while testing with it.

changelog: Improve error handling during desktop sessions that encounter unknown/invalid smartcard commands. This prevents abrupt desktop session termination with a "PDU error" message when using certain applications.