### PR TITLE
Streamable HTTP and SSE MCP server need 18.3.0+

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/sse.mdx
+++ b/docs/pages/enroll-resources/mcp-access/sse.mdx
@@ -39,7 +39,7 @@ streamable-HTTP transport instead.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.1.0 or higher)"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.3.0 or higher)"!)
 - A host, e.g., an EC2 instance, where you will run the Teleport Application
   Service.
 - The endpoint of the SSE MCP server <Var name="MCP endpoint" initial="http://my-sse-server/sse" />.

--- a/docs/pages/enroll-resources/mcp-access/streamable-http.mdx
+++ b/docs/pages/enroll-resources/mcp-access/streamable-http.mdx
@@ -31,7 +31,7 @@ as audit events, providing visibility into user activity.
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.1.0 or higher)"!)
+(!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v18.3.0 or higher)"!)
 - A host, e.g., an EC2 instance, where you will run the Teleport Application
   Service.
 - The endpoint of the streamable-HTTP MCP server <Var name="MCP endpoint" initial="http://my-http-server/mcp" />.


### PR DESCRIPTION
Support for Streamable HTTP and SSE MCP servers was added in #60519, which first appeared in 18.3.0, not 18.1.0
https://goteleport.com/docs/changelog/#1830-102825