### PR TITLE
Docs: update server discovery with managed SSM Doc and HTTP Proxy

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -70,10 +70,14 @@ the Discovery Service:
 }
 ```
 
-## Step 3/7. Create SSM Documents
+## Step 3/7. [Optional] Create SSM Documents
 
-In each region you plan to discover instances in, create the following SSM document
-in the AWS Systems Manager and name it `TeleportDiscoveryInstaller`:
+When executing the installation script on discovered EC2 instances, the Discovery Service uses an SSM document.
+You can use the pre-defined SSM document `AWS-RunShellScript` or create your own if you need further customization.
+
+If using the pre-defined document, skip this step and set the SSM Document to `AWS-RunShellScript` in step 5.
+
+If you need to customize the installation process, create the following SSM document in each region using AWS Systems Manager and name it `TeleportDiscoveryInstaller`:
 
 ```yaml
 schemaVersion: '2.2'
@@ -207,10 +211,14 @@ to the Discovery Service's role, adding the <Var name="new role ARN" />:
 }
 ```
 
-### Step 3/5. Create SSM Documents
+### Step 3/5. [Optional] Create SSM Documents
 
-In each region you plan to discover instances in, create the following SSM document
-in the AWS Systems Manager and name it `TeleportDiscoveryInstaller`:
+When executing the installation script on discovered EC2 instances, the Discovery Service uses an SSM document.
+You can use the pre-defined SSM document `AWS-RunShellScript` or create your own if you need further customization.
+
+If using the pre-defined document, skip this step and set the SSM Document to `AWS-RunShellScript` in step 4.
+
+If you need to customize the installation process, create the following SSM document in each region using AWS Systems Manager and name it `TeleportDiscoveryInstaller`:
 
 ```yaml
 schemaVersion: '2.2'

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -48,6 +48,10 @@ discovery_service:
         join_params:
           token_name: aws-discovery-iam-token
           method: iam
+    ssm:
+      # Use the pre-defined SSM document "AWS-RunShellScript" or a custom one.
+      # When using a custom document, ensure it is created in each region you plan to discover instances in.
+      document_name: "AWS-RunShellScript"
      tags:
        "env": "prod" # Match EC2 instances where tag:env=prod
 ```

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
@@ -17,6 +17,10 @@ discovery_service:
       join_params:
         token_name: aws-discovery-iam-token
         method: iam
+    ssm:
+      # Use the pre-defined SSM document "AWS-RunShellScript" or a custom one.
+      # When using a custom document, ensure it is created in each region you plan to discover instances in.
+      document_name: "AWS-RunShellScript"
     tags:
       "env": "prod" # Match EC2 instances where tag:env=prod
     assume_role_arn: "<Var name="role ARN" />"

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -51,11 +51,27 @@ discovery_service:
         # script_name is the name of the Teleport install script to use.
         # Optional, defaults to: "default-installer".
         script_name: "default-installer"
+        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
+        # Optional proxy settings for the install script.
+        # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+        # environment variables for the install script.
+        http_proxy_settings:
+          https_proxy: http://172.31.5.130:3128
+          http_proxy: http://172.31.5.130:3128
+          no_proxy: my-local-domain
       # Optional section: ssm is used to configure which AWS SSM document to use
       # If the ssm section isnt provided the below defaults are used.
       ssm:
         # document_name is the name of the SSM document that should be
         # executed when installing teleport on matching nodes
+        # Can be set to "AWS-RunShellScript" which is a pre-defined SSM Document,
+        # removing the need to create a custom SSM Document in each region.
         # Optional, defaults to: "TeleportDiscoveryInstaller".
         document_name: "TeleportDiscoveryInstaller"
       # Optional role for which the Discovery Service should create the EKS access entry.
@@ -85,6 +101,30 @@ discovery_service:
       # '*' - discovers resources in all resource groups within configured subscription(s) (default).
       # Any resource_groups: `az group list -o table`
       resource_groups: ["group1", "group2"]
+      # Optional section: install is used to provide parameters to the Teleport installation in Azure VMs.
+      # Only applicable for VM discovery.
+      install:
+        join_params:
+          # token_name is the name of the Teleport invite token to use.
+          # Optional, defaults to: "azure-discovery-token".
+          token_name:  "azure-discovery-token"
+        # script_name is the name of the Teleport install script to use.
+        # Optional, defaults to: "default-installer".
+        script_name: "default-installer"
+        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
+        # Optional proxy settings for the install script.
+        # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+        # environment variables for the install script.
+        http_proxy_settings:
+          https_proxy: http://172.31.5.130:3128
+          http_proxy: http://172.31.5.130:3128
+          no_proxy: my-local-domain
       # Azure resource tag filters used to match resources.
       tags:
         "*": "*"
@@ -104,6 +144,30 @@ discovery_service:
         # Email addresses of service accounts that instances can join with.
         # If empty, any service account is allowed.
         service_accounts: []
+        # Optional section: install is used to provide parameters to the Teleport installation in Google Cloud VMs.
+        # Only applicable for gce discovery.
+        install:
+          join_params:
+            # token_name is the name of the Teleport invite token to use.
+            # Optional, defaults to: "gcp-discovery-token".
+            token_name:  "gcp-discovery-token"
+          # script_name is the name of the Teleport install script to use.
+          # Optional, defaults to: "default-installer".
+          script_name: "default-installer"
+          # Optional: use a non-global teleport installation, allowing for multiple agent installations.
+          # Requires managed updates to be enabled.
+          # Supported characters are alphanumeric characters and `-`.
+          suffix: "<suffix>"
+          # Optional: when using managed updates, set the update group of the installation.
+          # Supported characters are alphanumeric characters and `-`.
+          update_group: "<update-group>"
+          # Optional proxy settings for the install script.
+          # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+          # environment variables for the install script.
+          http_proxy_settings:
+            https_proxy: http://172.31.5.130:3128
+            http_proxy: http://172.31.5.130:3128
+            no_proxy: my-local-domain
         # GCP resource label filters used to match resources.
         labels:
           "*": "*"

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -111,9 +111,7 @@ export function DiscoveryConfigSsm() {
   const { clusterId } = useStickyClusterId();
 
   const [selectedRegion, setSelectedRegion] = useState<Regions>();
-  const [ssmDocumentName, setSsmDocumentName] = useState(
-    'TeleportDiscoveryInstaller'
-  );
+  const [ssmDocumentName, setSsmDocumentName] = useState('AWS-RunShellScript');
   const [scriptUrl, setScriptUrl] = useState('');
   const joinTokenRef = useRef<JoinToken>(undefined);
   const [tags, setTags] = useState<AWSLabels>([]);


### PR DESCRIPTION
This PR updates docs for AWS EC2 Server discovery to default to using the AWS-RunShellScript SSM Document.

This Document is managed by AWS and present in all Accounts and Regions.
This means users now don't need to create the SSM Doc manually.

This is possible after [adapting the Discovery Service](https://github.com/gravitational/teleport/pull/60224) and [bootstraping scripts](https://github.com/gravitational/teleport/pull/60725) to account to this AWS SSM Document.


It also updates the reference docs for all the new available fields in discovery_service:
- http proxy settings during installation (ie. setting HTTP_PROXY family ENVs)
- install suffix (managed updates)
- install update group (managed updates)


Depends on https://github.com/gravitational/teleport/pull/60725