### PR TITLE
Release 17.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 17.7.9 (11/05/25)
+
+* Fixed configuration files such as `.kube/config` referring to non-existent `tsh` binaries. [#60872](https://github.com/gravitational/teleport/pull/60872)
+* Fixed an issue in the web UI where a bot with zero tokens would show a validation error. [#60759](https://github.com/gravitational/teleport/pull/60759)
+* The browser window for SSO MFA is slightly taller in order to accommodate larger elements like QR codes. [#60702](https://github.com/gravitational/teleport/pull/60702)
+* Fixed MongoDB topology monitoring connection leak in the Teleport Database Service. [#60693](https://github.com/gravitational/teleport/pull/60693)
+* Okta-managed apps are now pinned correctly in the web UI. [#60677](https://github.com/gravitational/teleport/pull/60677)
+* Slack access plugin no longer crashes in the event access list is unsupported. [#60674](https://github.com/gravitational/teleport/pull/60674)
+* Fixed tsh scp failing on files that grow during transfer. [#60608](https://github.com/gravitational/teleport/pull/60608)
+* Allowed moderated session peers to perform file transfers. [#60605](https://github.com/gravitational/teleport/pull/60605)
+* Fixed a startup error `EADDRINUSE: address already in use` in Teleport Connect on macOS and Linux that could occur with long system usernames. [#60577](https://github.com/gravitational/teleport/pull/60577)
+* MWI: `tbot`'s auto-generated service names are now simpler and easier to use in the `/readyz` endpoint. [#60459](https://github.com/gravitational/teleport/pull/60459)
+* Client tools managed updates stores OS and ARCH in the configuration. This ensures compatibility when `TELEPORT_HOME` directory is shared with a virtual instance running a different OS or architecture. [#60413](https://github.com/gravitational/teleport/pull/60413)
+* Updated LDAP dial timeout from 15 seconds to 30 seconds. [#60392](https://github.com/gravitational/teleport/pull/60392)
+* Fixed a bug that prevented using database role names longer than 30 chars for MySQL auto user provisioning. Now role names as long as 32 chars, which is the MySQL limit, can be used. [#60378](https://github.com/gravitational/teleport/pull/60378)
+* Fixed a bug in Proxy Recording Mode that causes SSH sessions in the WebUI to fail. [#60368](https://github.com/gravitational/teleport/pull/60368)
+* Added `extraEnv` and `extraArgs` to the teleport-operator helm chart. [#60356](https://github.com/gravitational/teleport/pull/60356)
+* Fixed malformed audit events breaking the audit log. [#60335](https://github.com/gravitational/teleport/pull/60335)
+* Added editing bot description to the web UI. [#60213](https://github.com/gravitational/teleport/pull/60213)
+
 ## 17.7.8 (10/15/25)
 
 * Updated error messages displayed by `tsh ssh` when access to hosts is denied and when attempting to connect to a host that is offline or not enrolled in the cluster. [#60226](https://github.com/gravitational/teleport/pull/60226)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=17.7.8
+VERSION=17.7.9
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "17.7.8"
+const Version = "17.7.9"
 
 const VersionMajor = 17
 const VersionMinor = 7
-const VersionPatch = 8
+const VersionPatch = 9
 const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.7.8</string>
+		<string>17.7.9</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.7.8</string>
+		<string>17.7.9</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>17.7.8</string>
+		<string>17.7.9</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>17.7.8</string>
+		<string>17.7.9</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -60,6 +60,7 @@
     "Dfumu",
     "Distroless",
     "Divio's",
+    "EADDRINUSE",
     "EBSCSI",
     "ECCP",
     "ECMWF",

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-datadog-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-datadog-17.7.9
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-datadog-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-datadog-17.7.9
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-datadog-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-datadog-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-discord-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-discord-17.7.9
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-discord-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-discord-17.7.9
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-discord-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-discord-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-email-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-email-17.7.9
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-email-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-email-17.7.9
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-email:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-jira-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-jira-17.7.9
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-jira-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-jira-17.7.9
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-jira-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-jira-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-mattermost-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-mattermost-17.7.9
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-mattermost-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-mattermost-17.7.9
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-mattermost-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-mattermost-17.7.9
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-mattermost-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-mattermost-17.7.9
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-mattermost-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-mattermost-17.7.9
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-mattermost-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-mattermost-17.7.9
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-mattermost-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-mattermost-17.7.9
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.8
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:17.7.9
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-msteams-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-msteams-17.7.9
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-msteams-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-msteams-17.7.9
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-msteams-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-msteams-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-pagerduty-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-pagerduty-17.7.9
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-pagerduty-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-pagerduty-17.7.9
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-pagerduty-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-pagerduty-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-slack-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-slack-17.7.9
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-slack-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-slack-17.7.9
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-plugin-slack-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-plugin-slack-17.7.9
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-event-handler-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-event-handler-17.7.9
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-plugin-event-handler-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-plugin-event-handler-17.7.9
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -82,7 +82,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.7.8
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:17.7.9
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.7.8
+            helm.sh/chart: tbot-17.7.9
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:17.7.8
+            image: public.ecr.aws/gravitational/tbot-distroless:17.7.9
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-17.7.8
+            helm.sh/chart: tbot-17.7.9
         spec:
           containers:
           - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:17.7.8
+            image: public.ecr.aws/gravitational/tbot-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-cluster-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-cluster-17.7.9
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -1955,8 +1955,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-cluster-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-cluster-17.7.9
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -274,7 +274,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -378,7 +378,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-cluster-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-cluster-17.7.9
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 17.7.8
-        helm.sh/chart: teleport-cluster-17.7.8
+        app.kubernetes.io/version: 17.7.9
+        helm.sh/chart: teleport-cluster-17.7.9
         teleport.dev/majorVersion: "17"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 83b023dee1804d3912b525a771465e29b33ae969dda9c4922a00895edfc5ce93
+            checksum/config: 14b54df4a3e0842b885d10edfb7bfc018f0d48b4de05841830ed914663844f17
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 17.7.8
-            helm.sh/chart: teleport-cluster-17.7.8
+            app.kubernetes.io/version: 17.7.9
+            helm.sh/chart: teleport-cluster-17.7.9
             teleport.dev/majorVersion: "17"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v16.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -349,7 +349,7 @@ should set resources for wait-auth-update initContainer when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -418,7 +418,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
       resources:
         limits:
@@ -475,7 +475,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -544,7 +544,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
       resources:
         limits:
@@ -601,7 +601,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -670,7 +670,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -727,7 +727,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -796,7 +796,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v16.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "17.7.8"
+.version: &version "17.7.9"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+          image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -91,7 +91,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -188,7 +188,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -293,7 +293,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -366,7 +366,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -459,7 +459,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+            image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -542,7 +542,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -615,7 +615,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -688,7 +688,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -775,7 +775,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -860,7 +860,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -933,7 +933,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1006,7 +1006,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1081,7 +1081,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1159,7 +1159,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1240,7 +1240,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1323,7 +1323,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1408,7 +1408,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1489,7 +1489,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1562,7 +1562,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1693,7 +1693,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1852,7 +1852,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1998,7 +1998,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2071,7 +2071,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2158,7 +2158,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2231,7 +2231,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2314,7 +2314,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2387,7 +2387,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2467,7 +2467,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2540,7 +2540,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2613,7 +2613,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2686,7 +2686,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:17.7.8
+      image: public.ecr.aws/gravitational/teleport-distroless:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.8
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.8
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:17.7.9
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6


### PR DESCRIPTION

* Fixed configuration files such as `.kube/config` referring to non-existent `tsh` binaries. [#60872](https://github.com/gravitational/teleport/pull/60872)
* Fixed an issue in the web UI where a bot with zero tokens would show a validation error. [#60759](https://github.com/gravitational/teleport/pull/60759)
* The browser window for SSO MFA is slightly taller in order to accommodate larger elements like QR codes. [#60702](https://github.com/gravitational/teleport/pull/60702)
* Fixed MongoDB topology monitoring connection leak in the Teleport Database Service. [#60693](https://github.com/gravitational/teleport/pull/60693)
* Okta-managed apps are now pinned correctly in the web UI. [#60677](https://github.com/gravitational/teleport/pull/60677)
* Slack access plugin no longer crashes in the event access list is unsupported. [#60674](https://github.com/gravitational/teleport/pull/60674)
* Fixed tsh scp failing on files that grow during transfer. [#60608](https://github.com/gravitational/teleport/pull/60608)
* Allowed moderated session peers to perform file transfers. [#60605](https://github.com/gravitational/teleport/pull/60605)
* Fixed a startup error `EADDRINUSE: address already in use` in Teleport Connect on macOS and Linux that could occur with long system usernames. [#60577](https://github.com/gravitational/teleport/pull/60577)
* MWI: `tbot`'s auto-generated service names are now simpler and easier to use in the `/readyz` endpoint. [#60459](https://github.com/gravitational/teleport/pull/60459)
* Client tools managed updates stores OS and ARCH in the configuration. This ensures compatibility when `TELEPORT_HOME` directory is shared with a virtual instance running a different OS or architecture. [#60413](https://github.com/gravitational/teleport/pull/60413)
* Updated LDAP dial timeout from 15 seconds to 30 seconds. [#60392](https://github.com/gravitational/teleport/pull/60392)
* Fixed a bug that prevented using database role names longer than 30 chars for MySQL auto user provisioning. Now role names as long as 32 chars, which is the MySQL limit, can be used. [#60378](https://github.com/gravitational/teleport/pull/60378)
* Fixed a bug in Proxy Recording Mode that causes SSH sessions in the WebUI to fail. [#60368](https://github.com/gravitational/teleport/pull/60368)
* Added `extraEnv` and `extraArgs` to the teleport-operator helm chart. [#60356](https://github.com/gravitational/teleport/pull/60356)
* Fixed malformed audit events breaking the audit log. [#60335](https://github.com/gravitational/teleport/pull/60335)
* Added editing bot description to the web UI. [#60213](https://github.com/gravitational/teleport/pull/60213)