### PR TITLE
fix db service crash when fetching aws meta failed

### DIFF
--- a/lib/srv/db/common/connect/connect.go
+++ b/lib/srv/db/common/connect/connect.go
@@ -223,7 +223,7 @@ type ConnectParams struct {
 }
 
 func (p *ConnectParams) CheckAndSetDefaults() error {
-	if p.Logger != nil {
+	if p.Logger == nil {
 		p.Logger = slog.Default()
 	}
 

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -51,7 +51,9 @@ func ConvertError(err error) error {
 
 	var pgErr pgError
 	if errors.As(err, &pgErr) {
-		return ConvertError(pgErr.Unwrap())
+		if unwrapped := pgErr.Unwrap(); unwrapped != nil && unwrapped.Error() != "" {
+			return ConvertError(unwrapped)
+		}
 	}
 
 	var c causer

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -46,30 +46,20 @@ func ConvertError(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Unwrap original error first.
-	err = trace.Unwrap(err)
 
-	var pgErr pgError
-	if errors.As(err, &pgErr) {
-		if unwrapped := pgErr.Unwrap(); unwrapped != nil && unwrapped.Error() != "" {
-			return ConvertError(unwrapped)
-		}
-	}
-
-	var c causer
-	if errors.As(err, &c) {
-		return ConvertError(c.Cause())
-	}
-	if _, ok := status.FromError(err); ok {
-		return trail.FromGRPC(err)
-	}
-
+	var causeErr causer
 	var googleAPIErr *googleapi.Error
 	var awsRequestFailureErr *awshttp.ResponseError
 	var azResponseErr *azcore.ResponseError
 	var pgError *pgconn.PgError
 	var myError *mysql.MyError
+
+	// Unwrap trace error first.
 	switch err := trace.Unwrap(err); {
+	case errors.As(err, &causeErr):
+		return ConvertError(causeErr.Cause())
+	case isGRPCStatusError(err):
+		return trail.FromGRPC(err)
 	case errors.As(err, &googleAPIErr):
 		return convertGCPError(googleAPIErr)
 	case errors.As(err, &awsRequestFailureErr):
@@ -82,6 +72,11 @@ func ConvertError(err error) error {
 		return convertMySQLError(myError)
 	}
 	return err // Return unmodified.
+}
+
+func isGRPCStatusError(err error) bool {
+	_, ok := status.FromError(err)
+	return ok
 }
 
 // convertGCPError converts GCP errors to trace errors.
@@ -122,11 +117,6 @@ func fmtEscape(err error) string {
 // causer defines an interface for errors wrapped by the "errors" package.
 type causer interface {
 	Cause() error
-}
-
-// pgError defines an interface for errors wrapped by Postgres driver.
-type pgError interface {
-	Unwrap() error
 }
 
 // ConvertConnectError converts common connection errors to trace errors with

--- a/lib/srv/db/common/errors_test.go
+++ b/lib/srv/db/common/errors_test.go
@@ -22,11 +22,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgerrcode"
-
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 	"github.com/stretchr/testify/require"
 )
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5654,7 +5654,12 @@ func TestMakeProfileInfo_NoInternalLogins(t *testing.T) {
 }
 
 func TestBenchmarkPostgres(t *testing.T) {
-	t.Parallel()
+	// Set insecure mode to allow db agent to establish reverse tunnel.
+	isInsecure := lib.IsInsecureDevMode()
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() {
+		lib.SetInsecureDevMode(isInsecure)
+	})
 
 	// Canceling the context right after the test ensures the local proxy
 	// started by the benchmark command is closed and the remaining connections
@@ -5707,7 +5712,7 @@ func TestBenchmarkPostgres(t *testing.T) {
 	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, alice, connector.GetName()))
 	require.NoError(t, err)
 
-	benchmarkErrorLineParser := regexp.MustCompile("`host=(.+) +user=(.+) database=(.+)`: (.+)$")
+	benchmarkErrorLineParser := regexp.MustCompile("`host=(.+?) +user=(.+?) database=(.+?)`: (.+)$")
 	args := []string{
 		"bench", "postgres", "--insecure",
 		// Benchmark options to limit benchmark to a single execution.
@@ -5726,16 +5731,16 @@ func TestBenchmarkPostgres(t *testing.T) {
 		"connect to database": {
 			database:            "postgres-local",
 			additionalFlags:     []string{"--db-user", "username", "--db-name", "database"},
-			expectedErrContains: "server error",
+			expectedErrContains: "lookup external-pg",
 			// When connecting to Teleport databases, it will use a local proxy.
 			expectedHost:     "127.0.0.1",
 			expectedUser:     "username",
 			expectedDatabase: "database",
 		},
 		"direct connection": {
-			database:            "postgres://direct_user@test:5432/direct_database",
-			expectedErrContains: "hostname resolving error",
-			expectedHost:        "test",
+			database:            "postgres://direct_user@direct-pg:5432/direct_database",
+			expectedErrContains: "lookup direct-pg",
+			expectedHost:        "direct-pg",
 			expectedUser:        "direct_user",
 			expectedDatabase:    "direct_database",
 		},


### PR DESCRIPTION
changelog: fix an issue sometimes db service panics when fetching aws metadata fails

before
```
2025-11-05T16:34:14.054-05:00 DEBU [PROC:1]    Service is completed and removed pid:13823.1 service:db.init service/supervisor.go:255
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0xe0 pc=0x1061c3624]

goroutine 1727 [running]:
github.com/gravitational/teleport/lib/srv/discovery/common.MetadataFromRDSInstance(0x0)
	github.com/gravitational/teleport/lib/srv/discovery/common/database.go:1073 +0x24
github.com/gravitational/teleport/lib/srv/db/cloud.fetchRDSInstanceMetadata({0x10ff032e0?, 0x140007ba910?}, {0x10ff2e9f8?, 0x14002eed888?}, {0x140013acf80?, 0x0?})
	github.com/gravitational/teleport/lib/srv/db/cloud/meta.go:392 +0x70
github.com/gravitational/teleport/lib/srv/db/cloud.(*Metadata).fetchRDSMetadata(0x140031c2a80, {0x10ff032e0, 0x140007ba910}, {0x11000c458?, 0x14002eb7408?})
	github.com/gravitational/teleport/lib/srv/db/cloud/meta.go:248 +0x224
```

after (warning log but no panic)
```
2025-11-06T13:03:17.584-05:00 WARN [DB:SERVIC] Failed to fetch cloud metadata. db:test-rds error:[
ERROR REPORT:
Original Error: *smithy.OperationError operation error RDS: DescribeDBInstances, get identity: get credentials: failed to refresh cached credentials, the SSO session has expired or is invalid
Stack Trace:
	github.com/gravitational/teleport/lib/srv/db/cloud/meta.go:390 github.com/gravitational/teleport/lib/srv/db/cloud.fetchRDSInstanceMetadata
```