### PR TITLE
Adjust log level on some noisy entries

### DIFF
--- a/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
+++ b/lib/auth/machineid/machineidv1/spiffe_federation_syncer.go
@@ -216,12 +216,12 @@ type trustDomainSyncState struct {
 // the local cluster. It does this by creating a goroutine that manages each
 // federated cluster.
 func (s *SPIFFEFederationSyncer) syncTrustDomains(ctx context.Context) error {
-	s.cfg.Logger.InfoContext(
+	s.cfg.Logger.DebugContext(
 		ctx,
 		"Obtained lock, SPIFFEFederation syncer is starting",
 	)
 	defer func() {
-		s.cfg.Logger.InfoContext(
+		s.cfg.Logger.DebugContext(
 			ctx, "SPIFFEFederation syncer has stopped",
 		)
 	}()

--- a/lib/auth/machineid/workloadidentityv1/revocation_service.go
+++ b/lib/auth/machineid/workloadidentityv1/revocation_service.go
@@ -607,7 +607,7 @@ func (s *RevocationService) signCRL(
 		tracing.EndSpan(span, err)
 	}()
 
-	s.logger.InfoContext(ctx, "Starting to generate new CRL")
+	s.logger.DebugContext(ctx, "Starting to generate new CRL")
 	ca, err := s.certAuthorityGetter.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       types.SPIFFECA,
 		DomainName: s.clusterName,
@@ -659,7 +659,7 @@ func (s *RevocationService) signCRL(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	s.logger.InfoContext(ctx, "Finished generating new CRL", "revocations", len(revocations))
+	s.logger.DebugContext(ctx, "Finished generating new CRL", "revocations", len(revocations))
 	return signedCRL, nil
 }
 

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/interval"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
 var (
@@ -1269,7 +1270,7 @@ func (c *Cache) fetchAndWatch(ctx context.Context, retry retryutils.Retry, timer
 			"duration", fetchAndApplyDuration.String(),
 		)
 	} else {
-		c.Logger.DebugContext(ctx, "fetch and apply",
+		c.Logger.Log(ctx, logutils.TraceLevel, "fetch and apply",
 			"cache_target", c.Config.target,
 			"duration", fetchAndApplyDuration.String(),
 		)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -250,7 +250,8 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		if role == types.RoleAdmin || role == types.RoleAuth {
 			return newConnector(identity, identity)
 		}
-		process.logger.InfoContext(process.ExitContext(), "Connecting to the cluster with TLS client certificate.", "cluster", identity.ClusterName)
+		process.logger.InfoContext(process.ExitContext(), "Connecting to the cluster with TLS client certificate.",
+			"cluster", identity.ClusterName, "role", role.String())
 		connector, err := process.getConnector(identity, identity)
 		if err != nil {
 			// In the event that a user is attempting to connect a machine to

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3791,14 +3791,14 @@ func (process *TeleportProcess) initUploaderService() error {
 	for _, path := range paths {
 		for i := 1; i < len(path); i++ {
 			dir := filepath.Join(path[:i+1]...)
-			logger.InfoContext(process.ExitContext(), "Creating directory.", "directory", dir)
+			logger.Log(process.ExitContext(), logutils.TraceLevel, "Creating directory.", "directory", dir)
 			err := os.Mkdir(dir, 0o755)
 			err = trace.ConvertSystemError(err)
 			if err != nil && !trace.IsAlreadyExists(err) {
 				return trace.Wrap(err)
 			}
 			if uid != nil && gid != nil {
-				logger.InfoContext(process.ExitContext(), "Setting directory owner.", "directory", dir, "uid", *uid, "gid", *gid)
+				logger.Log(process.ExitContext(), logutils.TraceLevel, "Setting directory owner.", "directory", dir, "uid", *uid, "gid", *gid)
 				err := os.Lchown(dir, *uid, *gid)
 				if err != nil {
 					return trace.ConvertSystemError(err)

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -214,7 +214,7 @@ func (e *Event) String() string {
 }
 
 func (s *LocalSupervisor) Register(srv Service) {
-	s.log.DebugContext(s.closeContext, "Adding service to supervisor", "service", srv.Name())
+	s.log.Log(s.closeContext, logutils.TraceLevel, "Adding service to supervisor", "service", srv.Name())
 	s.Lock()
 	defer s.Unlock()
 	s.services = append(s.services, srv)
@@ -252,7 +252,7 @@ func (s *LocalSupervisor) RemoveService(srv Service) error {
 	for i, el := range s.services {
 		if el == srv {
 			s.services = slices.Delete(s.services, i, i+1)
-			l.DebugContext(s.closeContext, "Service is completed and removed")
+			l.Log(s.closeContext, logutils.TraceLevel, "Service is completed and removed")
 			return nil
 		}
 	}
@@ -324,7 +324,7 @@ func (s *LocalSupervisor) serve(srv Service) {
 		}
 
 		l := s.log.With("service", srv.Name())
-		l.DebugContext(s.closeContext, "Service has started")
+		l.Log(s.closeContext, logutils.TraceLevel, "Service has started")
 		err := srv.Serve()
 		if err != nil {
 			if errors.Is(err, ErrTeleportExited) {

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -246,7 +246,7 @@ func (p *resourceWatcher) hasStaleView() bool {
 // runWatchLoop runs a watch loop.
 func (p *resourceWatcher) runWatchLoop() {
 	for {
-		p.Logger.DebugContext(p.ctx, "Starting watch.")
+		p.Logger.Log(p.ctx, logutils.TraceLevel, "Starting watch.")
 		err := p.watch()
 
 		select {

--- a/lib/watcher/ready.go
+++ b/lib/watcher/ready.go
@@ -133,7 +133,7 @@ func waitForInitEvent(ctx context.Context, w types.Watcher, cfg WaitForReadyConf
 			cfg.Logger.ErrorContext(ctx, "expected init event, got something else (this is a bug)", "name", cfg.Watch.Name, "attempt", attempt, "event_type", evt.Type)
 			return trace.BadParameter("unexpected event type: %v", evt.Type)
 		}
-		cfg.Logger.InfoContext(ctx, "event stream initialized", "name", cfg.Watch.Name, "duration", cfg.Clock.Since(start).String())
+		cfg.Logger.DebugContext(ctx, "event stream initialized", "name", cfg.Watch.Name, "duration", cfg.Clock.Since(start).String())
 		return nil
 
 	case <-w.Done():


### PR DESCRIPTION
Most of the items moved to trace here generate lots of log noise but haven't been critical to troubleshooting in my experience.

Also moved some periodic INFO level items to debug.