### PR TITLE
Fix web sftp breaking with proxy protocol on unset listen addr

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1701,6 +1701,59 @@ func (w *WebClient) SSH(termReq web.TerminalRequest) (*terminal.Stream, error) {
 	return terminal.NewStream(context.Background(), terminal.StreamConfig{WS: ws}), nil
 }
 
+func (w *WebClient) SFTP(path string, upload []byte) ([]byte, error) {
+	u := &url.URL{
+		Host:   w.i.Web,
+		Scheme: client.HTTPS,
+		Path: fmt.Sprintf(
+			"/v1/webapi/sites/%s/nodes/%s/%s/scp",
+			w.i.Config.Auth.ClusterName.GetClusterName(),
+			w.tc.Host,
+			w.tc.HostLogin,
+		),
+	}
+
+	q := u.Query()
+	q.Set("location", path)
+	q.Set("filename", "foo.txt")
+	u.RawQuery = q.Encode()
+	header := http.Header{}
+	header.Add("Origin", "http://localhost")
+	for _, cookie := range w.cookies {
+		header.Add("Cookie", cookie.String())
+	}
+	header.Set("Authorization", "Bearer "+w.token)
+
+	ctx := w.i.Process.GracefulExitContext()
+	method := http.MethodGet
+	if upload != nil {
+		method = http.MethodPost
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), bytes.NewReader(upload))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req.Header = header
+	transport, err := defaults.Transport()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	clt := &http.Client{Transport: transport}
+	resp, err := clt.Do(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return body, trace.ReadError(resp.StatusCode, body)
+}
+
 func (w *WebClient) JoinKubernetesSession(id string, mode types.SessionParticipantMode) (*terminal.Stream, error) {
 	u := url.URL{
 		Host:   w.i.Web,


### PR DESCRIPTION
This change fixes a bug where file uploads/downloads in the web ui would fail if a) proxy protocol was active and b) `proxy_service.web_listen_addr` was unspecified. This was caused by the dialer in lib/web/files.go using the config file value directly as the client destination address, which the proxy header signer would reject as not a valid ip address if empty. This is fixed by giving the web handler the actual address of the web listener, instead of just the config value.

Fixes #60709.

Changelog: Fixed web upload/download failure behind load balancers when web listen address is unspecified

Test plan:
- [x] Create a cluster with a node and web listen addr unset (public addr is fine). Put the cluster behind a load balancer. Open a web session to the node and verify that file uploads/downloads work correctly.