### PR TITLE
fix: continue waiting for request approval when unrelated requests get deleted

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -5719,7 +5719,11 @@ func awaitRequestResolution(ctx context.Context, clt authclient.ClientI, req typ
 					return nil, trace.BadParameter("unexpected resource type %T", event.Resource)
 				}
 			case types.OpDelete:
-				return nil, trace.Errorf("request %s has expired or been deleted...", event.Resource.GetName())
+				// Delete events are not filtered, only return if the deleted
+				// request matches the request we're waiting for.
+				if event.Resource.GetName() == req.GetName() {
+					return nil, trace.Errorf("request %s has expired or been deleted...", event.Resource.GetName())
+				}
 			default:
 				logger.WarnContext(ctx, "Skipping unknown event type", "event_type", event.Type)
 			}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/61016

It appears that watchers do not filter OpDelete events, which caused a bug in `tsh` when waiting for access request approval, it would erroneously report `request has expired or been deleted...` when *any* access request in the cluster got deleted, not just the request it was waiting for.

Manual test plan:

- [x] tried `tsh ssh` with an automatic access request, deleted a different request, still succeeded after approving the correct request
- [x] tried `tsh login --request-roles access`, deleted a different request, still succeeded after approving the correct request

changelog: fixed a bug causing `tsh` to stop waiting for access request approval and incorrectly report that the request had been deleted