### PR TITLE
Implement filtering for instances

### DIFF
--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -19,11 +19,19 @@ package inventory
 import (
 	"context"
 	"encoding/base32"
+	"fmt"
 	"log/slog"
+	"maps"
 	"math"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/charlievieth/strcase"
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"golang.org/x/time/rate"
 	"google.golang.org/protobuf/proto"
@@ -35,8 +43,11 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cache"
+	"github.com/gravitational/teleport/lib/expression"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/set"
 	"github.com/gravitational/teleport/lib/utils/sortcache"
+	"github.com/gravitational/teleport/lib/utils/typical"
 )
 
 const (
@@ -45,6 +56,12 @@ const (
 
 	// botInstancePrefix is the backend prefix for bot instances.
 	botInstancePrefix = "bot_instance"
+)
+
+var (
+	// unifiedExpressionParser is a cached unified expression parser
+	unifiedExpressionParser     *typical.Parser[*unifiedFilterEnvironment, bool]
+	unifiedExpressionParserOnce sync.Once
 )
 
 // instanceTypeToKind converts an InstanceType enum to a resource kind string.
@@ -72,6 +89,10 @@ const (
 	// inventoryTypeIndex sorts instances by type, display name
 	// and unique ID.
 	inventoryTypeIndex inventoryIndex = "type"
+
+	// inventoryVersionIndex sorts instances by version, display name
+	// and unique ID.
+	inventoryVersionIndex inventoryIndex = "version"
 
 	// inventoryIDIndex allows lookup by instance ID.
 	// Uses ordered.Encode(bot name, instance ID, kind) where the bot name is "" for regular instances
@@ -140,6 +161,79 @@ func (u *inventoryInstance) getTypeKey() bytestring {
 	}
 
 	return bytestring(ordered.Encode(u.getKind(), name, id))
+}
+
+// getVersionKey returns the composite key for sorting by version using semver ordering.
+func (u *inventoryInstance) getVersionKey() bytestring {
+	var versionStr, name, id string
+	if u.isInstance() {
+		versionStr = u.instance.Spec.Version
+		name = u.instance.GetHostname()
+		id = u.instance.GetName()
+	} else {
+		if u.bot.Status != nil && len(u.bot.Status.LatestHeartbeats) > 0 {
+			versionStr = u.bot.Status.LatestHeartbeats[0].Version
+		}
+		name = u.bot.GetSpec().GetBotName()
+		id = u.bot.GetSpec().GetInstanceId()
+	}
+
+	// If version is empty, treat it as 0.0.0
+	if versionStr == "" {
+		return bytestring(ordered.Encode(uint64(0), uint64(0), uint64(0), ordered.Inf, name, id))
+	}
+
+	// Strip "v" prefix if it's there, eg. v1.2.3 -> 1.2.3
+	versionStr = strings.TrimPrefix(versionStr, "v")
+
+	// Parse as semver
+	v, err := semver.NewVersion(versionStr)
+	if err != nil {
+		// Invalid semvers sort after all other versions
+		return bytestring(ordered.Encode(ordered.Inf, versionStr, name, id))
+	}
+
+	// For releases (ie. anything not a pre-release), we use ordered.Inf before the metadata to ensure it sorts after all prereleases
+	if v.PreRelease == "" {
+		return bytestring(ordered.Encode(v.Major, v.Minor, v.Patch, ordered.Inf, v.Metadata, name, id))
+	}
+
+	// For pre-releases
+
+	parts := strings.Split(string(v.PreRelease), ".")
+
+	// Pre-allocate the slice
+	// The 3 is for major, minor, patch
+	// The len(parts)*2 is for pre-release parts (each one needs 2 for tag+value)
+	// The 4 is for the sentinel value, metadata, name, id
+	encodeArgs := make([]any, 0, 3+len(parts)*2+4)
+	encodeArgs = append(encodeArgs, v.Major, v.Minor, v.Patch)
+
+	// We encode each pre-release part with a tag to ensure correct ordering:
+	// We use 0 for numeric parts (so that they always sort before tag 1)
+	// We use 1 for alphanumeric parts (so that they always sort after tag 0, but before ordered.Inf which we use for releases)
+	for _, part := range parts {
+		// Check if the part is numeric or alphanumeric
+		if num, err := strconv.ParseUint(part, 10, 64); err == nil {
+			encodeArgs = append(encodeArgs, uint64(0), num)
+		} else {
+			encodeArgs = append(encodeArgs, uint64(1), part)
+		}
+	}
+
+	// We use "" as sentinel value to mark the "end" of pre-releases
+	// This way we can make sure that for example, "alpha" < "alpha.1"
+	// "alpha" would be [..., 1, "alpha", ""] and "alpha.1" would be [..., 1, "alpha", 0, 1, ""]
+	// Since it'll compare "" < 0, "alpha" will come first
+	encodeArgs = append(encodeArgs, "")
+
+	// Metadata eg. "+build123" doesn't affect semver ordering, but we add it to ensure that
+	// two versions that differ only in metadata have a consistent order
+	encodeArgs = append(encodeArgs, v.Metadata)
+
+	encodeArgs = append(encodeArgs, name, id)
+
+	return bytestring(ordered.Encode(encodeArgs...))
 }
 
 // getIDKey returns the key for lookup by instance ID.
@@ -225,6 +319,7 @@ func NewInventoryCache(cfg InventoryCacheConfig) (*InventoryCache, error) {
 			Indexes: map[inventoryIndex]func(*inventoryInstance) string{
 				inventoryAlphabeticalIndex: (*inventoryInstance).getAlphabeticalKey,
 				inventoryTypeIndex:         (*inventoryInstance).getTypeKey,
+				inventoryVersionIndex:      (*inventoryInstance).getVersionKey,
 				inventoryIDIndex:           (*inventoryInstance).getIDKey,
 			},
 		}),
@@ -532,6 +627,33 @@ func (ic *InventoryCache) processDeleteEvent(event types.Event) error {
 	return nil
 }
 
+// parsedFilter holds the expression filters.
+type parsedFilter struct {
+	filter                    *inventoryv1.ListUnifiedInstancesFilter
+	unifiedInstanceExpression typical.Expression[*unifiedFilterEnvironment, bool]
+}
+
+// parseFilter returns a parsedFilter given a ListUnifiedInstancesFilter.
+func (ic *InventoryCache) parseFilter(filter *inventoryv1.ListUnifiedInstancesFilter) (*parsedFilter, error) {
+	pf := &parsedFilter{
+		filter: filter,
+	}
+
+	if filter == nil || filter.PredicateExpression == "" {
+		return pf, nil
+	}
+
+	parser := getUnifiedExpressionParser()
+
+	expr, err := parser.Parse(filter.PredicateExpression)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	pf.unifiedInstanceExpression = expr
+
+	return pf, nil
+}
+
 // ListUnifiedInstances returns a page of instances and bot_instances. This API will refuse any requests when the cache is unhealthy or not yet
 // fully initialized.
 func (ic *InventoryCache) ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error) {
@@ -553,36 +675,69 @@ func (ic *InventoryCache) ListUnifiedInstances(ctx context.Context, req *invento
 		startKey = string(decoded)
 	}
 
+	parsed, err := ic.parseFilter(req.GetFilter())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var items []*inventoryv1.UnifiedInstanceItem
 	var nextPageToken string
 
-	index := inventoryAlphabeticalIndex
-	var endKey string
-	// Determine if we should use the type index.
-	useTypeIndex := req.GetFilter() != nil && len(req.GetFilter().GetInstanceTypes()) == 1
-	if useTypeIndex {
+	var index inventoryIndex
+
+	switch req.GetSort() {
+	case inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_TYPE:
 		index = inventoryTypeIndex
-		if req.PageToken == "" {
-			kind, err := instanceTypeToKind(req.GetFilter().GetInstanceTypes()[0])
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			startKey = string(ordered.Encode(kind))
-			endKey = string(ordered.Encode(kind, ordered.Inf))
-		}
+	case inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION:
+		index = inventoryVersionIndex
+	case inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME:
+		index = inventoryAlphabeticalIndex
+	default:
+		index = inventoryAlphabeticalIndex
 	}
 
-	for sf := range ic.cache.Ascend(index, startKey, endKey) {
-		if !ic.matchesFilter(sf, req.GetFilter()) {
+	var endKey string
+
+	// Determine sort order (ascending vs descending)
+	isDesc := req.GetOrder() == inventoryv1.SortOrder_SORT_ORDER_DESCENDING
+
+	// For type index with a single instance type filter, set bounds
+	if index == inventoryTypeIndex && req.GetFilter() != nil && len(req.GetFilter().GetInstanceTypes()) == 1 {
+		kind, err := instanceTypeToKind(req.GetFilter().GetInstanceTypes()[0])
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		start := string(ordered.Encode(kind))
+		end := string(ordered.Encode(kind, ordered.Inf))
+
+		// If we're going in descending order, the start key becomes the end key, and vice versa
+		if isDesc {
+			start, end = end, start
+		}
+
+		if req.PageToken == "" {
+			startKey = start
+		}
+		endKey = end
+	}
+
+	// Iterate over items in the cache
+	iterator := ic.cache.Ascend
+	if isDesc {
+		iterator = ic.cache.Descend
+	}
+
+	for sf := range iterator(index, startKey, endKey) {
+		if !ic.matchesFilter(sf, parsed) {
 			continue
 		}
 
 		if len(items) == int(req.PageSize) {
-			var rawKey string
-			if index == inventoryAlphabeticalIndex {
-				rawKey = sf.getAlphabeticalKey()
-			} else {
-				rawKey = sf.getTypeKey()
+			// Get the key for the current item based on the index
+			rawKey, err := ic.getKeyForIndex(sf, index)
+			if err != nil {
+				return nil, trace.Wrap(err)
 			}
 			// Encode the next page token to base32hex
 			nextPageToken = base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString([]byte(rawKey))
@@ -600,32 +755,323 @@ func (ic *InventoryCache) ListUnifiedInstances(ctx context.Context, req *invento
 }
 
 // matchesFilter checks if a unified instance matches the filter criteria.
-func (ic *InventoryCache) matchesFilter(ui *inventoryInstance, filter *inventoryv1.ListUnifiedInstancesFilter) bool {
-	// If no filter is provided, match all instances
-	if filter == nil || len(filter.InstanceTypes) == 0 {
+func (ic *InventoryCache) matchesFilter(ui *inventoryInstance, parsed *parsedFilter) bool {
+	if parsed == nil || parsed.filter == nil {
 		return true
 	}
 
-	instanceKind := ui.getKind()
-	matched := false
+	filter := parsed.filter
+
+	// Filter by instance types
+	isInstance := ui.isInstance()
+	matchesType := false
 	for _, instanceType := range filter.InstanceTypes {
-		kind, err := instanceTypeToKind(instanceType)
-		if err != nil {
-			// Skip unknown instance types
-			continue
+		if instanceType == inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE && isInstance {
+			matchesType = true
+			break
 		}
-		if kind == instanceKind {
-			matched = true
+		if instanceType == inventoryv1.InstanceType_INSTANCE_TYPE_BOT_INSTANCE && !isInstance {
+			matchesType = true
 			break
 		}
 	}
-
-	if !matched {
+	if len(filter.InstanceTypes) > 0 && !matchesType {
 		return false
 	}
 
-	// TODO(rudream): implement additional filtering criteria (search, services, etc.)
+	// Basic search
+	if filter.Search != "" {
+		var searchableText string
+		if ui.isInstance() {
+			// For instances, search by hostname or instance ID
+			searchableText = ui.instance.Spec.Hostname + " " + ui.instance.GetName()
+		} else {
+			// For bot instances, search by bot name or instance ID
+			searchableText = ui.bot.Spec.BotName + " " + ui.bot.GetMetadata().GetName()
+		}
+
+		searchTerms := strings.Fields(filter.Search)
+		matchedAll := true
+		for _, term := range searchTerms {
+			if !strcase.Contains(searchableText, term) {
+				matchedAll = false
+				break
+			}
+		}
+
+		if !matchedAll {
+			return false
+		}
+	}
+
+	// Filter by services (only applies to instances)
+	if len(filter.Services) > 0 {
+		// Bot instances don't have services, so exclude them when the services filter is active
+		if !ui.isInstance() {
+			return false
+		}
+		filterServices := set.New(filter.Services...)
+		hasService := false
+		for _, svc := range ui.instance.Spec.Services {
+			if filterServices.Contains(string(svc)) {
+				hasService = true
+				break
+			}
+		}
+		if !hasService {
+			return false
+		}
+	}
+
+	// Filter by updater groups
+	if len(filter.UpdaterGroups) > 0 {
+		var updateGroup string
+		if ui.isInstance() {
+			if ui.instance.Spec.UpdaterInfo != nil {
+				updateGroup = ui.instance.Spec.UpdaterInfo.UpdateGroup
+			}
+		} else {
+			if len(ui.bot.Status.LatestHeartbeats) > 0 && ui.bot.Status.LatestHeartbeats[0].UpdaterInfo != nil {
+				updateGroup = ui.bot.Status.LatestHeartbeats[0].UpdaterInfo.UpdateGroup
+			}
+		}
+		if !slices.Contains(filter.UpdaterGroups, updateGroup) {
+			return false
+		}
+	}
+
+	// Filter by upgraders
+	if len(filter.Upgraders) > 0 {
+		var upgrader string
+		if ui.isInstance() {
+			upgrader = ui.instance.Spec.ExternalUpgrader
+		} else {
+			if len(ui.bot.Status.LatestHeartbeats) > 0 {
+				upgrader = ui.bot.Status.LatestHeartbeats[0].ExternalUpdater
+			}
+		}
+		if !slices.Contains(filter.Upgraders, upgrader) {
+			return false
+		}
+	}
+
+	// Filter with predicate language query
+	if filter.PredicateExpression != "" {
+		match, err := ic.matchSearchKeywords(ui, parsed)
+		if err != nil {
+			ic.cfg.Logger.DebugContext(context.Background(), "Failed to filter instances using predicate expression", "error", err)
+			return false
+		}
+		if !match {
+			return false
+		}
+	}
+
 	return true
+}
+
+// matchSearchKeywords evaluates predicate language expressions against a unified instance.
+func (ic *InventoryCache) matchSearchKeywords(ui *inventoryInstance, parsed *parsedFilter) (bool, error) {
+	if parsed.unifiedInstanceExpression == nil {
+		return true, nil
+	}
+
+	env := &unifiedFilterEnvironment{
+		ui: ui,
+	}
+
+	match, err := parsed.unifiedInstanceExpression.Evaluate(env)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	return match, nil
+}
+
+// unifiedFilterEnvironment is the filter environment for evaluating expressions on both instances and bot instances.
+type unifiedFilterEnvironment struct {
+	ui *inventoryInstance
+}
+
+func (e *unifiedFilterEnvironment) GetVersion() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		return e.ui.instance.Spec.Version
+	}
+	// For bot instances, get version from latest heartbeat
+	if e.ui.bot.Status != nil && len(e.ui.bot.Status.LatestHeartbeats) > 0 {
+		return e.ui.bot.Status.LatestHeartbeats[0].Version
+	}
+	return ""
+}
+
+func (e *unifiedFilterEnvironment) GetHostname() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		return e.ui.instance.Spec.Hostname
+	}
+	// For bot instances, get hostname from latest heartbeat
+	if e.ui.bot.Status != nil && len(e.ui.bot.Status.LatestHeartbeats) > 0 {
+		return e.ui.bot.Status.LatestHeartbeats[0].Hostname
+	}
+	return ""
+}
+
+func (e *unifiedFilterEnvironment) GetName() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		return e.ui.instance.GetMetadata().Name
+	}
+	return e.ui.bot.GetMetadata().GetName()
+}
+
+func (e *unifiedFilterEnvironment) GetBotName() string {
+	if e == nil || e.ui == nil || e.ui.isInstance() {
+		return ""
+	}
+	return e.ui.bot.Spec.BotName
+}
+
+func (e *unifiedFilterEnvironment) GetInstanceID() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		return e.ui.instance.GetName()
+	}
+	return e.ui.bot.Spec.InstanceId
+}
+
+func (e *unifiedFilterEnvironment) GetServices() []string {
+	if e == nil || e.ui == nil || !e.ui.isInstance() {
+		return nil
+	}
+	services := e.ui.instance.Spec.Services
+	result := make([]string, len(services))
+	for i, svc := range services {
+		result[i] = string(svc)
+	}
+	return result
+}
+
+func (e *unifiedFilterEnvironment) GetUpdaterGroup() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		if e.ui.instance.Spec.UpdaterInfo != nil {
+			return e.ui.instance.Spec.UpdaterInfo.UpdateGroup
+		}
+		return ""
+	}
+	// For bot instances, get from latest heartbeat
+	if e.ui.bot.Status != nil && len(e.ui.bot.Status.LatestHeartbeats) > 0 && e.ui.bot.Status.LatestHeartbeats[0].UpdaterInfo != nil {
+		return e.ui.bot.Status.LatestHeartbeats[0].UpdaterInfo.UpdateGroup
+	}
+	return ""
+}
+
+func (e *unifiedFilterEnvironment) GetExternalUpgrader() string {
+	if e == nil || e.ui == nil {
+		return ""
+	}
+	if e.ui.isInstance() {
+		return e.ui.instance.Spec.ExternalUpgrader
+	}
+	// For bot instances, get from latest heartbeat
+	if e.ui.bot.Status != nil && len(e.ui.bot.Status.LatestHeartbeats) > 0 {
+		return e.ui.bot.Status.LatestHeartbeats[0].ExternalUpdater
+	}
+	return ""
+}
+
+// getUnifiedExpressionParser returns a cached parser instance, initializing it once.
+// Panics if the parser cannot be created, similar to regexp.MustCompile.
+func getUnifiedExpressionParser() *typical.Parser[*unifiedFilterEnvironment, bool] {
+	unifiedExpressionParserOnce.Do(func() {
+		spec := expression.DefaultParserSpec[*unifiedFilterEnvironment]()
+
+		newVariables := map[string]typical.Variable{
+			"version": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetVersion(), nil
+			}),
+			"status.latest_heartbeat.version": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetVersion(), nil
+			}),
+			"hostname": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetHostname(), nil
+			}),
+			"spec.hostname": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetHostname(), nil
+			}),
+			"status.latest_heartbeat.hostname": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetHostname(), nil
+			}),
+			"name": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetName(), nil
+			}),
+			"metadata.name": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetName(), nil
+			}),
+			"spec.bot_name": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetBotName(), nil
+			}),
+			"spec.instance_id": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetInstanceID(), nil
+			}),
+			"spec.services": typical.DynamicVariable(func(env *unifiedFilterEnvironment) ([]string, error) {
+				return env.GetServices(), nil
+			}),
+			"spec.updater_group": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetUpdaterGroup(), nil
+			}),
+			"status.latest_heartbeat.updater_info.update_group": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetUpdaterGroup(), nil
+			}),
+			"spec.external_upgrader": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetExternalUpgrader(), nil
+			}),
+			"status.latest_heartbeat.external_updater": typical.DynamicVariable(func(env *unifiedFilterEnvironment) (string, error) {
+				return env.GetExternalUpgrader(), nil
+			}),
+		}
+
+		if len(spec.Variables) < 1 {
+			spec.Variables = newVariables
+		} else {
+			maps.Copy(spec.Variables, newVariables)
+		}
+
+		var err error
+		unifiedExpressionParser, err = typical.NewParser[*unifiedFilterEnvironment, bool](spec)
+		if err != nil {
+			panic(fmt.Sprintf("failed to initialize unified expression parser: %v", err))
+		}
+	})
+
+	return unifiedExpressionParser
+}
+
+// getKeyForIndex returns the key a the given instance based on the index
+func (ic *InventoryCache) getKeyForIndex(ui *inventoryInstance, index inventoryIndex) (string, error) {
+	switch index {
+	case inventoryAlphabeticalIndex:
+		return ui.getAlphabeticalKey(), nil
+	case inventoryTypeIndex:
+		return ui.getTypeKey(), nil
+	case inventoryVersionIndex:
+		return ui.getVersionKey(), nil
+	case inventoryIDIndex:
+		return ui.getIDKey(), nil
+	default:
+		return "", trace.BadParameter("unknown index: %v", index)
+	}
 }
 
 // unifiedInstanceToProto converts a unified instance to a proto UnifiedInstanceItem.

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -17,13 +17,17 @@
 package inventory
 
 import (
+	"cmp"
 	"context"
 	"encoding/base32"
 	"fmt"
+	"slices"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -40,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/local/generic"
+	libslices "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // testCache holds the resources needed for creating a test cache
@@ -58,6 +63,32 @@ func (tc *testCache) Close() error {
 		errors = append(errors, tc.Backend.Close())
 	}
 	return trace.NewAggregate(errors...)
+}
+
+func getItemName(item *inventoryv1.UnifiedInstanceItem) string {
+	if item == nil {
+		return ""
+	}
+	if instance := item.GetInstance(); instance != nil {
+		return instance.Spec.Hostname
+	} else if bot := item.GetBotInstance(); bot != nil {
+		return bot.Spec.BotName
+	}
+	return ""
+}
+
+func getItemVersion(item *inventoryv1.UnifiedInstanceItem) string {
+	if item == nil {
+		return ""
+	}
+	if instance := item.GetInstance(); instance != nil {
+		return instance.Spec.Version
+	} else if bot := item.GetBotInstance(); bot != nil {
+		if len(bot.Status.LatestHeartbeats) > 0 {
+			return bot.Status.LatestHeartbeats[0].Version
+		}
+	}
+	return ""
 }
 
 // setupTestCache creates a new test cache
@@ -457,8 +488,8 @@ func TestInventoryCache(t *testing.T) {
 		require.NoError(t, err)
 		defer inventoryCache.Close()
 
-		// Wait for the inventory cache to initialize.
-		time.Sleep(time.Second)
+		// Wait for the inventory cache to initialize by blocking until all the initialization goroutines are durably blocked, which means
+		// the cache has been initialized.
 		synctest.Wait()
 		require.True(t, inventoryCache.IsHealthy())
 
@@ -485,15 +516,7 @@ func TestInventoryCache(t *testing.T) {
 			"proxy1.example.com",
 		}
 
-		for i, item := range listResp.Items {
-			var actualName string
-			if instance := item.GetInstance(); instance != nil {
-				actualName = instance.Spec.Hostname
-			} else if bot := item.GetBotInstance(); bot != nil {
-				actualName = bot.Spec.BotName
-			}
-			require.Equal(t, expectedOrder[i], actualName, "item %d should be %s", i, expectedOrder[i])
-		}
+		require.Equal(t, expectedOrder, libslices.Map(listResp.Items, getItemName))
 
 		// Verify pagination works as intended
 		firstPageResp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
@@ -650,8 +673,8 @@ func TestInventoryCacheWatcher(t *testing.T) {
 		require.NoError(t, err)
 		defer inventoryCache.Close()
 
-		// Wait for the inventory cache to initialize
-		time.Sleep(time.Second)
+		// Wait for the inventory cache to initialize by blocking until all the initialization goroutines are durably blocked, which means
+		// the cache has been initialized.
 		synctest.Wait()
 		require.True(t, inventoryCache.IsHealthy())
 
@@ -805,6 +828,822 @@ func TestInventoryCacheRateLimiting(t *testing.T) {
 		require.Equal(t, numInstances, finalCount,
 			"expected all %d instances to be loaded, got %d", numInstances, finalCount)
 	})
+}
+
+// TestInventoryCacheFiltering tests the filtering for the inventory cache.
+func TestInventoryCacheFiltering(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		bk, err := memory.New(memory.Config{
+			Context: ctx,
+		})
+		require.NoError(t, err)
+		defer bk.Close()
+
+		p, err := setupTestCache(t, cache.ForAuth)
+		require.NoError(t, err)
+		defer p.Close()
+
+		instances := []*types.InstanceV1{
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "node1",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname:         "node1.example.com",
+					Version:          "18.1.0",
+					Services:         []types.SystemRole{types.RoleNode},
+					UpdaterInfo:      &types.UpdaterV2Info{UpdateGroup: "group1"},
+					ExternalUpgrader: "kube",
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "node2",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname:         "node2.example.com",
+					Version:          "18.2.0",
+					Services:         []types.SystemRole{types.RoleNode, types.RoleProxy},
+					UpdaterInfo:      &types.UpdaterV2Info{UpdateGroup: "group1"},
+					ExternalUpgrader: "unit",
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "auth1",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname:         "auth1.example.com",
+					Version:          "19.0.0",
+					Services:         []types.SystemRole{types.RoleAuth},
+					UpdaterInfo:      &types.UpdaterV2Info{UpdateGroup: "group2"},
+					ExternalUpgrader: "kube",
+				},
+			},
+		}
+
+		bots := []*machineidv1.BotInstance{
+			{
+				Kind:    types.KindBotInstance,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "bot1-instance1",
+				},
+				Spec: &machineidv1.BotInstanceSpec{
+					BotName:    "bot1",
+					InstanceId: "instance1",
+				},
+				Status: &machineidv1.BotInstanceStatus{
+					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+						{
+							RecordedAt:      timestamppb.Now(),
+							Version:         "18.1.5",
+							Hostname:        "bot-host1.example.com",
+							ExternalUpdater: "kube",
+							UpdaterInfo:     &types.UpdaterV2Info{UpdateGroup: "bot-group1"},
+						},
+					},
+				},
+			},
+			{
+				Kind:    types.KindBotInstance,
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "bot2-instance2",
+				},
+				Spec: &machineidv1.BotInstanceSpec{
+					BotName:    "bot2",
+					InstanceId: "instance2",
+				},
+				Status: &machineidv1.BotInstanceStatus{
+					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+						{
+							RecordedAt:      timestamppb.Now(),
+							Version:         "19.0.1",
+							Hostname:        "bot-host2.example.com",
+							ExternalUpdater: "unit",
+							UpdaterInfo:     &types.UpdaterV2Info{UpdateGroup: "bot-group2"},
+						},
+					},
+				},
+			},
+		}
+
+		mockInventory := &mockInventoryService{instances: instances}
+		mockBotCache := &mockBotInstanceCache{bots: bots}
+
+		inventoryCache, err := NewInventoryCache(InventoryCacheConfig{
+			PrimaryCache:       p.Cache,
+			Events:             local.NewEventsService(bk),
+			Inventory:          mockInventory,
+			BotInstanceBackend: mockBotCache,
+			TargetVersion:      "19.0.0",
+		})
+		require.NoError(t, err)
+		defer inventoryCache.Close()
+
+		// Wait for the inventory cache to initialize by blocking until all the initialization goroutines are durably blocked, which means
+		// the cache has been initialized.
+		synctest.Wait()
+		require.True(t, inventoryCache.IsHealthy())
+
+		// Test searching by hostname
+		resp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Search: "node1",
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "node1.example.com", resp.Items[0].GetInstance().Spec.Hostname)
+
+		// Test searching by bot name
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Search:        "bot2",
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_BOT_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "bot2", resp.Items[0].GetBotInstance().Spec.BotName)
+
+		// Test filtering by services
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Services:      []string{string(types.RoleAuth), string(types.RoleProxy)},
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 2)
+		require.Equal(t, "auth1.example.com", resp.Items[0].GetInstance().Spec.Hostname)
+		require.Equal(t, "node2.example.com", resp.Items[1].GetInstance().Spec.Hostname)
+
+		// Test filtering by updater groups
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				UpdaterGroups: []string{"group1"},
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 2)
+
+		// Test filtering by external upgraders
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Upgraders:     []string{"kube"},
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 2)
+		for _, item := range resp.Items {
+			require.Equal(t, "kube", item.GetInstance().Spec.ExternalUpgrader)
+		}
+
+		// Test predicate query filtering by version (less than)
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				PredicateExpression: `older_than(status.latest_heartbeat.version, "18.2.0")`,
+				InstanceTypes:       []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "18.1.0", resp.Items[0].GetInstance().Spec.Version)
+
+		// Test predicate query filtering by version (greater than) for both instance types.
+		// This should return 2 instances and 1 bot instance.
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				PredicateExpression: `newer_than(status.latest_heartbeat.version, "18.1.6")`,
+				InstanceTypes:       []inventoryv1.InstanceType{},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 3)
+
+		// Test predicate query filtering by version (between)
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				PredicateExpression: `between(status.latest_heartbeat.version, "18.0.0", "19.0.0")`,
+				InstanceTypes:       []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 2)
+
+		// Test predicate query filtering by hostname
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				PredicateExpression: `hostname == "node2.example.com"`,
+				InstanceTypes:       []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "node2.example.com", resp.Items[0].GetInstance().Spec.Hostname)
+
+		// Test filtering with multiple filters.
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Services:            []string{string(types.RoleNode)},
+				UpdaterGroups:       []string{"group1"},
+				PredicateExpression: `older_than(status.latest_heartbeat.version, "18.2.0")`,
+				InstanceTypes:       []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "node1.example.com", resp.Items[0].GetInstance().Spec.Hostname)
+
+		// Test filtering bot instances by updater group
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				UpdaterGroups: []string{"bot-group1"},
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_BOT_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		require.Equal(t, "bot1", resp.Items[0].GetBotInstance().Spec.BotName)
+
+		// Test filtering both instances and bot instances by upgrader
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				Upgraders: []string{"kube"},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 3)
+		upgraders := make(map[string]bool)
+		for _, item := range resp.Items {
+			if item.GetInstance() != nil {
+				upgraders[item.GetInstance().Spec.ExternalUpgrader] = true
+			} else if item.GetBotInstance() != nil && len(item.GetBotInstance().Status.LatestHeartbeats) > 0 {
+				upgraders[item.GetBotInstance().Status.LatestHeartbeats[0].ExternalUpdater] = true
+			}
+		}
+		require.True(t, upgraders["kube"])
+		require.Len(t, upgraders, 1)
+	})
+}
+
+// TestInventoryCacheSorting tests the sorting functionality of the inventory cache
+func TestInventoryCacheSorting(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		bk, err := memory.New(memory.Config{
+			Context: ctx,
+		})
+		require.NoError(t, err)
+		defer bk.Close()
+
+		p, err := setupTestCache(t, cache.ForAuth)
+		require.NoError(t, err)
+		defer p.Close()
+
+		instances := []*types.InstanceV1{
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance1",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "zzzz",
+					Version:  "19.0.0",
+					Services: []types.SystemRole{types.RoleNode},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance2",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "aaaa",
+					Version:  "18.1.0",
+					Services: []types.SystemRole{types.RoleNode},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance3",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "mmmm",
+					Version:  "18.2.5",
+					Services: []types.SystemRole{types.RoleProxy},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance4",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "cccc",
+					Version:  "19.1.0-beta.1", // Prerelease version
+					Services: []types.SystemRole{types.RoleAuth},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance5",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "pppp",
+					Version:  "19.1.0-alpha", // Prerelease version (should sort before beta)
+					Services: []types.SystemRole{types.RoleNode},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance6",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "vvvv",
+					Version:  "v18.0.0", // v-prefix (should be parsed correctly)
+					Services: []types.SystemRole{types.RoleNode},
+				},
+			},
+			{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: "instance7",
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: "iiii",
+					Version:  "not-a-version", // Invalid version (should sort last)
+					Services: []types.SystemRole{types.RoleNode},
+				},
+			},
+		}
+
+		// Create test bot instances with different bot names and versions
+		bots := []*machineidv1.BotInstance{
+			{
+				Metadata: &headerv1.Metadata{
+					Name: "bot1",
+				},
+				Spec: &machineidv1.BotInstanceSpec{
+					BotName:    "yyyy",
+					InstanceId: "bot1",
+				},
+				Status: &machineidv1.BotInstanceStatus{
+					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+						{
+							RecordedAt: timestamppb.Now(),
+							Version:    "18.0.0",
+						},
+					},
+				},
+			},
+			{
+				Metadata: &headerv1.Metadata{
+					Name: "bot2",
+				},
+				Spec: &machineidv1.BotInstanceSpec{
+					BotName:    "bbbb",
+					InstanceId: "bot2",
+				},
+				Status: &machineidv1.BotInstanceStatus{
+					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+						{
+							RecordedAt: timestamppb.Now(),
+							Version:    "19.2.0",
+						},
+					},
+				},
+			},
+			{
+				Metadata: &headerv1.Metadata{
+					Name: "bot3",
+				},
+				Spec: &machineidv1.BotInstanceSpec{
+					BotName:    "dddd",
+					InstanceId: "bot3",
+				},
+				Status: &machineidv1.BotInstanceStatus{
+					LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+						{
+							RecordedAt: timestamppb.Now(),
+							Version:    "18.1.5",
+						},
+					},
+				},
+			},
+		}
+
+		mockInventory := &mockInventoryService{instances: instances}
+		mockBotCache := &mockBotInstanceCache{bots: bots}
+
+		inventoryCache, err := NewInventoryCache(InventoryCacheConfig{
+			PrimaryCache:       p.Cache,
+			Events:             local.NewEventsService(bk),
+			Inventory:          mockInventory,
+			BotInstanceBackend: mockBotCache,
+			TargetVersion:      "19.0.0",
+		})
+		require.NoError(t, err)
+		defer inventoryCache.Close()
+
+		// Wait for the inventory cache to initialize by blocking until all the initialization goroutines are durably blocked, which means
+		// the cache has been initialized.
+		synctest.Wait()
+		require.True(t, inventoryCache.IsHealthy())
+
+		// Test sort by name ascending
+		resp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		expectedNames := []string{
+			"aaaa",
+			"bbbb",
+			"cccc",
+			"dddd",
+			"iiii",
+			"mmmm",
+			"pppp",
+			"vvvv",
+			"yyyy",
+			"zzzz",
+		}
+
+		require.Equal(t, expectedNames, libslices.Map(resp.Items, getItemName))
+
+		// Test sort by name descending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_DESCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		expectedNames = []string{
+			"zzzz",
+			"yyyy",
+			"vvvv",
+			"pppp",
+			"mmmm",
+			"iiii",
+			"dddd",
+			"cccc",
+			"bbbb",
+			"aaaa",
+		}
+
+		require.Equal(t, expectedNames, libslices.Map(resp.Items, getItemName))
+
+		// Test sort by type ascending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_TYPE,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		// Expect all bot instances first (sorted by name), then all instances (sorted by name)
+		expectedNames = []string{
+			"bbbb",
+			"dddd",
+			"yyyy",
+			"aaaa",
+			"cccc",
+			"iiii",
+			"mmmm",
+			"pppp",
+			"vvvv",
+			"zzzz",
+		}
+
+		require.Equal(t, expectedNames, libslices.Map(resp.Items, getItemName))
+
+		// Test sort by type descending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_TYPE,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_DESCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		// Expect all instances first (desc sorted by name), then all bot instances (desc sorted by name)
+		expectedNames = []string{
+			"zzzz",
+			"vvvv",
+			"pppp",
+			"mmmm",
+			"iiii",
+			"cccc",
+			"aaaa",
+			"yyyy",
+			"dddd",
+			"bbbb",
+		}
+
+		require.Equal(t, expectedNames, libslices.Map(resp.Items, getItemName))
+
+		// Test sorting by version ascending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		expectedVersions := []string{
+			"v18.0.0", // v-prefix version (treated as 18.0.0)
+			"18.0.0",
+			"18.1.0",
+			"18.1.5",
+			"18.2.5",
+			"19.0.0",
+			"19.1.0-alpha",
+			"19.1.0-beta.1",
+			"19.2.0",
+			"not-a-version", // invalid version
+		}
+
+		require.Equal(t, expectedVersions, libslices.Map(resp.Items, getItemVersion))
+
+		// Test sort by version descending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_DESCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 10)
+
+		expectedVersions = []string{
+			"not-a-version",
+			"19.2.0",
+			"19.1.0-beta.1",
+			"19.1.0-alpha",
+			"19.0.0",
+			"18.2.5",
+			"18.1.5",
+			"18.1.0",
+			"18.0.0",
+			"v18.0.0",
+		}
+
+		require.Equal(t, expectedVersions, libslices.Map(resp.Items, getItemVersion))
+
+		// Test sorting by version with pagination
+		firstPageResp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 3,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, firstPageResp.Items, 3)
+		require.NotEmpty(t, firstPageResp.NextPageToken)
+
+		// Verify first page has the correct versions
+		expectedFirstPageVersions := []string{"v18.0.0", "18.0.0", "18.1.0"}
+		require.Equal(t, expectedFirstPageVersions, libslices.Map(firstPageResp.Items, getItemVersion))
+
+		// Fetch second page
+		secondPageResp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize:  3,
+			PageToken: firstPageResp.NextPageToken,
+			Sort:      inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:     inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, secondPageResp.Items, 3)
+		require.NotEmpty(t, secondPageResp.NextPageToken)
+
+		// Verify second page has the correct versions
+		expectedSecondPageVersions := []string{"18.1.5", "18.2.5", "19.0.0"}
+		require.Equal(t, expectedSecondPageVersions, libslices.Map(secondPageResp.Items, getItemVersion))
+
+		// Fetch third page
+		thirdPageResp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize:  3,
+			PageToken: secondPageResp.NextPageToken,
+			Sort:      inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:     inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, thirdPageResp.Items, 3)
+		require.NotEmpty(t, thirdPageResp.NextPageToken)
+
+		// Verify third page has the correct versions
+		expectedThirdPageVersions := []string{"19.1.0-alpha", "19.1.0-beta.1", "19.2.0"}
+		require.Equal(t, expectedThirdPageVersions, libslices.Map(thirdPageResp.Items, getItemVersion))
+
+		// Fetch fourth page
+		fourthPageResp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize:  3,
+			PageToken: thirdPageResp.NextPageToken,
+			Sort:      inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:     inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+		})
+		require.NoError(t, err)
+		require.Len(t, fourthPageResp.Items, 1)
+		require.Empty(t, fourthPageResp.NextPageToken)
+
+		// Verify fourth page has the invalid version
+		var actualVersion string
+		if instance := fourthPageResp.Items[0].GetInstance(); instance != nil {
+			actualVersion = instance.Spec.Version
+		} else if bot := fourthPageResp.Items[0].GetBotInstance(); bot != nil {
+			actualVersion = bot.Status.LatestHeartbeats[0].Version
+		}
+		require.Equal(t, "not-a-version", actualVersion)
+
+		// Test sorting by version while filtering for only instances
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 7)
+
+		expectedVersions = []string{"v18.0.0", "18.1.0", "18.2.5", "19.0.0", "19.1.0-alpha", "19.1.0-beta.1", "not-a-version"}
+		require.Equal(t, expectedVersions, libslices.Map(resp.Items, func(item *inventoryv1.UnifiedInstanceItem) string {
+			return item.GetInstance().Spec.Version
+		}))
+
+		// Test sorting by version while filtering for only bot instances
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION,
+			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				InstanceTypes: []inventoryv1.InstanceType{inventoryv1.InstanceType_INSTANCE_TYPE_BOT_INSTANCE},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 3)
+
+		expectedBotVersions := []string{"18.0.0", "18.1.5", "19.2.0"}
+		require.Equal(t, expectedBotVersions, libslices.Map(resp.Items, func(item *inventoryv1.UnifiedInstanceItem) string {
+			return item.GetBotInstance().Status.LatestHeartbeats[0].Version
+		}))
+	})
+}
+
+// TestSemverSorting tests that semver ordering works properly
+func TestSemverSorting(t *testing.T) {
+	// Expected ordering
+	versions := []struct {
+		version string
+		desc    string
+	}{
+		{"1.0.0-1", "prerelease numeric 1"},
+		{"1.0.0-2", "prerelease numeric 2"},
+		{"1.0.0-11", "prerelease numeric 11"},
+		{"1.0.0-alpha", "prerelease alpha"},
+		{"1.0.0-alpha.1", "prerelease alpha.1"},
+		{"1.0.0-beta", "prerelease beta"},
+		{"1.0.0", "release"},
+		{"1.0.1", "patch increment"},
+		{"1.1.0", "minor version increment"},
+		{"2.0.0", "major version increment"},
+		{"invalid", "invalid version"},
+	}
+
+	// Create the instances
+	instances := make([]*inventoryInstance, len(versions))
+	for i, v := range versions {
+		instances[i] = &inventoryInstance{
+			instance: &types.InstanceV1{
+				ResourceHeader: types.ResourceHeader{
+					Metadata: types.Metadata{
+						Name: fmt.Sprintf("instance-%d", i),
+					},
+				},
+				Spec: types.InstanceSpecV1{
+					Hostname: fmt.Sprintf("host-%d", i),
+					Version:  v.version,
+				},
+			},
+		}
+	}
+
+	// Sort instances by version key
+	sorted := slices.SortedFunc(slices.Values(instances), func(a, b *inventoryInstance) int {
+		keyA := a.getVersionKey()
+		keyB := b.getVersionKey()
+		if keyA < keyB {
+			return -1
+		} else if keyA > keyB {
+			return 1
+		}
+		return 0
+	})
+
+	require.Equal(t, instances, sorted)
+}
+
+// TestGetVersionKeyOrdering verifies that the version keys returned by getVersionKey
+// are correct and match semver.Compare
+func TestGetVersionKeyOrdering(t *testing.T) {
+	versions := []string{
+		"1.0.0-alpha",
+		"2.1.0-rc.1",
+		"1.0.0-alpha.1",
+		"v2.1.0",
+		"1.1.0",
+		"1.0.0-beta",
+		"1.0.0",
+		"1.0.0-beta.2",
+		"1.0.0-alpha.beta",
+		"1.0.0-beta.11",
+		"1.0.0-rc.1",
+		"1.0.1",
+		"1.2.0-alpha",
+		"1.2.0",
+		"2.0.0",
+		"v3.0.0-beta",
+	}
+
+	// Sort with semver.Compare
+	semverSorted := slices.Clone(versions)
+	slices.SortFunc(semverSorted, func(a, b string) int {
+		semverA := semver.New(strings.TrimPrefix(a, "v"))
+		semverB := semver.New(strings.TrimPrefix(b, "v"))
+		return semverA.Compare(*semverB)
+	})
+
+	// Sort with getVersionKey
+	keySorted := slices.Clone(versions)
+	slices.SortFunc(keySorted, func(a, b string) int {
+		instA := &inventoryInstance{instance: &types.InstanceV1{Spec: types.InstanceSpecV1{Version: a}}}
+		instB := &inventoryInstance{instance: &types.InstanceV1{Spec: types.InstanceSpecV1{Version: b}}}
+		return cmp.Compare(instA.getVersionKey(), instB.getVersionKey())
+	})
+
+	require.Equal(t, semverSorted, keySorted)
+}
+
+// TestGetUnifiedExpressionParser tests that the parser can be initialized successfully
+func TestGetUnifiedExpressionParser(t *testing.T) {
+	parser := getUnifiedExpressionParser()
+	require.NotNil(t, parser)
+
+	expr, err := parser.Parse(`hostname == "test"`)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	// Verify the between function is available
+	expr, err = parser.Parse(`between(version, "1.0.0", "2.0.0")`)
+	require.NoError(t, err)
+	require.NotNil(t, expr)
+
+	// Test an invalid predicate expression
+	expr, err = parser.Parse(`asdafafa("afafafa")`)
+	require.Error(t, err)
+	require.Nil(t, expr)
 }
 
 // mockInventoryService is a mock implementation of services.Inventory.

--- a/lib/expression/parser.go
+++ b/lib/expression/parser.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/lib/utils"
@@ -127,16 +128,24 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				func(t time.Time, other time.Time) (bool, error) {
 					return t.After(other), nil
 				}),
-			"between": typical.BinaryVariadicFunction[evaluationEnv](
-				func(t time.Time, interval ...time.Time) (bool, error) {
-					if len(interval) != 2 {
-						return false, trace.BadParameter("between expected 2 parameters: got %v", len(interval))
+			"between": typical.TernaryFunction[evaluationEnv](
+				func(value any, arg1 any, arg2 any) (bool, error) {
+					// If the value provided is a time, do a time comparison
+					if t, ok := value.(time.Time); ok {
+						firstTime, ok1 := arg1.(time.Time)
+						secondTime, ok2 := arg2.(time.Time)
+						if !ok1 || !ok2 {
+							return false, trace.BadParameter("the time parameters provided are invalid time values")
+						}
+
+						if firstTime.After(secondTime) {
+							firstTime, secondTime = secondTime, firstTime
+						}
+						return t.After(firstTime) && t.Before(secondTime), nil
 					}
-					first, second := interval[0], interval[1]
-					if first.After(second) {
-						first, second = second, first
-					}
-					return t.After(first) && t.Before(second), nil
+
+					// If it's not a time, try semver comparison
+					return SemverBetween(value, arg1, arg2)
 				}),
 			"contains_any": typical.BinaryFunction[evaluationEnv](
 				func(s1, s2 Set) (bool, error) {
@@ -160,6 +169,9 @@ func DefaultParserSpec[evaluationEnv any]() typical.ParserSpec[evaluationEnv] {
 				func(s Set) (bool, error) {
 					return len(s.s) == 0, nil
 				}),
+			//TODO(rudream): add newer_than, older_than, and between functions to predicate docs
+			"newer_than": typical.BinaryFunction[evaluationEnv](SemverGt),
+			"older_than": typical.BinaryFunction[evaluationEnv](SemverLt),
 		},
 		Methods: map[string]typical.Function{
 			"add": typical.BinaryVariadicFunction[evaluationEnv](
@@ -300,4 +312,72 @@ func choose(options ...option) (any, error) {
 type option struct {
 	condition bool
 	value     any
+}
+
+// SemverGt compares two semantic versions and returns true if a > b.
+func SemverGt(a, b any) (bool, error) {
+	va, err := ToSemver(a)
+	if va == nil || err != nil {
+		return false, err
+	}
+	vb, err := ToSemver(b)
+	if vb == nil || err != nil {
+		return false, err
+	}
+	return va.Compare(*vb) > 0, nil
+}
+
+// SemverLt compares two semantic versions and returns true if a < b.
+func SemverLt(a, b any) (bool, error) {
+	va, err := ToSemver(a)
+	if va == nil || err != nil {
+		return false, err
+	}
+	vb, err := ToSemver(b)
+	if vb == nil || err != nil {
+		return false, err
+	}
+	return va.Compare(*vb) < 0, nil
+}
+
+// SemverEq compares two semantic versions and returns true if a == b.
+func SemverEq(a, b any) (bool, error) {
+	va, err := ToSemver(a)
+	if va == nil || err != nil {
+		return false, err
+	}
+	vb, err := ToSemver(b)
+	if vb == nil || err != nil {
+		return false, err
+	}
+	return va.Compare(*vb) == 0, nil
+}
+
+// SemverBetween checks if c is between versions a and b (inclusive of a, exclusive of b).
+func SemverBetween(c, a, b any) (bool, error) {
+	gt, err := SemverGt(c, a)
+	if err != nil {
+		return false, err
+	}
+	eq, err := SemverEq(c, a)
+	if err != nil {
+		return false, err
+	}
+	lt, err := SemverLt(c, b)
+	if err != nil {
+		return false, err
+	}
+	return (gt || eq) && lt, nil
+}
+
+// ToSemver converts a value to a semantic version.
+func ToSemver(anyV any) (*semver.Version, error) {
+	switch v := anyV.(type) {
+	case *semver.Version:
+		return v, nil
+	case string:
+		return semver.NewVersion(v)
+	default:
+		return nil, trace.BadParameter("type %T cannot be parsed as semver.Version", v)
+	}
 }


### PR DESCRIPTION
## Purpose

This PR is part of https://github.com/gravitational/teleport/issues/60528

This PR adds filtering functionality for the instances inventory. Where applicable, predicate expression variables have been kept consistent with bot instances.

Required merge:
-  https://github.com/gravitational/teleport/pull/60535