### PR TITLE
Connect: close cluster clients when profile changes

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -177,7 +177,7 @@ func (p *Profile) TLSConfig() (*tls.Config, error) {
 
 // Expiry returns the credential expiry.
 func (p *Profile) Expiry() (time.Time, bool) {
-	certPEMBlock, err := os.ReadFile(p.TLSCertPath())
+	certPEMBlock, err := p.TLSCert()
 	if err != nil {
 		return time.Time{}, false
 	}
@@ -186,6 +186,12 @@ func (p *Profile) Expiry() (time.Time, bool) {
 		return time.Time{}, false
 	}
 	return cert.NotAfter, true
+}
+
+// TLSCert returns the profile's TLS certificate.
+func (p *Profile) TLSCert() ([]byte, error) {
+	certPEMBlock, err := os.ReadFile(p.TLSCertPath())
+	return certPEMBlock, trace.Wrap(err)
 }
 
 // RequireKubeLocalProxy returns true if this profile indicates a local proxy

--- a/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/cluster.pb.go
@@ -27,6 +27,7 @@ import (
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -328,8 +329,10 @@ type LoggedInUser struct {
 	IsDeviceTrusted bool `protobuf:"varint,9,opt,name=is_device_trusted,json=isDeviceTrusted,proto3" json:"is_device_trusted,omitempty"`
 	// Indicates whether access may be hindered by the lack of a trusted device.
 	TrustedDeviceRequirement types.TrustedDeviceRequirement `protobuf:"varint,10,opt,name=trusted_device_requirement,json=trustedDeviceRequirement,proto3,enum=types.TrustedDeviceRequirement" json:"trusted_device_requirement,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// Expiration time of the certificate.
+	ValidUntil    *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=valid_until,json=validUntil,proto3" json:"valid_until,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *LoggedInUser) Reset() {
@@ -423,6 +426,13 @@ func (x *LoggedInUser) GetTrustedDeviceRequirement() types.TrustedDeviceRequirem
 		return x.TrustedDeviceRequirement
 	}
 	return types.TrustedDeviceRequirement(0)
+}
+
+func (x *LoggedInUser) GetValidUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ValidUntil
+	}
+	return nil
 }
 
 // ACL is the access control list of the user
@@ -756,7 +766,7 @@ var File_teleport_lib_teleterm_v1_cluster_proto protoreflect.FileDescriptor
 
 const file_teleport_lib_teleterm_v1_cluster_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/lib/teleterm/v1/cluster.proto\x12\x18teleport.lib.teleterm.v1\x1a6teleport/legacy/types/trusted_device_requirement.proto\"\xf8\x03\n" +
+	"&teleport/lib/teleterm/v1/cluster.proto\x12\x18teleport.lib.teleterm.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a6teleport/legacy/types/trusted_device_requirement.proto\"\xf8\x03\n" +
 	"\aCluster\x12\x10\n" +
 	"\x03uri\x18\x01 \x01(\tR\x03uri\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x1d\n" +
@@ -771,7 +781,7 @@ const file_teleport_lib_teleterm_v1_cluster_proto_rawDesc = "" +
 	" \x01(\tR\fproxyVersion\x12N\n" +
 	"\x0eshow_resources\x18\v \x01(\x0e2'.teleport.lib.teleterm.v1.ShowResourcesR\rshowResources\x120\n" +
 	"\x14profile_status_error\x18\f \x01(\tR\x12profileStatusError\x12\x19\n" +
-	"\bsso_host\x18\r \x01(\tR\assoHost\"\xaa\x04\n" +
+	"\bsso_host\x18\r \x01(\tR\assoHost\"\xe7\x04\n" +
 	"\fLoggedInUser\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12/\n" +
@@ -782,7 +792,9 @@ const file_teleport_lib_teleterm_v1_cluster_proto_rawDesc = "" +
 	"\tuser_type\x18\b \x01(\x0e2/.teleport.lib.teleterm.v1.LoggedInUser.UserTypeR\buserType\x12*\n" +
 	"\x11is_device_trusted\x18\t \x01(\bR\x0fisDeviceTrusted\x12]\n" +
 	"\x1atrusted_device_requirement\x18\n" +
-	" \x01(\x0e2\x1f.types.TrustedDeviceRequirementR\x18trustedDeviceRequirement\"M\n" +
+	" \x01(\x0e2\x1f.types.TrustedDeviceRequirementR\x18trustedDeviceRequirement\x12;\n" +
+	"\vvalid_until\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"validUntil\"M\n" +
 	"\bUserType\x12\x19\n" +
 	"\x15USER_TYPE_UNSPECIFIED\x10\x00\x12\x13\n" +
 	"\x0fUSER_TYPE_LOCAL\x10\x01\x12\x11\n" +
@@ -844,6 +856,7 @@ var file_teleport_lib_teleterm_v1_cluster_proto_goTypes = []any{
 	(*ResourceAccess)(nil),              // 5: teleport.lib.teleterm.v1.ResourceAccess
 	(*Features)(nil),                    // 6: teleport.lib.teleterm.v1.Features
 	(types.TrustedDeviceRequirement)(0), // 7: types.TrustedDeviceRequirement
+	(*timestamppb.Timestamp)(nil),       // 8: google.protobuf.Timestamp
 }
 var file_teleport_lib_teleterm_v1_cluster_proto_depIdxs = []int32{
 	3,  // 0: teleport.lib.teleterm.v1.Cluster.logged_in_user:type_name -> teleport.lib.teleterm.v1.LoggedInUser
@@ -852,24 +865,25 @@ var file_teleport_lib_teleterm_v1_cluster_proto_depIdxs = []int32{
 	4,  // 3: teleport.lib.teleterm.v1.LoggedInUser.acl:type_name -> teleport.lib.teleterm.v1.ACL
 	1,  // 4: teleport.lib.teleterm.v1.LoggedInUser.user_type:type_name -> teleport.lib.teleterm.v1.LoggedInUser.UserType
 	7,  // 5: teleport.lib.teleterm.v1.LoggedInUser.trusted_device_requirement:type_name -> types.TrustedDeviceRequirement
-	5,  // 6: teleport.lib.teleterm.v1.ACL.auth_connectors:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 7: teleport.lib.teleterm.v1.ACL.roles:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 8: teleport.lib.teleterm.v1.ACL.users:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 9: teleport.lib.teleterm.v1.ACL.trusted_clusters:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 10: teleport.lib.teleterm.v1.ACL.events:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 11: teleport.lib.teleterm.v1.ACL.tokens:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 12: teleport.lib.teleterm.v1.ACL.servers:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 13: teleport.lib.teleterm.v1.ACL.apps:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 14: teleport.lib.teleterm.v1.ACL.dbs:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 15: teleport.lib.teleterm.v1.ACL.kubeservers:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 16: teleport.lib.teleterm.v1.ACL.access_requests:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 17: teleport.lib.teleterm.v1.ACL.recorded_sessions:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	5,  // 18: teleport.lib.teleterm.v1.ACL.active_sessions:type_name -> teleport.lib.teleterm.v1.ResourceAccess
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	8,  // 6: teleport.lib.teleterm.v1.LoggedInUser.valid_until:type_name -> google.protobuf.Timestamp
+	5,  // 7: teleport.lib.teleterm.v1.ACL.auth_connectors:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 8: teleport.lib.teleterm.v1.ACL.roles:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 9: teleport.lib.teleterm.v1.ACL.users:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 10: teleport.lib.teleterm.v1.ACL.trusted_clusters:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 11: teleport.lib.teleterm.v1.ACL.events:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 12: teleport.lib.teleterm.v1.ACL.tokens:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 13: teleport.lib.teleterm.v1.ACL.servers:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 14: teleport.lib.teleterm.v1.ACL.apps:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 15: teleport.lib.teleterm.v1.ACL.dbs:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 16: teleport.lib.teleterm.v1.ACL.kubeservers:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 17: teleport.lib.teleterm.v1.ACL.access_requests:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 18: teleport.lib.teleterm.v1.ACL.recorded_sessions:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	5,  // 19: teleport.lib.teleterm.v1.ACL.active_sessions:type_name -> teleport.lib.teleterm.v1.ResourceAccess
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_teleterm_v1_cluster_proto_init() }

--- a/gen/proto/go/teleport/lib/teleterm/v1/service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/service.pb.go
@@ -337,6 +337,86 @@ func (x *LogoutRequest) GetRemoveProfile() bool {
 	return false
 }
 
+type ClearStaleClusterClientsRequest struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *ClearStaleClusterClientsRequest) Reset() {
+	*x = ClearStaleClusterClientsRequest{}
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearStaleClusterClientsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearStaleClusterClientsRequest) ProtoMessage() {}
+
+func (x *ClearStaleClusterClientsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearStaleClusterClientsRequest.ProtoReflect.Descriptor instead.
+func (*ClearStaleClusterClientsRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *ClearStaleClusterClientsRequest) GetRootClusterUri() string {
+	if x != nil {
+		return x.RootClusterUri
+	}
+	return ""
+}
+
+type ClearStaleClusterClientsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ClearStaleClusterClientsResponse) Reset() {
+	*x = ClearStaleClusterClientsResponse{}
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClearStaleClusterClientsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClearStaleClusterClientsResponse) ProtoMessage() {}
+
+func (x *ClearStaleClusterClientsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClearStaleClusterClientsResponse.ProtoReflect.Descriptor instead.
+func (*ClearStaleClusterClientsResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{4}
+}
+
 type StartHeadlessWatcherRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	RootClusterUri string                 `protobuf:"bytes,1,opt,name=root_cluster_uri,json=rootClusterUri,proto3" json:"root_cluster_uri,omitempty"`
@@ -346,7 +426,7 @@ type StartHeadlessWatcherRequest struct {
 
 func (x *StartHeadlessWatcherRequest) Reset() {
 	*x = StartHeadlessWatcherRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -358,7 +438,7 @@ func (x *StartHeadlessWatcherRequest) String() string {
 func (*StartHeadlessWatcherRequest) ProtoMessage() {}
 
 func (x *StartHeadlessWatcherRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[3]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -371,7 +451,7 @@ func (x *StartHeadlessWatcherRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHeadlessWatcherRequest.ProtoReflect.Descriptor instead.
 func (*StartHeadlessWatcherRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{3}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *StartHeadlessWatcherRequest) GetRootClusterUri() string {
@@ -389,7 +469,7 @@ type StartHeadlessWatcherResponse struct {
 
 func (x *StartHeadlessWatcherResponse) Reset() {
 	*x = StartHeadlessWatcherResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[4]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -401,7 +481,7 @@ func (x *StartHeadlessWatcherResponse) String() string {
 func (*StartHeadlessWatcherResponse) ProtoMessage() {}
 
 func (x *StartHeadlessWatcherResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[4]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -414,7 +494,7 @@ func (x *StartHeadlessWatcherResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StartHeadlessWatcherResponse.ProtoReflect.Descriptor instead.
 func (*StartHeadlessWatcherResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{4}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{6}
 }
 
 type GetAccessRequestRequest struct {
@@ -428,7 +508,7 @@ type GetAccessRequestRequest struct {
 
 func (x *GetAccessRequestRequest) Reset() {
 	*x = GetAccessRequestRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[5]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -440,7 +520,7 @@ func (x *GetAccessRequestRequest) String() string {
 func (*GetAccessRequestRequest) ProtoMessage() {}
 
 func (x *GetAccessRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[5]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -453,7 +533,7 @@ func (x *GetAccessRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessRequestRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessRequestRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{5}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *GetAccessRequestRequest) GetClusterUri() string {
@@ -480,7 +560,7 @@ type GetAccessRequestsRequest struct {
 
 func (x *GetAccessRequestsRequest) Reset() {
 	*x = GetAccessRequestsRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[6]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -492,7 +572,7 @@ func (x *GetAccessRequestsRequest) String() string {
 func (*GetAccessRequestsRequest) ProtoMessage() {}
 
 func (x *GetAccessRequestsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[6]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -505,7 +585,7 @@ func (x *GetAccessRequestsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessRequestsRequest.ProtoReflect.Descriptor instead.
 func (*GetAccessRequestsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{6}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetAccessRequestsRequest) GetClusterUri() string {
@@ -524,7 +604,7 @@ type GetAccessRequestResponse struct {
 
 func (x *GetAccessRequestResponse) Reset() {
 	*x = GetAccessRequestResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[7]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -536,7 +616,7 @@ func (x *GetAccessRequestResponse) String() string {
 func (*GetAccessRequestResponse) ProtoMessage() {}
 
 func (x *GetAccessRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[7]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -549,7 +629,7 @@ func (x *GetAccessRequestResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessRequestResponse.ProtoReflect.Descriptor instead.
 func (*GetAccessRequestResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{7}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetAccessRequestResponse) GetRequest() *AccessRequest {
@@ -568,7 +648,7 @@ type GetAccessRequestsResponse struct {
 
 func (x *GetAccessRequestsResponse) Reset() {
 	*x = GetAccessRequestsResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[8]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -580,7 +660,7 @@ func (x *GetAccessRequestsResponse) String() string {
 func (*GetAccessRequestsResponse) ProtoMessage() {}
 
 func (x *GetAccessRequestsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[8]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -593,7 +673,7 @@ func (x *GetAccessRequestsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAccessRequestsResponse.ProtoReflect.Descriptor instead.
 func (*GetAccessRequestsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{8}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *GetAccessRequestsResponse) GetRequests() []*AccessRequest {
@@ -613,7 +693,7 @@ type DeleteAccessRequestRequest struct {
 
 func (x *DeleteAccessRequestRequest) Reset() {
 	*x = DeleteAccessRequestRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[9]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -625,7 +705,7 @@ func (x *DeleteAccessRequestRequest) String() string {
 func (*DeleteAccessRequestRequest) ProtoMessage() {}
 
 func (x *DeleteAccessRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[9]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -638,7 +718,7 @@ func (x *DeleteAccessRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAccessRequestRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAccessRequestRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{9}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DeleteAccessRequestRequest) GetRootClusterUri() string {
@@ -681,7 +761,7 @@ type CreateAccessRequestRequest struct {
 
 func (x *CreateAccessRequestRequest) Reset() {
 	*x = CreateAccessRequestRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[10]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -693,7 +773,7 @@ func (x *CreateAccessRequestRequest) String() string {
 func (*CreateAccessRequestRequest) ProtoMessage() {}
 
 func (x *CreateAccessRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[10]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -706,7 +786,7 @@ func (x *CreateAccessRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessRequestRequest.ProtoReflect.Descriptor instead.
 func (*CreateAccessRequestRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{10}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *CreateAccessRequestRequest) GetRootClusterUri() string {
@@ -781,7 +861,7 @@ type CreateAccessRequestResponse struct {
 
 func (x *CreateAccessRequestResponse) Reset() {
 	*x = CreateAccessRequestResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[11]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -793,7 +873,7 @@ func (x *CreateAccessRequestResponse) String() string {
 func (*CreateAccessRequestResponse) ProtoMessage() {}
 
 func (x *CreateAccessRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[11]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -806,7 +886,7 @@ func (x *CreateAccessRequestResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAccessRequestResponse.ProtoReflect.Descriptor instead.
 func (*CreateAccessRequestResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{11}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *CreateAccessRequestResponse) GetRequest() *AccessRequest {
@@ -827,7 +907,7 @@ type AssumeRoleRequest struct {
 
 func (x *AssumeRoleRequest) Reset() {
 	*x = AssumeRoleRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[12]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -839,7 +919,7 @@ func (x *AssumeRoleRequest) String() string {
 func (*AssumeRoleRequest) ProtoMessage() {}
 
 func (x *AssumeRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[12]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -852,7 +932,7 @@ func (x *AssumeRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssumeRoleRequest.ProtoReflect.Descriptor instead.
 func (*AssumeRoleRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{12}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *AssumeRoleRequest) GetRootClusterUri() string {
@@ -886,7 +966,7 @@ type GetRequestableRolesRequest struct {
 
 func (x *GetRequestableRolesRequest) Reset() {
 	*x = GetRequestableRolesRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[13]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -898,7 +978,7 @@ func (x *GetRequestableRolesRequest) String() string {
 func (*GetRequestableRolesRequest) ProtoMessage() {}
 
 func (x *GetRequestableRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[13]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -911,7 +991,7 @@ func (x *GetRequestableRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRequestableRolesRequest.ProtoReflect.Descriptor instead.
 func (*GetRequestableRolesRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{13}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *GetRequestableRolesRequest) GetClusterUri() string {
@@ -938,7 +1018,7 @@ type GetRequestableRolesResponse struct {
 
 func (x *GetRequestableRolesResponse) Reset() {
 	*x = GetRequestableRolesResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[14]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +1030,7 @@ func (x *GetRequestableRolesResponse) String() string {
 func (*GetRequestableRolesResponse) ProtoMessage() {}
 
 func (x *GetRequestableRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[14]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +1043,7 @@ func (x *GetRequestableRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRequestableRolesResponse.ProtoReflect.Descriptor instead.
 func (*GetRequestableRolesResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{14}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *GetRequestableRolesResponse) GetRoles() []string {
@@ -995,7 +1075,7 @@ type ReviewAccessRequestRequest struct {
 
 func (x *ReviewAccessRequestRequest) Reset() {
 	*x = ReviewAccessRequestRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[15]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1007,7 +1087,7 @@ func (x *ReviewAccessRequestRequest) String() string {
 func (*ReviewAccessRequestRequest) ProtoMessage() {}
 
 func (x *ReviewAccessRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[15]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1020,7 +1100,7 @@ func (x *ReviewAccessRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewAccessRequestRequest.ProtoReflect.Descriptor instead.
 func (*ReviewAccessRequestRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{15}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ReviewAccessRequestRequest) GetRootClusterUri() string {
@@ -1074,7 +1154,7 @@ type ReviewAccessRequestResponse struct {
 
 func (x *ReviewAccessRequestResponse) Reset() {
 	*x = ReviewAccessRequestResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[16]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1086,7 +1166,7 @@ func (x *ReviewAccessRequestResponse) String() string {
 func (*ReviewAccessRequestResponse) ProtoMessage() {}
 
 func (x *ReviewAccessRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[16]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1099,7 +1179,7 @@ func (x *ReviewAccessRequestResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReviewAccessRequestResponse.ProtoReflect.Descriptor instead.
 func (*ReviewAccessRequestResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{16}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *ReviewAccessRequestResponse) GetRequest() *AccessRequest {
@@ -1121,7 +1201,7 @@ type PromoteAccessRequestRequest struct {
 
 func (x *PromoteAccessRequestRequest) Reset() {
 	*x = PromoteAccessRequestRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[17]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1133,7 +1213,7 @@ func (x *PromoteAccessRequestRequest) String() string {
 func (*PromoteAccessRequestRequest) ProtoMessage() {}
 
 func (x *PromoteAccessRequestRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[17]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1146,7 +1226,7 @@ func (x *PromoteAccessRequestRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteAccessRequestRequest.ProtoReflect.Descriptor instead.
 func (*PromoteAccessRequestRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{17}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *PromoteAccessRequestRequest) GetRootClusterUri() string {
@@ -1186,7 +1266,7 @@ type PromoteAccessRequestResponse struct {
 
 func (x *PromoteAccessRequestResponse) Reset() {
 	*x = PromoteAccessRequestResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1198,7 +1278,7 @@ func (x *PromoteAccessRequestResponse) String() string {
 func (*PromoteAccessRequestResponse) ProtoMessage() {}
 
 func (x *PromoteAccessRequestResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[18]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1211,7 +1291,7 @@ func (x *PromoteAccessRequestResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PromoteAccessRequestResponse.ProtoReflect.Descriptor instead.
 func (*PromoteAccessRequestResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{18}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *PromoteAccessRequestResponse) GetRequest() *AccessRequest {
@@ -1231,7 +1311,7 @@ type GetSuggestedAccessListsRequest struct {
 
 func (x *GetSuggestedAccessListsRequest) Reset() {
 	*x = GetSuggestedAccessListsRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1243,7 +1323,7 @@ func (x *GetSuggestedAccessListsRequest) String() string {
 func (*GetSuggestedAccessListsRequest) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[19]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1256,7 +1336,7 @@ func (x *GetSuggestedAccessListsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsRequest.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{19}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *GetSuggestedAccessListsRequest) GetRootClusterUri() string {
@@ -1282,7 +1362,7 @@ type GetSuggestedAccessListsResponse struct {
 
 func (x *GetSuggestedAccessListsResponse) Reset() {
 	*x = GetSuggestedAccessListsResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1294,7 +1374,7 @@ func (x *GetSuggestedAccessListsResponse) String() string {
 func (*GetSuggestedAccessListsResponse) ProtoMessage() {}
 
 func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[20]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1307,7 +1387,7 @@ func (x *GetSuggestedAccessListsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetSuggestedAccessListsResponse.ProtoReflect.Descriptor instead.
 func (*GetSuggestedAccessListsResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{20}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *GetSuggestedAccessListsResponse) GetAccessLists() []*v1.AccessList {
@@ -1346,7 +1426,7 @@ type ListKubernetesResourcesRequest struct {
 
 func (x *ListKubernetesResourcesRequest) Reset() {
 	*x = ListKubernetesResourcesRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1358,7 +1438,7 @@ func (x *ListKubernetesResourcesRequest) String() string {
 func (*ListKubernetesResourcesRequest) ProtoMessage() {}
 
 func (x *ListKubernetesResourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[21]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1371,7 +1451,7 @@ func (x *ListKubernetesResourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKubernetesResourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListKubernetesResourcesRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{21}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *ListKubernetesResourcesRequest) GetClusterUri() string {
@@ -1446,7 +1526,7 @@ type ListKubernetesResourcesResponse struct {
 
 func (x *ListKubernetesResourcesResponse) Reset() {
 	*x = ListKubernetesResourcesResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1458,7 +1538,7 @@ func (x *ListKubernetesResourcesResponse) String() string {
 func (*ListKubernetesResourcesResponse) ProtoMessage() {}
 
 func (x *ListKubernetesResourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[22]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1471,7 +1551,7 @@ func (x *ListKubernetesResourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKubernetesResourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListKubernetesResourcesResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{22}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *ListKubernetesResourcesResponse) GetResources() []*KubeResource {
@@ -1498,7 +1578,7 @@ type ListKubernetesServersRequest struct {
 
 func (x *ListKubernetesServersRequest) Reset() {
 	*x = ListKubernetesServersRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[23]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1510,7 +1590,7 @@ func (x *ListKubernetesServersRequest) String() string {
 func (*ListKubernetesServersRequest) ProtoMessage() {}
 
 func (x *ListKubernetesServersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[23]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1523,7 +1603,7 @@ func (x *ListKubernetesServersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKubernetesServersRequest.ProtoReflect.Descriptor instead.
 func (*ListKubernetesServersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{23}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *ListKubernetesServersRequest) GetPageSize() int32 {
@@ -1567,7 +1647,7 @@ type ListKubernetesServersResponse struct {
 
 func (x *ListKubernetesServersResponse) Reset() {
 	*x = ListKubernetesServersResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[24]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1579,7 +1659,7 @@ func (x *ListKubernetesServersResponse) String() string {
 func (*ListKubernetesServersResponse) ProtoMessage() {}
 
 func (x *ListKubernetesServersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[24]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1592,7 +1672,7 @@ func (x *ListKubernetesServersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListKubernetesServersResponse.ProtoReflect.Descriptor instead.
 func (*ListKubernetesServersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{24}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *ListKubernetesServersResponse) GetResources() []*KubeServer {
@@ -1619,7 +1699,7 @@ type CredentialInfo struct {
 
 func (x *CredentialInfo) Reset() {
 	*x = CredentialInfo{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[25]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1631,7 +1711,7 @@ func (x *CredentialInfo) String() string {
 func (*CredentialInfo) ProtoMessage() {}
 
 func (x *CredentialInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[25]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1644,7 +1724,7 @@ func (x *CredentialInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CredentialInfo.ProtoReflect.Descriptor instead.
 func (*CredentialInfo) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{25}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *CredentialInfo) GetUsername() string {
@@ -1666,7 +1746,7 @@ type LoginPasswordlessResponse struct {
 
 func (x *LoginPasswordlessResponse) Reset() {
 	*x = LoginPasswordlessResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[26]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1678,7 +1758,7 @@ func (x *LoginPasswordlessResponse) String() string {
 func (*LoginPasswordlessResponse) ProtoMessage() {}
 
 func (x *LoginPasswordlessResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[26]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1691,7 +1771,7 @@ func (x *LoginPasswordlessResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginPasswordlessResponse.ProtoReflect.Descriptor instead.
 func (*LoginPasswordlessResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{26}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *LoginPasswordlessResponse) GetPrompt() PasswordlessPrompt {
@@ -1723,7 +1803,7 @@ type LoginPasswordlessRequest struct {
 
 func (x *LoginPasswordlessRequest) Reset() {
 	*x = LoginPasswordlessRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[27]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1735,7 +1815,7 @@ func (x *LoginPasswordlessRequest) String() string {
 func (*LoginPasswordlessRequest) ProtoMessage() {}
 
 func (x *LoginPasswordlessRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[27]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1748,7 +1828,7 @@ func (x *LoginPasswordlessRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginPasswordlessRequest.ProtoReflect.Descriptor instead.
 func (*LoginPasswordlessRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{27}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *LoginPasswordlessRequest) GetRequest() isLoginPasswordlessRequest_Request {
@@ -1824,7 +1904,7 @@ type FileTransferRequest struct {
 
 func (x *FileTransferRequest) Reset() {
 	*x = FileTransferRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[28]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1836,7 +1916,7 @@ func (x *FileTransferRequest) String() string {
 func (*FileTransferRequest) ProtoMessage() {}
 
 func (x *FileTransferRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[28]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1849,7 +1929,7 @@ func (x *FileTransferRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileTransferRequest.ProtoReflect.Descriptor instead.
 func (*FileTransferRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{28}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *FileTransferRequest) GetLogin() string {
@@ -1896,7 +1976,7 @@ type FileTransferProgress struct {
 
 func (x *FileTransferProgress) Reset() {
 	*x = FileTransferProgress{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1908,7 +1988,7 @@ func (x *FileTransferProgress) String() string {
 func (*FileTransferProgress) ProtoMessage() {}
 
 func (x *FileTransferProgress) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[29]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1921,7 +2001,7 @@ func (x *FileTransferProgress) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileTransferProgress.ProtoReflect.Descriptor instead.
 func (*FileTransferProgress) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{29}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *FileTransferProgress) GetPercentage() uint32 {
@@ -1947,7 +2027,7 @@ type LoginRequest struct {
 
 func (x *LoginRequest) Reset() {
 	*x = LoginRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1959,7 +2039,7 @@ func (x *LoginRequest) String() string {
 func (*LoginRequest) ProtoMessage() {}
 
 func (x *LoginRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[30]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1972,7 +2052,7 @@ func (x *LoginRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginRequest.ProtoReflect.Descriptor instead.
 func (*LoginRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{30}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *LoginRequest) GetClusterUri() string {
@@ -2034,7 +2114,7 @@ type AddClusterRequest struct {
 
 func (x *AddClusterRequest) Reset() {
 	*x = AddClusterRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[31]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2046,7 +2126,7 @@ func (x *AddClusterRequest) String() string {
 func (*AddClusterRequest) ProtoMessage() {}
 
 func (x *AddClusterRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[31]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2059,7 +2139,7 @@ func (x *AddClusterRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AddClusterRequest.ProtoReflect.Descriptor instead.
 func (*AddClusterRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{31}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *AddClusterRequest) GetName() string {
@@ -2077,7 +2157,7 @@ type ListClustersRequest struct {
 
 func (x *ListClustersRequest) Reset() {
 	*x = ListClustersRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[32]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2089,7 +2169,7 @@ func (x *ListClustersRequest) String() string {
 func (*ListClustersRequest) ProtoMessage() {}
 
 func (x *ListClustersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[32]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2102,7 +2182,7 @@ func (x *ListClustersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClustersRequest.ProtoReflect.Descriptor instead.
 func (*ListClustersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{32}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{34}
 }
 
 type ListClustersResponse struct {
@@ -2114,7 +2194,7 @@ type ListClustersResponse struct {
 
 func (x *ListClustersResponse) Reset() {
 	*x = ListClustersResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[33]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2126,7 +2206,7 @@ func (x *ListClustersResponse) String() string {
 func (*ListClustersResponse) ProtoMessage() {}
 
 func (x *ListClustersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[33]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2139,7 +2219,7 @@ func (x *ListClustersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListClustersResponse.ProtoReflect.Descriptor instead.
 func (*ListClustersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{33}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *ListClustersResponse) GetClusters() []*Cluster {
@@ -2158,7 +2238,7 @@ type ListLeafClustersRequest struct {
 
 func (x *ListLeafClustersRequest) Reset() {
 	*x = ListLeafClustersRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[34]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2170,7 +2250,7 @@ func (x *ListLeafClustersRequest) String() string {
 func (*ListLeafClustersRequest) ProtoMessage() {}
 
 func (x *ListLeafClustersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[34]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2183,7 +2263,7 @@ func (x *ListLeafClustersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListLeafClustersRequest.ProtoReflect.Descriptor instead.
 func (*ListLeafClustersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{34}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *ListLeafClustersRequest) GetClusterUri() string {
@@ -2202,7 +2282,7 @@ type ListDatabaseUsersRequest struct {
 
 func (x *ListDatabaseUsersRequest) Reset() {
 	*x = ListDatabaseUsersRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[35]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2214,7 +2294,7 @@ func (x *ListDatabaseUsersRequest) String() string {
 func (*ListDatabaseUsersRequest) ProtoMessage() {}
 
 func (x *ListDatabaseUsersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[35]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2227,7 +2307,7 @@ func (x *ListDatabaseUsersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatabaseUsersRequest.ProtoReflect.Descriptor instead.
 func (*ListDatabaseUsersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{35}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ListDatabaseUsersRequest) GetDbUri() string {
@@ -2246,7 +2326,7 @@ type ListDatabaseUsersResponse struct {
 
 func (x *ListDatabaseUsersResponse) Reset() {
 	*x = ListDatabaseUsersResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[36]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2258,7 +2338,7 @@ func (x *ListDatabaseUsersResponse) String() string {
 func (*ListDatabaseUsersResponse) ProtoMessage() {}
 
 func (x *ListDatabaseUsersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[36]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2271,7 +2351,7 @@ func (x *ListDatabaseUsersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatabaseUsersResponse.ProtoReflect.Descriptor instead.
 func (*ListDatabaseUsersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{36}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ListDatabaseUsersResponse) GetUsers() []string {
@@ -2298,7 +2378,7 @@ type ListResourcesParams struct {
 
 func (x *ListResourcesParams) Reset() {
 	*x = ListResourcesParams{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[37]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2310,7 +2390,7 @@ func (x *ListResourcesParams) String() string {
 func (*ListResourcesParams) ProtoMessage() {}
 
 func (x *ListResourcesParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[37]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2323,7 +2403,7 @@ func (x *ListResourcesParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListResourcesParams.ProtoReflect.Descriptor instead.
 func (*ListResourcesParams) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{37}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *ListResourcesParams) GetStartKey() string {
@@ -2364,7 +2444,7 @@ type ListDatabaseServersRequest struct {
 
 func (x *ListDatabaseServersRequest) Reset() {
 	*x = ListDatabaseServersRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[38]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2376,7 +2456,7 @@ func (x *ListDatabaseServersRequest) String() string {
 func (*ListDatabaseServersRequest) ProtoMessage() {}
 
 func (x *ListDatabaseServersRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[38]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2389,7 +2469,7 @@ func (x *ListDatabaseServersRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatabaseServersRequest.ProtoReflect.Descriptor instead.
 func (*ListDatabaseServersRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{38}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *ListDatabaseServersRequest) GetClusterUri() string {
@@ -2416,7 +2496,7 @@ type ListDatabaseServersResponse struct {
 
 func (x *ListDatabaseServersResponse) Reset() {
 	*x = ListDatabaseServersResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[39]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2428,7 +2508,7 @@ func (x *ListDatabaseServersResponse) String() string {
 func (*ListDatabaseServersResponse) ProtoMessage() {}
 
 func (x *ListDatabaseServersResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[39]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2441,7 +2521,7 @@ func (x *ListDatabaseServersResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListDatabaseServersResponse.ProtoReflect.Descriptor instead.
 func (*ListDatabaseServersResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{39}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *ListDatabaseServersResponse) GetResources() []*DatabaseServer {
@@ -2470,7 +2550,7 @@ type CreateGatewayRequest struct {
 
 func (x *CreateGatewayRequest) Reset() {
 	*x = CreateGatewayRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[40]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2482,7 +2562,7 @@ func (x *CreateGatewayRequest) String() string {
 func (*CreateGatewayRequest) ProtoMessage() {}
 
 func (x *CreateGatewayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[40]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2495,7 +2575,7 @@ func (x *CreateGatewayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateGatewayRequest.ProtoReflect.Descriptor instead.
 func (*CreateGatewayRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{40}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CreateGatewayRequest) GetTargetUri() string {
@@ -2534,7 +2614,7 @@ type ListGatewaysRequest struct {
 
 func (x *ListGatewaysRequest) Reset() {
 	*x = ListGatewaysRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[41]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2546,7 +2626,7 @@ func (x *ListGatewaysRequest) String() string {
 func (*ListGatewaysRequest) ProtoMessage() {}
 
 func (x *ListGatewaysRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[41]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2559,7 +2639,7 @@ func (x *ListGatewaysRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGatewaysRequest.ProtoReflect.Descriptor instead.
 func (*ListGatewaysRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{41}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{43}
 }
 
 type ListGatewaysResponse struct {
@@ -2571,7 +2651,7 @@ type ListGatewaysResponse struct {
 
 func (x *ListGatewaysResponse) Reset() {
 	*x = ListGatewaysResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[42]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2583,7 +2663,7 @@ func (x *ListGatewaysResponse) String() string {
 func (*ListGatewaysResponse) ProtoMessage() {}
 
 func (x *ListGatewaysResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[42]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2596,7 +2676,7 @@ func (x *ListGatewaysResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListGatewaysResponse.ProtoReflect.Descriptor instead.
 func (*ListGatewaysResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{42}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ListGatewaysResponse) GetGateways() []*Gateway {
@@ -2615,7 +2695,7 @@ type RemoveGatewayRequest struct {
 
 func (x *RemoveGatewayRequest) Reset() {
 	*x = RemoveGatewayRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[43]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2627,7 +2707,7 @@ func (x *RemoveGatewayRequest) String() string {
 func (*RemoveGatewayRequest) ProtoMessage() {}
 
 func (x *RemoveGatewayRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[43]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2640,7 +2720,7 @@ func (x *RemoveGatewayRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveGatewayRequest.ProtoReflect.Descriptor instead.
 func (*RemoveGatewayRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{43}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *RemoveGatewayRequest) GetGatewayUri() string {
@@ -2660,7 +2740,7 @@ type SetGatewayTargetSubresourceNameRequest struct {
 
 func (x *SetGatewayTargetSubresourceNameRequest) Reset() {
 	*x = SetGatewayTargetSubresourceNameRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[44]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2672,7 +2752,7 @@ func (x *SetGatewayTargetSubresourceNameRequest) String() string {
 func (*SetGatewayTargetSubresourceNameRequest) ProtoMessage() {}
 
 func (x *SetGatewayTargetSubresourceNameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[44]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2685,7 +2765,7 @@ func (x *SetGatewayTargetSubresourceNameRequest) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use SetGatewayTargetSubresourceNameRequest.ProtoReflect.Descriptor instead.
 func (*SetGatewayTargetSubresourceNameRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{44}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *SetGatewayTargetSubresourceNameRequest) GetGatewayUri() string {
@@ -2712,7 +2792,7 @@ type SetGatewayLocalPortRequest struct {
 
 func (x *SetGatewayLocalPortRequest) Reset() {
 	*x = SetGatewayLocalPortRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[45]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2724,7 +2804,7 @@ func (x *SetGatewayLocalPortRequest) String() string {
 func (*SetGatewayLocalPortRequest) ProtoMessage() {}
 
 func (x *SetGatewayLocalPortRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[45]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2737,7 +2817,7 @@ func (x *SetGatewayLocalPortRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetGatewayLocalPortRequest.ProtoReflect.Descriptor instead.
 func (*SetGatewayLocalPortRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{45}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *SetGatewayLocalPortRequest) GetGatewayUri() string {
@@ -2763,7 +2843,7 @@ type GetAuthSettingsRequest struct {
 
 func (x *GetAuthSettingsRequest) Reset() {
 	*x = GetAuthSettingsRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[46]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2775,7 +2855,7 @@ func (x *GetAuthSettingsRequest) String() string {
 func (*GetAuthSettingsRequest) ProtoMessage() {}
 
 func (x *GetAuthSettingsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[46]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2788,7 +2868,7 @@ func (x *GetAuthSettingsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAuthSettingsRequest.ProtoReflect.Descriptor instead.
 func (*GetAuthSettingsRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{46}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetAuthSettingsRequest) GetClusterUri() string {
@@ -2807,7 +2887,7 @@ type UpdateTshdEventsServerAddressRequest struct {
 
 func (x *UpdateTshdEventsServerAddressRequest) Reset() {
 	*x = UpdateTshdEventsServerAddressRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[47]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2819,7 +2899,7 @@ func (x *UpdateTshdEventsServerAddressRequest) String() string {
 func (*UpdateTshdEventsServerAddressRequest) ProtoMessage() {}
 
 func (x *UpdateTshdEventsServerAddressRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[47]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2832,7 +2912,7 @@ func (x *UpdateTshdEventsServerAddressRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateTshdEventsServerAddressRequest.ProtoReflect.Descriptor instead.
 func (*UpdateTshdEventsServerAddressRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{47}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *UpdateTshdEventsServerAddressRequest) GetAddress() string {
@@ -2850,7 +2930,7 @@ type UpdateTshdEventsServerAddressResponse struct {
 
 func (x *UpdateTshdEventsServerAddressResponse) Reset() {
 	*x = UpdateTshdEventsServerAddressResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[48]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2862,7 +2942,7 @@ func (x *UpdateTshdEventsServerAddressResponse) String() string {
 func (*UpdateTshdEventsServerAddressResponse) ProtoMessage() {}
 
 func (x *UpdateTshdEventsServerAddressResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[48]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2875,7 +2955,7 @@ func (x *UpdateTshdEventsServerAddressResponse) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use UpdateTshdEventsServerAddressResponse.ProtoReflect.Descriptor instead.
 func (*UpdateTshdEventsServerAddressResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{48}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{50}
 }
 
 type UpdateHeadlessAuthenticationStateRequest struct {
@@ -2889,7 +2969,7 @@ type UpdateHeadlessAuthenticationStateRequest struct {
 
 func (x *UpdateHeadlessAuthenticationStateRequest) Reset() {
 	*x = UpdateHeadlessAuthenticationStateRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[49]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2901,7 +2981,7 @@ func (x *UpdateHeadlessAuthenticationStateRequest) String() string {
 func (*UpdateHeadlessAuthenticationStateRequest) ProtoMessage() {}
 
 func (x *UpdateHeadlessAuthenticationStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[49]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2914,7 +2994,7 @@ func (x *UpdateHeadlessAuthenticationStateRequest) ProtoReflect() protoreflect.M
 
 // Deprecated: Use UpdateHeadlessAuthenticationStateRequest.ProtoReflect.Descriptor instead.
 func (*UpdateHeadlessAuthenticationStateRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{49}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *UpdateHeadlessAuthenticationStateRequest) GetRootClusterUri() string {
@@ -2946,7 +3026,7 @@ type UpdateHeadlessAuthenticationStateResponse struct {
 
 func (x *UpdateHeadlessAuthenticationStateResponse) Reset() {
 	*x = UpdateHeadlessAuthenticationStateResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[50]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2958,7 +3038,7 @@ func (x *UpdateHeadlessAuthenticationStateResponse) String() string {
 func (*UpdateHeadlessAuthenticationStateResponse) ProtoMessage() {}
 
 func (x *UpdateHeadlessAuthenticationStateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[50]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2971,7 +3051,7 @@ func (x *UpdateHeadlessAuthenticationStateResponse) ProtoReflect() protoreflect.
 
 // Deprecated: Use UpdateHeadlessAuthenticationStateResponse.ProtoReflect.Descriptor instead.
 func (*UpdateHeadlessAuthenticationStateResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{50}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{52}
 }
 
 type CreateConnectMyComputerRoleRequest struct {
@@ -2983,7 +3063,7 @@ type CreateConnectMyComputerRoleRequest struct {
 
 func (x *CreateConnectMyComputerRoleRequest) Reset() {
 	*x = CreateConnectMyComputerRoleRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[51]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2995,7 +3075,7 @@ func (x *CreateConnectMyComputerRoleRequest) String() string {
 func (*CreateConnectMyComputerRoleRequest) ProtoMessage() {}
 
 func (x *CreateConnectMyComputerRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[51]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3008,7 +3088,7 @@ func (x *CreateConnectMyComputerRoleRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use CreateConnectMyComputerRoleRequest.ProtoReflect.Descriptor instead.
 func (*CreateConnectMyComputerRoleRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{51}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *CreateConnectMyComputerRoleRequest) GetRootClusterUri() string {
@@ -3029,7 +3109,7 @@ type CreateConnectMyComputerRoleResponse struct {
 
 func (x *CreateConnectMyComputerRoleResponse) Reset() {
 	*x = CreateConnectMyComputerRoleResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[52]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3041,7 +3121,7 @@ func (x *CreateConnectMyComputerRoleResponse) String() string {
 func (*CreateConnectMyComputerRoleResponse) ProtoMessage() {}
 
 func (x *CreateConnectMyComputerRoleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[52]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3054,7 +3134,7 @@ func (x *CreateConnectMyComputerRoleResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use CreateConnectMyComputerRoleResponse.ProtoReflect.Descriptor instead.
 func (*CreateConnectMyComputerRoleResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{52}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *CreateConnectMyComputerRoleResponse) GetCertsReloaded() bool {
@@ -3073,7 +3153,7 @@ type CreateConnectMyComputerNodeTokenRequest struct {
 
 func (x *CreateConnectMyComputerNodeTokenRequest) Reset() {
 	*x = CreateConnectMyComputerNodeTokenRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[53]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3085,7 +3165,7 @@ func (x *CreateConnectMyComputerNodeTokenRequest) String() string {
 func (*CreateConnectMyComputerNodeTokenRequest) ProtoMessage() {}
 
 func (x *CreateConnectMyComputerNodeTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[53]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3098,7 +3178,7 @@ func (x *CreateConnectMyComputerNodeTokenRequest) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use CreateConnectMyComputerNodeTokenRequest.ProtoReflect.Descriptor instead.
 func (*CreateConnectMyComputerNodeTokenRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{53}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{55}
 }
 
 func (x *CreateConnectMyComputerNodeTokenRequest) GetRootClusterUri() string {
@@ -3117,7 +3197,7 @@ type CreateConnectMyComputerNodeTokenResponse struct {
 
 func (x *CreateConnectMyComputerNodeTokenResponse) Reset() {
 	*x = CreateConnectMyComputerNodeTokenResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[54]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[56]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3129,7 +3209,7 @@ func (x *CreateConnectMyComputerNodeTokenResponse) String() string {
 func (*CreateConnectMyComputerNodeTokenResponse) ProtoMessage() {}
 
 func (x *CreateConnectMyComputerNodeTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[54]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[56]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3142,7 +3222,7 @@ func (x *CreateConnectMyComputerNodeTokenResponse) ProtoReflect() protoreflect.M
 
 // Deprecated: Use CreateConnectMyComputerNodeTokenResponse.ProtoReflect.Descriptor instead.
 func (*CreateConnectMyComputerNodeTokenResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{54}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{56}
 }
 
 func (x *CreateConnectMyComputerNodeTokenResponse) GetToken() string {
@@ -3161,7 +3241,7 @@ type WaitForConnectMyComputerNodeJoinRequest struct {
 
 func (x *WaitForConnectMyComputerNodeJoinRequest) Reset() {
 	*x = WaitForConnectMyComputerNodeJoinRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[55]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[57]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3173,7 +3253,7 @@ func (x *WaitForConnectMyComputerNodeJoinRequest) String() string {
 func (*WaitForConnectMyComputerNodeJoinRequest) ProtoMessage() {}
 
 func (x *WaitForConnectMyComputerNodeJoinRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[55]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[57]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3186,7 +3266,7 @@ func (x *WaitForConnectMyComputerNodeJoinRequest) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use WaitForConnectMyComputerNodeJoinRequest.ProtoReflect.Descriptor instead.
 func (*WaitForConnectMyComputerNodeJoinRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{55}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{57}
 }
 
 func (x *WaitForConnectMyComputerNodeJoinRequest) GetRootClusterUri() string {
@@ -3205,7 +3285,7 @@ type WaitForConnectMyComputerNodeJoinResponse struct {
 
 func (x *WaitForConnectMyComputerNodeJoinResponse) Reset() {
 	*x = WaitForConnectMyComputerNodeJoinResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[56]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3217,7 +3297,7 @@ func (x *WaitForConnectMyComputerNodeJoinResponse) String() string {
 func (*WaitForConnectMyComputerNodeJoinResponse) ProtoMessage() {}
 
 func (x *WaitForConnectMyComputerNodeJoinResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[56]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3230,7 +3310,7 @@ func (x *WaitForConnectMyComputerNodeJoinResponse) ProtoReflect() protoreflect.M
 
 // Deprecated: Use WaitForConnectMyComputerNodeJoinResponse.ProtoReflect.Descriptor instead.
 func (*WaitForConnectMyComputerNodeJoinResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{56}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{58}
 }
 
 func (x *WaitForConnectMyComputerNodeJoinResponse) GetServer() *Server {
@@ -3249,7 +3329,7 @@ type DeleteConnectMyComputerNodeRequest struct {
 
 func (x *DeleteConnectMyComputerNodeRequest) Reset() {
 	*x = DeleteConnectMyComputerNodeRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[57]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3261,7 +3341,7 @@ func (x *DeleteConnectMyComputerNodeRequest) String() string {
 func (*DeleteConnectMyComputerNodeRequest) ProtoMessage() {}
 
 func (x *DeleteConnectMyComputerNodeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[57]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3274,7 +3354,7 @@ func (x *DeleteConnectMyComputerNodeRequest) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use DeleteConnectMyComputerNodeRequest.ProtoReflect.Descriptor instead.
 func (*DeleteConnectMyComputerNodeRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{57}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{59}
 }
 
 func (x *DeleteConnectMyComputerNodeRequest) GetRootClusterUri() string {
@@ -3292,7 +3372,7 @@ type DeleteConnectMyComputerNodeResponse struct {
 
 func (x *DeleteConnectMyComputerNodeResponse) Reset() {
 	*x = DeleteConnectMyComputerNodeResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[58]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3304,7 +3384,7 @@ func (x *DeleteConnectMyComputerNodeResponse) String() string {
 func (*DeleteConnectMyComputerNodeResponse) ProtoMessage() {}
 
 func (x *DeleteConnectMyComputerNodeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[58]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3317,7 +3397,7 @@ func (x *DeleteConnectMyComputerNodeResponse) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use DeleteConnectMyComputerNodeResponse.ProtoReflect.Descriptor instead.
 func (*DeleteConnectMyComputerNodeResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{58}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{60}
 }
 
 type GetConnectMyComputerNodeNameRequest struct {
@@ -3329,7 +3409,7 @@ type GetConnectMyComputerNodeNameRequest struct {
 
 func (x *GetConnectMyComputerNodeNameRequest) Reset() {
 	*x = GetConnectMyComputerNodeNameRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[59]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3341,7 +3421,7 @@ func (x *GetConnectMyComputerNodeNameRequest) String() string {
 func (*GetConnectMyComputerNodeNameRequest) ProtoMessage() {}
 
 func (x *GetConnectMyComputerNodeNameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[59]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3354,7 +3434,7 @@ func (x *GetConnectMyComputerNodeNameRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use GetConnectMyComputerNodeNameRequest.ProtoReflect.Descriptor instead.
 func (*GetConnectMyComputerNodeNameRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{59}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{61}
 }
 
 func (x *GetConnectMyComputerNodeNameRequest) GetRootClusterUri() string {
@@ -3373,7 +3453,7 @@ type GetConnectMyComputerNodeNameResponse struct {
 
 func (x *GetConnectMyComputerNodeNameResponse) Reset() {
 	*x = GetConnectMyComputerNodeNameResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[60]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3385,7 +3465,7 @@ func (x *GetConnectMyComputerNodeNameResponse) String() string {
 func (*GetConnectMyComputerNodeNameResponse) ProtoMessage() {}
 
 func (x *GetConnectMyComputerNodeNameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[60]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3398,7 +3478,7 @@ func (x *GetConnectMyComputerNodeNameResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use GetConnectMyComputerNodeNameResponse.ProtoReflect.Descriptor instead.
 func (*GetConnectMyComputerNodeNameResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{60}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{62}
 }
 
 func (x *GetConnectMyComputerNodeNameResponse) GetName() string {
@@ -3438,7 +3518,7 @@ type ListUnifiedResourcesRequest struct {
 
 func (x *ListUnifiedResourcesRequest) Reset() {
 	*x = ListUnifiedResourcesRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[61]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[63]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3450,7 +3530,7 @@ func (x *ListUnifiedResourcesRequest) String() string {
 func (*ListUnifiedResourcesRequest) ProtoMessage() {}
 
 func (x *ListUnifiedResourcesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[61]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[63]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3463,7 +3543,7 @@ func (x *ListUnifiedResourcesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnifiedResourcesRequest.ProtoReflect.Descriptor instead.
 func (*ListUnifiedResourcesRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{61}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{63}
 }
 
 func (x *ListUnifiedResourcesRequest) GetClusterUri() string {
@@ -3548,7 +3628,7 @@ type SortBy struct {
 
 func (x *SortBy) Reset() {
 	*x = SortBy{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[62]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3560,7 +3640,7 @@ func (x *SortBy) String() string {
 func (*SortBy) ProtoMessage() {}
 
 func (x *SortBy) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[62]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3573,7 +3653,7 @@ func (x *SortBy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SortBy.ProtoReflect.Descriptor instead.
 func (*SortBy) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{62}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{64}
 }
 
 func (x *SortBy) GetIsDesc() bool {
@@ -3602,7 +3682,7 @@ type ListUnifiedResourcesResponse struct {
 
 func (x *ListUnifiedResourcesResponse) Reset() {
 	*x = ListUnifiedResourcesResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[63]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3614,7 +3694,7 @@ func (x *ListUnifiedResourcesResponse) String() string {
 func (*ListUnifiedResourcesResponse) ProtoMessage() {}
 
 func (x *ListUnifiedResourcesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[63]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3627,7 +3707,7 @@ func (x *ListUnifiedResourcesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListUnifiedResourcesResponse.ProtoReflect.Descriptor instead.
 func (*ListUnifiedResourcesResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{63}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{65}
 }
 
 func (x *ListUnifiedResourcesResponse) GetResources() []*PaginatedResource {
@@ -3661,7 +3741,7 @@ type PaginatedResource struct {
 
 func (x *PaginatedResource) Reset() {
 	*x = PaginatedResource{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[64]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[66]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3673,7 +3753,7 @@ func (x *PaginatedResource) String() string {
 func (*PaginatedResource) ProtoMessage() {}
 
 func (x *PaginatedResource) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[64]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[66]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3686,7 +3766,7 @@ func (x *PaginatedResource) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PaginatedResource.ProtoReflect.Descriptor instead.
 func (*PaginatedResource) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{64}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{66}
 }
 
 func (x *PaginatedResource) GetResource() isPaginatedResource_Resource {
@@ -3791,7 +3871,7 @@ type GetUserPreferencesRequest struct {
 
 func (x *GetUserPreferencesRequest) Reset() {
 	*x = GetUserPreferencesRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[65]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[67]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3803,7 +3883,7 @@ func (x *GetUserPreferencesRequest) String() string {
 func (*GetUserPreferencesRequest) ProtoMessage() {}
 
 func (x *GetUserPreferencesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[65]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[67]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3816,7 +3896,7 @@ func (x *GetUserPreferencesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserPreferencesRequest.ProtoReflect.Descriptor instead.
 func (*GetUserPreferencesRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{65}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{67}
 }
 
 func (x *GetUserPreferencesRequest) GetClusterUri() string {
@@ -3835,7 +3915,7 @@ type GetUserPreferencesResponse struct {
 
 func (x *GetUserPreferencesResponse) Reset() {
 	*x = GetUserPreferencesResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[66]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3847,7 +3927,7 @@ func (x *GetUserPreferencesResponse) String() string {
 func (*GetUserPreferencesResponse) ProtoMessage() {}
 
 func (x *GetUserPreferencesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[66]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3860,7 +3940,7 @@ func (x *GetUserPreferencesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetUserPreferencesResponse.ProtoReflect.Descriptor instead.
 func (*GetUserPreferencesResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{66}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{68}
 }
 
 func (x *GetUserPreferencesResponse) GetUserPreferences() *UserPreferences {
@@ -3880,7 +3960,7 @@ type UpdateUserPreferencesRequest struct {
 
 func (x *UpdateUserPreferencesRequest) Reset() {
 	*x = UpdateUserPreferencesRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[67]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3892,7 +3972,7 @@ func (x *UpdateUserPreferencesRequest) String() string {
 func (*UpdateUserPreferencesRequest) ProtoMessage() {}
 
 func (x *UpdateUserPreferencesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[67]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3905,7 +3985,7 @@ func (x *UpdateUserPreferencesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserPreferencesRequest.ProtoReflect.Descriptor instead.
 func (*UpdateUserPreferencesRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{67}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{69}
 }
 
 func (x *UpdateUserPreferencesRequest) GetClusterUri() string {
@@ -3931,7 +4011,7 @@ type UpdateUserPreferencesResponse struct {
 
 func (x *UpdateUserPreferencesResponse) Reset() {
 	*x = UpdateUserPreferencesResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[68]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3943,7 +4023,7 @@ func (x *UpdateUserPreferencesResponse) String() string {
 func (*UpdateUserPreferencesResponse) ProtoMessage() {}
 
 func (x *UpdateUserPreferencesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[68]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3956,7 +4036,7 @@ func (x *UpdateUserPreferencesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateUserPreferencesResponse.ProtoReflect.Descriptor instead.
 func (*UpdateUserPreferencesResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{68}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{70}
 }
 
 func (x *UpdateUserPreferencesResponse) GetUserPreferences() *UserPreferences {
@@ -3978,7 +4058,7 @@ type UserPreferences struct {
 
 func (x *UserPreferences) Reset() {
 	*x = UserPreferences{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[69]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3990,7 +4070,7 @@ func (x *UserPreferences) String() string {
 func (*UserPreferences) ProtoMessage() {}
 
 func (x *UserPreferences) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[69]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4003,7 +4083,7 @@ func (x *UserPreferences) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserPreferences.ProtoReflect.Descriptor instead.
 func (*UserPreferences) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{69}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{71}
 }
 
 func (x *UserPreferences) GetClusterPreferences() *v11.ClusterUserPreferences {
@@ -4033,7 +4113,7 @@ type AuthenticateWebDeviceRequest struct {
 
 func (x *AuthenticateWebDeviceRequest) Reset() {
 	*x = AuthenticateWebDeviceRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[70]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[72]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4045,7 +4125,7 @@ func (x *AuthenticateWebDeviceRequest) String() string {
 func (*AuthenticateWebDeviceRequest) ProtoMessage() {}
 
 func (x *AuthenticateWebDeviceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[70]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[72]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4058,7 +4138,7 @@ func (x *AuthenticateWebDeviceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticateWebDeviceRequest.ProtoReflect.Descriptor instead.
 func (*AuthenticateWebDeviceRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{70}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{72}
 }
 
 func (x *AuthenticateWebDeviceRequest) GetDeviceWebToken() *v12.DeviceWebToken {
@@ -4087,7 +4167,7 @@ type AuthenticateWebDeviceResponse struct {
 
 func (x *AuthenticateWebDeviceResponse) Reset() {
 	*x = AuthenticateWebDeviceResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[71]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[73]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4099,7 +4179,7 @@ func (x *AuthenticateWebDeviceResponse) String() string {
 func (*AuthenticateWebDeviceResponse) ProtoMessage() {}
 
 func (x *AuthenticateWebDeviceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[71]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[73]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4112,7 +4192,7 @@ func (x *AuthenticateWebDeviceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticateWebDeviceResponse.ProtoReflect.Descriptor instead.
 func (*AuthenticateWebDeviceResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{71}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{73}
 }
 
 func (x *AuthenticateWebDeviceResponse) GetConfirmationToken() *v12.DeviceConfirmationToken {
@@ -4131,7 +4211,7 @@ type GetAppRequest struct {
 
 func (x *GetAppRequest) Reset() {
 	*x = GetAppRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[72]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[74]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4143,7 +4223,7 @@ func (x *GetAppRequest) String() string {
 func (*GetAppRequest) ProtoMessage() {}
 
 func (x *GetAppRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[72]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[74]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4156,7 +4236,7 @@ func (x *GetAppRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAppRequest.ProtoReflect.Descriptor instead.
 func (*GetAppRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{72}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{74}
 }
 
 func (x *GetAppRequest) GetAppUri() string {
@@ -4175,7 +4255,7 @@ type GetAppResponse struct {
 
 func (x *GetAppResponse) Reset() {
 	*x = GetAppResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[73]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4187,7 +4267,7 @@ func (x *GetAppResponse) String() string {
 func (*GetAppResponse) ProtoMessage() {}
 
 func (x *GetAppResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[73]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4200,7 +4280,7 @@ func (x *GetAppResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAppResponse.ProtoReflect.Descriptor instead.
 func (*GetAppResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{73}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{75}
 }
 
 func (x *GetAppResponse) GetApp() *App {
@@ -4223,7 +4303,7 @@ type TargetDesktop struct {
 
 func (x *TargetDesktop) Reset() {
 	*x = TargetDesktop{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[74]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4235,7 +4315,7 @@ func (x *TargetDesktop) String() string {
 func (*TargetDesktop) ProtoMessage() {}
 
 func (x *TargetDesktop) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[74]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4248,7 +4328,7 @@ func (x *TargetDesktop) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TargetDesktop.ProtoReflect.Descriptor instead.
 func (*TargetDesktop) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{74}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{76}
 }
 
 func (x *TargetDesktop) GetDesktopUri() string {
@@ -4279,7 +4359,7 @@ type ConnectToDesktopRequest struct {
 
 func (x *ConnectToDesktopRequest) Reset() {
 	*x = ConnectToDesktopRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[75]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4291,7 +4371,7 @@ func (x *ConnectToDesktopRequest) String() string {
 func (*ConnectToDesktopRequest) ProtoMessage() {}
 
 func (x *ConnectToDesktopRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[75]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4304,7 +4384,7 @@ func (x *ConnectToDesktopRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectToDesktopRequest.ProtoReflect.Descriptor instead.
 func (*ConnectToDesktopRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{75}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{77}
 }
 
 func (x *ConnectToDesktopRequest) GetData() []byte {
@@ -4332,7 +4412,7 @@ type ConnectToDesktopResponse struct {
 
 func (x *ConnectToDesktopResponse) Reset() {
 	*x = ConnectToDesktopResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[76]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4344,7 +4424,7 @@ func (x *ConnectToDesktopResponse) String() string {
 func (*ConnectToDesktopResponse) ProtoMessage() {}
 
 func (x *ConnectToDesktopResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[76]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4357,7 +4437,7 @@ func (x *ConnectToDesktopResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ConnectToDesktopResponse.ProtoReflect.Descriptor instead.
 func (*ConnectToDesktopResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{76}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{78}
 }
 
 func (x *ConnectToDesktopResponse) GetData() []byte {
@@ -4382,7 +4462,7 @@ type SetSharedDirectoryForDesktopSessionRequest struct {
 
 func (x *SetSharedDirectoryForDesktopSessionRequest) Reset() {
 	*x = SetSharedDirectoryForDesktopSessionRequest{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[77]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4394,7 +4474,7 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) String() string {
 func (*SetSharedDirectoryForDesktopSessionRequest) ProtoMessage() {}
 
 func (x *SetSharedDirectoryForDesktopSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[77]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4407,7 +4487,7 @@ func (x *SetSharedDirectoryForDesktopSessionRequest) ProtoReflect() protoreflect
 
 // Deprecated: Use SetSharedDirectoryForDesktopSessionRequest.ProtoReflect.Descriptor instead.
 func (*SetSharedDirectoryForDesktopSessionRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{77}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{79}
 }
 
 func (x *SetSharedDirectoryForDesktopSessionRequest) GetDesktopUri() string {
@@ -4440,7 +4520,7 @@ type SetSharedDirectoryForDesktopSessionResponse struct {
 
 func (x *SetSharedDirectoryForDesktopSessionResponse) Reset() {
 	*x = SetSharedDirectoryForDesktopSessionResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[78]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4452,7 +4532,7 @@ func (x *SetSharedDirectoryForDesktopSessionResponse) String() string {
 func (*SetSharedDirectoryForDesktopSessionResponse) ProtoMessage() {}
 
 func (x *SetSharedDirectoryForDesktopSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[78]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4465,7 +4545,7 @@ func (x *SetSharedDirectoryForDesktopSessionResponse) ProtoReflect() protoreflec
 
 // Deprecated: Use SetSharedDirectoryForDesktopSessionResponse.ProtoReflect.Descriptor instead.
 func (*SetSharedDirectoryForDesktopSessionResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{78}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{80}
 }
 
 // LoginPasswordlessRequestInit contains fields needed to init the stream request.
@@ -4479,7 +4559,7 @@ type LoginPasswordlessRequest_LoginPasswordlessRequestInit struct {
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessRequestInit) Reset() {
 	*x = LoginPasswordlessRequest_LoginPasswordlessRequestInit{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[79]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4491,7 +4571,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessRequestInit) String() string 
 func (*LoginPasswordlessRequest_LoginPasswordlessRequestInit) ProtoMessage() {}
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessRequestInit) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[79]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4504,7 +4584,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessRequestInit) ProtoReflect() p
 
 // Deprecated: Use LoginPasswordlessRequest_LoginPasswordlessRequestInit.ProtoReflect.Descriptor instead.
 func (*LoginPasswordlessRequest_LoginPasswordlessRequestInit) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{27, 0}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{29, 0}
 }
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessRequestInit) GetClusterUri() string {
@@ -4525,7 +4605,7 @@ type LoginPasswordlessRequest_LoginPasswordlessPINResponse struct {
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessPINResponse) Reset() {
 	*x = LoginPasswordlessRequest_LoginPasswordlessPINResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[80]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[82]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4537,7 +4617,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessPINResponse) String() string 
 func (*LoginPasswordlessRequest_LoginPasswordlessPINResponse) ProtoMessage() {}
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessPINResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[80]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[82]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4550,7 +4630,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessPINResponse) ProtoReflect() p
 
 // Deprecated: Use LoginPasswordlessRequest_LoginPasswordlessPINResponse.ProtoReflect.Descriptor instead.
 func (*LoginPasswordlessRequest_LoginPasswordlessPINResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{27, 1}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{29, 1}
 }
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessPINResponse) GetPin() string {
@@ -4573,7 +4653,7 @@ type LoginPasswordlessRequest_LoginPasswordlessCredentialResponse struct {
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) Reset() {
 	*x = LoginPasswordlessRequest_LoginPasswordlessCredentialResponse{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[81]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[83]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4585,7 +4665,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) String() 
 func (*LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) ProtoMessage() {}
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[81]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[83]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4598,7 +4678,7 @@ func (x *LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) ProtoRefl
 
 // Deprecated: Use LoginPasswordlessRequest_LoginPasswordlessCredentialResponse.ProtoReflect.Descriptor instead.
 func (*LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{27, 2}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{29, 2}
 }
 
 func (x *LoginPasswordlessRequest_LoginPasswordlessCredentialResponse) GetIndex() int64 {
@@ -4623,7 +4703,7 @@ type LoginRequest_LocalParams struct {
 
 func (x *LoginRequest_LocalParams) Reset() {
 	*x = LoginRequest_LocalParams{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[82]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4635,7 +4715,7 @@ func (x *LoginRequest_LocalParams) String() string {
 func (*LoginRequest_LocalParams) ProtoMessage() {}
 
 func (x *LoginRequest_LocalParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[82]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4648,7 +4728,7 @@ func (x *LoginRequest_LocalParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginRequest_LocalParams.ProtoReflect.Descriptor instead.
 func (*LoginRequest_LocalParams) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{30, 0}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{32, 0}
 }
 
 func (x *LoginRequest_LocalParams) GetUser() string {
@@ -4685,7 +4765,7 @@ type LoginRequest_SsoParams struct {
 
 func (x *LoginRequest_SsoParams) Reset() {
 	*x = LoginRequest_SsoParams{}
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[83]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4697,7 +4777,7 @@ func (x *LoginRequest_SsoParams) String() string {
 func (*LoginRequest_SsoParams) ProtoMessage() {}
 
 func (x *LoginRequest_SsoParams) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[83]
+	mi := &file_teleport_lib_teleterm_v1_service_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4710,7 +4790,7 @@ func (x *LoginRequest_SsoParams) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LoginRequest_SsoParams.ProtoReflect.Descriptor instead.
 func (*LoginRequest_SsoParams) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{30, 1}
+	return file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP(), []int{32, 1}
 }
 
 func (x *LoginRequest_SsoParams) GetProviderType() string {
@@ -4739,7 +4819,10 @@ const file_teleport_lib_teleterm_v1_service_proto_rawDesc = "" +
 	"\rLogoutRequest\x12\x1f\n" +
 	"\vcluster_uri\x18\x01 \x01(\tR\n" +
 	"clusterUri\x12%\n" +
-	"\x0eremove_profile\x18\x02 \x01(\bR\rremoveProfile\"G\n" +
+	"\x0eremove_profile\x18\x02 \x01(\bR\rremoveProfile\"K\n" +
+	"\x1fClearStaleClusterClientsRequest\x12(\n" +
+	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\"\"\n" +
+	" ClearStaleClusterClientsResponse\"G\n" +
 	"\x1bStartHeadlessWatcherRequest\x12(\n" +
 	"\x10root_cluster_uri\x18\x01 \x01(\tR\x0erootClusterUri\"\x1e\n" +
 	"\x1cStartHeadlessWatcherResponse\"f\n" +
@@ -5025,7 +5108,7 @@ const file_teleport_lib_teleterm_v1_service_proto_rawDesc = "" +
 	")HEADLESS_AUTHENTICATION_STATE_UNSPECIFIED\x10\x00\x12)\n" +
 	"%HEADLESS_AUTHENTICATION_STATE_PENDING\x10\x01\x12(\n" +
 	"$HEADLESS_AUTHENTICATION_STATE_DENIED\x10\x02\x12*\n" +
-	"&HEADLESS_AUTHENTICATION_STATE_APPROVED\x10\x032\xca+\n" +
+	"&HEADLESS_AUTHENTICATION_STATE_APPROVED\x10\x032\xde,\n" +
 	"\x0fTerminalService\x12\xa0\x01\n" +
 	"\x1dUpdateTshdEventsServerAddress\x12>.teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressRequest\x1a?.teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressResponse\x12q\n" +
 	"\x10ListRootClusters\x12-.teleport.lib.teleterm.v1.ListClustersRequest\x1a..teleport.lib.teleterm.v1.ListClustersResponse\x12u\n" +
@@ -5057,7 +5140,8 @@ const file_teleport_lib_teleterm_v1_service_proto_rawDesc = "" +
 	"GetCluster\x12+.teleport.lib.teleterm.v1.GetClusterRequest\x1a!.teleport.lib.teleterm.v1.Cluster\x12X\n" +
 	"\x05Login\x12&.teleport.lib.teleterm.v1.LoginRequest\x1a'.teleport.lib.teleterm.v1.EmptyResponse\x12\x80\x01\n" +
 	"\x11LoginPasswordless\x122.teleport.lib.teleterm.v1.LoginPasswordlessRequest\x1a3.teleport.lib.teleterm.v1.LoginPasswordlessResponse(\x010\x01\x12Z\n" +
-	"\x06Logout\x12'.teleport.lib.teleterm.v1.LogoutRequest\x1a'.teleport.lib.teleterm.v1.EmptyResponse\x12o\n" +
+	"\x06Logout\x12'.teleport.lib.teleterm.v1.LogoutRequest\x1a'.teleport.lib.teleterm.v1.EmptyResponse\x12\x91\x01\n" +
+	"\x18ClearStaleClusterClients\x129.teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest\x1a:.teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse\x12o\n" +
 	"\fTransferFile\x12-.teleport.lib.teleterm.v1.FileTransferRequest\x1a..teleport.lib.teleterm.v1.FileTransferProgress0\x01\x12n\n" +
 	"\x10ReportUsageEvent\x121.teleport.lib.teleterm.v1.ReportUsageEventRequest\x1a'.teleport.lib.teleterm.v1.EmptyResponse\x12\xac\x01\n" +
 	"!UpdateHeadlessAuthenticationState\x12B.teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest\x1aC.teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse\x12\x9a\x01\n" +
@@ -5087,7 +5171,7 @@ func file_teleport_lib_teleterm_v1_service_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_lib_teleterm_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_teleport_lib_teleterm_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 84)
+var file_teleport_lib_teleterm_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 86)
 var file_teleport_lib_teleterm_v1_service_proto_goTypes = []any{
 	(PasswordlessPrompt)(0),                                              // 0: teleport.lib.teleterm.v1.PasswordlessPrompt
 	(FileTransferDirection)(0),                                           // 1: teleport.lib.teleterm.v1.FileTransferDirection
@@ -5095,242 +5179,246 @@ var file_teleport_lib_teleterm_v1_service_proto_goTypes = []any{
 	(*EmptyResponse)(nil),                                                // 3: teleport.lib.teleterm.v1.EmptyResponse
 	(*GetClusterRequest)(nil),                                            // 4: teleport.lib.teleterm.v1.GetClusterRequest
 	(*LogoutRequest)(nil),                                                // 5: teleport.lib.teleterm.v1.LogoutRequest
-	(*StartHeadlessWatcherRequest)(nil),                                  // 6: teleport.lib.teleterm.v1.StartHeadlessWatcherRequest
-	(*StartHeadlessWatcherResponse)(nil),                                 // 7: teleport.lib.teleterm.v1.StartHeadlessWatcherResponse
-	(*GetAccessRequestRequest)(nil),                                      // 8: teleport.lib.teleterm.v1.GetAccessRequestRequest
-	(*GetAccessRequestsRequest)(nil),                                     // 9: teleport.lib.teleterm.v1.GetAccessRequestsRequest
-	(*GetAccessRequestResponse)(nil),                                     // 10: teleport.lib.teleterm.v1.GetAccessRequestResponse
-	(*GetAccessRequestsResponse)(nil),                                    // 11: teleport.lib.teleterm.v1.GetAccessRequestsResponse
-	(*DeleteAccessRequestRequest)(nil),                                   // 12: teleport.lib.teleterm.v1.DeleteAccessRequestRequest
-	(*CreateAccessRequestRequest)(nil),                                   // 13: teleport.lib.teleterm.v1.CreateAccessRequestRequest
-	(*CreateAccessRequestResponse)(nil),                                  // 14: teleport.lib.teleterm.v1.CreateAccessRequestResponse
-	(*AssumeRoleRequest)(nil),                                            // 15: teleport.lib.teleterm.v1.AssumeRoleRequest
-	(*GetRequestableRolesRequest)(nil),                                   // 16: teleport.lib.teleterm.v1.GetRequestableRolesRequest
-	(*GetRequestableRolesResponse)(nil),                                  // 17: teleport.lib.teleterm.v1.GetRequestableRolesResponse
-	(*ReviewAccessRequestRequest)(nil),                                   // 18: teleport.lib.teleterm.v1.ReviewAccessRequestRequest
-	(*ReviewAccessRequestResponse)(nil),                                  // 19: teleport.lib.teleterm.v1.ReviewAccessRequestResponse
-	(*PromoteAccessRequestRequest)(nil),                                  // 20: teleport.lib.teleterm.v1.PromoteAccessRequestRequest
-	(*PromoteAccessRequestResponse)(nil),                                 // 21: teleport.lib.teleterm.v1.PromoteAccessRequestResponse
-	(*GetSuggestedAccessListsRequest)(nil),                               // 22: teleport.lib.teleterm.v1.GetSuggestedAccessListsRequest
-	(*GetSuggestedAccessListsResponse)(nil),                              // 23: teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse
-	(*ListKubernetesResourcesRequest)(nil),                               // 24: teleport.lib.teleterm.v1.ListKubernetesResourcesRequest
-	(*ListKubernetesResourcesResponse)(nil),                              // 25: teleport.lib.teleterm.v1.ListKubernetesResourcesResponse
-	(*ListKubernetesServersRequest)(nil),                                 // 26: teleport.lib.teleterm.v1.ListKubernetesServersRequest
-	(*ListKubernetesServersResponse)(nil),                                // 27: teleport.lib.teleterm.v1.ListKubernetesServersResponse
-	(*CredentialInfo)(nil),                                               // 28: teleport.lib.teleterm.v1.CredentialInfo
-	(*LoginPasswordlessResponse)(nil),                                    // 29: teleport.lib.teleterm.v1.LoginPasswordlessResponse
-	(*LoginPasswordlessRequest)(nil),                                     // 30: teleport.lib.teleterm.v1.LoginPasswordlessRequest
-	(*FileTransferRequest)(nil),                                          // 31: teleport.lib.teleterm.v1.FileTransferRequest
-	(*FileTransferProgress)(nil),                                         // 32: teleport.lib.teleterm.v1.FileTransferProgress
-	(*LoginRequest)(nil),                                                 // 33: teleport.lib.teleterm.v1.LoginRequest
-	(*AddClusterRequest)(nil),                                            // 34: teleport.lib.teleterm.v1.AddClusterRequest
-	(*ListClustersRequest)(nil),                                          // 35: teleport.lib.teleterm.v1.ListClustersRequest
-	(*ListClustersResponse)(nil),                                         // 36: teleport.lib.teleterm.v1.ListClustersResponse
-	(*ListLeafClustersRequest)(nil),                                      // 37: teleport.lib.teleterm.v1.ListLeafClustersRequest
-	(*ListDatabaseUsersRequest)(nil),                                     // 38: teleport.lib.teleterm.v1.ListDatabaseUsersRequest
-	(*ListDatabaseUsersResponse)(nil),                                    // 39: teleport.lib.teleterm.v1.ListDatabaseUsersResponse
-	(*ListResourcesParams)(nil),                                          // 40: teleport.lib.teleterm.v1.ListResourcesParams
-	(*ListDatabaseServersRequest)(nil),                                   // 41: teleport.lib.teleterm.v1.ListDatabaseServersRequest
-	(*ListDatabaseServersResponse)(nil),                                  // 42: teleport.lib.teleterm.v1.ListDatabaseServersResponse
-	(*CreateGatewayRequest)(nil),                                         // 43: teleport.lib.teleterm.v1.CreateGatewayRequest
-	(*ListGatewaysRequest)(nil),                                          // 44: teleport.lib.teleterm.v1.ListGatewaysRequest
-	(*ListGatewaysResponse)(nil),                                         // 45: teleport.lib.teleterm.v1.ListGatewaysResponse
-	(*RemoveGatewayRequest)(nil),                                         // 46: teleport.lib.teleterm.v1.RemoveGatewayRequest
-	(*SetGatewayTargetSubresourceNameRequest)(nil),                       // 47: teleport.lib.teleterm.v1.SetGatewayTargetSubresourceNameRequest
-	(*SetGatewayLocalPortRequest)(nil),                                   // 48: teleport.lib.teleterm.v1.SetGatewayLocalPortRequest
-	(*GetAuthSettingsRequest)(nil),                                       // 49: teleport.lib.teleterm.v1.GetAuthSettingsRequest
-	(*UpdateTshdEventsServerAddressRequest)(nil),                         // 50: teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressRequest
-	(*UpdateTshdEventsServerAddressResponse)(nil),                        // 51: teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressResponse
-	(*UpdateHeadlessAuthenticationStateRequest)(nil),                     // 52: teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest
-	(*UpdateHeadlessAuthenticationStateResponse)(nil),                    // 53: teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse
-	(*CreateConnectMyComputerRoleRequest)(nil),                           // 54: teleport.lib.teleterm.v1.CreateConnectMyComputerRoleRequest
-	(*CreateConnectMyComputerRoleResponse)(nil),                          // 55: teleport.lib.teleterm.v1.CreateConnectMyComputerRoleResponse
-	(*CreateConnectMyComputerNodeTokenRequest)(nil),                      // 56: teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenRequest
-	(*CreateConnectMyComputerNodeTokenResponse)(nil),                     // 57: teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenResponse
-	(*WaitForConnectMyComputerNodeJoinRequest)(nil),                      // 58: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinRequest
-	(*WaitForConnectMyComputerNodeJoinResponse)(nil),                     // 59: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse
-	(*DeleteConnectMyComputerNodeRequest)(nil),                           // 60: teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeRequest
-	(*DeleteConnectMyComputerNodeResponse)(nil),                          // 61: teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeResponse
-	(*GetConnectMyComputerNodeNameRequest)(nil),                          // 62: teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameRequest
-	(*GetConnectMyComputerNodeNameResponse)(nil),                         // 63: teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameResponse
-	(*ListUnifiedResourcesRequest)(nil),                                  // 64: teleport.lib.teleterm.v1.ListUnifiedResourcesRequest
-	(*SortBy)(nil),                                                       // 65: teleport.lib.teleterm.v1.SortBy
-	(*ListUnifiedResourcesResponse)(nil),                                 // 66: teleport.lib.teleterm.v1.ListUnifiedResourcesResponse
-	(*PaginatedResource)(nil),                                            // 67: teleport.lib.teleterm.v1.PaginatedResource
-	(*GetUserPreferencesRequest)(nil),                                    // 68: teleport.lib.teleterm.v1.GetUserPreferencesRequest
-	(*GetUserPreferencesResponse)(nil),                                   // 69: teleport.lib.teleterm.v1.GetUserPreferencesResponse
-	(*UpdateUserPreferencesRequest)(nil),                                 // 70: teleport.lib.teleterm.v1.UpdateUserPreferencesRequest
-	(*UpdateUserPreferencesResponse)(nil),                                // 71: teleport.lib.teleterm.v1.UpdateUserPreferencesResponse
-	(*UserPreferences)(nil),                                              // 72: teleport.lib.teleterm.v1.UserPreferences
-	(*AuthenticateWebDeviceRequest)(nil),                                 // 73: teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest
-	(*AuthenticateWebDeviceResponse)(nil),                                // 74: teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse
-	(*GetAppRequest)(nil),                                                // 75: teleport.lib.teleterm.v1.GetAppRequest
-	(*GetAppResponse)(nil),                                               // 76: teleport.lib.teleterm.v1.GetAppResponse
-	(*TargetDesktop)(nil),                                                // 77: teleport.lib.teleterm.v1.TargetDesktop
-	(*ConnectToDesktopRequest)(nil),                                      // 78: teleport.lib.teleterm.v1.ConnectToDesktopRequest
-	(*ConnectToDesktopResponse)(nil),                                     // 79: teleport.lib.teleterm.v1.ConnectToDesktopResponse
-	(*SetSharedDirectoryForDesktopSessionRequest)(nil),                   // 80: teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest
-	(*SetSharedDirectoryForDesktopSessionResponse)(nil),                  // 81: teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionResponse
-	(*LoginPasswordlessRequest_LoginPasswordlessRequestInit)(nil),        // 82: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessRequestInit
-	(*LoginPasswordlessRequest_LoginPasswordlessPINResponse)(nil),        // 83: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessPINResponse
-	(*LoginPasswordlessRequest_LoginPasswordlessCredentialResponse)(nil), // 84: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessCredentialResponse
-	(*LoginRequest_LocalParams)(nil),                                     // 85: teleport.lib.teleterm.v1.LoginRequest.LocalParams
-	(*LoginRequest_SsoParams)(nil),                                       // 86: teleport.lib.teleterm.v1.LoginRequest.SsoParams
-	(*AccessRequest)(nil),                                                // 87: teleport.lib.teleterm.v1.AccessRequest
-	(*ResourceID)(nil),                                                   // 88: teleport.lib.teleterm.v1.ResourceID
-	(*timestamppb.Timestamp)(nil),                                        // 89: google.protobuf.Timestamp
-	(*v1.AccessList)(nil),                                                // 90: teleport.accesslist.v1.AccessList
-	(*KubeResource)(nil),                                                 // 91: teleport.lib.teleterm.v1.KubeResource
-	(*KubeServer)(nil),                                                   // 92: teleport.lib.teleterm.v1.KubeServer
-	(*Cluster)(nil),                                                      // 93: teleport.lib.teleterm.v1.Cluster
-	(*DatabaseServer)(nil),                                               // 94: teleport.lib.teleterm.v1.DatabaseServer
-	(*Gateway)(nil),                                                      // 95: teleport.lib.teleterm.v1.Gateway
-	(*Server)(nil),                                                       // 96: teleport.lib.teleterm.v1.Server
-	(*Database)(nil),                                                     // 97: teleport.lib.teleterm.v1.Database
-	(*Kube)(nil),                                                         // 98: teleport.lib.teleterm.v1.Kube
-	(*App)(nil),                                                          // 99: teleport.lib.teleterm.v1.App
-	(*WindowsDesktop)(nil),                                               // 100: teleport.lib.teleterm.v1.WindowsDesktop
-	(*v11.ClusterUserPreferences)(nil),                                   // 101: teleport.userpreferences.v1.ClusterUserPreferences
-	(*v11.UnifiedResourcePreferences)(nil),                               // 102: teleport.userpreferences.v1.UnifiedResourcePreferences
-	(*v12.DeviceWebToken)(nil),                                           // 103: teleport.devicetrust.v1.DeviceWebToken
-	(*v12.DeviceConfirmationToken)(nil),                                  // 104: teleport.devicetrust.v1.DeviceConfirmationToken
-	(*ReportUsageEventRequest)(nil),                                      // 105: teleport.lib.teleterm.v1.ReportUsageEventRequest
-	(*AuthSettings)(nil),                                                 // 106: teleport.lib.teleterm.v1.AuthSettings
+	(*ClearStaleClusterClientsRequest)(nil),                              // 6: teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest
+	(*ClearStaleClusterClientsResponse)(nil),                             // 7: teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse
+	(*StartHeadlessWatcherRequest)(nil),                                  // 8: teleport.lib.teleterm.v1.StartHeadlessWatcherRequest
+	(*StartHeadlessWatcherResponse)(nil),                                 // 9: teleport.lib.teleterm.v1.StartHeadlessWatcherResponse
+	(*GetAccessRequestRequest)(nil),                                      // 10: teleport.lib.teleterm.v1.GetAccessRequestRequest
+	(*GetAccessRequestsRequest)(nil),                                     // 11: teleport.lib.teleterm.v1.GetAccessRequestsRequest
+	(*GetAccessRequestResponse)(nil),                                     // 12: teleport.lib.teleterm.v1.GetAccessRequestResponse
+	(*GetAccessRequestsResponse)(nil),                                    // 13: teleport.lib.teleterm.v1.GetAccessRequestsResponse
+	(*DeleteAccessRequestRequest)(nil),                                   // 14: teleport.lib.teleterm.v1.DeleteAccessRequestRequest
+	(*CreateAccessRequestRequest)(nil),                                   // 15: teleport.lib.teleterm.v1.CreateAccessRequestRequest
+	(*CreateAccessRequestResponse)(nil),                                  // 16: teleport.lib.teleterm.v1.CreateAccessRequestResponse
+	(*AssumeRoleRequest)(nil),                                            // 17: teleport.lib.teleterm.v1.AssumeRoleRequest
+	(*GetRequestableRolesRequest)(nil),                                   // 18: teleport.lib.teleterm.v1.GetRequestableRolesRequest
+	(*GetRequestableRolesResponse)(nil),                                  // 19: teleport.lib.teleterm.v1.GetRequestableRolesResponse
+	(*ReviewAccessRequestRequest)(nil),                                   // 20: teleport.lib.teleterm.v1.ReviewAccessRequestRequest
+	(*ReviewAccessRequestResponse)(nil),                                  // 21: teleport.lib.teleterm.v1.ReviewAccessRequestResponse
+	(*PromoteAccessRequestRequest)(nil),                                  // 22: teleport.lib.teleterm.v1.PromoteAccessRequestRequest
+	(*PromoteAccessRequestResponse)(nil),                                 // 23: teleport.lib.teleterm.v1.PromoteAccessRequestResponse
+	(*GetSuggestedAccessListsRequest)(nil),                               // 24: teleport.lib.teleterm.v1.GetSuggestedAccessListsRequest
+	(*GetSuggestedAccessListsResponse)(nil),                              // 25: teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse
+	(*ListKubernetesResourcesRequest)(nil),                               // 26: teleport.lib.teleterm.v1.ListKubernetesResourcesRequest
+	(*ListKubernetesResourcesResponse)(nil),                              // 27: teleport.lib.teleterm.v1.ListKubernetesResourcesResponse
+	(*ListKubernetesServersRequest)(nil),                                 // 28: teleport.lib.teleterm.v1.ListKubernetesServersRequest
+	(*ListKubernetesServersResponse)(nil),                                // 29: teleport.lib.teleterm.v1.ListKubernetesServersResponse
+	(*CredentialInfo)(nil),                                               // 30: teleport.lib.teleterm.v1.CredentialInfo
+	(*LoginPasswordlessResponse)(nil),                                    // 31: teleport.lib.teleterm.v1.LoginPasswordlessResponse
+	(*LoginPasswordlessRequest)(nil),                                     // 32: teleport.lib.teleterm.v1.LoginPasswordlessRequest
+	(*FileTransferRequest)(nil),                                          // 33: teleport.lib.teleterm.v1.FileTransferRequest
+	(*FileTransferProgress)(nil),                                         // 34: teleport.lib.teleterm.v1.FileTransferProgress
+	(*LoginRequest)(nil),                                                 // 35: teleport.lib.teleterm.v1.LoginRequest
+	(*AddClusterRequest)(nil),                                            // 36: teleport.lib.teleterm.v1.AddClusterRequest
+	(*ListClustersRequest)(nil),                                          // 37: teleport.lib.teleterm.v1.ListClustersRequest
+	(*ListClustersResponse)(nil),                                         // 38: teleport.lib.teleterm.v1.ListClustersResponse
+	(*ListLeafClustersRequest)(nil),                                      // 39: teleport.lib.teleterm.v1.ListLeafClustersRequest
+	(*ListDatabaseUsersRequest)(nil),                                     // 40: teleport.lib.teleterm.v1.ListDatabaseUsersRequest
+	(*ListDatabaseUsersResponse)(nil),                                    // 41: teleport.lib.teleterm.v1.ListDatabaseUsersResponse
+	(*ListResourcesParams)(nil),                                          // 42: teleport.lib.teleterm.v1.ListResourcesParams
+	(*ListDatabaseServersRequest)(nil),                                   // 43: teleport.lib.teleterm.v1.ListDatabaseServersRequest
+	(*ListDatabaseServersResponse)(nil),                                  // 44: teleport.lib.teleterm.v1.ListDatabaseServersResponse
+	(*CreateGatewayRequest)(nil),                                         // 45: teleport.lib.teleterm.v1.CreateGatewayRequest
+	(*ListGatewaysRequest)(nil),                                          // 46: teleport.lib.teleterm.v1.ListGatewaysRequest
+	(*ListGatewaysResponse)(nil),                                         // 47: teleport.lib.teleterm.v1.ListGatewaysResponse
+	(*RemoveGatewayRequest)(nil),                                         // 48: teleport.lib.teleterm.v1.RemoveGatewayRequest
+	(*SetGatewayTargetSubresourceNameRequest)(nil),                       // 49: teleport.lib.teleterm.v1.SetGatewayTargetSubresourceNameRequest
+	(*SetGatewayLocalPortRequest)(nil),                                   // 50: teleport.lib.teleterm.v1.SetGatewayLocalPortRequest
+	(*GetAuthSettingsRequest)(nil),                                       // 51: teleport.lib.teleterm.v1.GetAuthSettingsRequest
+	(*UpdateTshdEventsServerAddressRequest)(nil),                         // 52: teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressRequest
+	(*UpdateTshdEventsServerAddressResponse)(nil),                        // 53: teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressResponse
+	(*UpdateHeadlessAuthenticationStateRequest)(nil),                     // 54: teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest
+	(*UpdateHeadlessAuthenticationStateResponse)(nil),                    // 55: teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse
+	(*CreateConnectMyComputerRoleRequest)(nil),                           // 56: teleport.lib.teleterm.v1.CreateConnectMyComputerRoleRequest
+	(*CreateConnectMyComputerRoleResponse)(nil),                          // 57: teleport.lib.teleterm.v1.CreateConnectMyComputerRoleResponse
+	(*CreateConnectMyComputerNodeTokenRequest)(nil),                      // 58: teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenRequest
+	(*CreateConnectMyComputerNodeTokenResponse)(nil),                     // 59: teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenResponse
+	(*WaitForConnectMyComputerNodeJoinRequest)(nil),                      // 60: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinRequest
+	(*WaitForConnectMyComputerNodeJoinResponse)(nil),                     // 61: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse
+	(*DeleteConnectMyComputerNodeRequest)(nil),                           // 62: teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeRequest
+	(*DeleteConnectMyComputerNodeResponse)(nil),                          // 63: teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeResponse
+	(*GetConnectMyComputerNodeNameRequest)(nil),                          // 64: teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameRequest
+	(*GetConnectMyComputerNodeNameResponse)(nil),                         // 65: teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameResponse
+	(*ListUnifiedResourcesRequest)(nil),                                  // 66: teleport.lib.teleterm.v1.ListUnifiedResourcesRequest
+	(*SortBy)(nil),                                                       // 67: teleport.lib.teleterm.v1.SortBy
+	(*ListUnifiedResourcesResponse)(nil),                                 // 68: teleport.lib.teleterm.v1.ListUnifiedResourcesResponse
+	(*PaginatedResource)(nil),                                            // 69: teleport.lib.teleterm.v1.PaginatedResource
+	(*GetUserPreferencesRequest)(nil),                                    // 70: teleport.lib.teleterm.v1.GetUserPreferencesRequest
+	(*GetUserPreferencesResponse)(nil),                                   // 71: teleport.lib.teleterm.v1.GetUserPreferencesResponse
+	(*UpdateUserPreferencesRequest)(nil),                                 // 72: teleport.lib.teleterm.v1.UpdateUserPreferencesRequest
+	(*UpdateUserPreferencesResponse)(nil),                                // 73: teleport.lib.teleterm.v1.UpdateUserPreferencesResponse
+	(*UserPreferences)(nil),                                              // 74: teleport.lib.teleterm.v1.UserPreferences
+	(*AuthenticateWebDeviceRequest)(nil),                                 // 75: teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest
+	(*AuthenticateWebDeviceResponse)(nil),                                // 76: teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse
+	(*GetAppRequest)(nil),                                                // 77: teleport.lib.teleterm.v1.GetAppRequest
+	(*GetAppResponse)(nil),                                               // 78: teleport.lib.teleterm.v1.GetAppResponse
+	(*TargetDesktop)(nil),                                                // 79: teleport.lib.teleterm.v1.TargetDesktop
+	(*ConnectToDesktopRequest)(nil),                                      // 80: teleport.lib.teleterm.v1.ConnectToDesktopRequest
+	(*ConnectToDesktopResponse)(nil),                                     // 81: teleport.lib.teleterm.v1.ConnectToDesktopResponse
+	(*SetSharedDirectoryForDesktopSessionRequest)(nil),                   // 82: teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest
+	(*SetSharedDirectoryForDesktopSessionResponse)(nil),                  // 83: teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionResponse
+	(*LoginPasswordlessRequest_LoginPasswordlessRequestInit)(nil),        // 84: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessRequestInit
+	(*LoginPasswordlessRequest_LoginPasswordlessPINResponse)(nil),        // 85: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessPINResponse
+	(*LoginPasswordlessRequest_LoginPasswordlessCredentialResponse)(nil), // 86: teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessCredentialResponse
+	(*LoginRequest_LocalParams)(nil),                                     // 87: teleport.lib.teleterm.v1.LoginRequest.LocalParams
+	(*LoginRequest_SsoParams)(nil),                                       // 88: teleport.lib.teleterm.v1.LoginRequest.SsoParams
+	(*AccessRequest)(nil),                                                // 89: teleport.lib.teleterm.v1.AccessRequest
+	(*ResourceID)(nil),                                                   // 90: teleport.lib.teleterm.v1.ResourceID
+	(*timestamppb.Timestamp)(nil),                                        // 91: google.protobuf.Timestamp
+	(*v1.AccessList)(nil),                                                // 92: teleport.accesslist.v1.AccessList
+	(*KubeResource)(nil),                                                 // 93: teleport.lib.teleterm.v1.KubeResource
+	(*KubeServer)(nil),                                                   // 94: teleport.lib.teleterm.v1.KubeServer
+	(*Cluster)(nil),                                                      // 95: teleport.lib.teleterm.v1.Cluster
+	(*DatabaseServer)(nil),                                               // 96: teleport.lib.teleterm.v1.DatabaseServer
+	(*Gateway)(nil),                                                      // 97: teleport.lib.teleterm.v1.Gateway
+	(*Server)(nil),                                                       // 98: teleport.lib.teleterm.v1.Server
+	(*Database)(nil),                                                     // 99: teleport.lib.teleterm.v1.Database
+	(*Kube)(nil),                                                         // 100: teleport.lib.teleterm.v1.Kube
+	(*App)(nil),                                                          // 101: teleport.lib.teleterm.v1.App
+	(*WindowsDesktop)(nil),                                               // 102: teleport.lib.teleterm.v1.WindowsDesktop
+	(*v11.ClusterUserPreferences)(nil),                                   // 103: teleport.userpreferences.v1.ClusterUserPreferences
+	(*v11.UnifiedResourcePreferences)(nil),                               // 104: teleport.userpreferences.v1.UnifiedResourcePreferences
+	(*v12.DeviceWebToken)(nil),                                           // 105: teleport.devicetrust.v1.DeviceWebToken
+	(*v12.DeviceConfirmationToken)(nil),                                  // 106: teleport.devicetrust.v1.DeviceConfirmationToken
+	(*ReportUsageEventRequest)(nil),                                      // 107: teleport.lib.teleterm.v1.ReportUsageEventRequest
+	(*AuthSettings)(nil),                                                 // 108: teleport.lib.teleterm.v1.AuthSettings
 }
 var file_teleport_lib_teleterm_v1_service_proto_depIdxs = []int32{
-	87,  // 0: teleport.lib.teleterm.v1.GetAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
-	87,  // 1: teleport.lib.teleterm.v1.GetAccessRequestsResponse.requests:type_name -> teleport.lib.teleterm.v1.AccessRequest
-	88,  // 2: teleport.lib.teleterm.v1.CreateAccessRequestRequest.resource_ids:type_name -> teleport.lib.teleterm.v1.ResourceID
-	89,  // 3: teleport.lib.teleterm.v1.CreateAccessRequestRequest.assume_start_time:type_name -> google.protobuf.Timestamp
-	89,  // 4: teleport.lib.teleterm.v1.CreateAccessRequestRequest.max_duration:type_name -> google.protobuf.Timestamp
-	89,  // 5: teleport.lib.teleterm.v1.CreateAccessRequestRequest.request_ttl:type_name -> google.protobuf.Timestamp
-	87,  // 6: teleport.lib.teleterm.v1.CreateAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
-	88,  // 7: teleport.lib.teleterm.v1.GetRequestableRolesRequest.resource_ids:type_name -> teleport.lib.teleterm.v1.ResourceID
-	89,  // 8: teleport.lib.teleterm.v1.ReviewAccessRequestRequest.assume_start_time:type_name -> google.protobuf.Timestamp
-	87,  // 9: teleport.lib.teleterm.v1.ReviewAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
-	87,  // 10: teleport.lib.teleterm.v1.PromoteAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
-	90,  // 11: teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
-	91,  // 12: teleport.lib.teleterm.v1.ListKubernetesResourcesResponse.resources:type_name -> teleport.lib.teleterm.v1.KubeResource
-	40,  // 13: teleport.lib.teleterm.v1.ListKubernetesServersRequest.params:type_name -> teleport.lib.teleterm.v1.ListResourcesParams
-	92,  // 14: teleport.lib.teleterm.v1.ListKubernetesServersResponse.resources:type_name -> teleport.lib.teleterm.v1.KubeServer
+	89,  // 0: teleport.lib.teleterm.v1.GetAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
+	89,  // 1: teleport.lib.teleterm.v1.GetAccessRequestsResponse.requests:type_name -> teleport.lib.teleterm.v1.AccessRequest
+	90,  // 2: teleport.lib.teleterm.v1.CreateAccessRequestRequest.resource_ids:type_name -> teleport.lib.teleterm.v1.ResourceID
+	91,  // 3: teleport.lib.teleterm.v1.CreateAccessRequestRequest.assume_start_time:type_name -> google.protobuf.Timestamp
+	91,  // 4: teleport.lib.teleterm.v1.CreateAccessRequestRequest.max_duration:type_name -> google.protobuf.Timestamp
+	91,  // 5: teleport.lib.teleterm.v1.CreateAccessRequestRequest.request_ttl:type_name -> google.protobuf.Timestamp
+	89,  // 6: teleport.lib.teleterm.v1.CreateAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
+	90,  // 7: teleport.lib.teleterm.v1.GetRequestableRolesRequest.resource_ids:type_name -> teleport.lib.teleterm.v1.ResourceID
+	91,  // 8: teleport.lib.teleterm.v1.ReviewAccessRequestRequest.assume_start_time:type_name -> google.protobuf.Timestamp
+	89,  // 9: teleport.lib.teleterm.v1.ReviewAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
+	89,  // 10: teleport.lib.teleterm.v1.PromoteAccessRequestResponse.request:type_name -> teleport.lib.teleterm.v1.AccessRequest
+	92,  // 11: teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse.access_lists:type_name -> teleport.accesslist.v1.AccessList
+	93,  // 12: teleport.lib.teleterm.v1.ListKubernetesResourcesResponse.resources:type_name -> teleport.lib.teleterm.v1.KubeResource
+	42,  // 13: teleport.lib.teleterm.v1.ListKubernetesServersRequest.params:type_name -> teleport.lib.teleterm.v1.ListResourcesParams
+	94,  // 14: teleport.lib.teleterm.v1.ListKubernetesServersResponse.resources:type_name -> teleport.lib.teleterm.v1.KubeServer
 	0,   // 15: teleport.lib.teleterm.v1.LoginPasswordlessResponse.prompt:type_name -> teleport.lib.teleterm.v1.PasswordlessPrompt
-	28,  // 16: teleport.lib.teleterm.v1.LoginPasswordlessResponse.credentials:type_name -> teleport.lib.teleterm.v1.CredentialInfo
-	82,  // 17: teleport.lib.teleterm.v1.LoginPasswordlessRequest.init:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessRequestInit
-	83,  // 18: teleport.lib.teleterm.v1.LoginPasswordlessRequest.pin:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessPINResponse
-	84,  // 19: teleport.lib.teleterm.v1.LoginPasswordlessRequest.credential:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessCredentialResponse
+	30,  // 16: teleport.lib.teleterm.v1.LoginPasswordlessResponse.credentials:type_name -> teleport.lib.teleterm.v1.CredentialInfo
+	84,  // 17: teleport.lib.teleterm.v1.LoginPasswordlessRequest.init:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessRequestInit
+	85,  // 18: teleport.lib.teleterm.v1.LoginPasswordlessRequest.pin:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessPINResponse
+	86,  // 19: teleport.lib.teleterm.v1.LoginPasswordlessRequest.credential:type_name -> teleport.lib.teleterm.v1.LoginPasswordlessRequest.LoginPasswordlessCredentialResponse
 	1,   // 20: teleport.lib.teleterm.v1.FileTransferRequest.direction:type_name -> teleport.lib.teleterm.v1.FileTransferDirection
-	85,  // 21: teleport.lib.teleterm.v1.LoginRequest.local:type_name -> teleport.lib.teleterm.v1.LoginRequest.LocalParams
-	86,  // 22: teleport.lib.teleterm.v1.LoginRequest.sso:type_name -> teleport.lib.teleterm.v1.LoginRequest.SsoParams
-	93,  // 23: teleport.lib.teleterm.v1.ListClustersResponse.clusters:type_name -> teleport.lib.teleterm.v1.Cluster
-	40,  // 24: teleport.lib.teleterm.v1.ListDatabaseServersRequest.params:type_name -> teleport.lib.teleterm.v1.ListResourcesParams
-	94,  // 25: teleport.lib.teleterm.v1.ListDatabaseServersResponse.resources:type_name -> teleport.lib.teleterm.v1.DatabaseServer
-	95,  // 26: teleport.lib.teleterm.v1.ListGatewaysResponse.gateways:type_name -> teleport.lib.teleterm.v1.Gateway
+	87,  // 21: teleport.lib.teleterm.v1.LoginRequest.local:type_name -> teleport.lib.teleterm.v1.LoginRequest.LocalParams
+	88,  // 22: teleport.lib.teleterm.v1.LoginRequest.sso:type_name -> teleport.lib.teleterm.v1.LoginRequest.SsoParams
+	95,  // 23: teleport.lib.teleterm.v1.ListClustersResponse.clusters:type_name -> teleport.lib.teleterm.v1.Cluster
+	42,  // 24: teleport.lib.teleterm.v1.ListDatabaseServersRequest.params:type_name -> teleport.lib.teleterm.v1.ListResourcesParams
+	96,  // 25: teleport.lib.teleterm.v1.ListDatabaseServersResponse.resources:type_name -> teleport.lib.teleterm.v1.DatabaseServer
+	97,  // 26: teleport.lib.teleterm.v1.ListGatewaysResponse.gateways:type_name -> teleport.lib.teleterm.v1.Gateway
 	2,   // 27: teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest.state:type_name -> teleport.lib.teleterm.v1.HeadlessAuthenticationState
-	96,  // 28: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse.server:type_name -> teleport.lib.teleterm.v1.Server
-	65,  // 29: teleport.lib.teleterm.v1.ListUnifiedResourcesRequest.sort_by:type_name -> teleport.lib.teleterm.v1.SortBy
-	67,  // 30: teleport.lib.teleterm.v1.ListUnifiedResourcesResponse.resources:type_name -> teleport.lib.teleterm.v1.PaginatedResource
-	97,  // 31: teleport.lib.teleterm.v1.PaginatedResource.database:type_name -> teleport.lib.teleterm.v1.Database
-	96,  // 32: teleport.lib.teleterm.v1.PaginatedResource.server:type_name -> teleport.lib.teleterm.v1.Server
-	98,  // 33: teleport.lib.teleterm.v1.PaginatedResource.kube:type_name -> teleport.lib.teleterm.v1.Kube
-	99,  // 34: teleport.lib.teleterm.v1.PaginatedResource.app:type_name -> teleport.lib.teleterm.v1.App
-	100, // 35: teleport.lib.teleterm.v1.PaginatedResource.windows_desktop:type_name -> teleport.lib.teleterm.v1.WindowsDesktop
-	72,  // 36: teleport.lib.teleterm.v1.GetUserPreferencesResponse.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
-	72,  // 37: teleport.lib.teleterm.v1.UpdateUserPreferencesRequest.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
-	72,  // 38: teleport.lib.teleterm.v1.UpdateUserPreferencesResponse.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
-	101, // 39: teleport.lib.teleterm.v1.UserPreferences.cluster_preferences:type_name -> teleport.userpreferences.v1.ClusterUserPreferences
-	102, // 40: teleport.lib.teleterm.v1.UserPreferences.unified_resource_preferences:type_name -> teleport.userpreferences.v1.UnifiedResourcePreferences
-	103, // 41: teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest.device_web_token:type_name -> teleport.devicetrust.v1.DeviceWebToken
-	104, // 42: teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse.confirmation_token:type_name -> teleport.devicetrust.v1.DeviceConfirmationToken
-	99,  // 43: teleport.lib.teleterm.v1.GetAppResponse.app:type_name -> teleport.lib.teleterm.v1.App
-	77,  // 44: teleport.lib.teleterm.v1.ConnectToDesktopRequest.target_desktop:type_name -> teleport.lib.teleterm.v1.TargetDesktop
-	50,  // 45: teleport.lib.teleterm.v1.TerminalService.UpdateTshdEventsServerAddress:input_type -> teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressRequest
-	35,  // 46: teleport.lib.teleterm.v1.TerminalService.ListRootClusters:input_type -> teleport.lib.teleterm.v1.ListClustersRequest
-	37,  // 47: teleport.lib.teleterm.v1.TerminalService.ListLeafClusters:input_type -> teleport.lib.teleterm.v1.ListLeafClustersRequest
-	6,   // 48: teleport.lib.teleterm.v1.TerminalService.StartHeadlessWatcher:input_type -> teleport.lib.teleterm.v1.StartHeadlessWatcherRequest
-	38,  // 49: teleport.lib.teleterm.v1.TerminalService.ListDatabaseUsers:input_type -> teleport.lib.teleterm.v1.ListDatabaseUsersRequest
-	41,  // 50: teleport.lib.teleterm.v1.TerminalService.ListDatabaseServers:input_type -> teleport.lib.teleterm.v1.ListDatabaseServersRequest
-	9,   // 51: teleport.lib.teleterm.v1.TerminalService.GetAccessRequests:input_type -> teleport.lib.teleterm.v1.GetAccessRequestsRequest
-	8,   // 52: teleport.lib.teleterm.v1.TerminalService.GetAccessRequest:input_type -> teleport.lib.teleterm.v1.GetAccessRequestRequest
-	12,  // 53: teleport.lib.teleterm.v1.TerminalService.DeleteAccessRequest:input_type -> teleport.lib.teleterm.v1.DeleteAccessRequestRequest
-	13,  // 54: teleport.lib.teleterm.v1.TerminalService.CreateAccessRequest:input_type -> teleport.lib.teleterm.v1.CreateAccessRequestRequest
-	18,  // 55: teleport.lib.teleterm.v1.TerminalService.ReviewAccessRequest:input_type -> teleport.lib.teleterm.v1.ReviewAccessRequestRequest
-	16,  // 56: teleport.lib.teleterm.v1.TerminalService.GetRequestableRoles:input_type -> teleport.lib.teleterm.v1.GetRequestableRolesRequest
-	15,  // 57: teleport.lib.teleterm.v1.TerminalService.AssumeRole:input_type -> teleport.lib.teleterm.v1.AssumeRoleRequest
-	20,  // 58: teleport.lib.teleterm.v1.TerminalService.PromoteAccessRequest:input_type -> teleport.lib.teleterm.v1.PromoteAccessRequestRequest
-	22,  // 59: teleport.lib.teleterm.v1.TerminalService.GetSuggestedAccessLists:input_type -> teleport.lib.teleterm.v1.GetSuggestedAccessListsRequest
-	24,  // 60: teleport.lib.teleterm.v1.TerminalService.ListKubernetesResources:input_type -> teleport.lib.teleterm.v1.ListKubernetesResourcesRequest
-	26,  // 61: teleport.lib.teleterm.v1.TerminalService.ListKubernetesServers:input_type -> teleport.lib.teleterm.v1.ListKubernetesServersRequest
-	34,  // 62: teleport.lib.teleterm.v1.TerminalService.AddCluster:input_type -> teleport.lib.teleterm.v1.AddClusterRequest
-	44,  // 63: teleport.lib.teleterm.v1.TerminalService.ListGateways:input_type -> teleport.lib.teleterm.v1.ListGatewaysRequest
-	43,  // 64: teleport.lib.teleterm.v1.TerminalService.CreateGateway:input_type -> teleport.lib.teleterm.v1.CreateGatewayRequest
-	46,  // 65: teleport.lib.teleterm.v1.TerminalService.RemoveGateway:input_type -> teleport.lib.teleterm.v1.RemoveGatewayRequest
-	47,  // 66: teleport.lib.teleterm.v1.TerminalService.SetGatewayTargetSubresourceName:input_type -> teleport.lib.teleterm.v1.SetGatewayTargetSubresourceNameRequest
-	48,  // 67: teleport.lib.teleterm.v1.TerminalService.SetGatewayLocalPort:input_type -> teleport.lib.teleterm.v1.SetGatewayLocalPortRequest
-	49,  // 68: teleport.lib.teleterm.v1.TerminalService.GetAuthSettings:input_type -> teleport.lib.teleterm.v1.GetAuthSettingsRequest
+	98,  // 28: teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse.server:type_name -> teleport.lib.teleterm.v1.Server
+	67,  // 29: teleport.lib.teleterm.v1.ListUnifiedResourcesRequest.sort_by:type_name -> teleport.lib.teleterm.v1.SortBy
+	69,  // 30: teleport.lib.teleterm.v1.ListUnifiedResourcesResponse.resources:type_name -> teleport.lib.teleterm.v1.PaginatedResource
+	99,  // 31: teleport.lib.teleterm.v1.PaginatedResource.database:type_name -> teleport.lib.teleterm.v1.Database
+	98,  // 32: teleport.lib.teleterm.v1.PaginatedResource.server:type_name -> teleport.lib.teleterm.v1.Server
+	100, // 33: teleport.lib.teleterm.v1.PaginatedResource.kube:type_name -> teleport.lib.teleterm.v1.Kube
+	101, // 34: teleport.lib.teleterm.v1.PaginatedResource.app:type_name -> teleport.lib.teleterm.v1.App
+	102, // 35: teleport.lib.teleterm.v1.PaginatedResource.windows_desktop:type_name -> teleport.lib.teleterm.v1.WindowsDesktop
+	74,  // 36: teleport.lib.teleterm.v1.GetUserPreferencesResponse.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
+	74,  // 37: teleport.lib.teleterm.v1.UpdateUserPreferencesRequest.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
+	74,  // 38: teleport.lib.teleterm.v1.UpdateUserPreferencesResponse.user_preferences:type_name -> teleport.lib.teleterm.v1.UserPreferences
+	103, // 39: teleport.lib.teleterm.v1.UserPreferences.cluster_preferences:type_name -> teleport.userpreferences.v1.ClusterUserPreferences
+	104, // 40: teleport.lib.teleterm.v1.UserPreferences.unified_resource_preferences:type_name -> teleport.userpreferences.v1.UnifiedResourcePreferences
+	105, // 41: teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest.device_web_token:type_name -> teleport.devicetrust.v1.DeviceWebToken
+	106, // 42: teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse.confirmation_token:type_name -> teleport.devicetrust.v1.DeviceConfirmationToken
+	101, // 43: teleport.lib.teleterm.v1.GetAppResponse.app:type_name -> teleport.lib.teleterm.v1.App
+	79,  // 44: teleport.lib.teleterm.v1.ConnectToDesktopRequest.target_desktop:type_name -> teleport.lib.teleterm.v1.TargetDesktop
+	52,  // 45: teleport.lib.teleterm.v1.TerminalService.UpdateTshdEventsServerAddress:input_type -> teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressRequest
+	37,  // 46: teleport.lib.teleterm.v1.TerminalService.ListRootClusters:input_type -> teleport.lib.teleterm.v1.ListClustersRequest
+	39,  // 47: teleport.lib.teleterm.v1.TerminalService.ListLeafClusters:input_type -> teleport.lib.teleterm.v1.ListLeafClustersRequest
+	8,   // 48: teleport.lib.teleterm.v1.TerminalService.StartHeadlessWatcher:input_type -> teleport.lib.teleterm.v1.StartHeadlessWatcherRequest
+	40,  // 49: teleport.lib.teleterm.v1.TerminalService.ListDatabaseUsers:input_type -> teleport.lib.teleterm.v1.ListDatabaseUsersRequest
+	43,  // 50: teleport.lib.teleterm.v1.TerminalService.ListDatabaseServers:input_type -> teleport.lib.teleterm.v1.ListDatabaseServersRequest
+	11,  // 51: teleport.lib.teleterm.v1.TerminalService.GetAccessRequests:input_type -> teleport.lib.teleterm.v1.GetAccessRequestsRequest
+	10,  // 52: teleport.lib.teleterm.v1.TerminalService.GetAccessRequest:input_type -> teleport.lib.teleterm.v1.GetAccessRequestRequest
+	14,  // 53: teleport.lib.teleterm.v1.TerminalService.DeleteAccessRequest:input_type -> teleport.lib.teleterm.v1.DeleteAccessRequestRequest
+	15,  // 54: teleport.lib.teleterm.v1.TerminalService.CreateAccessRequest:input_type -> teleport.lib.teleterm.v1.CreateAccessRequestRequest
+	20,  // 55: teleport.lib.teleterm.v1.TerminalService.ReviewAccessRequest:input_type -> teleport.lib.teleterm.v1.ReviewAccessRequestRequest
+	18,  // 56: teleport.lib.teleterm.v1.TerminalService.GetRequestableRoles:input_type -> teleport.lib.teleterm.v1.GetRequestableRolesRequest
+	17,  // 57: teleport.lib.teleterm.v1.TerminalService.AssumeRole:input_type -> teleport.lib.teleterm.v1.AssumeRoleRequest
+	22,  // 58: teleport.lib.teleterm.v1.TerminalService.PromoteAccessRequest:input_type -> teleport.lib.teleterm.v1.PromoteAccessRequestRequest
+	24,  // 59: teleport.lib.teleterm.v1.TerminalService.GetSuggestedAccessLists:input_type -> teleport.lib.teleterm.v1.GetSuggestedAccessListsRequest
+	26,  // 60: teleport.lib.teleterm.v1.TerminalService.ListKubernetesResources:input_type -> teleport.lib.teleterm.v1.ListKubernetesResourcesRequest
+	28,  // 61: teleport.lib.teleterm.v1.TerminalService.ListKubernetesServers:input_type -> teleport.lib.teleterm.v1.ListKubernetesServersRequest
+	36,  // 62: teleport.lib.teleterm.v1.TerminalService.AddCluster:input_type -> teleport.lib.teleterm.v1.AddClusterRequest
+	46,  // 63: teleport.lib.teleterm.v1.TerminalService.ListGateways:input_type -> teleport.lib.teleterm.v1.ListGatewaysRequest
+	45,  // 64: teleport.lib.teleterm.v1.TerminalService.CreateGateway:input_type -> teleport.lib.teleterm.v1.CreateGatewayRequest
+	48,  // 65: teleport.lib.teleterm.v1.TerminalService.RemoveGateway:input_type -> teleport.lib.teleterm.v1.RemoveGatewayRequest
+	49,  // 66: teleport.lib.teleterm.v1.TerminalService.SetGatewayTargetSubresourceName:input_type -> teleport.lib.teleterm.v1.SetGatewayTargetSubresourceNameRequest
+	50,  // 67: teleport.lib.teleterm.v1.TerminalService.SetGatewayLocalPort:input_type -> teleport.lib.teleterm.v1.SetGatewayLocalPortRequest
+	51,  // 68: teleport.lib.teleterm.v1.TerminalService.GetAuthSettings:input_type -> teleport.lib.teleterm.v1.GetAuthSettingsRequest
 	4,   // 69: teleport.lib.teleterm.v1.TerminalService.GetCluster:input_type -> teleport.lib.teleterm.v1.GetClusterRequest
-	33,  // 70: teleport.lib.teleterm.v1.TerminalService.Login:input_type -> teleport.lib.teleterm.v1.LoginRequest
-	30,  // 71: teleport.lib.teleterm.v1.TerminalService.LoginPasswordless:input_type -> teleport.lib.teleterm.v1.LoginPasswordlessRequest
+	35,  // 70: teleport.lib.teleterm.v1.TerminalService.Login:input_type -> teleport.lib.teleterm.v1.LoginRequest
+	32,  // 71: teleport.lib.teleterm.v1.TerminalService.LoginPasswordless:input_type -> teleport.lib.teleterm.v1.LoginPasswordlessRequest
 	5,   // 72: teleport.lib.teleterm.v1.TerminalService.Logout:input_type -> teleport.lib.teleterm.v1.LogoutRequest
-	31,  // 73: teleport.lib.teleterm.v1.TerminalService.TransferFile:input_type -> teleport.lib.teleterm.v1.FileTransferRequest
-	105, // 74: teleport.lib.teleterm.v1.TerminalService.ReportUsageEvent:input_type -> teleport.lib.teleterm.v1.ReportUsageEventRequest
-	52,  // 75: teleport.lib.teleterm.v1.TerminalService.UpdateHeadlessAuthenticationState:input_type -> teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest
-	54,  // 76: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerRole:input_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerRoleRequest
-	56,  // 77: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerNodeToken:input_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenRequest
-	58,  // 78: teleport.lib.teleterm.v1.TerminalService.WaitForConnectMyComputerNodeJoin:input_type -> teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinRequest
-	60,  // 79: teleport.lib.teleterm.v1.TerminalService.DeleteConnectMyComputerNode:input_type -> teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeRequest
-	62,  // 80: teleport.lib.teleterm.v1.TerminalService.GetConnectMyComputerNodeName:input_type -> teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameRequest
-	64,  // 81: teleport.lib.teleterm.v1.TerminalService.ListUnifiedResources:input_type -> teleport.lib.teleterm.v1.ListUnifiedResourcesRequest
-	68,  // 82: teleport.lib.teleterm.v1.TerminalService.GetUserPreferences:input_type -> teleport.lib.teleterm.v1.GetUserPreferencesRequest
-	70,  // 83: teleport.lib.teleterm.v1.TerminalService.UpdateUserPreferences:input_type -> teleport.lib.teleterm.v1.UpdateUserPreferencesRequest
-	73,  // 84: teleport.lib.teleterm.v1.TerminalService.AuthenticateWebDevice:input_type -> teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest
-	75,  // 85: teleport.lib.teleterm.v1.TerminalService.GetApp:input_type -> teleport.lib.teleterm.v1.GetAppRequest
-	78,  // 86: teleport.lib.teleterm.v1.TerminalService.ConnectToDesktop:input_type -> teleport.lib.teleterm.v1.ConnectToDesktopRequest
-	80,  // 87: teleport.lib.teleterm.v1.TerminalService.SetSharedDirectoryForDesktopSession:input_type -> teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest
-	51,  // 88: teleport.lib.teleterm.v1.TerminalService.UpdateTshdEventsServerAddress:output_type -> teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressResponse
-	36,  // 89: teleport.lib.teleterm.v1.TerminalService.ListRootClusters:output_type -> teleport.lib.teleterm.v1.ListClustersResponse
-	36,  // 90: teleport.lib.teleterm.v1.TerminalService.ListLeafClusters:output_type -> teleport.lib.teleterm.v1.ListClustersResponse
-	7,   // 91: teleport.lib.teleterm.v1.TerminalService.StartHeadlessWatcher:output_type -> teleport.lib.teleterm.v1.StartHeadlessWatcherResponse
-	39,  // 92: teleport.lib.teleterm.v1.TerminalService.ListDatabaseUsers:output_type -> teleport.lib.teleterm.v1.ListDatabaseUsersResponse
-	42,  // 93: teleport.lib.teleterm.v1.TerminalService.ListDatabaseServers:output_type -> teleport.lib.teleterm.v1.ListDatabaseServersResponse
-	11,  // 94: teleport.lib.teleterm.v1.TerminalService.GetAccessRequests:output_type -> teleport.lib.teleterm.v1.GetAccessRequestsResponse
-	10,  // 95: teleport.lib.teleterm.v1.TerminalService.GetAccessRequest:output_type -> teleport.lib.teleterm.v1.GetAccessRequestResponse
-	3,   // 96: teleport.lib.teleterm.v1.TerminalService.DeleteAccessRequest:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	14,  // 97: teleport.lib.teleterm.v1.TerminalService.CreateAccessRequest:output_type -> teleport.lib.teleterm.v1.CreateAccessRequestResponse
-	19,  // 98: teleport.lib.teleterm.v1.TerminalService.ReviewAccessRequest:output_type -> teleport.lib.teleterm.v1.ReviewAccessRequestResponse
-	17,  // 99: teleport.lib.teleterm.v1.TerminalService.GetRequestableRoles:output_type -> teleport.lib.teleterm.v1.GetRequestableRolesResponse
-	3,   // 100: teleport.lib.teleterm.v1.TerminalService.AssumeRole:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	21,  // 101: teleport.lib.teleterm.v1.TerminalService.PromoteAccessRequest:output_type -> teleport.lib.teleterm.v1.PromoteAccessRequestResponse
-	23,  // 102: teleport.lib.teleterm.v1.TerminalService.GetSuggestedAccessLists:output_type -> teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse
-	25,  // 103: teleport.lib.teleterm.v1.TerminalService.ListKubernetesResources:output_type -> teleport.lib.teleterm.v1.ListKubernetesResourcesResponse
-	27,  // 104: teleport.lib.teleterm.v1.TerminalService.ListKubernetesServers:output_type -> teleport.lib.teleterm.v1.ListKubernetesServersResponse
-	93,  // 105: teleport.lib.teleterm.v1.TerminalService.AddCluster:output_type -> teleport.lib.teleterm.v1.Cluster
-	45,  // 106: teleport.lib.teleterm.v1.TerminalService.ListGateways:output_type -> teleport.lib.teleterm.v1.ListGatewaysResponse
-	95,  // 107: teleport.lib.teleterm.v1.TerminalService.CreateGateway:output_type -> teleport.lib.teleterm.v1.Gateway
-	3,   // 108: teleport.lib.teleterm.v1.TerminalService.RemoveGateway:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	95,  // 109: teleport.lib.teleterm.v1.TerminalService.SetGatewayTargetSubresourceName:output_type -> teleport.lib.teleterm.v1.Gateway
-	95,  // 110: teleport.lib.teleterm.v1.TerminalService.SetGatewayLocalPort:output_type -> teleport.lib.teleterm.v1.Gateway
-	106, // 111: teleport.lib.teleterm.v1.TerminalService.GetAuthSettings:output_type -> teleport.lib.teleterm.v1.AuthSettings
-	93,  // 112: teleport.lib.teleterm.v1.TerminalService.GetCluster:output_type -> teleport.lib.teleterm.v1.Cluster
-	3,   // 113: teleport.lib.teleterm.v1.TerminalService.Login:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	29,  // 114: teleport.lib.teleterm.v1.TerminalService.LoginPasswordless:output_type -> teleport.lib.teleterm.v1.LoginPasswordlessResponse
-	3,   // 115: teleport.lib.teleterm.v1.TerminalService.Logout:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	32,  // 116: teleport.lib.teleterm.v1.TerminalService.TransferFile:output_type -> teleport.lib.teleterm.v1.FileTransferProgress
-	3,   // 117: teleport.lib.teleterm.v1.TerminalService.ReportUsageEvent:output_type -> teleport.lib.teleterm.v1.EmptyResponse
-	53,  // 118: teleport.lib.teleterm.v1.TerminalService.UpdateHeadlessAuthenticationState:output_type -> teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse
-	55,  // 119: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerRole:output_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerRoleResponse
-	57,  // 120: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerNodeToken:output_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenResponse
-	59,  // 121: teleport.lib.teleterm.v1.TerminalService.WaitForConnectMyComputerNodeJoin:output_type -> teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse
-	61,  // 122: teleport.lib.teleterm.v1.TerminalService.DeleteConnectMyComputerNode:output_type -> teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeResponse
-	63,  // 123: teleport.lib.teleterm.v1.TerminalService.GetConnectMyComputerNodeName:output_type -> teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameResponse
-	66,  // 124: teleport.lib.teleterm.v1.TerminalService.ListUnifiedResources:output_type -> teleport.lib.teleterm.v1.ListUnifiedResourcesResponse
-	69,  // 125: teleport.lib.teleterm.v1.TerminalService.GetUserPreferences:output_type -> teleport.lib.teleterm.v1.GetUserPreferencesResponse
-	71,  // 126: teleport.lib.teleterm.v1.TerminalService.UpdateUserPreferences:output_type -> teleport.lib.teleterm.v1.UpdateUserPreferencesResponse
-	74,  // 127: teleport.lib.teleterm.v1.TerminalService.AuthenticateWebDevice:output_type -> teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse
-	76,  // 128: teleport.lib.teleterm.v1.TerminalService.GetApp:output_type -> teleport.lib.teleterm.v1.GetAppResponse
-	79,  // 129: teleport.lib.teleterm.v1.TerminalService.ConnectToDesktop:output_type -> teleport.lib.teleterm.v1.ConnectToDesktopResponse
-	81,  // 130: teleport.lib.teleterm.v1.TerminalService.SetSharedDirectoryForDesktopSession:output_type -> teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionResponse
-	88,  // [88:131] is the sub-list for method output_type
-	45,  // [45:88] is the sub-list for method input_type
+	6,   // 73: teleport.lib.teleterm.v1.TerminalService.ClearStaleClusterClients:input_type -> teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest
+	33,  // 74: teleport.lib.teleterm.v1.TerminalService.TransferFile:input_type -> teleport.lib.teleterm.v1.FileTransferRequest
+	107, // 75: teleport.lib.teleterm.v1.TerminalService.ReportUsageEvent:input_type -> teleport.lib.teleterm.v1.ReportUsageEventRequest
+	54,  // 76: teleport.lib.teleterm.v1.TerminalService.UpdateHeadlessAuthenticationState:input_type -> teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest
+	56,  // 77: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerRole:input_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerRoleRequest
+	58,  // 78: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerNodeToken:input_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenRequest
+	60,  // 79: teleport.lib.teleterm.v1.TerminalService.WaitForConnectMyComputerNodeJoin:input_type -> teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinRequest
+	62,  // 80: teleport.lib.teleterm.v1.TerminalService.DeleteConnectMyComputerNode:input_type -> teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeRequest
+	64,  // 81: teleport.lib.teleterm.v1.TerminalService.GetConnectMyComputerNodeName:input_type -> teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameRequest
+	66,  // 82: teleport.lib.teleterm.v1.TerminalService.ListUnifiedResources:input_type -> teleport.lib.teleterm.v1.ListUnifiedResourcesRequest
+	70,  // 83: teleport.lib.teleterm.v1.TerminalService.GetUserPreferences:input_type -> teleport.lib.teleterm.v1.GetUserPreferencesRequest
+	72,  // 84: teleport.lib.teleterm.v1.TerminalService.UpdateUserPreferences:input_type -> teleport.lib.teleterm.v1.UpdateUserPreferencesRequest
+	75,  // 85: teleport.lib.teleterm.v1.TerminalService.AuthenticateWebDevice:input_type -> teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest
+	77,  // 86: teleport.lib.teleterm.v1.TerminalService.GetApp:input_type -> teleport.lib.teleterm.v1.GetAppRequest
+	80,  // 87: teleport.lib.teleterm.v1.TerminalService.ConnectToDesktop:input_type -> teleport.lib.teleterm.v1.ConnectToDesktopRequest
+	82,  // 88: teleport.lib.teleterm.v1.TerminalService.SetSharedDirectoryForDesktopSession:input_type -> teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest
+	53,  // 89: teleport.lib.teleterm.v1.TerminalService.UpdateTshdEventsServerAddress:output_type -> teleport.lib.teleterm.v1.UpdateTshdEventsServerAddressResponse
+	38,  // 90: teleport.lib.teleterm.v1.TerminalService.ListRootClusters:output_type -> teleport.lib.teleterm.v1.ListClustersResponse
+	38,  // 91: teleport.lib.teleterm.v1.TerminalService.ListLeafClusters:output_type -> teleport.lib.teleterm.v1.ListClustersResponse
+	9,   // 92: teleport.lib.teleterm.v1.TerminalService.StartHeadlessWatcher:output_type -> teleport.lib.teleterm.v1.StartHeadlessWatcherResponse
+	41,  // 93: teleport.lib.teleterm.v1.TerminalService.ListDatabaseUsers:output_type -> teleport.lib.teleterm.v1.ListDatabaseUsersResponse
+	44,  // 94: teleport.lib.teleterm.v1.TerminalService.ListDatabaseServers:output_type -> teleport.lib.teleterm.v1.ListDatabaseServersResponse
+	13,  // 95: teleport.lib.teleterm.v1.TerminalService.GetAccessRequests:output_type -> teleport.lib.teleterm.v1.GetAccessRequestsResponse
+	12,  // 96: teleport.lib.teleterm.v1.TerminalService.GetAccessRequest:output_type -> teleport.lib.teleterm.v1.GetAccessRequestResponse
+	3,   // 97: teleport.lib.teleterm.v1.TerminalService.DeleteAccessRequest:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	16,  // 98: teleport.lib.teleterm.v1.TerminalService.CreateAccessRequest:output_type -> teleport.lib.teleterm.v1.CreateAccessRequestResponse
+	21,  // 99: teleport.lib.teleterm.v1.TerminalService.ReviewAccessRequest:output_type -> teleport.lib.teleterm.v1.ReviewAccessRequestResponse
+	19,  // 100: teleport.lib.teleterm.v1.TerminalService.GetRequestableRoles:output_type -> teleport.lib.teleterm.v1.GetRequestableRolesResponse
+	3,   // 101: teleport.lib.teleterm.v1.TerminalService.AssumeRole:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	23,  // 102: teleport.lib.teleterm.v1.TerminalService.PromoteAccessRequest:output_type -> teleport.lib.teleterm.v1.PromoteAccessRequestResponse
+	25,  // 103: teleport.lib.teleterm.v1.TerminalService.GetSuggestedAccessLists:output_type -> teleport.lib.teleterm.v1.GetSuggestedAccessListsResponse
+	27,  // 104: teleport.lib.teleterm.v1.TerminalService.ListKubernetesResources:output_type -> teleport.lib.teleterm.v1.ListKubernetesResourcesResponse
+	29,  // 105: teleport.lib.teleterm.v1.TerminalService.ListKubernetesServers:output_type -> teleport.lib.teleterm.v1.ListKubernetesServersResponse
+	95,  // 106: teleport.lib.teleterm.v1.TerminalService.AddCluster:output_type -> teleport.lib.teleterm.v1.Cluster
+	47,  // 107: teleport.lib.teleterm.v1.TerminalService.ListGateways:output_type -> teleport.lib.teleterm.v1.ListGatewaysResponse
+	97,  // 108: teleport.lib.teleterm.v1.TerminalService.CreateGateway:output_type -> teleport.lib.teleterm.v1.Gateway
+	3,   // 109: teleport.lib.teleterm.v1.TerminalService.RemoveGateway:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	97,  // 110: teleport.lib.teleterm.v1.TerminalService.SetGatewayTargetSubresourceName:output_type -> teleport.lib.teleterm.v1.Gateway
+	97,  // 111: teleport.lib.teleterm.v1.TerminalService.SetGatewayLocalPort:output_type -> teleport.lib.teleterm.v1.Gateway
+	108, // 112: teleport.lib.teleterm.v1.TerminalService.GetAuthSettings:output_type -> teleport.lib.teleterm.v1.AuthSettings
+	95,  // 113: teleport.lib.teleterm.v1.TerminalService.GetCluster:output_type -> teleport.lib.teleterm.v1.Cluster
+	3,   // 114: teleport.lib.teleterm.v1.TerminalService.Login:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	31,  // 115: teleport.lib.teleterm.v1.TerminalService.LoginPasswordless:output_type -> teleport.lib.teleterm.v1.LoginPasswordlessResponse
+	3,   // 116: teleport.lib.teleterm.v1.TerminalService.Logout:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	7,   // 117: teleport.lib.teleterm.v1.TerminalService.ClearStaleClusterClients:output_type -> teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse
+	34,  // 118: teleport.lib.teleterm.v1.TerminalService.TransferFile:output_type -> teleport.lib.teleterm.v1.FileTransferProgress
+	3,   // 119: teleport.lib.teleterm.v1.TerminalService.ReportUsageEvent:output_type -> teleport.lib.teleterm.v1.EmptyResponse
+	55,  // 120: teleport.lib.teleterm.v1.TerminalService.UpdateHeadlessAuthenticationState:output_type -> teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse
+	57,  // 121: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerRole:output_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerRoleResponse
+	59,  // 122: teleport.lib.teleterm.v1.TerminalService.CreateConnectMyComputerNodeToken:output_type -> teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenResponse
+	61,  // 123: teleport.lib.teleterm.v1.TerminalService.WaitForConnectMyComputerNodeJoin:output_type -> teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse
+	63,  // 124: teleport.lib.teleterm.v1.TerminalService.DeleteConnectMyComputerNode:output_type -> teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeResponse
+	65,  // 125: teleport.lib.teleterm.v1.TerminalService.GetConnectMyComputerNodeName:output_type -> teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameResponse
+	68,  // 126: teleport.lib.teleterm.v1.TerminalService.ListUnifiedResources:output_type -> teleport.lib.teleterm.v1.ListUnifiedResourcesResponse
+	71,  // 127: teleport.lib.teleterm.v1.TerminalService.GetUserPreferences:output_type -> teleport.lib.teleterm.v1.GetUserPreferencesResponse
+	73,  // 128: teleport.lib.teleterm.v1.TerminalService.UpdateUserPreferences:output_type -> teleport.lib.teleterm.v1.UpdateUserPreferencesResponse
+	76,  // 129: teleport.lib.teleterm.v1.TerminalService.AuthenticateWebDevice:output_type -> teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse
+	78,  // 130: teleport.lib.teleterm.v1.TerminalService.GetApp:output_type -> teleport.lib.teleterm.v1.GetAppResponse
+	81,  // 131: teleport.lib.teleterm.v1.TerminalService.ConnectToDesktop:output_type -> teleport.lib.teleterm.v1.ConnectToDesktopResponse
+	83,  // 132: teleport.lib.teleterm.v1.TerminalService.SetSharedDirectoryForDesktopSession:output_type -> teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionResponse
+	89,  // [89:133] is the sub-list for method output_type
+	45,  // [45:89] is the sub-list for method input_type
 	45,  // [45:45] is the sub-list for extension type_name
 	45,  // [45:45] is the sub-list for extension extendee
 	0,   // [0:45] is the sub-list for field type_name
@@ -5351,16 +5439,16 @@ func file_teleport_lib_teleterm_v1_service_proto_init() {
 	file_teleport_lib_teleterm_v1_server_proto_init()
 	file_teleport_lib_teleterm_v1_usage_events_proto_init()
 	file_teleport_lib_teleterm_v1_windows_desktop_proto_init()
-	file_teleport_lib_teleterm_v1_service_proto_msgTypes[27].OneofWrappers = []any{
+	file_teleport_lib_teleterm_v1_service_proto_msgTypes[29].OneofWrappers = []any{
 		(*LoginPasswordlessRequest_Init)(nil),
 		(*LoginPasswordlessRequest_Pin)(nil),
 		(*LoginPasswordlessRequest_Credential)(nil),
 	}
-	file_teleport_lib_teleterm_v1_service_proto_msgTypes[30].OneofWrappers = []any{
+	file_teleport_lib_teleterm_v1_service_proto_msgTypes[32].OneofWrappers = []any{
 		(*LoginRequest_Local)(nil),
 		(*LoginRequest_Sso)(nil),
 	}
-	file_teleport_lib_teleterm_v1_service_proto_msgTypes[64].OneofWrappers = []any{
+	file_teleport_lib_teleterm_v1_service_proto_msgTypes[66].OneofWrappers = []any{
 		(*PaginatedResource_Database)(nil),
 		(*PaginatedResource_Server)(nil),
 		(*PaginatedResource_Kube)(nil),
@@ -5373,7 +5461,7 @@ func file_teleport_lib_teleterm_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_teleterm_v1_service_proto_rawDesc), len(file_teleport_lib_teleterm_v1_service_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   84,
+			NumMessages:   86,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/proto/go/teleport/lib/teleterm/v1/service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/v1/service_grpc.pb.go
@@ -64,6 +64,7 @@ const (
 	TerminalService_Login_FullMethodName                               = "/teleport.lib.teleterm.v1.TerminalService/Login"
 	TerminalService_LoginPasswordless_FullMethodName                   = "/teleport.lib.teleterm.v1.TerminalService/LoginPasswordless"
 	TerminalService_Logout_FullMethodName                              = "/teleport.lib.teleterm.v1.TerminalService/Logout"
+	TerminalService_ClearStaleClusterClients_FullMethodName            = "/teleport.lib.teleterm.v1.TerminalService/ClearStaleClusterClients"
 	TerminalService_TransferFile_FullMethodName                        = "/teleport.lib.teleterm.v1.TerminalService/TransferFile"
 	TerminalService_ReportUsageEvent_FullMethodName                    = "/teleport.lib.teleterm.v1.TerminalService/ReportUsageEvent"
 	TerminalService_UpdateHeadlessAuthenticationState_FullMethodName   = "/teleport.lib.teleterm.v1.TerminalService/UpdateHeadlessAuthenticationState"
@@ -178,6 +179,8 @@ type TerminalServiceClient interface {
 	// Optionally removes the profile.
 	// This operation is idempotent and can be safely invoked multiple times.
 	Logout(ctx context.Context, in *LogoutRequest, opts ...grpc.CallOption) (*EmptyResponse, error)
+	// Closes root and leaf cluster clients that use outdated TLS certificates.
+	ClearStaleClusterClients(ctx context.Context, in *ClearStaleClusterClientsRequest, opts ...grpc.CallOption) (*ClearStaleClusterClientsResponse, error)
 	// TransferFile sends a request to download/upload a file
 	TransferFile(ctx context.Context, in *FileTransferRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[FileTransferProgress], error)
 	// ReportUsageEvent allows to send usage events that are then anonymized and forwarded to prehog
@@ -520,6 +523,16 @@ func (c *terminalServiceClient) Logout(ctx context.Context, in *LogoutRequest, o
 	return out, nil
 }
 
+func (c *terminalServiceClient) ClearStaleClusterClients(ctx context.Context, in *ClearStaleClusterClientsRequest, opts ...grpc.CallOption) (*ClearStaleClusterClientsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ClearStaleClusterClientsResponse)
+	err := c.cc.Invoke(ctx, TerminalService_ClearStaleClusterClients_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *terminalServiceClient) TransferFile(ctx context.Context, in *FileTransferRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[FileTransferProgress], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &TerminalService_ServiceDesc.Streams[1], TerminalService_TransferFile_FullMethodName, cOpts...)
@@ -779,6 +792,8 @@ type TerminalServiceServer interface {
 	// Optionally removes the profile.
 	// This operation is idempotent and can be safely invoked multiple times.
 	Logout(context.Context, *LogoutRequest) (*EmptyResponse, error)
+	// Closes root and leaf cluster clients that use outdated TLS certificates.
+	ClearStaleClusterClients(context.Context, *ClearStaleClusterClientsRequest) (*ClearStaleClusterClientsResponse, error)
 	// TransferFile sends a request to download/upload a file
 	TransferFile(*FileTransferRequest, grpc.ServerStreamingServer[FileTransferProgress]) error
 	// ReportUsageEvent allows to send usage events that are then anonymized and forwarded to prehog
@@ -921,6 +936,9 @@ func (UnimplementedTerminalServiceServer) LoginPasswordless(grpc.BidiStreamingSe
 }
 func (UnimplementedTerminalServiceServer) Logout(context.Context, *LogoutRequest) (*EmptyResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Logout not implemented")
+}
+func (UnimplementedTerminalServiceServer) ClearStaleClusterClients(context.Context, *ClearStaleClusterClientsRequest) (*ClearStaleClusterClientsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ClearStaleClusterClients not implemented")
 }
 func (UnimplementedTerminalServiceServer) TransferFile(*FileTransferRequest, grpc.ServerStreamingServer[FileTransferProgress]) error {
 	return status.Errorf(codes.Unimplemented, "method TransferFile not implemented")
@@ -1481,6 +1499,24 @@ func _TerminalService_Logout_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _TerminalService_ClearStaleClusterClients_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ClearStaleClusterClientsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(TerminalServiceServer).ClearStaleClusterClients(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: TerminalService_ClearStaleClusterClients_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(TerminalServiceServer).ClearStaleClusterClients(ctx, req.(*ClearStaleClusterClientsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _TerminalService_TransferFile_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(FileTransferRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -1847,6 +1883,10 @@ var TerminalService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Logout",
 			Handler:    _TerminalService_Logout_Handler,
+		},
+		{
+			MethodName: "ClearStaleClusterClients",
+			Handler:    _TerminalService_ClearStaleClusterClients_Handler,
 		},
 		{
 			MethodName: "ReportUsageEvent",

--- a/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/cluster_pb.ts
@@ -30,6 +30,7 @@ import { UnknownFieldHandler } from "@protobuf-ts/runtime";
 import type { PartialMessage } from "@protobuf-ts/runtime";
 import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
+import { Timestamp } from "../../../../google/protobuf/timestamp_pb";
 import { TrustedDeviceRequirement } from "../../../legacy/types/trusted_device_requirement_pb";
 /**
  * Cluster describes cluster fields.
@@ -191,6 +192,12 @@ export interface LoggedInUser {
      * @generated from protobuf field: types.TrustedDeviceRequirement trusted_device_requirement = 10;
      */
     trustedDeviceRequirement: TrustedDeviceRequirement;
+    /**
+     * Expiration time of the certificate.
+     *
+     * @generated from protobuf field: google.protobuf.Timestamp valid_until = 11;
+     */
+    validUntil?: Timestamp;
 }
 /**
  * UserType indicates whether the user was created through an SSO provider or in Teleport itself.
@@ -541,7 +548,8 @@ class LoggedInUser$Type extends MessageType<LoggedInUser> {
             { no: 7, name: "requestable_roles", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/ },
             { no: 8, name: "user_type", kind: "enum", T: () => ["teleport.lib.teleterm.v1.LoggedInUser.UserType", LoggedInUser_UserType, "USER_TYPE_"] },
             { no: 9, name: "is_device_trusted", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 10, name: "trusted_device_requirement", kind: "enum", T: () => ["types.TrustedDeviceRequirement", TrustedDeviceRequirement, "TRUSTED_DEVICE_REQUIREMENT_"] }
+            { no: 10, name: "trusted_device_requirement", kind: "enum", T: () => ["types.TrustedDeviceRequirement", TrustedDeviceRequirement, "TRUSTED_DEVICE_REQUIREMENT_"] },
+            { no: 11, name: "valid_until", kind: "message", T: () => Timestamp }
         ]);
     }
     create(value?: PartialMessage<LoggedInUser>): LoggedInUser {
@@ -590,6 +598,9 @@ class LoggedInUser$Type extends MessageType<LoggedInUser> {
                 case /* types.TrustedDeviceRequirement trusted_device_requirement */ 10:
                     message.trustedDeviceRequirement = reader.int32();
                     break;
+                case /* google.protobuf.Timestamp valid_until */ 11:
+                    message.validUntil = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.validUntil);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -629,6 +640,9 @@ class LoggedInUser$Type extends MessageType<LoggedInUser> {
         /* types.TrustedDeviceRequirement trusted_device_requirement = 10; */
         if (message.trustedDeviceRequirement !== 0)
             writer.tag(10, WireType.Varint).int32(message.trustedDeviceRequirement);
+        /* google.protobuf.Timestamp valid_until = 11; */
+        if (message.validUntil)
+            Timestamp.internalBinaryWrite(message.validUntil, writer.tag(11, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.client.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.client.ts
@@ -54,6 +54,8 @@ import type { ReportUsageEventRequest } from "./usage_events_pb";
 import type { FileTransferProgress } from "./service_pb";
 import type { FileTransferRequest } from "./service_pb";
 import type { ServerStreamingCall } from "@protobuf-ts/runtime-rpc";
+import type { ClearStaleClusterClientsResponse } from "./service_pb";
+import type { ClearStaleClusterClientsRequest } from "./service_pb";
 import type { LogoutRequest } from "./service_pb";
 import type { LoginPasswordlessResponse } from "./service_pb";
 import type { LoginPasswordlessRequest } from "./service_pb";
@@ -315,6 +317,12 @@ export interface ITerminalServiceClient {
      * @generated from protobuf rpc: Logout(teleport.lib.teleterm.v1.LogoutRequest) returns (teleport.lib.teleterm.v1.EmptyResponse);
      */
     logout(input: LogoutRequest, options?: RpcOptions): UnaryCall<LogoutRequest, EmptyResponse>;
+    /**
+     * Closes root and leaf cluster clients that use outdated TLS certificates.
+     *
+     * @generated from protobuf rpc: ClearStaleClusterClients(teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest) returns (teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse);
+     */
+    clearStaleClusterClients(input: ClearStaleClusterClientsRequest, options?: RpcOptions): UnaryCall<ClearStaleClusterClientsRequest, ClearStaleClusterClientsResponse>;
     /**
      * TransferFile sends a request to download/upload a file
      *
@@ -724,12 +732,21 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
         return stackIntercept<LogoutRequest, EmptyResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * Closes root and leaf cluster clients that use outdated TLS certificates.
+     *
+     * @generated from protobuf rpc: ClearStaleClusterClients(teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest) returns (teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse);
+     */
+    clearStaleClusterClients(input: ClearStaleClusterClientsRequest, options?: RpcOptions): UnaryCall<ClearStaleClusterClientsRequest, ClearStaleClusterClientsResponse> {
+        const method = this.methods[28], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ClearStaleClusterClientsRequest, ClearStaleClusterClientsResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * TransferFile sends a request to download/upload a file
      *
      * @generated from protobuf rpc: TransferFile(teleport.lib.teleterm.v1.FileTransferRequest) returns (stream teleport.lib.teleterm.v1.FileTransferProgress);
      */
     transferFile(input: FileTransferRequest, options?: RpcOptions): ServerStreamingCall<FileTransferRequest, FileTransferProgress> {
-        const method = this.methods[28], opt = this._transport.mergeOptions(options);
+        const method = this.methods[29], opt = this._transport.mergeOptions(options);
         return stackIntercept<FileTransferRequest, FileTransferProgress>("serverStreaming", this._transport, method, opt, input);
     }
     /**
@@ -738,7 +755,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: ReportUsageEvent(teleport.lib.teleterm.v1.ReportUsageEventRequest) returns (teleport.lib.teleterm.v1.EmptyResponse);
      */
     reportUsageEvent(input: ReportUsageEventRequest, options?: RpcOptions): UnaryCall<ReportUsageEventRequest, EmptyResponse> {
-        const method = this.methods[29], opt = this._transport.mergeOptions(options);
+        const method = this.methods[30], opt = this._transport.mergeOptions(options);
         return stackIntercept<ReportUsageEventRequest, EmptyResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -748,7 +765,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: UpdateHeadlessAuthenticationState(teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateRequest) returns (teleport.lib.teleterm.v1.UpdateHeadlessAuthenticationStateResponse);
      */
     updateHeadlessAuthenticationState(input: UpdateHeadlessAuthenticationStateRequest, options?: RpcOptions): UnaryCall<UpdateHeadlessAuthenticationStateRequest, UpdateHeadlessAuthenticationStateResponse> {
-        const method = this.methods[30], opt = this._transport.mergeOptions(options);
+        const method = this.methods[31], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateHeadlessAuthenticationStateRequest, UpdateHeadlessAuthenticationStateResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -759,7 +776,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: CreateConnectMyComputerRole(teleport.lib.teleterm.v1.CreateConnectMyComputerRoleRequest) returns (teleport.lib.teleterm.v1.CreateConnectMyComputerRoleResponse);
      */
     createConnectMyComputerRole(input: CreateConnectMyComputerRoleRequest, options?: RpcOptions): UnaryCall<CreateConnectMyComputerRoleRequest, CreateConnectMyComputerRoleResponse> {
-        const method = this.methods[31], opt = this._transport.mergeOptions(options);
+        const method = this.methods[32], opt = this._transport.mergeOptions(options);
         return stackIntercept<CreateConnectMyComputerRoleRequest, CreateConnectMyComputerRoleResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -768,7 +785,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: CreateConnectMyComputerNodeToken(teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenRequest) returns (teleport.lib.teleterm.v1.CreateConnectMyComputerNodeTokenResponse);
      */
     createConnectMyComputerNodeToken(input: CreateConnectMyComputerNodeTokenRequest, options?: RpcOptions): UnaryCall<CreateConnectMyComputerNodeTokenRequest, CreateConnectMyComputerNodeTokenResponse> {
-        const method = this.methods[32], opt = this._transport.mergeOptions(options);
+        const method = this.methods[33], opt = this._transport.mergeOptions(options);
         return stackIntercept<CreateConnectMyComputerNodeTokenRequest, CreateConnectMyComputerNodeTokenResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -782,7 +799,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: WaitForConnectMyComputerNodeJoin(teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinRequest) returns (teleport.lib.teleterm.v1.WaitForConnectMyComputerNodeJoinResponse);
      */
     waitForConnectMyComputerNodeJoin(input: WaitForConnectMyComputerNodeJoinRequest, options?: RpcOptions): UnaryCall<WaitForConnectMyComputerNodeJoinRequest, WaitForConnectMyComputerNodeJoinResponse> {
-        const method = this.methods[33], opt = this._transport.mergeOptions(options);
+        const method = this.methods[34], opt = this._transport.mergeOptions(options);
         return stackIntercept<WaitForConnectMyComputerNodeJoinRequest, WaitForConnectMyComputerNodeJoinResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -791,7 +808,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: DeleteConnectMyComputerNode(teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeRequest) returns (teleport.lib.teleterm.v1.DeleteConnectMyComputerNodeResponse);
      */
     deleteConnectMyComputerNode(input: DeleteConnectMyComputerNodeRequest, options?: RpcOptions): UnaryCall<DeleteConnectMyComputerNodeRequest, DeleteConnectMyComputerNodeResponse> {
-        const method = this.methods[34], opt = this._transport.mergeOptions(options);
+        const method = this.methods[35], opt = this._transport.mergeOptions(options);
         return stackIntercept<DeleteConnectMyComputerNodeRequest, DeleteConnectMyComputerNodeResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -800,7 +817,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: GetConnectMyComputerNodeName(teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameRequest) returns (teleport.lib.teleterm.v1.GetConnectMyComputerNodeNameResponse);
      */
     getConnectMyComputerNodeName(input: GetConnectMyComputerNodeNameRequest, options?: RpcOptions): UnaryCall<GetConnectMyComputerNodeNameRequest, GetConnectMyComputerNodeNameResponse> {
-        const method = this.methods[35], opt = this._transport.mergeOptions(options);
+        const method = this.methods[36], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetConnectMyComputerNodeNameRequest, GetConnectMyComputerNodeNameResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -809,7 +826,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: ListUnifiedResources(teleport.lib.teleterm.v1.ListUnifiedResourcesRequest) returns (teleport.lib.teleterm.v1.ListUnifiedResourcesResponse);
      */
     listUnifiedResources(input: ListUnifiedResourcesRequest, options?: RpcOptions): UnaryCall<ListUnifiedResourcesRequest, ListUnifiedResourcesResponse> {
-        const method = this.methods[36], opt = this._transport.mergeOptions(options);
+        const method = this.methods[37], opt = this._transport.mergeOptions(options);
         return stackIntercept<ListUnifiedResourcesRequest, ListUnifiedResourcesResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -818,7 +835,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: GetUserPreferences(teleport.lib.teleterm.v1.GetUserPreferencesRequest) returns (teleport.lib.teleterm.v1.GetUserPreferencesResponse);
      */
     getUserPreferences(input: GetUserPreferencesRequest, options?: RpcOptions): UnaryCall<GetUserPreferencesRequest, GetUserPreferencesResponse> {
-        const method = this.methods[37], opt = this._transport.mergeOptions(options);
+        const method = this.methods[38], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetUserPreferencesRequest, GetUserPreferencesResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -828,7 +845,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: UpdateUserPreferences(teleport.lib.teleterm.v1.UpdateUserPreferencesRequest) returns (teleport.lib.teleterm.v1.UpdateUserPreferencesResponse);
      */
     updateUserPreferences(input: UpdateUserPreferencesRequest, options?: RpcOptions): UnaryCall<UpdateUserPreferencesRequest, UpdateUserPreferencesResponse> {
-        const method = this.methods[38], opt = this._transport.mergeOptions(options);
+        const method = this.methods[39], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateUserPreferencesRequest, UpdateUserPreferencesResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -841,7 +858,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: AuthenticateWebDevice(teleport.lib.teleterm.v1.AuthenticateWebDeviceRequest) returns (teleport.lib.teleterm.v1.AuthenticateWebDeviceResponse);
      */
     authenticateWebDevice(input: AuthenticateWebDeviceRequest, options?: RpcOptions): UnaryCall<AuthenticateWebDeviceRequest, AuthenticateWebDeviceResponse> {
-        const method = this.methods[39], opt = this._transport.mergeOptions(options);
+        const method = this.methods[40], opt = this._transport.mergeOptions(options);
         return stackIntercept<AuthenticateWebDeviceRequest, AuthenticateWebDeviceResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -851,7 +868,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: GetApp(teleport.lib.teleterm.v1.GetAppRequest) returns (teleport.lib.teleterm.v1.GetAppResponse);
      */
     getApp(input: GetAppRequest, options?: RpcOptions): UnaryCall<GetAppRequest, GetAppResponse> {
-        const method = this.methods[40], opt = this._transport.mergeOptions(options);
+        const method = this.methods[41], opt = this._transport.mergeOptions(options);
         return stackIntercept<GetAppRequest, GetAppResponse>("unary", this._transport, method, opt, input);
     }
     /**
@@ -860,7 +877,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: ConnectToDesktop(stream teleport.lib.teleterm.v1.ConnectToDesktopRequest) returns (stream teleport.lib.teleterm.v1.ConnectToDesktopResponse);
      */
     connectToDesktop(options?: RpcOptions): DuplexStreamingCall<ConnectToDesktopRequest, ConnectToDesktopResponse> {
-        const method = this.methods[41], opt = this._transport.mergeOptions(options);
+        const method = this.methods[42], opt = this._transport.mergeOptions(options);
         return stackIntercept<ConnectToDesktopRequest, ConnectToDesktopResponse>("duplex", this._transport, method, opt);
     }
     /**
@@ -874,7 +891,7 @@ export class TerminalServiceClient implements ITerminalServiceClient, ServiceInf
      * @generated from protobuf rpc: SetSharedDirectoryForDesktopSession(teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionRequest) returns (teleport.lib.teleterm.v1.SetSharedDirectoryForDesktopSessionResponse);
      */
     setSharedDirectoryForDesktopSession(input: SetSharedDirectoryForDesktopSessionRequest, options?: RpcOptions): UnaryCall<SetSharedDirectoryForDesktopSessionRequest, SetSharedDirectoryForDesktopSessionResponse> {
-        const method = this.methods[42], opt = this._transport.mergeOptions(options);
+        const method = this.methods[43], opt = this._transport.mergeOptions(options);
         return stackIntercept<SetSharedDirectoryForDesktopSessionRequest, SetSharedDirectoryForDesktopSessionResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.grpc-server.ts
@@ -50,6 +50,8 @@ import { UpdateHeadlessAuthenticationStateRequest } from "./service_pb";
 import { ReportUsageEventRequest } from "./usage_events_pb";
 import { FileTransferProgress } from "./service_pb";
 import { FileTransferRequest } from "./service_pb";
+import { ClearStaleClusterClientsResponse } from "./service_pb";
+import { ClearStaleClusterClientsRequest } from "./service_pb";
 import { LogoutRequest } from "./service_pb";
 import { LoginPasswordlessResponse } from "./service_pb";
 import { LoginPasswordlessRequest } from "./service_pb";
@@ -308,6 +310,12 @@ export interface ITerminalService extends grpc.UntypedServiceImplementation {
      * @generated from protobuf rpc: Logout(teleport.lib.teleterm.v1.LogoutRequest) returns (teleport.lib.teleterm.v1.EmptyResponse);
      */
     logout: grpc.handleUnaryCall<LogoutRequest, EmptyResponse>;
+    /**
+     * Closes root and leaf cluster clients that use outdated TLS certificates.
+     *
+     * @generated from protobuf rpc: ClearStaleClusterClients(teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest) returns (teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse);
+     */
+    clearStaleClusterClients: grpc.handleUnaryCall<ClearStaleClusterClientsRequest, ClearStaleClusterClientsResponse>;
     /**
      * TransferFile sends a request to download/upload a file
      *
@@ -709,6 +717,16 @@ export const terminalServiceDefinition: grpc.ServiceDefinition<ITerminalService>
         requestDeserialize: bytes => LogoutRequest.fromBinary(bytes),
         responseSerialize: value => Buffer.from(EmptyResponse.toBinary(value)),
         requestSerialize: value => Buffer.from(LogoutRequest.toBinary(value))
+    },
+    clearStaleClusterClients: {
+        path: "/teleport.lib.teleterm.v1.TerminalService/ClearStaleClusterClients",
+        originalName: "ClearStaleClusterClients",
+        requestStream: false,
+        responseStream: false,
+        responseDeserialize: bytes => ClearStaleClusterClientsResponse.fromBinary(bytes),
+        requestDeserialize: bytes => ClearStaleClusterClientsRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(ClearStaleClusterClientsResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(ClearStaleClusterClientsRequest.toBinary(value))
     },
     transferFile: {
         path: "/teleport.lib.teleterm.v1.TerminalService/TransferFile",

--- a/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/v1/service_pb.ts
@@ -83,6 +83,20 @@ export interface LogoutRequest {
     removeProfile: boolean;
 }
 /**
+ * @generated from protobuf message teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest
+ */
+export interface ClearStaleClusterClientsRequest {
+    /**
+     * @generated from protobuf field: string root_cluster_uri = 1;
+     */
+    rootClusterUri: string;
+}
+/**
+ * @generated from protobuf message teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse
+ */
+export interface ClearStaleClusterClientsResponse {
+}
+/**
  * @generated from protobuf message teleport.lib.teleterm.v1.StartHeadlessWatcherRequest
  */
 export interface StartHeadlessWatcherRequest {
@@ -1536,6 +1550,78 @@ class LogoutRequest$Type extends MessageType<LogoutRequest> {
  * @generated MessageType for protobuf message teleport.lib.teleterm.v1.LogoutRequest
  */
 export const LogoutRequest = new LogoutRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ClearStaleClusterClientsRequest$Type extends MessageType<ClearStaleClusterClientsRequest> {
+    constructor() {
+        super("teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest", [
+            { no: 1, name: "root_cluster_uri", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ClearStaleClusterClientsRequest>): ClearStaleClusterClientsRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.rootClusterUri = "";
+        if (value !== undefined)
+            reflectionMergePartial<ClearStaleClusterClientsRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ClearStaleClusterClientsRequest): ClearStaleClusterClientsRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string root_cluster_uri */ 1:
+                    message.rootClusterUri = reader.string();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ClearStaleClusterClientsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string root_cluster_uri = 1; */
+        if (message.rootClusterUri !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.rootClusterUri);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.teleterm.v1.ClearStaleClusterClientsRequest
+ */
+export const ClearStaleClusterClientsRequest = new ClearStaleClusterClientsRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ClearStaleClusterClientsResponse$Type extends MessageType<ClearStaleClusterClientsResponse> {
+    constructor() {
+        super("teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse", []);
+    }
+    create(value?: PartialMessage<ClearStaleClusterClientsResponse>): ClearStaleClusterClientsResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        if (value !== undefined)
+            reflectionMergePartial<ClearStaleClusterClientsResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ClearStaleClusterClientsResponse): ClearStaleClusterClientsResponse {
+        return target ?? this.create();
+    }
+    internalBinaryWrite(message: ClearStaleClusterClientsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.teleterm.v1.ClearStaleClusterClientsResponse
+ */
+export const ClearStaleClusterClientsResponse = new ClearStaleClusterClientsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class StartHeadlessWatcherRequest$Type extends MessageType<StartHeadlessWatcherRequest> {
     constructor() {
@@ -5879,6 +5965,7 @@ export const TerminalService = new ServiceType("teleport.lib.teleterm.v1.Termina
     { name: "Login", options: {}, I: LoginRequest, O: EmptyResponse },
     { name: "LoginPasswordless", serverStreaming: true, clientStreaming: true, options: {}, I: LoginPasswordlessRequest, O: LoginPasswordlessResponse },
     { name: "Logout", options: {}, I: LogoutRequest, O: EmptyResponse },
+    { name: "ClearStaleClusterClients", options: {}, I: ClearStaleClusterClientsRequest, O: ClearStaleClusterClientsResponse },
     { name: "TransferFile", serverStreaming: true, options: {}, I: FileTransferRequest, O: FileTransferProgress },
     { name: "ReportUsageEvent", options: {}, I: ReportUsageEventRequest, O: EmptyResponse },
     { name: "UpdateHeadlessAuthenticationState", options: {}, I: UpdateHeadlessAuthenticationStateRequest, O: UpdateHeadlessAuthenticationStateResponse },

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -134,6 +134,12 @@ func TestTeleterm(t *testing.T) {
 		testClientCache(t, pack, creds)
 	})
 
+	t.Run("clearing stale cached clients", func(t *testing.T) {
+		t.Parallel()
+
+		testClearingStaleCachedClients(t, pack, creds)
+	})
+
 	t.Run("logging out", func(t *testing.T) {
 		t.Parallel()
 		testLogout(t, pack, creds)
@@ -552,30 +558,62 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 	thirdCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)
 	require.NotEqual(t, secondCallForClient, thirdCallForClient)
+}
 
-	// Test closing stale clients.
-	fourthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
+func testClearingStaleCachedClients(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.UserCreds) {
+	ctx := context.Background()
+
+	tc := mustLogin(t, pack.Root.User.GetName(), pack, creds)
+
+	storageFakeClock := clockwork.NewFakeClockAt(time.Now())
+
+	storage, err := clusters.NewStorage(clusters.Config{
+		ClientStore:        tc.ClientStore,
+		Clock:              storageFakeClock,
+		InsecureSkipVerify: tc.InsecureSkipVerify,
+	})
+	require.NoError(t, err)
+
+	cluster, _, err := storage.Add(ctx, tc.WebProxyAddr)
+	require.NoError(t, err)
+
+	tshdEventsClient := daemon.NewTshdEventsClient(func() (grpc.DialOption, error) {
+		return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
+	})
+
+	daemonService, err := daemon.New(daemon.Config{
+		Storage:          storage,
+		TshdEventsClient: tshdEventsClient,
+		KubeconfigsDir:   t.TempDir(),
+		AgentsDir:        t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		daemonService.Stop()
+	})
+
+	firstCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)
 	err = daemonService.ClearStaleCachedClientsForRoot(cluster.URI)
 	require.NoError(t, err)
 	// Ensure the client wasn't closed.
-	fifthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
+	secondCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)
-	require.Equal(t, fourthCallForClient, fifthCallForClient)
+	require.Equal(t, firstCallForClient, secondCallForClient)
 	// Reissue user certs by assuming a role with a bogus ID in DropAccessRequests.
 	accessRequest := &api.AssumeRoleRequest{
 		RootClusterUri: cluster.URI.String(),
 		DropRequestIds: []string{"does-not-matter"},
 	}
-	err = cluster.AssumeRole(ctx, fourthCallForClient, accessRequest)
+	err = cluster.AssumeRole(ctx, firstCallForClient, accessRequest)
 	require.NoError(t, err)
 	// The cert has changed, so after clearing stale clients,
 	// GetCachedClient should return a new client.
 	err = daemonService.ClearStaleCachedClientsForRoot(cluster.URI)
 	require.NoError(t, err)
-	sixthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
+	thirdCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)
-	require.NotEqual(t, fifthCallForClient, sixthCallForClient)
+	require.NotEqual(t, secondCallForClient, thirdCallForClient)
 }
 
 func testLogout(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.UserCreds) {

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -556,7 +556,7 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 	// Test closing stale clients.
 	fourthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)
-	err = daemonService.ClearCachedStaleClientsForRoot(cluster.URI)
+	err = daemonService.ClearStaleCachedClientsForRoot(cluster.URI)
 	require.NoError(t, err)
 	// Ensure the client wasn't closed.
 	fifthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
@@ -571,7 +571,7 @@ func testClientCache(t *testing.T, pack *dbhelpers.DatabasePack, creds *helpers.
 	require.NoError(t, err)
 	// The cert has changed, so after clearing stale clients,
 	// GetCachedClient should return a new client.
-	err = daemonService.ClearCachedStaleClientsForRoot(cluster.URI)
+	err = daemonService.ClearStaleCachedClientsForRoot(cluster.URI)
 	require.NoError(t, err)
 	sixthCallForClient, err := daemonService.GetCachedClient(ctx, cluster.URI)
 	require.NoError(t, err)

--- a/lib/client/clientcache/clientcache.go
+++ b/lib/client/clientcache/clientcache.go
@@ -56,7 +56,7 @@ type profile interface {
 }
 
 // isTLSCertStale checks if the cached client uses the current TLS cert
-// (read from the agent). If not, the TLS is considered "stale".
+// (read from the agent). If not, the TLS cert is considered stale.
 func (c *clientWithMetadata) isTLSCertStale() (bool, error) {
 	pr, err := c.getProfile()
 	if err != nil {

--- a/lib/client/clientcache/clientcache.go
+++ b/lib/client/clientcache/clientcache.go
@@ -166,8 +166,7 @@ func (c *Cache) Get(ctx context.Context, profileName, leafClusterName string) (*
 			client:  newClient,
 			tlsCert: keyRing.TLSCert,
 			getProfile: func() (profile, error) {
-				pr, err := tc.GetProfile(tc.WebProxyAddr)
-				return pr, trace.Wrap(err)
+				return tc.GetProfile(tc.WebProxyAddr)
 			},
 		})
 

--- a/lib/client/clientcache/clientcache_test.go
+++ b/lib/client/clientcache/clientcache_test.go
@@ -1,0 +1,180 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package clientcache
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"log/slog"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	apiprofile "github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/observability/tracing"
+	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestClearingClientsWithStaleCert(t *testing.T) {
+	privateKey, err := keys.ParsePrivateKey(fixtures.PEMBytes["rsa"])
+	require.NoError(t, err)
+	tlsCert, sshCert, err := makeCerts(privateKey)
+	require.NoError(t, err)
+
+	keyRing := client.NewKeyRing(privateKey, privateKey)
+	keyRing.KeyRingIndex = client.KeyRingIndex{
+		ProxyHost:   "localhost",
+		Username:    "testuser",
+		ClusterName: "root",
+	}
+	keyRing.Cert = sshCert
+	keyRing.TLSCert = tlsCert
+
+	profile := &apiprofile.Profile{
+		WebProxyAddr: keyRing.ProxyHost,
+		Username:     keyRing.Username,
+		SiteName:     keyRing.ClusterName,
+	}
+	clientStore := client.NewFSClientStore(t.TempDir())
+	err = clientStore.SaveProfile(profile, true)
+	require.NoError(t, err)
+	err = clientStore.AddKeyRing(keyRing)
+	require.NoError(t, err)
+
+	cache, err := New(Config{
+		NewClientFunc: func(ctx context.Context, profileName, leafClusterName string) (*client.TeleportClient, error) {
+			config := &client.Config{
+				ClientStore:  clientStore,
+				SSHProxyAddr: "localhost:3080",
+				WebProxyAddr: "localhost:3080",
+				Username:     "testuser",
+				Tracer:       tracing.NoopProvider().Tracer("test"),
+				SiteName:     "root",
+			}
+			if leafClusterName != "" {
+				config.SiteName = leafClusterName
+			}
+			tc, err := client.NewClient(config)
+
+			return tc, err
+		},
+		RetryWithReloginFunc: func(ctx context.Context, tc *client.TeleportClient, fn func() error, opts ...client.RetryWithReloginOption) error {
+			return fn()
+		},
+		Logger: slog.New(slog.DiscardHandler),
+	})
+	require.NoError(t, err)
+
+	// Get clients.
+	rootClient, err := cache.Get(t.Context(), "root", "")
+	require.NoError(t, err)
+	leaf1Client, err := cache.Get(t.Context(), "root", "leaf1")
+	require.NoError(t, err)
+
+	// Update the TLS cert.
+	tlsCert, _, err = makeCerts(privateKey)
+	require.NoError(t, err)
+	keyRing.TLSCert = tlsCert
+	err = clientStore.AddKeyRing(keyRing)
+	require.NoError(t, err)
+
+	// Get the client for a new leaf after the cert has been updated.
+	leaf2Client, err := cache.Get(t.Context(), "root", "leaf2")
+	require.NoError(t, err)
+
+	// Clear stale clients.
+	err = cache.ClearForRoot("root", WithClearingOnlyClientsWithStaleCert())
+	require.NoError(t, err)
+
+	newRootClient, err := cache.Get(t.Context(), "root", "")
+	require.NoError(t, err)
+	newLeaf1Client, err := cache.Get(t.Context(), "root", "leaf1")
+	require.NoError(t, err)
+	newLeaf2Client, err := cache.Get(t.Context(), "root", "leaf2")
+	require.NoError(t, err)
+	// Clients opened before updating the cert should be reopened.
+	require.NotEqual(t, newRootClient, rootClient)
+	require.NotEqual(t, newLeaf1Client, leaf1Client)
+	// The client opened after updating the cert should be untouched.
+	require.Equal(t, newLeaf2Client, leaf2Client)
+}
+
+// makeCerts makes TSL and SSH certs.
+func makeCerts(privateKey *keys.PrivateKey) ([]byte, []byte, error) {
+	cert, err := tlsca.GenerateSelfSignedCAWithSigner(privateKey, pkix.Name{
+		CommonName:   "root",
+		Organization: []string{"localhost"},
+	}, nil, defaults.CATTL)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	ca, err := tlsca.FromCertAndSigner(cert, privateKey)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	keygen := testauthority.New()
+
+	clock := clockwork.NewRealClock()
+	identity := tlsca.Identity{
+		Username: "testuser",
+	}
+
+	subject, err := identity.Subject()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	tlsCert, err := ca.GenerateCertificate(tlsca.CertificateRequest{
+		Clock:     clock,
+		PublicKey: privateKey.Public(),
+		Subject:   subject,
+		NotAfter:  clock.Now().UTC().Add(defaults.CATTL),
+	})
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	signer, err := keys.ParsePrivateKey([]byte(fixtures.SSHCAPrivateKey))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	caSigner, err := ssh.NewSignerFromKey(signer)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	sshCert, err := keygen.GenerateUserCert(sshca.UserCertificateRequest{
+		CASigner:      caSigner,
+		PublicUserKey: ssh.MarshalAuthorizedKey(privateKey.SSHPublicKey()),
+		Identity: sshca.Identity{
+			Username:   "testuser",
+			Principals: []string{"testuser"},
+		},
+	})
+
+	return tlsCert, sshCert, trace.Wrap(err)
+}

--- a/lib/teleterm/apiserver/handler/handler_clusters.go
+++ b/lib/teleterm/apiserver/handler/handler_clusters.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
+	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 )
 
@@ -81,6 +82,17 @@ func (s *Handler) GetCluster(ctx context.Context, req *api.GetClusterRequest) (*
 	apiRootClusterWithDetails, err := newAPIRootClusterWithDetails(cluster)
 
 	return apiRootClusterWithDetails, trace.Wrap(err)
+}
+
+// ClearStaleClusterClients closes root and leaf cluster clients that use outdated TLS certificates.
+func (s *Handler) ClearStaleClusterClients(_ context.Context, req *api.ClearStaleClusterClientsRequest) (*api.ClearStaleClusterClientsResponse, error) {
+	parsed, err := uri.Parse(req.RootClusterUri)
+	if err != nil {
+		return &api.ClearStaleClusterClientsResponse{}, trace.Wrap(err)
+	}
+
+	err = s.DaemonService.ClearCachedStaleClientsForRoot(parsed)
+	return &api.ClearStaleClusterClientsResponse{}, trace.Wrap(err)
 }
 
 func newAPIRootCluster(cluster *clusters.Cluster) *api.Cluster {

--- a/lib/teleterm/apiserver/handler/handler_clusters.go
+++ b/lib/teleterm/apiserver/handler/handler_clusters.go
@@ -91,7 +91,7 @@ func (s *Handler) ClearStaleClusterClients(_ context.Context, req *api.ClearStal
 		return &api.ClearStaleClusterClientsResponse{}, trace.Wrap(err)
 	}
 
-	err = s.DaemonService.ClearCachedStaleClientsForRoot(parsed)
+	err = s.DaemonService.ClearStaleCachedClientsForRoot(parsed)
 	return &api.ClearStaleClusterClientsResponse{}, trace.Wrap(err)
 }
 

--- a/lib/teleterm/apiserver/handler/handler_clusters.go
+++ b/lib/teleterm/apiserver/handler/handler_clusters.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport/api/constants"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
@@ -95,6 +96,7 @@ func newAPIRootCluster(cluster *clusters.Cluster) *api.Cluster {
 			Roles:           loggedInUser.Roles,
 			ActiveRequests:  loggedInUser.ActiveRequests,
 			IsDeviceTrusted: cluster.HasDeviceTrustExtensions(),
+			ValidUntil:      timestamppb.New(loggedInUser.ValidUntil),
 		},
 		SsoHost: cluster.SSOHost,
 	}

--- a/lib/teleterm/clusters/cluster.go
+++ b/lib/teleterm/clusters/cluster.go
@@ -21,6 +21,7 @@ package clusters
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -312,6 +313,7 @@ func (c *Cluster) GetLoggedInUser() LoggedInUser {
 		SSHLogins:      c.status.Logins,
 		Roles:          c.status.Roles,
 		ActiveRequests: c.status.ActiveRequests,
+		ValidUntil:     c.status.ValidUntil,
 	}
 }
 
@@ -353,6 +355,8 @@ type LoggedInUser struct {
 	Roles []string
 	// ActiveRequests is the user active requests
 	ActiveRequests []string
+	// ValidUntil is expiration time of the certificate.
+	ValidUntil time.Time
 }
 
 // AddMetadataToRetryableError is Connect's equivalent of client.RetryWithRelogin. By adding the

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -95,7 +95,7 @@ type ClientCache interface {
 	Get(ctx context.Context, profileName, leafClusterName string) (*client.ClusterClient, error)
 	// ClearForRoot closes and removes clients from the cache
 	// for the root cluster and its leaf clusters.
-	ClearForRoot(profileName string) error
+	ClearForRoot(profileName string, opts ...clientcache.ClearOption) error
 	// Clear closes and removes all clients.
 	Clear() error
 }

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -40,6 +40,7 @@ import (
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/client/clientcache"
 	"github.com/gravitational/teleport/lib/client/sso"
 	dtauthn "github.com/gravitational/teleport/lib/devicetrust/authn"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -1281,6 +1282,14 @@ func (s *Service) GetCachedClient(ctx context.Context, resourceURI uri.ResourceU
 func (s *Service) ClearCachedClientsForRoot(clusterURI uri.ResourceURI) error {
 	profileName := clusterURI.GetProfileName()
 	return trace.Wrap(s.clientCache.ClearForRoot(profileName))
+}
+
+// ClearCachedStaleClientsForRoot closes and removes clients from the cache
+// for the root cluster and its leaf clusters, if their cert is outdated.
+func (s *Service) ClearCachedStaleClientsForRoot(clusterURI uri.ResourceURI) error {
+	profileName := clusterURI.GetProfileName()
+	err := s.clientCache.ClearForRoot(profileName, clientcache.WithClearingOnlyClientsWithStaleCert())
+	return trace.Wrap(err)
 }
 
 // SetSharedDirectoryForDesktopSession opens a directory for a desktop session and enables file system operations for it.

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -1284,9 +1284,9 @@ func (s *Service) ClearCachedClientsForRoot(clusterURI uri.ResourceURI) error {
 	return trace.Wrap(s.clientCache.ClearForRoot(profileName))
 }
 
-// ClearCachedStaleClientsForRoot closes and removes clients from the cache
+// ClearStaleCachedClientsForRoot closes and removes clients from the cache
 // for the root cluster and its leaf clusters, if their cert is outdated.
-func (s *Service) ClearCachedStaleClientsForRoot(clusterURI uri.ResourceURI) error {
+func (s *Service) ClearStaleCachedClientsForRoot(clusterURI uri.ResourceURI) error {
 	profileName := clusterURI.GetProfileName()
 	err := s.clientCache.ClearForRoot(profileName, clientcache.WithClearingOnlyClientsWithStaleCert())
 	return trace.Wrap(err)

--- a/proto/teleport/lib/teleterm/v1/cluster.proto
+++ b/proto/teleport/lib/teleterm/v1/cluster.proto
@@ -20,6 +20,7 @@ syntax = "proto3";
 
 package teleport.lib.teleterm.v1;
 
+import "google/protobuf/timestamp.proto";
 import "teleport/legacy/types/trusted_device_requirement.proto";
 
 option go_package = "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1;teletermv1";
@@ -111,6 +112,8 @@ message LoggedInUser {
   bool is_device_trusted = 9;
   // Indicates whether access may be hindered by the lack of a trusted device.
   types.TrustedDeviceRequirement trusted_device_requirement = 10;
+  // Expiration time of the certificate.
+  google.protobuf.Timestamp valid_until = 11;
 }
 
 // ACL is the access control list of the user

--- a/proto/teleport/lib/teleterm/v1/service.proto
+++ b/proto/teleport/lib/teleterm/v1/service.proto
@@ -135,6 +135,8 @@ service TerminalService {
   // Optionally removes the profile.
   // This operation is idempotent and can be safely invoked multiple times.
   rpc Logout(LogoutRequest) returns (EmptyResponse);
+  // Closes root and leaf cluster clients that use outdated TLS certificates.
+  rpc ClearStaleClusterClients(ClearStaleClusterClientsRequest) returns (ClearStaleClusterClientsResponse);
   // TransferFile sends a request to download/upload a file
   rpc TransferFile(FileTransferRequest) returns (stream FileTransferProgress);
   // ReportUsageEvent allows to send usage events that are then anonymized and forwarded to prehog
@@ -203,6 +205,12 @@ message LogoutRequest {
   // Whether to remove the associated YAML profile after logout.
   bool remove_profile = 2;
 }
+
+message ClearStaleClusterClientsRequest {
+  string root_cluster_uri = 1;
+}
+
+message ClearStaleClusterClientsResponse {}
 
 message StartHeadlessWatcherRequest {
   string root_cluster_uri = 1;

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -209,6 +209,12 @@ export class ClusterLifecycleManager {
     if (hasLoggedOut) {
       await this.handleClusterLogout(next);
     } else {
+      const client = await this.getTshdClient();
+      // Only clear clients with outdated certificates.
+      // The watcher 'changed' event may be emitted right after the user logs in
+      // or assumes a role via Connect (which already closes all clients
+      // for the profile), so we avoid closing them again if they're already up to date.
+      await client.clearStaleClusterClients({ rootClusterUri: next.uri });
       await this.syncOrUpdateCluster(next);
     }
   }

--- a/web/packages/teleterm/src/services/tshd/cluster.ts
+++ b/web/packages/teleterm/src/services/tshd/cluster.ts
@@ -103,6 +103,7 @@ export function mergeClusterProfileWithDetails({
       activeRequests: profile.loggedInUser.activeRequests,
       roles: profile.loggedInUser.roles,
       isDeviceTrusted: profile.loggedInUser.isDeviceTrusted,
+      validUntil: profile.loggedInUser.validUntil,
       userType:
         details.loggedInUser?.userType || LoggedInUser_UserType.UNSPECIFIED,
       trustedDeviceRequirement:

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -74,6 +74,7 @@ export class MockTshClient implements TshdClient {
   login = () => new MockedUnaryCall({});
   loginPasswordless = undefined;
   logout = () => new MockedUnaryCall({});
+  clearStaleClusterClients = () => new MockedUnaryCall({});
   transferFile = undefined;
   reportUsageEvent = () => new MockedUnaryCall({});
   createConnectMyComputerRole = () =>

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
 import {
@@ -24,6 +25,7 @@ import {
 } from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
 import {
   ACL,
+  LoggedInUser_UserType,
   ShowResources,
 } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { WindowsDesktop } from 'gen-proto-ts/teleport/lib/teleterm/v1/windows_desktop_pb';
@@ -259,7 +261,8 @@ export const makeLoggedInUser = (
   roles: [],
   requestableRoles: [],
   suggestedReviewers: [],
-  userType: tsh.LoggedInUser_UserType.LOCAL,
+  userType: LoggedInUser_UserType.LOCAL,
+  validUntil: Timestamp.fromDate(new Date()),
   ...props,
 });
 

--- a/web/packages/teleterm/src/ui/TopBar/Identity/Identity.story.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/Identity.story.tsx
@@ -16,9 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { useLayoutEffect } from 'react';
 
 import Flex from 'design/Flex';
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import { TrustedDeviceRequirement } from 'gen-proto-ts/teleport/legacy/types/trusted_device_requirement_pb';
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 
@@ -32,21 +34,122 @@ import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { IdentityContainer } from './Identity';
 
-export default {
+interface StoryProps {
+  clusters: ('violet' | 'orange' | 'green')[];
+  activeCluster: boolean;
+  activeClusterExpired: boolean;
+  deviceTrust: 'enrolled' | 'required-not-enrolled' | 'not-enrolled';
+  showProfileErrors: boolean;
+}
+
+const meta: Meta<StoryProps> = {
   title: 'Teleterm/Identity',
+  component: props => {
+    const hasOrange = props.clusters.includes('orange');
+    const hasViolet = props.clusters.includes('violet');
+    const hasGreen = props.clusters.includes('green');
+    const clusters = [
+      hasOrange &&
+        makeRootCluster({
+          ...clusterOrange,
+          profileStatusError: props.showProfileErrors ? profileStatusError : '',
+        }),
+      hasViolet &&
+        makeRootCluster({
+          ...clusterViolet,
+          profileStatusError: props.showProfileErrors ? profileStatusError : '',
+        }),
+      hasGreen &&
+        makeRootCluster({
+          ...clusterGreen,
+          profileStatusError: props.showProfileErrors ? profileStatusError : '',
+        }),
+    ].filter(Boolean);
+
+    const hasClusterWithLoggedInUser =
+      props.activeCluster && (hasOrange || hasViolet);
+    if (hasClusterWithLoggedInUser) {
+      clusters[0].loggedInUser = makeLoggedInUser({
+        ...clusters[0].loggedInUser,
+        validUntil: Timestamp.fromDate(
+          props.activeClusterExpired
+            ? new Date()
+            : new Date(Date.now() + 24 * 60 * 60 * 1000)
+        ),
+        isDeviceTrusted: props.deviceTrust === 'enrolled',
+        trustedDeviceRequirement:
+          props.deviceTrust === 'required-not-enrolled'
+            ? TrustedDeviceRequirement.REQUIRED
+            : TrustedDeviceRequirement.NOT_REQUIRED,
+      });
+    }
+
+    return (
+      <OpenIdentityPopover
+        clusters={clusters}
+        activeClusterUri={hasClusterWithLoggedInUser && clusters[0]?.uri}
+      />
+    );
+  },
+  argTypes: {
+    clusters: {
+      control: { type: 'check' },
+      options: ['violet', 'orange', 'green'],
+      description: 'List of clusters to show.',
+    },
+    activeCluster: {
+      control: { type: 'boolean' },
+      description: 'Makes "violet" or "orange" an active cluster.',
+    },
+    deviceTrust: {
+      control: { type: 'radio' },
+      options: ['enrolled', 'required-not-enrolled', 'not-enrolled'],
+      description: 'Controls device trust requirement.',
+    },
+    activeClusterExpired: {
+      control: { type: 'boolean' },
+      description: 'Whether the active cluster has expired cert.',
+    },
+    showProfileErrors: {
+      control: { type: 'boolean' },
+      description: 'Shows profile errors for all clusters.',
+    },
+  },
+  args: {
+    clusters: ['violet', 'orange', 'green'],
+    activeCluster: true,
+    deviceTrust: 'not-enrolled',
+    activeClusterExpired: false,
+    showProfileErrors: false,
+  },
 };
 
+export default meta;
+
 const clusterOrange = makeRootCluster({
-  name: 'orange',
+  name: 'orange-psv-eindhoven-eredivisie-production-lorem-ipsum',
   loggedInUser: makeLoggedInUser({
-    name: 'bob',
-    roles: ['access', 'editor'],
+    name: 'ruud-van-nistelrooy-van-der-sar',
+    roles: [
+      'circle-mark-app-access',
+      'grafana-lite-app-access',
+      'grafana-gold-app-access',
+      'release-lion-app-access',
+      'release-fox-app-access',
+      'sales-center-lorem-app-access',
+      'sales-center-ipsum-db-access',
+      'sales-center-shop-app-access',
+      'sales-center-floor-db-access',
+    ],
   }),
   uri: '/clusters/orange',
 });
 const clusterViolet = makeRootCluster({
   name: 'violet',
-  loggedInUser: makeLoggedInUser({ name: 'sammy' }),
+  loggedInUser: makeLoggedInUser({
+    name: 'sammy',
+    roles: ['access', 'editor'],
+  }),
   uri: '/clusters/violet',
 });
 const clusterGreen = makeRootCluster({
@@ -66,8 +169,14 @@ const OpenIdentityPopover = (props: {
   props.clusters.forEach(c => {
     ctx.addRootCluster(c);
   });
+  ctx.workspacesService.addWorkspace(clusterGreen.uri);
+  ctx.workspacesService.addWorkspace(clusterViolet.uri);
+  ctx.workspacesService.addWorkspace(clusterOrange.uri);
   ctx.workspacesService.setState(draftState => {
     draftState.rootClusterUri = props.activeClusterUri;
+    draftState.workspaces[clusterGreen.uri].color = 'green';
+    draftState.workspaces[clusterViolet.uri].color = 'purple';
+    draftState.workspaces[clusterOrange.uri].color = 'yellow';
   });
   useOpenPopover();
 
@@ -98,125 +207,60 @@ const useOpenPopover = () => {
   }, []);
 };
 
-export function NoRootClusters() {
-  return <OpenIdentityPopover clusters={[]} activeClusterUri={undefined} />;
-}
+export const NoRootClusters: StoryObj<StoryProps> = {
+  args: {
+    clusters: [],
+  },
+};
 
-export function OneClusterWithNoActiveCluster() {
-  return (
-    <OpenIdentityPopover
-      activeClusterUri={undefined}
-      clusters={[makeRootCluster({ loggedInUser: undefined })]}
-    />
-  );
-}
+export const OneClusterWithNoActiveCluster: StoryObj<StoryProps> = {
+  args: {
+    clusters: ['orange'],
+    activeCluster: false,
+  },
+};
 
-export function OneClusterWithActiveCluster() {
-  const cluster = makeRootCluster({
-    loggedInUser: makeLoggedInUser({
-      name: 'alice',
-      roles: ['access', 'editor'],
-    }),
-  });
+export const OneClusterWithActiveCluster: StoryObj<StoryProps> = {
+  args: {
+    clusters: ['violet'],
+  },
+};
 
-  return (
-    <OpenIdentityPopover clusters={[cluster]} activeClusterUri={cluster.uri} />
-  );
-}
+export const ManyClustersWithNoActiveCluster: StoryObj<StoryProps> = {
+  args: {
+    clusters: ['orange', 'green', 'violet'],
+    activeCluster: false,
+  },
+};
 
-export function ManyClustersWithNoActiveCluster() {
-  return (
-    <OpenIdentityPopover
-      clusters={[clusterOrange, clusterViolet, clusterGreen]}
-      activeClusterUri={undefined}
-    />
-  );
-}
+export const ManyClustersWithActiveCluster: StoryObj<StoryProps> = {
+  args: {
+    clusters: ['orange', 'green', 'violet'],
+  },
+};
 
-export function ManyClustersWithActiveCluster() {
-  return (
-    <OpenIdentityPopover
-      clusters={[clusterOrange, clusterViolet, clusterGreen]}
-      activeClusterUri={clusterOrange.uri}
-    />
-  );
-}
+export const ManyClustersWithProfileErrorsAndActiveCluster: StoryObj<StoryProps> =
+  {
+    args: {
+      clusters: ['orange', 'green', 'violet'],
+      showProfileErrors: true,
+    },
+  };
 
-export function ManyClustersWithProfileErrorsAndActiveCluster() {
-  return (
-    <OpenIdentityPopover
-      clusters={[
-        makeRootCluster({ ...clusterOrange, profileStatusError }),
-        makeRootCluster({ ...clusterViolet, profileStatusError }),
-        makeRootCluster({ ...clusterGreen, profileStatusError }),
-      ]}
-      activeClusterUri={clusterOrange.uri}
-    />
-  );
-}
+export const TrustedDeviceEnrolled: StoryObj<StoryProps> = {
+  args: {
+    deviceTrust: 'enrolled',
+  },
+};
 
-export function LongNamesWithManyRoles() {
-  return (
-    <OpenIdentityPopover
-      clusters={[
-        clusterOrange,
-        makeRootCluster({
-          ...clusterViolet,
-          name: 'psv-eindhoven-eredivisie-production-lorem-ipsum',
-          loggedInUser: makeLoggedInUser({
-            roles: [
-              'circle-mark-app-access',
-              'grafana-lite-app-access',
-              'grafana-gold-app-access',
-              'release-lion-app-access',
-              'release-fox-app-access',
-              'sales-center-lorem-app-access',
-              'sales-center-ipsum-db-access',
-              'sales-center-shop-app-access',
-              'sales-center-floor-db-access',
-            ],
-            name: 'ruud-van-nistelrooy-van-der-sar',
-          }),
-        }),
-        clusterGreen,
-      ]}
-      activeClusterUri={clusterViolet.uri}
-    />
-  );
-}
+export const TrustedDeviceRequiredButNotEnrolled: StoryObj<StoryProps> = {
+  args: {
+    deviceTrust: 'required-not-enrolled',
+  },
+};
 
-export function TrustedDeviceEnrolled() {
-  return (
-    <OpenIdentityPopover
-      clusters={[
-        clusterOrange,
-        makeRootCluster({
-          ...clusterViolet,
-          loggedInUser: makeLoggedInUser({
-            isDeviceTrusted: true,
-            roles: ['circle-mark-app-access', 'grafana-lite-app-access'],
-          }),
-        }),
-      ]}
-      activeClusterUri={clusterViolet.uri}
-    />
-  );
-}
-
-export function TrustedDeviceRequiredButNotEnrolled() {
-  return (
-    <OpenIdentityPopover
-      clusters={[
-        clusterOrange,
-        makeRootCluster({
-          ...clusterViolet,
-          loggedInUser: makeLoggedInUser({
-            trustedDeviceRequirement: TrustedDeviceRequirement.REQUIRED,
-            roles: ['circle-mark-app-access', 'grafana-lite-app-access'],
-          }),
-        }),
-      ]}
-      activeClusterUri={clusterViolet.uri}
-    />
-  );
-}
+export const ActiveClusterExpired: StoryObj<StoryProps> = {
+  args: {
+    activeClusterExpired: true,
+  },
+};

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -16,12 +16,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { formatDistanceToNowStrict, isPast } from 'date-fns';
 import { JSX } from 'react';
 import styled from 'styled-components';
 
-import { ButtonText, Flex, Label, P3 } from 'design';
-import { Logout, Refresh, ShieldCheck, ShieldWarning } from 'design/Icon';
+import { ButtonText, Flex, Label, P3, Stack } from 'design';
+import { Clock, Logout, ShieldCheck, ShieldWarning } from 'design/Icon';
 import Link from 'design/Link';
+import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 
 import { ProfileStatusError } from 'teleterm/ui/components/ProfileStatusError';
@@ -46,6 +48,10 @@ export function ActiveCluster(props: {
   onLogout(): void;
 }) {
   const clusterName = routing.parseClusterName(props.activeCluster.uri);
+  const validUntil =
+    props.activeCluster.loggedInUser?.validUntil &&
+    Timestamp.toDate(props.activeCluster.loggedInUser.validUntil);
+
   return (
     <>
       <Flex p={3} pb={2} flexWrap="nowrap" gap={2} flexDirection="column">
@@ -63,13 +69,6 @@ export function ActiveCluster(props: {
           </Flex>
 
           <Flex flexDirection="row" alignItems="flex-start" gap={1}>
-            <ButtonText
-              title={`Refresh session in ${clusterName}`}
-              size="small"
-              onClick={() => props.onRefresh()}
-            >
-              <Refresh size="small" />
-            </ButtonText>
             <ButtonText
               title={`Log out from ${clusterName}`}
               onClick={() => props.onLogout()}
@@ -103,7 +102,30 @@ export function ActiveCluster(props: {
             </Label>
           ))}
         </Flex>
-        <DeviceTrustMessage status={props.deviceTrustStatus} />
+        <Stack gap={0}>
+          {validUntil && (
+            <Flex gap={1} color="text.slightlyMuted">
+              <Clock size="small" />
+              <P3>
+                <span title={validUntil.toLocaleString()}>
+                  {isPast(validUntil)
+                    ? 'Session expired.'
+                    : `Session expires ${formatDistanceToNowStrict(validUntil, { addSuffix: true })}.`}
+                </span>
+                <Link
+                  onClick={() => props.onRefresh()}
+                  ml={1}
+                  css={`
+                    cursor: pointer;
+                  `}
+                >
+                  Refresh…
+                </Link>
+              </P3>
+            </Flex>
+          )}
+          <DeviceTrustMessage status={props.deviceTrustStatus} />
+        </Stack>
       </Flex>
       <Separator />
     </>

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -21,7 +21,13 @@ import { JSX } from 'react';
 import styled from 'styled-components';
 
 import { ButtonText, Flex, Label, P3, Stack } from 'design';
-import { Clock, Logout, ShieldCheck, ShieldWarning } from 'design/Icon';
+import {
+  Clock,
+  Logout,
+  Refresh,
+  ShieldCheck,
+  ShieldWarning,
+} from 'design/Icon';
 import Link from 'design/Link';
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
 import { Cluster } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
@@ -75,7 +81,8 @@ export function ActiveCluster(props: {
               intent="danger"
               size="small"
             >
-              <Logout size="small" />
+              <Logout mr={1} size="small" />
+              Log out
             </ButtonText>
           </Flex>
         </Flex>
@@ -104,24 +111,44 @@ export function ActiveCluster(props: {
         </Flex>
         <Stack gap={0}>
           {validUntil && (
-            <Flex gap={1} color="text.slightlyMuted">
-              <Clock size="small" />
-              <P3>
-                <span title={validUntil.toLocaleString()}>
-                  {isPast(validUntil)
-                    ? 'Session expired.'
-                    : `Session expires ${formatDistanceToNowStrict(validUntil, { addSuffix: true })}.`}
-                </span>
-                <Link
-                  onClick={() => props.onRefresh()}
-                  ml={1}
-                  css={`
-                    cursor: pointer;
-                  `}
-                >
-                  Refresh…
-                </Link>
-              </P3>
+            <Flex
+              justifyContent="space-between"
+              width="100%"
+              alignItems="center"
+              gap={1}
+            >
+              <Flex gap={1} color="text.slightlyMuted">
+                <Clock size="small" />
+                <P3>
+                  {isPast(validUntil) ? (
+                    'Session expired.'
+                  ) : (
+                    <>
+                      Session expires{' '}
+                      <span
+                        title={validUntil.toLocaleString()}
+                        css={`
+                          text-decoration: underline;
+                          text-decoration-style: dotted;
+                        `}
+                      >
+                        {formatDistanceToNowStrict(validUntil, {
+                          addSuffix: true,
+                        })}
+                        .
+                      </span>
+                    </>
+                  )}
+                </P3>
+              </Flex>
+              <ButtonText
+                title={`Refresh session in ${clusterName}`}
+                onClick={() => props.onLogout()}
+                size="small"
+              >
+                <Refresh mr={1} size="small" />
+                Refresh
+              </ButtonText>
             </Flex>
           )}
           <DeviceTrustMessage status={props.deviceTrustStatus} />

--- a/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Identity/IdentityList/IdentityList.tsx
@@ -76,13 +76,19 @@ export function ActiveCluster(props: {
 
           <Flex flexDirection="row" alignItems="flex-start" gap={1}>
             <ButtonText
+              title={`Refresh session in ${clusterName}`}
+              size="small"
+              onClick={() => props.onRefresh()}
+            >
+              <Refresh size="small" />
+            </ButtonText>
+            <ButtonText
               title={`Log out from ${clusterName}`}
               onClick={() => props.onLogout()}
               intent="danger"
               size="small"
             >
-              <Logout mr={1} size="small" />
-              Log out
+              <Logout size="small" />
             </ButtonText>
           </Flex>
         </Flex>
@@ -111,44 +117,29 @@ export function ActiveCluster(props: {
         </Flex>
         <Stack gap={0}>
           {validUntil && (
-            <Flex
-              justifyContent="space-between"
-              width="100%"
-              alignItems="center"
-              gap={1}
-            >
-              <Flex gap={1} color="text.slightlyMuted">
-                <Clock size="small" />
-                <P3>
-                  {isPast(validUntil) ? (
-                    'Session expired.'
-                  ) : (
-                    <>
-                      Session expires{' '}
-                      <span
-                        title={validUntil.toLocaleString()}
-                        css={`
-                          text-decoration: underline;
-                          text-decoration-style: dotted;
-                        `}
-                      >
-                        {formatDistanceToNowStrict(validUntil, {
-                          addSuffix: true,
-                        })}
-                        .
-                      </span>
-                    </>
-                  )}
-                </P3>
-              </Flex>
-              <ButtonText
-                title={`Refresh session in ${clusterName}`}
-                onClick={() => props.onLogout()}
-                size="small"
-              >
-                <Refresh mr={1} size="small" />
-                Refresh
-              </ButtonText>
+            <Flex gap={1} color="text.slightlyMuted">
+              <Clock size="small" />
+              <P3>
+                {isPast(validUntil) ? (
+                  'Session expired.'
+                ) : (
+                  <>
+                    Session expires{' '}
+                    <span
+                      title={validUntil.toLocaleString()}
+                      css={`
+                        text-decoration: underline;
+                        text-decoration-style: dotted;
+                      `}
+                    >
+                      {formatDistanceToNowStrict(validUntil, {
+                        addSuffix: true,
+                      })}
+                      .
+                    </span>
+                  </>
+                )}
+              </P3>
             </Flex>
           )}
           <DeviceTrustMessage status={props.deviceTrustStatus} />


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/25806
Supersedes https://github.com/gravitational/teleport/pull/59370#issuecomment-3486224995

When a user logs in as a different user or assumes a role through tsh, the profile watcher detects this change and synchronizes the cluster state accordingly.
However, one component remains unchanged - the cluster client in the tsh daemon. As a result, all remote calls in the app continue using the old certificate. This could result in situations where, for instance, the resource view continues to display the "old" resources.
To address this, when a profile change is detected, we now clear the clients for both the root and leaf clusters (but only if their certificates are outdated).

However, there's one more case to handle. Currently, the watcher cannot detect when a user logs in again as the same user. In that situation, all properties of the `Cluster` object stay the same, so the watcher assumes that nothing has changed. As a result, the cluster client isn't refreshed, which can cause the relogin dialog to appear unexpectedly.
To fix this, I added a `ValidUntil` field, which allows the watcher to detect re-logins.

Once I had this field added, I also exposed it in the profile switcher (which should partially address https://github.com/gravitational/teleport/issues/54183; I haven't had time to experiment with showing it in the status bar).