### PR TITLE
[v18] Connect: clear client cache only after a successful login

### DIFF
--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -40,10 +40,6 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 		return nil, trace.BadParameter("cluster URI must be a root URI")
 	}
 
-	if err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	if req.Params == nil {
 		return nil, trace.BadParameter("missing login parameters")
 	}
@@ -59,6 +55,13 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 		}
 	default:
 		return nil, trace.BadParameter("unsupported login parameters")
+	}
+
+	// Clear the cache after login, not before.
+	// During a re-login, another thread might try to retrieve a client from the cache.
+	// Because the cache is empty, it could initialize a new client using the previous certificate.
+	if err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return &api.EmptyResponse{}, nil
@@ -91,16 +94,16 @@ func (s *Handler) LoginPasswordless(stream api.TerminalService_LoginPasswordless
 	// daemon.Service.ResolveClusterURI.
 	clusterClient.MFAPromptConstructor = nil
 
-	if err := s.DaemonService.ClearCachedClientsForRoot(cluster.URI); err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Start the prompt flow.
 	if err := cluster.PasswordlessLogin(stream.Context(), stream); err != nil {
 		return trace.Wrap(err)
 	}
 
-	return nil
+	// Clear the cache after login, not before.
+	// During a re-login, another thread might try to retrieve a client from the cache.
+	// Because the cache is empty, it could initialize a new client using the previous certificate.
+	err = s.DaemonService.ClearCachedClientsForRoot(cluster.URI)
+	return trace.Wrap(err)
 }
 
 // Logout logs a user out from a cluster


### PR DESCRIPTION
Backport #61036 to branch/v18

changelog: Fixed an issue where resources in Teleport Connect were not always refreshed correctly after re-logging in as a different user
