### PR TITLE
Server Discovery UI: default to AWS-RunShellScript SSM Doc

### DIFF
--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -111,9 +111,7 @@ export function DiscoveryConfigSsm() {
   const { clusterId } = useStickyClusterId();
 
   const [selectedRegion, setSelectedRegion] = useState<Regions>();
-  const [ssmDocumentName, setSsmDocumentName] = useState(
-    'TeleportDiscoveryInstaller'
-  );
+  const [ssmDocumentName, setSsmDocumentName] = useState('AWS-RunShellScript');
   const [scriptUrl, setScriptUrl] = useState('');
   const joinTokenRef = useRef<JoinToken>(undefined);
   const [tags, setTags] = useState<AWSLabels>([]);


### PR DESCRIPTION
This ensures the suggested document is the pre-defined one.
Teleport autodiscover command is already compatible with this pre-defined document: https://github.com/gravitational/teleport/pull/60224

The one-off script is changed [here](https://github.com/gravitational/teleport/pull/60725), which needs to be merged first.