### PR TITLE
test join request conversion

### DIFF
--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -147,15 +147,17 @@ func requestFromMessage(msg messages.Request) (*joinv1.JoinRequest, error) {
 
 func clientInitToMessage(req *joinv1.ClientInit) *messages.ClientInit {
 	msg := &messages.ClientInit{
-		JoinMethod:       req.JoinMethod,
-		TokenName:        req.TokenName,
-		SystemRole:       req.SystemRole,
-		ForwardedByProxy: req.ForwardedByProxy,
+		TokenName:        req.GetTokenName(),
+		SystemRole:       req.GetSystemRole(),
+		ForwardedByProxy: req.GetForwardedByProxy(),
+	}
+	if joinMethod := req.GetJoinMethod(); joinMethod != "" {
+		msg.JoinMethod = &joinMethod
 	}
 	if proxySuppliedParams := req.GetProxySuppliedParameters(); proxySuppliedParams != nil {
 		msg.ProxySuppliedParams = &messages.ProxySuppliedParams{
-			RemoteAddr:    proxySuppliedParams.RemoteAddr,
-			ClientVersion: proxySuppliedParams.ClientVersion,
+			RemoteAddr:    proxySuppliedParams.GetRemoteAddr(),
+			ClientVersion: proxySuppliedParams.GetClientVersion(),
 		}
 	}
 	return msg
@@ -178,7 +180,7 @@ func clientInitFromMessage(msg *messages.ClientInit) *joinv1.ClientInit {
 }
 
 func tokenInitToMessage(req *joinv1.TokenInit) (*messages.TokenInit, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -229,10 +231,10 @@ func clientParamsFromMessage(msg messages.ClientParams) (*joinv1.ClientParams, e
 
 func hostParamsToMessage(req *joinv1.HostParams) *messages.HostParams {
 	return &messages.HostParams{
-		PublicKeys:           publicKeysToMessage(req.PublicKeys),
-		HostName:             req.HostName,
-		AdditionalPrincipals: req.AdditionalPrincipals,
-		DNSNames:             req.DnsNames,
+		PublicKeys:           publicKeysToMessage(req.GetPublicKeys()),
+		HostName:             req.GetHostName(),
+		AdditionalPrincipals: req.GetAdditionalPrincipals(),
+		DNSNames:             req.GetDnsNames(),
 	}
 }
 
@@ -247,10 +249,10 @@ func hostParamsFromMessage(msg *messages.HostParams) *joinv1.HostParams {
 
 func botParamsToMessage(req *joinv1.BotParams) *messages.BotParams {
 	msg := &messages.BotParams{
-		PublicKeys: publicKeysToMessage(req.PublicKeys),
+		PublicKeys: publicKeysToMessage(req.GetPublicKeys()),
 	}
 	if req.Expires != nil {
-		expires := req.Expires.AsTime()
+		expires := req.GetExpires().AsTime()
 		msg.Expires = &expires
 	}
 	return msg
@@ -267,12 +269,9 @@ func botParamsFromMessage(msg *messages.BotParams) *joinv1.BotParams {
 }
 
 func publicKeysToMessage(req *joinv1.PublicKeys) messages.PublicKeys {
-	if req == nil {
-		return messages.PublicKeys{}
-	}
 	return messages.PublicKeys{
-		PublicTLSKey: req.PublicTlsKey,
-		PublicSSHKey: req.PublicSshKey,
+		PublicTLSKey: req.GetPublicTlsKey(),
+		PublicSSHKey: req.GetPublicSshKey(),
 	}
 }
 
@@ -331,7 +330,7 @@ func challengeSolutionFromMessage(msg messages.Request) (*joinv1.ChallengeSoluti
 
 // responseToMessage converts a gRPC JoinResponse into a protocol-agnostic [messages.Response].
 func responseToMessage(resp *joinv1.JoinResponse) (messages.Response, error) {
-	switch typedResp := resp.Payload.(type) {
+	switch typedResp := resp.GetPayload().(type) {
 	case *joinv1.JoinResponse_Init:
 		return serverInitToMessage(typedResp.Init)
 	case *joinv1.JoinResponse_Challenge:
@@ -391,13 +390,13 @@ func responseFromMessage(msg messages.Response) (*joinv1.JoinResponse, error) {
 	}
 }
 
-func serverInitToMessage(req *joinv1.ServerInit) (*messages.ServerInit, error) {
-	sas, err := types.SignatureAlgorithmSuiteFromString(req.SignatureAlgorithmSuite)
+func serverInitToMessage(resp *joinv1.ServerInit) (*messages.ServerInit, error) {
+	sas, err := types.SignatureAlgorithmSuiteFromString(resp.GetSignatureAlgorithmSuite())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &messages.ServerInit{
-		JoinMethod:              req.JoinMethod,
+		JoinMethod:              resp.GetJoinMethod(),
 		SignatureAlgorithmSuite: sas,
 	}, nil
 }
@@ -410,7 +409,7 @@ func serverInitFromMessage(msg *messages.ServerInit) *joinv1.ServerInit {
 }
 
 func challengeToMessage(resp *joinv1.Challenge) (messages.Response, error) {
-	switch payload := resp.Payload.(type) {
+	switch payload := resp.GetPayload().(type) {
 	case *joinv1.Challenge_BoundKeypairChallenge:
 		return boundKeypairChallengeToMessage(payload.BoundKeypairChallenge), nil
 	case *joinv1.Challenge_BoundKeypairRotationRequest:
@@ -456,20 +455,20 @@ func challengeFromMessage(resp messages.Response) (*joinv1.Challenge, error) {
 }
 
 func resultToMessage(resp *joinv1.Result) (messages.Response, error) {
-	switch resp.Payload.(type) {
+	switch payload := resp.GetPayload().(type) {
 	case *joinv1.Result_HostResult:
-		return hostResultToMessage(resp.GetHostResult()), nil
+		return hostResultToMessage(payload.HostResult), nil
 	case *joinv1.Result_BotResult:
-		return botResultToMessage(resp.GetBotResult()), nil
+		return botResultToMessage(payload.BotResult), nil
 	default:
-		return nil, trace.BadParameter("unrecodgnize result payload type %T", resp.Payload)
+		return nil, trace.BadParameter("unrecognized result payload type %T", payload)
 	}
 }
 
 func hostResultToMessage(resp *joinv1.HostResult) *messages.HostResult {
 	return &messages.HostResult{
-		Certificates: certificatesToMessage(resp.Certificates),
-		HostID:       resp.HostId,
+		Certificates: certificatesToMessage(resp.GetCertificates()),
+		HostID:       resp.GetHostId(),
 	}
 }
 
@@ -482,8 +481,8 @@ func hostResultFromMessage(msg *messages.HostResult) *joinv1.HostResult {
 
 func botResultToMessage(resp *joinv1.BotResult) *messages.BotResult {
 	return &messages.BotResult{
-		Certificates:       certificatesToMessage(resp.Certificates),
-		BoundKeypairResult: boundKeypairResultToMessage(resp.BoundKeypairResult),
+		Certificates:       certificatesToMessage(resp.GetCertificates()),
+		BoundKeypairResult: boundKeypairResultToMessage(resp.GetBoundKeypairResult()),
 	}
 }
 
@@ -496,10 +495,10 @@ func botResultFromMessage(msg *messages.BotResult) *joinv1.BotResult {
 
 func certificatesToMessage(certs *joinv1.Certificates) messages.Certificates {
 	return messages.Certificates{
-		TLSCert:    certs.TlsCert,
-		TLSCACerts: certs.TlsCaCerts,
-		SSHCert:    certs.SshCert,
-		SSHCAKeys:  certs.SshCaKeys,
+		TLSCert:    certs.GetTlsCert(),
+		TLSCACerts: certs.GetTlsCaCerts(),
+		SSHCert:    certs.GetSshCert(),
+		SSHCAKeys:  certs.GetSshCaKeys(),
 	}
 }
 
@@ -514,7 +513,7 @@ func certificatesFromMessage(certs *messages.Certificates) *joinv1.Certificates 
 
 func givingUpToMessage(req *joinv1.GivingUp) *messages.GivingUp {
 	reason := messages.GivingUpReasonUnspecified
-	switch req.Reason {
+	switch req.GetReason() {
 	case joinv1.GivingUp_REASON_UNSUPPORTED_JOIN_METHOD:
 		reason = messages.GivingUpReasonUnsupportedJoinMethod
 	case joinv1.GivingUp_REASON_UNSUPPORTED_MESSAGE_TYPE:
@@ -524,7 +523,7 @@ func givingUpToMessage(req *joinv1.GivingUp) *messages.GivingUp {
 	}
 	return &messages.GivingUp{
 		Reason: reason,
-		Msg:    req.Msg,
+		Msg:    req.GetMsg(),
 	}
 }
 

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -199,13 +199,13 @@ func tokenInitFromMessage(msg *messages.TokenInit) (*joinv1.TokenInit, error) {
 
 func clientParamsToMessage(req *joinv1.ClientParams) (messages.ClientParams, error) {
 	var msg messages.ClientParams
-	switch req.GetPayload().(type) {
+	switch payload := req.GetPayload().(type) {
 	case *joinv1.ClientParams_HostParams:
-		msg.HostParams = hostParamsToMessage(req.GetHostParams())
+		msg.HostParams = hostParamsToMessage(payload.HostParams)
 	case *joinv1.ClientParams_BotParams:
-		msg.BotParams = botParamsToMessage(req.GetBotParams())
+		msg.BotParams = botParamsToMessage(payload.BotParams)
 	default:
-		return msg, trace.BadParameter("unrecognized ClientParams payload type %T", req.Payload)
+		return msg, trace.BadParameter("unrecognized ClientParams payload type %T", payload)
 	}
 	return msg, nil
 }
@@ -267,6 +267,9 @@ func botParamsFromMessage(msg *messages.BotParams) *joinv1.BotParams {
 }
 
 func publicKeysToMessage(req *joinv1.PublicKeys) messages.PublicKeys {
+	if req == nil {
+		return messages.PublicKeys{}
+	}
 	return messages.PublicKeys{
 		PublicTLSKey: req.PublicTlsKey,
 		PublicSSHKey: req.PublicSshKey,

--- a/lib/join/joinv1/messages_boundkeypair.go
+++ b/lib/join/joinv1/messages_boundkeypair.go
@@ -24,14 +24,14 @@ import (
 )
 
 func boundKeypairInitToMessage(req *joinv1.BoundKeypairInit) (*messages.BoundKeypairInit, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &messages.BoundKeypairInit{
 		ClientParams:      clientParams,
-		InitialJoinSecret: req.InitialJoinSecret,
-		PreviousJoinState: req.PreviousJoinState,
+		InitialJoinSecret: req.GetInitialJoinSecret(),
+		PreviousJoinState: req.GetPreviousJoinState(),
 	}, nil
 }
 
@@ -49,8 +49,8 @@ func boundKeypairInitFromMessage(msg *messages.BoundKeypairInit) (*joinv1.BoundK
 
 func boundKeypairChallengeToMessage(resp *joinv1.BoundKeypairChallenge) *messages.BoundKeypairChallenge {
 	return &messages.BoundKeypairChallenge{
-		PublicKey: resp.PublicKey,
-		Challenge: resp.Challenge,
+		PublicKey: resp.GetPublicKey(),
+		Challenge: resp.GetChallenge(),
 	}
 }
 
@@ -63,13 +63,13 @@ func boundKeypairChallengeFromMessage(msg *messages.BoundKeypairChallenge) *join
 
 func boundKeypairChallengeSolutionToMessage(req *joinv1.BoundKeypairChallengeSolution) *messages.BoundKeypairChallengeSolution {
 	return &messages.BoundKeypairChallengeSolution{
-		Solution: req.Solution,
+		Solution: req.GetSolution(),
 	}
 }
 
 func boundKeypairRotationRequestToMessage(resp *joinv1.BoundKeypairRotationRequest) *messages.BoundKeypairRotationRequest {
 	return &messages.BoundKeypairRotationRequest{
-		SignatureAlgorithmSuite: resp.SignatureAlgorithmSuite,
+		SignatureAlgorithmSuite: resp.GetSignatureAlgorithmSuite(),
 	}
 }
 
@@ -87,7 +87,7 @@ func boundKeypairChallengeSolutionFromMessage(msg *messages.BoundKeypairChalleng
 
 func boundKeypairRotationResponseToMessage(req *joinv1.BoundKeypairRotationResponse) *messages.BoundKeypairRotationResponse {
 	return &messages.BoundKeypairRotationResponse{
-		PublicKey: req.PublicKey,
+		PublicKey: req.GetPublicKey(),
 	}
 }
 
@@ -102,8 +102,8 @@ func boundKeypairResultToMessage(req *joinv1.BoundKeypairResult) *messages.Bound
 		return nil
 	}
 	return &messages.BoundKeypairResult{
-		JoinState: req.JoinState,
-		PublicKey: req.PublicKey,
+		JoinState: req.GetJoinState(),
+		PublicKey: req.GetPublicKey(),
 	}
 }
 

--- a/lib/join/joinv1/messages_ec2.go
+++ b/lib/join/joinv1/messages_ec2.go
@@ -24,13 +24,13 @@ import (
 )
 
 func ec2InitToMessage(req *joinv1.EC2Init) (*messages.EC2Init, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &messages.EC2Init{
 		ClientParams: clientParams,
-		Document:     req.Document,
+		Document:     req.GetDocument(),
 	}, nil
 }
 

--- a/lib/join/joinv1/messages_iam.go
+++ b/lib/join/joinv1/messages_iam.go
@@ -24,7 +24,7 @@ import (
 )
 
 func iamInitToMessage(req *joinv1.IAMInit) (*messages.IAMInit, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -45,7 +45,7 @@ func iamInitFromMessage(msg *messages.IAMInit) (*joinv1.IAMInit, error) {
 
 func iamChallengeToMessage(req *joinv1.IAMChallenge) *messages.IAMChallenge {
 	return &messages.IAMChallenge{
-		Challenge: req.Challenge,
+		Challenge: req.GetChallenge(),
 	}
 }
 
@@ -57,7 +57,7 @@ func iamChallengeFromMessage(msg *messages.IAMChallenge) *joinv1.IAMChallenge {
 
 func iamChallengeSolutionToMessage(req *joinv1.IAMChallengeSolution) *messages.IAMChallengeSolution {
 	return &messages.IAMChallengeSolution{
-		STSIdentityRequest: req.StsIdentityRequest,
+		STSIdentityRequest: req.GetStsIdentityRequest(),
 	}
 }
 

--- a/lib/join/joinv1/messages_oidc.go
+++ b/lib/join/joinv1/messages_oidc.go
@@ -24,13 +24,13 @@ import (
 )
 
 func oidcInitToMessage(req *joinv1.OIDCInit) (*messages.OIDCInit, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &messages.OIDCInit{
 		ClientParams: clientParams,
-		IDToken:      req.IdToken,
+		IDToken:      req.GetIdToken(),
 	}, nil
 }
 

--- a/lib/join/joinv1/messages_oracle.go
+++ b/lib/join/joinv1/messages_oracle.go
@@ -24,7 +24,7 @@ import (
 )
 
 func oracleInitToMessage(req *joinv1.OracleInit) (*messages.OracleInit, error) {
-	clientParams, err := clientParamsToMessage(req.ClientParams)
+	clientParams, err := clientParamsToMessage(req.GetClientParams())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -45,7 +45,7 @@ func oracleInitFromMessage(msg *messages.OracleInit) (*joinv1.OracleInit, error)
 
 func oracleChallengeToMessage(req *joinv1.OracleChallenge) *messages.OracleChallenge {
 	return &messages.OracleChallenge{
-		Challenge: req.Challenge,
+		Challenge: req.GetChallenge(),
 	}
 }
 
@@ -57,10 +57,10 @@ func oracleChallengeFromMessage(msg *messages.OracleChallenge) *joinv1.OracleCha
 
 func oracleChallengeSolutionToMessage(req *joinv1.OracleChallengeSolution) *messages.OracleChallengeSolution {
 	return &messages.OracleChallengeSolution{
-		Cert:            req.Cert,
-		Intermediate:    req.Intermediate,
-		Signature:       req.Signature,
-		SignedRootCAReq: req.SignedRootCaReq,
+		Cert:            req.GetCert(),
+		Intermediate:    req.GetIntermediate(),
+		Signature:       req.GetSignature(),
+		SignedRootCAReq: req.GetSignedRootCaReq(),
 	}
 }
 

--- a/lib/join/joinv1/messages_test.go
+++ b/lib/join/joinv1/messages_test.go
@@ -1,0 +1,178 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinv1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+)
+
+// TestRequestToMessage tests that parsing a gRPC [joinv1.JoinRequest] into a
+// [messages.Request] does not trigger a panic on the server. These gRPC
+// requests come in over the network from untrusted clients.
+func TestRequestToMessage(t *testing.T) {
+	for _, tc := range []struct {
+		desc string
+		req  *joinv1.JoinRequest
+	}{
+		{
+			desc: "nil req",
+		},
+		{
+			desc: "nil payload",
+			req:  &joinv1.JoinRequest{},
+		},
+		{
+			desc: "empty ClientInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_ClientInit{},
+			},
+		},
+		{
+			desc: "empty TokenInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_TokenInit{},
+			},
+		},
+		{
+			desc: "empty BoundKeypairInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_BoundKeypairInit{},
+			},
+		},
+		{
+			desc: "empty IAMInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_IamInit{},
+			},
+		},
+		{
+			desc: "empty EC2Init",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Ec2Init{},
+			},
+		},
+		{
+			desc: "empty OIDCInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_OidcInit{},
+			},
+		},
+		{
+			desc: "empty OracleInit",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_OracleInit{},
+			},
+		},
+		{
+			desc: "empty HostParams",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_TokenInit{
+					TokenInit: &joinv1.TokenInit{
+						ClientParams: &joinv1.ClientParams{
+							Payload: &joinv1.ClientParams_HostParams{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty BotParams",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_TokenInit{
+					TokenInit: &joinv1.TokenInit{
+						ClientParams: &joinv1.ClientParams{
+							Payload: &joinv1.ClientParams_BotParams{},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty Solution",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Solution{},
+			},
+		},
+		{
+			desc: "empty BoundKeypairChallengeSolution",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Solution{
+					Solution: &joinv1.ChallengeSolution{
+						Payload: &joinv1.ChallengeSolution_BoundKeypairChallengeSolution{},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty BoundKeypairRotationResponse",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Solution{
+					Solution: &joinv1.ChallengeSolution{
+						Payload: &joinv1.ChallengeSolution_BoundKeypairRotationResponse{},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty IamChallengeSolution",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Solution{
+					Solution: &joinv1.ChallengeSolution{
+						Payload: &joinv1.ChallengeSolution_IamChallengeSolution{},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty OracleChallengeSolution",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_Solution{
+					Solution: &joinv1.ChallengeSolution{
+						Payload: &joinv1.ChallengeSolution_OracleChallengeSolution{},
+					},
+				},
+			},
+		},
+		{
+			desc: "empty GivingUp",
+			req: &joinv1.JoinRequest{
+				Payload: &joinv1.JoinRequest_GivingUp{},
+			},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Put the request through a marshal/unmarshal to more closely
+			// model a request that could actually come in over the network.
+			// For example, in unmarshalled messages, the inner pointer of a
+			// oneof can never be nil.
+			buf, err := proto.Marshal(tc.req)
+			require.NoError(t, err)
+			var req joinv1.JoinRequest
+			err = proto.Unmarshal(buf, &req)
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				_, _ = requestToMessage(&req)
+			})
+		})
+	}
+}


### PR DESCRIPTION
This PR adds tests to make sure the new gRPC join service won't panic when handling crafted JoinRequests containing nil pointers, it also fixes 2 bugs caught by the test.