### PR TITLE
Update `Lint` workflow path filter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,8 +66,6 @@ jobs:
               - 'integrations/terraform/templates/**'
               - 'integrations/terraform/provider/**'
               # rendered doc changes
-              - 'docs/pages/admin-guides/**'
-              - 'docs/pages/enroll-resources/**'
               - 'docs/pages/reference/infrastructure-as-code/operator-resources/**'
               - 'docs/pages/reference/infrastructure-as-code/terraform-provider/**'
               - 'examples/chart/teleport-cluster/charts/teleport-operator/operator-crds'
@@ -80,6 +78,7 @@ jobs:
               - 'pnpm-lock.yaml'
               - 'tsconfig.json'
               - 'tsconfig.node.json'
+              - 'docs/pages/reference/audit-events.mdx'
 
   lint-go:
     name: Lint (Go)


### PR DESCRIPTION
- Remove paths that no longer exist. The up-to-date counterparts of these paths do not contain generated files, so we can remove them.
- Add the audit event reference to the `has_ui` filter. We can use this to prevent manual changes to the audit event reference.