### PR TITLE
Web: allow listing system roles when requested

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -989,7 +989,13 @@ func (h *Handler) bindDefaultEndpoints() {
 	// User Status (used by client to check if user session is valid)
 	h.GET("/webapi/user/status", h.WithAuth(h.getUserStatus))
 
+	// TODO(kimlisa): DELETE IN 20.0 along with the api path defined in `config.ts`
+	// Replaced by its v2 endpoint
 	h.GET("/webapi/roles", h.WithAuth(h.listRolesHandle))
+	// v2 introduces a query param for optionally including system roles
+	// in the list and optionally include returning the object version
+	// of resource (only supported for roles).
+	h.GET("/v2/webapi/roles", h.WithAuth(h.listRolesHandle))
 	h.POST("/webapi/roles", h.WithAuth(h.createRoleHandle))
 	h.GET("/webapi/roles/:name", h.WithAuth(h.getRole))
 	h.PUT("/webapi/roles/:name", h.WithAuth(h.updateRoleHandle))

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -61,12 +61,15 @@ func listRoles(clt resourcesAPIGetter, values url.Values) (*listResourcesWithout
 		return nil, trace.Wrap(err)
 	}
 
+	skipSystemRoles := values.Get("includeSystemRoles") != "yes"
+	includeRoleObject := values.Get("includeObject") == "yes"
+
 	roles, err := clt.ListRoles(context.TODO(), &proto.ListRolesRequest{
 		Limit:    limit,
 		StartKey: values.Get("startKey"),
 		Filter: &types.RoleFilter{
 			SearchKeywords:  client.ParseSearchKeywords(values.Get("search"), ' '),
-			SkipSystemRoles: true,
+			SkipSystemRoles: skipSystemRoles,
 		},
 	})
 	if err != nil {
@@ -78,7 +81,7 @@ func listRoles(clt resourcesAPIGetter, values url.Values) (*listResourcesWithout
 		typeRoles = append(typeRoles, role)
 	}
 
-	uiRoles, err := ui.NewRoles(typeRoles)
+	uiRoles, err := ui.NewRoles(typeRoles, includeRoleObject)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -180,7 +183,7 @@ func (h *Handler) updateRoleHandle(w http.ResponseWriter, r *http.Request, param
 // via the public ping endpoint.
 func (h *Handler) getPresetRoles(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	presets := auth.GetPresetRoles()
-	return ui.NewRoles(presets)
+	return ui.NewRoles(presets, false /* without role object */)
 }
 
 // getGithubConnectorHandle returns a GitHub connector by name.

--- a/lib/web/ui/resource.go
+++ b/lib/web/ui/resource.go
@@ -42,6 +42,9 @@ type ResourceItem struct {
 	Description string `json:"description,omitempty"`
 	// Content is resource yaml content.
 	Content string `json:"content"`
+	// Object is the resource itself (the non string format).
+	// Supported for roles.
+	Object types.Resource `json:"object,omitempty"`
 }
 
 // NewResourceItem creates UI objects for a resource.
@@ -66,12 +69,16 @@ func NewResourceItem(resource types.Resource) (*ResourceItem, error) {
 }
 
 // NewRoles creates resource item for each role.
-func NewRoles(roles []types.Role) ([]ResourceItem, error) {
+func NewRoles(roles []types.Role, includeRoleObject bool) ([]ResourceItem, error) {
 	items := make([]ResourceItem, 0, len(roles))
 	for _, role := range roles {
 		item, err := NewResourceItem(role)
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+
+		if includeRoleObject {
+			item.Object = role
 		}
 
 		items = append(items, *item)

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -331,7 +331,10 @@ const cfg = {
       get: '/v1/webapi/roles/:name',
       delete: '/v1/webapi/roles/:name',
       update: '/v1/webapi/roles/:name',
+      // TODO(kimlisa): DELETE IN 20.0 along with its backend endpoint in `apiserver.go`
       list: '/v1/webapi/roles?startKey=:startKey?&search=:search?&limit=:limit?',
+      listV2:
+        '/v2/webapi/roles?startKey=:startKey?&search=:search?&limit=:limit?&includeSystemRoles=:includeSystemRoles?&includeObject=:includeObject?',
       listWithoutQueryParam: '/v1/webapi/roles',
     },
 
@@ -1283,7 +1286,7 @@ const cfg = {
           action: 'get' | 'delete' | 'update';
           name: string;
         }
-      | { action: 'list'; params?: UrlListRolesParams }
+      | { action: 'list' | 'listv2'; params?: UrlListRolesParams }
   ) {
     const action = req.action;
     switch (action) {
@@ -1293,13 +1296,24 @@ const cfg = {
         return generatePath(cfg.api.role.delete, { name: req.name });
       case 'update':
         return generatePath(cfg.api.role.update, { name: req.name });
-      case 'list':
+      case 'list': {
         const params = req.params;
         return generatePath(cfg.api.role.list, {
           search: params?.search || undefined,
           startKey: params?.startKey || undefined,
           limit: params?.limit || undefined,
         });
+      }
+      case 'listv2': {
+        const params = req.params;
+        return generatePath(cfg.api.role.listV2, {
+          search: params?.search || undefined,
+          startKey: params?.startKey || undefined,
+          limit: params?.limit || undefined,
+          includeSystemRoles: params?.includeSystemRoles || undefined,
+          includeObject: params?.includeObject || undefined,
+        });
+      }
       default:
         action satisfies never;
     }
@@ -1925,6 +1939,18 @@ export interface UrlListRolesParams {
   search?: string;
   limit?: number;
   startKey?: string;
+  /**
+   * default is without system roles.
+   * Only supported with v2 endpoint.
+   */
+  includeSystemRoles?: 'yes' | '';
+  /**
+   * default is without the object.
+   * (only a string content of the resource for yaml purposes)
+   *
+   * Only supported with v2 endpoint and role resource.
+   */
+  includeObject?: 'yes' | '';
 }
 
 export interface UrlListUsersParams {

--- a/web/packages/teleport/src/services/resources/resource.ts
+++ b/web/packages/teleport/src/services/resources/resource.ts
@@ -24,7 +24,10 @@ import api from 'teleport/services/api';
 import { ResourcesResponse, UnifiedResource } from '../agents';
 import auth, { MfaChallengeScope } from '../auth/auth';
 import { MfaChallengeResponse } from '../mfa';
-import { isPathNotFoundError } from '../version/unsupported';
+import {
+  isPathNotFoundError,
+  withGenericUnsupportedError,
+} from '../version/unsupported';
 import { yamlService } from '../yaml';
 import { YamlSupportedResourceKind } from '../yaml/types';
 import {
@@ -130,13 +133,30 @@ class ResourceService {
   }
 
   async fetchRoles(
-    params?: UrlListRolesParams,
+    params?: Omit<UrlListRolesParams, 'includeSystemRoles' | 'includeObject'>,
     signal?: AbortSignal
   ): Promise<{
     items: RoleResource[];
     startKey: string;
   }> {
     return await api.get(cfg.getRoleUrl({ action: 'list', params }), signal);
+  }
+
+  async fetchRolesV2(
+    params?: UrlListRolesParams,
+    signal?: AbortSignal
+  ): Promise<{
+    items: RoleResource[];
+    startKey: string;
+  }> {
+    try {
+      return await api.get(
+        cfg.getRoleUrl({ action: 'listv2', params }),
+        signal
+      );
+    } catch (err) {
+      withGenericUnsupportedError(err, '18.4.2');
+    }
   }
 
   async fetchRequestableRoles(

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -40,7 +40,12 @@ export type Kind =
   | KindJoinToken;
 
 /** Teleport role in a resource format. */
-export type RoleResource = Resource<KindRole>;
+export type RoleResource = Resource<KindRole> & {
+  /**
+   * Only defined if querying roles were requested with "includeObject".
+   */
+  object?: Role;
+};
 
 /** Teleport role with only the role name and description, used for displaying requestable roles. */
 export type RequestableRole = {


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Creates a v2 endpoint that allows including system roles when querying for roles.
Default is to not list with system roles (as it was before)