### PR TITLE
Gracefully handle corrupted private keys

### DIFF
--- a/api/utils/keys/privatekey_test.go
+++ b/api/utils/keys/privatekey_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -172,26 +173,56 @@ func TestParseMismatchedPEMHeader(t *testing.T) {
 // that the preferredErr logic in Parse(Private|Public)Key returns an error for
 // each PEM type.
 func TestParseCorruptedKey(t *testing.T) {
-	for _, tc := range []string{
-		"RSA PRIVATE KEY",
-		"PRIVATE KEY",
-		"EC PRIVATE KEY",
-	} {
-		t.Run(tc, func(t *testing.T) {
-			b := pem.EncodeToMemory(&pem.Block{Type: tc, Bytes: []byte("foo")})
-			_, err := keys.ParsePrivateKey(b)
-			require.Error(t, err)
+	t.Parallel()
+	privateKeyTests := []struct {
+		name    string
+		pemData []byte
+	}{
+		{
+			name:    "PRIVATE KEY",
+			pemData: pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("foo")}),
+		},
+		{
+			name:    "RSA PRIVATE KEY",
+			pemData: pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: []byte("foo")}),
+		},
+		{
+			name:    "EC PRIVATE KEY",
+			pemData: pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: []byte("foo")}),
+		},
+		{
+			name:    "not a private key pem file",
+			pemData: []byte("foo"),
+		},
+	}
+	for _, tc := range privateKeyTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := keys.ParsePrivateKey(tc.pemData)
+			require.True(t, trace.IsBadParameter(err), "wanted BadParameter, got: %v", err)
 		})
 	}
 
-	for _, tc := range []string{
-		"RSA PUBLIC KEY",
-		"PUBLIC KEY",
-	} {
-		t.Run(tc, func(t *testing.T) {
-			b := pem.EncodeToMemory(&pem.Block{Type: tc, Bytes: []byte("foo")})
-			_, err := keys.ParsePublicKey(b)
-			require.Error(t, err)
+	publicKeyTests := []struct {
+		name    string
+		pemData []byte
+	}{
+		{
+			name:    "RSA PUBLIC KEY",
+			pemData: pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: []byte("foo")}),
+		},
+		{
+			name:    "PUBLIC KEY",
+			pemData: pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: []byte("foo")}),
+		},
+		{
+			name:    "not a public key pem file",
+			pemData: []byte("foo"),
+		},
+	}
+	for _, tc := range publicKeyTests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := keys.ParsePublicKey(tc.pemData)
+			require.True(t, trace.IsBadParameter(err), "wanted BadParameter, got: %v", err)
 		})
 	}
 }

--- a/api/utils/keys/publickey.go
+++ b/api/utils/keys/publickey.go
@@ -89,5 +89,5 @@ func ParsePublicKey(keyPEM []byte) (crypto.PublicKey, error) {
 	// If both parse functions returned an error, preferedErr is guaranteed to
 	// be set to the error from the parse function that usually matches the PEM
 	// block type.
-	return nil, trace.Wrap(preferredErr, "parsing public key PEM")
+	return nil, trace.BadParameter("parsing public key PEM: %s", preferredErr)
 }

--- a/lib/client/keystore.go
+++ b/lib/client/keystore.go
@@ -426,10 +426,9 @@ func (fs *FSKeyStore) DeleteKeyRing(idx KeyRingIndex) error {
 		fs.publicKeyPath(idx),
 		fs.tlsCertPath(idx),
 	}
+	var deleteErrs []error
 	for _, fn := range files {
-		if err := utils.RemoveSecure(fn); err != nil {
-			return trace.ConvertSystemError(err)
-		}
+		deleteErrs = append(deleteErrs, trace.ConvertSystemError(utils.RemoveSecure(fn)))
 	}
 	// we also need to delete the extra PuTTY-formatted .ppk file when running on Windows,
 	// but it may not exist when upgrading from v9 -> v10 and logging into an existing cluster.
@@ -446,7 +445,8 @@ func (fs *FSKeyStore) DeleteKeyRing(idx KeyRingIndex) error {
 
 	// Clear ClusterName to delete the user certs stored for all clusters.
 	idx.ClusterName = ""
-	return fs.DeleteUserCerts(idx, WithAllCerts...)
+	deleteErrs = append(deleteErrs, fs.DeleteUserCerts(idx, WithAllCerts...))
+	return trace.NewAggregate(deleteErrs...)
 }
 
 // DeleteUserCerts deletes only the specified parts of the user's keyring,


### PR DESCRIPTION
This change updates tsh to gracefully handle corrupted private key files. Previously, if the key was corrupted, every tsh command would fail (including logout), and the only way to fix it would be to manually remove `~/.tsh`. Now, if the key is corrupted `tsh logout` will successfully log out, and any command that calls `RetryWithRelogin` will also work properly.

Part of #59549.

Changelog: Fixed corrupted private keys breaking tsh

# Test Plan
Assume each test case starts logged in with a manually corrupted key (this can be done by running `echo "some data" > ~/.tsh/keys/<proxy-addr>/<teleport-user>`.
- [x] `tsh status` reports that the session is no longer valid.
- [x] `tsh logout` successfully logs out the user.
- [x] A command with RetryWithRelogin (e.g. `tsh ls`) successfully logs in when the key is corrupted.