### PR TITLE
Azure method support in new join service

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -114,6 +114,7 @@ import (
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/join"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
+	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/bitbucket"
 	joinboundkeypair "github.com/gravitational/teleport/lib/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/join/circleci"
@@ -1338,6 +1339,9 @@ type Server struct {
 	// env0IDTokenValidator is a helper to validate env0 OIDC tokens. Used to
 	// override the implementation used in tests.
 	env0IDTokenValidator join.Env0TokenValidator
+
+	// azureJoinConfig holds configuration for the Azure join method.
+	azureJoinConfig *azurejoin.AzureJoinConfig
 
 	// loadAllCAs tells tsh to load the host CAs for all clusters when trying to ssh into a node.
 	loadAllCAs bool

--- a/lib/auth/bot_test.go
+++ b/lib/auth/bot_test.go
@@ -23,10 +23,6 @@ import (
 	"context"
 	"crypto"
 	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
-	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -36,10 +32,8 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/digitorus/pkcs7"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -58,16 +52,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/utils/keys"
-	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/cloud/azure"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/kube/token"
@@ -738,89 +729,6 @@ func TestRegisterBot_RemoteAddr(t *testing.T) {
 			}
 			return req, nil
 		})
-		require.NoError(t, err)
-		checkCertLoginIP(t, certs.TLS, remoteAddr)
-	})
-
-	t.Run("Azure method", func(t *testing.T) {
-		subID := uuid.NewString()
-		resourceGroup := "rg"
-		rsID := vmResourceID(subID, resourceGroup, "test-vm")
-		vmID := "vmID"
-
-		accessToken, err := makeToken(rsID, "", a.GetClock().Now())
-		require.NoError(t, err)
-
-		// add token to auth server
-		azureTokenName := "azure-test-token"
-		azureToken, err := types.NewProvisionTokenFromSpec(
-			azureTokenName,
-			time.Now().Add(time.Minute),
-			types.ProvisionTokenSpecV2{
-				Roles:      []types.SystemRole{types.RoleBot},
-				Azure:      &types.ProvisionTokenSpecV2Azure{Allow: []*types.ProvisionTokenSpecV2Azure_Rule{{Subscription: subID}}},
-				BotName:    botName,
-				JoinMethod: types.JoinMethodAzure,
-			})
-		require.NoError(t, err)
-		require.NoError(t, a.UpsertToken(ctx, azureToken))
-
-		vmClient := &mockAzureVMClient{
-			vms: map[string]*azure.VirtualMachine{
-				rsID: {
-					ID:            rsID,
-					Name:          "test-vm",
-					Subscription:  subID,
-					ResourceGroup: resourceGroup,
-					VMID:          vmID,
-				},
-			},
-		}
-		getVMClient := makeVMClientGetter(map[string]*mockAzureVMClient{
-			subID: vmClient,
-		})
-
-		tlsConfig, err := fixtures.LocalTLSConfig()
-		require.NoError(t, err)
-
-		block, _ := pem.Decode(fixtures.LocalhostKey)
-		pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-		require.NoError(t, err)
-
-		certs, err := a.RegisterUsingAzureMethodWithOpts(context.Background(), func(challenge string) (*proto.RegisterUsingAzureMethodRequest, error) {
-			ad := auth.AttestedData{
-				Nonce:          challenge,
-				SubscriptionID: subID,
-				ID:             vmID,
-			}
-			adBytes, err := json.Marshal(&ad)
-			require.NoError(t, err)
-			s, err := pkcs7.NewSignedData(adBytes)
-			require.NoError(t, err)
-			require.NoError(t, s.AddSigner(tlsConfig.Certificate, pkey, pkcs7.SignerInfoConfig{}))
-			signature, err := s.Finish()
-			require.NoError(t, err)
-			signedAD := auth.SignedAttestedData{
-				Encoding:  "pkcs7",
-				Signature: base64.StdEncoding.EncodeToString(signature),
-			}
-			signedADBytes, err := json.Marshal(&signedAD)
-			require.NoError(t, err)
-
-			req := &proto.RegisterUsingAzureMethodRequest{
-				RegisterUsingTokenRequest: &types.RegisterUsingTokenRequest{
-					Token:        azureTokenName,
-					HostID:       "test-node",
-					Role:         types.RoleBot,
-					PublicSSHKey: sshPubKey,
-					PublicTLSKey: tlsPubKey,
-					RemoteAddr:   remoteAddr,
-				},
-				AttestedData: signedADBytes,
-				AccessToken:  accessToken,
-			}
-			return req, nil
-		}, auth.WithAzureCerts([]*x509.Certificate{tlsConfig.Certificate}), auth.WithAzureVerifyFunc(mockVerifyToken(nil)), auth.WithAzureVMClientGetter(getVMClient))
 		require.NoError(t, err)
 		checkCertLoginIP(t, certs.TLS, remoteAddr)
 	})

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -70,8 +70,6 @@ const (
 
 	MaxUserAgentLen = maxUserAgentLen
 	ForwardedTag    = forwardedTag
-
-	AzureAccessTokenAudience = azureAccessTokenAudience
 )
 
 var (
@@ -307,10 +305,6 @@ func TrimUserAgent(userAgent string) string {
 	return trimUserAgent(userAgent)
 }
 
-func IsAllowedDomain(cn string, domains []string) bool {
-	return isAllowedDomain(cn, domains)
-}
-
 func GetSnowflakeJWTParams(ctx context.Context, accountName, userName string, publicKey []byte) (string, string) {
 	return getSnowflakeJWTParams(ctx, accountName, userName, publicKey)
 }
@@ -336,31 +330,6 @@ func CheckHeaders(headers http.Header, challenge string, clock clockwork.Clock) 
 }
 
 type GitHubManager = githubManager
-type AttestedData = attestedData
-type SignedAttestedData = signedAttestedData
-type AzureRegisterOption = azureRegisterOption
-type AzureRegisterConfig = azureRegisterConfig
-type AzureVMClientGetter = vmClientGetter
-type AzureVerifyTokenFunc = azureVerifyTokenFunc
-type AccessTokenClaims = accessTokenClaims
-
-func WithAzureCerts(certs []*x509.Certificate) AzureRegisterOption {
-	return func(cfg *AzureRegisterConfig) {
-		cfg.certificateAuthorities = certs
-	}
-}
-
-func WithAzureVerifyFunc(verify azureVerifyTokenFunc) AzureRegisterOption {
-	return func(cfg *AzureRegisterConfig) {
-		cfg.verify = verify
-	}
-}
-
-func WithAzureVMClientGetter(getVMClient vmClientGetter) AzureRegisterOption {
-	return func(cfg *AzureRegisterConfig) {
-		cfg.getVMClient = getVMClient
-	}
-}
 
 func (s *TLSServer) GRPCServer() *GRPCServer {
 	return s.grpcServer

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -80,6 +80,10 @@ type AzureParams struct {
 	ClientID string
 	// IMDSClient overrides the client used to fetch data from Azure IMDS.
 	IMDSClient AzureIMDSClient
+	// IssuerHTTPClient, if set, overrides the default HTTP client used to
+	// fetch the intermediate CA which issued the attested data document
+	// signing certificate. Only used when joining via the new join service.
+	IssuerHTTPClient utils.HTTPDoClient
 }
 
 // AzureIMDSClient is a client to Azure's IMDS.

--- a/lib/auth/join_azure_legacy.go
+++ b/lib/auth/join_azure_legacy.go
@@ -1,0 +1,119 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/azurejoin"
+	"github.com/gravitational/teleport/lib/join/legacyjoin"
+)
+
+// RegisterUsingAzureMethod registers the caller using the Azure join method
+// and returns signed certs to join the cluster.
+//
+// The caller must provide a ChallengeResponseFunc which returns a
+// *proto.RegisterUsingAzureMethodRequest with a signed attested data document
+// including the challenge as a nonce.
+//
+// TODO(nklaassen): DELETE IN 20 when removing the legacy join service.
+func (a *Server) RegisterUsingAzureMethod(
+	ctx context.Context,
+	challengeResponse client.RegisterAzureChallengeResponseFunc,
+) (certs *proto.Certs, err error) {
+	var provisionToken types.ProvisionToken
+	var joinRequest *types.RegisterUsingTokenRequest
+	defer func() {
+		// Emit a log message and audit event on join failure.
+		if err != nil {
+			a.handleJoinFailure(ctx, err, provisionToken, nil, joinRequest)
+		}
+	}()
+
+	if legacyjoin.Disabled() {
+		return nil, trace.Wrap(legacyjoin.ErrDisabled)
+	}
+
+	challenge, err := azurejoin.GenerateAzureChallenge()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	req, err := challengeResponse(challenge)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	joinRequest = req.RegisterUsingTokenRequest
+
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	provisionToken, err = a.checkTokenJoinRequestCommon(ctx, req.RegisterUsingTokenRequest)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if provisionToken.GetJoinMethod() != types.JoinMethodAzure {
+		return nil, trace.AccessDenied("this token does not support the Azure join method")
+	}
+
+	ptv2, ok := provisionToken.(*types.ProvisionTokenV2)
+	if !ok {
+		return nil, trace.Wrap(err, "Azure join method only supports ProvisionTokenV2, got %T", provisionToken)
+	}
+
+	joinAttrs, err := azurejoin.CheckAzureRequest(ctx, azurejoin.CheckAzureRequestParams{
+		AzureJoinConfig: a.GetAzureJoinConfig(),
+		Token:           ptv2,
+		Challenge:       challenge,
+		AttestedData:    req.AttestedData,
+		AccessToken:     req.AccessToken,
+		Logger:          a.logger,
+		Clock:           a.GetClock(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "checking Azure challenge response")
+	}
+
+	if req.RegisterUsingTokenRequest.Role == types.RoleBot {
+		params := makeBotCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/, &workloadidentityv1pb.JoinAttrs{
+			Azure: joinAttrs,
+		})
+		certs, _, err := a.GenerateBotCertsForJoin(ctx, provisionToken, params)
+		return certs, trace.Wrap(err)
+	}
+	params := makeHostCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/)
+	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
+	return certs, trace.Wrap(err)
+}
+
+// GetAzureJoinConfig gets configuration options for azure joining.
+func (a *Server) GetAzureJoinConfig() *azurejoin.AzureJoinConfig {
+	return a.azureJoinConfig
+}
+
+// SetAzureJoinConfig sets configuration options for azure joining.
+func (a *Server) SetAzureJoinConfig(c *azurejoin.AzureJoinConfig) {
+	a.azureJoinConfig = c
+}

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -1,22 +1,20 @@
-/*
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package auth
+package azurejoin
 
 import (
 	"cmp"
@@ -37,21 +35,19 @@ import (
 	"github.com/digitorus/pkcs7"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
-	"github.com/gravitational/teleport/api/client"
-	"github.com/gravitational/teleport/api/client/proto"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/join/joinutils"
-	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
-	azureAccessTokenAudience = "https://management.azure.com/"
+	AzureAccessTokenAudience = "https://management.azure.com/"
 
 	// azureUserAgent specifies the Azure User-Agent identification for telemetry.
 	azureUserAgent = "teleport"
@@ -64,7 +60,8 @@ const (
 // Structs for unmarshaling attested data. Schema can be found at
 // https://learn.microsoft.com/en-us/azure/virtual-machines/linux/instance-metadata-service?tabs=linux#response-2
 
-type signedAttestedData struct {
+// SignedAttestedData models the response from the attested data IMDS endpoint.
+type SignedAttestedData struct {
 	Encoding  string `json:"encoding"`
 	Signature string `json:"signature"`
 }
@@ -80,7 +77,8 @@ type timestamp struct {
 	ExpiresOn string `json:"expiresOn"`
 }
 
-type attestedData struct {
+// AttestedData models the decoded data returned from the attested data IMDS endpoint.
+type AttestedData struct {
 	LicenseType    string    `json:"licenseType"`
 	Nonce          string    `json:"nonce"`
 	Plan           plan      `json:"plan"`
@@ -90,7 +88,8 @@ type attestedData struct {
 	SKU            string    `json:"sku"`
 }
 
-type accessTokenClaims struct {
+// AccessTokenClaims models the claims in an Azure access token.
+type AccessTokenClaims struct {
 	oidc.TokenClaims
 	TenantID string `json:"tid"`
 	Version  string `json:"ver"`
@@ -111,7 +110,7 @@ type accessTokenClaims struct {
 	AzureResourceID            string `json:"xms_az_rid"`
 }
 
-func (c *accessTokenClaims) AsJWTClaims() jwt.Claims {
+func (c *AccessTokenClaims) asJWTClaims() jwt.Claims {
 	return jwt.Claims{
 		Issuer:    c.Issuer,
 		Subject:   c.Subject,
@@ -123,24 +122,32 @@ func (c *accessTokenClaims) AsJWTClaims() jwt.Claims {
 	}
 }
 
-type azureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*accessTokenClaims, error)
+// AzureVerifyTokenFunc is a function type that verifies an azure VM token.
+type AzureVerifyTokenFunc func(ctx context.Context, rawIDToken string) (*AccessTokenClaims, error)
 
-type vmClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
+// VMClientGetter is a function type that returns an Azure VM client for a
+// given subscription authenticated with a given static token credential.
+type VMClientGetter func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error)
 
-type azureRegisterConfig struct {
-	certificateAuthorities []*x509.Certificate
-	verify                 azureVerifyTokenFunc
-	getVMClient            vmClientGetter
+// AzureJoinConfig holds configurable options for Azure joining.
+type AzureJoinConfig struct {
+	// CertificateAuthorities, if set, overrides the root certificate
+	// authorities used to verify VM attested data.
+	CertificateAuthorities []*x509.Certificate
+	// Verify, if set, overrides the function used to verify azure VM tokens.
+	Verify AzureVerifyTokenFunc
+	// GetVMClient, if set, overrides the function used to get Azure VM clients.
+	GetVMClient VMClientGetter
 }
 
-func azureVerifyFuncFromOIDCVerifier(clientID string) azureVerifyTokenFunc {
-	return func(ctx context.Context, rawIDToken string) (*accessTokenClaims, error) {
+func azureVerifyFuncFromOIDCVerifier(clientID string) AzureVerifyTokenFunc {
+	return func(ctx context.Context, rawIDToken string) (*AccessTokenClaims, error) {
 		token, err := jwt.ParseSigned(rawIDToken)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 		// Need to get the tenant ID before we verify so we can construct the issuer URL.
-		var unverifiedClaims accessTokenClaims
+		var unverifiedClaims AccessTokenClaims
 		if err := token.UnsafeClaimsWithoutVerification(&unverifiedClaims); err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -148,24 +155,24 @@ func azureVerifyFuncFromOIDCVerifier(clientID string) azureVerifyTokenFunc {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return liboidc.ValidateToken[*accessTokenClaims](ctx, issuer, clientID, rawIDToken)
+		return liboidc.ValidateToken[*AccessTokenClaims](ctx, issuer, clientID, rawIDToken)
 	}
 }
 
-func (cfg *azureRegisterConfig) CheckAndSetDefaults(ctx context.Context) error {
-	if cfg.verify == nil {
-		cfg.verify = azureVerifyFuncFromOIDCVerifier(azureAccessTokenAudience)
+func (cfg *AzureJoinConfig) checkAndSetDefaults() error {
+	if cfg.Verify == nil {
+		cfg.Verify = azureVerifyFuncFromOIDCVerifier(AzureAccessTokenAudience)
 	}
 
-	if cfg.certificateAuthorities == nil {
+	if cfg.CertificateAuthorities == nil {
 		certs, err := getAzureRootCerts()
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		cfg.certificateAuthorities = certs
+		cfg.CertificateAuthorities = certs
 	}
-	if cfg.getVMClient == nil {
-		cfg.getVMClient = func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error) {
+	if cfg.GetVMClient == nil {
+		cfg.GetVMClient = func(subscriptionID string, token *azure.StaticCredential) (azure.VirtualMachinesClient, error) {
 			// The User-Agent is added for debugging purposes. It helps identify
 			// and isolate teleport traffic.
 			opts := &armpolicy.ClientOptions{
@@ -182,13 +189,11 @@ func (cfg *azureRegisterConfig) CheckAndSetDefaults(ctx context.Context) error {
 	return nil
 }
 
-type azureRegisterOption func(cfg *azureRegisterConfig)
-
 // parseAndVeryAttestedData verifies that an attested data document was signed
 // by Azure. If verification is successful, it returns the ID of the VM that
 // produced the document.
 func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge string, certs []*x509.Certificate) (subscriptionID, vmID string, err error) {
-	var signedAD signedAttestedData
+	var signedAD SignedAttestedData
 	if err := utils.FastUnmarshal(adBytes, &signedAD); err != nil {
 		return "", "", trace.Wrap(err)
 	}
@@ -206,7 +211,7 @@ func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge s
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
-	var ad attestedData
+	var ad AttestedData
 	if err := utils.FastUnmarshal(p7.Content, &ad); err != nil {
 		return "", "", trace.Wrap(err)
 	}
@@ -244,14 +249,14 @@ func parseAndVerifyAttestedData(ctx context.Context, adBytes []byte, challenge s
 // correct Azure VM. Returns the Azure join attributes
 func verifyVMIdentity(
 	ctx context.Context,
-	cfg *azureRegisterConfig,
+	cfg *AzureJoinConfig,
 	accessToken,
 	subscriptionID,
 	vmID string,
 	requestStart time.Time,
 	logger *slog.Logger,
 ) (joinAttrs *workloadidentityv1pb.JoinAttrsAzure, err error) {
-	tokenClaims, err := cfg.verify(ctx, accessToken)
+	tokenClaims, err := cfg.Verify(ctx, accessToken)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -270,11 +275,11 @@ func verifyVMIdentity(
 
 	expectedClaims := jwt.Expected{
 		Issuer:   expectedIssuer,
-		Audience: jwt.Audience{azureAccessTokenAudience},
+		Audience: jwt.Audience{AzureAccessTokenAudience},
 		Time:     requestStart,
 	}
 
-	if err := tokenClaims.AsJWTClaims().Validate(expectedClaims); err != nil {
+	if err := tokenClaims.asJWTClaims().Validate(expectedClaims); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -299,7 +304,7 @@ func verifyVMIdentity(
 		Token:     accessToken,
 		ExpiresOn: tokenClaims.GetExpiration(),
 	})
-	vmClient, err := cfg.getVMClient(subscriptionID, tokenCredential)
+	vmClient, err := cfg.GetVMClient(subscriptionID, tokenCredential)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -339,7 +344,7 @@ func verifyVMIdentity(
 }
 
 // claimsToIdentifiers returns the vm identifiers from the provided claims.
-func claimsToIdentifiers(tokenClaims *accessTokenClaims) (subscriptionID, resourceGroupID string, err error) {
+func claimsToIdentifiers(tokenClaims *AccessTokenClaims) (subscriptionID, resourceGroupID string, err error) {
 	// xms_az_rid claim is omitted when the VM is assigned a System-Assigned Identity.
 	// The xms_mirid claim should be used instead.
 	rid := cmp.Or(tokenClaims.AzureResourceID, tokenClaims.ManangedIdentityResourceID)
@@ -369,6 +374,7 @@ func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzur
 	}
 	return trace.AccessDenied("instance %v did not match any allow rules in token %v", vmID, token.GetName())
 }
+
 func azureResourceGroupIsAllowed(allowedResourceGroups []string, vmResourceGroup string) bool {
 	if len(allowedResourceGroups) == 0 {
 		return true
@@ -395,126 +401,78 @@ func azureJoinToAttrs(subscriptionID, resourceGroupID string) *workloadidentityv
 	}
 }
 
-func (a *Server) checkAzureRequest(
-	ctx context.Context,
-	challenge string,
-	req *proto.RegisterUsingAzureMethodRequest,
-	cfg *azureRegisterConfig,
-) (*workloadidentityv1pb.JoinAttrsAzure, error) {
-	requestStart := a.clock.Now()
-	tokenName := req.RegisterUsingTokenRequest.Token
-	provisionToken, err := a.GetToken(ctx, tokenName)
-	if err != nil {
+// CheckAzureRequestParams holds all parameters for [CheckAzureRequest].
+type CheckAzureRequestParams struct {
+	// AzureJoinConfig holds configurable options for Azure joining.
+	AzureJoinConfig *AzureJoinConfig
+	// Token is the token used for the incoming request.
+	Token *types.ProvisionTokenV2
+	// Challenge is the challenge that was issued.
+	Challenge string
+	// AttestedData is the Azure attested data that was returned by the joining
+	// client. It must include the challenge as a nonce.
+	AttestedData []byte
+	// AccessToken is the Azure access token that was returned by the joining client
+	AccessToken string
+	// Logger will be used for logging.
+	Logger *slog.Logger
+	// Clock overrides the system time.
+	Clock clockwork.Clock
+}
+
+func (p *CheckAzureRequestParams) checkAndSetDefaults() error {
+	switch {
+	case p.AzureJoinConfig == nil:
+		p.AzureJoinConfig = &AzureJoinConfig{}
+	case p.Token == nil:
+		return trace.BadParameter("Token is required")
+	case len(p.Challenge) == 0:
+		return trace.BadParameter("Challenge is required")
+	case len(p.AttestedData) == 0:
+		return trace.BadParameter("AttestedData is required")
+	case len(p.AccessToken) == 0:
+		return trace.BadParameter("AccessToken is required")
+	case p.Logger == nil:
+		return trace.BadParameter("Logger is required")
+	case p.Clock == nil:
+		p.Clock = clockwork.NewRealClock()
+	}
+	return trace.Wrap(p.AzureJoinConfig.checkAndSetDefaults())
+}
+
+// CheckAzureRequest checks an azure join request by verifying the VMs claims
+// and checking that they match an allow rule from the join token.
+func CheckAzureRequest(ctx context.Context, params CheckAzureRequestParams) (*workloadidentityv1pb.JoinAttrsAzure, error) {
+	if err := params.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if provisionToken.GetJoinMethod() != types.JoinMethodAzure {
-		return nil, trace.AccessDenied("this token does not support the Azure join method")
-	}
-	token, ok := provisionToken.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("azure join method only supports ProvisionTokenV2, '%T' was provided", provisionToken)
+	requestStart := params.Clock.Now()
+
+	subID, vmID, err := parseAndVerifyAttestedData(
+		ctx,
+		params.AttestedData,
+		params.Challenge,
+		params.AzureJoinConfig.CertificateAuthorities,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	subID, vmID, err := parseAndVerifyAttestedData(ctx, req.AttestedData, challenge, cfg.certificateAuthorities)
+	attrs, err := verifyVMIdentity(ctx, params.AzureJoinConfig, params.AccessToken, subID, vmID, requestStart, params.Logger)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	attrs, err := verifyVMIdentity(ctx, cfg, req.AccessToken, subID, vmID, requestStart, a.logger)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err := checkAzureAllowRules(vmID, attrs, token); err != nil {
+	if err := checkAzureAllowRules(vmID, attrs, params.Token); err != nil {
 		return attrs, trace.Wrap(err)
 	}
 
 	return attrs, nil
 }
 
-func generateAzureChallenge() (string, error) {
+// GenerateAzureChallenge generates a challenge for the Azure join method.
+func GenerateAzureChallenge() (string, error) {
 	challenge, err := joinutils.GenerateChallenge(base64.RawURLEncoding, 24)
 	return challenge, trace.Wrap(err)
-}
-
-// RegisterUsingAzureMethodWithOpts registers the caller using the Azure join method
-// and returns signed certs to join the cluster.
-//
-// The caller must provide a ChallengeResponseFunc which returns a
-// *proto.RegisterUsingAzureMethodRequest with a signed attested data document
-// including the challenge as a nonce.
-func (a *Server) RegisterUsingAzureMethodWithOpts(
-	ctx context.Context,
-	challengeResponse client.RegisterAzureChallengeResponseFunc,
-	opts ...azureRegisterOption,
-) (certs *proto.Certs, err error) {
-	var provisionToken types.ProvisionToken
-	var joinRequest *types.RegisterUsingTokenRequest
-	defer func() {
-		// Emit a log message and audit event on join failure.
-		if err != nil {
-			a.handleJoinFailure(ctx, err, provisionToken, nil, joinRequest)
-		}
-	}()
-
-	if legacyjoin.Disabled() {
-		return nil, trace.Wrap(legacyjoin.ErrDisabled)
-	}
-
-	cfg := &azureRegisterConfig{}
-	for _, opt := range opts {
-		opt(cfg)
-	}
-	if err := cfg.CheckAndSetDefaults(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	challenge, err := generateAzureChallenge()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	req, err := challengeResponse(challenge)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	joinRequest = req.RegisterUsingTokenRequest
-
-	if err := req.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	provisionToken, err = a.checkTokenJoinRequestCommon(ctx, req.RegisterUsingTokenRequest)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	joinAttrs, err := a.checkAzureRequest(ctx, challenge, req, cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if req.RegisterUsingTokenRequest.Role == types.RoleBot {
-		params := makeBotCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/, &workloadidentityv1pb.JoinAttrs{
-			Azure: joinAttrs,
-		})
-		certs, _, err := a.GenerateBotCertsForJoin(ctx, provisionToken, params)
-		return certs, trace.Wrap(err)
-	}
-	params := makeHostCertsParams(req.RegisterUsingTokenRequest, nil /*rawClaims*/)
-	certs, err = a.GenerateHostCertsForJoin(ctx, provisionToken, params)
-	return certs, trace.Wrap(err)
-}
-
-// RegisterUsingAzureMethod registers the caller using the Azure join method
-// and returns signed certs to join the cluster.
-//
-// The caller must provide a ChallengeResponseFunc which returns a
-// *proto.RegisterUsingAzureMethodRequest with a signed attested data document
-// including the challenge as a nonce.
-func (a *Server) RegisterUsingAzureMethod(
-	ctx context.Context,
-	challengeResponse client.RegisterAzureChallengeResponseFunc,
-) (certs *proto.Certs, err error) {
-	return a.RegisterUsingAzureMethodWithOpts(ctx, challengeResponse)
 }
 
 // fixAzureSigningAlgorithm fixes a mismatch between the object IDs of the

--- a/lib/join/azurejoin/azure_certs.go
+++ b/lib/join/azurejoin/azure_certs.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -49,14 +48,9 @@ func isAllowedDomain(cn string, domains []string) bool {
 }
 
 // getAzureIssuerCert fetches a x509 certificate's issuing certificate.
-func getAzureIssuerCert(ctx context.Context, cert *x509.Certificate) (*x509.Certificate, error) {
+func getAzureIssuerCert(ctx context.Context, cert *x509.Certificate, httpClient utils.HTTPDoClient) (*x509.Certificate, error) {
 	if len(cert.IssuingCertificateURL) == 0 {
 		return nil, nil
-	}
-
-	httpClient, err := defaults.HTTPClient()
-	if err != nil {
-		return nil, trace.Wrap(err)
 	}
 
 	// Azure sends only one issuing cert.

--- a/lib/join/azurejoin/azure_certs.go
+++ b/lib/join/azurejoin/azure_certs.go
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth
+package azurejoin
 
 import (
 	"context"

--- a/lib/join/azurejoin/azure_certs_test.go
+++ b/lib/join/azurejoin/azure_certs_test.go
@@ -16,14 +16,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package auth_test
+package azurejoin
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/gravitational/teleport/lib/auth"
 )
 
 func TestIsAllowedDomain(t *testing.T) {
@@ -71,7 +69,7 @@ func TestIsAllowedDomain(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.assert(t, auth.IsAllowedDomain(tc.url, allowedDomains))
+			tc.assert(t, isAllowedDomain(tc.url, allowedDomains))
 		})
 	}
 }

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -204,6 +204,7 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	case types.JoinMethodUnspecified:
 		// leave joinMethodPtr nil to let the server pick based on the token
 	case types.JoinMethodToken,
+		types.JoinMethodAzure,
 		types.JoinMethodAzureDevops,
 		types.JoinMethodBitbucket,
 		types.JoinMethodBoundKeypair,
@@ -306,6 +307,8 @@ func joinWithMethod(
 	switch types.JoinMethod(method) {
 	case types.JoinMethodToken:
 		return tokenJoin(stream, clientParams)
+	case types.JoinMethodAzure:
+		return azureJoin(ctx, stream, joinParams, clientParams)
 	case types.JoinMethodAzureDevops:
 		if joinParams.IDToken == "" {
 			joinParams.IDToken, err = azuredevops.NewIDTokenSource(os.Getenv).GetIDToken(ctx)

--- a/lib/join/joinclient/join_azure.go
+++ b/lib/join/joinclient/join_azure.go
@@ -1,0 +1,77 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package joinclient
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/cloud/imds/azure"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+)
+
+func azureJoin(ctx context.Context, stream messages.ClientStream, joinParams JoinParams, clientParams messages.ClientParams) (messages.Response, error) {
+	// The Azure join method involves the following messages:
+	//
+	// client->server ClientInit
+	// client<-server ServerInit
+	// client->server AzureInit
+	// client<-server AzureChallenge
+	// client->server AzureChallengeSolution
+	// client<-server Result
+	//
+	// At this point the ServerInit messages has already been received, what's
+	// left is to send the AzureInit message, handle the challenge-response, and
+	// receive and return the final result.
+	if err := stream.Send(&messages.AzureInit{
+		ClientParams: clientParams,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending AzureInit")
+	}
+
+	challenge, err := messages.RecvResponse[*messages.AzureChallenge](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving AzureChallenge")
+	}
+
+	imds := joinParams.AzureParams.IMDSClient
+	if imds == nil {
+		imds = azure.NewInstanceMetadataClient()
+	}
+	if !imds.IsAvailable(ctx) {
+		return nil, trace.AccessDenied("could not reach instance metadata. Is Teleport running on an Azure VM?")
+	}
+	ad, err := imds.GetAttestedData(ctx, challenge.Challenge)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	accessToken, err := imds.GetAccessToken(ctx, joinParams.AzureParams.ClientID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := stream.Send(&messages.AzureChallengeSolution{
+		AttestedData: ad,
+		AccessToken:  accessToken,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending AzureChallengeSolution")
+	}
+
+	result, err := stream.Recv()
+	return result, trace.Wrap(err, "receiving join result")
+}

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
+	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/bitbucket"
 	"github.com/gravitational/teleport/lib/join/circleci"
 	"github.com/gravitational/teleport/lib/join/ec2join"
@@ -104,6 +105,7 @@ type AuthService interface {
 	GetK8sOIDCValidator() *kubetoken.KubernetesOIDCTokenValidator
 	GetSpaceliftIDTokenValidator() spacelift.Validator
 	GetTerraformIDTokenValidator() terraformcloud.Validator
+	GetAzureJoinConfig() *azurejoin.AzureJoinConfig
 	services.Presence
 }
 
@@ -296,6 +298,8 @@ func (s *Server) handleJoinMethod(
 	joinMethod types.JoinMethod,
 ) (messages.Response, error) {
 	switch joinMethod {
+	case types.JoinMethodAzure:
+		return s.handleAzureJoin(stream, authCtx, clientInit, token)
 	case types.JoinMethodAzureDevops:
 		return s.handleOIDCJoin(stream, authCtx, clientInit, token, s.validateAzureDevopsToken)
 	case types.JoinMethodBitbucket:

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -77,7 +77,7 @@ func (s *Server) handleAzureJoin(
 		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
 	}
 
-	// Verify the client's idenitty and make sure it matches an allow rule in the provision token.
+	// Verify the client's identity and make sure it matches an allow rule in the provision token.
 	claims, err := azurejoin.CheckAzureRequest(stream.Context(), azurejoin.CheckAzureRequestParams{
 		AzureJoinConfig: s.cfg.AuthService.GetAzureJoinConfig(),
 		Token:           ptv2,

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -1,0 +1,108 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package join
+
+import (
+	"github.com/gravitational/trace"
+
+	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/azurejoin"
+	"github.com/gravitational/teleport/lib/join/internal/authz"
+	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/provision"
+)
+
+// handleAzureJoin handles join attempts for the Azure join method.
+//
+// The Azure join method involves the following messages:
+//
+// client->server ClientInit
+// client<-server ServerInit
+// client->server AzureInit
+// client<-server AzureChallenge
+// client->server AzureChallengeSolution
+// client<-server Result
+//
+// At this point the ServerInit message has already been sent, what's left is
+// to receive the AzureInit message, handle the challenge-response, and send the
+// final result if everything checks out.
+func (s *Server) handleAzureJoin(
+	stream messages.ServerStream,
+	authCtx *authz.Context,
+	clientInit *messages.ClientInit,
+	token provision.Token,
+) (messages.Response, error) {
+	// Receive the AzureInit message from the client.
+	azureInit, err := messages.RecvRequest[*messages.AzureInit](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving AzureInit message")
+	}
+	// Set any diagnostic info from the ClientParams.
+	setDiagnosticClientParams(stream.Diagnostic(), &azureInit.ClientParams)
+
+	// Generate and send the challenge.
+	challenge, err := azurejoin.GenerateAzureChallenge()
+	if err != nil {
+		return nil, trace.Wrap(err, "generating challenge")
+	}
+	if err := stream.Send(&messages.AzureChallenge{
+		Challenge: challenge,
+	}); err != nil {
+		return nil, trace.Wrap(err, "sending AzureChallenge")
+	}
+
+	// Receive the solution from the client.
+	solution, err := messages.RecvRequest[*messages.AzureChallengeSolution](stream)
+	if err != nil {
+		return nil, trace.Wrap(err, "receiving AzureChallengeSolution")
+	}
+
+	ptv2, ok := token.(*types.ProvisionTokenV2)
+	if !ok {
+		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
+	}
+
+	// Verify the client's idenitty and make sure it matches an allow rule in the provision token.
+	claims, err := azurejoin.CheckAzureRequest(stream.Context(), azurejoin.CheckAzureRequestParams{
+		AzureJoinConfig: s.cfg.AuthService.GetAzureJoinConfig(),
+		Token:           ptv2,
+		Challenge:       challenge,
+		AttestedData:    solution.AttestedData,
+		AccessToken:     solution.AccessToken,
+		Logger:          log,
+		Clock:           s.cfg.AuthService.GetClock(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err, "checking Azure challenge solution")
+	}
+
+	// Make and return the final result message.
+	result, err := s.makeResult(
+		stream.Context(),
+		stream.Diagnostic(),
+		authCtx,
+		clientInit,
+		&azureInit.ClientParams,
+		token,
+		nil, // rawClaims
+		&workloadidentityv1pb.JoinAttrs{
+			Azure: claims,
+		},
+	)
+	return result, trace.Wrap(err)
+}

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -72,6 +72,15 @@ func (s *Server) handleAzureJoin(
 		return nil, trace.Wrap(err, "receiving AzureChallengeSolution")
 	}
 
+	switch {
+	case len(solution.AttestedData) == 0:
+		return nil, trace.BadParameter("client did not send attested data")
+	case len(solution.Intermediate) == 0:
+		return nil, trace.BadParameter("client did not send intermediate CAs")
+	case len(solution.AccessToken) == 0:
+		return nil, trace.BadParameter("client did not send access token")
+	}
+
 	ptv2, ok := token.(*types.ProvisionTokenV2)
 	if !ok {
 		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
@@ -83,6 +92,7 @@ func (s *Server) handleAzureJoin(
 		Token:           ptv2,
 		Challenge:       challenge,
 		AttestedData:    solution.AttestedData,
+		Intermediate:    solution.Intermediate,
 		AccessToken:     solution.AccessToken,
 		Logger:          log,
 		Clock:           s.cfg.AuthService.GetClock(),


### PR DESCRIPTION
Part of [RFD 27e](https://github.com/gravitational/teleport.e/blob/master/rfd/0027e-auth-assigned-uuids.md)

This PR adds support for the Azure join method to the new join service and client. Both the new and legacy gRPC servers are updated to use common logic that verifies the request.

Depends on https://github.com/gravitational/teleport/pull/61128

Manual Test Plan:

- [x] Azure VM can join via new join service
- [x] Join attempt denied with subscription mismatch
- [x] Join attempt denied with resource group mismatch
- [x] Older agent version can join via legacy join service