### PR TITLE
Remove unused ProcessReloadContext

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3652,7 +3652,7 @@ func (process *TeleportProcess) initSSH() error {
 		} else {
 			logger.InfoContext(process.ExitContext(), "Shutting down gracefully.")
 			ctx := payloadContext(event.Payload)
-			restartingOnGracefulShutdown = services.IsProcessReloading(ctx) || services.HasProcessForked(ctx)
+			restartingOnGracefulShutdown = services.HasProcessForked(ctx)
 			warnOnErr(ctx, s.Shutdown(ctx), logger)
 		}
 

--- a/lib/services/process.go
+++ b/lib/services/process.go
@@ -20,17 +20,6 @@ package services
 
 import "context"
 
-// ProcessReloadContext adds a flag to the context to indicate the Teleport
-// process is reloading.
-func ProcessReloadContext(parent context.Context) context.Context {
-	return addFlagToContext[processReloadFlag](parent)
-}
-
-// IsProcessReloading returns true if the Teleport process is reloading.
-func IsProcessReloading(ctx context.Context) bool {
-	return getFlagFromContext[processReloadFlag](ctx)
-}
-
 // ProcessForkedContext adds a flag to the context to indicate the Teleport
 // process has running forked child(ren).
 func ProcessForkedContext(parent context.Context) context.Context {
@@ -47,12 +36,6 @@ func HasProcessForked(ctx context.Context) bool {
 // should be deleted based on the process shutdown context.
 func ShouldDeleteServerHeartbeatsOnShutdown(ctx context.Context) bool {
 	switch {
-	// During a reload, deregistration of the old heartbeats by the old
-	// instance may race with the creation of the new heartbeats by the new
-	// instance. Thus skip deleting the heartbeats to prevent them from
-	// disappearing momentarily after the reload.
-	case IsProcessReloading(ctx):
-		return false
 	// A child process can be forked to upgrade the Teleport binary. The child
 	// will take over the heartbeats so do NOT delete them in that case. In
 	// worst case scenarios if the child fails to register new heartbeats, the
@@ -72,5 +55,4 @@ func getFlagFromContext[FlagType any](ctx context.Context) bool {
 	return ok
 }
 
-type processReloadFlag struct{}
 type processForkedFlag struct{}

--- a/lib/services/process_test.go
+++ b/lib/services/process_test.go
@@ -31,8 +31,5 @@ func TestShouldDeleteServerHeartbeatsOnShutdown(t *testing.T) {
 
 	require.True(t, ShouldDeleteServerHeartbeatsOnShutdown(ctx))
 	require.True(t, ShouldDeleteServerHeartbeatsOnShutdown(context.WithValue(ctx, contextKey("key"), "value")))
-	require.False(t, ShouldDeleteServerHeartbeatsOnShutdown(ProcessReloadContext(ctx)))
 	require.False(t, ShouldDeleteServerHeartbeatsOnShutdown(ProcessForkedContext(ctx)))
-	require.False(t, ShouldDeleteServerHeartbeatsOnShutdown(ProcessReloadContext(ProcessForkedContext(ctx))))
-	require.False(t, ShouldDeleteServerHeartbeatsOnShutdown(context.WithValue(ProcessReloadContext(ctx), contextKey("key"), "value")))
 }


### PR DESCRIPTION
`ProcessReloadContext`/`IsProcessReloading` are not used in .e neither.

`ShouldDeleteServerHeartbeatsOnShutdown` is used in .e, but since, nothing is setting `ProcessReloadContext` it's safe to remove the key.

Backports

- [x] https://github.com/gravitational/teleport/pull/61170