### PR TITLE
[v18] MWI Docs: Move use-cases into subfolder (#60944)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -766,7 +766,7 @@
     },
     {
       "source": "/machine-workload-identity/mwi-use-cases/mwi-ci-cd/",
-      "destination": "/machine-workload-identity/mwi-ci-cd/",
+      "destination": "/machine-workload-identity/use-cases/mwi-ci-cd/",
       "permanent": true
     },
     {
@@ -2302,6 +2302,31 @@
     {
       "source": "/reference/user-types/",
       "destination": "/reference/access-controls/user-types/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-workload-identity/ai-agents-mwi/",
+      "destination": "/machine-workload-identity/use-cases/ai-agents-mwi/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-workload-identity/hybrid-multi-mwi/",
+      "destination": "/machine-workload-identity/use-cases/hybrid-multi-mwi/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-workload-identity/iac-mwi/",
+      "destination": "/machine-workload-identity/use-cases/iac-mwi/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-workload-identity/mwi-ci-cd/",
+      "destination": "/machine-workload-identity/use-cases/mwi-ci-cd/",
+      "permanent": true
+    },
+    {
+      "source": "/machine-workload-identity/workload-mwi/",
+      "destination": "/machine-workload-identity/use-cases/workload-mwi/",
       "permanent": true
     },
     {

--- a/docs/pages/machine-workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/getting-started.mdx
@@ -2,6 +2,7 @@
 title: Machine and Workload Identity Getting Started Guide
 description: Getting started with Teleport Machine and Workload Identity
 sidebar_label: Getting Started
+sidebar_position: 2
 videoBanner: YzVK2tr6u-U
 tags:
  - get-started
@@ -12,8 +13,8 @@ tags:
 {/* lint disable page-structure remark-lint */}
 
 Teleport Machine and Workload Identity (MWI) provides secure access for Non-Human Identities across multiple platforms
-and resource types, supporting everything from [Infrastructure-as-Code](../machine-workload-identity/iac-mwi.mdx)
-workflows to [AI agent](../machine-workload-identity/ai-agents-mwi.mdx) operations. This guide focuses on a popular
+and resource types, supporting everything from [Infrastructure-as-Code](./use-cases/iac-mwi.mdx)
+workflows to [AI agent](./use-cases/ai-agents-mwi.mdx) operations. This guide focuses on a popular
 implementation: executing commands on deployment targets through CI/CD pipelines. Even if your specific use case differs,
 this guide covers the fundamental MWI setup process, after which you can reference the dedicated use case pages for tool-specific guidance.
 

--- a/docs/pages/machine-workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/introduction.mdx
@@ -2,6 +2,7 @@
 title: "Introduction to Machine & Workload Identity"
 description: "Replace static secrets with secure, short-lived identities for machines and workloads."
 sidebar_label: "Introduction"
+sidebar_position: 1
 tags:
  - mwi
  - infrastructure-identity
@@ -38,7 +39,7 @@ Zero Trust Access & Flexible Workload Identity can work together to create a com
 
 ### CI/CD pipeline with end-to-end authentication
 
-A [CI/CD system](../machine-workload-identity/mwi-ci-cd.mdx) securely deploys services to Kubernetes and establishes secure communication channels between them:
+A [CI/CD system](./use-cases/mwi-ci-cd.mdx) securely deploys services to Kubernetes and establishes secure communication channels between them:
 
 - The pipeline authenticates through the proxy to deploy to Kubernetes and receives credentials to interact with cloud APIs (e.g., to push container images)
 - Services deployed by the pipeline receive SPIFFE identities for mutual TLS. The pipeline manages the identity lifecycle for the services it deploys

--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -56,27 +56,27 @@ Teleport Machine & Workload Identity replaces static secrets across your infrast
     {
       title: "Secure CI/CD pipelines with identity-based auth",
       description: "Replace long-lived secrets in CI/CD pipelines",
-      href: "./mwi-ci-cd/",
+      href: "./use-cases/mwi-ci-cd/",
     },  
     {
       title: "Guard infrastructure as code with short-lived certs",
       description: "Manage IaC workflows in Terraform and Pulumi",
-      href: "./iac-mwi/",
+      href: "./use-cases/iac-mwi/",
     },
     {
       title: "Configure workload-to-workload authentication",
       description: "Set up service-to-service authentication with mTLS",
-      href: "./workload-mwi/",
+      href: "./use-cases/workload-mwi/",
     },  
     {
       title: "Manage AI agent identities with role-based access",
       description: "Use RBAC to manage autonomous agents and processes",
-      href: "./ai-agents-mwi/",
+      href: "./use-cases/ai-agents-mwi/",
     },
     {
       title: "Configure hybrid & multi-cloud authentication",
       description: "Set up universal identities across cloud platforms",
-      href: "./hybrid-multi-mwi/",
+      href: "./use-cases/hybrid-multi-mwi/",
     },
   ]}
 />

--- a/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/ai-agents-mwi.mdx
@@ -1,6 +1,7 @@
 ---
 title: AI Agents with Machine & Workload Identity
-description: Managing AI Agents with Machine & Workload Identity
+description: Use Machine & Workload Identity to securely grant agentic AI access to infrastructure.
+sidebar_label: Agentic AI
 tags:
  - conceptual
  - mwi
@@ -13,8 +14,8 @@ Security must be enforced deterministically; AI agents cannot be trusted to foll
 Teleport solves this by issuing each agent its own identity and requiring the agent's actions (for example, database queries) to flow through the Teleport proxy. 
 This allows Teleport to apply Role-Based Access Control (RBAC) at both the network and protocol level.
 
-Teleport can secure any type of infrastructure it supports, such as SSH servers, Kubernetes clusters, databases, or MCP servers, when accessed by agents. 
-All queries, commands, and requests executed by the agent are logged, providing full visibility and [auditability](../reference/deployment/monitoring/audit.mdx).
+Teleport can secure infrastructure components such as SSH servers, Kubernetes clusters, databases, or MCP servers, when accessed by agents.
+All queries, commands, and requests executed by the agent are logged, providing full visibility and [auditability](../../reference/deployment/monitoring/audit.mdx).
 
 ## Interested in a design partnership?
 

--- a/docs/pages/machine-workload-identity/use-cases/hybrid-multi-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/hybrid-multi-mwi.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hybrid & Multi-Cloud with Machine & Workload Identity
-description: Managing hybrid and multi-cloud systems with Machine & Workload Identity
+description: Use Machine & Workload Identity to streamline the management of identity and access for machines and workloads across cloud providers and on-prem environments.
+sidebar_label: Hybrid & Multi-Cloud
 tags:
  - conceptual
  - mwi
@@ -44,7 +45,7 @@ Teleport issues credentials compatible with all major cloud providers that can a
 
 ## Secure and auditable access with ephemeral credentials
 
-Teleport generates a credential in x.509 or JWT form, compatible with:
+Teleport generates a credential in X.509 or JWT form, compatible with:
 
 - AWS IAM Roles Anywhere
 - Google Cloud Workload Identity Federation

--- a/docs/pages/machine-workload-identity/use-cases/iac-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/iac-mwi.mdx
@@ -1,6 +1,7 @@
 ---
 title: Infrastructure-as-Code with Machine & Workload Identity
-description: Configuring IaC with Machine & Workload Identity
+description: Use Machine & Workload Identity to replace the use of static secrets in Infrastructure-as-Code workflows.
+sidebar_label: Infrastructure-as-Code
 tags:
  - conceptual
  - mwi
@@ -58,4 +59,4 @@ When your IaC runs, Teleport generates a short-lived credential compatible with:
 The cloud provider issues a temporary credential linked to an IAM role, which allows the IaC workflow to perform its tasks. This credential exists only for the duration of the run and automatically expires once it completes. 
 By design, this minimizes the risk of credential exposure and eliminates the need for manual rotation or long-term management. Because all major cloud providers support this method of authentication, IaC pipelines that manage resources across multiple clouds can rely on a single mechanism instead of juggling separate credential processes. 
 
-Teleport further enhances this model by recording every credential issuance in a comprehensive [audit log](../reference/deployment/monitoring/audit.mdx), simplifying compliance and reporting.
+Teleport further enhances this model by recording every credential issuance in a comprehensive [audit log](../../reference/deployment/monitoring/audit.mdx), simplifying compliance and reporting.

--- a/docs/pages/machine-workload-identity/use-cases/mwi-ci-cd.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/mwi-ci-cd.mdx
@@ -1,6 +1,7 @@
 ---
 title: CI/CD with Machine & Workload Identity
-description: Configuring CI/CD with Machine & Workload Identity
+description: Use Machine & Workload Identity to replace static secrets in CI/CD pipelines for accessing servers, databases, Kubernetes clusters and applications.
+sidebar_label: CI/CD
 tags:
  - ci-cd
  - conceptual
@@ -85,7 +86,7 @@ API endpoints and full audit visibility.
 
 ### Further reading
 
-- [Architecture](../reference/architecture/machine-id-architecture.mdx): A technical deep-dive into how Machine ID
+- [Architecture](../../reference/architecture/machine-id-architecture.mdx): A technical deep-dive into how Machine ID
   works.
-- [Reference](../reference/machine-workload-identity/machine-workload-identity.mdx): Complete documentation of available
+- [Reference](../../reference/machine-workload-identity/machine-workload-identity.mdx): Complete documentation of available
   configuration options.

--- a/docs/pages/machine-workload-identity/use-cases/use-cases.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/use-cases.mdx
@@ -1,0 +1,12 @@
+---
+title: Machine & Workload Identity Use Cases
+description: Popular use cases for Teleport Machine & Workload Identity
+sidebar_label: Use Cases
+sidebar_position: 3
+tags:
+ - conceptual
+ - mwi
+ - infrastructure-identity
+---
+
+<DocCardList />

--- a/docs/pages/machine-workload-identity/use-cases/workload-mwi.mdx
+++ b/docs/pages/machine-workload-identity/use-cases/workload-mwi.mdx
@@ -1,6 +1,7 @@
 ---
 title: Service to Service mTLS with Machine & Workload Identity
-description: Managing Service to Service mTLS with Machine & Workload Identity
+description: Use Machine & Workload Identity to issue flexible, short-lived cryptographic identity documents for service to service authentication.
+sidebar_label: Service to Service mTLS
 tags:
  - conceptual
  - mwi
@@ -16,8 +17,8 @@ more secure and reliable.
 ## Eliminate secrets from your applications
 
 Teleport issues special credentials to applications in the form of x.509 certificates or JWTs, after 
-verifying their identity (to get started, see [Introduction to Workload Identity](workload-identity/introduction.mdx). 
-These credentials are automatically rotated every 20 minutes by default. They contain a URI that 
+verifying their identity (to get started, see [Introduction to Workload Identity](../workload-identity/introduction.mdx).
+These credentials are automatically rotated every 20 minutes by default. They contain a URI that
 uniquely identifies the application. Applications using the credentials automatically gain mTLS, 
 and can verify that a request or response not only comes from a trusted certificate, but from a specific trusted application. 
 This makes it possible to guarantee separation of tenants, geographic areas, etc.
@@ -31,5 +32,5 @@ with a wide ecosystem of libraries and SDKs.
 
 ### Further reading
 
-- [Best Practices for Teleport Workload Identity](./workload-identity/best-practices.mdx): Learn how Teleport verifies applications and issues credentials
-- [Introduction to SPIFFE:](./workload-identity/spiffe.mdx) Learn about the open-source standard for workload identities and federation
+- [Best Practices for Teleport Workload Identity](../workload-identity/best-practices.mdx): Learn how Teleport verifies applications and issues credentials
+- [Introduction to SPIFFE:](../workload-identity/spiffe.mdx) Learn about the open-source standard for workload identities and federation


### PR DESCRIPTION
Backport #60944