### PR TITLE
Kubernetes: Handle GOAWAY requests

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -720,8 +720,23 @@ func (f *Forwarder) writeResponseErrorToBody(rw http.ResponseWriter, respErr err
 	http.Error(rw, respErr.Error(), http.StatusInternalServerError)
 }
 
-// formatStatusResponseError formats the error response into a kube Status object.
+// formatForwardResponseError handles errors returned from requests to the Kubernetes API.
+// Any errors produced as a result of a GOAWAY request are forwarded to users as [http.StatusTooManyRequests]
+// with a Retry-After header set to inform clients that they should retry the request. All
+// other errors are formatted as a [metav1.Status] and written to the [http.ResponseWriter].
 func (f *Forwarder) formatStatusResponseError(rw http.ResponseWriter, respErr error) {
+	// This detects failed requests that were terminated by the server due to GOAWAY. There
+	// is no direct way to detect these errors. No exported constants or error types exist from the
+	// standard library, see https://github.com/golang/net/blob/5ac9daca088ab4f378d7df849f6c7d28bea86071/http2/transport.go#L694.
+	// When a failed request is found, we return a response that indicates  to clients that they
+	// should retry the request themselves.
+	if errString := respErr.Error(); strings.HasSuffix(errString, `after Request.Body was written; define Request.GetBody to avoid this error`) &&
+		strings.Contains(errString, `http2: Transport: cannot retry err`) {
+		rw.Header().Set("Retry-After", "1")
+		rw.WriteHeader(http.StatusTooManyRequests)
+		return
+	}
+
 	code := trace.ErrorToCode(respErr)
 	status := &metav1.Status{
 		Status: metav1.StatusFailure,


### PR DESCRIPTION
This is an attempt to address #57766.

When a request is terminated because the upstream Kubernetes API Server GOAWAY chance is exceeded, clients are informed to retry by replying with a 429 status code and a Retry-After header.

This deviates from the approaches taken in https://github.com/gravitational/teleport/pull/57881 and https://github.com/gravitational/teleport/pull/60695 to favor simplicity and avoid buffering request data in a teleport process. The downside to this approach is that it requires clients to properly handle retry requests. Since we cannot guarantee that every Kubernetes client used by customers will properly retry a request I've opted not close the linked issue as a result of this change. Instead we'll wait for feedback from customers that have been experiencing this issue to see if this truly resolves the problem for them. At which time I'll circle back and close the issue. If this doesn't remediate the problems, then we can pursue more expensive solutions similar to those taken in the linked PRs.


changelog: GOAWAY errors received from Kubernetes API Servers configured with a non-zero --goaway-chance are now forward to clients to be retried.


### Manual Testing

Testing was adapted from https://github.com/gravitational/teleport/pull/57881 and https://github.com/gravitational/teleport/pull/60695 on a local Kubernetes cluster and an EKS cluster.

#### --goaway-chance=0.0 prior to this change

- [x] manually smoke tested various kubectl commands 
- [x] ran the test scripts from the linked PRs without errors

#### --goaway-chance=0.0 with this change

- [x] manually smoke tested various kubectl commands 
- [x] ran the test scripts from the linked PRs without errors

#### --goaway-chance=0.2 prior to this change

- [x] manually smoke tested various kubectl commands 
- [x] ran the test scripts from the linked PRs with errors

#### --goaway-chance=0.2 with this change

- [x] manually smoke tested various kubectl commands 
- [x] ran the test scripts from the linked PRs without errors
