### PR TITLE
Buddy: Deflake TestPortForwardProxy_run_connsClosed

### DIFF
--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -454,10 +454,10 @@ func TestPortForwardProxy_run_connsClosed(t *testing.T) {
 		}
 	}, 5*time.Second, 100*time.Millisecond, "streams werent properly removed from targetConn")
 
-	require.Eventually(t, func() bool {
-		return sourceConn.streamsClosed()
-	}, 5*time.Second, 100*time.Millisecond, "sourceConn streams not closed")
-	require.True(t, targetConn.streamsClosed(), "targetConn streams not closed")
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		assert.True(t, sourceConn.streamsClosed(), "sourceConn streams not closed")
+		assert.True(t, targetConn.streamsClosed(), "targetConn streams not closed")
+	}, 15*time.Second, 100*time.Millisecond, "streams not closed")
 }
 
 type fakeSPDYStream struct {

--- a/lib/kube/proxy/portforward_test.go
+++ b/lib/kube/proxy/portforward_test.go
@@ -454,7 +454,9 @@ func TestPortForwardProxy_run_connsClosed(t *testing.T) {
 		}
 	}, 5*time.Second, 100*time.Millisecond, "streams werent properly removed from targetConn")
 
-	require.True(t, sourceConn.streamsClosed(), "sourceConn streams not closed")
+	require.Eventually(t, func() bool {
+		return sourceConn.streamsClosed()
+	}, 5*time.Second, 100*time.Millisecond, "sourceConn streams not closed")
 	require.True(t, targetConn.streamsClosed(), "targetConn streams not closed")
 }
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/60157.

Verified the change with the following test.

```
go test -c -race /src/teleport/lib/kube/proxy
docker run --cpus="0.15" -v/src/teleport:/teleport golang:1.25.1-bookworm /teleport/proxy.test -test.count=1000 -test.timeout=120m -test.failfast -test.v  -test.run "TestPortForwardProxy_run_connsClosed"
```