### PR TITLE
ESLint: Enable `preserve-caught-error`

### DIFF
--- a/web/packages/build/eslint.config.mjs
+++ b/web/packages/build/eslint.config.mjs
@@ -162,6 +162,13 @@ export default tseslint.config(
       // https://github.com/facebook/react/issues/34289
       // https://github.com/facebook/react/issues/34313
       'react-hooks/preserve-manual-memoization': 'off',
+
+      'preserve-caught-error': [
+        'error',
+        {
+          requireCatchParameter: true,
+        },
+      ],
     },
   },
   {

--- a/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx
@@ -219,8 +219,8 @@ export function parseRepoAddress(repoAddr: string): {
   let url;
   try {
     url = new URL(repoAddr);
-  } catch {
-    throw new Error('Must be a valid URL');
+  } catch (error) {
+    throw new Error('Must be a valid URL', { cause: error });
   }
 
   const paths = url.pathname.split('/');

--- a/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
+++ b/web/packages/teleport/src/Integrations/Operations/useIntegrationOperation.ts
@@ -67,7 +67,7 @@ export function useIntegrationOperation() {
           },
         });
       } catch (err) {
-        throw new Error(`Health check failed: ${err}`);
+        throw new Error(`Health check failed: ${err}`, { cause: err });
       }
     }
   }

--- a/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
+++ b/web/packages/teleport/src/components/ReAuthenticate/useReAuthenticate.ts
@@ -93,7 +93,7 @@ export default function useReAuthenticate({
             totpCode
           );
         } catch (err) {
-          throw new Error(getReAuthenticationErrorMessage(err));
+          throw new Error(getReAuthenticationErrorMessage(err), { cause: err });
         }
 
         try {

--- a/web/packages/teleterm/src/mainProcess/loadInstallationId/loadInstallationId.ts
+++ b/web/packages/teleterm/src/mainProcess/loadInstallationId/loadInstallationId.ts
@@ -46,7 +46,8 @@ function writeInstallationId(filePath: string): string {
     fs.writeFileSync(filePath, newId);
   } catch (error) {
     throw new Error(
-      `Could not write installation_id to ${filePath}, ${error.message}`
+      `Could not write installation_id to ${filePath}, ${error.message}`,
+      { cause: error }
     );
   }
   return newId;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Setup.tsx
@@ -241,7 +241,8 @@ function AgentSetup() {
                 !error.isResolvableWithRelogin
               ) {
                 throw new Error(
-                  `Cannot set up the role: ${error.message}. Contact your administrator for permissions to manage users and roles.`
+                  `Cannot set up the role: ${error.message}. Contact your administrator for permissions to manage users and roles.`,
+                  { cause: error }
                 );
               }
               throw error;


### PR DESCRIPTION
* https://github.com/gravitational/teleport.e/pull/7545 needs to be merged first and the e ref needs to be updated before this PR gets merged.

[`preserve-caught-error`](https://eslint.org/docs/latest/rules/preserve-caught-error) complains if there's a catch block which throws a new error but does not pass the original error as the cause.

https://github.com/gravitational/teleport.e/pull/7481 removed a line with [`throw new Error(err)`](https://github.com/gravitational/teleport.e/pull/7481/files#diff-6529c03b32eeb074773225ec0a9b54d4dfcacf70474ceccf38ddefa82ae1ae1cL97) which unnecessarily wrapped the existing error with another one.

While `preserve-caught-error` would not necessarily catch it (it'd be completely fine with `throw new Error(err, {cause: err})`), it'd at least bring some attention to it by complaining about the lack of `cause` which in turn would perhaps steer the dev into `throw err`.

When I saw that line in that PR, I started looking for ESLint rules which can help with this problem. `preserve-caught-error` seemed generally useful and as there were only a couple of violations in our code base, I decided to post a PR which enables it. Adding a cause of an error should is good for debugging.

I also enabled the `requireCatchParameter: true` option for this rule. Without it, the callsite in `web/packages/teleport/src/Bots/Add/GitHubActions/useGitHubFlow.tsx` would not have been caught. This option requires that any catch block which throws an error must have the catch parameter.