### PR TITLE
[v18] Desktop Access: Gracefully Handle Invalid Smartcard Commands

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -338,24 +338,27 @@ impl ScardBackend {
         req: DeviceControlRequest<ScardIoCtlCode>,
         call: TransmitCall,
     ) -> PduResult<()> {
-        let cmd =
-            CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer).map_err(|err| {
-                pdu_other_err!(
-                    "",
-                    source:SmartcardBackendError(format!(
-                        "failed to parse smartcard command {:?}: {:?}",
-                        &call.send_buffer, err
-                    ))
-                )
-            })?;
+        let cmd = CardCommand::<TRANSMIT_DATA_LIMIT>::try_from(&call.send_buffer);
 
-        let card = self.contexts.get_card(&call.handle)?;
-        let resp = card.handle(cmd)?;
+        match cmd {
+            Ok(cmd) => {
+                let card = self.contexts.get_card(&call.handle)?;
+                let resp = card.handle(cmd)?;
 
-        self.send_device_control_response(
-            req,
-            TransmitReturn::new(ReturnCode::Success, None, resp.encode()),
-        )
+                self.send_device_control_response(
+                    req,
+                    TransmitReturn::new(ReturnCode::Success, None, resp.encode()),
+                )?;
+            }
+            Err(err) => {
+                warn!("error parsing smart card command: {:?} - {:?}", call, err);
+                self.send_device_control_response(
+                    req,
+                    TransmitReturn::new(ReturnCode::InvalidValue, None, Vec::new()),
+                )?;
+            }
+        }
+        Ok(())
     }
 
     fn handle_status(&mut self, req: DeviceControlRequest<ScardIoCtlCode>) -> PduResult<()> {


### PR DESCRIPTION
Backport #61045 to branch/v18

changelog: Improve error handling during desktop sessions that encounter unknown/invalid smartcard commands. This prevents abrupt desktop session termination with a "PDU error" message when using certain applications.
