### PR TITLE
Remove Rust Toolchain Warning on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ bpf-bytecode:
 endif
 
 .PHONY: rdpclient
-rdpclient: rustup-toolchain-warning
+rdpclient:
 ifeq ("$(with_rdpclient)", "yes")
 	$(RDPCLIENT_ENV) \
 		cargo build -p rdp-client $(if $(FIPS),--features=fips) --release --locked $(CARGO_TARGET)
@@ -1866,7 +1866,7 @@ ensure-js-deps:
 ifeq ($(WEBASSETS_SKIP_BUILD),1)
 ensure-wasm-deps:
 else
-ensure-wasm-deps: rustup-toolchain-warning ensure-wasm-bindgen ensure-wasm-opt
+ensure-wasm-deps: ensure-wasm-bindgen ensure-wasm-opt
 
 WASM_BINDGEN_VERSION = $(shell awk ' \
   $$1 == "name" && $$3 == "\"wasm-bindgen\"" { in_pkg=1; next } \
@@ -1922,26 +1922,6 @@ rustup-set-version: ; # obsoleted by toolchain file
 .PHONY: rustup-install-target-toolchain
 rustup-install-target-toolchain:
 	rustup target add $(RUST_TARGET_ARCH)
-
-
-define rust_toolchain_warning
-  The active Rust toolchain version does not match the toolchain required
-  to build Teleport. This is likely caused by a directory override. You
-  can inspect your current overrides with 'rustup show active-toolchain'
-  and clear directory overrides with 'rustup override unset'
-endef
-export rust_toolchain_warning
-
-# inspect the current active toolchain and display a warning if it doesn't
-# match the version defined in our toolchain file.
-.PHONY: rustup-toolchain-warning
-rustup-toolchain-warning: EXPECTED = $(shell $(MAKE) print-rust-toolchain-version)
-rustup-toolchain-warning:
-	@if [ "$(shell rustup show active-toolchain | cut -d'-' -f1)" != "$(EXPECTED)" ]; then \
-		echo -en "\033[31m";\
-		echo  "$$rust_toolchain_warning";\
-		echo  -en "\033[0m";\
-	fi
 
 # changelog generates PR changelog between the provided base tag and the tip of
 # the specified branch.

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ bpf-bytecode:
 endif
 
 .PHONY: rdpclient
-rdpclient:
+rdpclient: rustup-toolchain-warning
 ifeq ("$(with_rdpclient)", "yes")
 	$(RDPCLIENT_ENV) \
 		cargo build -p rdp-client $(if $(FIPS),--features=fips) --release --locked $(CARGO_TARGET)
@@ -1866,7 +1866,7 @@ ensure-js-deps:
 ifeq ($(WEBASSETS_SKIP_BUILD),1)
 ensure-wasm-deps:
 else
-ensure-wasm-deps: ensure-wasm-bindgen ensure-wasm-opt
+ensure-wasm-deps: rustup-toolchain-warning ensure-wasm-bindgen ensure-wasm-opt
 
 WASM_BINDGEN_VERSION = $(shell awk ' \
   $$1 == "name" && $$3 == "\"wasm-bindgen\"" { in_pkg=1; next } \
@@ -1922,6 +1922,31 @@ rustup-set-version: ; # obsoleted by toolchain file
 .PHONY: rustup-install-target-toolchain
 rustup-install-target-toolchain:
 	rustup target add $(RUST_TARGET_ARCH)
+
+
+define rust_toolchain_warning
+  The active Rust toolchain version does not match the toolchain required
+  to build Teleport. This is likely caused by a directory override. You
+  can inspect your current overrides with 'rustup show active-toolchain'
+  and clear directory overrides with 'rustup override unset'
+endef
+export rust_toolchain_warning
+
+# inspect the current active toolchain and display a warning if it doesn't
+# match the version defined in our toolchain file.
+.PHONY: rustup-toolchain-warning
+ifneq ($(OS),Windows_NT)
+rustup-toolchain-warning: EXPECTED = $(shell $(MAKE) print-rust-toolchain-version)
+rustup-toolchain-warning:
+	@if [ "$(shell rustup show active-toolchain | cut -d'-' -f1)" != "$(EXPECTED)" ]; then \
+		echo -en "\033[31m";\
+		echo  "$$rust_toolchain_warning";\
+		echo  -en "\033[0m";\
+	fi
+
+else
+rustup-toolchain-warning: ;
+endif
 
 # changelog generates PR changelog between the provided base tag and the tip of
 # the specified branch.


### PR DESCRIPTION
This warning was intended to help provide guidance to developers who may encounter Rust build errors after upgrading our required toolchain version. Unfortunately, this change seems to have caused an issue on our Windows runner in GHA where the build runs so slowly that it times out. 

This PR gates the warning on Windows to fix the build.