### PR TITLE
[v17] Add debug logging to `tsh` when there is a SAN mismatch connecting to Auth via Proxy

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -322,17 +322,19 @@ func formatCertError(err error) string {
 	if errors.As(err, &hostnameErr) {
 		return fmt.Sprintf(`The certificate does not match the address %v you are connecting to.
 
-This usually happens if you are connecting using an internal address or a DNS name that is not present in the certificate's Subject Alternative Names (SANs).
+  This usually happens if you are connecting using an internal address or a DNS name that is not present in the
+  certificate's Subject Alternative Names (SANs).
 
-To fix this, make sure you use the public address as configured in Teleport, or ask your administrator to add the address you are using to the proxy's certificate SANs.
+  To fix this, make sure you use the public address as configured in Teleport, or ask your administrator to add the
+  address you are using to the proxy's certificate SANs.
 
-If you know what you are doing, you can bypass this check by using the --insecure flag.
+  If you know what you are doing, you can bypass this check by using the --insecure flag.
 
 DEBUG INFO:
 
-Environment Variables: %+v
+  Environment Variables: %+v
 
-Presented Certificate: %+v
+  Presented Certificate: %+v
 `, hostnameErr.Host, os.Environ(), hostnameErr.Certificate)
 	}
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -320,10 +320,20 @@ func formatCertError(err error) string {
 
 	var hostnameErr x509.HostnameError
 	if errors.As(err, &hostnameErr) {
-		return fmt.Sprintf("Cannot establish https connection to %s:\n%s\n%s\n",
-			hostnameErr.Host,
-			hostnameErr.Error(),
-			"try a different hostname for --proxy or specify --insecure flag if you know what you're doing.")
+		return fmt.Sprintf(`The certificate does not match the address %v you are connecting to.
+
+This usually happens if you are connecting using an internal address or a DNS name that is not present in the certificate's Subject Alternative Names (SANs).
+
+To fix this, make sure you use the public address as configured in Teleport, or ask your administrator to add the address you are using to the proxy's certificate SANs.
+
+If you know what you are doing, you can bypass this check by using the --insecure flag.
+
+DEBUG INFO:
+
+Environment Variables: %+v
+
+Presented Certificate: %+v
+`, hostnameErr.Host, os.Environ(), hostnameErr.Certificate)
 	}
 
 	var certInvalidErr x509.CertificateInvalidError

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -347,7 +347,8 @@ DEBUG INFO:
     Subject: %s
     Issuer: %s
     Serial Number: %s
-    Expiration: %s
+    Not Before: %s
+    Not After: %s
     DNS Names: %v
     IP Addresses: %v`,
 			hostnameErr.Host,
@@ -355,6 +356,7 @@ DEBUG INFO:
 			hostnameErr.Certificate.Subject,
 			hostnameErr.Certificate.Issuer,
 			hostnameErr.Certificate.SerialNumber,
+			hostnameErr.Certificate.NotBefore,
 			hostnameErr.Certificate.NotAfter,
 			hostnameErr.Certificate.DNSNames,
 			hostnameErr.Certificate.IPAddresses,

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -320,7 +320,18 @@ func formatCertError(err error) string {
 
 	var hostnameErr x509.HostnameError
 	if errors.As(err, &hostnameErr) {
-		return fmt.Sprintf(`The certificate does not match the address %v you are connecting to.
+		// Filter environment variables to only include those related to proxy settings.
+		proxyEnv := make(map[string]string)
+		for _, key := range []string{
+			"https_proxy", "http_proxy", "no_proxy",
+			"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+		} {
+			if val, ok := os.LookupEnv(key); ok {
+				proxyEnv[key] = val
+			}
+		}
+
+		return fmt.Sprintf(`The certificate does not match the address %q you are attempting to connect to.
 
   This usually happens if you are connecting using an internal address or a DNS name that is not present in the
   certificate's Subject Alternative Names (SANs).
@@ -332,10 +343,10 @@ func formatCertError(err error) string {
 
 DEBUG INFO:
 
-  Environment Variables: %+v
+  Proxy Environment Variables: %v
 
-  Presented Certificate: %+v
-`, hostnameErr.Host, os.Environ(), hostnameErr.Certificate)
+  Server Certificate Details: %+v
+`, hostnameErr.Host, proxyEnv, hostnameErr.Certificate)
 	}
 
 	var certInvalidErr x509.CertificateInvalidError

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -332,7 +332,7 @@ func formatCertError(err error) string {
 				}
 			}
 
-			return fmt.Sprintf(`Cannot connect to the Auth service via the Teleport Proxy using the internal cluster domain %q.
+			return fmt.Sprintf(`Cannot connect to the Auth service via the Teleport Proxy.
 
   There might be one or more network intermediaries (like a proxy or VPN) that are modifying your connection before it
   reaches the Teleport Proxy. These intermediaries can alter how your connection is seen by the Teleport Proxy and
@@ -341,6 +341,7 @@ func formatCertError(err error) string {
   To fix this, ensure that any network intermediaries are properly configured and not interfering with your connection.
 
 DEBUG INFO:
+  Host: %s
   Proxy Environment Variables:
 %s
   Server Certificate Details:

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -332,11 +332,17 @@ func formatCertError(err error) string {
 
 		return fmt.Sprintf(`The certificate does not match the address %q you are attempting to connect to.
 
-  This usually happens if you are connecting using an internal address or a DNS name that is not present in the
-  certificate's Subject Alternative Names (SANs).
+  This usually happens for one or more of the following reasons:
 
-  To fix this, make sure you use the public address as configured in Teleport, or ask your administrator to add the
-  address you are using to the proxy's certificate SANs.
+    - You are connecting using an address that is not present in the certificate's Subject Alternative Names (SANs).
+    - The Teleport Proxy is misconfigured and is presenting a certificate that does not include its public address in the SANs.
+    - There is some network intermediary (like a proxy or VPN) that is modifying your connection that may alter how it is seen by the Teleport Proxy and routed.
+
+  To fix this, ensure the following:
+
+    - You are using the public address as configured in Teleport.
+    - The Teleport Proxy is configured to present a certificate that includes its public address in the SANs.
+    - Any network intermediaries are properly configured and not interfering with your connection.
 
   If you know what you are doing, you can bypass this check by using the --insecure flag.
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -342,6 +342,7 @@ func formatCertError(err error) string {
 
 DEBUG INFO:
   Host: %s
+
   Proxy Environment Variables:
 %s
   Server Certificate Details:

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -320,18 +320,18 @@ func formatCertError(err error) string {
 
 	var hostnameErr x509.HostnameError
 	if errors.As(err, &hostnameErr) {
-		var proxyEnvBuilder strings.Builder
-		for _, key := range []string{
-			"https_proxy", "http_proxy", "no_proxy",
-			"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
-		} {
-			if val, ok := os.LookupEnv(key); ok {
-				fmt.Fprintf(proxyEnvBuilder, "    %s: %s\n", key, val)
-			}
-		}
-
 		// Special case for connecting to Auth via Proxy using internal cluster domain.
 		if strings.HasSuffix(hostnameErr.Host, ".teleport.cluster.local") {
+			var proxyEnvBuilder strings.Builder
+			for _, key := range []string{
+				"https_proxy", "http_proxy", "no_proxy",
+				"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
+			} {
+				if val, ok := os.LookupEnv(key); ok {
+					fmt.Fprintf(&proxyEnvBuilder, "    %s: %s\n", key, val)
+				}
+			}
+
 			return fmt.Sprintf(`Cannot connect to the Auth service via the Teleport Proxy using the internal cluster domain %q.
 
   There might be one or more network intermediaries (like a proxy or VPN) that are modifying your connection before it

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -326,7 +326,7 @@ func formatCertError(err error) string {
 			"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY",
 		} {
 			if val, ok := os.LookupEnv(key); ok {
-				proxyEnvBuilder.WriteString(fmt.Sprintf("    %s: %s\n", key, val))
+				fmt.Fprintf(proxyEnvBuilder, "    %s: %s\n", key, val)
 			}
 		}
 

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -305,13 +305,18 @@ func TestFormatCertError(t *testing.T) {
 		require.Contains(t, msg, "The proxy you are connecting to has presented a certificate signed by a")
 	})
 
+	t.Run("HostnameErrorConnectingToAuth", func(t *testing.T) {
+		cert := &x509.Certificate{Raw: []byte("dummy")}
+		err := x509.HostnameError{Certificate: cert, Host: "99999999999999999999999999999999.teleport.cluster.local"}
+		msg := formatCertError(err)
+		require.Contains(t, msg, "Cannot connect to the Auth service via the Teleport Proxy using the internal cluster domain \"99999999999999999999999999999999.teleport.cluster.local\"")
+	})
+
 	t.Run("HostnameError", func(t *testing.T) {
 		cert := &x509.Certificate{Raw: []byte("dummy")}
 		err := x509.HostnameError{Certificate: cert, Host: "example.com"}
 		msg := formatCertError(err)
-		require.Contains(t, msg, "The certificate does not match the address \"example.com\"")
-		require.Contains(t, msg, "Proxy Environment Variables")
-		require.Contains(t, msg, "Server Certificate Details")
+		require.Contains(t, msg, "Cannot establish https connection to example.com")
 	})
 
 	t.Run("CertificateInvalidError", func(t *testing.T) {

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -320,6 +320,12 @@ func TestFormatCertError(t *testing.T) {
 		require.Contains(t, msg, "The certificate presented by the proxy is invalid")
 	})
 
+	t.Run("CertificateNotTrustedError", func(t *testing.T) {
+		err := errors.New("certificate is not trusted")
+		msg := formatCertError(err)
+		require.Contains(t, msg, "The proxy you are connecting to has presented a certificate signed by")
+	})
+
 	t.Run("NoMatch", func(t *testing.T) {
 		err := errors.New("some other error")
 		msg := formatCertError(err)

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2025  Gravitational, Inc.
+ * Copyright (C) 2023  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -309,7 +309,8 @@ func TestFormatCertError(t *testing.T) {
 		cert := &x509.Certificate{Raw: []byte("dummy")}
 		err := x509.HostnameError{Certificate: cert, Host: "99999999999999999999999999999999.teleport.cluster.local"}
 		msg := formatCertError(err)
-		require.Contains(t, msg, "Cannot connect to the Auth service via the Teleport Proxy using the internal cluster domain \"99999999999999999999999999999999.teleport.cluster.local\"")
+		require.Contains(t, msg, "Cannot connect to the Auth service via the Teleport Proxy.")
+		require.Contains(t, msg, "Host: 99999999999999999999999999999999.teleport.cluster.local")
 	})
 
 	t.Run("HostnameError", func(t *testing.T) {


### PR DESCRIPTION
Backport #61059 to branch/v17

changelog: Improve error message of `tsh` when there is a certificate DNS SAN mismatch when connecting to Auth via Proxy. 
