### PR TITLE
Fix flaky test `TestMinimumUpload`

### DIFF
--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -542,7 +542,7 @@ func TestMinimumUpload(t *testing.T) {
 	var partFiles []fs.FileInfo
 	filepath.WalkDir(p.scanDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return trace.Wrap(err, "walking directory tree")
 		}
 
 		if d.IsDir() {
@@ -551,7 +551,7 @@ func TestMinimumUpload(t *testing.T) {
 
 		info, err := d.Info()
 		if err != nil {
-			return err
+			return trace.Wrap(err, "retrieving file info")
 		}
 
 		// skip non-part files.

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -540,11 +540,21 @@ func TestMinimumUpload(t *testing.T) {
 	// Before completing the file stream, which writes upload part files into a .tar, check that
 	// each file part was within specific size expectations.
 	var partFiles []fs.FileInfo
-	err = filepath.Walk(p.scanDir, func(path string, info fs.FileInfo, err error) error {
+	filepath.WalkDir(p.scanDir, func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+
 		// skip non-part files.
 		if ext := filepath.Ext(info.Name()); ext == ".part" {
 			partFiles = append(partFiles, info)
 		}
+
 		return nil
 	})
 	require.NoError(t, err)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -541,6 +541,10 @@ func TestMinimumUpload(t *testing.T) {
 	// each file part was within specific size expectations.
 	var partFiles []fs.FileInfo
 	filepath.WalkDir(p.scanDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if d.IsDir() {
 			return nil
 		}


### PR DESCRIPTION
flake: https://github.com/gravitational/teleport.e/actions/runs/19191500177/job/54866565429

It looks like the use of file infos inside `filepath.Walk` could lead to a nil pointer exception. I wasn't able to reproduce locally, but I upgraded it to use `filepath.WalkDir` to catch file info errors directly.