### PR TITLE
Reduce sidebar label repetition

### DIFF
--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Access Requests
+sidebar_label: Configuration
 description: Describes the options available for configuring just-in-time access to roles and resources in your Teleport cluster.
 tags:
  - access-requests

--- a/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
+++ b/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Automatic Reviews
+sidebar_label: Automatic Reviews
 description: Describes how to configure Access Automation Rules for Automatic Reviews.
 tags:
  - access-requests

--- a/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/oss-role-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Community Edition Role Access Requests
+sidebar_label: In Teleport Community Edition
 description: Teleport Community Edition allows users to request access to roles from the CLI.
 tags:
  - access-requests

--- a/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
@@ -1,5 +1,6 @@
 ---
 title: Okta App and Group Sync
+sidebar_label: App and Group Sync
 description: Explains how to enable the Okta app and group sync integration, which imports Okta configurations into the Teleport RBAC system.
 tags:
  - how-to

--- a/docs/pages/identity-governance/integrations/okta/scim-integration.mdx
+++ b/docs/pages/identity-governance/integrations/okta/scim-integration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Okta SCIM Integration
+sidebar_label: SCIM Integration
 description: Explains how to use the guided integration enrollment flow to enable the Okta SCIM integration, which allows Teleport to immediately reflect changes in Okta.
 tags:
  - how-to

--- a/docs/pages/identity-governance/integrations/okta/user-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/user-sync.mdx
@@ -1,5 +1,6 @@
 ---
 title: Okta User Sync
+sidebar_label: User Sync
 description: Explains how to set up Okta user sync with the guided integration flow.
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/access-guides/applications.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/applications.mdx
@@ -1,7 +1,7 @@
 ---
 title: Machine & Workload Identity with Application Access
 description: How to use Machine & Workload Identity to access applications
-sidebar_label: Application Access
+sidebar_label: Applications
 tags:
  - how-to
  - mwi

--- a/docs/pages/machine-workload-identity/access-guides/databases.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/databases.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machine & Workload Identity with Database Access
-sidebar_label: Database Access
+sidebar_label: Databases
 description: How to use Machine & Workload Identity to access database servers
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/access-guides/kubernetes.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/kubernetes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machine & Workload Identity with Kubernetes Access
-sidebar_label: Kubernetes Access
+sidebar_label: Kubernetes Clusters
 description: How to use Machine & Workload Identity to access Kubernetes clusters
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/access-guides/ssh.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/ssh.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machine & Workload Identity with Server Access
-sidebar_label: Server Access
+sidebar_label: Linux Servers
 description: How to use Machine & Workload Identity to access servers via SSH
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuring Workload Identity and AWS OIDC Federation
+sidebar_label: AWS OIDC Federation
 description: Configuring AWS to accept Workload Identity JWTs as authentication using OIDC Federation
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-roles-anywhere.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuring Workload Identity and AWS Roles Anywhere
+sidebar_label: AWS Roles Anywhere
 description: Configuring AWS to accept Workload Identity certificates as authentication using AWS Roles Anywhere
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuring Workload Identity and Azure Federated Credentials
+sidebar_label: Azure Federated Credentials
 description: Configuring Azure to accept Workload Identity JWTs as authentication using Azure Federated Credentials
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/best-practices.mdx
@@ -1,5 +1,6 @@
 ---
 title: Best Practices for Teleport Workload Identity
+sidebar_label: Best Practices
 description: Answers common questions and describes best practices for using Teleport Workload Identity in production.
 tags:
  - conceptual

--- a/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/gcp-workload-identity-federation-jwt.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuring Workload Identity and GCP Workload Identity Federation with JWTs
+sidebar_label: GCP Workload Identity Federation with JWTs
 description: Configuring GCP to accept Workload Identity JWTs as authentication using Workload Identity Federation
 tags:
  - how-to

--- a/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with Workload Identity
+sidebar_label: Getting Started
 description: Getting started with Teleport Workload Identity for SPIFFE and Machine ID
 tags:
  - get-started

--- a/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/introduction.mdx
@@ -1,5 +1,6 @@
 ---
 title: Introduction to Workload Identity
+sidebar_label: Introduction
 description: Describes Teleport Workload Identity, which securely issues flexible, short-lived cryptographic identities to workloads and non-human identities.
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/access-list.mdx
@@ -1,5 +1,6 @@
 ---
 title: Creating Access Lists with IaC
+sidebar_label: Access Lists
 description: Use Infrastructure-as-Code tooling to create Access Lists.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/agentless-ssh-servers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Registering Agentless OpenSSH Servers with IaC
+sidebar_label: Agentless OpenSSH Servers
 description: Use infrastructure-as-code tooling to register Agentless OpenSSH servers in Teleport.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources.mdx
@@ -1,5 +1,6 @@
 ---
 title: Importing Teleport Resources into Terraform
+sidebar_label: Importing Resources
 description: How to import your existing Teleport resources into Terraform
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/kubernetes-oidc-join-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuring Kubernetes OIDC Joining With IaC
+sidebar_label: Kubernetes OIDC Joining
 description: Use infrastructure-as-code tooling to join Teleport Kubernetes agents.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-operator.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Login Rules Using Kubernetes Operator 
+sidebar_label: Login Rules (Kubernetes Operator)
 description: Use Teleport's Kubernetes Operator to deploy Login Rules to your cluster
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/login-rules-terraform.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploying Login Rules via Terraform 
+sidebar_label: Login Rules (Terraform)
 description: Use Teleport's Terraform Provider to deploy Login Rules to your cluster
 tags:
  - sso

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/trusted-cluster.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/trusted-cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Trusted Clusters With IaC
+sidebar_label: Trusted Clusters
 description: Use infrastructure-as-code tooling to create Teleport trusted clusters.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/user-and-role.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Users And Roles With IaC
+sidebar_label: Users and Roles
 description: Use infrastructure-as-code tooling to create Teleport users and roles.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/sso/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/adfs.mdx
@@ -1,5 +1,6 @@
 ---
 title: SSO with Active Directory Federation Services
+sidebar_label: Active Directory Federation Services
 description: How to configure Teleport access with Active Directory Federation Services
 tags:
  - sso

--- a/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authentication with Microsoft Entra ID (OIDC)
+sidebar_label: Microsoft Entra ID (OIDC)
 description: How to configure Teleport access with Microsoft Entra ID (formerly Azure AD) as an OIDC identity provider.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/sso/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authentication with Microsoft Entra ID (SAML)
+sidebar_label: Microsoft Entra ID (SAML)
 description: How to configure Teleport access with Microsoft Entra ID (formerly Azure AD) as a SAML identity provider.
 tags:
  - sso

--- a/docs/pages/zero-trust-access/sso/github-sso.mdx
+++ b/docs/pages/zero-trust-access/sso/github-sso.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set up Single Sign-On with GitHub
+sidebar_label: GitHub
 description: Setting up GitHub SSO
 videoBanner: XjgN2WWFCX8
 tags:

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authentication With GitLab as an SSO provider
+sidebar_label: GitLab
 description: How to configure Teleport access using GitLab for SSO
 tags:
  - sso

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authentication with Google Workspace (G Suite)
+sidebar_label: Google Workspace (G Suite)
 description: How to configure Teleport access with Google Workspace (formerly known as G Suite)
 videoBanner: WTLWc6nnPfk
 tags:

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -1,5 +1,6 @@
 ---
-title: OAuth2 and OIDC authentication
+title: OAuth2 and OIDC Authentication
+sidebar_label: OAuth2 and OIDC
 description: How to configure Teleport access with OAuth2 or OpenID connect (OIDC)
 tags:
  - sso

--- a/docs/pages/zero-trust-access/sso/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: Authentication With Okta as an SSO Provider
+sidebar_label: Okta
 description: How to configure Teleport access using Okta for SSO
 videoBanner: SM4Am-i8cj4
 tags:

--- a/docs/pages/zero-trust-access/sso/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/one-login.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authentication with OneLogin as an SSO Provider
+sidebar_label: OneLogin
 description: How to configure Teleport access using OneLogin as an SSO provider
 tags:
  - sso


### PR DESCRIPTION
Make sidebar labels easier to read by including only the words within a label that are necessary to distinguish it from other labels in the same sidebar:

- Managing Resources with IaC
- SSO
- Machine & Workload Identity access guides
- Top-level MWI guides
- Access Requests
- Identity Governance Okta integration