### PR TITLE
Adding usage limits to scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -152,9 +152,7 @@ type ScopedTokenSpec struct {
 	// Supported joining methods for scoped tokens only include 'token'.
 	JoinMethod string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
 	// The number of resources that can be provisioned using this token.
-	MaxUses *int32 `protobuf:"varint,5,opt,name=max_uses,json=maxUses,proto3,oneof" json:"max_uses,omitempty"`
-	// The number of successful provisioning attempts made using this token.
-	AttemptedUses int32 `protobuf:"varint,6,opt,name=attempted_uses,json=attemptedUses,proto3" json:"attempted_uses,omitempty"`
+	MaxUses       *int32 `protobuf:"varint,5,opt,name=max_uses,json=maxUses,proto3,oneof" json:"max_uses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -217,20 +215,15 @@ func (x *ScopedTokenSpec) GetMaxUses() int32 {
 	return 0
 }
 
-func (x *ScopedTokenSpec) GetAttemptedUses() int32 {
-	if x != nil {
-		return x.AttemptedUses
-	}
-	return 0
-}
-
 // The token's status including how many usage attempts have been made.
 type ScopedTokenStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The number of successful provisioning attempts made using this token.
 	AttemptedUses int32 `protobuf:"varint,1,opt,name=attempted_uses,json=attemptedUses,proto3" json:"attempted_uses,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// The public keys associated with successful provisioning attempts.
+	PublicKeysProvisioned [][]byte `protobuf:"bytes,2,rep,name=public_keys_provisioned,json=publicKeysProvisioned,proto3" json:"public_keys_provisioned,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
 }
 
 func (x *ScopedTokenStatus) Reset() {
@@ -270,6 +263,13 @@ func (x *ScopedTokenStatus) GetAttemptedUses() int32 {
 	return 0
 }
 
+func (x *ScopedTokenStatus) GetPublicKeysProvisioned() [][]byte {
+	if x != nil {
+		return x.PublicKeysProvisioned
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -282,17 +282,17 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xc3\x01\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x9c\x01\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
 	"\vjoin_method\x18\x03 \x01(\tR\n" +
 	"joinMethod\x12\x1e\n" +
-	"\bmax_uses\x18\x05 \x01(\x05H\x00R\amaxUses\x88\x01\x01\x12%\n" +
-	"\x0eattempted_uses\x18\x06 \x01(\x05R\rattemptedUsesB\v\n" +
-	"\t_max_uses\":\n" +
+	"\bmax_uses\x18\x05 \x01(\x05H\x00R\amaxUses\x88\x01\x01B\v\n" +
+	"\t_max_uses\"r\n" +
 	"\x11ScopedTokenStatus\x12%\n" +
-	"\x0eattempted_uses\x18\x01 \x01(\x05R\rattemptedUsesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x0eattempted_uses\x18\x01 \x01(\x05R\rattemptedUses\x126\n" +
+	"\x17public_keys_provisioned\x18\x02 \x03(\fR\x15publicKeysProvisionedBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -141,7 +141,11 @@ type ScopedTokenSpec struct {
 	Roles []string `protobuf:"bytes,2,rep,name=roles,proto3" json:"roles,omitempty"`
 	// The joining method required in order to use this token.
 	// Supported joining methods for scoped tokens only include 'token'.
-	JoinMethod    string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
+	JoinMethod string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
+	// The number of resources that can be provisioned using this token.
+	MaxUses *int32 `protobuf:"varint,5,opt,name=max_uses,json=maxUses,proto3,oneof" json:"max_uses,omitempty"`
+	// The number of successful provisioning attempts made using this token.
+	AttemptedUses int32 `protobuf:"varint,6,opt,name=attempted_uses,json=attemptedUses,proto3" json:"attempted_uses,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -197,6 +201,20 @@ func (x *ScopedTokenSpec) GetJoinMethod() string {
 	return ""
 }
 
+func (x *ScopedTokenSpec) GetMaxUses() int32 {
+	if x != nil && x.MaxUses != nil {
+		return *x.MaxUses
+	}
+	return 0
+}
+
+func (x *ScopedTokenSpec) GetAttemptedUses() int32 {
+	if x != nil {
+		return x.AttemptedUses
+	}
+	return 0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -208,12 +226,15 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
-	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"o\n" +
+	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"\xc3\x01\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
 	"\vjoin_method\x18\x03 \x01(\tR\n" +
-	"joinMethodBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"joinMethod\x12\x1e\n" +
+	"\bmax_uses\x18\x05 \x01(\x05H\x00R\amaxUses\x88\x01\x01\x12%\n" +
+	"\x0eattempted_uses\x18\x06 \x01(\x05R\rattemptedUsesB\v\n" +
+	"\t_max_usesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -248,6 +269,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 	if File_teleport_scopes_joining_v1_token_proto != nil {
 		return
 	}
+	file_teleport_scopes_joining_v1_token_proto_msgTypes[1].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -53,7 +53,9 @@ type ScopedToken struct {
 	// Scope is the scope of the token resource.
 	Scope string `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Spec is the token specification.
-	Spec          *ScopedTokenSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ScopedTokenSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	// The token's status including how many usage attempts have been made.
+	Status        *ScopedTokenStatus `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -126,6 +128,13 @@ func (x *ScopedToken) GetScope() string {
 func (x *ScopedToken) GetSpec() *ScopedTokenSpec {
 	if x != nil {
 		return x.Spec
+	}
+	return nil
+}
+
+func (x *ScopedToken) GetStatus() *ScopedTokenStatus {
+	if x != nil {
+		return x.Status
 	}
 	return nil
 }
@@ -215,18 +224,65 @@ func (x *ScopedTokenSpec) GetAttemptedUses() int32 {
 	return 0
 }
 
+// The token's status including how many usage attempts have been made.
+type ScopedTokenStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The number of successful provisioning attempts made using this token.
+	AttemptedUses int32 `protobuf:"varint,1,opt,name=attempted_uses,json=attemptedUses,proto3" json:"attempted_uses,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedTokenStatus) Reset() {
+	*x = ScopedTokenStatus{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedTokenStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedTokenStatus) ProtoMessage() {}
+
+func (x *ScopedTokenStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedTokenStatus.ProtoReflect.Descriptor instead.
+func (*ScopedTokenStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ScopedTokenStatus) GetAttemptedUses() int32 {
+	if x != nil {
+		return x.AttemptedUses
+	}
+	return 0
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a!teleport/header/v1/metadata.proto\"\xe7\x01\n" +
+	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\vScopedToken\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
-	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"\xc3\x01\n" +
+	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xc3\x01\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -234,7 +290,9 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"joinMethod\x12\x1e\n" +
 	"\bmax_uses\x18\x05 \x01(\x05H\x00R\amaxUses\x88\x01\x01\x12%\n" +
 	"\x0eattempted_uses\x18\x06 \x01(\x05R\rattemptedUsesB\v\n" +
-	"\t_max_usesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\t_max_uses\":\n" +
+	"\x11ScopedTokenStatus\x12%\n" +
+	"\x0eattempted_uses\x18\x01 \x01(\x05R\rattemptedUsesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -248,20 +306,22 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
-	(*ScopedToken)(nil),     // 0: teleport.scopes.joining.v1.ScopedToken
-	(*ScopedTokenSpec)(nil), // 1: teleport.scopes.joining.v1.ScopedTokenSpec
-	(*v1.Metadata)(nil),     // 2: teleport.header.v1.Metadata
+	(*ScopedToken)(nil),       // 0: teleport.scopes.joining.v1.ScopedToken
+	(*ScopedTokenSpec)(nil),   // 1: teleport.scopes.joining.v1.ScopedTokenSpec
+	(*ScopedTokenStatus)(nil), // 2: teleport.scopes.joining.v1.ScopedTokenStatus
+	(*v1.Metadata)(nil),       // 3: teleport.header.v1.Metadata
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	2, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	3, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2, // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -276,7 +336,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -42,6 +42,9 @@ message ScopedToken {
 
   // Spec is the token specification.
   ScopedTokenSpec spec = 6;
+
+  // The token's status including how many usage attempts have been made.
+  ScopedTokenStatus status = 7;
 }
 
 // ScopedTokenSpec is the specification of a scoped token.
@@ -63,4 +66,10 @@ message ScopedTokenSpec {
 
   // The number of successful provisioning attempts made using this token.
   int32 attempted_uses = 6;
+}
+
+// The token's status including how many usage attempts have been made.
+message ScopedTokenStatus {
+  // The number of successful provisioning attempts made using this token.
+  int32 attempted_uses = 1;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -63,13 +63,13 @@ message ScopedTokenSpec {
 
   // The number of resources that can be provisioned using this token.
   optional int32 max_uses = 5;
-
-  // The number of successful provisioning attempts made using this token.
-  int32 attempted_uses = 6;
 }
 
 // The token's status including how many usage attempts have been made.
 message ScopedTokenStatus {
   // The number of successful provisioning attempts made using this token.
   int32 attempted_uses = 1;
+
+  // The public keys associated with successful provisioning attempts.
+  repeated bytes public_keys_provisioned = 2;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -57,4 +57,10 @@ message ScopedTokenSpec {
   // The joining method required in order to use this token.
   // Supported joining methods for scoped tokens only include 'token'.
   string join_method = 3;
+
+  // The number of resources that can be provisioned using this token.
+  optional int32 max_uses = 5;
+
+  // The number of successful provisioning attempts made using this token.
+  int32 attempted_uses = 6;
 }

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -455,7 +455,7 @@ func (s *Server) makeHostResult(
 	token provision.Token,
 	rawClaims any,
 ) (*messages.HostResult, error) {
-	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(token), token.GetAssignedScope(), rawClaims)
+	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(token), rawClaims)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -481,7 +481,6 @@ func makeHostCertsParams(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	joinMethod types.JoinMethod,
-	scope string,
 	rawClaims any,
 ) (*HostCertsParams, error) {
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 // handleTokenJoin handles join attempts for the token join method.
@@ -53,8 +54,8 @@ func (s *Server) handleTokenJoin(
 	// Scoped tokens have usage limits, so once we've verified that host certs could
 	// be generated we need to attempt to consume the token. Any error should be
 	// considered a join failure.
-	if token.GetAssignedScope() != "" {
-		if _, err := s.cfg.ScopedTokenService.ConsumeScopedToken(stream.Context(), token.GetName()); err != nil {
+	if scopedToken, ok := token.(*joining.Token); ok {
+		if _, err := s.cfg.ScopedTokenService.ConsumeScopedToken(stream.Context(), scopedToken.Scoped(), tokenInit.ClientParams.HostParams.PublicKeys.PublicTLSKey); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -144,7 +144,7 @@ func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
 	}
 
 	maxUses := token.Spec.MaxUses
-	if maxUses != nil && token.Spec.AttemptedUses >= *maxUses {
+	if maxUses != nil && token.GetStatus().GetAttemptedUses() >= *maxUses {
 		return trace.Wrap(ErrTokenExhausted)
 	}
 

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -94,6 +94,10 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 		}
 	}
 
+	if spec.MaxUses != nil && *spec.MaxUses < 0 {
+		return trace.BadParameter("max uses must not be a negative")
+	}
+
 	return nil
 }
 

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -133,7 +133,11 @@ func (s *ScopedTokenService) ConsumeScopedToken(ctx context.Context, name string
 		if token.Spec.MaxUses == nil {
 			return token, nil
 		}
-		token.Spec.AttemptedUses++
+
+		if token.Status == nil {
+			token.Status = &joiningv1.ScopedTokenStatus{}
+		}
+		token.Status.AttemptedUses++
 		token, err = s.svc.ConditionalUpdateResource(ctx, token)
 		if err == nil {
 			return token, nil

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -34,6 +34,10 @@ type ScopedTokenService interface {
 	// be used for provisioning. If the token is expired, [UseScopedToken] should also
 	// delete it from the backend.
 	UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
+	// ConsumeScopedToken consumes a usage of a scoped token. This function should return a
+	// [trace.LimitExceeded] error if the token is expired or has no remaining uses, which
+	// should indicate a failure to use the token.
+	ConsumeScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
 	// ListScopedTokens retrieves a paginated list of scoped join tokens
 	ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error)
 

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -31,13 +31,14 @@ type ScopedTokenService interface {
 	GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.GetScopedTokenResponse, error)
 
 	// UseScopedToken fetches a scoped join token by unique name and checks if it can
-	// be used for provisioning. If the token is expired, [UseScopedToken] should also
-	// delete it from the backend.
+	// be used for provisioning. If the token is expired, UseScopedToken should also
+	// attempt to delete it from the backend.
 	UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
-	// ConsumeScopedToken consumes a usage of a scoped token. This function should return a
-	// [trace.LimitExceeded] error if the token is expired or has no remaining uses, which
-	// should indicate a failure to use the token.
-	ConsumeScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
+	// ConsumeScopedToken consumes a usage of a scoped token, optionally for a specific
+	// public key. This function should return a [*trace.LimitExceededError] if the
+	// token is expired or has no remaining uses, which should indicate a failure to
+	// use the token.
+	ConsumeScopedToken(ctx context.Context, token *joiningv1.ScopedToken, publicKey []byte) (*joiningv1.ScopedToken, error)
 	// ListScopedTokens retrieves a paginated list of scoped join tokens
 	ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error)
 

--- a/lib/utils/lockmap/lockmap.go
+++ b/lib/utils/lockmap/lockmap.go
@@ -1,0 +1,92 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lockmap
+
+import (
+	"sync"
+)
+
+type lock[T comparable] struct {
+	lm *LockMap[T]
+
+	key      T
+	mx       sync.Mutex
+	refCount int
+}
+
+// A LockMap is a thread-safe map of ref counted [sync.Mutex] used to synchronize access
+// to a set of keys. Entries are created lazily and ref counted so that the lock map
+// does not grow unbounded.
+type LockMap[T comparable] struct {
+	locks map[T]*lock[T]
+	mx    sync.Mutex
+}
+
+// New returns an empty, initialized [LockMap].
+func New[T comparable]() *LockMap[T] {
+	return &LockMap[T]{
+		locks: map[T]*lock[T]{},
+		mx:    sync.Mutex{},
+	}
+}
+
+// An Unlocker is returned by [LockMap.Lock] and must be called to release a given lock and
+// decrement its ref count.
+type Unlocker interface {
+	Unlock()
+}
+
+// Lock acquires a lock for the given key, creating one if needed, and returns an [Unlocker].
+// Each lock is ref counted and removed when that count reaches 0. This allows reusing a lock
+// when it's under contention while preventing unbounded growth of the lock map.
+func (lm *LockMap[T]) Lock(key T) Unlocker {
+	// alias the LockMap's mutex to avoid confusion
+	mapMx := &lm.mx
+	mapMx.Lock()
+
+	l, ok := lm.locks[key]
+	if !ok {
+		l = &lock[T]{key: key, lm: lm}
+		lm.locks[key] = l
+	}
+	l.refCount++
+	mapMx.Unlock()
+
+	l.mx.Lock()
+	return l
+}
+
+// Unlock releases a lock for the given key. If the ref count for the lock is zero, it is removed
+// from the map.
+func (l *lock[T]) Unlock() {
+	// alias the LockMap's mutex to avoid confusion
+	mapMx := &l.lm.mx
+	mapMx.Lock()
+	l.refCount--
+	if l.refCount < 1 {
+		delete(l.lm.locks, l.key)
+	}
+	mapMx.Unlock()
+	l.mx.Unlock()
+}
+
+// Len returns the number of entries remaining in the [LockMap].
+func (lm *LockMap[T]) Len() int {
+	lm.mx.Lock()
+	defer lm.mx.Unlock()
+	return len(lm.locks)
+}

--- a/lib/utils/lockmap/lockmap_test.go
+++ b/lib/utils/lockmap/lockmap_test.go
@@ -1,0 +1,67 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package lockmap_test
+
+import (
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/lockmap"
+)
+
+func TestLockMap(t *testing.T) {
+	expectMap := map[int]int{
+		0: 100,
+		1: 101,
+		2: 102,
+		3: 103,
+		4: 104,
+	}
+
+	// storing results in an array to avoid errors with unguarded concurrent
+	// map access
+	resultArr := [5]int{}
+
+	lm := lockmap.New[int]()
+
+	// spin up a bunch of goroutines to concurrently increment up to the
+	// expected values
+	synctest.Test(t, func(t *testing.T) {
+		for key, expect := range expectMap {
+			for range expect {
+				go func(idx int) {
+					unlocker := lm.Lock(key)
+					resultArr[key]++
+					unlocker.Unlock()
+				}(key)
+			}
+		}
+
+		synctest.Wait()
+	})
+
+	// make sure final counts match
+	for key, expect := range expectMap {
+		assert.Equal(t, expect, resultArr[key])
+	}
+
+	// make sure the lock map correctly drops all entries
+	require.Zero(t, lm.Len())
+}

--- a/lib/utils/lockmap/lockmap_test.go
+++ b/lib/utils/lockmap/lockmap_test.go
@@ -39,7 +39,7 @@ func TestLockMap(t *testing.T) {
 	// map access
 	resultArr := [5]int{}
 
-	lm := lockmap.New[int]()
+	var lm lockmap.LockMap[int]
 
 	// spin up a bunch of goroutines to concurrently increment up to the
 	// expected values
@@ -47,9 +47,9 @@ func TestLockMap(t *testing.T) {
 		for key, expect := range expectMap {
 			for range expect {
 				go func(idx int) {
-					unlocker := lm.Lock(key)
+					lm.Lock(key)
 					resultArr[key]++
-					unlocker.Unlock()
+					lm.Unlock(key)
 				}(key)
 			}
 		}

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -101,25 +101,30 @@ func TestScopedTokens(t *testing.T) {
 	require.Len(t, out.Roles, 1)
 	require.Equal(t, types.KindNode, strings.ToLower(out.Roles[0]))
 
+	// with --max-uses
+	buf, err = runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node", "--format", teleport.JSON, "--max-uses", "10"}, scopeFlags...))
+	require.NoError(t, err)
+	out = mustDecodeJSON[addedToken](t, buf)
+
 	// Test all output formats of "tokens ls".
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(buf.String(), "Token "))
-	require.Equal(t, 6, strings.Count(buf.String(), "\n")) // account for header lines
+	require.Equal(t, 7, strings.Count(buf.String(), "\n")) // account for header lines
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})
 	require.NoError(t, err)
-	require.Equal(t, 4, strings.Count(buf.String(), "\n"))
+	require.Equal(t, 5, strings.Count(buf.String(), "\n"))
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.JSON})
 	require.NoError(t, err)
 	jsonOut := mustDecodeJSON[[]listedScopedToken](t, buf)
-	require.Len(t, jsonOut, 4)
+	require.Len(t, jsonOut, 5)
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.YAML})
 	require.NoError(t, err)
 	yamlOut := []listedScopedToken{}
 	mustDecodeYAMLDocuments(t, buf, &yamlOut)
-	require.Len(t, yamlOut, 4)
+	require.Len(t, yamlOut, 5)
 	require.Equal(t, jsonOut, yamlOut)
 }


### PR DESCRIPTION
This PR adds usage limits to scoped tokens as described in #59784.

It adds `max_uses` and `attempted_uses` fields to the `ScopedToken` resource and extends usage validation to assert that `attempted_uses` must be less than `max_uses`. Two fields are used instead of decrementing `max_uses` so that it's easy to answer questions about how many provisioning attempts there have been versus how many the token was initially configured with. This also allows for tracking total provisioning attempts if we later add support for updating `max_uses` on an existing token.

Token usage is incremented immediately following a successful generation of host certs, which does not necessarily mean a successful join. This means it's possible for a limited use token to provision fewer resources than configured but it should not be possible to provision more.