### PR TITLE
Provide accurate error to clients trying to join a node in proxy recording mode

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2403,7 +2403,7 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 			return trace.Wrap(err)
 		}
 	} else if services.IsRecordAtProxy(recConfig.GetMode()) {
-		return trace.BadParameter("session joining is not supported in proxy recording mode")
+		return trace.BadParameter("session joining is not supported in proxy recording mode. If you are a Teleport administrator, you can learn more about recording modes at: https://goteleport.com/docs/reference/architecture/session-recording")
 	}
 
 	session, err := clt.AuthClient.GetSessionTracker(ctx, string(sessionID))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4272,7 +4272,7 @@ func (h *Handler) generateSession(ctx context.Context, req *TerminalRequest, clu
 // fetchJoinSession fetches an active or pending SSH session by the SessionID passed in the TerminalRequest.
 func (h *Handler) fetchJoinSession(ctx context.Context, clt authclient.ClientI, req *TerminalRequest, siteName string) (session.Session, types.SessionTracker, error) {
 	// Session joining is not supported in proxy recording mode
-	if recConfig, err := clt.GetSessionRecordingConfig(ctx); err != nil {
+	if recConfig, err := h.auth.accessPoint.GetSessionRecordingConfig(ctx); err != nil {
 		// If the user can't see the recording mode, just let them try joining below
 		if !trace.IsAccessDenied(err) {
 			return session.Session{}, nil, trace.Wrap(err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4278,7 +4278,7 @@ func (h *Handler) fetchJoinSession(ctx context.Context, clt authclient.ClientI, 
 			return session.Session{}, nil, trace.Wrap(err)
 		}
 	} else if services.IsRecordAtProxy(recConfig.GetMode()) {
-		return session.Session{}, nil, trace.BadParameter("session joining is not supported in proxy recording mode")
+		return session.Session{}, nil, trace.BadParameter("session joining is not supported in proxy recording mode. If you are a Teleport administrator, you can learn more about recording modes at: https://goteleport.com/docs/reference/architecture/session-recording")
 	}
 
 	sessionID, err := session.ParseID(req.JoinSessionID.String())

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -4293,7 +4293,7 @@ func (h *Handler) fetchJoinSession(ctx context.Context, clt authclient.ClientI, 
 	}
 
 	if types.IsOpenSSHNodeSubKind(tracker.GetTargetSubKind()) {
-		return session.Session{}, nil, trace.BadParameter("session joining is only supported for Teleport nodes, not OpenSSH nodes")
+		return session.Session{}, nil, trace.BadParameter("session joining is only supported for nodes which are Teleport agents, not OpenSSH nodes")
 	}
 
 	if tracker.GetSessionKind() != types.SSHSessionKind || tracker.GetState() == types.SessionState_SessionStateTerminated {

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -80,8 +80,8 @@ type TerminalRequest struct {
 	// Term is the initial PTY size.
 	Term session.TerminalParams `json:"term"`
 
-	// SessionID is a Teleport session ID to join as.
-	SessionID session.ID `json:"sid"`
+	// JoinSessionID is a Teleport session ID to join as.
+	JoinSessionID session.ID `json:"sid"`
 
 	// ProxyHostPort is the address of the server to connect to.
 	ProxyHostPort string `json:"-"`

--- a/lib/web/terminal_test.go
+++ b/lib/web/terminal_test.go
@@ -115,7 +115,7 @@ func connectToHost(ctx context.Context, cfg connectConfig) (*testTerminal, error
 			W: 100,
 			H: 100,
 		},
-		SessionID:         cfg.sessionID,
+		JoinSessionID:     cfg.sessionID,
 		ParticipantMode:   cfg.participantMode,
 		KeepAliveInterval: cfg.keepAliveInterval,
 	}


### PR DESCRIPTION
This PR introduces the same client-side check for session joining as seen in the [`tsh` client](https://github.com/gravitational/teleport/blob/3da95140e6b2089360858fe3887f8b1fa062e8e9/lib/client/api.go#L2399-L2427).

Note: The best way to handle this would be to remove the client side check (which has 1-2 additional round trips) and instead return an error from the forwarding node. Recent changes made it so that we do reach the forwarding node, but we still fail in odd ways, such as hanging on the terminal size request or the current session ID request. This could be fixed by changing the order or operations to create the session before attempting to make global requests, but such a change it outside the boundaries of this simple fix.

Fixes https://github.com/gravitational/teleport/issues/42346

Manual tests:
- Proxy recording mode:
  - [x] Attempt to join a Teleport Node session from the WebUI, get the `session joining is not supported in proxy recording mode` error. 
  - [x] Attempt to join an OpenSSH Node session from the WebUI, get the `session joining is not supported in proxy recording mode` error. 
- Node recording mode:
  - [x] Attempt to join an OpenSSH Node session from the WebUI, get the `session joining is only supported for Teleport nodes, not OpenSSH nodes` error. 