### PR TITLE
[v18] Server Discovery UI: default to AWS-RunShellScript SSM Doc

### DIFF
--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -111,9 +111,7 @@ export function DiscoveryConfigSsm() {
   const { clusterId } = useStickyClusterId();
 
   const [selectedRegion, setSelectedRegion] = useState<Regions>();
-  const [ssmDocumentName, setSsmDocumentName] = useState(
-    'TeleportDiscoveryInstaller'
-  );
+  const [ssmDocumentName, setSsmDocumentName] = useState('AWS-RunShellScript');
   const [scriptUrl, setScriptUrl] = useState('');
   const joinTokenRef = useRef<JoinToken>(undefined);
   const [tags, setTags] = useState<AWSLabels>([]);


### PR DESCRIPTION
Backport #61107 to branch/v18