### PR TITLE
Docs: add advanced configuration to Server Discovery

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/azure-discovery.mdx
@@ -29,7 +29,7 @@ Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
 other Linux distributions, you can install Teleport manually.)
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/6. Create an Azure invite token
+## Step 1/5. Create an Azure invite token
 
 When discovering Azure virtual machines, Teleport makes use of Azure invite tokens for
 authenticating joining SSH Service instances.
@@ -66,7 +66,7 @@ Add the token to the Teleport cluster with:
 $ tctl create -f token.yaml
 ```
 
-## Step 2/6. Configure IAM permissions for Teleport
+## Step 2/5. Configure IAM permissions for Teleport
 
 The Teleport Discovery Service needs Azure IAM permissions to discover and register Azure virtual machines.
 
@@ -202,7 +202,7 @@ and replace the subscription in `assignableScopes` with your own subscription id
 
 (!docs/pages/includes/server-access/azure-assign-service-principal.mdx!)
 
-## Step 3/6. Set up managed identities for discovered nodes
+## Step 3/5. Set up managed identities for discovered nodes
 
 Every Azure VM to be discovered must have a managed identity assigned to it
 with at least the `Microsoft.Compute/virtualMachines/read` permission.
@@ -212,7 +212,7 @@ with at least the `Microsoft.Compute/virtualMachines/read` permission.
 If the VMs to be discovered have more than one managed identity assigned to
 them, save the client ID of the identity you just created for step 5.
 
-## Step 4/6. Install the Teleport Discovery Service
+## Step 4/5. Install the Teleport Discovery Service
 
 <Admonition type="tip">
 
@@ -225,7 +225,7 @@ Install Teleport on the virtual machine that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 5/6. Configure Teleport to discover Azure instances
+## Step 5/5. Configure Teleport to discover Azure instances
 
 If you are running the Discovery Service on its own host, the service requires a
 valid invite token to connect to the cluster. Generate one by running the
@@ -267,13 +267,6 @@ discovery_service:
       tags:
         "env": "prod" # Match virtual machines where tag:env=prod
       install:
-        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
-        # Requires managed updates to be enabled.
-        # Supported characters are alphanumeric characters and `-`.
-        suffix: "<suffix>"
-        # Optional: when using managed updates, set the update group of the installation.
-        # Supported characters are alphanumeric characters and `-`.
-        update_group: "<update-group>"
         azure:
           # Optional: If the VMs to discover have more than one managed
           # identity assigned to them, set the client ID here to the client
@@ -286,22 +279,14 @@ discovery_service:
 - Adjust the keys under `discovery_service.azure` to match your Azure environment,
   specifically the regions and tags you want to associate with the Discovery
   Service.
-- Set the `install.suffix` key to install teleport in a non-global location, allowing
-  for multiple, simultaneously installations from different clusters.
-  Requires [agent managed updates](../../../upgrading/agent-managed-updates/agent-managed-updates.mdx).
-- When using [agent managed updates](../../../upgrading/agent-managed-updates/agent-managed-updates.mdx), you can
-  configure the update group by setting the `install.update_group` key.
-
-## Step 6/6. [Optional] Customize the default installer script
-
-(!docs/pages/includes/server-access/custom-installer.mdx matcher="azure"!)
-
-If `client_id` is set in the Discovery Service config, custom installers will
-also have the `{{ .AzureClientID }}` templating option.
 
 ## Auto-discovery labels
 
 (!docs/pages/includes/auto-discovery/auto-discovery-labels.mdx!)
+
+## Advanced configuration
+
+(!docs/pages/includes/auto-discovery/azure-vm-advanced-config.mdx!)
 
 ## Troubleshooting
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-guided.mdx
@@ -40,11 +40,11 @@ receive commands from the Discovery Service. For a list of permissions included
 in the policy, see the [AWS
 documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
 
-## Step 1/7. Create an EC2 invite token
+## Step 1/6. Create an EC2 invite token
 
 (!docs/pages/includes/auto-discovery/ec2-invite-token.mdx!)
 
-## Step 2/7. Configure IAM policies
+## Step 2/6. Configure IAM policies
 
 The `teleport discovery bootstrap` command will automate the process of
 defining and implementing IAM policies required to make auto-discovery work. It
@@ -77,7 +77,7 @@ the command:
 
 Create this policy and apply it to the Node (EC2 instance) that will run the Discovery Service.
 
-## Step 3/7. Install Teleport on the Discovery Node
+## Step 3/6. Install Teleport on the Discovery Node
 
 <Admonition type="tip">
 
@@ -90,11 +90,11 @@ Install Teleport on the EC2 instance that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 4/7. Configure Teleport to discover EC2 instances
+## Step 4/6. Configure Teleport to discover EC2 instances
 
 (!docs/pages/includes/auto-discovery/ec2-config.mdx!)
 
-## Step 5/7. Bootstrap the Discovery Service AWS configuration
+## Step 5/6. Bootstrap the Discovery Service AWS configuration
 
 On the same Node as above, run `teleport discovery bootstrap`. This command
 will generate and display the additional IAM policies and AWS Systems Manager (SSM) documents
@@ -123,15 +123,11 @@ Review the policies and confirm:
 Confirm? [y/N]: y
 ✅[AWS] Create IAM Policy "TeleportEC2Discovery"... done.
 ✅[AWS] Create IAM Policy "TeleportEC2DiscoveryBoundary"... done.
-✅[AWS] Create IAM SSM Document "TeleportDiscoveryInstaller"... done.
+✅[AWS] Create IAM SSM Document "AWS-RunShellScript"... done.
 ✅[AWS] Attach IAM policies to "alex-discovery-role"... done.
 ```
 
-## Step 6/7. [Optional] Customize the default installer script
-
-(!docs/pages/includes/server-access/custom-installer.mdx cloud="AWS" matcher="aws" matchTypes="[\"ec2\"]" extraMatchField="regions: [\"us-east-1\",\"us-west-1\"]"!)
-
-## Step 7/7. Start Teleport
+## Step 6/6. Start Teleport
 
 (!docs/pages/includes/aws-credentials.mdx service="the Discovery Service"!)
 
@@ -243,6 +239,10 @@ and view its logs with `journalctl -fu teleport`.
 ## Auto-discovery labels
 
 (!docs/pages/includes/auto-discovery/auto-discovery-labels.mdx!)
+
+## Advanced configuration
+
+(!docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx!)
 
 ## Troubleshooting
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-manual.mdx
@@ -40,11 +40,11 @@ receive commands from the Discovery Service. For a list of permissions included
 in the policy, see the [AWS
 documentation](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html).
 
-## Step 1/7. Create an EC2 invite token
+## Step 1/5. Create an EC2 invite token
 
 (!docs/pages/includes/auto-discovery/ec2-invite-token.mdx!)
 
-## Step 2/7. Configure IAM policies
+## Step 2/5. Configure IAM policies
 
 Create the following policy and attach it to the EC2 instance that will run
 the Discovery Service:
@@ -70,42 +70,7 @@ the Discovery Service:
 }
 ```
 
-## Step 3/7. Create SSM Documents
-
-In each region you plan to discover instances in, create the following SSM document
-in the AWS Systems Manager and name it `TeleportDiscoveryInstaller`:
-
-```yaml
-schemaVersion: '2.2'
-description: aws:runShellScript
-parameters:
-  token:
-    type: String
-    description: "(Required) The Teleport invite token to use when joining the cluster."
-  scriptName:
-    type: String
-    description: "(Required) The Teleport installer script to use when joining the cluster."
-  env:
-    type: String
-    description: "Environment variables exported to the script. Format 'ENV=var FOO=bar'"
-    default: "X=$X"
-mainSteps:
-- action: aws:downloadContent
-  name: downloadContent
-  inputs:
-    sourceType: "HTTP"
-    destinationPath: "/tmp/installTeleport.sh"
-    sourceInfo:
-      url: "https://<Var name="teleport.example.com:443" />/webapi/scripts/installer/{{ scriptName }}"
-- action: aws:runShellScript
-  name: runShellScript
-  inputs:
-    timeoutSeconds: '300'
-    runCommand:
-      - export {{ env }}; /bin/sh /tmp/installTeleport.sh "{{ token }}"
-```
-
-## Step 4/7. Install Teleport on the Discovery Node
+## Step 3/5. Install Teleport on the Discovery Node
 
 <Admonition type="tip">
 
@@ -118,15 +83,11 @@ Install Teleport on the EC2 instance that will run the Discovery Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 5/7. Configure Teleport to discover EC2 instances
+## Step 4/5. Configure Teleport to discover EC2 instances
 
 (!docs/pages/includes/auto-discovery/ec2-config.mdx!)
 
-## Step 6/7. [Optional] Customize the default installer script
-
-(!docs/pages/includes/server-access/custom-installer.mdx matcher="aws"!)
-
-## Step 7/7. Start Teleport
+## Step 5/5. Start Teleport
 
 (!docs/pages/includes/aws-credentials.mdx service="the Discovery Service"!)
 
@@ -260,6 +221,10 @@ and view its logs with `journalctl -fu teleport`.
 ## Auto-discovery labels
 
 (!docs/pages/includes/auto-discovery/auto-discovery-labels.mdx!)
+
+## Advanced configuration
+
+(!docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx!)
 
 ## Troubleshooting
 

--- a/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/gcp-discovery.mdx
@@ -28,7 +28,7 @@ Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
 other Linux distributions, you can install Teleport manually.)
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/6. Create a GCP invite token
+## Step 1/5. Create a GCP invite token
 
 When discovering GCP compute instances, Teleport makes use of GCP invite tokens for
 authenticating joining SSH Service instances.
@@ -69,7 +69,7 @@ Add the token to the Teleport cluster with:
 $ tctl create -f token.yaml
 ```
 
-## Step 2/6. Configure IAM permissions for Teleport
+## Step 2/5. Configure IAM permissions for Teleport
 
 Create a service account that will give Teleport IAM permissions needed to
 discover instances.
@@ -160,7 +160,7 @@ discover instances.
 </TabItem>
 </Tabs>
 
-## Step 3/6. Configure instances to be discovered
+## Step 3/5. Configure instances to be discovered
 
 Ensure that each instance to be discovered has a service account assigned to
 it. No permissions are required on the service account. To check if an instance
@@ -214,7 +214,7 @@ the host keys to the guest attributes below:
 </TabItem>
 </Tabs>
 
-## Step 4/6. Install the Teleport Discovery Service
+## Step 4/5. Install the Teleport Discovery Service
 
 <Admonition type="tip">
 
@@ -227,7 +227,7 @@ Install Teleport on the virtual machine that will run the Discovery Service.
 
 (!docs/pages/includes/install-linux.mdx!)
 
-## Step 5/6. Configure Teleport to discover GCP compute instances
+## Step 5/5. Configure Teleport to discover GCP compute instances
 
 If you are running the Discovery Service on its own host, the service requires a
 valid invite token to connect to the cluster. Generate one by running the
@@ -275,13 +275,6 @@ discovery_service:
       labels:
         "env": "prod" # Match virtual machines where label:env=prod
       install:
-        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
-        # Requires managed updates to be enabled.
-        # Supported characters are alphanumeric characters and `-`.
-        suffix: "<suffix>"
-        # Optional: when using managed updates, set the update group of the installation.
-        # Supported characters are alphanumeric characters and `-`.
-        update_group: "<update-group>"
         public_proxy_addr: "<Var name="teleport.example.com" />:443"
 ```
 
@@ -290,11 +283,6 @@ discovery_service:
 - Adjust the keys under `discovery_service.gcp` to match your GCP environment,
   specifically the projects, locations, service accounts, and tags you want to associate with the Discovery
   Service.
-- Set the `install.suffix` key to install teleport in a non-global location, allowing
-  for multiple, simultaneously installations from different clusters.
-  Requires [agent managed updates](../../../upgrading/agent-managed-updates/agent-managed-updates.mdx).
-- When using [agent managed updates](../../../upgrading/agent-managed-updates/agent-managed-updates.mdx), you can
-  configure the update group by setting the `install.update_group` key.
 
 ### GCP credentials
 
@@ -307,13 +295,13 @@ instance and assign the service account to that instance. Refer to
 [Set Up Application Default Credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc)
 for details on alternate methods.
 
-## Step 6/6. [Optional] Customize the default installer script
-
-(!docs/pages/includes/server-access/custom-installer.mdx matcher="gcp"!)
-
 ## Auto-discovery labels
 
 (!docs/pages/includes/auto-discovery/auto-discovery-labels.mdx!)
+
+## Advanced configuration
+
+(!docs/pages/includes/auto-discovery/gcp-vm-advanced-config.mdx!)
 
 ## Next steps
 

--- a/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
@@ -10,7 +10,7 @@
 
 When executing the installation script on discovered EC2 instances, the Discovery Service uses an SSM document.
 
-The `AWS-RunShellScript` SSM document works in most cases and is always available.
+The default `AWS-RunShellScript` SSM document works in most cases and is always available in AWS.
 
 However, if you need to customize the installation process for your environment, you can create a custom SSM Document and configure the Discovery Service to use it during installation.
 

--- a/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
@@ -1,0 +1,64 @@
+{/* this comment is here to make the includes below render */}
+
+(!docs/pages/includes/auto-discovery/server-advanced-config.mdx matcher="aws"!)
+
+### Use a custom installation script
+
+(!docs/pages/includes/server-access/custom-installer.mdx matcher="aws"!) 
+
+### Use a custom SSM Document
+
+When executing the installation script on discovered EC2 instances, the Discovery Service uses an SSM document.
+
+The `AWS-RunShellScript` SSM document works in most cases and is always available.
+
+However, if you need to customize the installation process for your environment, you can create a custom SSM Document and configure the Discovery Service to use it during installation.
+
+The custom document's parameters must include `env`, `scriptName` and `token`.
+
+The recommended approach is to use the following document and customize it as needed:
+
+```yaml
+schemaVersion: '2.2'
+description: aws:runShellScript
+parameters:
+  token:
+    type: String
+    description: "(Required) The Teleport invite token to use when joining the cluster."
+  scriptName:
+    type: String
+    description: "(Required) The Teleport installer script to use when joining the cluster."
+  env:
+    type: String
+    description: "Environment variables exported to the script. Format 'ENV=var FOO=bar'"
+    default: "X=$X"
+mainSteps:
+- action: aws:downloadContent
+  name: downloadContent
+  inputs:
+    sourceType: "HTTP"
+    destinationPath: "/tmp/installTeleport.sh"
+    sourceInfo:
+      url: "https://<Var name="teleport.example.com:443" />/webapi/scripts/installer/{{ scriptName }}"
+- action: aws:runShellScript
+  name: runShellScript
+  inputs:
+    timeoutSeconds: '300'
+    runCommand:
+      - export {{ env }}; /bin/sh /tmp/installTeleport.sh "{{ token }}"
+```
+
+Create this document using AWS Systems Manager in each region where you plan to discover instances.
+
+Edit your Discovery Service configuration to use the custom SSM Document, by setting the `ssm.document_name` key:
+
+```yaml
+# teleport.yaml
+version: v3
+# ...
+discovery_service:
+  enabled: true
+  {{ matcher }}:
+   - ssm:
+       document_name: "TeleportDiscoveryInstaller"
+```

--- a/docs/pages/includes/auto-discovery/azure-vm-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/azure-vm-advanced-config.mdx
@@ -1,0 +1,10 @@
+{/* this comment is here to make the includes below render */}
+
+(!docs/pages/includes/auto-discovery/server-advanced-config.mdx matcher="azure"!)
+
+### Use a custom installation script
+
+(!docs/pages/includes/server-access/custom-installer.mdx matcher="azure"!)
+
+If `client_id` is set in the Discovery Service config, custom installers will
+also have the `{{ .AzureClientID }}` templating option.

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -37,14 +37,9 @@ discovery_service:
   aws:
    - types: ["ec2"]
      regions: ["us-east-1","us-west-1"]
+     ssm:
+       document_name: "AWS-RunShellScript"
      install:
-        # Optional: use a non-global teleport installation, allowing for multiple agent installations.
-        # Requires managed updates to be enabled.
-        # Supported characters are alphanumeric characters and `-`.
-        suffix: "<suffix>"
-        # Optional: when using managed updates, set the update group of the installation.
-        # Supported characters are alphanumeric characters and `-`.
-        update_group: "<update-group>"
         join_params:
           token_name: aws-discovery-iam-token
           method: iam
@@ -57,8 +52,3 @@ discovery_service:
 - Adjust the keys under `discovery_service.aws` to match your EC2 environment,
   specifically the regions and tags you want to associate with the Discovery
   Service.
-- Set the `install.suffix` key to install teleport in a non-global location, allowing
-  for multiple, simultaneously installations from different clusters.
-  Requires [agent managed updates](../../upgrading/agent-managed-updates/agent-managed-updates.mdx).
-- When using [agent managed updates](../../upgrading/agent-managed-updates/agent-managed-updates.mdx), you can
-  configure the update group by setting the `install.update_group` key.

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
@@ -10,6 +10,8 @@ discovery_service:
   discovery_group: "aws-prod"
   aws:
   - types: ["ec2"]
+    ssm:
+      document_name: "AWS-RunShellScript"
     # Add new entry after existing entries
   - types: ["ec2"]
     regions: ["us-east-1","us-west-1"]
@@ -17,11 +19,15 @@ discovery_service:
       join_params:
         token_name: aws-discovery-iam-token
         method: iam
+    ssm:
+      document_name: "AWS-RunShellScript"
     tags:
       "env": "prod" # Match EC2 instances where tag:env=prod
     assume_role_arn: "<Var name="role ARN" />"
     external_id: "<Var name="optional external ID" />"
   - types: ["ec2"]
+    ssm:
+      document_name: "AWS-RunShellScript"
     # Add a new entry for each account.
     # ...
 ```

--- a/docs/pages/includes/auto-discovery/gcp-vm-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/gcp-vm-advanced-config.mdx
@@ -1,0 +1,7 @@
+{/* this comment is here to make the includes below render */}
+
+(!docs/pages/includes/auto-discovery/server-advanced-config.mdx matcher="gcp"!)
+
+### Use a custom installation script
+
+(!docs/pages/includes/server-access/custom-installer.mdx matcher="gcp"!)

--- a/docs/pages/includes/auto-discovery/server-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/server-advanced-config.mdx
@@ -1,0 +1,61 @@
+{{ matcher="bar" }}
+
+This section covers configuration options for discovering and enrolling servers.
+
+### Install multiple Teleport agents on the same instance
+
+When using blue-green deployments or other multiple clusters setups, you might want to access your instances from different clusters.
+
+Teleport supports installing and running multiple agents on the same instance, using a suffixed installation which allows you to isolate each installation.
+
+To configure the Discovery Service to use a suffixed installation, specify the `install.suffix` key in your Discovery Service configuration:
+
+```yaml
+# teleport.yaml
+version: v3
+# ...
+discovery_service:
+  enabled: true
+  {{ matcher }}:
+   - install:
+       suffix: "blue-cluster"
+``` 
+
+Requires [agent managed updates](../../upgrading/agent-managed-updates/agent-managed-updates.mdx) to be enabled.
+
+### Define the group for Managed Updates
+
+If you are using Teleport [Agent managed updates](../../upgrading/agent-managed-updates/agent-managed-updates.mdx), you can configure the update group so that you can control which instances get updated together.
+
+To set the update group, specify the `install.update_group` key in your Discovery Service configuration:
+
+```yaml
+# teleport.yaml
+version: v3
+# ...
+discovery_service:
+  enabled: true
+  {{ matcher }}:
+   - install:
+       update_group: "update-group-1"
+```
+
+### Configure HTTP Proxy during installation
+
+For instances which require a proxy to access the installation files, you can configure HTTP Proxy settings in the Discovery Service.
+
+You must set the `install.http_proxy_settings` key in your configuration:
+
+```yaml
+# teleport.yaml
+version: v3
+# ...
+discovery_service:
+  enabled: true
+  {{ matcher }}:
+   - install:
+       http_proxy_settings:
+         https_proxy: http://172.31.5.130:3128
+         http_proxy: http://172.31.5.130:3128
+         no_proxy: my-local-domain
+``` 

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -40,8 +40,7 @@ discovery_service:
       # Optional AWS external ID that the Discovery Service will use to assume
       # a role in an external AWS account.
       external_id: "example-external-id"
-      # Optional section: install is used to provide parameters to the AWS SSM document.
-      # If the install section isn't provided, the below defaults are used.
+      # Optional section: install is used to provide parameters to the installer script.
       # Only applicable for EC2 discovery.
       install:
         join_params:
@@ -51,13 +50,29 @@ discovery_service:
         # script_name is the name of the Teleport install script to use.
         # Optional, defaults to: "default-installer".
         script_name: "default-installer"
+        # Optional: adds a suffix to teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
+        # Optional: proxy settings for the install script.
+        # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+        # environment variables for the install script.
+        http_proxy_settings:
+          https_proxy: http://172.31.5.130:3128
+          http_proxy: http://172.31.5.130:3128
+          no_proxy: my-local-domain
       # Optional section: ssm is used to configure which AWS SSM document to use
       # If the ssm section isnt provided the below defaults are used.
       ssm:
         # document_name is the name of the SSM document that should be
         # executed when installing teleport on matching nodes
+        # Can be set to "AWS-RunShellScript" which is a pre-defined SSM Document,
+        # removing the need to create a custom SSM Document in each region.
         # Optional, defaults to: "TeleportDiscoveryInstaller".
-        document_name: "TeleportDiscoveryInstaller"
+        document_name: "AWS-RunShellScript"
       # Optional role for which the Discovery Service should create the EKS access entry.
       # If not set, the Discovery Service will attempt to create the access
       # entry using its own identity.
@@ -85,6 +100,30 @@ discovery_service:
       # '*' - discovers resources in all resource groups within configured subscription(s) (default).
       # Any resource_groups: `az group list -o table`
       resource_groups: ["group1", "group2"]
+      # Optional section: install is used to provide parameters to the Teleport installation in Azure VMs.
+      # Only applicable for VM discovery.
+      install:
+        join_params:
+          # token_name is the name of the Teleport invite token to use.
+          # Optional, defaults to: "azure-discovery-token".
+          token_name:  "azure-discovery-token"
+        # script_name is the name of the Teleport install script to use.
+        # Optional, defaults to: "default-installer".
+        script_name: "default-installer"
+        # Optional: adds a suffix to teleport installation, allowing for multiple agent installations.
+        # Requires managed updates to be enabled.
+        # Supported characters are alphanumeric characters and `-`.
+        suffix: "<suffix>"
+        # Optional: when using managed updates, set the update group of the installation.
+        # Supported characters are alphanumeric characters and `-`.
+        update_group: "<update-group>"
+        # Optional proxy settings for the install script.
+        # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+        # environment variables for the install script.
+        http_proxy_settings:
+          https_proxy: http://172.31.5.130:3128
+          http_proxy: http://172.31.5.130:3128
+          no_proxy: my-local-domain
       # Azure resource tag filters used to match resources.
       tags:
         "*": "*"
@@ -104,6 +143,30 @@ discovery_service:
         # Email addresses of service accounts that instances can join with.
         # If empty, any service account is allowed.
         service_accounts: []
+        # Optional section: install is used to provide parameters to the Teleport installation in Google Cloud VMs.
+        # Only applicable for VM discovery.
+        install:
+          join_params:
+            # token_name is the name of the Teleport invite token to use.
+            # Optional, defaults to: "gcp-discovery-token".
+            token_name:  "gcp-discovery-token"
+          # script_name is the name of the Teleport install script to use.
+          # Optional, defaults to: "default-installer".
+          script_name: "default-installer"
+          # Optional: adds a suffix to teleport installation, allowing for multiple agent installations.
+          # Requires managed updates to be enabled.
+          # Supported characters are alphanumeric characters and `-`.
+          suffix: "<suffix>"
+          # Optional: when using managed updates, set the update group of the installation.
+          # Supported characters are alphanumeric characters and `-`.
+          update_group: "<update-group>"
+          # Optional proxy settings for the install script.
+          # Sets the http_proxy, HTTP_PROXY, https_proxy, HTTPS_PROXY, no_proxy, and NO_PROXY
+          # environment variables for the install script.
+          http_proxy_settings:
+            https_proxy: http://172.31.5.130:3128
+            http_proxy: http://172.31.5.130:3128
+            no_proxy: my-local-domain
         # GCP resource label filters used to match resources.
         labels:
           "*": "*"

--- a/docs/pages/includes/server-access/custom-installer-aws.yaml
+++ b/docs/pages/includes/server-access/custom-installer-aws.yaml
@@ -5,11 +5,15 @@ discovery_service:
       tags:
        - "env": "prod"
       regions: ["us-west1", "us-east1"]
-      install: # optional section when default-installer is used.
+      install:
         script_name: "default-installer"
+      ssm:
+        document_name: "AWS-RunShellScript"
     - types: ["ec2"]
       tags:
        - "env": "devel"
       regions: ["us-west1", "us-east1"]
       install:
         script_name: "devel-installer"
+      ssm:
+        document_name: "AWS-RunShellScript"


### PR DESCRIPTION
I've added some features to server discovery lately:
- http proxy settings during installation (HTTP_PROXY family of env vars)
- suffix'd installations (multiple teleport agents running in the same instance, connecting to different clusters)
- enrolling installations in specific managed updates 

This means two things:
- we need to changed the docs 3 times: for AWS EC2, Azure and GCP VMs
- the guides are getting too large

This PR aims to fix those two issues, as well as documenting the new features.

We now have a simpler guide, but have an advanced configuration section.
The main guide should cover 90% of the scenarios, but then users can optionally incorporate advanced configurations as needed.

I've also converged every common configuration into a single file, so that we don't have to write the same thing 3 times (one per each Cloud).

This changed was triggered by this comment in another PR
https://github.com/gravitational/teleport/pull/61053#discussion_r2496569331