### PR TITLE
Clean up docs sidebar sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2003,7 +2003,7 @@ to other supported database protocols.
 Teleport database access for SQL Server remains in Preview mode with more UX
 improvements coming in future releases.
 
-Refer to [the guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx) to set
+Refer to [the guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/sql-server-ad.mdx) to set
 up access to a SQL Server with Active Directory authentication.
 
 ### Snowflake database access (Preview)
@@ -2523,7 +2523,7 @@ Directory authentication support for database access. Audit logging of query
 activity is not included in the preview release and will be implemented in a
 later 9.x release.
 
-[SQL Server guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/sql-server-ad.mdx)
+[SQL Server guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/sql-server-ad.mdx)
 
 #### RDS MariaDB
 
@@ -2531,7 +2531,7 @@ Teleport 9 updates MariaDB support with auto-discovery and connection to AWS RDS
 MariaDB databases using IAM authentication. The minimum MariaDB version that
 supports IAM authentication is 10.6.
 
-[Updated RDS guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx)
+[Updated RDS guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
 
 #### Other Improvements
 
@@ -2637,7 +2637,7 @@ With RDS auto discovery Teleport database agents can automatically discover RDS
 instances and Aurora clusters in an AWS account.
 
 See updated
-[RDS guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx) for
+[RDS guide](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx) for
 more information.
 
 #### WebAuthn
@@ -2966,8 +2966,8 @@ Configure database access following the [Getting Started](./docs/pages/enroll-re
 ##### Guides
 
 * [AWS RDS/Aurora
-  PostgreSQL](./docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx)
-* [AWS RDS/Aurora MySQL](./docs/pages/enroll-resources/database-access/enroll-aws-databases/rds.mdx)
+  PostgreSQL](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
+* [AWS RDS/Aurora MySQL](docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
 * [Self-hosted PostgreSQL](./docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx)
 * [Self-hosted MySQL](./docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/mysql-self-hosted.mdx)
 * [GUI clients](docs/pages/connect-your-client/gui-clients.mdx)

--- a/docs/config.json
+++ b/docs/config.json
@@ -2597,12 +2597,12 @@
     },
     {
       "source": "/identity-governance/entra-id/manual-installation/",
-      "destination": "/identity-governance/integrations/entra-id/manual-installation/",
+      "destination": "/identity-governance/integrations/entra-id/setup/manual-installation/",
       "permanent": true
     },
     {
       "source": "/identity-governance/entra-id/terraform/",
-      "destination": "/identity-governance/integrations/entra-id/terraform/",
+      "destination": "/identity-governance/integrations/entra-id/setup/terraform/",
       "permanent": true
     },
     {
@@ -2693,6 +2693,81 @@
     {
       "source": "/enroll-resources/server-access/guides/recording-proxy-mode/",
       "destination": "/reference/architecture/session-recording/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/database-access/enroll-aws-databases/rds-oracle/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds/rds-oracle/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-mysql/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-mysql/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-postgres/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-sqlserver/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/database-access/enroll-aws-databases/sql-server-ad/",
+      "destination": "/enroll-resources/database-access/enroll-aws-databases/rds/sql-server-ad/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/mcp-access/sse/",
+      "destination": "/enroll-resources/mcp-access/enrolling-mcp-servers/sse/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/mcp-access/stdio/",
+      "destination": "/enroll-resources/mcp-access/enrolling-mcp-servers/stdio/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/mcp-access/streamable-http/",
+      "destination": "/enroll-resources/mcp-access/enrolling-mcp-servers/streamable-http/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/integrations/entra-id/manual-installation/",
+      "destination": "/identity-governance/integrations/entra-id/setup/manual-installation/",
+      "permanent": true
+    },
+    {
+      "source": "/identity-governance/integrations/entra-id/terraform/",
+      "destination": "/identity-governance/integrations/entra-id/setup/terraform/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/guides/amazon-athena/",
+      "destination": "/enroll-resources/application-access/protect-apps/amazon-athena/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/guides/api-access/",
+      "destination": "/enroll-resources/application-access/protect-apps/api-access/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/guides/connecting-apps/",
+      "destination": "/enroll-resources/application-access/protect-apps/connecting-apps/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/guides/dynamodb/",
+      "destination": "/enroll-resources/application-access/protect-apps/dynamodb/",
+      "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/guides/tcp/",
+      "destination": "/enroll-resources/application-access/protect-apps/tcp/",
       "permanent": true
     }
   ]

--- a/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/database-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access for MCP
+sidebar_label: Databases
 description: How to configure MCP clients to use Teleport databases as MCP servers.
 tags:
  - mcp
@@ -16,7 +17,7 @@ This guide explains how to connect to your **PostgreSQL** Teleport databases wit
 
 - Teleport Database Service with a PostgreSQL database enrolled. See our [guides](../../enroll-resources/database-access/database-access.mdx)
   for options on how to enroll PostgreSQL databases with Teleport, such as
-  the [AWS RDS PostgreSQL](../../enroll-resources/database-access/enroll-aws-databases/rds.mdx)
+  the [AWS RDS PostgreSQL](../../enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
   and [self-hosted PostgreSQL](../../enroll-resources/database-access/enroll-self-hosted-databases/postgres-self-hosted.mdx) guides.
 
 <Admonition type="warning" title="Security considerations">

--- a/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/mcp-access.mdx
@@ -1,5 +1,6 @@
 ---
-title: MCP Access
+title: Access MCP Servers with Teleport
+sidebar_label: MCP Servers
 description: How to configure MCP clients to use MCP servers served by Teleport.
 tags:
  - mcp
@@ -21,7 +22,7 @@ Teleport.
   <summary>Configure MCP Access</summary>
 
   - [Quick-start with demo MCP server](../../enroll-resources/mcp-access/getting-started.mdx).
-  - [MCP Access with Stdio MCP Server](../../enroll-resources/mcp-access/stdio.mdx)
+  - [MCP Access with Stdio MCP Server](../../enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx)
   </details>
   
 ### Step 1/2. Installation

--- a/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
+++ b/docs/pages/connect-your-client/model-context-protocol/model-context-protocol.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Securing Agentic AI with Teleport Zero Trust Access"
+sidebar_label: MCP Clients
 description: "Access control and audit between LLMs and data sources or MCP servers."
 tags:
  - conceptual

--- a/docs/pages/connect-your-client/vnet.mdx
+++ b/docs/pages/connect-your-client/vnet.mdx
@@ -119,7 +119,7 @@ Teleport Connect.
 
 <Admonition type="note" title="Support for multiple ports">
 Unless the application specifies [multiple
-ports](../enroll-resources/application-access/guides/tcp.mdx#configuring-access-to-multiple-ports),
+ports](../enroll-resources/application-access/protect-apps/tcp.mdx#configuring-access-to-multiple-ports),
 VNet proxies connections over any port used by the application client. For multi-port apps, the port
 number must match one of the target ports of the app. To see a list of target ports, click the
 three dot menu next to an application in Teleport Connect or execute `tsh apps ls`.

--- a/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
+++ b/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enable a New Service on an Agent
+sidebar_label: Enabling a New Service
 description: Explains how to edit the services that are running on a Teleport Agent.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/aws-ec2.mdx
+++ b/docs/pages/enroll-resources/agents/aws-ec2.mdx
@@ -1,5 +1,6 @@
 ---
 title: Joining Services via AWS EC2 Identity Document
+sidebar_label: EC2 Identity Document
 description: Use the EC2 join method to add services to your Teleport cluster on AWS
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/aws-iam.mdx
+++ b/docs/pages/enroll-resources/agents/aws-iam.mdx
@@ -1,5 +1,6 @@
 ---
 title: Joining Services via AWS IAM Role
+sidebar_label: IAM Role
 description: Use the IAM join method to add services to your Teleport cluster on AWS
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: Joining Services via Azure Managed Identity
+sidebar_label: Azure Managed Identity
 description: Use the Azure join method to join Teleport services to your Teleport cluster on Azure
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/gcp.mdx
+++ b/docs/pages/enroll-resources/agents/gcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Join Services with GCP
+sidebar_label: Google Cloud
 description: Use the GCP join method to add services to your Teleport cluster.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-token.mdx
@@ -1,5 +1,6 @@
 ---
 title: Join Services with a Secure Token
+sidebar_label: Secure Token
 description: This guide shows you how to join a Teleport instance to your cluster using a join token in order to proxy access to resources in your infrastructure.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/kubernetes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Joining Services via Kubernetes ServiceAccount Token
+sidebar_label: Kubernetes ServiceAccount Token
 description: Use Kubernetes ServiceAccount tokens to join services running in the same Kubernetes cluster as the Auth Service.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -1,5 +1,6 @@
 ---
 title: Join Services with Oracle Cloud
+sidebar_label: Oracle Cloud
 description: Use the Oracle join method to add services to your Teleport cluster.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console-roles-anywhere.mdx
@@ -1,5 +1,6 @@
 ---
 title: AWS Console and CLI Access with Roles Anywhere
+sidebar_label: AWS (via Roles Anywhere)
 description: How to use AWS IAM Roles Anywhere with Teleport for AWS Console and CLI access
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/aws-console.mdx
@@ -1,5 +1,6 @@
 ---
 title: Access AWS With Teleport Application Access
+sidebar_label: AWS (via Teleport Application Service)
 description: How to access AWS with Teleport application access.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure-aks-workload-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Protect Azure CLIs with Teleport Application Access on AKS"
+sidebar_label: Azure (using AKS)
 description: How to enable secure access to Azure CLIs on Azure Kubernetes Service with Workload Identity.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: Protect Azure CLIs and APIs with Teleport
+sidebar_label: Azure
 description: How to enable secure access to Azure CLIs.
 tags:
  - teleport-as-idp

--- a/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/enroll-resources/application-access/cloud-apis/google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Protect Google Cloud API Access with Teleport"
+sidebar_label: Google Cloud
 description: How to enable secure access to Google Cloud APIs.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/controls.mdx
+++ b/docs/pages/enroll-resources/application-access/controls.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application Access Role-Based Access Control
+sidebar_label: Role-Based Access Control
 description: Role-Based Access Control (RBAC) for Teleport application access.
 tags:
  - conceptual

--- a/docs/pages/enroll-resources/application-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/application-access/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Protect a Web Application with Teleport
+sidebar_label: Getting Started
 description: Provides instructions to set up the Teleport Application Service and enable secure access to a web application.
 videoBanner: cvW4b96aPL0
 tags:
@@ -242,8 +243,8 @@ You are prompted to sign in if you haven't already been authenticated.
 
 Learn more about protecting applications with Teleport in the following topics:
 
-- [Connecting applications](./guides/connecting-apps.mdx).
+- [Connecting applications](protect-apps/connecting-apps.mdx).
 - Integrating with [JWT tokens](./jwt/introduction.mdx).
-- Accessing applications with [RESTful APIs](./guides/api-access.mdx).
+- Accessing applications with [RESTful APIs](protect-apps/api-access.mdx).
 - Setting configuration options AND running CLI commands in the [Application Service reference](../../reference/agent-services/application-access.mdx).
 - Using the Let's Encrypt [ACME protocol](https://letsencrypt.org/how-it-works/).

--- a/docs/pages/enroll-resources/application-access/guides/guides.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/guides.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application Access Guides
+sidebar_label: Guides
 description: Guides for configuring Teleport application access.
 template: "no-toc"
 tags:
@@ -13,11 +14,11 @@ RBAC and audit logging.
 
 Manage access to internal applications:
 
-- [Web App Access](connecting-apps.mdx): How to access web apps with Teleport.
-- [TCP App Access](tcp.mdx): How to access plain TCP apps with Teleport.
+- [Web App Access](../protect-apps/connecting-apps.mdx): How to access web apps with Teleport.
+- [TCP App Access](../protect-apps/tcp.mdx): How to access plain TCP apps with Teleport.
 - [VNet](vnet.mdx): How to configure VNet to support applications with custom public addresses.
-- [API Access](api-access.mdx): How to access REST APIs with Teleport.
+- [API Access](../protect-apps/api-access.mdx): How to access REST APIs with Teleport.
 - [Dynamic Registration](dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
-- [Amazon Athena Access](amazon-athena.mdx): How to access Amazon Athena with Teleport.
-- [Amazon DynamoDB Access](dynamodb.mdx): How to access Amazon DynamoDB as an application.
+- [Amazon Athena Access](../protect-apps/amazon-athena.mdx): How to access Amazon Athena with Teleport.
+- [Amazon DynamoDB Access](../protect-apps/dynamodb.mdx): How to access Amazon DynamoDB as an application.
 - [Application Service HA](ha.mdx): How to configure the Teleport Application Service for high availability. 

--- a/docs/pages/enroll-resources/application-access/guides/ha.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/ha.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application Access High Availability (HA)
+sidebar_label: High Availability
 description: How to configure Teleport application access in a Highly Available (HA) configuration.
 tags:
  - conceptual

--- a/docs/pages/enroll-resources/application-access/guides/vnet.mdx
+++ b/docs/pages/enroll-resources/application-access/guides/vnet.mdx
@@ -9,7 +9,7 @@ tags:
 
 VNet automatically proxies connections made to TCP applications available under the public address
 of a Proxy Service. This guide explains how to configure VNet to support apps with [custom public
-addresses](connecting-apps.mdx#customize-public-address).
+addresses](../protect-apps/connecting-apps.mdx#customize-public-address).
 
 ## How it works
 
@@ -35,7 +35,7 @@ to first update the VNet config in the Auth Service to include a matching DNS zo
 - A domain name under your control.
 
 {/* vale messaging.protocol-products = NO */}
-In this guide, we'll use the example app from [TCP Application Access guide](tcp.mdx) and make it
+In this guide, we'll use the example app from [TCP Application Access guide](../protect-apps/tcp.mdx) and make it
 available through VNet at <Var name="public_addr" initial="tcp-app.company.test"/> with
 <Var name="suffix" initial="company.test" /> as the custom DNS zone.
 {/* vale messaging.protocol-products = YES */}
@@ -144,9 +144,9 @@ $ tsh login --proxy=leaf.example.com --user=email@example.com
 
 ### Accessing web apps through VNet
 
-VNet does not officially support [web apps](connecting-apps.mdx) yet.
+VNet does not officially support [web apps](../protect-apps/connecting-apps.mdx) yet.
 However, since all web apps are served over TCP, it's possible to convert a web
-app to [a TCP app](tcp.mdx) to make it available via VNet.
+app to [a TCP app](../protect-apps/tcp.mdx) to make it available via VNet.
 You'll need to change the `uri` of the application to use `tcp://` instead of `https://`.
 
 Exposing plain HTTP web apps or APIs via VNet is not recommended.
@@ -167,8 +167,8 @@ There are a few more caveats when converting a Teleport web app to a TCP app:
   above in this guide to an address that is not a subdomain of the proxy address.
 - HTTPS Applications must handle their own TLS connections and have
   a valid certificate for the app `public_addr`.
-- [JWT Tokens](../jwt/introduction.mdx), [redirects](connecting-apps.mdx#rewrite-redirect) and
-  [header rewrites](connecting-apps.mdx#headers-passthrough) are not available for TCP apps.
+- [JWT Tokens](../jwt/introduction.mdx), [redirects](../protect-apps/connecting-apps.mdx#rewrite-redirect) and
+  [header rewrites](../protect-apps/connecting-apps.mdx#headers-passthrough) are not available for TCP apps.
 - Teleport records the start and the end of a session for TCP apps in the audit log, but [session
   chunks](../../../reference/architecture/session-recording.mdx) are not captured.
 

--- a/docs/pages/enroll-resources/application-access/introduction.mdx
+++ b/docs/pages/enroll-resources/application-access/introduction.mdx
@@ -60,9 +60,9 @@ private network, with no shared secrets.
 
 These guides explain how to protect internal applications with Teleport:
 
-- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport.
-- [TCP App Access](./guides/tcp.mdx): How to access plain TCP apps with Teleport.
-- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport.
+- [Web App Access](protect-apps/connecting-apps.mdx): How to access web apps with Teleport.
+- [TCP App Access](protect-apps/tcp.mdx): How to access plain TCP apps with Teleport.
+- [API Access](protect-apps/api-access.mdx): How to access REST APIs with Teleport.
 - [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
 - [Interactive Lab](https://goteleport.com/labs/): Try Teleport using our guided Teleport application access lab.
 

--- a/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/elasticsearch.mdx
@@ -17,7 +17,7 @@ with Teleport.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-- Running [Application Service](../guides/connecting-apps.mdx).
+- Running [Application Service](../protect-apps/connecting-apps.mdx).
 - Elasticsearch cluster version >= `8.2.0`.
 
 ## Step 1/3. Enable a JWT realm in Elasticsearch
@@ -145,6 +145,6 @@ $ curl \
 ## Next steps
 
 - Get more information about integrating with [Teleport JWT tokens](./introduction.mdx).
-- Learn more about [accessing APIs](../guides/api-access.mdx) with the Teleport
+- Learn more about [accessing APIs](../protect-apps/api-access.mdx) with the Teleport
   Application Service.
 - Take a look at application-related [Access Controls](../controls.mdx).

--- a/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
+++ b/docs/pages/enroll-resources/application-access/jwt/jwt.mdx
@@ -1,5 +1,6 @@
 ---
 title: Application Access JWT Authentication
+sidebar_label: JWT Authentication
 description: Guides for using Teleport application access JWT authentication.
 template: "no-toc"
 tags:

--- a/docs/pages/enroll-resources/application-access/protect-apps/amazon-athena.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/amazon-athena.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon Athena Access
+sidebar_label: Amazon Athena
 description: How to access Amazon Athena with Teleport
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/protect-apps/api-access.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/api-access.mdx
@@ -1,5 +1,6 @@
 ---
 title: Access REST APIs With Teleport Application Access
+sidebar_label: REST APIs
 description: How to access REST APIs with Teleport application access.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -1,5 +1,6 @@
 ---
 title: Web Application Access
+sidebar_label: Web Applications
 description: In this getting started guide, learn how to connect an application to your Teleport cluster by running the Teleport Application Service.
 tags:
  - how-to
@@ -445,4 +446,4 @@ do so by hitting the `/teleport-logout` endpoint:
 ## Next steps
 
 - Learn how to [configure web apps as TCP apps to access them through
-  VNet](vnet.mdx#accessing-web-apps-through-vnet).
+  VNet](../guides/vnet.mdx#accessing-web-apps-through-vnet).

--- a/docs/pages/enroll-resources/application-access/protect-apps/dynamodb.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/dynamodb.mdx
@@ -1,5 +1,6 @@
 ---
 title: Amazon DynamoDB using the Teleport Application Service
+sidebar_label: Amazon DynamoDB
 description: How to access Amazon DynamoDB through the Teleport Application Service
 tags:
  - how-to

--- a/docs/pages/enroll-resources/application-access/protect-apps/protect-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/protect-apps.mdx
@@ -1,0 +1,10 @@
+---
+title: Protecting Applications with Teleport
+sidebar_label: Protecting Applications
+description: Provides step-by-step instructions to protecting different kinds of applications with Teleport.
+---
+
+The guides in this section show you how to enroll specific kinds of applications
+with your Teleport cluster, including the following:
+
+<DocCardList kind="labelOnly" />

--- a/docs/pages/enroll-resources/application-access/protect-apps/tcp.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/tcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: TCP Application Access
+sidebar_label: TCP Applications
 description: How to configure Teleport for accessing plain TCP apps
 tags:
  - how-to
@@ -218,4 +219,4 @@ wide port range that happens to include ports that are meant to be available.
 
 - Learn about [access controls](../controls.mdx) for applications.
 - Learn how to [connect to TCP apps with VNet](../../../connect-your-client/vnet.mdx) and
-  [configure VNet for custom `public_addr`](vnet.mdx).
+  [configure VNet for custom `public_addr`](../guides/vnet.mdx).

--- a/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/troubleshooting-apps.mdx
@@ -201,7 +201,7 @@ likely to exceed the limit.
 {/* vale messaging.protocol-products = NO */}
 This configuration is available under the `jwt_claims` property of the
 application's `rewrite` configuration. See
-[Web Application Access](./guides/connecting-apps.mdx#configuring-the-jwt-token)
+[Web Application Access](protect-apps/connecting-apps.mdx#configuring-the-jwt-token)
 for details.
 {/* vale messaging.protocol-products = YES */}
 

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/aws.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport EKS Auto-Discovery
+sidebar_label: Elastic Kubernetes Service
 description: How to configure auto-discovery of AWS EKS clusters in Teleport.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/azure.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport AKS Auto-Discovery
+sidebar_label: Azure Kubernetes Service
 description: Auto-Discovery of AKS clusters in Azure cloud.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/kubernetes/google-cloud.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport GKE Auto-Discovery
+sidebar_label: Google Kubernetes Engine
 description: How to configure auto-discovery of Google Kubernetes Engine clusters in Teleport.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mariadb.mdx
@@ -15,7 +15,7 @@ tags:
 ## Prerequisites
 
 - Teleport cluster with a configured [self-hosted
-  MariaDB](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MariaDB](../enroll-aws-databases/rds.mdx)
+  MariaDB](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MariaDB](../enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
   database.
 - Ability to connect to and create user accounts in the target database.
 

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/mysql.mdx
@@ -34,7 +34,7 @@ stripping its privileges.
 ## Prerequisites
 
 - Teleport cluster with a configured [self-hosted
-  MySQL](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MySQL](../enroll-aws-databases/rds.mdx)
+  MySQL](../enroll-self-hosted-databases/mysql-self-hosted.mdx) or [RDS MySQL](../enroll-aws-databases/rds/mysql-postgres-mariadb.mdx)
   database.
 - Ability to connect to and create user accounts in the target database.
 - Automatic user provisioning is not compatible with MySQL versions lower than

--- a/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/auto-user-provisioning/postgres.mdx
@@ -16,7 +16,7 @@ tags:
 
 - Teleport cluster with a configured [self-hosted
   PostgreSQL](../enroll-self-hosted-databases/postgres-self-hosted.mdx) or [RDS
-  PostgreSQL](../enroll-aws-databases/rds.mdx) database. To configure
+  PostgreSQL](../enroll-aws-databases/rds/mysql-postgres-mariadb.mdx) database. To configure
   permissions for database objects like tables, your cluster must be on version
   v15.2 or above.
 - Ability to connect to and create user accounts in the target database.

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cassandra-keyspaces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon Keyspaces (Apache Cassandra)
-sidebar_label: Amazon Keyspaces (Apache Cassandra)
+sidebar_label: Keyspaces (Apache Cassandra)
 description: How to configure Teleport database access with Amazon Keyspaces (Apache Cassandra)
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-cross-account.mdx
@@ -1,5 +1,6 @@
 ---
 title: AWS Cross-Account Database Access
+sidebar_label: Cross-Account Database Access
 description: How to connect AWS databases in external AWS accounts to Teleport.
 tags:
  - conceptual

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-docdb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon DocumentDB
-sidebar_label: Amazon DocumentDB
+sidebar_label: DocumentDB
 description: How to access Amazon DocumentDB with Teleport database access
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-dynamodb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon DynamoDB
-sidebar_label: Amazon DynamoDB
+sidebar_label: DynamoDB
 description: How to access Amazon DynamoDB with Teleport database access
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-memorydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-memorydb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon MemoryDB
-sidebar_label: Amazon MemoryDB
+sidebar_label: MemoryDB
 description: How to configure Teleport database access with Amazon MemoryDB
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/aws-opensearch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon OpenSearch
-sidebar_label: Amazon OpenSearch
+sidebar_label: OpenSearch
 description: How to access Amazon OpenSearch with Teleport database access
 tags:
  - how-to
@@ -57,7 +57,7 @@ access conventions. You should adjust the AWS IAM permissions to fit your needs.
 <Admonition type="tip" title="Dashboard in private network">
 To access the OpenSearch Dashboard deployed within private VPC subnets using
 Teleport, you can enroll the Dashboard as a [Web
-application](../../application-access/guides/connecting-apps.mdx)
+application](../../application-access/protect-apps/connecting-apps.mdx)
 in Teleport.
 </Admonition>
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/elasticache-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/elasticache-serverless.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon ElastiCache Serverless for Redis and Valkey
-sidebar_label: Amazon ElastiCache Serverless
+sidebar_label: ElastiCache Serverless
 description: How to configure Teleport database access with Amazon ElastiCache Serverless for Redis and Valkey.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/enroll-aws-databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll AWS Databases
+sidebar_label: AWS
 description: "Provides instructions on protecting databases in your AWS-managed infrastructure with Teleport."
 tags:
  - zero-trust
@@ -28,11 +29,11 @@ with Teleport:
 - [Amazon MemoryDB](aws-memorydb.mdx)
 - [Amazon Keyspaces (Apache Cassandra)](aws-cassandra-keyspaces.mdx)
 - [Amazon OpenSearch](aws-opensearch.mdx)
-- [Amazon RDS Oracle](rds-oracle.mdx)
-- [Amazon RDS Proxy MySQL](rds-proxy-mysql.mdx)
-- [Amazon RDS Proxy for Microsoft SQL Server](rds-proxy-sqlserver.mdx)
-- [Amazon RDS Proxy for PostgreSQL](rds-proxy-postgres.mdx)
-- [Amazon RDS and Aurora](rds.mdx)
-- [Amazon RDS for SQL Server](sql-server-ad.mdx)
+- [Amazon RDS Oracle](rds/rds-oracle.mdx)
+- [Amazon RDS Proxy MySQL](rds-proxy/rds-proxy-mysql.mdx)
+- [Amazon RDS Proxy for Microsoft SQL Server](rds-proxy/rds-proxy-sqlserver.mdx)
+- [Amazon RDS Proxy for PostgreSQL](rds-proxy/rds-proxy-postgres.mdx)
+- [Amazon RDS and Aurora](rds/mysql-postgres-mariadb.mdx)
+- [Amazon RDS for SQL Server](rds/sql-server-ad.mdx)
 - [Amazon Redshift Serverless](redshift-serverless.mdx)
 - [Amazon Redshift](postgres-redshift.mdx)

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/postgres-redshift.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon Redshift
-sidebar_label: Amazon Redshift
+sidebar_label: Redshift
 description: How to configure Teleport database access with Amazon Redshift.
 videoBanner: UFhT52d5bYg
 tags:

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-mysql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon RDS Proxy for MariaDB/MySQL
-sidebar_label: Amazon RDS Proxy for MariaDB/MySQL
+sidebar_label: MariaDB/MySQL
 description: How to configure Teleport database access with Amazon RDS Proxy for MariaDB/MySQL.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-postgres.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-postgres.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon RDS Proxy for PostgreSQL
-sidebar_label: Amazon RDS Proxy for PostgreSQL
+sidebar_label: PostgreSQL
 description: How to configure Teleport database access with Amazon RDS Proxy for PostgreSQL
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-sqlserver.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-sqlserver.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon RDS Proxy for SQL Server
-sidebar_label: Amazon RDS Proxy for SQL Server
+sidebar_label: SQL Server
 description: How to configure Teleport database access with Amazon RDS Proxy for SQL Server
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy.mdx
@@ -1,0 +1,11 @@
+---
+title: Protecting Amazon RDS Proxy
+sidebar_label: RDS Proxy
+description: Provides guidance on enrolling Amazon RDS Proxy databases with Teleport.
+---
+
+The guides in this section show you how to enroll Amazon RDS Proxy databases
+with Teleport. For RDS databases, see [Protecting Amazon RDS
+Databases](../rds/rds.mdx):
+
+<DocCardList kind="labelOnly"/>

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon RDS and Aurora for PostgreSQL/MySQL/MariaDB
-sidebar_label: Amazon RDS and Aurora for PostgreSQL/MySQL/MariaDB
+sidebar_label: PostgreSQL/MySQL/MariaDB
 description: How to configure Teleport database access with Amazon RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 tags:
  - how-to
@@ -17,10 +17,10 @@ tags:
 
 <Tabs>
 <TabItem label="Self-Hosted">
-![Teleport Architecture RDS Self-Hosted](../../../../img/database-access/guides/rds_selfhosted.png)
+![Teleport Architecture RDS Self-Hosted](../../../../../img/database-access/guides/rds_selfhosted.png)
 </TabItem>
 <TabItem label="Cloud-Hosted">
-![Teleport Architecture RDS Cloud-Hosted](../../../../img/database-access/guides/rds_cloud.png)
+![Teleport Architecture RDS Cloud-Hosted](../../../../../img/database-access/guides/rds_cloud.png)
 </TabItem>
 
 </Tabs>
@@ -331,5 +331,5 @@ $ tsh db logout rds-example
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
-- Set up [automatic database user provisioning](../auto-user-provisioning/auto-user-provisioning.mdx).
+- Set up [automatic database user provisioning](../../auto-user-provisioning/auto-user-provisioning.mdx).
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/rds-oracle.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/rds-oracle.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon RDS Oracle with Kerberos Authentication
-sidebar_label: Amazon RDS Oracle
+sidebar_label: Oracle
 description: How to enroll Amazon RDS Oracle in your Teleport cluster with Kerberos authentication.
 tags:
  - how-to
@@ -222,7 +222,7 @@ be merged into the same `teleport.keytab` file.
 
   To check if the user has any SPNs assigned, go to the user's page in AWS Console and locate the "Account settings - optional" section.
 
-  ![AWS AD Set SPN](../../../../img/database-access/guides/aws_ad_set_spn.png)
+  ![AWS AD Set SPN](../../../../../img/database-access/guides/aws_ad_set_spn.png)
 
   Alternatively, run the following command on the
   Windows machine joined to your Active Directory domain:
@@ -391,7 +391,7 @@ Other clients can use:
   - a custom JDBC connection string: 'jdbc:oracle:thin:@tcps://localhost:12345/ORCL?TNS_ADMIN=/home/alice/.tsh/keys/teleport.example.com/alice-db/teleport.example.com/oracle-wallet'
 ```
 
-This method also enables use of various graphical clients, as explained in [Oracle graphical clients](../../../connect-your-client/gui-clients.mdx#oracle-graphical-clients) section.
+This method also enables use of various graphical clients, as explained in [Oracle graphical clients](../../../../connect-your-client/gui-clients.mdx#oracle-graphical-clients) section.
 
 ## Next steps
 

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/rds.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/rds.mdx
@@ -1,0 +1,11 @@
+---
+title: Protecting Amazon RDS and Aurora Databases
+sidebar_label: RDS and Aurora
+description: Guides for protecting Amazon RDS databases with Teleport
+---
+
+The guides in this section show you how to protect Amazon RDS and Aurora
+databases with Teleport. For RDS Proxy databases, see [Protecting Amazon RDS
+Proxy Databases](../rds-proxy/rds-proxy.mdx):
+
+<DocCardList kind="labelOnly"/>

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/rds/sql-server-ad.mdx
@@ -1,6 +1,6 @@
 ---
-title: Database Access with Amazon RDS for Microsoft SQL Server with Active Directory authentication
-sidebar_label: Amazon RDS for SQL Server
+title: Database Access with Amazon RDS for Microsoft SQL Server with Active Directory Authentication
+sidebar_label: SQL Server
 description: How to configure Teleport database access with RDS for SQL Server with Active Directory authentication.
 videoBanner: k2wz79XCexY
 tags:
@@ -26,10 +26,10 @@ Database Service forwards user traffic to the database.
 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-![Database access with SQL Server and AD authentication](../../../../img/database-access/sql-server-ad-1.png)
+![Database access with SQL Server and AD authentication](../../../../../img/database-access/sql-server-ad-1.png)
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-![Database access with SQL Server and AD authentication](../../../../img/database-access/sql-server-ad-2.png)
+![Database access with SQL Server and AD authentication](../../../../../img/database-access/sql-server-ad-2.png)
 </TabItem>
 </Tabs>
 
@@ -311,7 +311,7 @@ Alternatively, you can look SPNs up in the Attribute Editor of the Active Direct
 Users and Computers dialog on your AD-joined Windows machine. The RDS SQL Server
 object typically resides under the AWS Reserved / RDS path:
 
-![SPN](../../../../img/database-access/guides/sqlserver/spn@2x.png)
+![SPN](../../../../../img/database-access/guides/sqlserver/spn@2x.png)
 
 <Admonition type="tip">
   If you don't see Attribute Editor tab, make sure that "View > Advanced Features"

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redis-aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon ElastiCache for Redis and Valkey
-sidebar_label: Amazon ElastiCache
+sidebar_label: ElastiCache
 description: How to configure Teleport database access with Amazon ElastiCache for Redis and Valkey.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-aws-databases/redshift-serverless.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Amazon Redshift Serverless
-sidebar_label: Amazon Redshift Serverless
+sidebar_label: Redshift Serverless
 description: How to configure Teleport database access with Amazon Redshift Serverless.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-postgres-mysql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Azure PostgreSQL and MySQL
-sidebar_label: Azure PostgreSQL/MySQL
+sidebar_label: PostgreSQL/MySQL
 description: How to configure Teleport database access with Azure Database for PostgreSQL and MySQL.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/azure-sql-server-ad.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Azure SQL Server
-sidebar_label: Azure SQL Server
+sidebar_label: SQL Server
 description: How to configure Teleport database access with Azure SQL Server using Microsoft Entra authentication.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-azure-databases/enroll-azure-databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll Azure Databases
+sidebar_label: Azure
 description: "Provides instructions on protecting databases in your Azure-managed infrastructure with Teleport."
 tags:
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/enroll-google-cloud-databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll Google Cloud Databases
+sidebar_label: Google Cloud
 description: "Provides instructions on protecting databases in your Google Cloud-managed infrastructure with Teleport."
 tags:
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/mysql-cloudsql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Cloud SQL for MySQL
-sidebar_label: Cloud SQL for MySQL
+sidebar_label: MySQL
 description: How to configure Teleport database access with Cloud SQL for MySQL.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/postgres-cloudsql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Cloud SQL for PostgreSQL 
-sidebar_label: Cloud SQL for PostgreSQL
+sidebar_label: PostgreSQL
 description: How to configure Teleport database access with Cloud SQL for PostgreSQL.
 videoBanner: br9LZ3ZXqCk
 tags:

--- a/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-google-cloud-databases/spanner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Cloud Spanner
-sidebar_label: Cloud Spanner
+sidebar_label: Spanner
 description: How to configure Teleport database access with GCP's Cloud Spanner.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-managed-databases/enroll-managed-databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll Cloud-Hosted Database Platforms
+sidebar_label: Cloud-Hosted Database Platforms
 description: "Provides instructions on protecting managed databases in your infrastructure with Teleport."
 tags:
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases.mdx
+++ b/docs/pages/enroll-resources/database-access/enroll-self-hosted-databases/enroll-self-hosted-databases.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll Self-Hosted Databases
+sidebar_label: Self-Hosted
 description: "Provides instructions on protecting self-hosted databases in your infrastructure with Teleport."
 tags:
  - zero-trust

--- a/docs/pages/enroll-resources/database-access/faq.mdx
+++ b/docs/pages/enroll-resources/database-access/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access FAQ
+sidebar_label: FAQ
 description: Frequently asked questions about Teleport database access.
 tags:
  - faq

--- a/docs/pages/enroll-resources/database-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/database-access/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access Getting Started Guide
+sidebar_label: Getting Started
 description: Getting started with Teleport database access and AWS Aurora PostgreSQL.
 tags:
  - get-started

--- a/docs/pages/enroll-resources/database-access/rbac.mdx
+++ b/docs/pages/enroll-resources/database-access/rbac.mdx
@@ -1,5 +1,6 @@
 ---
 title: Database Access Controls
+sidebar_label: Access Controls
 description: Role-based access control (RBAC) for Teleport database access.
 tags:
  - conceptual

--- a/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
+++ b/docs/pages/enroll-resources/mcp-access/dynamic-registration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dynamic MCP Server Registration
-sidebar_position: 7
+sidebar_position: 5
 description: Register/unregister MCP servers without restarting Teleport.
 tags:
 - how-to

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/enrolling-mcp-servers.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/enrolling-mcp-servers.mdx
@@ -1,0 +1,6 @@
+---
+title: Protecting MCP Servers
+description: Provides guidance on enrolling various kinds of MCP servers with Teleport.
+---
+
+<DocCardList />

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/sse.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/sse.mdx
@@ -1,7 +1,6 @@
 ---
 title: MCP Access with SSE MCP Server
-sidebar_position: 5
-sidebar_label: Enroll an SSE MCP Server
+sidebar_label: SSE
 description: How to access MCP server with SSE transport.
 tags:
 - how-to
@@ -18,7 +17,7 @@ This guides shows you how to:
 
 ## How it works
 
-![How it works](../../../img/mcp-access/architecture-sse.svg)
+![How it works](../../../../img/mcp-access/architecture-sse.svg)
 
 Users can configure their MCP clients such as Claude Desktop to start an MCP
 server using `tsh`. Once successfully authorized, `tsh` establishes a session
@@ -75,7 +74,7 @@ everything everything MCP server SSE   env=dev
 
 Learn more about protecting MCP servers with Teleport in the following topics:
 
-- [MCP Access Control](./rbac.mdx).
-- [JWT Authentication to MCP server](./jwt.mdx)
-- [Register MCP servers dynamically](./dynamic-registration.mdx)
-- Configuration and CLI [reference](../../reference/agent-services/mcp-access.mdx).
+- [MCP Access Control](../rbac.mdx).
+- [JWT Authentication to MCP server](../jwt.mdx)
+- [Register MCP servers dynamically](../dynamic-registration.mdx)
+- Configuration and CLI [reference](../../../reference/agent-services/mcp-access.mdx).

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx
@@ -1,7 +1,6 @@
 ---
 title: MCP Access with Stdio MCP Server
-sidebar_position: 4
-sidebar_label: Enroll an Stdio MCP Server
+sidebar_label: Stdio
 description: How to access MCP server with stdio transport.
 tags:
 - how-to
@@ -18,7 +17,7 @@ This guides shows you how to:
 
 ## How it works
 
-![How it works](../../../img/mcp-access/architecture-stdio.svg)
+![How it works](../../../../img/mcp-access/architecture-stdio.svg)
 
 Users can configure their MCP clients such as Claude Desktop to start an MCP
 server using `tsh`. Once successfully authorized, `tsh` establishes a session
@@ -156,6 +155,6 @@ everything everything MCP server stdio env=dev
 
 Learn more about protecting MCP servers with Teleport in the following topics:
 
-- [MCP Access Control](./rbac.mdx).
-- [Register MCP servers dynamically](./dynamic-registration.mdx)
-- Configuration and CLI [reference](../../reference/agent-services/mcp-access.mdx).
+- [MCP Access Control](../rbac.mdx).
+- [Register MCP servers dynamically](../dynamic-registration.mdx)
+- Configuration and CLI [reference](../../../reference/agent-services/mcp-access.mdx).

--- a/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/streamable-http.mdx
+++ b/docs/pages/enroll-resources/mcp-access/enrolling-mcp-servers/streamable-http.mdx
@@ -1,7 +1,6 @@
 ---
 title: MCP Access with Streamable-HTTP MCP Server
-sidebar_position: 3
-sidebar_label: Enroll a Streamable-HTTP MCP Server
+sidebar_label: Streamable-HTTP
 description: How to access MCP server with streamable-HTTP transport.
 tags:
 - how-to
@@ -18,7 +17,7 @@ This guides shows you how to:
 
 ## How it works
 
-![How it works](../../../img/mcp-access/architecture-http.svg)
+![How it works](../../../../img/mcp-access/architecture-http.svg)
 
 Users can configure their MCP clients such as Claude Desktop to start an MCP
 server using `tsh`. Once successfully authorized, `tsh` establishes a session
@@ -84,14 +83,14 @@ $ npx @modelcontextprotocol/inspector --transport http --cli --method tools/list
 ```
 
 Alternatively, instead of `tsh`, you can use [Teleport
-Connect](../../connect-your-client/teleport-connect.mdx#connecting-to-an-mcp-server) which can maintain
+Connect](../../../connect-your-client/teleport-connect.mdx#connecting-to-an-mcp-server) which can maintain
 the local proxies in the background.
 
 ## Next Steps
 
 Learn more about protecting MCP servers with Teleport in the following topics:
 
-- [MCP Access Control](./rbac.mdx).
-- [JWT Authentication to MCP server](./jwt.mdx)
-- [Register MCP servers dynamically](./dynamic-registration.mdx)
-- Configuration and CLI [reference](../../reference/agent-services/mcp-access.mdx).
+- [MCP Access Control](../rbac.mdx).
+- [JWT Authentication to MCP server](../jwt.mdx)
+- [Register MCP servers dynamically](../dynamic-registration.mdx)
+- Configuration and CLI [reference](../../../reference/agent-services/mcp-access.mdx).

--- a/docs/pages/enroll-resources/mcp-access/jwt.mdx
+++ b/docs/pages/enroll-resources/mcp-access/jwt.mdx
@@ -1,6 +1,6 @@
 ---
 title: JWT Authentication to MCP Server
-sidebar_position: 6
+sidebar_position: 4
 description: How to use Teleport JWT to authenticate your MCP servers
 tags:
 - conceptual

--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -52,17 +52,17 @@ Connect an MCP server with the Teleport Application Service, configure and assig
     {
       title: "Enroll a streamable-HTTP MCP server",
       description: "Enroll an MCP server with streamable-HTTP transport into your Teleport cluster and connect to it through Teleport.",
-      href: "./streamable-http/",
+      href: "./enrolling-mcp-servers/streamable-http/",
     },  
     {
       title: "Enroll an stdio MCP server",
       description: "Enroll an MCP server with stdio transport into your Teleport cluster and connect to it through Teleport.",
-      href: "./stdio/",
+      href: "./enrolling-mcp-servers/stdio/",
     },  
     {
       title: "Enroll an SSE MCP server",
       description: "Enroll an MCP server with SSE (Server-Sent Events) transport into your Teleport cluster and connect to it through Teleport.",
-      href: "./sse/",
+      href: "./enrolling-mcp-servers/sse/",
     },  
     {
       title: "JWT authentication to MCP server",

--- a/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
+++ b/docs/pages/enroll-resources/mcp-access/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting MCP Access
-sidebar_position: 8
+sidebar_position: 6
 description: Describes common issues and solutions for access to MCP servers protected by Teleport.
 tags:
 - conceptual

--- a/docs/pages/enroll-resources/server-access/guides/auditd.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/auditd.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure SSH with the Linux Auditing System
+sidebar_label: Linux Auditing System
 description: How to configure Teleport SSH with auditd (Linux Auditing System).
 tags:
  - how-to

--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure Teleport to Create Host Users
+sidebar_label: Host User Creation
 description: How to configure Teleport to automatically create transient host users.
 tags:
  - how-to

--- a/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/ssh-pam.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure SSH with Pluggable Authentication Modules
+sidebar_label: Pluggable Authentication Modules
 description: How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
 tags:
  - conceptual

--- a/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
@@ -1,7 +1,7 @@
 ---
 title: Advanced Entra ID Integration Options
 description: Advanced Teleport Entra ID integration configuration options.
-sidebar_position: 5
+sidebar_position: 4
 tags:
  - identity-governance
  - azure

--- a/docs/pages/identity-governance/integrations/entra-id/configure-access.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/configure-access.mdx
@@ -1,7 +1,8 @@
 ---
-title: Configure access for Entra ID users
-description: Learn how to map Entra ID groups to Teleport roles with Nested Access List
-sidebar_position: 4
+title: Configure Teleport Access for Entra ID Users
+sidebar_label: Import Entra ID Groups
+description: Learn how to map Entra ID groups to Teleport roles with Nested Access Lists.
+sidebar_position: 3
 tags:
  - identity-governance
  - azure

--- a/docs/pages/identity-governance/integrations/entra-id/entra-id.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/entra-id.mdx
@@ -1,5 +1,6 @@
 ---
 title: Entra ID Integration
+sidebar_label: Microsoft Entra ID
 description: Describes how Entra ID integration works in Teleport.
 tags:
  - teleport-as-idp
@@ -74,5 +75,5 @@ configuration methods, for both Teleport as OIDC IdP and system credential based
 ## Guides
 
 - [Getting Started with the Entra ID Integration](getting-started.mdx)
-- [Configure the Entra ID Integration using Azure Portal](manual-installation.mdx)
-- [Configure the Entra ID Integration using Terraform](terraform.mdx)
+- [Configure the Entra ID Integration using Azure Portal](setup/manual-installation.mdx)
+- [Configure the Entra ID Integration using Terraform](setup/terraform.mdx)

--- a/docs/pages/identity-governance/integrations/entra-id/faq.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/faq.mdx
@@ -1,7 +1,8 @@
 ---
 title: Entra ID Integration FAQ
 description: Frequently asked questions on the Teleport Entra ID integration.
-sidebar_position: 6
+sidebar_label: FAQ
+sidebar_position: 5
 tags:
  - identity-governance
  - azure

--- a/docs/pages/identity-governance/integrations/entra-id/getting-started.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started with the Entra ID Integration
+sidebar_label: Getting Started
 description: Describes how to set up the Teleport Entra ID integration in Teleport.
 tags:
  - how-to

--- a/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configure the Entra ID Integration using Azure Portal
+sidebar_label: Azure Portal
 description: Describes how to manually set up Entra ID for the Teleport Entra ID integration.
 tags:
  - how-to
@@ -9,9 +10,9 @@ tags:
 ---
 
 This guide shows manual Entra ID configuration steps to set up Teleport Entra ID integration.
-See [getting started with Entra ID integration](getting-started.mdx) for a guided Entra ID configuration. 
+See [getting started with Entra ID integration](../getting-started.mdx) for a guided Entra ID configuration. 
 
-The set up is based on the [OIDC IdP authentication method](entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
+The set up is based on the [OIDC IdP authentication method](../entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
 
 {/* lint ignore page-structure remark-lint */}
 
@@ -26,7 +27,7 @@ In the Azure Portal, under “Azure services”, select “Enterprise applicatio
 Click on `+ New Application` button, then click `+ Create your own application` button.
 Enter a name for your application and create the application.
 
-![Entra ID Integration](../../../../img/igs/entraid/entra-create-enterprise-app.png)
+![Entra ID Integration](../../../../../img/igs/entraid/entra-create-enterprise-app.png)
 
 
 ## Step 2/5. Configure SSO
@@ -44,7 +45,7 @@ E.g. `https://example.teleport.sh/v1/webapi/saml/acs/entra-id`
 For “Attributes & Claims”, attributes with user will already be available for you but you will need to 
 add a `groups` claim. 
 
-![Entra ID Integration](../../../../img/igs/entraid/entra-sso-config.png)
+![Entra ID Integration](../../../../../img/igs/entraid/entra-sso-config.png)
 
 
 ## Step 3/5. Configure OIDC IdP
@@ -67,7 +68,7 @@ Under “Credential details”, configure the following values:
 - **Name:** teleport-oidc
 - **Description:** Teleport OIDC Identity Provider
 
-![Entra ID Integration](../../../../img/igs/entraid/entra-setup-oidc.png)
+![Entra ID Integration](../../../../../img/igs/entraid/entra-setup-oidc.png)
 
 ## Step 4/5. Configure API permissions
 
@@ -81,7 +82,7 @@ The following permissions need to be added to the application.
 - `Group.Read.All`
 - `User.Read.All`
 
-![Entra ID Integration](../../../../img/igs/entraid/entra-api-permission.png)
+![Entra ID Integration](../../../../../img/igs/entraid/entra-api-permission.png)
 
 
 ## Step 5/5. Install the Entra ID plugin
@@ -111,9 +112,9 @@ After you enter these values, Entra ID plugin will be installed with the OIDC Id
 
 ## Next steps
 
-- [Configure Access](configure-access.mdx) for Entra ID users.
-- Configure [group filters](advanced-options.mdx#group-filters). 
-- Learn more about [Access List](../../access-lists/access-lists.mdx) management.
-- Take a deeper look into setting up [Entra ID auth connector](../../../zero-trust-access/sso/entra-id.mdx). 
-- Learn how the [Identity Security integration with Entra ID](../../../identity-security/integrations/entra-id.mdx) works. 
-- See [FAQs](faq.mdx) related to the Teleport Entra ID integration. 
+- [Configure Access](../configure-access.mdx) for Entra ID users.
+- Configure [group filters](../advanced-options.mdx#group-filters). 
+- Learn more about [Access List](../../../access-lists/access-lists.mdx) management.
+- Take a deeper look into setting up [Entra ID auth connector](../../../../zero-trust-access/sso/entra-id.mdx). 
+- Learn how the [Identity Security integration with Entra ID](../../../../identity-security/integrations/entra-id.mdx) works. 
+- See [FAQs](../faq.mdx) related to the Teleport Entra ID integration. 

--- a/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
@@ -1,0 +1,7 @@
+---
+title: Setting up the Microsoft Entra ID Integration
+sidebar_label: Setup
+description: Provides instructions for setting up the Microsoft Entra ID integration using various methods.
+---
+
+<DocCardList />

--- a/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Configure the Entra ID Integration using Terraform
 description: Describes how to set up the Teleport Entra ID integration using Terraform
-sidebar_position: 3
+sidebar_label: Terraform
 tags:
  - teleport-as-idp
  - infrastructure-as-code
@@ -16,13 +16,13 @@ You will configure the Entra ID side of the configuration using Terraform and in
 plugin in Teleport using `tctl`. 
 
 For other supported configuration methods, see the following guides:
-- [Getting Started with the Entra ID Integration](getting-started.mdx)
+- [Getting Started with the Entra ID Integration](../getting-started.mdx)
 - [Configure the Entra ID Integration using Azure Portal](manual-installation.mdx)
 
 ## How it works
 
 If you are new to the Teleport Entra ID integration, start by reading [how the
-integration works](entra-id.mdx). The `entra-id-integration` Terraform module
+integration works](../entra-id.mdx). The `entra-id-integration` Terraform module
 sets up the integration by deploying a Microsoft Entra ID enterprise application and
 configuring it as a SAML identity provider for your Teleport cluster in order to
 enable authentication to Teleport via Microsoft Entra ID. 
@@ -66,7 +66,7 @@ If you have a self-hosted Teleport Cluster, you must ensure that the Teleport Pr
 
 Alternatively, using system credentials setup is best suited if you have a self-hosted Teleport cluster 
 or when the Teleport Proxy Service is not publicly accessible. You can learn more about the differences 
-on these authentication methods on this [page](entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
+on these authentication methods on this [page](../entra-id.mdx#choosing-the-microsoft-graph-api-authentication-method).
 
 At minimum, the Terraform example expects the following input variables:
 - `app_name`: Name of the enterprise application that will be created in Entra ID.
@@ -229,8 +229,8 @@ plugin service that imports users and groups from Entra ID to Teleport.
 
 ## Next steps
 
-- Learn how to [configure access](configure-access.mdx) for Entra ID users.
-- Configure [group filters](advanced-options.mdx#group-filters). 
-- Take a deeper look into setting up [Entra ID auth connector](../../../zero-trust-access/sso/entra-id.mdx). 
-- Learn how the [Identity Security integration with Entra ID](../../../identity-security/integrations/entra-id.mdx) works. 
-- See [FAQs](faq.mdx) related to the Teleport Entra ID integration. 
+- Learn how to [configure access](../configure-access.mdx) for Entra ID users.
+- Configure [group filters](../advanced-options.mdx#group-filters). 
+- Take a deeper look into setting up [Entra ID auth connector](../../../../zero-trust-access/sso/entra-id.mdx). 
+- Learn how the [Identity Security integration with Entra ID](../../../../identity-security/integrations/entra-id.mdx) works. 
+- See [FAQs](../faq.mdx) related to the Teleport Entra ID integration. 

--- a/docs/pages/identity-governance/integrations/okta/okta.mdx
+++ b/docs/pages/identity-governance/integrations/okta/okta.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enroll the Teleport Okta Integration
+sidebar_label: Okta
 description: Describes how to set up the Teleport Okta integration in order to grant Teleport users access to resources managed in Okta.
 sidebar_position: 4
 tags:

--- a/docs/pages/identity-governance/integrations/scim/scim.mdx
+++ b/docs/pages/identity-governance/integrations/scim/scim.mdx
@@ -1,5 +1,6 @@
 ---
 title: SCIM Integration
+sidebar_label: SCIM
 description: How to manage Access List membership using SCIM integration
 tags:
 - how-to

--- a/docs/pages/includes/application-access/jwt-inject.mdx
+++ b/docs/pages/includes/application-access/jwt-inject.mdx
@@ -1,4 +1,4 @@
-You can inject a JWT token into any header using [headers passthrough](../../enroll-resources/application-access/guides/connecting-apps.mdx#headers-passthrough)
+You can inject a JWT token into any header using [headers passthrough](../../enroll-resources/application-access/protect-apps/connecting-apps.mdx#headers-passthrough)
 configuration and the `{{internal.jwt}}` template variable. This variable will
 be replaced with JWT token signed by Teleport JWT CA containing user identity
 information like described above.

--- a/docs/pages/includes/database-access/rds-proxy.mdx
+++ b/docs/pages/includes/database-access/rds-proxy.mdx
@@ -15,9 +15,9 @@
 
 <Admonition type="note" title="Supported Engine Family">
 Teleport currently supports RDS Proxy instances with engine family
-[PostgreSQL](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx),
-[MariaDB/MySQL](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy-postgres.mdx) or
-[Microsoft SQL Server](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy-sqlserver.mdx).
+[PostgreSQL](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-postgres.mdx),
+[MariaDB/MySQL](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-postgres.mdx) or
+[Microsoft SQL Server](../../enroll-resources/database-access/enroll-aws-databases/rds-proxy/rds-proxy-sqlserver.mdx).
 </Admonition>
 
 (!docs/pages/includes/database-access/auto-discovery-tip.mdx dbType="RDS Proxy" providerType="AWS"!)

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -236,7 +236,7 @@ to match your cluster domain if it is different from the default value `cluster.
 `awsDatabases` configures AWS database auto-discovery.
 
 <Admonition type="note" title="IAM roles">
-  For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enroll-aws-databases/rds.mdx#step-36-create-iam-policies-for-teleport).
+  For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx#step-36-create-iam-policies-for-teleport).
   After configuring a role, you can use an `eks.amazonaws.com/role-arn` annotation with the `annotations.serviceAccount` value to associate it with the service account and grant permissions:
 
   ```yaml

--- a/docs/pages/machine-workload-identity/access-guides/mcp.mdx
+++ b/docs/pages/machine-workload-identity/access-guides/mcp.mdx
@@ -20,7 +20,7 @@ cluster.
 
 This guide focuses on granting machines access to MCP servers. If you wish to
 grant human users access to MCP servers, you should instead refer to the
-[MCP Access with Stdio MCP Server guide](../../enroll-resources/mcp-access/stdio.mdx).
+[MCP Access with Stdio MCP Server guide](../../enroll-resources/mcp-access/enrolling-mcp-servers/stdio.mdx).
 
 ## How it works
 

--- a/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
+++ b/docs/pages/reference/agent-services/auto-discovery-reference/kubernetes-application-discovery.mdx
@@ -136,7 +136,7 @@ annotations:
 ### `teleport.dev/app-rewrite`
 
 Controls rewrite configuration for Teleport app, if needed. It should
-contain full rewrite configuration in YAML format, same as one would use when configuring an app with dynamic registration syntax (see [documentation](../../../enroll-resources/application-access/guides/connecting-apps.mdx)).
+contain full rewrite configuration in YAML format, same as one would use when configuring an app with dynamic registration syntax (see [documentation](../../../enroll-resources/application-access/protect-apps/connecting-apps.mdx)).
 
 ```yaml
 annotations:

--- a/docs/pages/reference/architecture/agents.mdx
+++ b/docs/pages/reference/architecture/agents.mdx
@@ -253,7 +253,7 @@ CLI:
 
 |`tsh` command|Upstream infrastructure resource|
 |---|---|
-|`tsh proxy app`|HTTP and [TCP](../../enroll-resources/application-access/guides/tcp.mdx) applications|
+|`tsh proxy app`|HTTP and [TCP](../../enroll-resources/application-access/protect-apps/tcp.mdx) applications|
 |`tsh proxy aws`|[AWS SDK applications](../../enroll-resources/application-access/cloud-apis/aws-console.mdx)|
 |`tsh proxy azure`|[Azure SDK applications](../../enroll-resources/application-access/cloud-apis/azure.mdx)|
 |`tsh proxy gcloud`|[Google Cloud SDK applications](../../enroll-resources/application-access/cloud-apis/google-cloud.mdx)|

--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -232,7 +232,7 @@ Current limitations for this feature are:
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
 - For desktop access, only WebAuthn devices are supported.
 - When accessing a
-  [multi-port](../../enroll-resources/application-access/guides/tcp.mdx#configuring-access-to-multiple-ports)
+  [multi-port](../../enroll-resources/application-access/protect-apps/tcp.mdx#configuring-access-to-multiple-ports)
   TCP application through [VNet](../../connect-your-client/vnet.mdx), the first connection over
   each port triggers an MFA check.
 - For the `tsh db exec` command, only WebAuthn devices are supported.


### PR DESCRIPTION
Reduce repetitive words in sidebar entry labels in order to make the sidebar easier to read. In some sidebar sections, we used repetitive words to demarcate some parts of the sidebar from others. In these cases, add a new docs subsection to provide a clearer hierarchy.

This change includes the following sections:

- Identity Governance integrations, including a new sidebar section for Entra ID integration setup guides
- Enroll Resources Joining Agents
- Kubernetes Auto-Discovery
- Protecting cloud APIs
- Application access guides, including a new sidebar section for enrolling different kinds of applications
- Top-level application access guides
- Enrolling databases, including new subsections for RDS Proxy and RDS/Aurora databases
- New subsection for enrolling MCP servers