### PR TITLE
[mcp] defer sending session start event to capture more session metadata

### DIFF
--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -19,6 +19,7 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"net"
@@ -200,6 +201,7 @@ func makeTestAuthContext(t *testing.T, roleSet services.RoleSet, app types.Appli
 			Username:   user.GetName(),
 			Groups:     user.GetRoles(),
 			Principals: user.GetLogins(),
+			Expires:    time.Now().Add(time.Hour),
 		},
 	}
 	if app != nil {
@@ -357,6 +359,9 @@ func checkSessionStartAndInitializeEvents(t *testing.T, events []apievents.Audit
 	t.Helper()
 	// "notifications/initialized" may or may not slip in so just check the
 	// first two.
+	slices.SortFunc(events, func(a, b apievents.AuditEvent) int {
+		return cmp.Compare(a.GetIndex(), b.GetIndex())
+	})
 	require.GreaterOrEqual(t, len(events), 2)
 	sessionStart, ok := events[0].(*apievents.MCPSessionStart)
 	require.True(t, ok)

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -245,7 +245,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
 			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitOrAppendRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
 		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	}
@@ -253,7 +253,7 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 }
 
 func (t *streamableHTTPTransport) handleRequestAuthError(r *http.Request, mcpRequest *mcputils.JSONRPCRequest, errResp mcp.JSONRPCMessage, authErr error) (*http.Response, error) {
-	t.emitOrAppendRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
+	t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
 
 	errRespAsBody, err := json.Marshal(errResp)
 	if err != nil {

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -74,6 +74,7 @@ func (s *Server) handleStreamableHTTP(ctx context.Context, sessionCtx *SessionCt
 	if err != nil {
 		return trace.Wrap(err, "setting up session handler")
 	}
+	defer session.sessionAuditor.flush(s.cfg.ParentContext)
 
 	transport, err := s.makeStreamableHTTPTransport(session)
 	if err != nil {
@@ -165,7 +166,7 @@ func (t *streamableHTTPTransport) RoundTrip(r *http.Request) (*http.Response, er
 
 func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 	if id := header.Get(mcpSessionIDHeader); id != "" {
-		t.mcpSessionID.Store(&id)
+		t.updatePendingSessionStartEventWithExternalSessionID(id)
 	}
 }
 
@@ -216,11 +217,11 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		if errResp, authErr := t.sessionHandler.processClientRequestNoAudit(r.Context(), mcpRequest); authErr != nil {
+		if errResp, authErr := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); authErr != nil {
 			return t.handleRequestAuthError(r, mcpRequest, errResp, authErr)
 		}
 	case baseMessage.IsNotification():
-		// nothing to do, yet.
+		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
 	default:
 		// Not sending it to the server if we don't understand it.
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
@@ -242,17 +243,17 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		mcpRequest := baseMessage.MakeRequest()
 		// Only emit session start if "initialize" succeeded.
 		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
-			t.emitStartEvent(t.parentCtx, eventWithHeader(r.Header))
+			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitOrAppendRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
-		t.emitNotificationEvent(t.parentCtx, baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	}
 	return resp, trace.Wrap(err)
 }
 
 func (t *streamableHTTPTransport) handleRequestAuthError(r *http.Request, mcpRequest *mcputils.JSONRPCRequest, errResp mcp.JSONRPCMessage, authErr error) (*http.Response, error) {
-	t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
+	t.emitOrAppendRequestEvent(t.parentCtx, mcpRequest, eventWithError(authErr), eventWithHeader(r.Header))
 
 	errRespAsBody, err := json.Marshal(errResp)
 	if err != nil {
@@ -300,7 +301,11 @@ func newHTTPResponseReplacer(sessionHandler *sessionHandler) *streamableHTTPResp
 }
 
 func (p *streamableHTTPResponseReplacer) ProcessResponse(ctx context.Context, resp *mcputils.JSONRPCResponse) mcp.JSONRPCMessage {
-	return p.processServerResponse(ctx, resp)
+	method, response := p.processServerResponse(ctx, resp)
+	if method == mcputils.MethodInitialize {
+		p.sessionAuditor.updatePendingSessionStartEventWithInitializeResult(ctx, resp)
+	}
+	return response
 }
 func (p *streamableHTTPResponseReplacer) ProcessNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) mcp.JSONRPCMessage {
 	p.processServerNotification(ctx, notification)

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -105,6 +105,7 @@ func Test_handleStreamableHTTP(t *testing.T) {
 			wg.Go(func() {
 				defer conn.Close()
 				testCtx := setupTestContext(t, withAdminRole(t), withApp(app), withClientConn(conn))
+				testCtx.sessionID = "test-session-id" // use same session id
 				assert.NoError(t, s.HandleSession(t.Context(), testCtx.SessionCtx))
 			})
 		}
@@ -144,11 +145,6 @@ func Test_handleStreamableHTTP(t *testing.T) {
 			checkSessionStartHasExternalSessionID(),
 			checkSessionStartWithEgressAuthType("app-jwt"),
 		)
-
-		// First event must be the start event.
-		startEvent, ok := emitter.Events()[0].(*apievents.MCPSessionStart)
-		require.True(t, ok)
-		require.Equal(t, "app-jwt", startEvent.EgressAuthType)
 
 		// Close client and wait for end event.
 		require.NoError(t, client.Close())

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -139,6 +139,11 @@ func Test_handleStreamableHTTP(t *testing.T) {
 				libevents.MCPSessionRequestCode, // "tools/call"
 			}, sliceutils.Map(emitter.Events(), getEventCode))
 		}, 2*time.Second, time.Millisecond*100, "waiting for events")
+		checkSessionStartAndInitializeEvents(t, emitter.Events(),
+			checkSessionStartWithServerInfo("test-server", "1.0.0"),
+			checkSessionStartHasExternalSessionID(),
+			checkSessionStartWithEgressAuthType("app-jwt"),
+		)
 
 		// First event must be the start event.
 		startEvent, ok := emitter.Events()[0].(*apievents.MCPSessionStart)

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -257,6 +257,8 @@ func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageW
 func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, error) {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
 
+	// TODO(greedy52) add checks to ensure that the initialize request is the
+	// first request coming in (with the exception of the ping).
 	s.idTracker.PushRequest(req)
 	switch req.Method {
 	case mcputils.MethodToolsCall:

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -229,7 +229,7 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
 		msg, authErr := s.processClientRequest(ctx, request)
-		s.emitOrAppendRequestEvent(ctx, request, eventWithError(authErr))
+		s.emitRequestEvent(ctx, request, eventWithError(authErr))
 		if authErr != nil {
 			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, msg))
 		}

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -24,7 +24,6 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -60,9 +59,6 @@ type SessionCtx struct {
 	// Note that for stdio-based MCP server, a new session ID is generated per
 	// connection instead of using the web session ID from the app route.
 	sessionID session.ID
-
-	// mcpSessionID is the MCP session ID tracked by remote MCP server.
-	mcpSessionID atomicString
 
 	// jwt is the jwt token signed for this identity by Auth server.
 	jwt string
@@ -180,6 +176,11 @@ func newSessionHandler(cfg sessionHandlerConfig) (*sessionHandler, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// Always begins with session start event for single-connection sessions.
+	if cfg.sessionCtx.transport != types.MCPTransportHTTP {
+		cfg.sessionAuditor.appendStartEvent(cfg.parentCtx)
+	}
+
 	return &sessionHandler{
 		sessionHandlerConfig: cfg,
 		idTracker:            idTracker,
@@ -203,13 +204,23 @@ func (s *sessionHandler) checkAccessToTool(ctx context.Context, toolName string)
 	return trace.NewAggregate(authErr, err)
 }
 
-func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
-	s.emitNotificationEvent(ctx, notification)
-	messagesFromClient.WithLabelValues(s.transport, "notification", reportNotificationMethod(notification.Method)).Inc()
+// NOTE: the onClientXXX/onServerXXX functions and the close function below
+// provides helper to single-connection sessions and handles audit events.
+// The streamable-HTTP server handler does not use these function but uses
+// processClientXXX/processServerXXX functions directly instead and handles
+// audit events outside the sessionHandler. Ideally we should do some
+// refactoring to separate handler types.
+
+func (s *sessionHandler) close() {
+	s.sessionAuditor.flush(s.parentCtx)
+	if s.sessionCtx.transport != types.MCPTransportHTTP {
+		s.sessionAuditor.emitEndEvent(s.parentCtx)
+	}
 }
 
 func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.MessageWriter) mcputils.HandleNotificationFunc {
 	return func(ctx context.Context, notification *mcputils.JSONRPCNotification) error {
+		s.emitNotificationEvent(ctx, notification)
 		s.processClientNotification(ctx, notification)
 		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, notification))
 	}
@@ -217,8 +228,9 @@ func (s *sessionHandler) onClientNotification(serverRequestWriter mcputils.Messa
 
 func (s *sessionHandler) onClientRequest(clientResponseWriter, serverRequestWriter mcputils.MessageWriter) mcputils.HandleRequestFunc {
 	return func(ctx context.Context, request *mcputils.JSONRPCRequest) error {
-		msg, replyDirection := s.processClientRequest(ctx, request)
-		if replyDirection == replyToClient {
+		msg, authErr := s.processClientRequest(ctx, request)
+		s.emitOrAppendRequestEvent(ctx, request, eventWithError(authErr))
+		if authErr != nil {
 			return trace.Wrap(clientResponseWriter.WriteMessage(ctx, msg))
 		}
 		return trace.Wrap(serverRequestWriter.WriteMessage(ctx, msg))
@@ -234,31 +246,15 @@ func (s *sessionHandler) onServerNotification(clientResponseWriter mcputils.Mess
 
 func (s *sessionHandler) onServerResponse(clientResponseWriter mcputils.MessageWriter) mcputils.HandleResponseFunc {
 	return func(ctx context.Context, response *mcputils.JSONRPCResponse) error {
-		msgToClient := s.processServerResponse(ctx, response)
+		method, msgToClient := s.processServerResponse(ctx, response)
+		if method == mcputils.MethodInitialize {
+			s.sessionAuditor.updatePendingSessionStartEventWithInitializeResult(ctx, response)
+		}
 		return trace.Wrap(clientResponseWriter.WriteMessage(ctx, msgToClient))
 	}
 }
 
-type replyDirection bool
-
-const (
-	replyToClient replyDirection = true
-	replyToServer replyDirection = false
-)
-
-func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, replyDirection) {
-	s.idTracker.PushRequest(req)
-	reply, authErr := s.processClientRequestNoAudit(ctx, req)
-	s.emitRequestEvent(ctx, req, eventWithError(authErr))
-
-	// Not forwarding to server. Just send the auth error to client.
-	if authErr != nil {
-		return reply, replyToClient
-	}
-	return reply, replyToServer
-}
-
-func (s *sessionHandler) processClientRequestNoAudit(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, error) {
+func (s *sessionHandler) processClientRequest(ctx context.Context, req *mcputils.JSONRPCRequest) (mcp.JSONRPCMessage, error) {
 	messagesFromClient.WithLabelValues(s.transport, "request", reportRequestMethod(req.Method)).Inc()
 
 	s.idTracker.PushRequest(req)
@@ -272,15 +268,19 @@ func (s *sessionHandler) processClientRequestNoAudit(ctx context.Context, req *m
 	return req, nil
 }
 
-func (s *sessionHandler) processServerResponse(ctx context.Context, response *mcputils.JSONRPCResponse) mcp.JSONRPCMessage {
+func (s *sessionHandler) processClientNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
+	messagesFromClient.WithLabelValues(s.transport, "notification", reportNotificationMethod(notification.Method)).Inc()
+}
+
+func (s *sessionHandler) processServerResponse(ctx context.Context, response *mcputils.JSONRPCResponse) (string, mcp.JSONRPCMessage) {
 	method, _ := s.idTracker.PopByID(response.ID)
 	messagesFromServer.WithLabelValues(s.transport, "response", reportRequestMethod(method)).Inc()
 
 	switch method {
 	case mcputils.MethodToolsList:
-		return s.makeToolsCallResponse(ctx, response)
+		return method, s.makeToolsCallResponse(ctx, response)
 	}
-	return response
+	return method, response
 }
 
 func (s *sessionHandler) processServerNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) {
@@ -336,16 +336,4 @@ func makeToolAccessDeniedResponse(msg *mcputils.JSONRPCRequest, authErr error) m
 		"RBAC is enforced by your Teleport roles. Contact your Teleport Admin for more details.",
 		authErr,
 	)
-}
-
-type atomicString struct {
-	atomic.Pointer[string]
-}
-
-// String loads the atomic string value. If the point is nil, empty is returned.
-func (s *atomicString) String() string {
-	if loaded := s.Load(); loaded != nil {
-		return *loaded
-	}
-	return ""
 }

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -19,6 +19,9 @@
 package mcp
 
 import (
+	"context"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -29,6 +32,24 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
+
+type captureMessageWriter struct {
+	mu   sync.Mutex
+	msgs []mcp.JSONRPCMessage
+}
+
+func (c *captureMessageWriter) WriteMessage(_ context.Context, msg mcp.JSONRPCMessage) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, msg)
+	return nil
+}
+
+func (c *captureMessageWriter) messages() []mcp.JSONRPCMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.msgs)
+}
 
 func Test_sessionHandler(t *testing.T) {
 	tests := []struct {
@@ -82,23 +103,26 @@ func Test_sessionHandler(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("notification", func(t *testing.T) {
-				handler.processClientNotification(ctx, &mcputils.JSONRPCNotification{
+				msg := &mcputils.JSONRPCNotification{
 					JSONRPC: mcp.JSONRPC_VERSION,
 					Method:  "notifications/initialized",
-				})
+				}
+				capture := &captureMessageWriter{}
+				require.NoError(t, handler.onClientNotification(capture)(ctx, msg))
 				event := mockEmitter.LastEvent()
 				require.NotNil(t, event)
 				requestEvent, ok := event.(*apievents.MCPSessionNotification)
 				require.True(t, ok)
 				require.Equal(t, "notifications/initialized", requestEvent.Message.Method)
+				require.Equal(t, []mcp.JSONRPCMessage{msg}, capture.messages())
 			})
 
 			for _, allowedTool := range tt.allowedTools {
 				t.Run("allow tools call "+allowedTool, func(t *testing.T) {
 					clientReq := requestBuilder.makeToolsCallRequest(allowedTool)
-					msg, dir := handler.processClientRequest(ctx, clientReq)
-					require.Equal(t, replyToServer, dir)
-					require.Equal(t, clientReq, msg)
+					clientCapture := &captureMessageWriter{}
+					serverCapture := &captureMessageWriter{}
+					require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
 
 					event := mockEmitter.LastEvent()
 					require.NotNil(t, event)
@@ -107,17 +131,19 @@ func Test_sessionHandler(t *testing.T) {
 					require.True(t, requestEvent.Success)
 					require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
 					checkParamsHaveNameField(t, requestEvent.Message.Params, allowedTool)
+
+					// Server receives the client's request.
+					require.Equal(t, []mcp.JSONRPCMessage{clientReq}, serverCapture.messages())
+					require.Empty(t, clientCapture.messages())
 				})
 			}
 
 			for _, deniedTool := range tt.deniedTools {
 				t.Run("deny tools call "+deniedTool, func(t *testing.T) {
 					clientReq := requestBuilder.makeToolsCallRequest(deniedTool)
-					msg, dir := handler.processClientRequest(ctx, clientReq)
-					require.Equal(t, replyToClient, dir)
-					errMsg, ok := msg.(mcp.JSONRPCError)
-					require.True(t, ok)
-					require.Equal(t, clientReq.ID, errMsg.ID)
+					clientCapture := &captureMessageWriter{}
+					serverCapture := &captureMessageWriter{}
+					require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
 
 					event := mockEmitter.LastEvent()
 					require.NotNil(t, event)
@@ -126,6 +152,13 @@ func Test_sessionHandler(t *testing.T) {
 					require.False(t, requestEvent.Success)
 					require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
 					checkParamsHaveNameField(t, requestEvent.Message.Params, deniedTool)
+
+					// Server does not receive the client's request. An error is
+					// sent to client.
+					require.Empty(t, serverCapture.messages())
+					clientMessages := clientCapture.messages()
+					require.Len(t, clientMessages, 1)
+					require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
 				})
 			}
 
@@ -134,8 +167,8 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				_, dir := handler.processClientRequest(ctx, clientReq)
-				require.Equal(t, replyToServer, dir)
+				_, authErr := handler.processClientRequest(ctx, clientReq)
+				require.NoError(t, authErr)
 
 				// tools/list does not trigger audit event.
 				require.Nil(t, mockEmitter.LastEvent())
@@ -145,8 +178,11 @@ func Test_sessionHandler(t *testing.T) {
 				// filtering.
 				allTools := append(tt.allowedTools, tt.deniedTools...)
 				serverResponse := makeToolsCallResponse(t, clientReq.ID, allTools...)
-				processedResponse := handler.processServerResponse(ctx, serverResponse)
-				checkToolsListResponse(t, processedResponse, clientReq.ID, tt.allowedTools)
+				capture := &captureMessageWriter{}
+				require.NoError(t, handler.onServerResponse(capture)(ctx, serverResponse))
+				clientMessages := capture.messages()
+				require.Len(t, clientMessages, 1)
+				checkToolsListResponse(t, clientMessages[0], clientReq.ID, tt.allowedTools)
 			})
 		})
 	}

--- a/lib/srv/mcp/sse_test.go
+++ b/lib/srv/mcp/sse_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
-	apievents "github.com/gravitational/teleport/api/types/events"
+	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/mcptest"
@@ -83,17 +83,13 @@ func Test_handleStdioToSSE(t *testing.T) {
 	// Use a real client. Double check start event has the external MCP session
 	// ID.
 	stdioClient := mcptest.NewStdioClientFromConn(t, testCtx.clientSourceConn)
-	var startEvent *apievents.MCPSessionStart
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		var ok bool
-		event := emitter.LastEvent()
-		startEvent, ok = event.(*apievents.MCPSessionStart)
-		require.True(t, ok)
-	}, time.Second*5, time.Millisecond*100, "expect session start")
-	require.NotEmpty(t, startEvent.McpSessionId)
-
 	resp := mcptest.MustInitializeClient(t, stdioClient)
 	require.Equal(t, "test-server", resp.ServerInfo.Name)
+	checkSessionStartAndInitializeEvents(t, emitter.Events(),
+		checkSessionStartWithServerInfo("test-server", "1.0.0"),
+		checkSessionStartHasExternalSessionID(),
+		checkSessionStartWithEgressAuthType("app-jwt"),
+	)
 
 	// Make a tools call.
 	mcptest.MustCallServerTool(t, stdioClient)
@@ -105,4 +101,5 @@ func Test_handleStdioToSSE(t *testing.T) {
 		require.Fail(t, "timed out waiting for handler")
 	case <-handleDoneCh:
 	}
+	require.Equal(t, libevents.MCPSessionEndEvent, emitter.LastEvent().GetType())
 }

--- a/lib/srv/mcp/stdio.go
+++ b/lib/srv/mcp/stdio.go
@@ -84,6 +84,7 @@ func (s *Server) handleStdio(ctx context.Context, sessionCtx *SessionCtx, makeSe
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer session.close()
 
 	session.logger.InfoContext(ctx, "Started handling stdio session")
 	defer session.logger.InfoContext(ctx, "Completed handling stdio session")
@@ -131,11 +132,6 @@ func (s *Server) handleStdio(ctx context.Context, sessionCtx *SessionCtx, makeSe
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// TODO(greedy52) capture client info then emit start event with client
-	// information.
-	session.emitStartEvent(s.cfg.ParentContext)
-	defer session.emitEndEvent(s.cfg.ParentContext)
 
 	go clientRequestReader.Run(ctx)
 	go serverResponseReader.Run(ctx)

--- a/lib/srv/mcp/stdio_test.go
+++ b/lib/srv/mcp/stdio_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -96,18 +97,14 @@ func Test_handleStdio(t *testing.T) {
 		require.NoError(t, handlerErr)
 	}()
 
-	// Use a real client. Verify session start and end events.
+	// Use a real client.
 	stdioClient := mcptest.NewStdioClientFromConn(t, testCtx.clientSourceConn)
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		event := emitter.LastEvent()
-		_, ok := event.(*apievents.MCPSessionStart)
-		require.True(t, ok)
-	}, time.Second*5, time.Millisecond*100, "expect session start")
 
 	// Some basic tests on the demo server.
 	resp, err := mcptest.InitializeClient(ctx, stdioClient)
 	require.NoError(t, err)
 	require.Equal(t, "teleport-demo", resp.ServerInfo.Name)
+	checkSessionStartAndInitializeEvents(t, emitter.Events(), checkSessionStartWithServerInfo("teleport-demo", teleport.Version))
 
 	listToolsResult, err := stdioClient.ListTools(ctx, mcp.ListToolsRequest{})
 	require.NoError(t, err)


### PR DESCRIPTION
related:
- https://github.com/gravitational/cloud/pull/15206

This change is to prepare for more MCP session metadata to be sent to prehog.