### PR TITLE
Adding static scoped tokens to file config

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -558,6 +558,146 @@ func (x *ImmutableLabels) GetSsh() map[string]string {
 	return nil
 }
 
+// The resource representing static scoped tokens defined in the auth service file configuration. These are
+// represented as a separate resource so that they can be managed separately from dynamic scoped tokens as
+// a singleton.
+type StaticScopedTokens struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The resource kind.
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// The resource sub-kind.
+	SubKind string `protobuf:"bytes,2,opt,name=sub_kind,json=subKind,proto3" json:"sub_kind,omitempty"`
+	// The resource version.
+	Version string `protobuf:"bytes,3,opt,name=version,proto3" json:"version,omitempty"`
+	// The resource metadata.
+	Metadata *v1.Metadata `protobuf:"bytes,4,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// The scope of the resource.
+	Scope string `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
+	// The resource specification.
+	Spec          *StaticScopedTokensSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StaticScopedTokens) Reset() {
+	*x = StaticScopedTokens{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticScopedTokens) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticScopedTokens) ProtoMessage() {}
+
+func (x *StaticScopedTokens) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticScopedTokens.ProtoReflect.Descriptor instead.
+func (*StaticScopedTokens) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *StaticScopedTokens) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *StaticScopedTokens) GetSubKind() string {
+	if x != nil {
+		return x.SubKind
+	}
+	return ""
+}
+
+func (x *StaticScopedTokens) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *StaticScopedTokens) GetMetadata() *v1.Metadata {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+func (x *StaticScopedTokens) GetScope() string {
+	if x != nil {
+		return x.Scope
+	}
+	return ""
+}
+
+func (x *StaticScopedTokens) GetSpec() *StaticScopedTokensSpec {
+	if x != nil {
+		return x.Spec
+	}
+	return nil
+}
+
+// The specification representing the static scoped tokens
+// resource.
+type StaticScopedTokensSpec struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The statically parsed scoped tokens.
+	Tokens        []*ScopedToken `protobuf:"bytes,1,rep,name=tokens,proto3" json:"tokens,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *StaticScopedTokensSpec) Reset() {
+	*x = StaticScopedTokensSpec{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *StaticScopedTokensSpec) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*StaticScopedTokensSpec) ProtoMessage() {}
+
+func (x *StaticScopedTokensSpec) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use StaticScopedTokensSpec.ProtoReflect.Descriptor instead.
+func (*StaticScopedTokensSpec) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *StaticScopedTokensSpec) GetTokens() []*ScopedToken {
+	if x != nil {
+		return x.Tokens
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -601,7 +741,16 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x03ssh\x18\x01 \x03(\v24.teleport.scopes.joining.v1.ImmutableLabels.SshEntryR\x03ssh\x1a6\n" +
 	"\bSshEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01BYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xf5\x01\n" +
+	"\x12StaticScopedTokens\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
+	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
+	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
+	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
+	"\x05scope\x18\x05 \x01(\tR\x05scope\x12F\n" +
+	"\x04spec\x18\x06 \x01(\v22.teleport.scopes.joining.v1.StaticScopedTokensSpecR\x04spec\"Y\n" +
+	"\x16StaticScopedTokensSpec\x12?\n" +
+	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokensBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -615,35 +764,40 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
-	(*ScopedToken)(nil),           // 0: teleport.scopes.joining.v1.ScopedToken
-	(*ScopedTokenSpec)(nil),       // 1: teleport.scopes.joining.v1.ScopedTokenSpec
-	(*HostCertParams)(nil),        // 2: teleport.scopes.joining.v1.HostCertParams
-	(*SingleUseStatus)(nil),       // 3: teleport.scopes.joining.v1.SingleUseStatus
-	(*UsageStatus)(nil),           // 4: teleport.scopes.joining.v1.UsageStatus
-	(*ScopedTokenStatus)(nil),     // 5: teleport.scopes.joining.v1.ScopedTokenStatus
-	(*ImmutableLabels)(nil),       // 6: teleport.scopes.joining.v1.ImmutableLabels
-	nil,                           // 7: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*v1.Metadata)(nil),           // 8: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil), // 9: google.protobuf.Timestamp
+	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
+	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
+	(*HostCertParams)(nil),         // 2: teleport.scopes.joining.v1.HostCertParams
+	(*SingleUseStatus)(nil),        // 3: teleport.scopes.joining.v1.SingleUseStatus
+	(*UsageStatus)(nil),            // 4: teleport.scopes.joining.v1.UsageStatus
+	(*ScopedTokenStatus)(nil),      // 5: teleport.scopes.joining.v1.ScopedTokenStatus
+	(*ImmutableLabels)(nil),        // 6: teleport.scopes.joining.v1.ImmutableLabels
+	(*StaticScopedTokens)(nil),     // 7: teleport.scopes.joining.v1.StaticScopedTokens
+	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
+	nil,                            // 9: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*v1.Metadata)(nil),            // 10: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	8,  // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	10, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
-	9,  // 4: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	9,  // 5: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	11, // 4: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	11, // 5: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
 	2,  // 6: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
 	3,  // 7: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
 	4,  // 8: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	7,  // 9: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	10, // [10:10] is the sub-list for method output_type
-	10, // [10:10] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	9,  // 9: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	10, // 10: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 11: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 12: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -660,7 +814,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -124,3 +124,33 @@ message ImmutableLabels {
   // Labels that should be applied to SSH nodes.
   map<string, string> ssh = 1;
 }
+
+// The resource representing static scoped tokens defined in the auth service file configuration. These are
+// represented as a separate resource so that they can be managed separately from dynamic scoped tokens as
+// a singleton.
+message StaticScopedTokens {
+  // The resource kind.
+  string kind = 1;
+
+  // The resource sub-kind.
+  string sub_kind = 2;
+
+  // The resource version.
+  string version = 3;
+
+  // The resource metadata.
+  teleport.header.v1.Metadata metadata = 4;
+
+  // The scope of the resource.
+  string scope = 5;
+
+  // The resource specification.
+  StaticScopedTokensSpec spec = 6;
+}
+
+// The specification representing the static scoped tokens
+// resource.
+message StaticScopedTokensSpec {
+  // The statically parsed scoped tokens.
+  repeated ScopedToken tokens = 1;
+}

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -406,8 +406,14 @@ const (
 	// KindStaticTokens is a type of configuration resource that contains static tokens.
 	KindStaticTokens = "static_tokens"
 
+	// KindStaticScopedTokens is a type of configuration resource that contains static scoped tokens.
+	KindStaticScopedTokens = "static_scoped_tokens"
+
 	// MetaNameStaticTokens is the name of a configuration resource for static tokens.
 	MetaNameStaticTokens = "static-tokens"
+
+	// MetaNameStaticScopedTokens is the name of a configuration resource for static scoped tokens.
+	MetaNameStaticScopedTokens = "static-scoped-tokens"
 
 	// MetaNameSessionTracker is the prefix of resources used to track live sessions.
 	MetaNameSessionTracker = "session-tracker"

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -76,6 +76,7 @@ type Config struct {
 	Applications            services.Applications
 	BotInstance             services.BotInstance
 	ClusterConfig           services.ClusterConfiguration
+	StaticScopedToken       services.StaticScopedTokenService
 	CrownJewels             services.CrownJewels
 	DatabaseObjects         services.DatabaseObjects
 	DatabaseServices        services.DatabaseServices
@@ -162,6 +163,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		AppSession:              cfg.AppSession,
 		Apps:                    cfg.Applications,
 		ClusterConfig:           cfg.ClusterConfig,
+		StaticScopedToken:       cfg.StaticScopedToken,
 		AutoUpdateService:       cfg.AutoUpdateService,
 		CrownJewels:             cfg.CrownJewels,
 		DatabaseObjects:         cfg.DatabaseObjects,

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -612,6 +612,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
 		Plugin:                  p.AuthServer.Services.Plugins,
 		AppAuthConfig:           p.AuthServer.Services.AppAuthConfig,
+		StaticScopedToken:       p.AuthServer.Services.ClusterConfigurationInternal,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -45,6 +45,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	summarizerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/clusterconfig"
@@ -207,6 +208,10 @@ type InitConfig struct {
 	// StaticTokens are pre-defined host provisioning tokens supplied via config file for
 	// environments where paranoid security is not needed
 	StaticTokens types.StaticTokens
+
+	// StaticTokens are pre-defined, scoped host provisioning tokens supplied via config file for
+	// environments where paranoid security is not needed
+	StaticScopedTokens *joiningv1.StaticScopedTokens
 
 	// AuthPreference defines the authentication type (local, oidc) and second
 	// factor passed in from a configuration file.
@@ -600,6 +605,15 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		defer span.End()
 		asrv.logger.InfoContext(ctx, "Updating cluster configuration", "static_tokens", cfg.StaticTokens)
 		return trace.Wrap(asrv.SetStaticTokens(cfg.StaticTokens))
+	})
+
+	g.Go(func() error {
+		_, span := cfg.Tracer.Start(gctx, "auth/SetStaticScopedTokens")
+		defer span.End()
+		if cfg.StaticScopedTokens != nil {
+			return trace.Wrap(asrv.SetStaticScopedTokens(gctx, cfg.StaticScopedTokens))
+		}
+		return nil
 	})
 
 	var cn types.ClusterName

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -146,6 +146,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindSessionRecordingConfig},
 		{Kind: types.KindUIConfig},
 		{Kind: types.KindStaticTokens},
+		{Kind: types.KindStaticScopedTokens},
 		{Kind: types.KindToken},
 		{Kind: types.KindUser},
 		{Kind: types.KindRole},
@@ -656,6 +657,8 @@ type Config struct {
 	Trust services.Trust
 	// ClusterConfig is a cluster configuration service
 	ClusterConfig services.ClusterConfiguration
+	// StaticScopedToken manages the cluster's static scoped tokens.
+	StaticScopedToken services.StaticScopedTokenService
 	// AutoUpdateService is an autoupdate service.
 	AutoUpdateService services.AutoUpdateServiceGetter
 	// Provisioner is a provisioning service

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -594,6 +594,7 @@ func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 p.eventsC,
 		AppAuthConfig:           p.appAuthConfigs,
+		StaticScopedToken:       p.clusterConfigS,
 	}))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -864,6 +865,7 @@ func TestCompletenessInit(t *testing.T) {
 			BotInstanceService:      p.botInstanceService,
 			Plugin:                  p.plugin,
 			AppAuthConfig:           p.appAuthConfigs,
+			StaticScopedToken:       p.clusterConfigS,
 		}))
 		require.NoError(t, err)
 
@@ -953,6 +955,7 @@ func TestCompletenessReset(t *testing.T) {
 		BotInstanceService:      p.botInstanceService,
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
+		StaticScopedToken:       p.clusterConfigS,
 	}))
 	require.NoError(t, err)
 
@@ -1114,6 +1117,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		BotInstanceService:      p.botInstanceService,
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
+		StaticScopedToken:       p.clusterConfigS,
 	}))
 	require.NoError(t, err)
 
@@ -1214,6 +1218,7 @@ func initStrategy(t *testing.T) {
 		BotInstanceService:      p.botInstanceService,
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
+		StaticScopedToken:       p.clusterConfigS,
 	}))
 	require.NoError(t, err)
 
@@ -1887,6 +1892,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindSessionRecordingConfig:            types.DefaultSessionRecordingConfig(),
 		types.KindUIConfig:                          &types.UIConfigV1{},
 		types.KindStaticTokens:                      &types.StaticTokensV2{},
+		types.KindStaticScopedTokens:                &types.StaticTokensV2{},
 		types.KindToken:                             &types.ProvisionTokenV2{},
 		types.KindUser:                              &types.UserV2{},
 		types.KindRole:                              &types.RoleV6{Version: types.V4},

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -36,6 +36,7 @@ import (
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
 	provisioningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/provisioning/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
@@ -73,6 +74,7 @@ type collections struct {
 
 	provisionTokens                    *collection[types.ProvisionToken, provisionTokenIndex]
 	staticTokens                       *collection[types.StaticTokens, staticTokensIndex]
+	staticScopedTokens                 *collection[*joiningv1.StaticScopedTokens, staticScopedTokensIndex]
 	certAuthorities                    *collection[types.CertAuthority, certAuthorityIndex]
 	users                              *collection[types.User, userIndex]
 	roles                              *collection[types.Role, roleIndex]
@@ -191,6 +193,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.staticTokens = collect
 			out.byKind[resourceKind] = out.staticTokens
+		case types.KindStaticScopedTokens:
+			collect, err := newStaticScopedTokensCollection(c.StaticScopedToken, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.staticScopedTokens = collect
+			out.byKind[resourceKind] = out.staticScopedTokens
 		case types.KindCertAuthority:
 			collect, err := newCertAuthorityCollection(c.Trust, watch)
 			if err != nil {

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -261,6 +261,7 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 		RecordingEncryption:     recordingEncryption,
 		Plugin:                  plugin,
 		AppAuthConfig:           appAuthConfig,
+		StaticScopedToken:       clusterConfig,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 eventsC,
 	}))

--- a/lib/cache/static_scoped_tokens.go
+++ b/lib/cache/static_scoped_tokens.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type staticScopedTokensIndex string
+
+const staticScopedTokensNameIndex staticScopedTokensIndex = "name"
+
+func newStaticScopedTokensCollection(upstream services.StaticScopedTokenService, w types.WatchKind) (*collection[*joiningv1.StaticScopedTokens, staticScopedTokensIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter StaticScopedTokenService")
+	}
+
+	return &collection[*joiningv1.StaticScopedTokens, staticScopedTokensIndex]{
+		store: newStore(
+			types.KindStaticScopedTokens,
+			proto.CloneOf[*joiningv1.StaticScopedTokens],
+			map[staticScopedTokensIndex]func(*joiningv1.StaticScopedTokens) string{
+				staticScopedTokensNameIndex: func(s *joiningv1.StaticScopedTokens) string {
+					return s.GetMetadata().GetName()
+				},
+			},
+		),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*joiningv1.StaticScopedTokens, error) {
+			tokens, err := upstream.GetStaticScopedTokens(ctx)
+			return []*joiningv1.StaticScopedTokens{tokens}, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *joiningv1.StaticScopedTokens {
+			return &joiningv1.StaticScopedTokens{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: types.MetaNameStaticScopedTokens,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// GetStaticScopedTokens gets the list of static scoped tokens used to provision nodes.
+func (c *Cache) GetStaticScopedTokens(ctx context.Context) (*joiningv1.StaticScopedTokens, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetStaticScopedTokens")
+	defer span.End()
+
+	getter := genericGetter[*joiningv1.StaticScopedTokens, staticScopedTokensIndex]{
+		cache:      c,
+		collection: c.collections.staticScopedTokens,
+		index:      staticScopedTokensNameIndex,
+		upstreamGet: func(ctx context.Context, ident string) (*joiningv1.StaticScopedTokens, error) {
+			tokens, err := c.Config.StaticScopedToken.GetStaticScopedTokens(ctx)
+			return tokens, trace.Wrap(err)
+		},
+	}
+
+	out, err := getter.get(ctx, types.MetaNameStaticScopedTokens)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/static_scoped_tokens_test.go
+++ b/lib/cache/static_scoped_tokens_test.go
@@ -1,0 +1,83 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/scopes/joining"
+)
+
+func newStaticScopedTokens() *joiningv1.StaticScopedTokens {
+	return &joiningv1.StaticScopedTokens{
+		Kind:  types.KindStaticScopedTokens,
+		Scope: "/",
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameStaticScopedTokens,
+		},
+		Spec: &joiningv1.StaticScopedTokensSpec{
+			Tokens: []*joiningv1.ScopedToken{
+				{
+					Kind:  types.KindScopedToken,
+					Scope: "/",
+					Metadata: &headerv1.Metadata{
+						Name:    "tok1",
+						Expires: timestamppb.New(time.Now().UTC().Add(time.Hour)),
+					},
+					Spec: &joiningv1.ScopedTokenSpec{
+						Roles:         []string{types.RoleNode.String()},
+						JoinMethod:    string(types.JoinMethodToken),
+						UsageMode:     string(joining.TokenUsageModeUnlimited),
+						AssignedScope: "/local",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestStaticScopedTokens tests that CRUD operations on the StaticScopedTokens resource are
+// replicated from the backend to the cache.
+func TestStaticScopedTokens(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*joiningv1.StaticScopedTokens]{
+		newResource: func(name string) (*joiningv1.StaticScopedTokens, error) {
+			return newStaticScopedTokens(), nil
+		},
+		create: func(ctx context.Context, item *joiningv1.StaticScopedTokens) error {
+			return trace.Wrap(p.clusterConfigS.SetStaticScopedTokens(ctx, item))
+		},
+		update: func(ctx context.Context, item *joiningv1.StaticScopedTokens) error {
+			return trace.Wrap(p.clusterConfigS.SetStaticScopedTokens(ctx, item))
+		},
+		list:      singletonListAdapter(p.clusterConfigS.GetStaticScopedTokens),
+		cacheList: singletonListAdapter(p.cache.GetStaticScopedTokens),
+		deleteAll: p.clusterConfigS.DeleteStaticScopedTokens,
+	}, withSkipPaginationTest())
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -951,6 +951,12 @@ func applyAuthConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			return trace.Wrap(err)
 		}
 	}
+	if fc.Auth.StaticScopedTokens != nil {
+		cfg.Auth.StaticScopedTokens, err = fc.Auth.StaticScopedTokens.Parse()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	// read in and set authentication preferences
 	if fc.Auth.Authentication != nil {
 		cfg.Auth.Preference, err = fc.Auth.Authentication.Parse()

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -39,10 +39,13 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v2"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
@@ -51,6 +54,8 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
@@ -763,6 +768,9 @@ type Auth struct {
 	// for example: "auth,proxy,node:MTIzNGlvemRmOWE4MjNoaQo"
 	StaticTokens StaticTokens `yaml:"tokens,omitempty"`
 
+	// StaticScopedTokens are pre-defined, scoped host provisioning tokens supplied via config file
+	// for environments where paranoid security is not needed
+	StaticScopedTokens StaticScopedTokens `yaml:"scoped_tokens,omitempty"`
 	// Authentication holds authentication configuration information like authentication
 	// type, second factor type, specific connector information, etc.
 	Authentication *AuthenticationConfig `yaml:"authentication,omitempty"`
@@ -1069,6 +1077,98 @@ func (t StaticToken) Parse() ([]types.ProvisionTokenV1, error) {
 		})
 	}
 	return provisionTokens, nil
+}
+
+// StaticScopedTokens is the list of [StaticScopedToken] configurations that
+// should be used to generate the auth service's [joiningv1.StaticScopedTokens]
+// resource.
+type StaticScopedTokens []StaticScopedToken
+
+func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
+	var scopedTokens []*joiningv1.ScopedToken
+	for _, st := range t {
+		if err := st.Validate(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if st.Path != "" {
+			tokenDef, err := os.ReadFile(st.Path)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if err := yaml.Unmarshal(tokenDef, &st); err != nil {
+				return nil, trace.Wrap(err)
+			}
+		}
+
+		roles, err := types.NewTeleportRoles(st.Roles)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		scopedToken := &joiningv1.ScopedToken{
+			Version: types.V1,
+			Kind:    types.KindScopedToken,
+			Metadata: &headerv1.Metadata{
+				Name:    st.Name,
+				Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+			},
+			Scope: scopes.Root,
+			Spec: &joiningv1.ScopedTokenSpec{
+				Roles:         roles.StringSlice(),
+				AssignedScope: st.Scope,
+				JoinMethod:    string(types.JoinMethodToken),
+				UsageMode:     string(joining.TokenUsageModeUnlimited),
+			},
+			Status: &joiningv1.ScopedTokenStatus{
+				Secret: st.Secret,
+			},
+		}
+
+		if err := joining.StrongValidateToken(scopedToken); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		scopedTokens = append(scopedTokens, scopedToken)
+	}
+
+	return &joiningv1.StaticScopedTokens{
+		Version: types.V1,
+		Kind:    types.KindStaticScopedTokens,
+		Scope:   scopes.Root,
+		Metadata: &headerv1.Metadata{
+			Name: types.MetaNameStaticScopedTokens,
+		},
+		Spec: &joiningv1.StaticScopedTokensSpec{
+			Tokens: scopedTokens,
+		},
+	}, nil
+}
+
+// StaticScopedToken is a statically defined scoped token. It is meant to capture
+// yaml configuration that can be used to generate a [joiningv1.ScopedToken].
+type StaticScopedToken struct {
+	Name   string   `yaml:"name"`
+	Secret string   `yaml:"secret"`
+	Roles  []string `yaml:"roles"`
+	Scope  string   `yaml:"scope"`
+	Path   string   `yaml:"path"`
+}
+
+// Validate whether or not a [StaticScopedToken] is well formed.
+//
+// Returns an error if both the "path" field is defined alongside any of
+// the other fields.
+func (s StaticScopedToken) Validate() error {
+	isPathToken := s.Path != ""
+	isDefinedToken := s.Name != "" || s.Secret != "" || s.Roles != nil || s.Scope != ""
+
+	if isPathToken && isDefinedToken {
+		return trace.BadParameter("A static_scoped_token must either define a path to a yaml file describing the token or the token definition itself, but not both")
+	}
+
+	return nil
 }
 
 // AuthenticationConfig describes the auth_service/authentication section of teleport.yaml

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -20,8 +20,10 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -31,14 +33,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v2"
 
 	"github.com/gravitational/teleport/api/constants"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 )
@@ -568,6 +574,173 @@ ssh_service:
 			if tt.expectSecondFactor != nil {
 				tt.expectSecondFactor(t, cfg.Auth.Authentication.SecondFactor)
 			}
+		})
+	}
+}
+
+func TestAuthenticationConfigScopedStaticToken(t *testing.T) {
+	t.Parallel()
+
+	tokenFilePath := filepath.Join(t.TempDir(), "scoped-token.yml")
+	tokenFile, err := os.Create(tokenFilePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		tokenFile.Close()
+	})
+	tokenFile.WriteString(`
+name: file_scoped_token
+secret: secret_token_value
+roles: [node]
+scope: /test
+`)
+
+	tests := []struct {
+		desc         string
+		input        string
+		expectError  require.ErrorAssertionFunc
+		expectTokens []*joiningv1.ScopedToken
+	}{
+		{
+			desc: "fully defined static scoped token", input: `
+auth_service:
+  enabled: yes
+  scoped_tokens:
+    - name: fully_defined_token
+      roles: [node]
+      secret: secret_token_value
+      scope: /test
+teleport:
+  nodename: testing
+`,
+			expectError: require.NoError,
+			expectTokens: []*joiningv1.ScopedToken{
+				{
+					Version: types.V1,
+					Kind:    types.KindScopedToken,
+					Metadata: &headerv1.Metadata{
+						Name:    "fully_defined_token",
+						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+					},
+					Scope: "/",
+					Spec: &joiningv1.ScopedTokenSpec{
+						Roles:         []string{string(types.RoleNode)},
+						AssignedScope: "/test",
+						JoinMethod:    string(types.JoinMethodToken),
+						UsageMode:     string(joining.TokenUsageModeUnlimited),
+					},
+					Status: &joiningv1.ScopedTokenStatus{
+						Secret: "secret_token_value",
+					},
+				},
+			},
+		},
+		{
+			desc: "file based token", input: fmt.Sprintf(`
+auth_service:
+  enabled: yes
+  scoped_tokens:
+    - path: %s
+teleport:
+  nodename: testing
+`, tokenFilePath),
+			expectError: require.NoError,
+			expectTokens: []*joiningv1.ScopedToken{
+				{
+					Version: types.V1,
+					Kind:    types.KindScopedToken,
+					Metadata: &headerv1.Metadata{
+						Name:    "file_scoped_token",
+						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+					},
+					Scope: "/",
+					Spec: &joiningv1.ScopedTokenSpec{
+						Roles:         []string{string(types.RoleNode)},
+						AssignedScope: "/test",
+						JoinMethod:    string(types.JoinMethodToken),
+						UsageMode:     string(joining.TokenUsageModeUnlimited),
+					},
+					Status: &joiningv1.ScopedTokenStatus{
+						Secret: "secret_token_value",
+					},
+				},
+			},
+		},
+		{
+			desc: "fully defined token with a path", input: fmt.Sprintf(`
+auth_service:
+  enabled: yes
+  scoped_tokens:
+    - name: fully_defined_token
+      roles: [node]
+      secret: secret_token_value
+      scope: /test
+      path: %s
+teleport:
+  nodename: testing
+`, tokenFilePath),
+			expectError: require.Error,
+		},
+		{
+			desc: "multiple valid tokens", input: fmt.Sprintf(`
+auth_service:
+  enabled: yes
+  scoped_tokens:
+    - name: fully_defined_token
+      roles: [node]
+      secret: secret_token_value
+      scope: /test
+    - path: %s
+teleport:
+  nodename: testing
+`, tokenFilePath),
+			expectError: require.NoError,
+			expectTokens: []*joiningv1.ScopedToken{
+				{
+					Version: types.V1,
+					Kind:    types.KindScopedToken,
+					Metadata: &headerv1.Metadata{
+						Name:    "fully_defined_token",
+						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+					},
+					Scope: "/",
+					Spec: &joiningv1.ScopedTokenSpec{
+						Roles:         []string{string(types.RoleNode)},
+						AssignedScope: "/test",
+						JoinMethod:    string(types.JoinMethodToken),
+						UsageMode:     string(joining.TokenUsageModeUnlimited),
+					},
+					Status: &joiningv1.ScopedTokenStatus{
+						Secret: "secret_token_value",
+					},
+				},
+				{
+					Version: types.V1,
+					Kind:    types.KindScopedToken,
+					Metadata: &headerv1.Metadata{
+						Name:    "file_scoped_token",
+						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+					},
+					Scope: "/",
+					Spec: &joiningv1.ScopedTokenSpec{
+						Roles:         []string{string(types.RoleNode)},
+						AssignedScope: "/test",
+						JoinMethod:    string(types.JoinMethodToken),
+						UsageMode:     string(joining.TokenUsageModeUnlimited),
+					},
+					Status: &joiningv1.ScopedTokenStatus{
+						Secret: "secret_token_value",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			cfg, err := ReadConfig(strings.NewReader(tt.input))
+			assert.NoError(t, err)
+			tokens, err := cfg.Auth.StaticScopedTokens.Parse()
+			tt.expectError(t, err)
+			assert.Empty(t, cmp.Diff(tt.expectTokens, tokens.GetSpec().GetTokens(), protocmp.Transform()))
 		})
 	}
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2432,6 +2432,7 @@ func (process *TeleportProcess) initAuthService() error {
 			Identity:                    cfg.Identity,
 			Access:                      cfg.Access,
 			StaticTokens:                cfg.Auth.StaticTokens,
+			StaticScopedTokens:          cfg.Auth.StaticScopedTokens,
 			Roles:                       cfg.Auth.Roles,
 			AuthPreference:              cfg.Auth.Preference,
 			OIDCConnectors:              cfg.OIDCConnectors,
@@ -3032,6 +3033,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.AppSession = services.Identity
 	cfg.Applications = services.Applications
 	cfg.ClusterConfig = services.ClusterConfigurationInternal
+	cfg.StaticScopedToken = services.ClusterConfigurationInternal
 	cfg.CrownJewels = services.CrownJewels
 	cfg.DatabaseObjects = services.DatabaseObjects
 	cfg.DatabaseServices = services.DatabaseServices

--- a/lib/service/servicecfg/auth.go
+++ b/lib/service/servicecfg/auth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/backend"
@@ -69,6 +70,10 @@ type AuthConfig struct {
 	// StaticTokens are pre-defined host provisioning tokens supplied via config file for
 	// environments where paranoid security is not needed
 	StaticTokens types.StaticTokens
+
+	// StaticScopedTokens are pre-defined, scoped host provisioning tokens supplied via config file
+	// for environments where paranoid security is not needed
+	StaticScopedTokens *joiningv1.StaticScopedTokens
 
 	// StorageConfig contains configuration settings for the storage backend.
 	StorageConfig backend.Config

--- a/lib/services/configuration.go
+++ b/lib/services/configuration.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/modules"
@@ -48,7 +49,6 @@ type ClusterConfiguration interface {
 	SetStaticTokens(types.StaticTokens) error
 	// DeleteStaticTokens deletes static tokens resource
 	DeleteStaticTokens() error
-
 	// GetUIConfig gets the proxy service UI config from the backend
 	GetUIConfig(context.Context) (types.UIConfig, error)
 	// SetUIConfig sets the proxy service UI config from the backend
@@ -141,6 +141,7 @@ type ClusterConfiguration interface {
 // auth-specific methods.
 type ClusterConfigurationInternal interface {
 	ClusterConfiguration
+	StaticScopedTokenService
 
 	// SetClusterName sets services.ClusterName on the backend.
 	SetClusterName(types.ClusterName) error
@@ -156,6 +157,18 @@ type ClusterConfigurationInternal interface {
 	// applied should be the same backend used by the
 	// ClusterConfigurationInternal.
 	AppendCheckAuthPreferenceActions(actions []backend.ConditionalAction, revision string) ([]backend.ConditionalAction, error)
+}
+
+// StaticScopedTokenService is the interface for interacting with the cluster's
+// [*joiningv1.StaticScopedTokens].
+type StaticScopedTokenService interface {
+	// GetStaticScopedTokens gets [*joiningv1.StaticScopedTokens] from the backend.
+	GetStaticScopedTokens(context.Context) (*joiningv1.StaticScopedTokens, error)
+	// SetStaticScopedTokens sets [*joiningv1.StaticScopedTokens] to the backend.
+	SetStaticScopedTokens(context.Context, *joiningv1.StaticScopedTokens) error
+	// DeleteStaticScopedTokens deletes the [*joiningv1.StaticScopedTokens] resource resource
+	// from the backend
+	DeleteStaticScopedTokens(context.Context) error
 }
 
 // ValidateAuthPreference performs checks that should happen before persisting a

--- a/lib/services/local/configuration.go
+++ b/lib/services/local/configuration.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/itertools/stream"
@@ -172,6 +173,56 @@ func (s *ClusterConfigurationService) DeleteStaticTokens() error {
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return trace.NotFound("static tokens are not found")
+		}
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// GetStaticScopedTokens gets the list of static scoped tokens used to provision nodes.
+func (s *ClusterConfigurationService) GetStaticScopedTokens(ctx context.Context) (*joiningv1.StaticScopedTokens, error) {
+	item, err := s.Get(ctx, backend.NewKey(clusterConfigPrefix, types.MetaNameStaticScopedTokens))
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return nil, trace.NotFound("static scoped tokens not found")
+		}
+		return nil, trace.Wrap(err)
+	}
+	scopedTokens, err := services.UnmarshalProtoResource[*joiningv1.StaticScopedTokens](item.Value)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return scopedTokens, nil
+}
+
+// SetStaticScopedTokens sets the list of static scoped tokens used to provision nodes.
+func (s *ClusterConfigurationService) SetStaticScopedTokens(ctx context.Context, c *joiningv1.StaticScopedTokens) error {
+	if c == nil {
+		return trace.BadParameter("cannot set nil static scoped tokens")
+	}
+	value, err := services.MarshalProtoResource(c)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = s.Put(ctx, backend.Item{
+		Key:      backend.NewKey(clusterConfigPrefix, types.MetaNameStaticScopedTokens),
+		Value:    value,
+		Revision: c.GetMetadata().GetRevision(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// DeleteStaticScopedTokens deletes the list of static scoped tokens.
+func (s *ClusterConfigurationService) DeleteStaticScopedTokens(ctx context.Context) error {
+	err := s.Delete(ctx, backend.NewKey(clusterConfigPrefix, types.MetaNameStaticScopedTokens))
+	if err != nil {
+		if trace.IsNotFound(err) {
+			return trace.NotFound("static scoped tokens are not found")
 		}
 		return trace.Wrap(err)
 	}

--- a/lib/services/local/configuration_test.go
+++ b/lib/services/local/configuration_test.go
@@ -145,6 +145,18 @@ func TestStaticTokens(t *testing.T) {
 	suite.StaticTokens(t)
 }
 
+func TestStaticScopedTokens(t *testing.T) {
+	tt := setupConfigContext(t.Context(), t)
+
+	clusterConfig, err := NewClusterConfigurationService(tt.bk)
+	require.NoError(t, err)
+
+	suite := &ServicesTestSuite{
+		LocalConfigS: clusterConfig,
+	}
+	suite.StaticScopedTokens(t)
+}
+
 func TestSessionRecording(t *testing.T) {
 	// don't allow invalid session recording values
 	_, err := types.NewSessionRecordingConfigFromConfigFile(types.SessionRecordingConfigSpecV2{

--- a/lib/services/local/events.go
+++ b/lib/services/local/events.go
@@ -87,6 +87,8 @@ func (e *EventsService) NewWatcher(ctx context.Context, watch types.Watch) (type
 			parser = newProvisionTokenParser()
 		case types.KindStaticTokens:
 			parser = newStaticTokensParser()
+		case types.KindStaticScopedTokens:
+			parser = newStaticScopedTokenParser()
 		case types.KindClusterAuditConfig:
 			parser = newClusterAuditConfigParser()
 		case types.KindClusterNetworkingConfig:


### PR DESCRIPTION
This PR adds the ability to define static, scoped join tokens within the file config. Static scoped tokens function similarly to regular scoped tokens except they're more structured, move the token secret out of the name, and assign a scope at join time.

Here's an example showing unscoped and scoped tokens defined side by side:
```yaml
auth_service:
  enabled: yes
  tokens:
    - node:foo
  scoped_tokens:
    - name: bar
      roles: [node]
      secret: bar_secret_value
      scope: /foo/bar
```
Unscoped and scoped tokens can both be defined in the same `auth_service` block. The `scope` configuration defines which scope will be applied to resources provisioned using the `bar` token. The scope of the scoped token itself is set to `scopes.Root`. I considered adding a configuration for the scoped token's scope, but it seemed like a better UX to leave it out. Being defined in the file config prevents static tokens from gaining any benefit of a narrow scope anyway.

Joining with a static scoped token should work exactly like a regular scoped token provisioned with `tctl scoped token add`. Once the node has joined, its host certs can be inspected to confirm that the `AgentScope` property has been assigned.

Static scoped tokens can be sourced from a separate file to maintain parity with unscoped static tokens. However, the file must be the full `yml` representation of a scoped static token. A separate `path` field should be defined when sourcing from a file:
```yaml
# teleport.yml
auth_service:
  enabled: yes
  scoped_tokens:
    - path: scoped_token.yml

# scoped_token.yml
name: bar
roles: [node]
secret: bar_secret_value
scope: /foo/bar
```
If `path` is specified, all other token fields should be left undefined.

## Manual Test Plan
- [x] Spin up an auth service with a static scoped token as defined in the description above
- [x] Join a node to the cluster using the static scoped token name and secret
- [x] Confirm host certificate issued to node contains the `AgentScope` (alternatively, connect to the node over SSH using scoped credentials)