### PR TITLE
Client support for Kubernetes access with a Relay Service

### DIFF
--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -474,7 +474,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 			TeleportClusterName: cfg.KeyRing.ClusterName,
 			ClusterAddr:         cfg.KubeProxyAddr,
 			Credentials:         cfg.KeyRing,
-			TLSServerName:       cfg.KubeTLSServerName,
+			TLSServerNameFunc:   func(teleportClusterName, kubeClusterName string) string { return cfg.KubeTLSServerName },
 			KubeClusters:        kubeCluster,
 		}, cfg.KubeStoreAllCAs, writer); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/kube/relay/hash.go
+++ b/lib/kube/relay/hash.go
@@ -52,3 +52,10 @@ func SNILabelForKubeCluster(teleportClusterName, kubeClusterName string) string 
 	h := hashForTarget(teleportClusterName, kubeClusterName)
 	return SNIPrefixForKubeCluster + base32hex.EncodeToString(h[:])
 }
+
+// FullSNIForKubeCluster returns the full server name used to identify a
+// Kubernetes cluster as the target for a passively routed Relay connection,
+// i.e. the same value as [SNILabelForKubeCluster] followed by [SNISuffix].
+func FullSNIForKubeCluster(teleportClusterName, kubeClusterName string) string {
+	return SNILabelForKubeCluster(teleportClusterName, kubeClusterName) + SNISuffix
+}

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -236,7 +236,7 @@ func (l *LocalProxy) handleDownstreamConnection(ctx context.Context, downstreamC
 		return trace.Wrap(err)
 	}
 
-	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(l.cfg.SNI, cert))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -261,7 +261,7 @@ func (l *LocalProxy) HandleTCPConnector(ctx context.Context, connector func() (n
 		return trace.Wrap(err)
 	}
 
-	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(l.cfg.SNI, cert))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -299,20 +299,20 @@ func (l *LocalProxy) Close() error {
 	return nil
 }
 
-func (l *LocalProxy) getALPNDialerConfig(certs ...tls.Certificate) client.ALPNDialerConfig {
+func (l *LocalProxy) getALPNDialerConfig(serverName string, certs ...tls.Certificate) client.ALPNDialerConfig {
 	return client.ALPNDialerConfig{
 		ALPNConnUpgradeRequired: l.cfg.ALPNConnUpgradeRequired,
 		TLSConfig: &tls.Config{
 			NextProtos:         common.ProtocolsToString(l.cfg.Protocols),
 			InsecureSkipVerify: l.cfg.InsecureSkipVerify,
-			ServerName:         l.cfg.SNI,
+			ServerName:         serverName,
 			Certificates:       certs,
 			RootCAs:            l.cfg.RootCAs,
 		},
 	}
 }
 
-func (l *LocalProxy) makeHTTPReverseProxy(certs ...tls.Certificate) *httputil.ReverseProxy {
+func (l *LocalProxy) makeHTTPReverseProxy(serverName string, certs ...tls.Certificate) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Director: func(outReq *http.Request) {
 			outReq.URL.Scheme = "https"
@@ -341,7 +341,7 @@ func (l *LocalProxy) makeHTTPReverseProxy(certs ...tls.Certificate) *httputil.Re
 			http.Error(w, http.StatusText(code), code)
 		},
 		Transport: &http.Transport{
-			DialTLSContext: client.NewALPNDialer(l.getALPNDialerConfig(certs...)).DialContext,
+			DialTLSContext: client.NewALPNDialer(l.getALPNDialerConfig(serverName, certs...)).DialContext,
 		},
 	}
 }
@@ -404,15 +404,27 @@ func (l *LocalProxy) startHTTPAccessProxy(ctx context.Context) error {
 }
 
 func (l *LocalProxy) getHTTPReverseProxyForReq(req *http.Request) (*httputil.ReverseProxy, error) {
-	certs, err := l.cfg.HTTPMiddleware.OverwriteClientCerts(req)
-	if trace.IsNotImplemented(err) {
-		return l.makeHTTPReverseProxy(l.getCert()), nil
-	} else if err != nil {
+	serverName, ok, err := l.cfg.HTTPMiddleware.GetServerName(req)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if ok {
+		l.cfg.Log.DebugContext(req.Context(), "got SNI from middleware", "server_name", serverName)
+	} else {
+		serverName = l.cfg.SNI
+	}
 
-	l.cfg.Log.DebugContext(req.Context(), "overwrote certs")
-	return l.makeHTTPReverseProxy(certs...), nil
+	certs, ok, err := l.cfg.HTTPMiddleware.GetClientCerts(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if ok {
+		l.cfg.Log.DebugContext(req.Context(), "got certs from middleware")
+	} else {
+		certs = []tls.Certificate{l.getCert()}
+	}
+
+	return l.makeHTTPReverseProxy(serverName, certs...), nil
 }
 
 // getCert returns the local proxy's configured TLS certificate.

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -544,8 +544,9 @@ func TestKubeMiddleware(t *testing.T) {
 			require.Contains(t, rw.Buffer().String(), "context canceled")
 
 			// but certificate still was reissued.
-			certs, err := km.OverwriteClientCerts(req)
+			certs, ok, err := km.GetClientCerts(req)
 			require.NoError(t, err)
+			require.True(t, ok)
 			require.Len(t, certs, 1)
 			require.Equal(t, newCert, certs[0], "certificate was not reissued")
 
@@ -618,12 +619,13 @@ func TestKubeMiddleware(t *testing.T) {
 			// HandleRequest will reissue certificate if needed
 			km.HandleRequest(responsewriters.NewMemoryResponseWriter(), &req)
 
-			certs, err := km.OverwriteClientCerts(&req)
+			certs, ok, err := km.GetClientCerts(&req)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
+				require.True(t, ok)
 				require.Len(t, certs, 1)
 				require.Equal(t, tt.overwrittenCert, certs[0])
 			}

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -68,6 +68,10 @@ type OutputV2Config struct {
 	//
 	// By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
 	ContextNameTemplate string `yaml:"context_name_template,omitempty"`
+
+	// RelayAddress specifies the address of a relay transport server to use in
+	// the generated Kubernetes config file.
+	RelayAddress string `yaml:"relay_server,omitempty"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.

--- a/lib/tbot/services/k8s/output_v2_test.go
+++ b/lib/tbot/services/k8s/output_v2_test.go
@@ -303,13 +303,14 @@ func TestKubernetesV2OutputService_render(t *testing.T) {
 				[]types.CertAuthority{fakeCA(t, types.HostCA, mockClusterName)},
 			)
 			require.NoError(t, err)
+			mockSNI := client.GetKubeTLSServerName(mockClusterName)
 			status := &kubernetesStatusV2{
 				kubernetesClusterNames: []string{"a", "b", "c"},
 				defaultNamespaces: map[string]string{
 					"a": "namespace-a",
 				},
 				teleportClusterName: mockClusterName,
-				tlsServerName:       client.GetKubeTLSServerName(mockClusterName),
+				tlsServerNameFunc:   func(teleportClusterName, kubeClusterName string) string { return mockSNI },
 				credentials:         keyRing,
 				clusterAddr:         fmt.Sprintf("https://%s:443", mockClusterName),
 			}

--- a/lib/teleterm/clusters/cluster_gateways.go
+++ b/lib/teleterm/clusters/cluster_gateways.go
@@ -146,6 +146,7 @@ func (c *Cluster) createKubeGateway(ctx context.Context, params CreateGatewayPar
 		Cert:                          cert,
 		Insecure:                      c.clusterClient.InsecureSkipVerify,
 		WebProxyAddr:                  c.clusterClient.WebProxyAddr,
+		RelayAddr:                     c.clusterClient.RelayAddr,
 		Logger:                        c.Logger,
 		TCPPortAllocator:              params.TCPPortAllocator,
 		OnExpiredCert:                 params.OnExpiredCert,

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -69,6 +69,9 @@ type Config struct {
 	Username string
 	// WebProxyAddr
 	WebProxyAddr string
+	// RelayAddr, if set, is the address of the Relay service that should be
+	// used by protocols that support using a Relay.
+	RelayAddr string
 	// Logger is a component logger
 	Logger *slog.Logger
 	// TCPPortAllocator creates listeners on the given ports. This interface lets us avoid occupying

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -69,6 +69,7 @@ import (
 	kubeclient "github.com/gravitational/teleport/lib/client/kube"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -196,7 +197,11 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 		return trace.AccessDenied("this cluster does not support Kubernetes")
 	}
 
-	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	// TODO(espadolini): joining requires hitting the agent handling a specific
+	// session, which is not currently implemented through the relay, once it's
+	// possible we should probably get rid of the whole ignoreRelay parameter
+	const ignoreRelayTrue = true
+	kubeStatus, err := fetchKubeStatus(cf.Context, tc, ignoreRelayTrue)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -208,7 +213,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 	}
 
 	tlsConfig.InsecureSkipVerify = cf.InsecureSkipVerify
-	tlsConfig.ServerName = kubeStatus.tlsServerName
+	tlsConfig.ServerName = kubeStatus.tlsServerNameForCluster(cluster, kubeCluster)
 	session, err := client.NewKubeSession(cf.Context,
 		client.KubeSessionConfig{
 			KubeProxyAddr:                 tc.Config.KubeProxyAddr,
@@ -1275,7 +1280,8 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	err = retryWithAccessRequest(cf, tc, func() error {
 		err := client.RetryWithRelogin(cf.Context, tc, func() error {
 			var err error
-			kubeStatus, err = fetchKubeStatus(cf.Context, tc)
+			const ignoreRelayFalse = false
+			kubeStatus, err = fetchKubeStatus(cf.Context, tc, ignoreRelayFalse)
 			return trace.Wrap(err)
 		})
 		if err != nil {
@@ -1492,15 +1498,20 @@ type kubernetesStatus struct {
 	teleportClusterName string
 	kubeClusters        []types.KubeCluster
 	credentials         *client.KeyRing
-	tlsServerName       string
+	tlsServerNameFunc   func(teleportClusterName, kubeClusterName string) string
+}
+
+func (s *kubernetesStatus) tlsServerNameForCluster(teleportClusterName, kubeClusterName string) string {
+	if s.tlsServerNameFunc == nil {
+		return ""
+	}
+	return s.tlsServerNameFunc(teleportClusterName, kubeClusterName)
 }
 
 // fetchKubeStatus returns a kubernetesStatus populated from the given TeleportClient.
-func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernetesStatus, error) {
+func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient, ignoreRelay bool) (*kubernetesStatus, error) {
 	var err error
-	kubeStatus := &kubernetesStatus{
-		clusterAddr: tc.KubeClusterAddr(),
-	}
+	kubeStatus := &kubernetesStatus{}
 	kubeStatus.credentials, err = tc.LocalAgent().GetCoreKeyRing()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1510,9 +1521,22 @@ func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernete
 		return nil, trace.Wrap(err)
 	}
 
+	if !ignoreRelay && tc.RelayAddr != "" {
+		kubeStatus.clusterAddr = (&url.URL{
+			Scheme: "https",
+			Host:   tc.RelayAddr,
+		}).String()
+		kubeStatus.tlsServerNameFunc = kuberelay.FullSNIForKubeCluster
+		return kubeStatus, nil
+	}
+
+	kubeStatus.clusterAddr = tc.KubeClusterAddr()
 	if tc.TLSRoutingEnabled {
 		k8host, _ := tc.KubeProxyHostPort()
-		kubeStatus.tlsServerName = client.GetKubeTLSServerName(k8host)
+		tlsServerName := client.GetKubeTLSServerName(k8host)
+		kubeStatus.tlsServerNameFunc = func(teleportClusterName, kubeClusterName string) string {
+			return tlsServerName
+		}
 	}
 
 	return kubeStatus, nil
@@ -1526,7 +1550,7 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus, overrideCo
 		TeleportClusterName: kubeStatus.teleportClusterName,
 		Credentials:         kubeStatus.credentials,
 		ProxyAddr:           cf.Proxy,
-		TLSServerName:       kubeStatus.tlsServerName,
+		TLSServerNameFunc:   kubeStatus.tlsServerNameFunc,
 		Impersonate:         cf.kubernetesImpersonationConfig.kubernetesUser,
 		ImpersonateGroups:   cf.kubernetesImpersonationConfig.kubernetesGroups,
 		Namespace:           cf.kubeNamespace,
@@ -1591,7 +1615,7 @@ func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path, overrideCont
 	if _, err := tc.Ping(cf.Context); err != nil {
 		return trace.Wrap(err)
 	}
-	if tc.KubeProxyAddr == "" {
+	if tc.KubeProxyAddr == "" && tc.RelayAddr == "" {
 		// Kubernetes support disabled, don't touch kubeconfig.
 		return nil
 	}

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -458,6 +458,12 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 		return nil, nil, false
 	}
 
+	// TODO(espadolini): we could skip the local proxy when using a relay, but
+	// we can only know if we are using a relay once we have a TeleportClient
+	// and we load the profile, which will only happen later; seeing as it's
+	// only a little wasteful to spin up a local proxy it's fine for now, but if
+	// we rework the flow we should add a way to skip the local proxy when using
+	// a relay even if a connection through the control plane would require it
 	if !profile.RequireKubeLocalProxy() {
 		return nil, nil, false
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -6221,7 +6221,8 @@ func updateKubeConfigOnLogin(cf *CLIConf, tc *client.TeleportClient) error {
 	if len(cf.KubernetesCluster) == 0 {
 		return nil
 	}
-	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	const ignoreRelayFalse = false
+	kubeStatus, err := fetchKubeStatus(cf.Context, tc, ignoreRelayFalse)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
This PR adds client support for using Kubernetes Access through a Relay service. It's possible to use a Relay for Kube access through the kubeconfig file generated by `tsh kube login`, through the local proxy launched by `tsh proxy kube` and Teleport Connect (and internally launched as part of `tsh kube exec` and `tsh kubectl`), and through `tbot`'s `kubernetes/v2` service.

Use of the Relay is not currently supported for `tsh kube join` (but it could be supported in the future once the Relay gains the ability to route incoming Kube connections that ask for the agent serving a specific exec session) and for the credential files generated by `tsh login --format=kubernetes --out=foo` or `tctl auth sign --format=kubernetes --out=foo` (they use the same output mechanism and `tctl` has no idea that Relays exist).

Should be backported with #60974 and has #61419 as a prerequisite for backporting.

changelog: added support for Kubernetes Access when using a Relay service 