### PR TITLE
[reversetunnel] Use access point for cert auths

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -460,7 +460,7 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 	}
 
 	dialer := &agentDialer{
-		client:      p.Client,
+		client:      p.AccessPoint,
 		fips:        p.FIPS,
 		authMethods: p.AuthMethods,
 		options:     options,


### PR DESCRIPTION
This change allows the agent dialer to use cached
results for hostCheckerFunc. In the case of a transient grpc network failure, this allows the reverse tunnel to be re-established before the grpc timeout takes place.

Test plan:

- [x] Spawn two Linux VMs, one for auth/proxy and one for node. Simulate network change by toggling one of two interfaces on the node, measure time for the reverse tunnel to be functional again.

In local testing with 5 runs this on average brings the recovery time to 2m39s from 3m45s.

Changelog: Improve reverse tunnel dialing recovery from default route changes by 1min on average.