### PR TITLE
Fix `TestRevocationService_CRL` flakes with `testing/synctest`

### DIFF
--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -30,11 +30,13 @@ import (
 	"os"
 	"slices"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/mock"
@@ -56,8 +58,11 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/auth/keystore"
 	"github.com/gravitational/teleport/lib/auth/machineid/workloadidentityv1"
 	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/authz"
+	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	libevents "github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
@@ -65,9 +70,13 @@ import (
 	libjwt "github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/oidc/fakeissuer"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/lib/utils/testutils/grpctest"
 )
 
 func TestMain(m *testing.M) {
@@ -3449,181 +3458,231 @@ func TestRevocationService_UpsertWorkloadIdentityX509Revocation(t *testing.T) {
 
 func TestRevocationService_CRL(t *testing.T) {
 	t.Parallel()
-	revocationsEventCh := make(chan struct{})
-	fakeClock := clockwork.NewFakeClock()
-	srv, _ := newTestTLSServer(t, func(config *authtest.TLSServerConfig) {
-		config.APIConfig.MutateRevocationsServiceConfig = func(config *workloadidentityv1.RevocationServiceConfig) {
-			config.RevocationsEventProcessedCh = revocationsEventCh
-			config.Clock = fakeClock
-		}
-	})
-	ctx := context.Background()
 
-	authorizedUser, _, err := authtest.CreateUserAndRole(
-		srv.Auth(),
-		"authorized",
-		[]string{},
-		[]types.Rule{
-			{
-				Resources: []string{types.KindWorkloadIdentityX509Revocation},
-				Verbs: []string{
-					types.VerbRead,
-					types.VerbList,
-					types.VerbCreate,
-					types.VerbUpdate,
-					types.VerbDelete,
-				},
-			},
-		})
-	require.NoError(t, err)
-	authorizedClient, err := srv.NewClient(authtest.TestUser(authorizedUser.GetName()))
-	require.NoError(t, err)
-	revocationsClient := authorizedClient.WorkloadIdentityRevocationServiceClient()
-
-	// Fetch the SPIFFE CA so we can validate CRL signature.
-	ca, err := srv.Auth().GetCertAuthority(ctx, types.CertAuthID{
-		Type:       types.SPIFFECA,
-		DomainName: srv.ClusterName(),
-	}, false)
-	require.NoError(t, err)
-	caCert, err := tlsca.ParseCertificatePEM(ca.GetActiveKeys().TLS[0].Cert)
-	require.NoError(t, err)
-
-	checkCRL := func(
-		t *testing.T,
-		crlBytes []byte,
-		wantEntries []x509.RevocationListEntry,
-	) {
-		require.NotEmpty(t, crlBytes)
-
-		// Expect a DER encoded CRL directly (e.g no PEM)
-		parsed, err := x509.ParseRevocationList(crlBytes)
+	synctest.Test(t, func(t *testing.T) {
+		// == Setup ==
+		//
+		// Because this test depends on the "testing/synctest" package we can't
+		// use the newTestTLSServer helper, as it binds real listeners which
+		// aren't covered by synctest's "bubble". Instead, we must call the
+		// endpoint method directly, so we have to set up all of the service's
+		// dependencies ourselves.
+		backend, err := memory.New(memory.Config{})
 		require.NoError(t, err)
 
-		// Check CRL has a valid signature
-		require.NoError(t, parsed.CheckSignatureFrom(caCert))
+		store, err := local.NewWorkloadIdentityX509RevocationService(backend)
+		require.NoError(t, err)
 
-		diff := cmp.Diff(
-			wantEntries,
-			parsed.RevokedCertificateEntries,
-			cmp.Comparer(func(a, b *big.Int) bool {
-				return a.Cmp(b) == 0
-			}),
-			cmpopts.IgnoreFields(x509.RevocationListEntry{}, "Raw"),
-			cmpopts.SortSlices(func(a, b x509.RevocationListEntry) bool {
-				return a.SerialNumber.Cmp(b.SerialNumber) < 0
-			}),
+		clusterConfigService, err := local.NewClusterConfigurationService(backend)
+		require.NoError(t, err)
+
+		authPreference, err := types.NewAuthPreference(types.AuthPreferenceSpecV2{})
+		require.NoError(t, err)
+
+		_, err = clusterConfigService.CreateAuthPreference(t.Context(), authPreference)
+		require.NoError(t, err)
+
+		clusterName, err := types.NewClusterName(types.ClusterNameSpecV2{
+			ClusterName: "test.teleport.sh",
+			ClusterID:   uuid.NewString(),
+		})
+		require.NoError(t, err)
+
+		keys, err := keystore.NewManager(
+			t.Context(),
+			&servicecfg.KeystoreConfig{},
+			&keystore.Options{
+				ClusterName:          clusterName,
+				AuthPreferenceGetter: clusterConfigService,
+			},
 		)
-		require.Empty(t, diff)
-	}
+		require.NoError(t, err)
 
-	revokedAt := srv.Clock().Now()
-	createRevocation := func(t *testing.T, name string) {
-		_, err = revocationsClient.CreateWorkloadIdentityX509Revocation(
-			ctx,
-			&workloadidentityv1pb.CreateWorkloadIdentityX509RevocationRequest{
-				WorkloadIdentityX509Revocation: &workloadidentityv1pb.WorkloadIdentityX509Revocation{
+		tlsKeyPair, err := keys.NewTLSKeyPair(t.Context(), clusterName.GetClusterName(), cryptosuites.SPIFFECATLS)
+		require.NoError(t, err)
+
+		tlsCACert, err := tlsca.ParseCertificatePEM(tlsKeyPair.Cert)
+		require.NoError(t, err)
+
+		jwtKeyPair, err := keys.NewJWTKeyPair(t.Context(), cryptosuites.SPIFFECAJWT)
+		require.NoError(t, err)
+
+		ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+			Type:        types.SPIFFECA,
+			ClusterName: clusterName.GetClusterName(),
+			ActiveKeys: types.CAKeySet{
+				TLS: []*types.TLSKeyPair{tlsKeyPair},
+				JWT: []*types.JWTKeyPair{jwtKeyPair},
+			},
+		})
+		require.NoError(t, err)
+
+		caService := local.NewCAService(backend)
+		err = caService.CreateCertAuthority(t.Context(), ca)
+		require.NoError(t, err)
+
+		service, err := workloadidentityv1.NewRevocationService(&workloadidentityv1.RevocationServiceConfig{
+			Store: store,
+			Authorizer: authz.AuthorizerFunc(func(context.Context) (*authz.Context, error) {
+				return &authz.Context{}, nil
+			}),
+			Emitter:             &eventstest.MockAuditLog{},
+			EventsWatcher:       local.NewEventsService(backend),
+			ClusterName:         clusterName.GetClusterName(),
+			KeyStore:            keys,
+			Logger:              logtest.NewLogger(),
+			CertAuthorityGetter: caService,
+		})
+		require.NoError(t, err)
+		go service.RunCRLSigner(t.Context())
+
+		// == Helper Methods ==
+		checkCRL := func(
+			t *testing.T,
+			crlBytes []byte,
+			wantEntries []x509.RevocationListEntry,
+		) {
+			t.Helper()
+			require.NotEmpty(t, crlBytes)
+
+			// Expect a DER encoded CRL directly (e.g no PEM)
+			parsed, err := x509.ParseRevocationList(crlBytes)
+			require.NoError(t, err)
+
+			// Check CRL has a valid signature
+			require.NoError(t, parsed.CheckSignatureFrom(tlsCACert))
+
+			diff := cmp.Diff(
+				wantEntries,
+				parsed.RevokedCertificateEntries,
+				cmp.Comparer(func(a, b *big.Int) bool {
+					return a.Cmp(b) == 0
+				}),
+				cmpopts.IgnoreFields(x509.RevocationListEntry{}, "Raw"),
+				cmpopts.SortSlices(func(a, b x509.RevocationListEntry) bool {
+					return a.SerialNumber.Cmp(b.SerialNumber) < 0
+				}),
+			)
+			require.Empty(t, diff)
+		}
+
+		revokedAt := time.Now()
+		createRevocation := func(t *testing.T, name string) {
+			t.Helper()
+
+			_, err := store.CreateWorkloadIdentityX509Revocation(
+				t.Context(),
+				&workloadidentityv1pb.WorkloadIdentityX509Revocation{
 					Kind:    types.KindWorkloadIdentityX509Revocation,
 					Version: types.V1,
 					Metadata: &headerv1.Metadata{
 						Name:    name,
-						Expires: timestamppb.New(srv.Clock().Now().Add(time.Hour)),
+						Expires: timestamppb.New(time.Now().Add(time.Hour)),
 					},
 					Spec: &workloadidentityv1pb.WorkloadIdentityX509RevocationSpec{
 						Reason:    "compromised",
 						RevokedAt: timestamppb.New(revokedAt),
 					},
 				},
-			},
-		)
-		require.NoError(t, err)
-		// Wait for the revocation event to be processed.
-		select {
-		case <-time.After(5 * time.Second):
-			t.Fatalf("timed out waiting for revocation event to be processed")
-		case <-revocationsEventCh:
+			)
+			require.NoError(t, err)
+
+			// Wait for the revocation event to be processed.
+			synctest.Wait()
 		}
-	}
-	deleteRevocation := func(t *testing.T, name string) {
-		_, err = revocationsClient.DeleteWorkloadIdentityX509Revocation(
-			ctx,
-			&workloadidentityv1pb.DeleteWorkloadIdentityX509RevocationRequest{
-				Name: name,
-			},
-		)
-		require.NoError(t, err)
-		// Wait for the revocation event to be processed.
-		select {
-		case <-time.After(5 * time.Second):
-			t.Fatalf("timed out waiting for revocation event to be processed")
-		case <-revocationsEventCh:
+
+		deleteRevocation := func(t *testing.T, name string) {
+			t.Helper()
+
+			err := store.DeleteWorkloadIdentityX509Revocation(t.Context(), name)
+			require.NoError(t, err)
+
+			// Wait for the revocation event to be processed.
+			synctest.Wait()
 		}
-	}
 
-	// Fetch the initial, empty, CRL
-	stream, err := revocationsClient.StreamSignedCRL(
-		ctx, &workloadidentityv1pb.StreamSignedCRLRequest{},
-	)
-	require.NoError(t, err)
-	res, err := stream.Recv()
-	require.NoError(t, err)
-	checkCRL(t, res.Crl, nil)
+		// == Test Logic ==
+		ctx, cancel := context.WithCancel(t.Context())
+		t.Cleanup(cancel)
+		stream := grpctest.NewServerStream[workloadidentityv1pb.StreamSignedCRLResponse](ctx)
 
-	// Create new revocations
-	createRevocation(t, "ff")
-	createRevocation(t, "aa")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
-	t.Log("Advancing fake clock to pass debounce period")
-	fakeClock.Advance(6 * time.Second)
-	// The client should now receive a new CRL
-	res, err = stream.Recv()
-	require.NoError(t, err)
-	checkCRL(t, res.Crl, []x509.RevocationListEntry{
-		{
-			SerialNumber:   big.NewInt(170),
-			RevocationTime: revokedAt,
-		},
-		{
-			SerialNumber:   big.NewInt(255),
-			RevocationTime: revokedAt,
-		},
+		rpcErrCh := make(chan error, 1)
+		go func() {
+			rpcErrCh <- service.StreamSignedCRL(
+				&workloadidentityv1pb.StreamSignedCRLRequest{},
+				stream,
+			)
+		}()
+
+		// Fetch the initial, empty, CRL
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		checkCRL(t, res.Crl, nil)
+
+		// Create new revocations
+		createRevocation(t, "ff")
+		createRevocation(t, "aa")
+
+		t.Log("Advancing fake clock to pass debounce period")
+		time.Sleep(6 * time.Second)
+
+		// The client should now receive a new CRL
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		checkCRL(t, res.Crl, []x509.RevocationListEntry{
+			{
+				SerialNumber:   big.NewInt(170),
+				RevocationTime: revokedAt,
+			},
+			{
+				SerialNumber:   big.NewInt(255),
+				RevocationTime: revokedAt,
+			},
+		})
+
+		// Add another revocation, delete one revocation
+		createRevocation(t, "bb")
+		deleteRevocation(t, "aa")
+
+		t.Log("Advancing fake clock to pass debounce period")
+		time.Sleep(6 * time.Second)
+
+		// The client should now receive a new CRL
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		checkCRL(t, res.Crl, []x509.RevocationListEntry{
+			{
+				SerialNumber:   big.NewInt(255),
+				RevocationTime: revokedAt,
+			},
+			{
+				SerialNumber:   big.NewInt(187),
+				RevocationTime: revokedAt,
+			},
+		})
+
+		// Delete all remaining CRL
+		deleteRevocation(t, "bb")
+		deleteRevocation(t, "ff")
+
+		t.Log("Advancing fake clock to pass debounce period")
+		time.Sleep(6 * time.Second)
+
+		// The client should now receive a new CRL
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		checkCRL(t, res.Crl, nil)
+
+		// Wait ten minutes to see if the periodic CRL is sent.
+		t.Log("Advancing fake clock to pass the periodic timer")
+		time.Sleep(11 * time.Minute)
+
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		checkCRL(t, res.Crl, nil)
+
+		// Cancel the RPC context and check it didn't return an error.
+		cancel()
+		require.NoError(t, <-rpcErrCh)
 	})
-
-	// Add another revocation, delete one revocation
-	createRevocation(t, "bb")
-	deleteRevocation(t, "aa")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
-	t.Log("Advancing fake clock to pass debounce period")
-	fakeClock.Advance(6 * time.Second)
-	// The client should now receive a new CRL
-	res, err = stream.Recv()
-	require.NoError(t, err)
-	checkCRL(t, res.Crl, []x509.RevocationListEntry{
-		{
-			SerialNumber:   big.NewInt(255),
-			RevocationTime: revokedAt,
-		},
-		{
-			SerialNumber:   big.NewInt(187),
-			RevocationTime: revokedAt,
-		},
-	})
-
-	// Delete all remaining CRL
-	deleteRevocation(t, "bb")
-	deleteRevocation(t, "ff")
-	require.NoError(t, fakeClock.BlockUntilContext(ctx, 2))
-	t.Log("Advancing fake clock to pass debounce period")
-	fakeClock.Advance(6 * time.Second)
-	// The client should now receive a new CRL
-	res, err = stream.Recv()
-	require.NoError(t, err)
-	checkCRL(t, res.Crl, nil)
-
-	// Wait ten minutes to see if the periodic CRL is sent.
-	t.Log("Advancing fake clock to pass the periodic timer")
-	fakeClock.Advance(11 * time.Minute)
-	res, err = stream.Recv()
-	require.NoError(t, err)
-	checkCRL(t, res.Crl, nil)
 }

--- a/lib/utils/testutils/grpctest/grpc.go
+++ b/lib/utils/testutils/grpctest/grpc.go
@@ -144,3 +144,51 @@ func (s *server[T1, T2]) Recv() (*T1, error) {
 		return nil, s.ctx.Err()
 	}
 }
+
+// NewServerStream creates an in-memory grpc.ServerStreamingServer[T] (unidirectional)
+// for use in tests, particularly when using synctest.
+//
+// Users can consume the messages sent by the server by calling Recv.
+//
+// Private fields are purposefully written in a *not* concurrency-safe manner to
+// simulate non-concurrency safety of real over-the-network GRPC stream. It will
+// be caught when executing the test with the race detector enbled.
+func NewServerStream[T any](ctx context.Context) *ServerStream[T] {
+	return &ServerStream[T]{
+		ctx:      ctx,
+		toClient: make(chan *T, 1),
+	}
+}
+
+// ServerStream is an in-memory implementation of grpc.ServerStreamingServer[T]
+// for use in tests.
+type ServerStream[T any] struct {
+	grpc.ServerStream
+	ctx              context.Context
+	toClient         chan *T
+	sendRaceDetector bool // simulate non-concurrency safety
+}
+
+// Context returns the context for this stream.
+func (s *ServerStream[T]) Context() context.Context { return s.ctx }
+
+// Send satisfies grpc.ServerStreamingServer[T].
+func (s *ServerStream[T]) Send(t *T) error {
+	s.sendRaceDetector = true
+	select {
+	case s.toClient <- t:
+		return nil
+	case <-s.ctx.Done():
+		return s.ctx.Err()
+	}
+}
+
+// Recv can be called from tests to receive the most recent *T sent by the server.
+func (s *ServerStream[T]) Recv() (*T, error) {
+	select {
+	case t := <-s.toClient:
+		return t, nil
+	case <-s.ctx.Done():
+		return nil, s.ctx.Err()
+	}
+}


### PR DESCRIPTION
Closes #53541.

This test seems to only flake in very rare circumstances. I was only able to reproduce it by running for several hours in a Docker container with 2% CPU allocation. When it does fail, the stack trace suggests it has been blocked receiving from the events channel for several minutes, so it's very likely a strange race-condition which `synctest` should eliminate by allowing us to definitively know when all goroutines are "durably" blocked.

I've extended the excellent `grpctest` package @tigrato added with a method to create a unidirectional server stream.
