### PR TITLE
Add the lib/devicetpm package

### DIFF
--- a/lib/devicetpm/attest.go
+++ b/lib/devicetpm/attest.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package devicetpm
 
 import "github.com/google/go-attestation/attest"

--- a/lib/devicetpm/attest.go
+++ b/lib/devicetpm/attest.go
@@ -1,0 +1,25 @@
+package devicetpm
+
+import "github.com/google/go-attestation/attest"
+
+// OpenTPM calls [attest.OpenTPM] using TPM version 2.0.
+func OpenTPM(config *attest.OpenConfig) (*attest.TPM, error) {
+	if config == nil {
+		config = &attest.OpenConfig{}
+	}
+	config.TPMVersion = attest.TPMVersion20
+	return attest.OpenTPM(config)
+}
+
+// ActivationParameters prepares ap for TPM version 2.0.
+func ActivationParameters(ap *attest.ActivationParameters) *attest.ActivationParameters {
+	if ap != nil {
+		ap.TPMVersion = attest.TPMVersion20
+	}
+	return ap
+}
+
+// ParseAKPublic calls [attest.ParseAKPublic] using TPM version 2.0.
+func ParseAKPublic(public []byte) (*attest.AKPublic, error) {
+	return attest.ParseAKPublic(attest.TPMVersion20, public)
+}

--- a/lib/devicetpm/doc.go
+++ b/lib/devicetpm/doc.go
@@ -1,0 +1,5 @@
+// Package devicetpm wraps TPM-related methods for Device Trust.
+//
+// It is useful to keep consistent TPM interactions and to allow for clean
+// go-attestation upgrades on e/.
+package devicetpm

--- a/lib/devicetpm/doc.go
+++ b/lib/devicetpm/doc.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 // Package devicetpm wraps TPM-related methods for Device Trust.
 //
 // It is useful to keep consistent TPM interactions and to allow for clean


### PR DESCRIPTION
The lib/devicetpm package will be used by e/ to hide the TPMVersion field/parameter, as it was removed by go-atttestation v0.6.0. This allows for a clean upgrade without e/ breakages.

Note that the methods don't need to be used by OSS, we can simply upgrade the dependency and fix the call sites in one go here.

* https://github.com/google/go-attestation/releases/tag/v0.6.0

#61291