### PR TITLE
Update bpf session recording security warning ingress --> egress

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/bpf-session-recording.mdx
@@ -50,7 +50,7 @@ session). Also, a local user with both monitored and unmonitored console
 sessions or ptrace privileges may not be fully captured in recordings.
 
 Commands executed via daemons (systemd, crond, atd, etc.) could be outside of
-the recorded session scope. Proper network-based restrictions for ingress
+the recorded session scope. Proper network-based restrictions for egress
 traffic must also be implemented to prevent possible unauthorized data transfer.
 
 Additionally, certain forensic information such as full binary paths


### PR DESCRIPTION
From context, I believe this was the original intent of this sentence. Egress is how unauthorized data transfer out of a system would be labeled.