### PR TITLE
[v18] Add cache for AD SIDs

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -141,7 +141,7 @@ func (s *WindowsService) ldapSearchFilter(additionalFilters []string) string {
 
 // getDesktopsFromLDAP discovers Windows hosts via LDAP
 func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
-	tc, err := s.tlsConfigForLDAP()
+	tc, err := s.loadTLSConfigForLDAP()
 	if err != nil {
 		s.cfg.Logger.WarnContext(s.closeCtx, "could not request TLS certificate for LDAP discovery", "error", err)
 		return nil

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
@@ -79,10 +80,15 @@ const (
 	windowsDesktopServiceCertTTL = 8 * time.Hour
 
 	// windowsUserCertTTL is the TTL for certificates issued to users connecting
-	// to Windows hosts. These certicates are generated on-demand for each session,
+	// to Windows hosts. These certificates are generated on-demand for each session,
 	// so the TTL is deliberately set to a small value to give enough time to establish
 	// a single session.
 	windowsUserCertTTL = 5 * time.Minute
+
+	// tlsConfigCacheTTL is the TTL for the cached TLS config used for LDAP
+	// queries. It is set to half of the TTL of the certificate it is requesting
+	// for safety.
+	tlsConfigCacheTTL = windowsDesktopServiceCertTTL / 2
 )
 
 // computerAttributes are the attributes we fetch when discovering
@@ -111,7 +117,7 @@ type WindowsService struct {
 
 	ca *winpki.CertificateStoreClient
 
-	// lastDisoveryResults stores the results of the most recent LDAP search
+	// lastDiscoveryResults stores the results of the most recent LDAP search
 	// when desktop discovery is enabled.
 	// no synchronization is necessary because this is only read/written from
 	// the reconciler goroutine.
@@ -135,6 +141,14 @@ type WindowsService struct {
 	// Network Level Authentication (NLA) when attempting to connect
 	// to domain-joined Windows hosts
 	enableNLA bool
+
+	// sidCache caches ActiveDirectory SID lookups
+	sidCache *utils.FnCache
+
+	// ldapTLSConfig is used as a cache for LDAP TLS config
+	ldapTLSConfig          *tls.Config
+	ldapTLSConfigExpiresAt time.Time
+	ldapTLSConfigMu        sync.Mutex
 
 	closeCtx context.Context
 	close    func()
@@ -356,6 +370,23 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	}
 
 	ctx, close := context.WithCancel(context.Background())
+
+	// Only initialize the username-to-SID cache if AD is being
+	// used. We can determine this by checking if LDAP is configured
+	var sidCache *utils.FnCache
+	if cfg.LDAPConfig.Enabled() {
+		var err error
+		sidCache, err = utils.NewFnCache(utils.FnCacheConfig{
+			TTL:     4 * time.Hour,
+			Clock:   cfg.Clock,
+			Context: ctx,
+		})
+		if err != nil {
+			close()
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	s := &WindowsService{
 		cfg: cfg,
 		middleware: &auth.Middleware{
@@ -368,6 +399,7 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 		close:       close,
 		auditCache:  newSharedDirectoryAuditCache(),
 		enableNLA:   cfg.NLA,
+		sidCache:    sidCache,
 	}
 
 	s.ca = winpki.NewCertificateStoreClient(winpki.CertificateStoreConfig{
@@ -379,11 +411,7 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	})
 
 	if s.cfg.LDAPConfig.Enabled() {
-		tc, err := s.tlsConfigForLDAP()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		go s.runCRLUpdateLoop(tc)
+		go s.runCRLUpdateLoop()
 	}
 
 	ok := false
@@ -436,7 +464,7 @@ func (s *WindowsService) newSessionRecorder(recConfig types.SessionRecordingConf
 	})
 }
 
-func (s *WindowsService) tlsConfigForLDAP() (*tls.Config, error) {
+func (s *WindowsService) issueNewTLSConfigForLDAP() (*tls.Config, error) {
 	// trim NETBIOS name from username
 	user := s.cfg.Username
 	if i := strings.LastIndex(s.cfg.Username, `\`); i != -1 {
@@ -1181,24 +1209,34 @@ func timer() func() int64 {
 func (s *WindowsService) generateUserCert(ctx context.Context, username string, ttl time.Duration, desktop types.WindowsDesktop, createUsers bool, groups []string) (certDER, keyDER []byte, err error) {
 	var activeDirectorySID string
 	if !desktop.NonAD() {
-		tc, err := s.tlsConfigForLDAP()
+		// Use FnCache to fetch the SID, or load it from cache if we already have it
+		// The cache key is the username and domain combined to handle multi-domain setups
+		cacheKey := fmt.Sprintf("%s@%s", username, desktop.GetDomain())
+		sid, err := utils.FnCacheGet(ctx, s.sidCache, cacheKey, func(ctx context.Context) (string, error) {
+			tc, err := s.loadTLSConfigForLDAP()
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+
+			ldapClient, err := winpki.DialLDAP(ctx, s.getLDAPConfig(), tc)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+			defer ldapClient.Close()
+
+			s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username)
+			sid, err := ldapClient.GetActiveDirectorySID(ctx, username)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+
+			s.cfg.Logger.DebugContext(ctx, "Found objectSid for Windows user", "username", username)
+			return sid, nil
+		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
-
-		ldapClient, err := winpki.DialLDAP(ctx, s.getLDAPConfig(), tc)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-		defer ldapClient.Close()
-
-		s.cfg.Logger.DebugContext(ctx, "querying LDAP for objectSid of Windows user", "username", username)
-		activeDirectorySID, err = ldapClient.GetActiveDirectorySID(ctx, username)
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-
-		s.cfg.Logger.DebugContext(ctx, "Found objectSid Windows user", "username", username)
+		activeDirectorySID = sid
 	}
 	return s.generateCredentials(ctx, generateCredentialsRequest{
 		username:           username,
@@ -1317,11 +1355,15 @@ func (m *monitorErrorSender) WriteString(s string) (n int, err error) {
 // runCRLUpdateLoop publishes the Certificate Revocation List to the given
 // LDAP server. It continues to do so every 5 minutes (by default) to make sure it is present
 // and in the correct location.
-func (s *WindowsService) runCRLUpdateLoop(tlsConfig *tls.Config) {
+func (s *WindowsService) runCRLUpdateLoop() {
 	t := s.cfg.Clock.NewTicker(retryutils.SeventhJitter(s.cfg.PublishCRLInterval))
 	defer t.Stop()
 
 	for {
+		tlsConfig, err := s.loadTLSConfigForLDAP()
+		if err != nil {
+			s.cfg.Logger.ErrorContext(s.closeCtx, "failed to get TLS config for CRL update", "error", err)
+		}
 		if err := s.ca.Update(s.closeCtx, tlsConfig); err != nil && !errors.Is(err, context.Canceled) {
 			s.cfg.Logger.ErrorContext(s.closeCtx, "failed to publish CRL", "error", err)
 		}
@@ -1405,4 +1447,26 @@ func (s *WindowsService) getKDCAddress(ctx context.Context) (string, error) {
 	}
 
 	return "", trace.NotFound("no KDC servers responded successfully for domain %q: %v", s.cfg.Domain, lastErr)
+}
+
+func (s *WindowsService) loadTLSConfigForLDAP() (*tls.Config, error) {
+	s.ldapTLSConfigMu.Lock()
+	defer s.ldapTLSConfigMu.Unlock()
+
+	// If there is a config that isn't expired, return it
+	if s.ldapTLSConfig != nil && s.cfg.Clock.Now().Before(s.ldapTLSConfigExpiresAt) {
+		s.cfg.Logger.DebugContext(s.closeCtx, "using TLS config from cache", "expires_at", s.ldapTLSConfigExpiresAt)
+		return s.ldapTLSConfig, nil
+	}
+
+	s.cfg.Logger.DebugContext(s.closeCtx, "cache expired, generating new TLS for LDAP", "expires_at", s.ldapTLSConfigExpiresAt)
+	cfg, err := s.issueNewTLSConfigForLDAP()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s.ldapTLSConfig = cfg
+	s.ldapTLSConfigExpiresAt = s.cfg.Clock.Now().Add(tlsConfigCacheTTL)
+
+	return cfg, nil
 }


### PR DESCRIPTION
Backport #60878 to branch/v18

changelog: Added caches to reduce Active Directory user SID lookups and TLS certificate requests.
