### PR TITLE
Add "Overview" video to Introduction to Machine & Workload Identity

### DIFF
--- a/docs/pages/machine-workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/introduction.mdx
@@ -3,6 +3,7 @@ title: "Introduction to Machine & Workload Identity"
 description: "Replace static secrets with secure, short-lived identities for machines and workloads."
 sidebar_label: "Introduction"
 sidebar_position: 1
+videoBanner: "ZDWRt105tBg"
 tags:
  - mwi
  - infrastructure-identity


### PR DESCRIPTION
This PR adds the same video we use on the Machine & Workload Identity landing page (https://goteleport.com/docs/machine-workload-identity/) to the Introduction page - https://goteleport.com/docs/machine-workload-identity/introduction/

Why? The video is recent, high quality and provides a very good high-level overview of MWI. Because of SEO/internal links, users may directly land on our Introduction page and may not hit the Landing Page - and - they may miss coming across this video. Users visiting the introduction page are likely to have the same intentions as those hitting the Landing Page.

I'm not necessarily sure this is the right path. Perhaps it'd make more sense to change any links that currently link to the introduction page (those which are trying to send the user in the direction of Machine & Workload Identity as a whole) to instead point towards the landing page. I've raised this PR since it seems the easiest way to discuss this.