### PR TITLE
[v18] fix db service crash when fetching aws meta failed

### DIFF
--- a/lib/srv/db/common/connect/connect.go
+++ b/lib/srv/db/common/connect/connect.go
@@ -223,7 +223,7 @@ type ConnectParams struct {
 }
 
 func (p *ConnectParams) CheckAndSetDefaults() error {
-	if p.Logger != nil {
+	if p.Logger == nil {
 		p.Logger = slog.Default()
 	}
 

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -51,7 +51,9 @@ func ConvertError(err error) error {
 
 	var pgErr pgError
 	if errors.As(err, &pgErr) {
-		return ConvertError(pgErr.Unwrap())
+		if unwrapped := pgErr.Unwrap(); unwrapped != nil && unwrapped.Error() != "" {
+			return ConvertError(unwrapped)
+		}
 	}
 
 	var c causer

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -46,30 +46,20 @@ func ConvertError(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Unwrap original error first.
-	err = trace.Unwrap(err)
 
-	var pgErr pgError
-	if errors.As(err, &pgErr) {
-		if unwrapped := pgErr.Unwrap(); unwrapped != nil && unwrapped.Error() != "" {
-			return ConvertError(unwrapped)
-		}
-	}
-
-	var c causer
-	if errors.As(err, &c) {
-		return ConvertError(c.Cause())
-	}
-	if _, ok := status.FromError(err); ok {
-		return trail.FromGRPC(err)
-	}
-
+	var causeErr causer
 	var googleAPIErr *googleapi.Error
 	var awsRequestFailureErr *awshttp.ResponseError
 	var azResponseErr *azcore.ResponseError
 	var pgError *pgconn.PgError
 	var myError *mysql.MyError
+
+	// Unwrap trace error first.
 	switch err := trace.Unwrap(err); {
+	case errors.As(err, &causeErr):
+		return ConvertError(causeErr.Cause())
+	case isGRPCStatusError(err):
+		return trail.FromGRPC(err)
 	case errors.As(err, &googleAPIErr):
 		return convertGCPError(googleAPIErr)
 	case errors.As(err, &awsRequestFailureErr):
@@ -82,6 +72,11 @@ func ConvertError(err error) error {
 		return convertMySQLError(myError)
 	}
 	return err // Return unmodified.
+}
+
+func isGRPCStatusError(err error) bool {
+	_, ok := status.FromError(err)
+	return ok
 }
 
 // convertGCPError converts GCP errors to trace errors.
@@ -122,11 +117,6 @@ func fmtEscape(err error) string {
 // causer defines an interface for errors wrapped by the "errors" package.
 type causer interface {
 	Cause() error
-}
-
-// pgError defines an interface for errors wrapped by Postgres driver.
-type pgError interface {
-	Unwrap() error
 }
 
 // ConvertConnectError converts common connection errors to trace errors with

--- a/lib/srv/db/common/errors_test.go
+++ b/lib/srv/db/common/errors_test.go
@@ -22,11 +22,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgerrcode"
-
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Backport #61069 to branch/v18

changelog: fix an issue sometimes db service panics when fetching aws metadata fails
