### PR TITLE
Add proto definitions for command/enhanced summaries

### DIFF
--- a/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
+++ b/api/gen/proto/go/teleport/summarizer/v1/summarizer.pb.go
@@ -91,6 +91,254 @@ func (SummaryState) EnumDescriptor() ([]byte, []int) {
 	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{0}
 }
 
+// CommandCategory represents the category of a command.
+type CommandCategory int32
+
+const (
+	// CommandCategoryUnspecified is the default value and indicates that the command
+	// category is not specified.
+	CommandCategory_COMMAND_CATEGORY_UNSPECIFIED CommandCategory = 0
+	// CommandCategoryFileOperation indicates that the command is related to file
+	// operations, such as copying, moving, or deleting files.
+	CommandCategory_COMMAND_CATEGORY_FILE_OPERATION CommandCategory = 1
+	// CommandCategoryNetwork indicates that the command is related to network
+	// operations, such as connecting to a remote host or transferring data.
+	CommandCategory_COMMAND_CATEGORY_NETWORK CommandCategory = 2
+	// CommandCategoryProcess indicates that the command is related to process
+	// management, such as starting or stopping processes.
+	CommandCategory_COMMAND_CATEGORY_PROCESS CommandCategory = 3
+	// CommandCategorySystemConfig indicates that the command is related to system
+	// configuration, such as changing system settings or installing software.
+	CommandCategory_COMMAND_CATEGORY_SYSTEM_CONFIG CommandCategory = 4
+	// CommandCategoryDataAccess indicates that the command is related to data access,
+	// such as querying databases or reading data files.
+	CommandCategory_COMMAND_CATEGORY_DATA_ACCESS CommandCategory = 5
+	// CommandCategoryAuthentication indicates that the command is related to
+	// authentication, such as logging in or changing user credentials.
+	CommandCategory_COMMAND_CATEGORY_AUTHENTICATION CommandCategory = 6
+	// CommandCategoryOther indicates that the command does not fit into any of the
+	// other categories.
+	CommandCategory_COMMAND_CATEGORY_OTHER CommandCategory = 7
+)
+
+// Enum value maps for CommandCategory.
+var (
+	CommandCategory_name = map[int32]string{
+		0: "COMMAND_CATEGORY_UNSPECIFIED",
+		1: "COMMAND_CATEGORY_FILE_OPERATION",
+		2: "COMMAND_CATEGORY_NETWORK",
+		3: "COMMAND_CATEGORY_PROCESS",
+		4: "COMMAND_CATEGORY_SYSTEM_CONFIG",
+		5: "COMMAND_CATEGORY_DATA_ACCESS",
+		6: "COMMAND_CATEGORY_AUTHENTICATION",
+		7: "COMMAND_CATEGORY_OTHER",
+	}
+	CommandCategory_value = map[string]int32{
+		"COMMAND_CATEGORY_UNSPECIFIED":    0,
+		"COMMAND_CATEGORY_FILE_OPERATION": 1,
+		"COMMAND_CATEGORY_NETWORK":        2,
+		"COMMAND_CATEGORY_PROCESS":        3,
+		"COMMAND_CATEGORY_SYSTEM_CONFIG":  4,
+		"COMMAND_CATEGORY_DATA_ACCESS":    5,
+		"COMMAND_CATEGORY_AUTHENTICATION": 6,
+		"COMMAND_CATEGORY_OTHER":          7,
+	}
+)
+
+func (x CommandCategory) Enum() *CommandCategory {
+	p := new(CommandCategory)
+	*p = x
+	return p
+}
+
+func (x CommandCategory) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (CommandCategory) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_summarizer_v1_summarizer_proto_enumTypes[1].Descriptor()
+}
+
+func (CommandCategory) Type() protoreflect.EnumType {
+	return &file_teleport_summarizer_v1_summarizer_proto_enumTypes[1]
+}
+
+func (x CommandCategory) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use CommandCategory.Descriptor instead.
+func (CommandCategory) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{1}
+}
+
+// RiskLevel represents the risk level associated with a command.
+type RiskLevel int32
+
+const (
+	// RiskLevelUnspecified is the default value and indicates that the risk level
+	// is not specified.
+	RiskLevel_RISK_LEVEL_UNSPECIFIED RiskLevel = 0
+	// RiskLevelLow indicates that the command has a low risk level.
+	RiskLevel_RISK_LEVEL_LOW RiskLevel = 1
+	// RiskLevelMedium indicates that the command has a medium risk level.
+	RiskLevel_RISK_LEVEL_MEDIUM RiskLevel = 2
+	// RiskLevelHigh indicates that the command has a high risk level.
+	RiskLevel_RISK_LEVEL_HIGH RiskLevel = 3
+	// RiskLevelCritical indicates that the command has a critical risk level.
+	RiskLevel_RISK_LEVEL_CRITICAL RiskLevel = 4
+)
+
+// Enum value maps for RiskLevel.
+var (
+	RiskLevel_name = map[int32]string{
+		0: "RISK_LEVEL_UNSPECIFIED",
+		1: "RISK_LEVEL_LOW",
+		2: "RISK_LEVEL_MEDIUM",
+		3: "RISK_LEVEL_HIGH",
+		4: "RISK_LEVEL_CRITICAL",
+	}
+	RiskLevel_value = map[string]int32{
+		"RISK_LEVEL_UNSPECIFIED": 0,
+		"RISK_LEVEL_LOW":         1,
+		"RISK_LEVEL_MEDIUM":      2,
+		"RISK_LEVEL_HIGH":        3,
+		"RISK_LEVEL_CRITICAL":    4,
+	}
+)
+
+func (x RiskLevel) Enum() *RiskLevel {
+	p := new(RiskLevel)
+	*p = x
+	return p
+}
+
+func (x RiskLevel) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RiskLevel) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_summarizer_v1_summarizer_proto_enumTypes[2].Descriptor()
+}
+
+func (RiskLevel) Type() protoreflect.EnumType {
+	return &file_teleport_summarizer_v1_summarizer_proto_enumTypes[2]
+}
+
+func (x RiskLevel) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RiskLevel.Descriptor instead.
+func (RiskLevel) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{2}
+}
+
+// ThreatCategory represents the category of a detected threat.
+type ThreatCategory int32
+
+const (
+	// ThreatCategoryUnspecified is the default value and indicates that the threat
+	// category is not specified.
+	ThreatCategory_THREAT_CATEGORY_UNSPECIFIED ThreatCategory = 0
+	// ThreatCategoryReconnaissance indicates that the threat is related to reconnaissance
+	// activities, such as scanning or probing the system.
+	ThreatCategory_THREAT_CATEGORY_RECONNAISSANCE ThreatCategory = 1
+	// ThreatCategoryExecution indicates that the threat is related to execution activities,
+	// such as running malicious code.
+	ThreatCategory_THREAT_CATEGORY_EXECUTION ThreatCategory = 2
+	// ThreatCategoryPersistence indicates that the threat is related to persistence
+	// activities, such as installing backdoors.
+	ThreatCategory_THREAT_CATEGORY_PERSISTENCE ThreatCategory = 3
+	// ThreatCategoryPrivilegeEscalation indicates that the threat is related to privilege
+	// escalation activities, such as exploiting vulnerabilities to gain higher privileges.
+	ThreatCategory_THREAT_CATEGORY_PRIVILEGE_ESCALATION ThreatCategory = 4
+	// ThreatCategoryDefenseEvasion indicates that the threat is related to defense evasion
+	// activities, such as disabling security software.
+	ThreatCategory_THREAT_CATEGORY_DEFENSE_EVASION ThreatCategory = 5
+	// ThreatCategoryCredentialAccess indicates that the threat is related to credential
+	// access activities, such as stealing passwords.
+	ThreatCategory_THREAT_CATEGORY_CREDENTIAL_ACCESS ThreatCategory = 6
+	// ThreatCategoryDiscovery indicates that the threat is related to discovery activities,
+	// such as gathering information about the system.
+	ThreatCategory_THREAT_CATEGORY_DISCOVERY ThreatCategory = 7
+	// ThreatCategoryLateralMovement indicates that the threat is related to lateral movement
+	// activities, such as moving laterally within the network.
+	ThreatCategory_THREAT_CATEGORY_LATERAL_MOVEMENT ThreatCategory = 8
+	// ThreatCategoryCollection indicates that the threat is related to collection activities,
+	// such as collecting sensitive data.
+	ThreatCategory_THREAT_CATEGORY_COLLECTION ThreatCategory = 9
+	// ThreatCategoryExfiltration indicates that the threat is related to exfiltration
+	// activities, such as stealing data from the system.
+	ThreatCategory_THREAT_CATEGORY_EXFILTRATION ThreatCategory = 10
+	// ThreatCategoryImpact indicates that the threat is related to impact activities,
+	// such as disrupting system operations.
+	ThreatCategory_THREAT_CATEGORY_IMPACT ThreatCategory = 11
+	// ThreatCategoryNone indicates that there is no threat detected.
+	ThreatCategory_THREAT_CATEGORY_NONE ThreatCategory = 12
+)
+
+// Enum value maps for ThreatCategory.
+var (
+	ThreatCategory_name = map[int32]string{
+		0:  "THREAT_CATEGORY_UNSPECIFIED",
+		1:  "THREAT_CATEGORY_RECONNAISSANCE",
+		2:  "THREAT_CATEGORY_EXECUTION",
+		3:  "THREAT_CATEGORY_PERSISTENCE",
+		4:  "THREAT_CATEGORY_PRIVILEGE_ESCALATION",
+		5:  "THREAT_CATEGORY_DEFENSE_EVASION",
+		6:  "THREAT_CATEGORY_CREDENTIAL_ACCESS",
+		7:  "THREAT_CATEGORY_DISCOVERY",
+		8:  "THREAT_CATEGORY_LATERAL_MOVEMENT",
+		9:  "THREAT_CATEGORY_COLLECTION",
+		10: "THREAT_CATEGORY_EXFILTRATION",
+		11: "THREAT_CATEGORY_IMPACT",
+		12: "THREAT_CATEGORY_NONE",
+	}
+	ThreatCategory_value = map[string]int32{
+		"THREAT_CATEGORY_UNSPECIFIED":          0,
+		"THREAT_CATEGORY_RECONNAISSANCE":       1,
+		"THREAT_CATEGORY_EXECUTION":            2,
+		"THREAT_CATEGORY_PERSISTENCE":          3,
+		"THREAT_CATEGORY_PRIVILEGE_ESCALATION": 4,
+		"THREAT_CATEGORY_DEFENSE_EVASION":      5,
+		"THREAT_CATEGORY_CREDENTIAL_ACCESS":    6,
+		"THREAT_CATEGORY_DISCOVERY":            7,
+		"THREAT_CATEGORY_LATERAL_MOVEMENT":     8,
+		"THREAT_CATEGORY_COLLECTION":           9,
+		"THREAT_CATEGORY_EXFILTRATION":         10,
+		"THREAT_CATEGORY_IMPACT":               11,
+		"THREAT_CATEGORY_NONE":                 12,
+	}
+)
+
+func (x ThreatCategory) Enum() *ThreatCategory {
+	p := new(ThreatCategory)
+	*p = x
+	return p
+}
+
+func (x ThreatCategory) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ThreatCategory) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_summarizer_v1_summarizer_proto_enumTypes[3].Descriptor()
+}
+
+func (ThreatCategory) Type() protoreflect.EnumType {
+	return &file_teleport_summarizer_v1_summarizer_proto_enumTypes[3]
+}
+
+func (x ThreatCategory) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ThreatCategory.Descriptor instead.
+func (ThreatCategory) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{3}
+}
+
 // InferenceModel resource specifies a session summarization inference model
 // configuration. It tells Teleport how to use a specific provider and model to
 // summarize sessions.
@@ -734,9 +982,11 @@ type Summary struct {
 	SessionEndEvent *structpb.Struct `protobuf:"bytes,7,opt,name=session_end_event,json=sessionEndEvent,proto3" json:"session_end_event,omitempty"`
 	// ErrorMessage is an error message if the summarization failed. Available if
 	// the state is SUMMARY_STATE_ERROR.
-	ErrorMessage  string `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ErrorMessage string `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	// EnhancedSummary contains structured data extracted from the session.
+	EnhancedSummary *EnhancedSummary `protobuf:"bytes,9,opt,name=enhanced_summary,json=enhancedSummary,proto3" json:"enhanced_summary,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *Summary) Reset() {
@@ -825,6 +1075,397 @@ func (x *Summary) GetErrorMessage() string {
 	return ""
 }
 
+func (x *Summary) GetEnhancedSummary() *EnhancedSummary {
+	if x != nil {
+		return x.EnhancedSummary
+	}
+	return nil
+}
+
+// CommandAnalysis represents a summary of a single command executed during a
+// session.
+type CommandAnalysis struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Command is the command that was executed.
+	Command string `protobuf:"bytes,1,opt,name=command,proto3" json:"command,omitempty"`
+	// Category is the category of the command.
+	Category CommandCategory `protobuf:"varint,2,opt,name=category,proto3,enum=teleport.summarizer.v1.CommandCategory" json:"category,omitempty"`
+	// Success indicates whether the command executed successfully.
+	Success bool `protobuf:"varint,3,opt,name=success,proto3" json:"success,omitempty"`
+	// RiskLevel is the risk level associated with the command.
+	RiskLevel RiskLevel `protobuf:"varint,4,opt,name=risk_level,json=riskLevel,proto3,enum=teleport.summarizer.v1.RiskLevel" json:"risk_level,omitempty"`
+	// RiskScore is a numerical score representing the risk associated with the command.
+	RiskScore int32 `protobuf:"varint,5,opt,name=risk_score,json=riskScore,proto3" json:"risk_score,omitempty"`
+	// ThreatCategory is the category of any detected threat associated with the command.
+	ThreatCategory ThreatCategory `protobuf:"varint,6,opt,name=threat_category,json=threatCategory,proto3,enum=teleport.summarizer.v1.ThreatCategory" json:"threat_category,omitempty"`
+	// TimelineTitle is a brief title for the command's entry in the session timeline.
+	TimelineTitle string `protobuf:"bytes,7,opt,name=timeline_title,json=timelineTitle,proto3" json:"timeline_title,omitempty"`
+	// TimelineSubtitle is a more detailed subtitle for the command's entry in the session timeline.
+	TimelineSubtitle string `protobuf:"bytes,8,opt,name=timeline_subtitle,json=timelineSubtitle,proto3" json:"timeline_subtitle,omitempty"`
+	// ShortDescription is a concise description of the command and its purpose.
+	ShortDescription string `protobuf:"bytes,9,opt,name=short_description,json=shortDescription,proto3" json:"short_description,omitempty"`
+	// DetailedDescription is an in-depth explanation of the command, its function,
+	// and any relevant context.
+	DetailedDescription string `protobuf:"bytes,10,opt,name=detailed_description,json=detailedDescription,proto3" json:"detailed_description,omitempty"`
+	// ErrorMessages contains any error messages produced during the execution of the command.
+	ErrorMessages []string `protobuf:"bytes,11,rep,name=error_messages,json=errorMessages,proto3" json:"error_messages,omitempty"`
+	// SuspiciousFlags contains any suspicious flags or indicators associated with the command.
+	SuspiciousFlags []string `protobuf:"bytes,12,rep,name=suspicious_flags,json=suspiciousFlags,proto3" json:"suspicious_flags,omitempty"`
+	// SensitiveItems contains any sensitive items accessed or modified by the command.
+	SensitiveItems []string `protobuf:"bytes,13,rep,name=sensitive_items,json=sensitiveItems,proto3" json:"sensitive_items,omitempty"`
+	// SuspiciousPatterns contains any suspicious patterns detected in relation to the command.
+	SuspiciousPatterns []string `protobuf:"bytes,14,rep,name=suspicious_patterns,json=suspiciousPatterns,proto3" json:"suspicious_patterns,omitempty"`
+	// IOCs contains any indicators of compromise associated with the command.
+	Iocs []string `protobuf:"bytes,15,rep,name=iocs,proto3" json:"iocs,omitempty"`
+	// MitreAttackIDs contains any MITRE ATT&CK IDs relevant to the command.
+	MitreAttackIds []string `protobuf:"bytes,16,rep,name=mitre_attack_ids,json=mitreAttackIds,proto3" json:"mitre_attack_ids,omitempty"`
+	// HasSensitiveData indicates whether the command involved access to or modification of sensitive data.
+	HasSensitiveData bool `protobuf:"varint,17,opt,name=has_sensitive_data,json=hasSensitiveData,proto3" json:"has_sensitive_data,omitempty"`
+	// PrivilegeEscalation indicates whether the command involved privilege escalation.
+	PrivilegeEscalation bool `protobuf:"varint,18,opt,name=privilege_escalation,json=privilegeEscalation,proto3" json:"privilege_escalation,omitempty"`
+	// DataExfiltration indicates whether the command involved data exfiltration.
+	DataExfiltration bool `protobuf:"varint,19,opt,name=data_exfiltration,json=dataExfiltration,proto3" json:"data_exfiltration,omitempty"`
+	// Persistence indicates whether the command involved persistence mechanisms.
+	Persistence   bool `protobuf:"varint,20,opt,name=persistence,proto3" json:"persistence,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CommandAnalysis) Reset() {
+	*x = CommandAnalysis{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommandAnalysis) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommandAnalysis) ProtoMessage() {}
+
+func (x *CommandAnalysis) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommandAnalysis.ProtoReflect.Descriptor instead.
+func (*CommandAnalysis) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *CommandAnalysis) GetCommand() string {
+	if x != nil {
+		return x.Command
+	}
+	return ""
+}
+
+func (x *CommandAnalysis) GetCategory() CommandCategory {
+	if x != nil {
+		return x.Category
+	}
+	return CommandCategory_COMMAND_CATEGORY_UNSPECIFIED
+}
+
+func (x *CommandAnalysis) GetSuccess() bool {
+	if x != nil {
+		return x.Success
+	}
+	return false
+}
+
+func (x *CommandAnalysis) GetRiskLevel() RiskLevel {
+	if x != nil {
+		return x.RiskLevel
+	}
+	return RiskLevel_RISK_LEVEL_UNSPECIFIED
+}
+
+func (x *CommandAnalysis) GetRiskScore() int32 {
+	if x != nil {
+		return x.RiskScore
+	}
+	return 0
+}
+
+func (x *CommandAnalysis) GetThreatCategory() ThreatCategory {
+	if x != nil {
+		return x.ThreatCategory
+	}
+	return ThreatCategory_THREAT_CATEGORY_UNSPECIFIED
+}
+
+func (x *CommandAnalysis) GetTimelineTitle() string {
+	if x != nil {
+		return x.TimelineTitle
+	}
+	return ""
+}
+
+func (x *CommandAnalysis) GetTimelineSubtitle() string {
+	if x != nil {
+		return x.TimelineSubtitle
+	}
+	return ""
+}
+
+func (x *CommandAnalysis) GetShortDescription() string {
+	if x != nil {
+		return x.ShortDescription
+	}
+	return ""
+}
+
+func (x *CommandAnalysis) GetDetailedDescription() string {
+	if x != nil {
+		return x.DetailedDescription
+	}
+	return ""
+}
+
+func (x *CommandAnalysis) GetErrorMessages() []string {
+	if x != nil {
+		return x.ErrorMessages
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetSuspiciousFlags() []string {
+	if x != nil {
+		return x.SuspiciousFlags
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetSensitiveItems() []string {
+	if x != nil {
+		return x.SensitiveItems
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetSuspiciousPatterns() []string {
+	if x != nil {
+		return x.SuspiciousPatterns
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetIocs() []string {
+	if x != nil {
+		return x.Iocs
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetMitreAttackIds() []string {
+	if x != nil {
+		return x.MitreAttackIds
+	}
+	return nil
+}
+
+func (x *CommandAnalysis) GetHasSensitiveData() bool {
+	if x != nil {
+		return x.HasSensitiveData
+	}
+	return false
+}
+
+func (x *CommandAnalysis) GetPrivilegeEscalation() bool {
+	if x != nil {
+		return x.PrivilegeEscalation
+	}
+	return false
+}
+
+func (x *CommandAnalysis) GetDataExfiltration() bool {
+	if x != nil {
+		return x.DataExfiltration
+	}
+	return false
+}
+
+func (x *CommandAnalysis) GetPersistence() bool {
+	if x != nil {
+		return x.Persistence
+	}
+	return false
+}
+
+// SecurityRecommendation represents a security recommendation related to a command
+type SecurityRecommendation struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Title is a brief title for the security recommendation.
+	Title string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
+	// Description is a detailed description of the security recommendation.
+	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
+	// Severity indicates the severity level of the recommendation.
+	Severity      RiskLevel `protobuf:"varint,3,opt,name=severity,proto3,enum=teleport.summarizer.v1.RiskLevel" json:"severity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *SecurityRecommendation) Reset() {
+	*x = SecurityRecommendation{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SecurityRecommendation) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SecurityRecommendation) ProtoMessage() {}
+
+func (x *SecurityRecommendation) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SecurityRecommendation.ProtoReflect.Descriptor instead.
+func (*SecurityRecommendation) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *SecurityRecommendation) GetTitle() string {
+	if x != nil {
+		return x.Title
+	}
+	return ""
+}
+
+func (x *SecurityRecommendation) GetDescription() string {
+	if x != nil {
+		return x.Description
+	}
+	return ""
+}
+
+func (x *SecurityRecommendation) GetSeverity() RiskLevel {
+	if x != nil {
+		return x.Severity
+	}
+	return RiskLevel_RISK_LEVEL_UNSPECIFIED
+}
+
+// EnhancedSummary represents an enhanced summary of a session recording,
+// with structured data extracted from the session.
+type EnhancedSummary struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// ShortDescription is a concise description of the session.
+	ShortDescription string `protobuf:"bytes,1,opt,name=short_description,json=shortDescription,proto3" json:"short_description,omitempty"`
+	// DetailedDescription is an in-depth explanation of the session.
+	DetailedDescription string `protobuf:"bytes,2,opt,name=detailed_description,json=detailedDescription,proto3" json:"detailed_description,omitempty"`
+	// RiskLevel is the overall risk level associated with the session.
+	RiskLevel RiskLevel `protobuf:"varint,3,opt,name=risk_level,json=riskLevel,proto3,enum=teleport.summarizer.v1.RiskLevel" json:"risk_level,omitempty"`
+	// SuspiciousActivities is a list of suspicious activities detected during the session.
+	SuspiciousActivities []string `protobuf:"bytes,4,rep,name=suspicious_activities,json=suspiciousActivities,proto3" json:"suspicious_activities,omitempty"`
+	// CompromiseIndicators indicates whether any indicators of compromise were detected during the session.
+	CompromiseIndicators bool `protobuf:"varint,5,opt,name=compromise_indicators,json=compromiseIndicators,proto3" json:"compromise_indicators,omitempty"`
+	// NotableCommandIndexes is a list of indexes of commands that are considered notable.
+	NotableCommandIndexes []int32 `protobuf:"varint,6,rep,packed,name=notable_command_indexes,json=notableCommandIndexes,proto3" json:"notable_command_indexes,omitempty"`
+	// Commands is a list of command summaries extracted from the session.
+	Commands      []*CommandAnalysis `protobuf:"bytes,7,rep,name=commands,proto3" json:"commands,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *EnhancedSummary) Reset() {
+	*x = EnhancedSummary{}
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *EnhancedSummary) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EnhancedSummary) ProtoMessage() {}
+
+func (x *EnhancedSummary) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_summarizer_v1_summarizer_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EnhancedSummary.ProtoReflect.Descriptor instead.
+func (*EnhancedSummary) Descriptor() ([]byte, []int) {
+	return file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *EnhancedSummary) GetShortDescription() string {
+	if x != nil {
+		return x.ShortDescription
+	}
+	return ""
+}
+
+func (x *EnhancedSummary) GetDetailedDescription() string {
+	if x != nil {
+		return x.DetailedDescription
+	}
+	return ""
+}
+
+func (x *EnhancedSummary) GetRiskLevel() RiskLevel {
+	if x != nil {
+		return x.RiskLevel
+	}
+	return RiskLevel_RISK_LEVEL_UNSPECIFIED
+}
+
+func (x *EnhancedSummary) GetSuspiciousActivities() []string {
+	if x != nil {
+		return x.SuspiciousActivities
+	}
+	return nil
+}
+
+func (x *EnhancedSummary) GetCompromiseIndicators() bool {
+	if x != nil {
+		return x.CompromiseIndicators
+	}
+	return false
+}
+
+func (x *EnhancedSummary) GetNotableCommandIndexes() []int32 {
+	if x != nil {
+		return x.NotableCommandIndexes
+	}
+	return nil
+}
+
+func (x *EnhancedSummary) GetCommands() []*CommandAnalysis {
+	if x != nil {
+		return x.Commands
+	}
+	return nil
+}
+
 var File_teleport_summarizer_v1_summarizer_proto protoreflect.FileDescriptor
 
 const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
@@ -868,7 +1509,7 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\x13InferencePolicySpec\x12\x14\n" +
 	"\x05kinds\x18\x01 \x03(\tR\x05kinds\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x16\n" +
-	"\x06filter\x18\x03 \x01(\tR\x06filter\"\xa5\x03\n" +
+	"\x06filter\x18\x03 \x01(\tR\x06filter\"\xf9\x03\n" +
 	"\aSummary\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12:\n" +
@@ -879,12 +1520,80 @@ const file_teleport_summarizer_v1_summarizer_proto_rawDesc = "" +
 	"\n" +
 	"model_name\x18\x06 \x01(\tR\tmodelName\x12C\n" +
 	"\x11session_end_event\x18\a \x01(\v2\x17.google.protobuf.StructR\x0fsessionEndEvent\x12#\n" +
-	"\rerror_message\x18\b \x01(\tR\ferrorMessage*|\n" +
+	"\rerror_message\x18\b \x01(\tR\ferrorMessage\x12R\n" +
+	"\x10enhanced_summary\x18\t \x01(\v2'.teleport.summarizer.v1.EnhancedSummaryR\x0fenhancedSummary\"\x8a\a\n" +
+	"\x0fCommandAnalysis\x12\x18\n" +
+	"\acommand\x18\x01 \x01(\tR\acommand\x12C\n" +
+	"\bcategory\x18\x02 \x01(\x0e2'.teleport.summarizer.v1.CommandCategoryR\bcategory\x12\x18\n" +
+	"\asuccess\x18\x03 \x01(\bR\asuccess\x12@\n" +
+	"\n" +
+	"risk_level\x18\x04 \x01(\x0e2!.teleport.summarizer.v1.RiskLevelR\triskLevel\x12\x1d\n" +
+	"\n" +
+	"risk_score\x18\x05 \x01(\x05R\triskScore\x12O\n" +
+	"\x0fthreat_category\x18\x06 \x01(\x0e2&.teleport.summarizer.v1.ThreatCategoryR\x0ethreatCategory\x12%\n" +
+	"\x0etimeline_title\x18\a \x01(\tR\rtimelineTitle\x12+\n" +
+	"\x11timeline_subtitle\x18\b \x01(\tR\x10timelineSubtitle\x12+\n" +
+	"\x11short_description\x18\t \x01(\tR\x10shortDescription\x121\n" +
+	"\x14detailed_description\x18\n" +
+	" \x01(\tR\x13detailedDescription\x12%\n" +
+	"\x0eerror_messages\x18\v \x03(\tR\rerrorMessages\x12)\n" +
+	"\x10suspicious_flags\x18\f \x03(\tR\x0fsuspiciousFlags\x12'\n" +
+	"\x0fsensitive_items\x18\r \x03(\tR\x0esensitiveItems\x12/\n" +
+	"\x13suspicious_patterns\x18\x0e \x03(\tR\x12suspiciousPatterns\x12\x12\n" +
+	"\x04iocs\x18\x0f \x03(\tR\x04iocs\x12(\n" +
+	"\x10mitre_attack_ids\x18\x10 \x03(\tR\x0emitreAttackIds\x12,\n" +
+	"\x12has_sensitive_data\x18\x11 \x01(\bR\x10hasSensitiveData\x121\n" +
+	"\x14privilege_escalation\x18\x12 \x01(\bR\x13privilegeEscalation\x12+\n" +
+	"\x11data_exfiltration\x18\x13 \x01(\bR\x10dataExfiltration\x12 \n" +
+	"\vpersistence\x18\x14 \x01(\bR\vpersistence\"\x8f\x01\n" +
+	"\x16SecurityRecommendation\x12\x14\n" +
+	"\x05title\x18\x01 \x01(\tR\x05title\x12 \n" +
+	"\vdescription\x18\x02 \x01(\tR\vdescription\x12=\n" +
+	"\bseverity\x18\x03 \x01(\x0e2!.teleport.summarizer.v1.RiskLevelR\bseverity\"\x9a\x03\n" +
+	"\x0fEnhancedSummary\x12+\n" +
+	"\x11short_description\x18\x01 \x01(\tR\x10shortDescription\x121\n" +
+	"\x14detailed_description\x18\x02 \x01(\tR\x13detailedDescription\x12@\n" +
+	"\n" +
+	"risk_level\x18\x03 \x01(\x0e2!.teleport.summarizer.v1.RiskLevelR\triskLevel\x123\n" +
+	"\x15suspicious_activities\x18\x04 \x03(\tR\x14suspiciousActivities\x123\n" +
+	"\x15compromise_indicators\x18\x05 \x01(\bR\x14compromiseIndicators\x126\n" +
+	"\x17notable_command_indexes\x18\x06 \x03(\x05R\x15notableCommandIndexes\x12C\n" +
+	"\bcommands\x18\a \x03(\v2'.teleport.summarizer.v1.CommandAnalysisR\bcommands*|\n" +
 	"\fSummaryState\x12\x1d\n" +
 	"\x19SUMMARY_STATE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15SUMMARY_STATE_PENDING\x10\x01\x12\x19\n" +
 	"\x15SUMMARY_STATE_SUCCESS\x10\x02\x12\x17\n" +
-	"\x13SUMMARY_STATE_ERROR\x10\x03BXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
+	"\x13SUMMARY_STATE_ERROR\x10\x03*\x9b\x02\n" +
+	"\x0fCommandCategory\x12 \n" +
+	"\x1cCOMMAND_CATEGORY_UNSPECIFIED\x10\x00\x12#\n" +
+	"\x1fCOMMAND_CATEGORY_FILE_OPERATION\x10\x01\x12\x1c\n" +
+	"\x18COMMAND_CATEGORY_NETWORK\x10\x02\x12\x1c\n" +
+	"\x18COMMAND_CATEGORY_PROCESS\x10\x03\x12\"\n" +
+	"\x1eCOMMAND_CATEGORY_SYSTEM_CONFIG\x10\x04\x12 \n" +
+	"\x1cCOMMAND_CATEGORY_DATA_ACCESS\x10\x05\x12#\n" +
+	"\x1fCOMMAND_CATEGORY_AUTHENTICATION\x10\x06\x12\x1a\n" +
+	"\x16COMMAND_CATEGORY_OTHER\x10\a*\x80\x01\n" +
+	"\tRiskLevel\x12\x1a\n" +
+	"\x16RISK_LEVEL_UNSPECIFIED\x10\x00\x12\x12\n" +
+	"\x0eRISK_LEVEL_LOW\x10\x01\x12\x15\n" +
+	"\x11RISK_LEVEL_MEDIUM\x10\x02\x12\x13\n" +
+	"\x0fRISK_LEVEL_HIGH\x10\x03\x12\x17\n" +
+	"\x13RISK_LEVEL_CRITICAL\x10\x04*\xc8\x03\n" +
+	"\x0eThreatCategory\x12\x1f\n" +
+	"\x1bTHREAT_CATEGORY_UNSPECIFIED\x10\x00\x12\"\n" +
+	"\x1eTHREAT_CATEGORY_RECONNAISSANCE\x10\x01\x12\x1d\n" +
+	"\x19THREAT_CATEGORY_EXECUTION\x10\x02\x12\x1f\n" +
+	"\x1bTHREAT_CATEGORY_PERSISTENCE\x10\x03\x12(\n" +
+	"$THREAT_CATEGORY_PRIVILEGE_ESCALATION\x10\x04\x12#\n" +
+	"\x1fTHREAT_CATEGORY_DEFENSE_EVASION\x10\x05\x12%\n" +
+	"!THREAT_CATEGORY_CREDENTIAL_ACCESS\x10\x06\x12\x1d\n" +
+	"\x19THREAT_CATEGORY_DISCOVERY\x10\a\x12$\n" +
+	" THREAT_CATEGORY_LATERAL_MOVEMENT\x10\b\x12\x1e\n" +
+	"\x1aTHREAT_CATEGORY_COLLECTION\x10\t\x12 \n" +
+	"\x1cTHREAT_CATEGORY_EXFILTRATION\x10\n" +
+	"\x12\x1a\n" +
+	"\x16THREAT_CATEGORY_IMPACT\x10\v\x12\x18\n" +
+	"\x14THREAT_CATEGORY_NONE\x10\fBXZVgithub.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1;summarizerv1b\x06proto3"
 
 var (
 	file_teleport_summarizer_v1_summarizer_proto_rawDescOnce sync.Once
@@ -898,41 +1607,54 @@ func file_teleport_summarizer_v1_summarizer_proto_rawDescGZIP() []byte {
 	return file_teleport_summarizer_v1_summarizer_proto_rawDescData
 }
 
-var file_teleport_summarizer_v1_summarizer_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_teleport_summarizer_v1_summarizer_proto_enumTypes = make([]protoimpl.EnumInfo, 4)
+var file_teleport_summarizer_v1_summarizer_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_teleport_summarizer_v1_summarizer_proto_goTypes = []any{
-	(SummaryState)(0),             // 0: teleport.summarizer.v1.SummaryState
-	(*InferenceModel)(nil),        // 1: teleport.summarizer.v1.InferenceModel
-	(*InferenceModelSpec)(nil),    // 2: teleport.summarizer.v1.InferenceModelSpec
-	(*OpenAIProvider)(nil),        // 3: teleport.summarizer.v1.OpenAIProvider
-	(*BedrockProvider)(nil),       // 4: teleport.summarizer.v1.BedrockProvider
-	(*InferenceSecret)(nil),       // 5: teleport.summarizer.v1.InferenceSecret
-	(*InferenceSecretSpec)(nil),   // 6: teleport.summarizer.v1.InferenceSecretSpec
-	(*InferencePolicy)(nil),       // 7: teleport.summarizer.v1.InferencePolicy
-	(*InferencePolicySpec)(nil),   // 8: teleport.summarizer.v1.InferencePolicySpec
-	(*Summary)(nil),               // 9: teleport.summarizer.v1.Summary
-	(*v1.Metadata)(nil),           // 10: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil), // 11: google.protobuf.Timestamp
-	(*structpb.Struct)(nil),       // 12: google.protobuf.Struct
+	(SummaryState)(0),              // 0: teleport.summarizer.v1.SummaryState
+	(CommandCategory)(0),           // 1: teleport.summarizer.v1.CommandCategory
+	(RiskLevel)(0),                 // 2: teleport.summarizer.v1.RiskLevel
+	(ThreatCategory)(0),            // 3: teleport.summarizer.v1.ThreatCategory
+	(*InferenceModel)(nil),         // 4: teleport.summarizer.v1.InferenceModel
+	(*InferenceModelSpec)(nil),     // 5: teleport.summarizer.v1.InferenceModelSpec
+	(*OpenAIProvider)(nil),         // 6: teleport.summarizer.v1.OpenAIProvider
+	(*BedrockProvider)(nil),        // 7: teleport.summarizer.v1.BedrockProvider
+	(*InferenceSecret)(nil),        // 8: teleport.summarizer.v1.InferenceSecret
+	(*InferenceSecretSpec)(nil),    // 9: teleport.summarizer.v1.InferenceSecretSpec
+	(*InferencePolicy)(nil),        // 10: teleport.summarizer.v1.InferencePolicy
+	(*InferencePolicySpec)(nil),    // 11: teleport.summarizer.v1.InferencePolicySpec
+	(*Summary)(nil),                // 12: teleport.summarizer.v1.Summary
+	(*CommandAnalysis)(nil),        // 13: teleport.summarizer.v1.CommandAnalysis
+	(*SecurityRecommendation)(nil), // 14: teleport.summarizer.v1.SecurityRecommendation
+	(*EnhancedSummary)(nil),        // 15: teleport.summarizer.v1.EnhancedSummary
+	(*v1.Metadata)(nil),            // 16: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 17: google.protobuf.Timestamp
+	(*structpb.Struct)(nil),        // 18: google.protobuf.Struct
 }
 var file_teleport_summarizer_v1_summarizer_proto_depIdxs = []int32{
-	10, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
-	2,  // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
-	3,  // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
-	4,  // 3: teleport.summarizer.v1.InferenceModelSpec.bedrock:type_name -> teleport.summarizer.v1.BedrockProvider
-	10, // 4: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
-	6,  // 5: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
-	10, // 6: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 7: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
+	16, // 0: teleport.summarizer.v1.InferenceModel.metadata:type_name -> teleport.header.v1.Metadata
+	5,  // 1: teleport.summarizer.v1.InferenceModel.spec:type_name -> teleport.summarizer.v1.InferenceModelSpec
+	6,  // 2: teleport.summarizer.v1.InferenceModelSpec.openai:type_name -> teleport.summarizer.v1.OpenAIProvider
+	7,  // 3: teleport.summarizer.v1.InferenceModelSpec.bedrock:type_name -> teleport.summarizer.v1.BedrockProvider
+	16, // 4: teleport.summarizer.v1.InferenceSecret.metadata:type_name -> teleport.header.v1.Metadata
+	9,  // 5: teleport.summarizer.v1.InferenceSecret.spec:type_name -> teleport.summarizer.v1.InferenceSecretSpec
+	16, // 6: teleport.summarizer.v1.InferencePolicy.metadata:type_name -> teleport.header.v1.Metadata
+	11, // 7: teleport.summarizer.v1.InferencePolicy.spec:type_name -> teleport.summarizer.v1.InferencePolicySpec
 	0,  // 8: teleport.summarizer.v1.Summary.state:type_name -> teleport.summarizer.v1.SummaryState
-	11, // 9: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
-	11, // 10: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
-	12, // 11: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	17, // 9: teleport.summarizer.v1.Summary.inference_started_at:type_name -> google.protobuf.Timestamp
+	17, // 10: teleport.summarizer.v1.Summary.inference_finished_at:type_name -> google.protobuf.Timestamp
+	18, // 11: teleport.summarizer.v1.Summary.session_end_event:type_name -> google.protobuf.Struct
+	15, // 12: teleport.summarizer.v1.Summary.enhanced_summary:type_name -> teleport.summarizer.v1.EnhancedSummary
+	1,  // 13: teleport.summarizer.v1.CommandAnalysis.category:type_name -> teleport.summarizer.v1.CommandCategory
+	2,  // 14: teleport.summarizer.v1.CommandAnalysis.risk_level:type_name -> teleport.summarizer.v1.RiskLevel
+	3,  // 15: teleport.summarizer.v1.CommandAnalysis.threat_category:type_name -> teleport.summarizer.v1.ThreatCategory
+	2,  // 16: teleport.summarizer.v1.SecurityRecommendation.severity:type_name -> teleport.summarizer.v1.RiskLevel
+	2,  // 17: teleport.summarizer.v1.EnhancedSummary.risk_level:type_name -> teleport.summarizer.v1.RiskLevel
+	13, // 18: teleport.summarizer.v1.EnhancedSummary.commands:type_name -> teleport.summarizer.v1.CommandAnalysis
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_teleport_summarizer_v1_summarizer_proto_init() }
@@ -949,8 +1671,8 @@ func file_teleport_summarizer_v1_summarizer_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_summarizer_v1_summarizer_proto_rawDesc), len(file_teleport_summarizer_v1_summarizer_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   9,
+			NumEnums:      4,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/summarizer/v1/summarizer.proto
+++ b/api/proto/teleport/summarizer/v1/summarizer.proto
@@ -178,4 +178,168 @@ message Summary {
   // ErrorMessage is an error message if the summarization failed. Available if
   // the state is SUMMARY_STATE_ERROR.
   string error_message = 8;
+  // EnhancedSummary contains structured data extracted from the session.
+  EnhancedSummary enhanced_summary = 9;
+}
+
+// The following enums and messages should be kept in sync with `e/lib/auth/summarizer/schema/command.go`
+
+// CommandCategory represents the category of a command.
+enum CommandCategory {
+  // CommandCategoryUnspecified is the default value and indicates that the command
+  // category is not specified.
+  COMMAND_CATEGORY_UNSPECIFIED = 0;
+  // CommandCategoryFileOperation indicates that the command is related to file
+  // operations, such as copying, moving, or deleting files.
+  COMMAND_CATEGORY_FILE_OPERATION = 1;
+  // CommandCategoryNetwork indicates that the command is related to network
+  // operations, such as connecting to a remote host or transferring data.
+  COMMAND_CATEGORY_NETWORK = 2;
+  // CommandCategoryProcess indicates that the command is related to process
+  // management, such as starting or stopping processes.
+  COMMAND_CATEGORY_PROCESS = 3;
+  // CommandCategorySystemConfig indicates that the command is related to system
+  // configuration, such as changing system settings or installing software.
+  COMMAND_CATEGORY_SYSTEM_CONFIG = 4;
+  // CommandCategoryDataAccess indicates that the command is related to data access,
+  // such as querying databases or reading data files.
+  COMMAND_CATEGORY_DATA_ACCESS = 5;
+  // CommandCategoryAuthentication indicates that the command is related to
+  // authentication, such as logging in or changing user credentials.
+  COMMAND_CATEGORY_AUTHENTICATION = 6;
+  // CommandCategoryOther indicates that the command does not fit into any of the
+  // other categories.
+  COMMAND_CATEGORY_OTHER = 7;
+}
+
+// RiskLevel represents the risk level associated with a command.
+enum RiskLevel {
+  // RiskLevelUnspecified is the default value and indicates that the risk level
+  // is not specified.
+  RISK_LEVEL_UNSPECIFIED = 0;
+  // RiskLevelLow indicates that the command has a low risk level.
+  RISK_LEVEL_LOW = 1;
+  // RiskLevelMedium indicates that the command has a medium risk level.
+  RISK_LEVEL_MEDIUM = 2;
+  // RiskLevelHigh indicates that the command has a high risk level.
+  RISK_LEVEL_HIGH = 3;
+  // RiskLevelCritical indicates that the command has a critical risk level.
+  RISK_LEVEL_CRITICAL = 4;
+}
+
+// ThreatCategory represents the category of a detected threat.
+enum ThreatCategory {
+  // ThreatCategoryUnspecified is the default value and indicates that the threat
+  // category is not specified.
+  THREAT_CATEGORY_UNSPECIFIED = 0;
+  // ThreatCategoryReconnaissance indicates that the threat is related to reconnaissance
+  // activities, such as scanning or probing the system.
+  THREAT_CATEGORY_RECONNAISSANCE = 1;
+  // ThreatCategoryExecution indicates that the threat is related to execution activities,
+  // such as running malicious code.
+  THREAT_CATEGORY_EXECUTION = 2;
+  // ThreatCategoryPersistence indicates that the threat is related to persistence
+  // activities, such as installing backdoors.
+  THREAT_CATEGORY_PERSISTENCE = 3;
+  // ThreatCategoryPrivilegeEscalation indicates that the threat is related to privilege
+  // escalation activities, such as exploiting vulnerabilities to gain higher privileges.
+  THREAT_CATEGORY_PRIVILEGE_ESCALATION = 4;
+  // ThreatCategoryDefenseEvasion indicates that the threat is related to defense evasion
+  // activities, such as disabling security software.
+  THREAT_CATEGORY_DEFENSE_EVASION = 5;
+  // ThreatCategoryCredentialAccess indicates that the threat is related to credential
+  // access activities, such as stealing passwords.
+  THREAT_CATEGORY_CREDENTIAL_ACCESS = 6;
+  // ThreatCategoryDiscovery indicates that the threat is related to discovery activities,
+  // such as gathering information about the system.
+  THREAT_CATEGORY_DISCOVERY = 7;
+  // ThreatCategoryLateralMovement indicates that the threat is related to lateral movement
+  // activities, such as moving laterally within the network.
+  THREAT_CATEGORY_LATERAL_MOVEMENT = 8;
+  // ThreatCategoryCollection indicates that the threat is related to collection activities,
+  // such as collecting sensitive data.
+  THREAT_CATEGORY_COLLECTION = 9;
+  // ThreatCategoryExfiltration indicates that the threat is related to exfiltration
+  // activities, such as stealing data from the system.
+  THREAT_CATEGORY_EXFILTRATION = 10;
+  // ThreatCategoryImpact indicates that the threat is related to impact activities,
+  // such as disrupting system operations.
+  THREAT_CATEGORY_IMPACT = 11;
+  // ThreatCategoryNone indicates that there is no threat detected.
+  THREAT_CATEGORY_NONE = 12;
+}
+
+// CommandAnalysis represents a summary of a single command executed during a
+// session.
+message CommandAnalysis {
+  // Command is the command that was executed.
+  string command = 1;
+  // Category is the category of the command.
+  CommandCategory category = 2;
+  // Success indicates whether the command executed successfully.
+  bool success = 3;
+  // RiskLevel is the risk level associated with the command.
+  RiskLevel risk_level = 4;
+  // RiskScore is a numerical score representing the risk associated with the command.
+  int32 risk_score = 5;
+  // ThreatCategory is the category of any detected threat associated with the command.
+  ThreatCategory threat_category = 6;
+  // TimelineTitle is a brief title for the command's entry in the session timeline.
+  string timeline_title = 7;
+  // TimelineSubtitle is a more detailed subtitle for the command's entry in the session timeline.
+  string timeline_subtitle = 8;
+  // ShortDescription is a concise description of the command and its purpose.
+  string short_description = 9;
+  // DetailedDescription is an in-depth explanation of the command, its function,
+  // and any relevant context.
+  string detailed_description = 10;
+  // ErrorMessages contains any error messages produced during the execution of the command.
+  repeated string error_messages = 11;
+  // SuspiciousFlags contains any suspicious flags or indicators associated with the command.
+  repeated string suspicious_flags = 12;
+  // SensitiveItems contains any sensitive items accessed or modified by the command.
+  repeated string sensitive_items = 13;
+  // SuspiciousPatterns contains any suspicious patterns detected in relation to the command.
+  repeated string suspicious_patterns = 14;
+  // IOCs contains any indicators of compromise associated with the command.
+  repeated string iocs = 15;
+  // MitreAttackIDs contains any MITRE ATT&CK IDs relevant to the command.
+  repeated string mitre_attack_ids = 16;
+  // HasSensitiveData indicates whether the command involved access to or modification of sensitive data.
+  bool has_sensitive_data = 17;
+  // PrivilegeEscalation indicates whether the command involved privilege escalation.
+  bool privilege_escalation = 18;
+  // DataExfiltration indicates whether the command involved data exfiltration.
+  bool data_exfiltration = 19;
+  // Persistence indicates whether the command involved persistence mechanisms.
+  bool persistence = 20;
+}
+
+// SecurityRecommendation represents a security recommendation related to a command
+message SecurityRecommendation {
+  // Title is a brief title for the security recommendation.
+  string title = 1;
+  // Description is a detailed description of the security recommendation.
+  string description = 2;
+  // Severity indicates the severity level of the recommendation.
+  RiskLevel severity = 3;
+}
+
+// EnhancedSummary represents an enhanced summary of a session recording,
+// with structured data extracted from the session.
+message EnhancedSummary {
+  // ShortDescription is a concise description of the session.
+  string short_description = 1;
+  // DetailedDescription is an in-depth explanation of the session.
+  string detailed_description = 2;
+  // RiskLevel is the overall risk level associated with the session.
+  RiskLevel risk_level = 3;
+  // SuspiciousActivities is a list of suspicious activities detected during the session.
+  repeated string suspicious_activities = 4;
+  // CompromiseIndicators indicates whether any indicators of compromise were detected during the session.
+  bool compromise_indicators = 5;
+  // NotableCommandIndexes is a list of indexes of commands that are considered notable.
+  repeated int32 notable_command_indexes = 6;
+  // Commands is a list of command summaries extracted from the session.
+  repeated CommandAnalysis commands = 7;
 }


### PR DESCRIPTION
Related https://github.com/gravitational/teleport.e/pull/7573

This adds proto definitions for the enhanced session summaries/individual command analysis

Unfortunately I don't think there's a nice/easy way to have the generated protobuf code also specify the jsonschema stuff, so it needs to be kept in sync with the JSON schema structs