### PR TITLE
[v17] fix db service crash when fetching aws meta failed

### DIFF
--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -46,28 +46,20 @@ func ConvertError(err error) error {
 	if err == nil {
 		return nil
 	}
-	// Unwrap original error first.
-	err = trace.Unwrap(err)
 
-	var pgErr pgError
-	if errors.As(err, &pgErr) {
-		return ConvertError(pgErr.Unwrap())
-	}
-
-	var c causer
-	if errors.As(err, &c) {
-		return ConvertError(c.Cause())
-	}
-	if _, ok := status.FromError(err); ok {
-		return trail.FromGRPC(err)
-	}
-
+	var causeErr causer
 	var googleAPIErr *googleapi.Error
 	var awsRequestFailureErr awserr.RequestFailure
 	var azResponseErr *azcore.ResponseError
 	var pgError *pgconn.PgError
 	var myError *mysql.MyError
+
+	// Unwrap trace error first.
 	switch err := trace.Unwrap(err); {
+	case errors.As(err, &causeErr):
+		return ConvertError(causeErr.Cause())
+	case isGRPCStatusError(err):
+		return trail.FromGRPC(err)
 	case errors.As(err, &googleAPIErr):
 		return convertGCPError(googleAPIErr)
 	case errors.As(err, &awsRequestFailureErr):
@@ -80,6 +72,11 @@ func ConvertError(err error) error {
 		return convertMySQLError(myError)
 	}
 	return err // Return unmodified.
+}
+
+func isGRPCStatusError(err error) bool {
+	_, ok := status.FromError(err)
+	return ok
 }
 
 // convertGCPError converts GCP errors to trace errors.
@@ -120,11 +117,6 @@ func fmtEscape(err error) string {
 // causer defines an interface for errors wrapped by the "errors" package.
 type causer interface {
 	Cause() error
-}
-
-// pgError defines an interface for errors wrapped by Postgres driver.
-type pgError interface {
-	Unwrap() error
 }
 
 // ConvertConnectError converts common connection errors to trace errors with

--- a/lib/srv/db/common/errors_test.go
+++ b/lib/srv/db/common/errors_test.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,14 +57,57 @@ type someErr struct {
 }
 
 func (e *someErr) Error() string {
+	if e.inner == nil {
+		return "inner: nil"
+	}
 	return "inner: " + e.inner.Error()
 }
 func (e *someErr) Unwrap() error {
 	return e.inner
 }
 
-func TestConvertErrorWrappedError(t *testing.T) {
-	nestedErr := &someErr{inner: trace.Wrap(fmt.Errorf("dummy error"))}
-	out := ConvertError(nestedErr)
-	require.ErrorContains(t, out, "dummy error")
+func TestConvertError(t *testing.T) {
+	tests := []struct {
+		name               string
+		input              error
+		checkError         require.ErrorAssertionFunc
+		checkErrorContains string
+	}{
+		{
+			name:       "nil",
+			input:      nil,
+			checkError: require.NoError,
+		},
+		{
+			name: "PgError",
+			input: trace.Wrap(&pgconn.PgError{
+				Code:    pgerrcode.CannotConnectNow,
+				Message: "CannotConnectNow",
+			}),
+			checkError:         require.Error,
+			checkErrorContains: "CannotConnectNow",
+		},
+		{
+			name:               "wrapped",
+			input:              &someErr{inner: trace.Wrap(fmt.Errorf("dummy error"))},
+			checkError:         require.Error,
+			checkErrorContains: "dummy error",
+		},
+		{
+			name:  "wrapped nil",
+			input: &someErr{inner: &someErr{inner: nil}},
+			// We should NOT return `nil` by unwrapping.
+			checkError:         require.Error,
+			checkErrorContains: "inner: inner: nil",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := ConvertError(tt.input)
+			tt.checkError(t, output)
+			if output != nil {
+				require.ErrorContains(t, output, tt.checkErrorContains)
+			}
+		})
+	}
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5783,7 +5783,12 @@ func TestMakeProfileInfo_NoInternalLogins(t *testing.T) {
 }
 
 func TestBenchmarkPostgres(t *testing.T) {
-	t.Parallel()
+	// Set insecure mode to allow db agent to establish reverse tunnel.
+	isInsecure := lib.IsInsecureDevMode()
+	lib.SetInsecureDevMode(true)
+	t.Cleanup(func() {
+		lib.SetInsecureDevMode(isInsecure)
+	})
 
 	// Canceling the context right after the test ensures the local proxy
 	// started by the benchmark command is closed and the remaining connections
@@ -5837,7 +5842,7 @@ func TestBenchmarkPostgres(t *testing.T) {
 	}, setHomePath(tmpHomePath), setMockSSOLogin(authServer, alice, connector.GetName()))
 	require.NoError(t, err)
 
-	benchmarkErrorLineParser := regexp.MustCompile("`host=(.+) +user=(.+) database=(.+)`: (.+)$")
+	benchmarkErrorLineParser := regexp.MustCompile("`host=(.+?) +user=(.+?) database=(.+?)`: (.+)$")
 	args := []string{
 		"bench", "postgres", "--insecure",
 		// Benchmark options to limit benchmark to a single execution.
@@ -5856,16 +5861,16 @@ func TestBenchmarkPostgres(t *testing.T) {
 		"connect to database": {
 			database:            "postgres-local",
 			additionalFlags:     []string{"--db-user", "username", "--db-name", "database"},
-			expectedErrContains: "server error",
+			expectedErrContains: "lookup external-pg",
 			// When connecting to Teleport databases, it will use a local proxy.
 			expectedHost:     "127.0.0.1",
 			expectedUser:     "username",
 			expectedDatabase: "database",
 		},
 		"direct connection": {
-			database:            "postgres://direct_user@test:5432/direct_database",
-			expectedErrContains: "hostname resolving error",
-			expectedHost:        "test",
+			database:            "postgres://direct_user@direct-pg:5432/direct_database",
+			expectedErrContains: "lookup direct-pg",
+			expectedHost:        "direct-pg",
 			expectedUser:        "direct_user",
 			expectedDatabase:    "direct_database",
 		},


### PR DESCRIPTION
Backport #61069 to branch/v17

> [!NOTE]
> The actual issue does not happen on v17 due to older AWS SDK. I still think this `ConvertError` change is worth backporting but I removed the changelog.