### PR TITLE
AWS EC2 Discovery: discover in all enabled regions

### DIFF
--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -158,13 +158,6 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 			if len(m.Regions) > 1 {
 				return trace.BadParameter("when using %q as region, no other regions can be specified", Wildcard)
 			}
-
-			// Only EC2 supports discovering regions.
-			// TODO(marco): add support for other resources types.
-			if len(m.Types) > 1 || m.Types[0] != AWSMatcherEC2 {
-				return trace.BadParameter("only EC2 resource discovery supports discovering all regions, " +
-					"enumerate all the regions or create a separate matcher for discovering EC2 resources")
-			}
 			break
 		}
 

--- a/api/types/matchers_aws.go
+++ b/api/types/matchers_aws.go
@@ -150,7 +150,7 @@ func (m *AWSMatcher) CheckAndSetDefaults() error {
 	}
 
 	if len(m.Regions) == 0 {
-		m.Regions = []string{Wildcard}
+		return trace.BadParameter("discovery service requires at least one region, for EC2 you can also set the region to %q to iterate over all regions (requires account:ListRegions IAM permission)", Wildcard)
 	}
 
 	for _, region := range m.Regions {

--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -136,12 +136,20 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "wildcard is invalid for regions",
+			name: "wildcard is invalid for regions when using non-ec2 types",
 			in: &AWSMatcher{
 				Types:   []string{"ec2", "rds"},
 				Regions: []string{"*"},
 			},
 			errCheck: isBadParameterErr,
+		},
+		{
+			name: "wildcard is valid for the ec2 type",
+			in: &AWSMatcher{
+				Types:   []string{"ec2"},
+				Regions: []string{"*"},
+			},
+			errCheck: require.NoError,
 		},
 		{
 			name: "invalid type",
@@ -179,12 +187,12 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "no region",
+			name: "no region is valid for ec2 type",
 			in: &AWSMatcher{
 				Types:   []string{"ec2"},
 				Regions: []string{},
 			},
-			errCheck: isBadParameterErr,
+			errCheck: require.NoError,
 		},
 		{
 			name: "invalid assume role arn",

--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -136,14 +136,6 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "wildcard is invalid for regions when using non-ec2 types",
-			in: &AWSMatcher{
-				Types:   []string{"ec2", "rds"},
-				Regions: []string{"*"},
-			},
-			errCheck: isBadParameterErr,
-		},
-		{
 			name: "wildcard is valid for the ec2 type",
 			in: &AWSMatcher{
 				Types:   []string{"ec2"},

--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -187,10 +187,10 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "no region is valid for ec2 type",
+			name: "wildcard region is valid for ec2 type",
 			in: &AWSMatcher{
 				Types:   []string{"ec2"},
-				Regions: []string{},
+				Regions: []string{"*"},
 			},
 			errCheck: require.NoError,
 		},

--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -187,6 +187,14 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: require.NoError,
 		},
 		{
+			name: "no region",
+			in: &AWSMatcher{
+				Types:   []string{"ec2"},
+				Regions: []string{},
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
 			name: "invalid assume role arn",
 			in: &AWSMatcher{
 				Types:   []string{"ec2"},

--- a/go.mod
+++ b/go.mod
@@ -287,6 +287,8 @@ require (
 	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
 
+require github.com/aws/aws-sdk-go-v2/service/account v1.29.3
+
 require (
 	cel.dev/expr v0.25.0 // indirect
 	cloud.google.com/go v0.121.6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.6.13
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.20.5
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.10
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.42.2
@@ -286,8 +287,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 	software.sslmate.com/src/go-pkcs12 v0.6.0
 )
-
-require github.com/aws/aws-sdk-go-v2/service/account v1.29.3
 
 require (
 	cel.dev/expr v0.25.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -823,6 +823,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEG
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13/go.mod h1:/FDdxWhz1486obGrKKC1HONd7krpk38LBt+dutLcN9k=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2 h1:zZ6TJ93crR09QVPxqoFJnlioltKejaPLxY1dCcBjU20=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2/go.mod h1:BDzrZs53Hsb5MyAICN2dmtFWaeLONzMaseXyF9Bagt0=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.10 h1:lhHg2H2XeRix8Zk2UKxsJXKk93066CAZCw0x5pMRvDw=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.42.2 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -828,6 +828,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEG
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13/go.mod h1:/FDdxWhz1486obGrKKC1HONd7krpk38LBt+dutLcN9k=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2 h1:zZ6TJ93crR09QVPxqoFJnlioltKejaPLxY1dCcBjU20=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2/go.mod h1:BDzrZs53Hsb5MyAICN2dmtFWaeLONzMaseXyF9Bagt0=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.10 h1:lhHg2H2XeRix8Zk2UKxsJXKk93066CAZCw0x5pMRvDw=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.55.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.42.2 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -848,6 +848,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEG
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13 h1:eg/WYAa12vqTphzIdWMzqYRVKKnCboVPRlvaybNCqPA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.13/go.mod h1:/FDdxWhz1486obGrKKC1HONd7krpk38LBt+dutLcN9k=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2 h1:zZ6TJ93crR09QVPxqoFJnlioltKejaPLxY1dCcBjU20=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.41.2/go.mod h1:BDzrZs53Hsb5MyAICN2dmtFWaeLONzMaseXyF9Bagt0=
 github.com/aws/aws-sdk-go-v2/service/athena v1.55.10 h1:lhHg2H2XeRix8Zk2UKxsJXKk93066CAZCw0x5pMRvDw=

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -395,7 +395,7 @@ func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discover
 // MaybeDowngradeDiscoveryConfig tests the client version passed through the gRPC metadata,
 // and if necessary downgrades the Discovery Config resource for compatibility with the older client.
 // The following rules are applied:
-//   - if version is lower than 18.4.2, the AWS wildcard region is replaced with "aws-global" sentinel region
+//   - if version is lower than 18.5.0, the AWS wildcard region is replaced with "aws-global" sentinel region
 //     this ensures the client can still discover other resources without erroring out.
 func MaybeDowngradeDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
 	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
@@ -414,7 +414,7 @@ func MaybeDowngradeDiscoveryConfig(ctx context.Context, dc *discoveryconfig.Disc
 	return dc, nil
 }
 
-var minSupportedDiscoveryConfigAWSWildcardRegionVersion = semver.Version{Major: 18, Minor: 4, Patch: 2}
+var minSupportedDiscoveryConfigAWSWildcardRegionVersion = semver.Version{Major: 18, Minor: 5, Patch: 0}
 
 // For Auth Server v20.0.0, the expected minimum supported client version is v19.0.0, which supports the AWS wildcard region.
 // This function should be deleted at that time.

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -570,7 +570,7 @@ func TestDowngrade(t *testing.T) {
 	}{
 		{
 			name:          "no downgrade for recent client",
-			clientVersion: "18.4.2",
+			clientVersion: "18.5.0",
 			input: func() *discoveryconfig.DiscoveryConfig {
 				dc, err := discoveryconfig.NewDiscoveryConfig(
 					header.Metadata{Name: "dc1"},
@@ -606,7 +606,7 @@ func TestDowngrade(t *testing.T) {
 		},
 		{
 			name:          "downgrade for old client",
-			clientVersion: "18.4.1",
+			clientVersion: "18.4.2",
 			input: func() *discoveryconfig.DiscoveryConfig {
 				dc, err := discoveryconfig.NewDiscoveryConfig(
 					header.Metadata{Name: "dc1"},

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -90,6 +90,7 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -580,6 +581,13 @@ func WatchEvents(watch *authpb.Watch, stream WatchEvent, componentName string, a
 		}
 		if role, ok := event.Resource.(*types.RoleV6); ok {
 			downgraded, err := maybeDowngradeRole(stream.Context(), role)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			event.Resource = downgraded
+		}
+		if dc, ok := event.Resource.(*discoveryconfig.DiscoveryConfig); ok {
+			downgraded, err := discoveryconfigv1.MaybeDowngradeDiscoveryConfig(stream.Context(), dc)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/cloud/awsconfig/awsconfig.go
+++ b/lib/cloud/awsconfig/awsconfig.go
@@ -203,6 +203,17 @@ func (o *options) checkIntegrationCredentials() error {
 // when getting an AWS config.
 type OptionsFn func(*options)
 
+// AssumedRoles extracts the assumed roles from the provided options.
+// Only used in testing.
+func AssumedRoles(opts ...OptionsFn) []AssumeRole {
+	var options options
+	for _, optFn := range opts {
+		optFn(&options)
+	}
+
+	return options.assumeRoles
+}
+
 // WithAssumeRole configures options needed for assuming an AWS role.
 func WithAssumeRole(roleARN, externalID string) OptionsFn {
 	return func(options *options) {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1575,6 +1575,10 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 
 		for _, region := range matcher.Regions {
+			if region == types.Wildcard {
+				continue
+			}
+
 			if !awsregion.IsKnownRegion(region) {
 				const message = "AWS matcher uses unknown region" +
 					"This is either a typo or a new AWS region that is unknown to the AWS SDK used to compile this binary. "

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -4850,6 +4850,23 @@ func TestDiscoveryConfig(t *testing.T) {
 				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
 					{
 						"types":   []string{"ec2"},
+						"regions": []string{"invalid-region"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc:          "for EC2 discovery, region can be set to wildcard",
+			expectError:   require.NoError,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
 						"regions": []string{"*"},
 						"tags": cfgMap{
 							"discover_teleport": "yes",
@@ -4857,6 +4874,22 @@ func TestDiscoveryConfig(t *testing.T) {
 					},
 				}
 			},
+			expectedAWSMatchers: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"*"},
+				Tags: map[string]apiutils.Strings{
+					"discover_teleport": []string{"yes"},
+				},
+				Params: &types.InstallerParams{
+					JoinMethod:      types.JoinMethodIAM,
+					JoinToken:       "aws-discovery-iam-token",
+					SSHDConfig:      "/etc/ssh/sshd_config",
+					ScriptName:      "default-installer",
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				SSM: &types.AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
+			}},
 		},
 		{
 			desc:          "AWS section is filled with invalid join method",

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -167,6 +167,10 @@ func MakeEKSFetchersFromAWSMatchers(logger *slog.Logger, clients AWSClientGetter
 			for _, region := range matcher.Regions {
 				switch t {
 				case types.AWSMatcherEKS:
+					if region == types.Wildcard {
+						logger.WarnContext(context.Background(), "EKS discovery does not support region discovery, remove the '*' from the regions field", "discovery_config", discoveryConfigName)
+						continue
+					}
 					fetcher, err := NewEKSFetcher(
 						EKSFetcherConfig{
 							ClientGetter:        clients,

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -440,6 +440,8 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []t
 	return chunkInstances(instancesByRegion), nil
 }
 
+// chunkInstances splits instances into chunks of 50.
+// This is required because SSM SendCommand API calls only accept up to 50 instance IDs at a time.
 func chunkInstances(instancesByRegion map[string]EC2Instances) []Instances {
 	var instColl []Instances
 	for _, insts := range instancesByRegion {

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -318,7 +318,7 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		Values: []string{string(ec2types.InstanceStateNameRunning)},
 	}}
 
-	if _, ok := cfg.Matcher.Tags["*"]; !ok {
+	if _, ok := cfg.Matcher.Tags[types.Wildcard]; !ok {
 		for key, val := range cfg.Matcher.Tags {
 			tagFilters = append(tagFilters, ec2types.Filter{
 				Name:   aws.String("tag:" + key),


### PR DESCRIPTION
AWS EC2 Server discovery requires a list of regions, where the service is going to look for EC2 instances.

This PR changes the matcher so that it accepts a wildcard value for the regions field.

This will call `account.ListRegions` AWS API, which returns all the regions enabled for the current account.

Docs will be updated afterwards.

Demo:

<img width="3196" height="470" alt="image" src="https://github.com/user-attachments/assets/681422cd-6d32-4251-85e3-ab860f005978" />

```yaml
> tctl get discovery_config | yq .spec
aws:
  - install:
      enroll_mode: 1
      install_teleport: true
      join_method: iam
      join_token: teleport-ui-iam-1607154252
      script_name: default-installer
      sshd_config: /etc/ssh/sshd_config
    integration: teleportdev
    regions:
      - '*'
    ssm:
      document_name: AWS-RunShellScript
    tags:
      Discover: YesPlease
    types:
      - ec2
discovery_group: aws-prod
```


changelog: Added support for discovering EC2 instances in all regions, without enumerating them. Requires access to `account.ListRegions` in the IAM Role assumed by the Discovery Service.