### PR TITLE
deflake `TestSessionRecordingModes` test

### DIFF
--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -367,11 +367,11 @@ func (t *terminal) closeTTY() error {
 func (t *terminal) closePTY() {
 	defer t.log.DebugContext(t.serverContext.CancelContext(), "Closed PTY")
 
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	// wait until all copying is over (all participants have left)
 	t.wg.Wait()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
 
 	if t.pty == nil {
 		return


### PR DESCRIPTION
Fix flakiness in `TestSessionRecordingModes/BestEffort`

`TestSessionRecordingModes/BestEffort` test was extremely flaky because although the session was already terminated, the `session.leave` and `session.end` events were never received.

Upon session termination, interactive sessions wait for the terminal to be closed and also wait for the recorder to leave the session.

https://github.com/gravitational/teleport/blob/4247f2e4a2fe2d430e268c9f5476d83c3d0a6456/lib/srv/sess.go#L1509-L1516

`defaults.WaitCopyTimeout` is equal to 5s.

Due to an incorrect condition, the terminal acquired the lock before waiting for all parties to leave and then waited on the `sync.WaitGroup`. This caused the lock to be held indefinitely, as other goroutines also needed the same mutex, preventing the session writer from closing properly.

Depending on the order of occurence, if the incorrect condition was acquired before all parties leave the session, it would result in a deadlock causing the session events to never be emitted within 5 seconds because of the wait showed above.

Fixes https://github.com/gravitational/teleport/issues/57332