### PR TITLE
Include ($ENV_VAR) in CLI help output for env var flags

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -476,7 +476,7 @@ Usage: {{.App.Name}}{{template "FormatUsage" .App}}
 {{end -}}
 {{if .Context.Flags -}}
 Flags:
-{{.Context.Flags|FlagsToTwoColumnsCompact|FormatTwoColumns}}
+{{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
 {{end -}}
 {{if .Context.Args -}}
 Args:


### PR DESCRIPTION
Update the flag formatting configuration to include the [automatic env var help output supported by kingpin](https://github.com/gravitational/kingpin/blob/4e11223f9d3bd61da3b7a6a7be9088fb1ae3beb4/usage.go#L160). This change applies to all Teleport CLIs - `tsh`, `tctl`, `tbot`, `teleport` (no flags, no impact), and `teleport-update`.

Before:
```
> tsh help
Usage: tsh [<flags>] <command> [<args> ...]

Teleport Command Line Client.

Flags:
  -l, --login                    Remote host login.
      --proxy                    Teleport proxy address.
      --relay                    Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a
                                 different address was specified at login time.
      --user                     Teleport user, defaults to current local user.
      --ttl                      Minutes to live for a session.
  -i, --identity                 Identity file.
      --cert-format              SSH certificate format.
      --[no-]insecure            Do not verify server's certificate and host name. Use only in test environments.
      --auth                     Specify the name of authentication connector to use.
      --[no-]skip-version-check  Skip version checking between server and client.
  -d, --[no-]debug               Verbose logging to stdout.
      --[no-]os-log              Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. More
                                 details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.
  -k, --add-keys-to-agent        Controls how keys are handled. Valid values are [auto no yes only].
      --[no-]enable-escape-sequences  
                                 Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.
      --bind-addr                Override host:port used when opening a browser for cluster logins.
      --callback                 Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.
      --mfa-mode                 Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso).
      --[no-]headless            Use headless login. Shorthand for --auth=headless.
      --mlock                    Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).
      --piv-slot                 Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d".
  -J, --jumphost                 SSH jumphost.
```

After:
```
> tsh help
Usage: tsh [<flags>] <command> [<args> ...]

Teleport Command Line Client.

Flags:
  -l, --login=LOGIN              Remote host login. ($TELEPORT_LOGIN)
      --proxy=PROXY              Teleport proxy address. ($TELEPORT_PROXY)
      --relay=RELAY              Teleport relay address, "none" to explicitly disable the use of a relay, or "default" to use the cluster-provided address even if a
                                 different address was specified at login time. ($TELEPORT_RELAY)
      --user=USER                Teleport user, defaults to current local user. ($TELEPORT_USER)
      --ttl=TTL                  Minutes to live for a session.
  -i, --identity=IDENTITY        Identity file. ($TELEPORT_IDENTITY_FILE)
      --cert-format=CERT-FORMAT  SSH certificate format.
      --[no-]insecure            Do not verify server's certificate and host name. Use only in test environments.
      --auth=AUTH                Specify the name of authentication connector to use. ($TELEPORT_AUTH)
      --[no-]skip-version-check  Skip version checking between server and client.
  -d, --[no-]debug               Verbose logging to stdout.
      --[no-]os-log              Verbose logging to the unified logging system. This flag implies --debug. Also available through the TELEPORT_OS_LOG env var. More
                                 details see https://goteleport.com/docs/connect-your-client/tsh/#debug-logs.
  -k, --add-keys-to-agent="auto"  
                                 Controls how keys are handled. Valid values are [auto no yes only]. ($TELEPORT_ADD_KEYS_TO_AGENT)
      --[no-]enable-escape-sequences  
                                 Enable support for SSH escape sequences. Type '~?' during an SSH session to list supported sequences. Default is enabled.
      --bind-addr=BIND-ADDR      Override host:port used when opening a browser for cluster logins. ($TELEPORT_LOGIN_BIND_ADDR)
      --callback=CALLBACK        Override the base URL (host:port) of the link shown when opening a browser for cluster logins. Must be used with --bind-addr.
      --mfa-mode=auto            Preferred mode for MFA and Passwordless assertions (auto, cross-platform, platform, otp, sso). ($TELEPORT_MFA_MODE)
      --[no-]headless            Use headless login. Shorthand for --auth=headless. ($TELEPORT_HEADLESS)
      --mlock="auto"             Determines whether process memory will be locked and whether failure to do so will be accepted (off, auto, best_effort, strict).
                                 ($TELEPORT_MLOCK_MODE)
      --piv-slot=PIV-SLOT        Specify a PIV slot key to use for Hardware Key support instead of the default. Ex: "9d". ($TELEPORT_PIV_SLOT)
  -J, --jumphost=JUMPHOST        SSH jumphost.
```