### PR TITLE
docs: reiterate user need access to saml app in identity center access list and access request sections

### DIFF
--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -291,7 +291,11 @@ grants back to Identity Center as well. For example, imagine an Access List with
 the roles `AdminAccess-on-my-account` and `ReadOnlyAccess-on-my-account`. If the
 Access List owner removes the `AdminAccess-on-my-account` role from the Access Lists,
 that change will be propagated back to AWS and the corresponding Identity Center
-group will have its assignments updated to remove the `AdminAccess` Permission 
+group will have its assignments updated to remove the `AdminAccess` Permission.
+
+Note that along with granting users with Account Assignment roles, they must also
+be granted access to the [Identity Center SAML service provider](#configure-access-to-the-saml-service-provider) 
+to be able to log in to the AWS console. 
 
 ### Just-in-time Access with Resource Access Requests
 
@@ -304,7 +308,13 @@ checking "Show requestable resources" in the resource view.
 Users can then choose the specific Account Assignments they want access to by 
 selecting from the Permission Sets available to each AWS Account. Users
 can mix Permission Sets from multiple AWS Accounts, and even include other 
-Teleport-managed resources if necessary.
+Teleport-managed resources if necessary. Since users also need access to the 
+[Identity Center SAML service provider](#configure-access-to-the-saml-service-provider) 
+to be able to log in to the AWS console, Teleport Web UI auto-selects the service 
+provider resource when requesting access to the Account Assignments. If user does 
+not have a standing access to the service provider resource, and the user is not 
+configured with a role that allows them to request access to the resource, an 
+error will be returned in the Access Request UI. 
 
 ![Selecting Identity Center resources](../../../../img/identity-center/ic-select-ps.png)
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -311,7 +311,7 @@ can mix Permission Sets from multiple AWS Accounts, and even include other
 Teleport-managed resources if necessary. Since users also need access to the 
 [Identity Center SAML service provider](#configure-access-to-the-saml-service-provider) 
 to be able to log in to the AWS console, Teleport Web UI auto-selects the service 
-provider resource when requesting access to the Account Assignments. If user does 
+provider resource when requesting access to the Account Assignments. If the user does 
 not have a standing access to the service provider resource, and the user is not 
 configured with a role that allows them to request access to the resource, an 
 error will be returned in the Access Request UI. 


### PR DESCRIPTION
Though we now have a [dedicated section](https://sshah-ic-access-request.d3pp5qlev8mo18.amplifyapp.com/identity-governance/integrations/aws-iam-identity-center/guide/#step-67-configure-access) explaining configuring access to the identity center account, it was not obvious for some users that they also need to consider it when using access list and access request workflow. This update attempts to clear that confusion by mentioning saml app on each related sections. 

Auto-selecting saml resource when requesting access to the account assignment is being added with this PR https://github.com/gravitational/teleport.e/pull/7529