### PR TITLE
Guard against nil traits in GetInheritedMembershipRequires

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -292,6 +292,17 @@ func (r *Requires) IsEmpty() bool {
 	return len(r.Roles) == 0 && len(r.Traits) == 0
 }
 
+// Clone returns a deep copy of the [Requires]
+func (r *Requires) Clone() Requires {
+	if r == nil {
+		return Requires{}
+	}
+	return Requires{
+		Roles:  slices.Clone(r.Roles),
+		Traits: r.Traits.Clone(),
+	}
+}
+
 // Grants describes what access is granted by membership to the access list.
 type Grants struct {
 	// Roles are the roles that are granted to users who are members of the access list.

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -752,6 +752,7 @@ func collectAncestors(ctx context.Context, accessList *accesslist.AccessList, ki
 // inherited from any ancestor lists, and the Access List's own MembershipRequires.
 func GetInheritedMembershipRequires(ctx context.Context, accessList *accesslist.AccessList, g AccessListAndMembersGetter) (*accesslist.Requires, error) {
 	ownRequires := accessList.GetMembershipRequires()
+	ownRequires = ownRequires.Clone()
 	ancestors, err := GetAncestorsFor(ctx, accessList, RelationshipKindMember, g)
 	if err != nil {
 		return &ownRequires, trace.Wrap(err)
@@ -759,6 +760,9 @@ func GetInheritedMembershipRequires(ctx context.Context, accessList *accesslist.
 
 	roles := ownRequires.Roles
 	traits := ownRequires.Traits
+	if traits == nil {
+		traits = trait.Traits{}
+	}
 
 	for _, ancestor := range ancestors {
 		requires := ancestor.GetMembershipRequires()


### PR DESCRIPTION
- Deep-copy `accesslist.Requires` to avoid mutation
- Guard against nil `accesslist.Requires.Traits` before iterating
- Add test coverage to prevent regression
