### PR TITLE
Add tctl list-kinds

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -57,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
 	"github.com/gravitational/teleport/api/types/secreports"
 	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -93,10 +95,11 @@ type ResourceCommand struct {
 	filename string
 
 	// CLI subcommands:
-	deleteCmd *kingpin.CmdClause
-	getCmd    *kingpin.CmdClause
-	createCmd *kingpin.CmdClause
-	updateCmd *kingpin.CmdClause
+	deleteCmd    *kingpin.CmdClause
+	getCmd       *kingpin.CmdClause
+	createCmd    *kingpin.CmdClause
+	updateCmd    *kingpin.CmdClause
+	listKindsCmd *kingpin.CmdClause
 
 	verbose bool
 
@@ -205,6 +208,9 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 
 	rc.getCmd.Alias(getHelp)
 
+	rc.listKindsCmd = app.Command("list-kinds", "Lists all resource kinds supported by this tctl version.").Alias("api-resources")
+	rc.listKindsCmd.Flag("wide", "Do not truncate the Description column, even if it exceeds terminal width").BoolVar(&rc.verbose)
+
 	if rc.Stdout == nil {
 		rc.Stdout = os.Stdout
 	}
@@ -227,6 +233,10 @@ func (rc *ResourceCommand) TryRun(ctx context.Context, cmd string, clientFunc co
 		// tctl update
 	case rc.updateCmd.FullCommand():
 		commandFunc = rc.UpdateFields
+	case rc.listKindsCmd.FullCommand():
+		// early return before we try to build a client
+		// we don't need a valid client to run this command
+		return true, trace.Wrap(rc.listKinds())
 	default:
 		return false, nil
 	}
@@ -2420,4 +2430,37 @@ func (rc *ResourceCommand) createPlugin(ctx context.Context, client *authclient.
 	}
 	fmt.Printf("plugin %q has been updated\n", item.GetName())
 	return nil
+}
+
+// UpdateFields updates select resource fields: expiry and labels
+func (rc *ResourceCommand) listKinds() error {
+	// We must compute rows before, and cannot add them as we go
+	// because this breaks the "truncated columns behavior"
+	var rows [][]string
+	for kind, handler := range resources.Handlers() {
+		rows = append(rows, []string{
+			kind,
+			strings.Join(handler.SupportedCommands(), ","),
+			yesOrEmpty(handler.Singleton()),
+			yesOrEmpty(handler.MFARequired()),
+			handler.Description(),
+		})
+	}
+
+	var t asciitable.Table
+	headers := []string{"Kind", "Supported Commands", "Singleton", "MFA", "Description"}
+	if rc.verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Description")
+	}
+	t.SortRowsBy([]int{0}, true)
+	return trace.Wrap(t.WriteTo(rc.Stdout))
+}
+
+func yesOrEmpty(b bool) string {
+	if b {
+		return "yes"
+	}
+	return ""
 }

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -171,6 +171,12 @@ func (r *Handler) Description() string {
 	return r.description
 }
 
+// Singleton indicates if the handled resource is a singleton (only one can
+// exist in the Teleport cluster).
+func (r *Handler) Singleton() bool {
+	return r.singleton
+}
+
 // upsertVerb generates the correct string form of a verb based on the action taken
 func upsertVerb(exists bool, force bool) string {
 	if !force && exists {


### PR DESCRIPTION
Leverages work done in https://github.com/gravitational/teleport/issues/60370 to list all supported resources.

Will have an incomplete output until we have migrated every resource to the Handler format.

I did not add tests due to the lack of logic and the low value they'd add, let me know if you think something is test-worthy here.

Output in a large terminal looks like:
```
Kind                                   Supported Commands   Singleton MFA   Description                                                                                                               
-------------------------------------- -------------------- --------- ----- ------------------------------------------------------------------------------------------------------------------------- 
access_graph_settings                  get,create,update    true      false Configures Access Graph settings for the cluster.                                                                         
access_list                            get,create,rm        false     true  Used to grant roles or traits to users or other lists. Part of Identity Governance.                                       
access_request                         get                  false     false A request to access a set of roles or resources.                                                                          
app                                    get,create,rm,update false     false A dynamic resource representing an application that can be proxied via an application service.                            
app_server                             get,create,rm,update false     false Represents a proxied application in the cluster.                                                                          
auth_server                            get                  false     false The central authority of the Teleport cluster.                                                                            
autoupdate_agent_report                get,create           false     false Reports which agent versions are connected to which Teleport auth server.                                                 
autoupdate_agent_rollout               get,create,rm,update true      false Tracks the current state of the managed agent update rollout.                                                             
autoupdate_bot_instance_report         get,rm               true      false Report of bot instance counts by update group and version.                                                                
autoupdate_config                      get,create,rm,update true      false Configures if, when, and how managed updates happen.                                                                      
autoupdate_version                     get,create,rm,update true      false Controls which version agents and tools will update to. Cannot be changed in Teleport cloud.                              
bot                                    get,create,rm        false     true  Represents the identity of a machine or workload within Teleport.                                                         
bot_instance                           get                  false     false A single instance of the tbot agent running in Teleport.                                                                  
cluster_auth_preference                get,create,rm,update true      false Configures the cluster authentication. Can only be used when auth is not configured in teleport.yaml.                     
cluster_networking_config              get,create,rm,update true      false Configures the cluster networking. Can only be used when networking is not configured in teleport.yaml.                   
connectors                             get                  false     true  Meta resource listing GitHub, SAML, and OIDC connectors.                                                                  
db                                     get,create,rm,update false     false A dynamic resource representing a database that can be proxied via a database service.                                    
db_object                              get,create,rm,update false     false Representation of a database object that can be imported into Teleport.                                                   
db_object_import_rule                  get,create,rm,update false     false A dynamic resource representing a global database object import rule.                                                     
discovery_config                       get,create,rm,update false     false A configuration to auto discover and enroll resources in cloud providers.                                                 
git_server                             get,create,rm,update false     false Represents a Git service, such as GitHub, that Teleport can proxy Git connections to.                                     
github                                 get,create,rm,update false     true  Configures how users can connect using GitHub.                                                                            
installer                              get,create,rm        false     false Installer scripts used by the Discovery Service for setting up Teleport on agents.                                        
lock                                   get,create,rm        false     false Prevents a user, node or bot from interacting with Teleport.                                                              
node                                   get,create,rm        false     false Represents an SSH instance in the cluster, either a Teleport SSH agent or OpenSSH                                         
oidc                                   get,create,rm,update false     true  Configures how users can connect using a OIDC Identity Provider.                                                          
proxy                                  get,rm               false     false The Proxy is responsible for routing connections within the cluster.                                                      
role                                   get,create,rm,update false     false A set of permissions that can be granted to a user.                                                                       
saml                                   get,create,rm,update false     true  Configures how users can connect using a SAML Identity Provider.                                                          
session_recording_config               get,create,rm,update true      false Configures session recording for the cluster. Can only be used when session recording is not configured in teleport.yaml. 
sigstore_policy                        get,create,rm,update false     false Configures Sigstore attestation with SPIFFE                                                                               
spiffe_federation                      get,create,rm        false     false Manages SPIFFE federation relationships between this Teleport cluster and other trust domains.                            
token                                  get,create,rm        false     true  Allows instances, bots, and human users to join the Teleport cluster.                                                     
ui_config                              get,create,rm        true      false Configures the Web UI settings.                                                                                           
user                                   get,create,rm,update false     true  A human user within Teleport.                                                                                             
workload_identity                      get,create,rm        false     false Configures the issuance of SPIFFE SVIDs to workloads.                                                                     
workload_identity_x509_issuer_override get,create,rm,update false     false Overrides the issuers used for X.509 SVIDs                                                                                
workload_identity_x509_revocation      get,rm               false     false Controls the revocation of issued X.509 SVIDs                                                      
```

Changelog: Added `tctl api-resources` command to list every supported resource.