### PR TITLE
[manual] Update AMI IDs for 18.4.0

### DIFF
--- a/assets/aws/Makefile
+++ b/assets/aws/Makefile
@@ -2,7 +2,7 @@
 # This must be a _released_ version of Teleport, i.e. one which has binaries
 # available for download on https://goteleport.com/download
 # Unreleased versions will fail to build.
-TELEPORT_VERSION ?= 18.2.4
+TELEPORT_VERSION ?= 18.4.0
 
 # Teleport UID is the UID of a non-privileged 'teleport' user
 TELEPORT_UID ?= 1007

--- a/examples/aws/terraform/AMIS.md
+++ b/examples/aws/terraform/AMIS.md
@@ -6,116 +6,116 @@ This list is updated when new AMI versions are released.
 ### OSS
 
 ```
-# ap-northeast-1 v18.2.4 arm64 OSS: ami-03e9d0c5f4a5446ce
-# ap-northeast-1 v18.2.4 x86_64 OSS: ami-03c4415663c5f219c
-# ap-northeast-2 v18.2.4 arm64 OSS: ami-057ebb2edf60b402f
-# ap-northeast-2 v18.2.4 x86_64 OSS: ami-059fd1ee25c700e92
-# ap-northeast-3 v18.2.4 arm64 OSS: ami-0858913adb3692241
-# ap-northeast-3 v18.2.4 x86_64 OSS: ami-0f3787b638c89c1ef
-# ap-south-1 v18.2.4 arm64 OSS: ami-007129fb6e3fbb309
-# ap-south-1 v18.2.4 x86_64 OSS: ami-00d88da9770022a25
-# ap-southeast-1 v18.2.4 arm64 OSS: ami-0a34a3db505f74aee
-# ap-southeast-1 v18.2.4 x86_64 OSS: ami-0dfc9189d9479ba06
-# ap-southeast-2 v18.2.4 arm64 OSS: ami-0be0100d9994aface
-# ap-southeast-2 v18.2.4 x86_64 OSS: ami-0f8b5417cadc9d73b
-# ca-central-1 v18.2.4 arm64 OSS: ami-0326d1ce2926d9cc8
-# ca-central-1 v18.2.4 x86_64 OSS: ami-0a545b27f88162ecc
-# eu-central-1 v18.2.4 arm64 OSS: ami-0462bc9d533a13555
-# eu-central-1 v18.2.4 x86_64 OSS: ami-021a25a7a1e136f10
-# eu-north-1 v18.2.4 arm64 OSS: ami-0ddda4b6562e2e8a0
-# eu-north-1 v18.2.4 x86_64 OSS: ami-011766bb0a9328b54
-# eu-west-1 v18.2.4 arm64 OSS: ami-04668aff779f1e57d
-# eu-west-1 v18.2.4 x86_64 OSS: ami-0d1a2512b2ad4593a
-# eu-west-2 v18.2.4 arm64 OSS: ami-0eed689e1795fdd9e
-# eu-west-2 v18.2.4 x86_64 OSS: ami-038ac12ecbc9380b2
-# eu-west-3 v18.2.4 arm64 OSS: ami-085f2ffa77b032e14
-# eu-west-3 v18.2.4 x86_64 OSS: ami-0bd2b109c0783d863
-# sa-east-1 v18.2.4 arm64 OSS: ami-0b0dc8f7b5fe3a4aa
-# sa-east-1 v18.2.4 x86_64 OSS: ami-05b322e41450a9702
-# us-east-1 v18.2.4 arm64 OSS: ami-00f353c6eebf42e95
-# us-east-1 v18.2.4 x86_64 OSS: ami-019df2da25e415cc7
-# us-east-2 v18.2.4 arm64 OSS: ami-0e082ee7700cce9d6
-# us-east-2 v18.2.4 x86_64 OSS: ami-047f850e1f29dd683
-# us-west-1 v18.2.4 arm64 OSS: ami-0912156057b4b7651
-# us-west-1 v18.2.4 x86_64 OSS: ami-08646296863e08f03
-# us-west-2 v18.2.4 arm64 OSS: ami-04e131a9af36b6e0c
-# us-west-2 v18.2.4 x86_64 OSS: ami-0535822c00fd0bf12
+# ap-northeast-1 v18.4.0 arm64 OSS: ami-0796b49ac526add4c
+# ap-northeast-1 v18.4.0 x86_64 OSS: ami-0689c2c19d13598e4
+# ap-northeast-2 v18.4.0 arm64 OSS: ami-016a97d43877ccc40
+# ap-northeast-2 v18.4.0 x86_64 OSS: ami-0e7c19a20112bbc37
+# ap-northeast-3 v18.4.0 arm64 OSS: ami-0bcc61e77d243acf6
+# ap-northeast-3 v18.4.0 x86_64 OSS: ami-06572f53c69a2421f
+# ap-south-1 v18.4.0 arm64 OSS: ami-01ba40cd91ba711df
+# ap-south-1 v18.4.0 x86_64 OSS: ami-09e4b1b9d40052515
+# ap-southeast-1 v18.4.0 arm64 OSS: ami-0e21af53d0344e109
+# ap-southeast-1 v18.4.0 x86_64 OSS: ami-0ca4969075077bade
+# ap-southeast-2 v18.4.0 arm64 OSS: ami-0ac76cba2029831ed
+# ap-southeast-2 v18.4.0 x86_64 OSS: ami-0dbb436eead5f5dd2
+# ca-central-1 v18.4.0 arm64 OSS: ami-07e90fbb42df6e42b
+# ca-central-1 v18.4.0 x86_64 OSS: ami-083e8ee176eee712a
+# eu-central-1 v18.4.0 arm64 OSS: ami-03a9303a9d4d13126
+# eu-central-1 v18.4.0 x86_64 OSS: ami-0e85a3be504b5a3bb
+# eu-north-1 v18.4.0 arm64 OSS: ami-0d51b5b607c212fa2
+# eu-north-1 v18.4.0 x86_64 OSS: ami-03b10ffb39c22fe58
+# eu-west-1 v18.4.0 arm64 OSS: ami-08e4c738be1d3b69f
+# eu-west-1 v18.4.0 x86_64 OSS: ami-035096abc5c352173
+# eu-west-2 v18.4.0 arm64 OSS: ami-0bcb5a9ad1fa4db31
+# eu-west-2 v18.4.0 x86_64 OSS: ami-0326b01ad227a6c1b
+# eu-west-3 v18.4.0 arm64 OSS: ami-07cfc595d9e6e6bf4
+# eu-west-3 v18.4.0 x86_64 OSS: ami-02ee4e4cae0264608
+# sa-east-1 v18.4.0 arm64 OSS: ami-00c6765c9ce2f05bb
+# sa-east-1 v18.4.0 x86_64 OSS: ami-08026fe930f4f9538
+# us-east-1 v18.4.0 arm64 OSS: ami-0cc102d721b01f79b
+# us-east-1 v18.4.0 x86_64 OSS: ami-02de9316395a5fb2a
+# us-east-2 v18.4.0 arm64 OSS: ami-02743f9fd9331b1e1
+# us-east-2 v18.4.0 x86_64 OSS: ami-0261005cdacf1c951
+# us-west-1 v18.4.0 arm64 OSS: ami-03da7149470b296d3
+# us-west-1 v18.4.0 x86_64 OSS: ami-018043584d4129925
+# us-west-2 v18.4.0 arm64 OSS: ami-084138948b89c583f
+# us-west-2 v18.4.0 x86_64 OSS: ami-04033658e583b592c
 ```
 
 ### Enterprise
 
 ```
-# ap-northeast-1 v18.2.4 arm64 Enterprise: ami-089f510c7c3bab415
-# ap-northeast-1 v18.2.4 x86_64 Enterprise: ami-043fdb3df2b60bef9
-# ap-northeast-2 v18.2.4 arm64 Enterprise: ami-0177a9f639935543a
-# ap-northeast-2 v18.2.4 x86_64 Enterprise: ami-08ca1b95db713d47d
-# ap-northeast-3 v18.2.4 arm64 Enterprise: ami-0569ea8412e6270af
-# ap-northeast-3 v18.2.4 x86_64 Enterprise: ami-005c684585081780f
-# ap-south-1 v18.2.4 arm64 Enterprise: ami-00dec2fd09d9800c3
-# ap-south-1 v18.2.4 x86_64 Enterprise: ami-09f427a22e0d839c3
-# ap-southeast-1 v18.2.4 arm64 Enterprise: ami-0b5b8f2ea44df7955
-# ap-southeast-1 v18.2.4 x86_64 Enterprise: ami-0d30daecfb7899b58
-# ap-southeast-2 v18.2.4 arm64 Enterprise: ami-0ec3eea10f606ca16
-# ap-southeast-2 v18.2.4 x86_64 Enterprise: ami-0a866b43275664896
-# ca-central-1 v18.2.4 arm64 Enterprise: ami-00b7c88c8e91453e7
-# ca-central-1 v18.2.4 x86_64 Enterprise: ami-0d6ad9a467fef1a0f
-# eu-central-1 v18.2.4 arm64 Enterprise: ami-0f6c1ba78bea3892b
-# eu-central-1 v18.2.4 x86_64 Enterprise: ami-0839675150b627c8b
-# eu-north-1 v18.2.4 arm64 Enterprise: ami-0950ae470bac65358
-# eu-north-1 v18.2.4 x86_64 Enterprise: ami-00c093a88c8744bba
-# eu-west-1 v18.2.4 arm64 Enterprise: ami-0a85c9e9574c4a741
-# eu-west-1 v18.2.4 x86_64 Enterprise: ami-0b2b8fe11970d269f
-# eu-west-2 v18.2.4 arm64 Enterprise: ami-0dbac970c45929062
-# eu-west-2 v18.2.4 x86_64 Enterprise: ami-059ae391dbe7861ef
-# eu-west-3 v18.2.4 arm64 Enterprise: ami-0097643289ff39f8c
-# eu-west-3 v18.2.4 x86_64 Enterprise: ami-0176483ed89ca63c2
-# sa-east-1 v18.2.4 arm64 Enterprise: ami-048bf1a730a7df347
-# sa-east-1 v18.2.4 x86_64 Enterprise: ami-0e64e48f9baf41faa
-# us-east-1 v18.2.4 arm64 Enterprise: ami-01518e5b67ef72204
-# us-east-1 v18.2.4 x86_64 Enterprise: ami-020147d60daff8b18
-# us-east-2 v18.2.4 arm64 Enterprise: ami-0670e352692909474
-# us-east-2 v18.2.4 x86_64 Enterprise: ami-04f44e39293750a0f
-# us-west-1 v18.2.4 arm64 Enterprise: ami-0d37ab14376256d40
-# us-west-1 v18.2.4 x86_64 Enterprise: ami-04454e893d9a423f4
-# us-west-2 v18.2.4 arm64 Enterprise: ami-0c118841a90c524c4
-# us-west-2 v18.2.4 x86_64 Enterprise: ami-0f4b998cd39bc9f3b
+# ap-northeast-1 v18.4.0 arm64 Enterprise: ami-0f72748be19075b7f
+# ap-northeast-1 v18.4.0 x86_64 Enterprise: ami-0abc049f7652957b4
+# ap-northeast-2 v18.4.0 arm64 Enterprise: ami-03b93df0e99f2afb8
+# ap-northeast-2 v18.4.0 x86_64 Enterprise: ami-01b93edf40e7cfce2
+# ap-northeast-3 v18.4.0 arm64 Enterprise: ami-0d66662c718242682
+# ap-northeast-3 v18.4.0 x86_64 Enterprise: ami-0717723b7f58ddb70
+# ap-south-1 v18.4.0 arm64 Enterprise: ami-022a8a93a5eb458a6
+# ap-south-1 v18.4.0 x86_64 Enterprise: ami-0d10e3c6289ff652a
+# ap-southeast-1 v18.4.0 arm64 Enterprise: ami-0505285ebe3ade841
+# ap-southeast-1 v18.4.0 x86_64 Enterprise: ami-0a9a88f7ad890fb6e
+# ap-southeast-2 v18.4.0 arm64 Enterprise: ami-0414dcc5e63fff09b
+# ap-southeast-2 v18.4.0 x86_64 Enterprise: ami-05f7494ee54b2b952
+# ca-central-1 v18.4.0 arm64 Enterprise: ami-03da1b3a378d0a2e8
+# ca-central-1 v18.4.0 x86_64 Enterprise: ami-04e3e7cebcba24c92
+# eu-central-1 v18.4.0 arm64 Enterprise: ami-09cbd37fef08f7ee5
+# eu-central-1 v18.4.0 x86_64 Enterprise: ami-04dda2cdc06e808e4
+# eu-north-1 v18.4.0 arm64 Enterprise: ami-0235cb0500cbd0c9b
+# eu-north-1 v18.4.0 x86_64 Enterprise: ami-0c24b99a1d0151cbc
+# eu-west-1 v18.4.0 arm64 Enterprise: ami-0cc497032398201a9
+# eu-west-1 v18.4.0 x86_64 Enterprise: ami-039185fb917ca39b8
+# eu-west-2 v18.4.0 arm64 Enterprise: ami-0704707b67d767d36
+# eu-west-2 v18.4.0 x86_64 Enterprise: ami-0eb190b6b66854b22
+# eu-west-3 v18.4.0 arm64 Enterprise: ami-047a83d8e2ba600b8
+# eu-west-3 v18.4.0 x86_64 Enterprise: ami-0ab8b3c45c0c69c59
+# sa-east-1 v18.4.0 arm64 Enterprise: ami-0c1ad8b5466b81497
+# sa-east-1 v18.4.0 x86_64 Enterprise: ami-0d990e1ec228f7e18
+# us-east-1 v18.4.0 arm64 Enterprise: ami-0a4b77f5c9613248c
+# us-east-1 v18.4.0 x86_64 Enterprise: ami-0e6ed4548abb44b85
+# us-east-2 v18.4.0 arm64 Enterprise: ami-09dfbbec241980e17
+# us-east-2 v18.4.0 x86_64 Enterprise: ami-0727e54625e8a3e03
+# us-west-1 v18.4.0 arm64 Enterprise: ami-007af49bfbedfcb88
+# us-west-1 v18.4.0 x86_64 Enterprise: ami-0d3c194f6ba1a6427
+# us-west-2 v18.4.0 arm64 Enterprise: ami-086a36a0199ff70eb
+# us-west-2 v18.4.0 x86_64 Enterprise: ami-0d44c24be862e766e
 ```
 
 ### Enterprise FIPS
 
 ```
-# ap-northeast-1 v18.2.4 arm64 Enterprise FIPS: ami-0294faf4e3a61e721
-# ap-northeast-1 v18.2.4 x86_64 Enterprise FIPS: ami-0d8dce8767ca68197
-# ap-northeast-2 v18.2.4 arm64 Enterprise FIPS: ami-0a7cec40d2597ab77
-# ap-northeast-2 v18.2.4 x86_64 Enterprise FIPS: ami-0c784d731bf48864f
-# ap-northeast-3 v18.2.4 arm64 Enterprise FIPS: ami-0a7422013db2a3b1f
-# ap-northeast-3 v18.2.4 x86_64 Enterprise FIPS: ami-0e2292888839fbe97
-# ap-south-1 v18.2.4 arm64 Enterprise FIPS: ami-06c101fed13ebcfe6
-# ap-south-1 v18.2.4 x86_64 Enterprise FIPS: ami-0a0decd92861f3f39
-# ap-southeast-1 v18.2.4 arm64 Enterprise FIPS: ami-080ef71efcd36eb79
-# ap-southeast-1 v18.2.4 x86_64 Enterprise FIPS: ami-011ed96c9bc869d6a
-# ap-southeast-2 v18.2.4 arm64 Enterprise FIPS: ami-0efe9cda1641c3824
-# ap-southeast-2 v18.2.4 x86_64 Enterprise FIPS: ami-0c82fe2ee731b20d5
-# ca-central-1 v18.2.4 arm64 Enterprise FIPS: ami-0aa6f6ec4ddc7771d
-# ca-central-1 v18.2.4 x86_64 Enterprise FIPS: ami-0d249e9eea666fa36
-# eu-central-1 v18.2.4 arm64 Enterprise FIPS: ami-03bad437f3a737dd3
-# eu-central-1 v18.2.4 x86_64 Enterprise FIPS: ami-091c26eeb2c5b377f
-# eu-north-1 v18.2.4 arm64 Enterprise FIPS: ami-00ac06072c1bbfdd1
-# eu-north-1 v18.2.4 x86_64 Enterprise FIPS: ami-0a3322ccbe2cdada7
-# eu-west-1 v18.2.4 arm64 Enterprise FIPS: ami-0ba7d0b46881f752c
-# eu-west-1 v18.2.4 x86_64 Enterprise FIPS: ami-01a7159fe773cd475
-# eu-west-2 v18.2.4 arm64 Enterprise FIPS: ami-06d8699d5e8b46def
-# eu-west-2 v18.2.4 x86_64 Enterprise FIPS: ami-0901c9541cfc82698
-# eu-west-3 v18.2.4 arm64 Enterprise FIPS: ami-08f4f2f39d52fb15b
-# eu-west-3 v18.2.4 x86_64 Enterprise FIPS: ami-0f5f8311d2dc78686
-# sa-east-1 v18.2.4 arm64 Enterprise FIPS: ami-0be21a424e8a68456
-# sa-east-1 v18.2.4 x86_64 Enterprise FIPS: ami-024109d798c497f67
-# us-east-1 v18.2.4 arm64 Enterprise FIPS: ami-0d4c9cde5dc376ec0
-# us-east-1 v18.2.4 x86_64 Enterprise FIPS: ami-0d7e7b0100c4ad2da
-# us-east-2 v18.2.4 arm64 Enterprise FIPS: ami-0708618f0ba40a927
-# us-east-2 v18.2.4 x86_64 Enterprise FIPS: ami-0af6cf36d39d7d4fe
-# us-west-1 v18.2.4 arm64 Enterprise FIPS: ami-0eb09cfdf4acd360c
-# us-west-1 v18.2.4 x86_64 Enterprise FIPS: ami-05f67c4121e1242d3
-# us-west-2 v18.2.4 arm64 Enterprise FIPS: ami-0aabbfa4ead608432
-# us-west-2 v18.2.4 x86_64 Enterprise FIPS: ami-0b921db06b6f2a66a
+# ap-northeast-1 v18.4.0 arm64 Enterprise FIPS: ami-0e228805da889eb16
+# ap-northeast-1 v18.4.0 x86_64 Enterprise FIPS: ami-0034e3358bc40238b
+# ap-northeast-2 v18.4.0 arm64 Enterprise FIPS: ami-05cc20b8a252cdacc
+# ap-northeast-2 v18.4.0 x86_64 Enterprise FIPS: ami-021c419dd784eda5b
+# ap-northeast-3 v18.4.0 arm64 Enterprise FIPS: ami-0d01633dde5f0345e
+# ap-northeast-3 v18.4.0 x86_64 Enterprise FIPS: ami-07ceea58fdc3e4c06
+# ap-south-1 v18.4.0 arm64 Enterprise FIPS: ami-0a339dd88a273e98d
+# ap-south-1 v18.4.0 x86_64 Enterprise FIPS: ami-08ded112e4165b721
+# ap-southeast-1 v18.4.0 arm64 Enterprise FIPS: ami-04674d68550bf8439
+# ap-southeast-1 v18.4.0 x86_64 Enterprise FIPS: ami-026910b55d1b9fd4f
+# ap-southeast-2 v18.4.0 arm64 Enterprise FIPS: ami-03e1f5c50c993ed1c
+# ap-southeast-2 v18.4.0 x86_64 Enterprise FIPS: ami-0fd7a4ba473d0c04d
+# ca-central-1 v18.4.0 arm64 Enterprise FIPS: ami-0748be378d630f684
+# ca-central-1 v18.4.0 x86_64 Enterprise FIPS: ami-0baa078b3eb767405
+# eu-central-1 v18.4.0 arm64 Enterprise FIPS: ami-0f5dabe4d829f1e67
+# eu-central-1 v18.4.0 x86_64 Enterprise FIPS: ami-0e77369b3f3f406c7
+# eu-north-1 v18.4.0 arm64 Enterprise FIPS: ami-048d1c1f9c18d2aa8
+# eu-north-1 v18.4.0 x86_64 Enterprise FIPS: ami-06866d5de2f1a59ef
+# eu-west-1 v18.4.0 arm64 Enterprise FIPS: ami-0c1280a27dd326856
+# eu-west-1 v18.4.0 x86_64 Enterprise FIPS: ami-0cb7b9bce381c281b
+# eu-west-2 v18.4.0 arm64 Enterprise FIPS: ami-0ae21b7e73c7955ff
+# eu-west-2 v18.4.0 x86_64 Enterprise FIPS: ami-0b3d7ae25b6545120
+# eu-west-3 v18.4.0 arm64 Enterprise FIPS: ami-0a9bd191e9c4be4d8
+# eu-west-3 v18.4.0 x86_64 Enterprise FIPS: ami-0a87ff07ab8e133ff
+# sa-east-1 v18.4.0 arm64 Enterprise FIPS: ami-0d805440d19d0ea17
+# sa-east-1 v18.4.0 x86_64 Enterprise FIPS: ami-0262d68ab65f9cc6e
+# us-east-1 v18.4.0 arm64 Enterprise FIPS: ami-00d5f54a564137c66
+# us-east-1 v18.4.0 x86_64 Enterprise FIPS: ami-0a87af742838bf5f5
+# us-east-2 v18.4.0 arm64 Enterprise FIPS: ami-0b13b02b1b7abd7c5
+# us-east-2 v18.4.0 x86_64 Enterprise FIPS: ami-0ff77dc23268b7efb
+# us-west-1 v18.4.0 arm64 Enterprise FIPS: ami-0393e0a9aeac5883e
+# us-west-1 v18.4.0 x86_64 Enterprise FIPS: ami-017e2102188eb0511
+# us-west-2 v18.4.0 arm64 Enterprise FIPS: ami-0c856e6bb29c1d0c9
+# us-west-2 v18.4.0 x86_64 Enterprise FIPS: ami-01d6ac35b087b709e
 ```

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -46,7 +46,7 @@ export TF_VAR_cluster_name="teleport.example.com"
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-export TF_VAR_ami_name="teleport-ent-18.2.4-arm64"
+export TF_VAR_ami_name="teleport-ent-18.4.0-arm64"
 
 # Instance types used for authentication server auto scaling group
 # This should match to the AMI instance architecture type, ARM or x86

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -98,7 +98,7 @@ TF_VAR_license_path ?= "/path/to/license"
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
 # FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
-TF_VAR_ami_name ?= "teleport-ent-18.2.4-arm64"
+TF_VAR_ami_name ?= "teleport-ent-18.4.0-arm64"
 
 # Route 53 hosted zone to use, must be a root zone registered in AWS, e.g. example.com
 TF_VAR_route53_zone ?= "example.com"


### PR DESCRIPTION
Manual run of automation due to automation failure.