### PR TITLE
accessgraph sync: Add AWS IAM role for EKS audit logs

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -507,6 +507,18 @@ func StatementKMSDecrypt(kmsKeysARNs []string) *Statement {
 	}
 }
 
+// StatementEnableEKSAuditLogs returns the statement that allows fetching EKS
+// API server audit logs from CloudWatch Logs.
+func StatementAccessGraphAWSSyncEKSAuditLogs() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"logs:FilterLogEvents",
+		},
+		Resources: []string{"arn:aws:logs:*:*:log-group:/aws/eks/*"},
+	}
+}
+
 // StatementForAWSIdentityCenterAccess returns AWS IAM policy statement that grants
 // permissions required for Teleport identity center client.
 // TODO(sshah): make the roles more granular by restricting resources scoped to

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -308,6 +308,8 @@ type IntegrationConfAccessGraphAWSSync struct {
 	CloudTrailBucketARN string
 	// KMSKeyARNs is the ARN of the KMS key to use for decrypting the Identity Security Activity Center data.
 	KMSKeyARNs []string
+	// EnableEKSAuditLogs enables collection of EKS audit logs from CloudWatch logs.
+	EnableEKSAuditLogs bool
 }
 
 // IntegrationConfAccessGraphAzureSync contains the arguments of

--- a/lib/integrations/awsoidc/accessgraph_sync.go
+++ b/lib/integrations/awsoidc/accessgraph_sync.go
@@ -63,6 +63,9 @@ type AccessGraphAWSIAMConfigureRequest struct {
 	// KMSKeyARNs is the ARN of the KMS key to use for decrypting the Identity Security Activity Center data.
 	KMSKeyARNs []string
 
+	// EnableEKSAuditLogs enables collection of EKS audit logs from CloudWatch logs.
+	EnableEKSAuditLogs bool
+
 	// stdout is used to override stdout output in tests.
 	stdout io.Writer
 }
@@ -181,6 +184,9 @@ func ConfigureAccessGraphSyncIAM(ctx context.Context, clt AccessGraphIAMConfigur
 		statements = append(statements, awslib.StatementKMSDecrypt(req.KMSKeyARNs))
 	}
 
+	if req.EnableEKSAuditLogs {
+		statements = append(statements, awslib.StatementAccessGraphAWSSyncEKSAuditLogs())
+	}
 	policy := awslib.NewPolicyDocument(
 		statements...,
 	)

--- a/lib/integrations/awsoidc/accessgraph_sync_test.go
+++ b/lib/integrations/awsoidc/accessgraph_sync_test.go
@@ -286,6 +286,7 @@ func TestAccessGraphAWSIAMConfigWithActivityCenterOuput(t *testing.T) {
 		SQSQueueURL:         "https://sqs.us-west-2.amazonaws.com/123456789012/my-queue",
 		CloudTrailBucketARN: "arn:aws:s3:::my-cloudtrail-bucket",
 		KMSKeyARNs:          []string{"arn:aws:kms:us-west-2:123456789012:key/my-kms-key"},
+		EnableEKSAuditLogs:  true,
 	}
 	clt := mockAccessGraphAWSAMConfigClient{
 		CallerIdentityGetter: mockSTSClient{accountID: req.AccountID},

--- a/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
+++ b/lib/integrations/awsoidc/testdata/TestAccessGraphAWSIAMConfigWithActivityCenterOuput.golden
@@ -99,6 +99,11 @@ PutRolePolicy: {
                     "kms:GenerateDataKeyWithoutPlaintext"
                 ],
                 "Resource": "arn:aws:kms:us-west-2:123456789012:key/my-kms-key"
+            },
+            {
+                "Effect": "Allow",
+                "Action": "logs:FilterLogEvents",
+                "Resource": "arn:aws:logs:*:*:log-group:/aws/eks/*"
             }
         ]
     },

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -25,6 +25,7 @@ import (
 	"maps"
 	"net/http"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -1377,6 +1378,19 @@ func (h *Handler) awsAccessGraphOIDCSync(w http.ResponseWriter, r *http.Request,
 				return nil, trace.BadParameter("invalid kmsKeysARNs %q", keyARN)
 			}
 			argsList = append(argsList, fmt.Sprintf("--kms-key=%s", shsprintf.EscapeDefaultContext(keyARN)))
+		}
+	}
+
+	if eksAuditLogs := queryParams.Get("eksAuditLogs"); eksAuditLogs != "" {
+		enabled, err := strconv.ParseBool(eksAuditLogs)
+		if err != nil {
+			// The error returned by ParseBool contains no more information than this
+			// error. As we canot wrap both it and trace.BadParameter, we do the
+			// latter as a preferred error type.
+			return nil, trace.BadParameter("invalid boolean value for eksAuditLogs %q", eksAuditLogs)
+		}
+		if enabled {
+			argsList = append(argsList, "--eks-audit-logs")
 		}
 	}
 

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -223,6 +223,7 @@ func onIntegrationConfAccessGraphAWSSync(ctx context.Context, params config.Inte
 		SQSQueueURL:         params.SQSQueueURL,
 		CloudTrailBucketARN: params.CloudTrailBucketARN,
 		KMSKeyARNs:          params.KMSKeyARNs,
+		EnableEKSAuditLogs:  params.EnableEKSAuditLogs,
 	}
 	return trace.Wrap(awsoidc.ConfigureAccessGraphSyncIAM(ctx, clt, confReq))
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -539,6 +539,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfAccessGraphAWSSyncCmd.Flag("sqs-queue-url", "SQS Queue URL used to receive notifications from CloudTrail.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.SQSQueueURL)
 	integrationConfAccessGraphAWSSyncCmd.Flag("cloud-trail-bucket", "ARN of the S3 bucket where CloudTrail writes events to.").StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.CloudTrailBucketARN)
 	integrationConfAccessGraphAWSSyncCmd.Flag("kms-key", "List of KMS Keys used to decrypt SQS and S3 bucket data.").StringsVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.KMSKeyARNs)
+	integrationConfAccessGraphAWSSyncCmd.Flag("eks-audit-logs", "Enable collection of EKS audit logs").BoolVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.EnableEKSAuditLogs)
 
 	integrationConfAccessGraphAzureSyncCmd := integrationConfAccessGraphCmd.Command("azure", "Adds required Azure permissions for syncing Azure resources into Access Graph service.")
 	integrationConfAccessGraphAzureSyncCmd.Flag("managed-identity", "The ID of the managed identity to run the Discovery service.").Required().StringVar(&ccf.IntegrationConfAccessGraphAzureSyncArguments.ManagedIdentity)


### PR DESCRIPTION
Update the `teleport configure integration acces-graph aws-iam` command
to add a permission to access EKS audit logs via CloudWatch Logs if the
`--eks-audit-logs` flag is passed. This is necessary so that an
integration can pull the EKS audit logs if so configured in a discovery
access graph matcher.

Issue: https://github.com/gravitational/access-graph/issues/1589