### PR TITLE
Docs: fix example config for custom SSM Docs in EC2 Discovery

### DIFF
--- a/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
@@ -58,7 +58,7 @@ version: v3
 # ...
 discovery_service:
   enabled: true
-  {{ matcher }}:
+  aws:
    - ssm:
        document_name: "TeleportDiscoveryInstaller"
 ```


### PR DESCRIPTION
Before:

<img width="768" height="372" alt="image" src="https://github.com/user-attachments/assets/864a4452-e979-44d2-b3bd-b615989e0911" />


After:
<img width="402" height="310" alt="image" src="https://github.com/user-attachments/assets/f59d0f8d-0483-46c5-a483-fdc9d3412555" />
