### PR TITLE
Update tctl rm example

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -187,7 +187,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 	<resource name>  Resource name to delete
 
 	Examples:
-	$ tctl rm connector/github
+	$ tctl rm role/devs
 	$ tctl rm cluster/main`).SetValue(&rc.ref)
 
 	rc.getCmd = app.Command("get", "Print a YAML declaration of various Teleport resources.")


### PR DESCRIPTION
`tctl rm connector/...` is not supported. `saml/...`, `oidc/...` or `github/...` has to be used instead. I didn't want to change the example to `tctl rm github/github` because it looks strange.

I thought about adding support to `tctl rm connector/...`, but it's difficult to design something with good UX that also doesn't leak information about other connector types when you don't have access.

E.g. when you type `tctl rm saml/my_connector`, it return an error: `"my_connector" connector name is ambiguous, more than one connector type with this name exists, please specify saml/my_connector, oidc/my_connector or github/my_connector`

I guess the risk is low here, so maybe it's ok to add this support?