### PR TITLE
Fix TestClient_DialHost flakiness

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -25,6 +25,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0
 	golang.org/x/crypto v0.43.0
 	golang.org/x/net v0.46.0
+	golang.org/x/sync v0.17.0
 	golang.org/x/term v0.37.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5
 	google.golang.org/grpc v1.76.0
@@ -54,7 +55,6 @@ require (
 	github.com/russellhaering/goxmldsig v1.5.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	golang.org/x/mod v0.28.0 // indirect
-	golang.org/x/sync v0.17.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/tools v0.37.0 // indirect


### PR DESCRIPTION
Several of the test cases failed with unexpected EOF errors because the gRPC handler was terminating too early.

The `connection successfully established without agent forwarding` test case used the following series of events to validate ssh frames are forwarded correctly.

1) client sends message to server
2) server echoes the data back and immediately terminates the stream
3) client reads a message and validates the data was echoed
4) client tries to read again and gets an EOF error
5) client closes connection

The flakiness was a result of step 2. The server handler exiting immediately after sending the echo back to the client could result in the message never being received by the client. To make the test more reliable the test was updated to the following.

1) client sends message to server
2) server echoes the data back
3) client reads a message and validates the data was echoed 
4) client resends the message to the server
5) server receives the second message and terminates the stream 
6) client tries to read again and gets an EOF error 
7) client closes connection

This guarantees that the server stream handler will be alive after the echoed data is sent and the client has had a chance to process it.

The `connection successfully established with agent forwarding` test case was flaking for similar reasons. The gRPC handler spawned a goroutine to consume and forward agent frames but the handler did not wait for this goroutine to finish before returning. Depending on the timing of the test the handler could return prior to all agent frames being processed which terminated the gRPC stream and resulted in unexpected EOF errors at the client.

To remedy this logic in the handler was inverted such that processing the messasges from the gRPC stream is done in a loop in the main goroutine of the handler. Processing of agent frames is now done in a background goroutine spawned via an errgroup.Group. The main loop of the handler blocks waiting for the errgroup.Group to conclude prior to exiting to ensure all messages are exhausted before exiting.

Fixes https://github.com/gravitational/teleport/issues/32799.