### PR TITLE
Error message when running `tctl rm connector`

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1123,8 +1123,7 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 	// generic [resources.Handler].
 	if rc.ref.Kind == types.KindConnectors {
 		return trace.BadParameter(
-			"%q type is ambiguous. To delete the resource, please use its exact type. Possible resource identifiers are: %s",
-			types.KindConnectors,
+			"Deleting connector resources requires using an explicit connector type. Please try again with the appropriate type: %s",
 			[]string{
 				types.KindGithubConnector + "/" + rc.ref.Name,
 				types.KindOIDCConnector + "/" + rc.ref.Name,

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1118,7 +1118,7 @@ func (rc *ResourceCommand) updateStaticHostUser(ctx context.Context, client *aut
 
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client) (err error) {
-	// Connectors is a special case. As it's the only meta-resource we have,
+	// Connectors are a special case. As it's the only meta-resource we have,
 	// it's easier to special-case it here instead of adding a case in the
 	// generic [resources.Handler].
 	if rc.ref.Kind == types.KindConnectors {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1122,6 +1122,20 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 	if resourceHandler, found := resources.Handlers()[rc.ref.Kind]; found {
 		if err := resourceHandler.Delete(ctx, client, rc.ref); err != nil {
 			if trace.IsNotImplemented(err) {
+				// Connectors is a special case. As it's the only meta-resource we have,
+				// it's easier to special-case it here instead of adding a case in the
+				// generic [resources.Handler].
+				if rc.ref.Kind == types.KindConnectors {
+					return trace.BadParameter(
+						"%q type is ambiguous. To delete the resource, please use its exact type. Possible resource identifiers are: %s",
+						types.KindConnectors,
+						[]string{
+							types.KindGithubConnector + "/" + rc.ref.Name,
+							types.KindOIDCConnector + "/" + rc.ref.Name,
+							types.KindSAMLConnector + "/" + rc.ref.Name,
+						},
+					)
+				}
 				return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 			}
 			return trace.Wrap(err, "error deleting resource %q of type %q", rc.ref.Name, rc.ref.Kind)


### PR DESCRIPTION
We don't support `tctl rm connector/foo` because it's ambiguous, but this causes confusion. This PR adds an actionable error message:

```
ERROR: "connector" type is ambiguous. To delete the resource, please use its exact type. Possible resource identifiers are: [github/foo oidc/foo saml/foo]
```

See also: https://github.com/gravitational/teleport/pull/61371