### PR TITLE
Alias `tctl delete` -> `tctl rm`

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -187,7 +187,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 	rc.updateCmd.Flag("set-labels", "Set labels").StringVar(&rc.labels)
 	rc.updateCmd.Flag("set-ttl", "Set TTL").StringVar(&rc.ttl)
 
-	rc.deleteCmd = app.Command("rm", "Delete a resource.").Alias("del")
+	rc.deleteCmd = app.Command("rm", "Delete a resource.").Alias("del").Alias("delete")
 	rc.deleteCmd.Arg("resource type/resource name", `Resource to delete
 	<resource type>  Type of a resource [for example: connector,user,cluster,token]
 	<resource name>  Resource name to delete


### PR DESCRIPTION
While we're fixing the tctl papercuts, this is one that I hit weekly because of the similarity between tctl and kubectl.

We do `kubectl delete`, but `tctl rm`. We even had a `tctl del` alias. This PR adds the `tctl delete` alias to match `kubectl delete`.

Changelog: Added `tctl delete` as a `tctl rm` alias.