### PR TITLE
remove misleading 'update' command in tctl list-kinds

### DIFF
--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -157,9 +157,8 @@ func (r *Handler) SupportedCommands() []string {
 	if r.deleteHandler != nil {
 		verbs = append(verbs, "rm")
 	}
-	if r.updateHandler != nil {
-		verbs = append(verbs, "update")
-	}
+	// No check on the update handler for the "update" command because it is not
+	// doing anything useful today: https://github.com/gravitational/teleport/issues/61381
 
 	return verbs
 }


### PR DESCRIPTION
`tctl update` doesn't work for every resource with an update RPC. We should not tell users to use the `update` command until we've fixed it.

See also: https://github.com/gravitational/teleport/issues/61381