### PR TITLE
metrics.Registry.Wrap() handle empty subsystems properly

### DIFF
--- a/lib/observability/metrics/registry.go
+++ b/lib/observability/metrics/registry.go
@@ -20,6 +20,7 @@ package metrics
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -60,10 +61,18 @@ func (r *Registry) Subsystem() string {
 //	 go runFooService(ctx, log, reg.Wrap("foo"))
 //	 go runBarService(ctx, log, reg.Wrap("bar"))
 func (r *Registry) Wrap(subsystem string) *Registry {
+	var s []string
+	if r.subsystem != "" {
+		s = append(s, r.subsystem)
+	}
+	if subsystem != "" {
+		s = append(s, subsystem)
+	}
+
 	newReg := &Registry{
 		Registerer: r.Registerer,
 		namespace:  r.namespace,
-		subsystem:  r.subsystem + "_" + subsystem,
+		subsystem:  strings.Join(s, "_"),
 	}
 	return newReg
 }

--- a/lib/observability/metrics/registry.go
+++ b/lib/observability/metrics/registry.go
@@ -19,8 +19,8 @@
 package metrics
 
 import (
+	"cmp"
 	"errors"
-	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -61,18 +61,16 @@ func (r *Registry) Subsystem() string {
 //	 go runFooService(ctx, log, reg.Wrap("foo"))
 //	 go runBarService(ctx, log, reg.Wrap("bar"))
 func (r *Registry) Wrap(subsystem string) *Registry {
-	var s []string
-	if r.subsystem != "" {
-		s = append(s, r.subsystem)
-	}
-	if subsystem != "" {
-		s = append(s, subsystem)
+	if r.subsystem != "" && subsystem != "" {
+		subsystem = r.subsystem + "_" + subsystem
+	} else {
+		subsystem = cmp.Or(r.subsystem, subsystem)
 	}
 
 	newReg := &Registry{
 		Registerer: r.Registerer,
 		namespace:  r.namespace,
-		subsystem:  strings.Join(s, "_"),
+		subsystem:  subsystem,
 	}
 	return newReg
 }

--- a/lib/observability/metrics/registry_test.go
+++ b/lib/observability/metrics/registry_test.go
@@ -1,0 +1,72 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrap(t *testing.T) {
+	testNamespace := "namespace"
+	tests := []struct {
+		name              string
+		existingSubsystem string
+		wrappingSubsystem string
+		expectedSubsystem string
+	}{
+		{
+			name:              "empty subsystem + empty subsystem",
+			existingSubsystem: "",
+			wrappingSubsystem: "",
+			expectedSubsystem: "",
+		},
+		{
+			name:              "empty subsystem + non-empty subsystem",
+			existingSubsystem: "",
+			wrappingSubsystem: "test",
+			expectedSubsystem: "test",
+		},
+		{
+			name:              "non-empty subsystem + empty subsystem",
+			existingSubsystem: "test",
+			wrappingSubsystem: "",
+			expectedSubsystem: "test",
+		},
+		{
+			name:              "non-empty subsystem + non-empty subsystem",
+			existingSubsystem: "test",
+			wrappingSubsystem: "test",
+			expectedSubsystem: "test_test",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := &Registry{
+				Registerer: nil,
+				namespace:  testNamespace,
+				subsystem:  test.existingSubsystem,
+			}
+			result := r.Wrap(test.wrappingSubsystem)
+			require.Equal(t, test.expectedSubsystem, result.subsystem)
+			require.Equal(t, testNamespace, result.namespace)
+		})
+	}
+}


### PR DESCRIPTION
Properly handles empty subsystems during wrapping.

Fixes: https://github.com/gravitational/teleport/pull/61239/files/a24bba394eb3aeddc2a83497a83f0bf4661772d5#r2528783100