### PR TITLE
[v18] Docs: fix example config for custom SSM Docs in EC2 Discovery

### DIFF
--- a/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
+++ b/docs/pages/includes/auto-discovery/aws-ec2-advanced-config.mdx
@@ -58,7 +58,7 @@ version: v3
 # ...
 discovery_service:
   enabled: true
-  {{ matcher }}:
+  aws:
    - ssm:
        document_name: "TeleportDiscoveryInstaller"
 ```


### PR DESCRIPTION
Backport #61366 to branch/v18