### PR TITLE
[reversetunnel] agent side stale conn timeout

### DIFF
--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -35,8 +35,11 @@ import (
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/defaults"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
@@ -90,6 +93,10 @@ type SSHClient interface {
 	GlobalRequests() <-chan *ssh.Request
 	HandleChannelOpen(channelType string) <-chan ssh.NewChannel
 	Reply(*ssh.Request, bool, []byte) error
+
+	// TODO(okraport): DELETE IN v21.0.0 This callback is a temporary workaround during the migration while
+	// older Teleport versions do not support keepalive messages on reverse tunnel servers.
+	EnableWatchdog(timeout time.Duration)
 }
 
 // agentConfig represents an agent configuration.
@@ -98,6 +105,9 @@ type agentConfig struct {
 	addr utils.NetAddr
 	// keepAlive is the interval at which the agent will send heartbeats.
 	keepAlive time.Duration
+	// keepAliveCount specifies the amount of missed ping heartbeats
+	// to wait for before declaring the connection as broken.
+	keepAliveCount int
 	// stateCallback is called each time the state changes.
 	stateCallback AgentStateCallback
 	// sshDialer creates a new ssh connection.
@@ -120,6 +130,8 @@ type agentConfig struct {
 	localAuthAddresses []string
 	// proxySigner is used to sign PROXY headers for securely propagating client IP address
 	proxySigner multiplexer.PROXYHeaderSigner
+	// staleConnTimeoutDisabled is true if connection timeouts are disabled.
+	staleConnTimeoutDisabled bool
 }
 
 // checkAndSetDefaults ensures an agentConfig contains required parameters.
@@ -148,6 +160,13 @@ func (c *agentConfig) checkAndSetDefaults() error {
 	if c.logger == nil {
 		c.logger = slog.Default()
 	}
+	if c.keepAliveCount == 0 {
+		c.keepAliveCount = defaults.KeepAliveCountMax
+	}
+	if c.keepAlive == 0 {
+		c.keepAlive = defaults.KeepAliveInterval()
+	}
+
 	c.logger = c.logger.With(
 		"lease_id", c.lease.ID(),
 		"target", c.addr.String(),
@@ -355,6 +374,15 @@ func (a *agent) Start(ctx context.Context) error {
 		a.Stop()
 	}()
 
+	a.wg.Add(1)
+	go func() {
+		if err := a.sendKeepalives(); err != nil {
+			a.logger.DebugContext(a.ctx, "Failed to send keepalive", "error", err)
+		}
+		a.wg.Done()
+		a.Stop()
+	}()
+
 	_, err = a.updateState(AgentConnected)
 	if err != nil {
 		return trace.Wrap(err)
@@ -403,6 +431,13 @@ func (a *agent) connect() error {
 	return nil
 }
 
+// sendHeartbeat sends a ping message to the configured heartbeat channel.
+func (a *agent) sendHeartbeat(ctx context.Context) error {
+	bytes, _ := a.clock.Now().UTC().MarshalText()
+	_, err := a.hbChannel.SendRequest(ctx, "ping", false, bytes)
+	return trace.Wrap(err)
+}
+
 // sendFirstHeartbeat opens the heartbeat channel and sends the first
 // heartbeat.
 func (a *agent) sendFirstHeartbeat(ctx context.Context) error {
@@ -410,13 +445,14 @@ func (a *agent) sendFirstHeartbeat(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
 	sshutils.DiscardChannelData(channel)
 	go ssh.DiscardRequests(requests)
 
 	a.hbChannel = channel
 
 	// Send the first ping right away.
-	if _, err := a.hbChannel.SendRequest(ctx, "ping", false, nil); err != nil {
+	if err := a.sendHeartbeat(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -525,9 +561,7 @@ func (a *agent) handleDrainChannels(drainWGDone func()) error {
 			if a.drainCtx.Err() != nil {
 				continue
 			}
-			bytes, _ := a.clock.Now().UTC().MarshalText()
-			_, err := a.hbChannel.SendRequest(a.ctx, "ping", false, bytes)
-			if err != nil {
+			if err := a.sendHeartbeat(a.ctx); err != nil {
 				a.logger.ErrorContext(a.ctx, "failed to send ping request", "error", err)
 				return trace.Wrap(err)
 			}
@@ -592,6 +626,65 @@ func (a *agent) handleChannels() error {
 				a.wg.Done()
 			}()
 		}
+	}
+}
+
+// sendKeepalives sends keepalive requests to the server at regular intervals configured by [agent.keepAlive].
+//
+// It's possible on older servers that the keepalive request is not supported, the SendRequest will block until until
+// connection is destroyed. If the server responds successfully and the watchdog is configured, the watchdog will then
+// be enabled.
+func (a *agent) sendKeepalives() error {
+	first := true
+	ticker := time.NewTimer(0)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-a.ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		const wantReplyTrue = true
+		_, _, err := a.client.SendRequest(a.ctx, teleport.KeepAliveReqType, wantReplyTrue, nil)
+		ticker.Reset(retryutils.SeventhJitter(a.keepAlive))
+		if err != nil {
+			if !utils.IsOKNetworkError(err) {
+				a.logger.WarnContext(
+					a.ctx,
+					"Failed to send keepalive request",
+					"target_addr",
+					logutils.StringerAttr(a.client.RemoteAddr()),
+					"error",
+					err,
+				)
+			}
+			return trace.Wrap(err, "failed to send keepalive request")
+		}
+
+		if !first {
+			continue
+		}
+		first = false
+
+		if a.staleConnTimeoutDisabled {
+			continue
+		}
+
+		// If the connection has no activity within [a.keepAliveCount] heartbeat intervals, then the connection
+		// will be terminated.
+		timeout := a.keepAlive * time.Duration(a.keepAliveCount)
+		a.client.EnableWatchdog(timeout)
+		a.logger.InfoContext(
+			a.ctx,
+			"Keepalive successful, arming watchdog",
+			"target_addr",
+			logutils.StringerAttr(a.client.RemoteAddr()),
+			"timeout",
+			logutils.StringerAttr(timeout),
+		)
+
 	}
 }
 

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -69,6 +70,9 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 		return nil, trace.Wrap(err)
 	}
 
+	// Wrap the connection to support optional idle timeouts, this is optionally enabled by the agent via callback.
+	pconn, enableWatchdog := utils.ObeyIdleTimeoutDisarmed(pconn)
+
 	var principals []string
 	callback, err := apisshutils.NewHostKeyCallback(
 		apisshutils.HostKeyCallbackConfig{
@@ -113,10 +117,11 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 	client := tracessh.NewClient(conn, chans, emptyRequests)
 
 	return &sshClient{
-		Client:      client,
-		requests:    reqs,
-		newChannels: chans,
-		principals:  principals,
+		Client:         client,
+		requests:       reqs,
+		newChannels:    chans,
+		principals:     principals,
+		enableWatchdog: enableWatchdog,
 	}, nil
 }
 
@@ -142,9 +147,10 @@ func (d *agentDialer) hostCheckerFunc(ctx context.Context) apisshutils.CheckersG
 // sshClient implements the SSHClient interface.
 type sshClient struct {
 	*tracessh.Client
-	requests    <-chan *ssh.Request
-	newChannels <-chan ssh.NewChannel
-	principals  []string
+	requests       <-chan *ssh.Request
+	newChannels    <-chan ssh.NewChannel
+	principals     []string
+	enableWatchdog func(timeout time.Duration)
 }
 
 // NewChannels is a channel that receieves ssh new channel requests.
@@ -165,4 +171,10 @@ func (c *sshClient) Principals() []string {
 // Reply handles replying to a request.
 func (c *sshClient) Reply(request *ssh.Request, ok bool, payload []byte) error {
 	return request.Reply(ok, payload)
+}
+
+func (c *sshClient) EnableWatchdog(timeout time.Duration) {
+	if c.enableWatchdog != nil {
+		c.enableWatchdog(timeout)
+	}
 }

--- a/lib/reversetunnel/agent_test.go
+++ b/lib/reversetunnel/agent_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,8 +35,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
-	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/api/types"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
+	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -106,6 +110,9 @@ func (m *mockSSHClient) GlobalRequests() <-chan *ssh.Request {
 	return m.MockGlobalRequests
 }
 
+func (m *mockSSHClient) EnableWatchdog(timeout time.Duration) {
+}
+
 type fakeReaderWriter struct{}
 
 func (n fakeReaderWriter) Read(_ []byte) (int, error) {
@@ -142,7 +149,7 @@ type mockAgentInjection struct {
 	client SSHClient
 }
 
-func (m *mockAgentInjection) handleTransport(context.Context, ssh.Channel, <-chan *ssh.Request, sshutils.Conn) {
+func (m *mockAgentInjection) handleTransport(context.Context, ssh.Channel, <-chan *ssh.Request, apisshutils.Conn) {
 }
 
 func (m *mockAgentInjection) DialContext(context.Context, utils.NetAddr) (SSHClient, error) {
@@ -153,16 +160,20 @@ func (m *mockAgentInjection) getVersion(context.Context) (string, error) {
 	return teleport.Version, nil
 }
 
-func testAgent(t *testing.T) (*agent, *mockSSHClient) {
-	tracker, err := track.New(track.Config{
-		ClusterName: "test",
-	})
-	require.NoError(t, err)
+func testAgent(t *testing.T, config agentConfig) (*agent, *mockSSHClient) {
+	var err error
 
-	addr := utils.NetAddr{Addr: "test-proxy-addr"}
+	if config.tracker == nil {
+		config.tracker, err = track.New(track.Config{
+			ClusterName: "test",
+		})
+		require.NoError(t, err)
+	}
 
-	lease := tracker.TryAcquire()
-	require.NotNil(t, lease)
+	config.addr = utils.NetAddr{Addr: "test-proxy-addr"}
+
+	config.lease = config.tracker.TryAcquire()
+	require.NotNil(t, config.lease)
 
 	client := &mockSSHClient{
 		MockPrincipals:        []string{"default"},
@@ -174,15 +185,27 @@ func testAgent(t *testing.T) (*agent, *mockSSHClient) {
 		client: client,
 	}
 
-	agent, err := newAgent(agentConfig{
-		keepAlive:        time.Millisecond * 100,
-		addr:             addr,
-		transportHandler: inject,
-		sshDialer:        inject,
-		versionGetter:    inject,
-		tracker:          tracker,
-		lease:            lease,
-	})
+	if config.transportHandler == nil {
+		config.transportHandler = inject
+	}
+
+	if config.sshDialer == nil {
+		config.sshDialer = inject
+	}
+
+	if config.versionGetter == nil {
+		config.versionGetter = inject
+	}
+
+	if config.keepAlive == 0 {
+		config.keepAlive = time.Millisecond * 100
+	}
+
+	if config.keepAliveCount == 0 {
+		config.keepAliveCount = 1
+	}
+
+	agent, err := newAgent(config)
 	require.NoError(t, err, "Unexpected error during agent construction.")
 
 	return agent, client
@@ -234,7 +257,7 @@ func (c *callbackCounter) waitForCount(t *testing.T, count int) {
 
 // TestAgentFailedToClaimLease tests that an agent fails when it cannot claim a lease.
 func TestAgentFailedToClaimLease(t *testing.T) {
-	agent, client := testAgent(t)
+	agent, client := testAgent(t, agentConfig{})
 	claimedProxy := "claimed-proxy"
 
 	callback := newCallback()
@@ -264,7 +287,9 @@ func TestAgentFailedToClaimLease(t *testing.T) {
 
 // TestAgentStart tests an agent performs the necessary actions during startup.
 func TestAgentStart(t *testing.T) {
-	agent, client := testAgent(t)
+	agent, client := testAgent(t, agentConfig{
+		staleConnTimeoutDisabled: true,
+	})
 
 	callback := newCallback()
 	agent.stateCallback = callback.callback
@@ -272,6 +297,7 @@ func TestAgentStart(t *testing.T) {
 	openChannels := new(int32)
 	sentPings := new(int32)
 	versionReplies := new(int32)
+	keepaliveRequests := new(int32)
 
 	waitForVersion := make(chan struct{})
 	go func() {
@@ -313,6 +339,13 @@ func TestAgentStart(t *testing.T) {
 		return nil
 	}
 
+	client.MockSendRequest = func(ctx context.Context, name string, wantReply bool, payload []byte) (bool, []byte, error) {
+		atomic.AddInt32(keepaliveRequests, 1)
+		assert.Equal(t, teleport.KeepAliveReqType, name, "Unexpected request name.")
+		assert.True(t, wantReply, "Expected reply wanted.")
+		return false, nil, nil
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -322,6 +355,7 @@ func TestAgentStart(t *testing.T) {
 	require.Equal(t, 1, int(atomic.LoadInt32(openChannels)), "Expected only heartbeat channel to be opened.")
 	require.GreaterOrEqual(t, 1, int(atomic.LoadInt32(sentPings)), "Expected at least 1 ping to be sent.")
 	require.Equal(t, 1, int(atomic.LoadInt32(versionReplies)), "Expected 1 version reply.")
+	require.GreaterOrEqual(t, 1, int(atomic.LoadInt32(keepaliveRequests)), "Expected at least 1 keepalive to be sent.")
 
 	callback.waitForCount(t, 2)
 	require.Contains(t, callback.states, AgentConnecting)
@@ -366,7 +400,7 @@ func TestAgentStateTransitions(t *testing.T) {
 		},
 	}
 
-	agent, _ := testAgent(t)
+	agent, _ := testAgent(t, agentConfig{})
 	for _, tc := range tests {
 		msg := "failed testing agent state %s -> %s"
 		for _, state := range tc.noError {
@@ -381,4 +415,214 @@ func TestAgentStateTransitions(t *testing.T) {
 			require.Error(t, err, msg, tc.start, state)
 		}
 	}
+}
+
+type mockHeartbeatInstance struct {
+	sshServer               *sshutils.Server
+	supportsGlobalKeepalive bool
+	keepaliveCounter        atomic.Int64
+	ignoreKeepalives        atomic.Bool
+	t                       *testing.T
+}
+
+func (m *mockHeartbeatInstance) Start() error {
+	return trace.Wrap(m.sshServer.Start())
+}
+
+func (m *mockHeartbeatInstance) Stop() {
+	m.sshServer.Close()
+}
+
+func (m *mockHeartbeatInstance) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) {
+	switch r.Type {
+	case teleport.KeepAliveReqType:
+		m.keepaliveCounter.Add(1)
+		if m.supportsGlobalKeepalive && !m.ignoreKeepalives.Load() {
+			err := r.Reply(true, nil)
+			assert.NoError(m.t, err, "Failed to reply to keepalive request")
+		}
+	default:
+		err := r.Reply(false, nil)
+		assert.NoError(m.t, err, "Failed to reply to unknown request")
+	}
+}
+
+func (m *mockHeartbeatInstance) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionContext, nch ssh.NewChannel) {
+	switch nch.ChannelType() {
+	case chanHeartbeat:
+		go m.handleHeartbeat(ctx, ccx.NetConn, ccx.ServerConn, nch)
+	default:
+		nch.Reject(ssh.UnknownChannelType, "rejected")
+	}
+}
+
+func (m *mockHeartbeatInstance) handleHeartbeat(ctx context.Context, conn net.Conn, _ *ssh.ServerConn, nch ssh.NewChannel) {
+	ch, req, err := nch.Accept()
+	assert.NoError(m.t, err, "Failed to accept channel")
+
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	apisshutils.DiscardChannelData(ch)
+	if ch != nil {
+		defer func() {
+			ch.Close()
+		}()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case r, ok := <-req:
+			if !ok || r == nil {
+				return
+			}
+			r.Reply(false, nil)
+		}
+	}
+}
+
+func setupMockServerAndAgent(t *testing.T, tt *testAgentTimeoutCase) (*mockHeartbeatInstance, Agent) {
+	t.Helper()
+	ctx := t.Context()
+	ca, err := apisshutils.MakeTestSSHCA()
+	require.NoError(t, err)
+	cert, err := apisshutils.MakeRealHostCert(ca)
+	require.NoError(t, err)
+
+	mock := &mockHeartbeatInstance{
+		t:                       t,
+		supportsGlobalKeepalive: tt.supportsGlobalKeepalive,
+	}
+
+	sshServer, err := sshutils.NewServer(
+		"test",
+		utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"},
+		mock,
+		sshutils.StaticHostSigners(cert),
+		sshutils.AuthMethods{NoClient: true},
+		sshutils.SetInsecureSkipHostValidation(),
+		sshutils.SetRequestHandler(mock),
+	)
+	require.NoError(t, err)
+
+	mock.sshServer = sshServer
+	require.NoError(t, sshServer.Start()) // Start here to obtain the port for the resolver.
+
+	priv, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.Ed25519)
+	require.NoError(t, err)
+
+	signer, err := ssh.NewSignerFromKey(priv)
+	require.NoError(t, err)
+
+	resolver := func(context.Context) (*utils.NetAddr, types.ProxyListenerMode, error) {
+		return utils.MustParseAddr(sshServer.Addr()), types.ProxyListenerMode_Multiplex, nil
+	}
+
+	pool, err := NewAgentPool(ctx, AgentPoolConfig{
+		Resolver:                 resolver,
+		Client:                   &mockLocalClusterClient{},
+		AccessPoint:              &fakeClient{caKey: ca.PublicKey()},
+		Cluster:                  "test",
+		AuthMethods:              []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostUUID:                 uuid.NewString(),
+		StaleConnTimeoutDisabled: tt.staleConnTimeoutDisabled,
+	})
+	require.NoError(t, err)
+
+	pool.runtimeConfig.keepAliveInterval = tt.keepAliveInterval
+	pool.runtimeConfig.keepAliveCount = tt.keepAliveCount
+
+	tracker, err := track.New(track.Config{ClusterName: "test"})
+	require.NoError(t, err)
+
+	lease := tracker.TryAcquire()
+	require.NotNil(t, lease)
+
+	agent, err := pool.newAgent(ctx, tracker, lease)
+	require.NoError(t, err)
+
+	return mock, agent
+}
+
+type testAgentTimeoutCase struct {
+	name                     string
+	supportsGlobalKeepalive  bool
+	staleConnTimeoutDisabled bool
+	keepAliveInterval        time.Duration
+	keepAliveCount           int
+	testFn                   func(*testing.T, *mockHeartbeatInstance, Agent, time.Duration, time.Duration)
+}
+
+// TestAgentTimeout runs an agent against a mock SSH server and ensures that
+// heartbeats time out as expected when the server does not respond.
+func TestAgentTimeout(t *testing.T) {
+	t.Parallel()
+	cases := []testAgentTimeoutCase{
+		{
+			name:                    "server supports V2",
+			supportsGlobalKeepalive: true,
+			keepAliveInterval:       100 * time.Millisecond,
+			keepAliveCount:          3,
+			testFn: func(t *testing.T, mock *mockHeartbeatInstance, a Agent, waitFor time.Duration, tick time.Duration) {
+				mock.ignoreKeepalives.Store(true)
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+					assert.Equal(collect, AgentClosed, a.GetState())
+				}, waitFor, tick, "Expected agent to enter disconnected state after keepalive timeout.")
+			},
+		},
+		{
+			name:                     "server supports V2 but env override set",
+			supportsGlobalKeepalive:  true,
+			staleConnTimeoutDisabled: true,
+			keepAliveInterval:        100 * time.Millisecond,
+			keepAliveCount:           3,
+
+			testFn: func(t *testing.T, mock *mockHeartbeatInstance, a Agent, waitFor time.Duration, tick time.Duration) {
+				mock.ignoreKeepalives.Store(true)
+				require.Never(t, func() bool {
+					return a.GetState() != AgentConnected
+				}, waitFor, tick, "Expected agent to remain connected.")
+			},
+		},
+		{
+			name:                    "server does not support V2",
+			supportsGlobalKeepalive: false,
+			keepAliveInterval:       100 * time.Millisecond,
+			keepAliveCount:          5,
+			testFn: func(t *testing.T, mock *mockHeartbeatInstance, a Agent, waitFor time.Duration, tick time.Duration) {
+				mock.ignoreKeepalives.Store(true)
+
+				require.Never(t, func() bool {
+					return a.GetState() != AgentConnected
+				}, waitFor, tick, "Expected agent to remain connected.")
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			mock, agent := setupMockServerAndAgent(t, &tt)
+			require.NoError(t, mock.Start())
+			t.Cleanup(func() { mock.Stop() })
+
+			require.NoError(t, agent.Start(ctx))
+			t.Cleanup(func() { mock.ignoreKeepalives.Store(false) })
+			t.Cleanup(func() { agent.Stop() })
+			defaultDisconnectTimeout := (tt.keepAliveInterval * time.Duration(tt.keepAliveCount+1))
+			defaultTickTime := tt.keepAliveInterval / 2
+
+			// Wait for at least the first keepalive to hit the server
+			require.Equal(t, AgentConnected, agent.GetState())
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				assert.GreaterOrEqual(collect, mock.keepaliveCounter.Load(), int64(1))
+			}, defaultDisconnectTimeout, defaultTickTime, "Expected at least 1 keepalive to be received.")
+			tt.testFn(t, mock, agent, defaultDisconnectTimeout, defaultTickTime)
+		})
+	}
+
 }

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -27,6 +27,8 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -140,6 +142,8 @@ type AgentPoolConfig struct {
 	LocalAuthAddresses []string
 	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
 	PROXYSigner multiplexer.PROXYHeaderSigner
+	// StaleConnTimeoutDisabled is true if connection timeouts are disabled.
+	StaleConnTimeoutDisabled bool
 }
 
 // CheckAndSetDefaults checks and sets defaults.
@@ -442,6 +446,22 @@ func (p *AgentPool) getStateCallback(agent Agent) AgentStateCallback {
 	}
 }
 
+// isHeartbeatTimeoutDisabledByEnv returns true if the TELEPORT_UNSTABLE_DISABLE_AGENT_STALE_CONN_TIMEOUT
+// environment variable is set.
+//
+// Either "yes" or a "truthy" value (as defined by [strconv.ParseBool]) are
+// considered true.
+func IsAgentStaleConnTimeoutDisabledByEnv() bool {
+	const envVar = "TELEPORT_UNSTABLE_DISABLE_AGENT_STALE_CONN_TIMEOUT"
+
+	if val := os.Getenv(envVar); val != "" {
+		b, _ := strconv.ParseBool(val)
+		return b || val == "yes"
+	}
+
+	return false
+}
+
 // newAgent creates a new agent instance.
 func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease *track.Lease) (Agent, error) {
 	addr, _, err := p.Resolver(ctx)
@@ -470,17 +490,19 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 	}
 
 	agent, err := newAgent(agentConfig{
-		addr:               *addr,
-		keepAlive:          p.runtimeConfig.keepAliveInterval,
-		sshDialer:          dialer,
-		transportHandler:   p,
-		versionGetter:      p,
-		tracker:            tracker,
-		lease:              lease,
-		clock:              p.Clock,
-		logger:             p.logger,
-		localAuthAddresses: p.LocalAuthAddresses,
-		proxySigner:        p.PROXYSigner,
+		addr:                     *addr,
+		keepAlive:                p.runtimeConfig.keepAliveInterval,
+		keepAliveCount:           p.runtimeConfig.keepAliveCount,
+		sshDialer:                dialer,
+		transportHandler:         p,
+		versionGetter:            p,
+		tracker:                  tracker,
+		lease:                    lease,
+		clock:                    p.Clock,
+		logger:                   p.logger,
+		localAuthAddresses:       p.LocalAuthAddresses,
+		proxySigner:              p.PROXYSigner,
+		staleConnTimeoutDisabled: p.StaleConnTimeoutDisabled,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -625,6 +647,9 @@ type agentPoolRuntimeConfig struct {
 	connectionCount int
 	// keepAliveInterval is the interval agents will send heartbeats at.
 	keepAliveInterval time.Duration
+	// keepAliveCount specifies the amount of missed ping heartbeats
+	// to wait for before declaring the connection as broken.
+	keepAliveCount int
 	// isRemoteCluster forces the agent pool to connect to all proxies
 	// regardless of the configured tunnel strategy.
 	isRemoteCluster bool
@@ -652,6 +677,7 @@ func newAgentPoolRuntimeConfig() *agentPoolRuntimeConfig {
 		connectionCount:    defaultAgentConnectionCount,
 		proxyListenerMode:  types.ProxyListenerMode_Separate,
 		keepAliveInterval:  defaults.KeepAliveInterval(),
+		keepAliveCount:     defaults.KeepAliveCountMax,
 		clock:              clockwork.NewRealClock(),
 	}
 }

--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -495,6 +495,9 @@ func (s *leafCluster) handleHeartbeat(ctx context.Context, conn *remoteConn, ch 
 			tm := s.clock.Now().UTC()
 			conn.setLastHeartbeat(tm)
 			go s.registerHeartbeat(tm)
+			if err := req.Reply(true, nil); err != nil {
+				pinglog.DebugContext(ctx, "Failed to respond to ping request", "remote_addr", logutils.StringerAttr(conn.conn.RemoteAddr()), "error", err)
+			}
 		case t := <-offlineThresholdTimer.C:
 			conn.markInvalid(trace.ConnectionProblem(nil, "no heartbeats for %v", s.offlineThreshold))
 

--- a/lib/reversetunnel/local_cluster.go
+++ b/lib/reversetunnel/local_cluster.go
@@ -862,6 +862,9 @@ func (s *localCluster) handleHeartbeat(ctx context.Context, rconn *remoteConn, c
 
 			rconn.setLastHeartbeat(s.clock.Now().UTC())
 			rconn.markValid()
+			if err := req.Reply(true, nil); err != nil {
+				log.DebugContext(ctx, "Failed to respond to ping request", "remote_addr", logutils.StringerAttr(rconn.conn.RemoteAddr()), "error", err)
+			}
 		case t := <-offlineThresholdTimer.Chan():
 			rconn.markInvalid(trace.ConnectionProblem(nil, "no heartbeats for %v", s.offlineThreshold))
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -261,6 +261,8 @@ func realNewAgentPool(ctx context.Context, cfg RemoteClusterTunnelManagerConfig,
 		Resolver:        reversetunnelclient.StaticResolver(addr, apitypes.ProxyListenerMode_Separate),
 		IsRemoteCluster: true,
 		PROXYSigner:     cfg.PROXYSigner,
+
+		StaleConnTimeoutDisabled: IsAgentStaleConnTimeoutDisabledByEnv(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "failed creating reverse tunnel pool for remote cluster %q at address %q: %v", cluster, addr, err)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -388,6 +388,7 @@ func NewServer(cfg Config) (reversetunnelclient.Server, error) {
 		sshutils.SetCiphers(cfg.Ciphers),
 		sshutils.SetKEXAlgorithms(cfg.KEXAlgorithms),
 		sshutils.SetMACAlgorithms(cfg.MACAlgorithms),
+		sshutils.SetRequestHandler(srv),
 		sshutils.SetFIPS(cfg.FIPS),
 		sshutils.SetClock(cfg.Clock),
 		sshutils.SetIngressReporter(ingress.Tunnel, cfg.IngressReporter),
@@ -406,6 +407,21 @@ func remoteClustersMap(rc []types.RemoteCluster) map[string]types.RemoteCluster 
 		out[rc[i].GetName()] = rc[i]
 	}
 	return out
+}
+
+// HandleRequest processes global out-of-band requests.
+//
+// Only supports [teleport.KeepAliveReqType] requests, all other requests are discarded.
+func (s *server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionContext, r *ssh.Request) {
+	switch r.Type {
+	case teleport.KeepAliveReqType:
+		r.Reply(false, nil)
+	default:
+		if err := r.Reply(false, nil); err != nil {
+			s.logger.WarnContext(ctx, "Failed to reply to ssh request", "request_type", r.Type, "error", err)
+		}
+		s.logger.DebugContext(ctx, "Discarding global request", "request_type", r.Type)
+	}
 }
 
 // disconnectClusters disconnects reverse tunnel connections from leaf clusters
@@ -693,7 +709,7 @@ func (s *server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 		}
 		//nolint:sloglint // message should be a constant but in this case we are creating it at runtime.
 		s.logger.WarnContext(ctx, msg)
-		s.rejectRequest(nch, ssh.ConnectionFailed, msg)
+		s.rejectRequest(nch, ssh.UnknownChannelType, msg)
 		return
 	}
 }

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -184,16 +184,17 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 	agentPool, err := reversetunnel.NewAgentPool(
 		process.ExitContext(),
 		reversetunnel.AgentPoolConfig{
-			Component:            teleport.ComponentDatabase,
-			HostUUID:             conn.HostID(),
-			Resolver:             tunnelAddrResolver,
-			Client:               conn.Client,
-			Server:               dbService,
-			AccessPoint:          conn.Client,
-			AuthMethods:          conn.ClientAuthMethods(),
-			Cluster:              clusterName,
-			FIPS:                 process.Config.FIPS,
-			ConnectedProxyGetter: proxyGetter,
+			Component:                teleport.ComponentDatabase,
+			HostUUID:                 conn.HostID(),
+			Resolver:                 tunnelAddrResolver,
+			Client:                   conn.Client,
+			Server:                   dbService,
+			AccessPoint:              conn.Client,
+			AuthMethods:              conn.ClientAuthMethods(),
+			Cluster:                  clusterName,
+			FIPS:                     process.Config.FIPS,
+			ConnectedProxyGetter:     proxyGetter,
+			StaleConnTimeoutDisabled: reversetunnel.IsAgentStaleConnTimeoutDisabledByEnv(),
 		})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -117,16 +117,17 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 		agentPool, err = reversetunnel.NewAgentPool(
 			process.ExitContext(),
 			reversetunnel.AgentPoolConfig{
-				Component:            teleport.ComponentWindowsDesktop,
-				HostUUID:             conn.HostID(),
-				Resolver:             conn.TunnelProxyResolver(),
-				Client:               conn.Client,
-				AccessPoint:          accessPoint,
-				AuthMethods:          conn.ClientAuthMethods(),
-				Cluster:              conn.ClusterName(),
-				Server:               shtl,
-				FIPS:                 process.Config.FIPS,
-				ConnectedProxyGetter: proxyGetter,
+				Component:                teleport.ComponentWindowsDesktop,
+				HostUUID:                 conn.HostID(),
+				Resolver:                 conn.TunnelProxyResolver(),
+				Client:                   conn.Client,
+				AccessPoint:              accessPoint,
+				AuthMethods:              conn.ClientAuthMethods(),
+				Cluster:                  conn.ClusterName(),
+				Server:                   shtl,
+				FIPS:                     process.Config.FIPS,
+				ConnectedProxyGetter:     proxyGetter,
+				StaleConnTimeoutDisabled: reversetunnel.IsAgentStaleConnTimeoutDisabledByEnv(),
 			})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -132,16 +132,17 @@ func (process *TeleportProcess) initKubernetesService(logger *slog.Logger, conn 
 		agentPool, err = reversetunnel.NewAgentPool(
 			process.ExitContext(),
 			reversetunnel.AgentPoolConfig{
-				Component:            teleport.ComponentKube,
-				HostUUID:             conn.HostID(),
-				Resolver:             conn.TunnelProxyResolver(),
-				Client:               conn.Client,
-				AccessPoint:          accessPoint,
-				AuthMethods:          conn.ClientAuthMethods(),
-				Cluster:              teleportClusterName,
-				Server:               shtl,
-				FIPS:                 process.Config.FIPS,
-				ConnectedProxyGetter: proxyGetter,
+				Component:                teleport.ComponentKube,
+				HostUUID:                 conn.HostID(),
+				Resolver:                 conn.TunnelProxyResolver(),
+				Client:                   conn.Client,
+				AccessPoint:              accessPoint,
+				AuthMethods:              conn.ClientAuthMethods(),
+				Cluster:                  teleportClusterName,
+				Server:                   shtl,
+				FIPS:                     process.Config.FIPS,
+				ConnectedProxyGetter:     proxyGetter,
+				StaleConnTimeoutDisabled: reversetunnel.IsAgentStaleConnTimeoutDisabledByEnv(),
 			})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3623,16 +3623,17 @@ func (process *TeleportProcess) initSSH() error {
 			agentPool, err = reversetunnel.NewAgentPool(
 				process.ExitContext(),
 				reversetunnel.AgentPoolConfig{
-					Component:            teleport.ComponentNode,
-					HostUUID:             conn.HostID(),
-					Resolver:             conn.TunnelProxyResolver(),
-					Client:               conn.Client,
-					AccessPoint:          authClient,
-					AuthMethods:          conn.ClientAuthMethods(),
-					Cluster:              conn.ClusterName(),
-					Server:               serverHandler,
-					FIPS:                 process.Config.FIPS,
-					ConnectedProxyGetter: proxyGetter,
+					Component:                teleport.ComponentNode,
+					HostUUID:                 conn.HostID(),
+					Resolver:                 conn.TunnelProxyResolver(),
+					Client:                   conn.Client,
+					AccessPoint:              authClient,
+					AuthMethods:              conn.ClientAuthMethods(),
+					Cluster:                  conn.ClusterName(),
+					Server:                   serverHandler,
+					FIPS:                     process.Config.FIPS,
+					ConnectedProxyGetter:     proxyGetter,
+					StaleConnTimeoutDisabled: reversetunnel.IsAgentStaleConnTimeoutDisabledByEnv(),
 				})
 			if err != nil {
 				return trace.Wrap(err)
@@ -6768,16 +6769,17 @@ func (process *TeleportProcess) initApps() {
 		agentPool, err := reversetunnel.NewAgentPool(
 			process.ExitContext(),
 			reversetunnel.AgentPoolConfig{
-				Component:            teleport.ComponentApp,
-				HostUUID:             conn.HostID(),
-				Resolver:             tunnelAddrResolver,
-				Client:               conn.Client,
-				Server:               appServer,
-				AccessPoint:          accessPoint,
-				AuthMethods:          conn.ClientAuthMethods(),
-				Cluster:              clusterName,
-				FIPS:                 process.Config.FIPS,
-				ConnectedProxyGetter: proxyGetter,
+				Component:                teleport.ComponentApp,
+				HostUUID:                 conn.HostID(),
+				Resolver:                 tunnelAddrResolver,
+				Client:                   conn.Client,
+				Server:                   appServer,
+				AccessPoint:              accessPoint,
+				AuthMethods:              conn.ClientAuthMethods(),
+				Cluster:                  clusterName,
+				FIPS:                     process.Config.FIPS,
+				ConnectedProxyGetter:     proxyGetter,
+				StaleConnTimeoutDisabled: reversetunnel.IsAgentStaleConnTimeoutDisabledByEnv(),
 			})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1361,10 +1361,8 @@ func (s *Server) HandleRequest(ctx context.Context, ccx *sshutils.ConnectionCont
 		}
 		return
 	default:
-		if r.WantReply {
-			if err := r.Reply(false, nil); err != nil {
-				s.logger.WarnContext(ctx, "Failed to reply to ssh request", "request_type", r.Type, "error", err)
-			}
+		if err := r.Reply(false, nil); err != nil {
+			s.logger.WarnContext(ctx, "Failed to reply to ssh request", "request_type", r.Type, "error", err)
 		}
 		s.logger.DebugContext(ctx, "Discarding global request", "request_type", r.Type)
 	}


### PR DESCRIPTION
This commit introduces a watchdog mechanism to agent side ssh connections, allowing
the agent to detect stale connections and reconnect when needed.

The reverse tunnel server will now respond to keep alive messages as a out of band request, which the client will start sending to detect the health of the connection. This watchdog is only enabled if the server successfully responds to the first request, otherwise the agent will await a response until the connection is dropped. This way we do not require extra
feature detection on the agent side. 

The agent mirrors the server side behaviour and calculates the watchdog to be:
`keepAlive * keepAliveCount`,

The agent behaviour can be disabled by setting `TELEPORT_UNSTABLE_DISABLE_AGENT_STALE_CONN_TIMEOUT` to `yes`
or other truthy value.

This change also adds missing replies to ping messages where appropriate. Note that internally `r.Reply` checks the `WantReply` field. 

Testplan:
* [x] Manually test happy path locally.
* [x] Manually verify backwards compatibility.
* [x] Manually verify remote clusters work correctly including backwards compatibility. 

Changelog: Adds support for reverse tunnel agent stale connection timeout detection and recovery.