### PR TITLE
Split clusters in generated `kubeconfig` files

### DIFF
--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -237,9 +237,13 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 			// tsh does) that the profile name is exactly the same as the
 			// hostname of the Proxy web address, and it would be more correct
 			// to update every callsite to also pass the profile name
-			profileName, err := utils.Host(v.ProxyAddr)
-			if err != nil {
-				profileName = v.ProxyAddr
+			var profileName string
+			if v.ProxyAddr != "" {
+				p, err := utils.Host(v.ProxyAddr)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				profileName = p
 			}
 			if profileName != "" {
 				setStringExtensionInCluster(config.Clusters[contextName], extProfileName, profileName)
@@ -311,9 +315,13 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 				setStringExtensionInAuthInfo(config.AuthInfos[contextName], extKubeClusterName, kubeClusterName)
 			}
 
-			profileName, err := utils.Host(v.ProxyAddr)
-			if err != nil {
-				profileName = v.ProxyAddr
+			var profileName string
+			if v.ProxyAddr != "" {
+				p, err := utils.Host(v.ProxyAddr)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				profileName = p
 			}
 			if profileName != "" {
 				setStringExtensionInCluster(config.Clusters[contextName], extProfileName, profileName)

--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -22,6 +22,7 @@ package kubeconfig
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"os"
@@ -42,9 +43,24 @@ import (
 var log = logutils.NewPackageLogger(teleport.ComponentKey, teleport.ComponentKubeClient)
 
 const (
-	// teleportKubeClusterNameExtension is the name of the extension that
-	// contains the Teleport Kube cluster name.
-	teleportKubeClusterNameExtension = "teleport.kube.name"
+	// extKubeClusterName is the name of the extension that contains the
+	// Teleport Kube cluster name. Its associated value is a string.
+	extKubeClusterName = "teleport.kube.name"
+
+	// extTeleClusterName is the name of the extension that contains the
+	// Teleport cluster name. Its associated value is a string.
+	extTeleClusterName = "kubeconfig.teleport.dev/teleport-cluster-name"
+
+	// extProfileName is the name of the extension that contains the name of the
+	// profile that should be used to connect to the Kube cluster. Its
+	// associated value is a string.
+	extProfileName = "kubeconfig.teleport.dev/profile-name"
+
+	// extPreviousSelectedContext is the name of the extension that signals a
+	// context that was set as the current context before the Teleport client
+	// set a different context as the current context. Its associated value is
+	// written as a null and it's never read.
+	extPreviousSelectedContext = "teleport-prev-selec-ctx"
 )
 
 // Values are Teleport user data needed to generate kubeconfig entries.
@@ -163,15 +179,9 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 	if len(cas) == 0 {
 		return trace.BadParameter("TLS trusted CAs missing in provided credentials")
 	}
-	config.Clusters[v.TeleportClusterName] = &clientcmdapi.Cluster{
-		Server:                   v.ClusterAddr,
-		CertificateAuthorityData: cas,
-		TLSServerName:            v.TLSServerName,
-	}
 
 	if v.Exec != nil {
 		// Called from tsh, use the exec plugin model.
-		clusterName := v.TeleportClusterName
 		envVars := make([]clientcmdapi.ExecEnvVar, 0, len(v.Exec.Env))
 		if v.Exec.Env != nil {
 			for name, value := range v.Exec.Env {
@@ -181,7 +191,6 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 
 		for _, c := range v.KubeClusters {
 			contextName := ContextName(v.TeleportClusterName, c)
-			authName := contextName
 			if contextTmpl != nil {
 				if contextName, err = executeKubeContextTemplate(contextTmpl, v.TeleportClusterName, c); err != nil {
 					return trace.Wrap(err)
@@ -210,9 +219,36 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 			if len(envVars) > 0 {
 				authInfo.Exec.Env = envVars
 			}
-			config.AuthInfos[authName] = authInfo
+			config.AuthInfos[contextName] = authInfo
 
-			setContext(config.Contexts, contextName, clusterName, authName, c, v.Namespace)
+			setStringExtensionInAuthInfo(config.AuthInfos[contextName], extTeleClusterName, v.TeleportClusterName)
+			setStringExtensionInAuthInfo(config.AuthInfos[contextName], extKubeClusterName, c)
+
+			config.Clusters[contextName] = &clientcmdapi.Cluster{
+				Server:                   v.ClusterAddr,
+				CertificateAuthorityData: cas,
+				TLSServerName:            v.TLSServerName,
+			}
+
+			setStringExtensionInCluster(config.Clusters[contextName], extTeleClusterName, v.TeleportClusterName)
+			setStringExtensionInCluster(config.Clusters[contextName], extKubeClusterName, c)
+
+			// XXX(espadolini): this assumes (as just about everything in
+			// tsh does) that the profile name is exactly the same as the
+			// hostname of the Proxy web address, and it would be more correct
+			// to update every callsite to also pass the profile name
+			profileName, err := utils.Host(v.ProxyAddr)
+			if err != nil {
+				profileName = v.ProxyAddr
+			}
+			if profileName != "" {
+				setStringExtensionInCluster(config.Clusters[contextName], extProfileName, profileName)
+				setStringExtensionInAuthInfo(config.AuthInfos[contextName], extProfileName, profileName)
+			}
+
+			clusterName := contextName
+			authName := contextName
+			setContext(config.Contexts, contextName, clusterName, authName, profileName, v.TeleportClusterName, c, v.Namespace)
 		}
 		if v.SelectCluster != "" {
 			contextName := ContextName(v.TeleportClusterName, v.SelectCluster)
@@ -236,12 +272,11 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 			return trace.BadParameter("Multi-cluster mode not supported when using Credentials")
 		}
 
-		clusterName := v.TeleportClusterName
-		contextName := clusterName
+		contextName := v.TeleportClusterName
 		var kubeClusterName string
 		if len(v.KubeClusters) == 1 {
 			kubeClusterName = v.KubeClusters[0]
-			contextName = ContextName(clusterName, kubeClusterName)
+			contextName = ContextName(v.TeleportClusterName, kubeClusterName)
 		}
 
 		// Called when generating an identity file, use plaintext credentials.
@@ -261,7 +296,33 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 				ClientCertificateData: v.Credentials.TLSCert,
 				ClientKeyData:         keyPEM,
 			}
-			setContext(config.Contexts, contextName, clusterName, contextName, kubeClusterName, v.Namespace)
+
+			config.Clusters[contextName] = &clientcmdapi.Cluster{
+				Server:                   v.ClusterAddr,
+				CertificateAuthorityData: cas,
+				TLSServerName:            v.TLSServerName,
+			}
+
+			setStringExtensionInCluster(config.Clusters[contextName], extTeleClusterName, v.TeleportClusterName)
+			setStringExtensionInAuthInfo(config.AuthInfos[contextName], extTeleClusterName, v.TeleportClusterName)
+
+			if kubeClusterName != "" {
+				setStringExtensionInCluster(config.Clusters[contextName], extKubeClusterName, kubeClusterName)
+				setStringExtensionInAuthInfo(config.AuthInfos[contextName], extKubeClusterName, kubeClusterName)
+			}
+
+			profileName, err := utils.Host(v.ProxyAddr)
+			if err != nil {
+				profileName = v.ProxyAddr
+			}
+			if profileName != "" {
+				setStringExtensionInCluster(config.Clusters[contextName], extProfileName, profileName)
+				setStringExtensionInAuthInfo(config.AuthInfos[contextName], extProfileName, profileName)
+			}
+
+			authName := contextName
+			clusterName := contextName
+			setContext(config.Contexts, contextName, clusterName, authName, profileName, v.TeleportClusterName, kubeClusterName, v.Namespace)
 			setSelectedExtension(config.Contexts, config.CurrentContext, clusterName)
 			config.CurrentContext = contextName
 		} else if !trace.IsBadParameter(err) {
@@ -270,10 +331,29 @@ func UpdateConfig(path string, v Values, storeAllCAs bool, fs ConfigFS) error {
 		log.WarnContext(context.Background(), "Kubernetes integration is not supported when logging in with a hardware private key", "error", err)
 	}
 
+	// kubeconfig files generated by older versions of Teleport might use a
+	// single cluster with the same name as the Teleport cluster for all
+	// contexts, and we can't unconditionally delete it because there might be
+	// contexts that we haven't modified here that still use it (and it might in
+	// fact be used by the single-cluster mode if there's no kube cluster name
+	// available)
+	if _, legacyClusterExists := config.Clusters[v.TeleportClusterName]; legacyClusterExists {
+		var inUse bool
+		for _, context := range config.Contexts {
+			if context.Cluster == v.TeleportClusterName {
+				inUse = true
+				break
+			}
+		}
+		if !inUse {
+			delete(config.Clusters, v.TeleportClusterName)
+		}
+	}
+
 	return SaveConfig(path, *config, fs)
 }
 
-func setContext(contexts map[string]*clientcmdapi.Context, name, cluster, auth, kubeName, namespace string) {
+func setContext(contexts map[string]*clientcmdapi.Context, name, cluster, auth, profileName, teleportClusterName, kubeClusterName, namespace string) {
 	lastContext := contexts[name]
 	newContext := &clientcmdapi.Context{
 		Cluster:  cluster,
@@ -284,14 +364,14 @@ func setContext(contexts map[string]*clientcmdapi.Context, name, cluster, auth, 
 		newContext.Extensions = lastContext.Extensions
 	}
 
-	if newContext.Extensions == nil {
-		newContext.Extensions = make(map[string]runtime.Object)
+	if teleportClusterName != "" {
+		setStringExtensionInContext(newContext, extTeleClusterName, teleportClusterName)
 	}
-	if kubeName != "" {
-		newContext.Extensions[teleportKubeClusterNameExtension] = &runtime.Unknown{
-			// We need to wrap the kubeName in quotes to make sure it is parsed as a string.
-			Raw: fmt.Appendf(nil, "%q", kubeName),
-		}
+	if kubeClusterName != "" {
+		setStringExtensionInContext(newContext, extKubeClusterName, kubeClusterName)
+	}
+	if profileName != "" {
+		setStringExtensionInContext(newContext, extProfileName, profileName)
 	}
 
 	// If a user specifies the default namespace we should override it.
@@ -303,66 +383,91 @@ func setContext(contexts map[string]*clientcmdapi.Context, name, cluster, auth, 
 	contexts[name] = newContext
 }
 
-// RemoveByClusterName removes Teleport configuration from kubeconfig.
+// RemoveByProfileName removes Teleport configuration from the kubeconfig file
+// for a given profile.
 //
-// If `path` is empty, RemoveByClusterName will try to guess it based on the environment or
-// known defaults.
-func RemoveByClusterName(path, clusterName string) error {
+// If `path` is empty, RemoveByProfileName will try to guess it based on the
+// environment or known defaults.
+func RemoveByProfileName(path, profileName string) error {
 	// Load existing kubeconfig from disk.
 	config, err := Load(path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	removeByClusterName(config, clusterName)
+	removeByProfileName(config, profileName)
 
 	// Update kubeconfig on disk.
 	return trace.Wrap(Save(path, *config))
 }
 
-func removeByClusterName(config *clientcmdapi.Config, clusterName string) {
-	// Remove Teleport related AuthInfos, Clusters, and Contexts from kubeconfig.
-	maps.DeleteFunc(
-		config.Contexts,
-		func(key string, val *clientcmdapi.Context) bool {
-			if !strings.HasPrefix(key, clusterName) && val.Cluster != clusterName {
-				return false
-			}
-			delete(config.AuthInfos, val.AuthInfo)
-			delete(config.Clusters, val.Cluster)
-			return true
-		},
-	)
-	prevSelectedCluster := searchForSelectedCluster(config.Contexts)
-	// Take an element from the list of contexts and make it the current
-	// context, unless current context points to something else.
-	if strings.HasPrefix(config.CurrentContext, clusterName) {
-		config.CurrentContext = prevSelectedCluster
+func removeByProfileName(config *clientcmdapi.Config, profileName string) {
+	maps.DeleteFunc(config.Clusters, func(k string, v *clientcmdapi.Cluster) bool {
+		n, ok := getStringExtensionFromCluster(v, extProfileName)
+		return ok && n == profileName
+	})
+	maps.DeleteFunc(config.AuthInfos, func(k string, v *clientcmdapi.AuthInfo) bool {
+		n, ok := getStringExtensionFromAuthInfo(v, extProfileName)
+		return ok && n == profileName
+	})
+	maps.DeleteFunc(config.Contexts, func(k string, v *clientcmdapi.Context) bool {
+		n, ok := getStringExtensionFromContext(v, extProfileName)
+		return ok && n == profileName
+	})
+
+	if config.CurrentContext != "" {
+		if _, ok := config.Contexts[config.CurrentContext]; !ok {
+			// we shouldn't leave a deleted context as the current context, so
+			// we'll try restoring the context that was selected before we
+			// started updating the file or we blank it
+			config.CurrentContext = searchForSelectedCluster(config.Contexts)
+		}
 	}
 }
 
-// RemoveByServerAddr removes all clusters with the provided server address
-// from kubeconfig
+// RemoveByServerAddr removes all clusters with the provided server address from
+// kubeconfig, all contexts using said clusters, and all authinfos referenced by
+// those clusters.
 //
 // If `path` is empty, RemoveByServerAddr will try to guess it based on the
 // environment or known defaults.
-func RemoveByServerAddr(path, wantServer string) error {
+func RemoveByServerAddr(path, serverAddr string) error {
 	// Load existing kubeconfig from disk.
 	config, err := Load(path)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	removeByServerAddr(config, wantServer)
+	removeByServerAddr(config, serverAddr)
 
 	// Update kubeconfig on disk.
 	return trace.Wrap(Save(path, *config))
 }
 
-func removeByServerAddr(config *clientcmdapi.Config, wantServer string) {
+func removeByServerAddr(config *clientcmdapi.Config, serverAddr string) {
 	for clusterName, cluster := range config.Clusters {
-		if cluster.Server == wantServer {
-			removeByClusterName(config, clusterName)
+		if cluster.Server != serverAddr {
+			continue
+		}
+
+		delete(config.Clusters, clusterName)
+
+		for contextName, context := range config.Contexts {
+			if context.Cluster != clusterName {
+				continue
+			}
+
+			delete(config.AuthInfos, context.AuthInfo)
+			delete(config.Contexts, contextName)
+		}
+	}
+
+	if config.CurrentContext != "" {
+		if _, ok := config.Contexts[config.CurrentContext]; !ok {
+			// we shouldn't leave a deleted context as the current context, so
+			// we'll try restoring the context that was selected before we
+			// started updating the file or we blank it
+			config.CurrentContext = searchForSelectedCluster(config.Contexts)
 		}
 	}
 }
@@ -498,59 +603,117 @@ func PathFromEnv() string {
 	return configPath
 }
 
-// ContextName returns a kubeconfig context name generated by this package.
+// ContextName returns a kubeconfig context name generated by this package if no
+// template override is provided by the user.
 func ContextName(teleportCluster, kubeCluster string) string {
-	return fmt.Sprintf("%s-%s", teleportCluster, kubeCluster)
+	return teleportCluster + "-" + kubeCluster
 }
 
-// KubeClusterFromContext extracts the kubernetes cluster name from context
-// name generated by this package.
-func KubeClusterFromContext(contextName string, ctx *clientcmdapi.Context, teleportCluster string) string {
-	switch {
-	// If the context name starts with teleport cluster name, it was
-	// generated by tsh.
-	case strings.HasPrefix(contextName, teleportCluster+"-"):
-		return strings.TrimPrefix(contextName, teleportCluster+"-")
-		// If the context cluster matches teleport cluster, it was generated by
-		// tsh using --set-context-override flag.
-	case ctx != nil && ctx.Cluster == teleportCluster:
-		if v, ok := ctx.Extensions[teleportKubeClusterNameExtension]; ok {
-			if raw, ok := v.(*runtime.Unknown); ok && trimQuotes(string(raw.Raw)) != "" {
-				// The value is a JSON string, so we need to trim the quotes.
-				return trimQuotes(string(raw.Raw))
-			}
+// KubeClusterFromContext extracts the kubernetes cluster name from a kubeconfig
+// context generated by this package.
+func KubeClusterFromContext(contextName string, context *clientcmdapi.Context, teleportClusterName string) string {
+	if context == nil {
+		// we only have a context name available; assume the default format for
+		// context names because we can't do much else
+		if suffix, found := strings.CutPrefix(contextName, teleportClusterName+"-"); found {
+			return suffix
 		}
-		return contextName
-	default:
 		return ""
 	}
-}
 
-func trimQuotes(s string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(s, "\""), "\"")
-}
+	extTeleClusterName, hasExtTeleCluster := getStringExtensionFromContext(context, extTeleClusterName)
+	extKubeClusterName, hasExtKubeCluster := getStringExtensionFromContext(context, extKubeClusterName)
 
-// SelectContext switches the active kubeconfig context to point to the
-// provided kubeCluster in teleportCluster.
-func SelectContext(teleportCluster, kubeCluster string) error {
-	kc, err := Load("")
-	if err != nil {
-		return trace.Wrap(err)
+	if hasExtTeleCluster && hasExtKubeCluster && extTeleClusterName == teleportClusterName {
+		return extKubeClusterName
 	}
 
-	kubeContext := ContextName(teleportCluster, kubeCluster)
-	if _, ok := kc.Contexts[kubeContext]; !ok {
-		return trace.NotFound("kubeconfig context %q not found", kubeContext)
+	// older kubeconfig files produced by this package used the Teleport cluster
+	// name as the name of the cluster
+	if context.Cluster == teleportClusterName {
+		if hasExtKubeCluster {
+			return extKubeClusterName
+		}
+		contextName, _ := strings.CutPrefix(contextName, teleportClusterName+"-")
+		return contextName
 	}
-	setSelectedExtension(kc.Contexts, kc.CurrentContext, teleportCluster)
-	kc.CurrentContext = kubeContext
-	if err := Save("", *kc); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
+
+	return ""
 }
 
-const selectedExtension = "teleport-prev-selec-ctx"
+func jsonMarshalString(s string) []byte {
+	// this will encode invalid utf8 bytes as U+FFFD, but it is otherwise infallible
+	j, _ := json.Marshal(s)
+	return j
+}
+
+func getStringExtensionFromContext(context *clientcmdapi.Context, extName string) (string, bool) {
+	if context == nil {
+		return "", false
+	}
+	return getStringExtensionFromExtensionsMap(context.Extensions, extName)
+}
+func getStringExtensionFromCluster(cluster *clientcmdapi.Cluster, extName string) (string, bool) {
+	if cluster == nil {
+		return "", false
+	}
+	return getStringExtensionFromExtensionsMap(cluster.Extensions, extName)
+}
+func getStringExtensionFromAuthInfo(authInfo *clientcmdapi.AuthInfo, extName string) (string, bool) {
+	if authInfo == nil {
+		return "", false
+	}
+	return getStringExtensionFromExtensionsMap(authInfo.Extensions, extName)
+}
+func getStringExtensionFromExtensionsMap(extensions map[string]runtime.Object, extName string) (string, bool) {
+	rawExt, _ := extensions[extName].(*runtime.Unknown)
+	if rawExt == nil {
+		return "", false
+	}
+
+	var s string
+	if err := json.Unmarshal(rawExt.Raw, &s); err != nil {
+		return "", false
+	}
+
+	return s, true
+}
+
+func setStringExtensionInContext(context *clientcmdapi.Context, extName, extVal string) {
+	if context == nil {
+		return
+	}
+	if context.Extensions == nil {
+		context.Extensions = make(map[string]runtime.Object)
+	}
+	setStringExtensionInExtensionsMap(context.Extensions, extName, extVal)
+}
+func setStringExtensionInCluster(cluster *clientcmdapi.Cluster, extName, extVal string) {
+	if cluster == nil {
+		return
+	}
+	if cluster.Extensions == nil {
+		cluster.Extensions = make(map[string]runtime.Object)
+	}
+	setStringExtensionInExtensionsMap(cluster.Extensions, extName, extVal)
+}
+func setStringExtensionInAuthInfo(authInfo *clientcmdapi.AuthInfo, extName, extVal string) {
+	if authInfo == nil {
+		return
+	}
+	if authInfo.Extensions == nil {
+		authInfo.Extensions = make(map[string]runtime.Object)
+	}
+	setStringExtensionInExtensionsMap(authInfo.Extensions, extName, extVal)
+}
+func setStringExtensionInExtensionsMap(extensions map[string]runtime.Object, extName, extVal string) {
+	if extensions == nil {
+		return
+	}
+	extensions[extName] = &runtime.Unknown{
+		Raw: jsonMarshalString(extVal),
+	}
+}
 
 // setSelectedExtension sets an extension to indentify that the current non-teleport
 // context was selected before introducing Teleport contexts in kubeconfig.
@@ -563,14 +726,16 @@ const selectedExtension = "teleport-prev-selec-ctx"
 // this function deletes it and introduces it in the desired context.
 func setSelectedExtension(contexts map[string]*clientcmdapi.Context, prevCluster string, teleportCluster string) {
 	selected, ok := contexts[prevCluster]
-	if !ok || strings.HasPrefix(prevCluster, teleportCluster) || len(prevCluster) == 0 {
+	if !ok || strings.HasPrefix(prevCluster, teleportCluster+"-") || prevCluster == "" {
 		return
 	}
 	for _, v := range contexts {
-		delete(v.Extensions, selectedExtension)
+		delete(v.Extensions, extPreviousSelectedContext)
 	}
-
-	selected.Extensions[selectedExtension] = nil
+	if selected.Extensions == nil {
+		selected.Extensions = make(map[string]runtime.Object)
+	}
+	selected.Extensions[extPreviousSelectedContext] = nil
 }
 
 // searchForSelectedCluster looks for contexts that were previously selected
@@ -581,8 +746,8 @@ func searchForSelectedCluster(contexts map[string]*clientcmdapi.Context) string 
 	count := 0
 	selected := ""
 	for k, v := range contexts {
-		if _, ok := v.Extensions[selectedExtension]; ok {
-			delete(v.Extensions, selectedExtension)
+		if _, ok := v.Extensions[extPreviousSelectedContext]; ok {
+			delete(v.Extensions, extPreviousSelectedContext)
 			count++
 			selected = k
 		}

--- a/lib/kube/kubeconfig/kubeconfig_test.go
+++ b/lib/kube/kubeconfig/kubeconfig_test.go
@@ -184,25 +184,40 @@ func TestUpdate(t *testing.T) {
 
 	wantConfig := initialConfig.DeepCopy()
 	wantConfig.Contexts[wantConfig.CurrentContext].Extensions = map[string]runtime.Object{
-		selectedExtension: nil,
+		extPreviousSelectedContext: nil,
 	}
 	wantConfig.Clusters[clusterName] = &clientcmdapi.Cluster{
 		Server:                   clusterAddr,
 		CertificateAuthorityData: caCertPEM,
 		LocationOfOrigin:         kubeconfigPath,
-		Extensions:               map[string]runtime.Object{},
+		Extensions: map[string]runtime.Object{
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+		},
 	}
 	wantConfig.AuthInfos[clusterName] = &clientcmdapi.AuthInfo{
 		ClientCertificateData: creds.TLSCert,
 		ClientKeyData:         creds.TLSPrivateKey.PrivateKeyPEM(),
 		LocationOfOrigin:      kubeconfigPath,
-		Extensions:            map[string]runtime.Object{},
+		Extensions: map[string]runtime.Object{
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+		},
 	}
 	wantConfig.Contexts[clusterName] = &clientcmdapi.Context{
 		Cluster:          clusterName,
 		AuthInfo:         clusterName,
 		LocationOfOrigin: kubeconfigPath,
-		Extensions:       map[string]runtime.Object{},
+		Extensions: map[string]runtime.Object{
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+		},
 	}
 	wantConfig.CurrentContext = clusterName
 
@@ -289,19 +304,37 @@ func TestUpdateWithExec(t *testing.T) {
 
 			wantConfig := initialConfig.DeepCopy()
 			contextName := ContextName(clusterName, kubeCluster)
-			authInfoName := contextName
 			if tt.overrideContextName != "" {
 				contextName = tt.overrideContextName
 			}
-			wantConfig.Clusters[clusterName] = &clientcmdapi.Cluster{
+			authAndClusterName := contextName
+			wantConfig.Clusters[authAndClusterName] = &clientcmdapi.Cluster{
 				Server:                   clusterAddr,
 				CertificateAuthorityData: caCertPEM,
 				LocationOfOrigin:         kubeconfigPath,
-				Extensions:               map[string]runtime.Object{},
+				Extensions: map[string]runtime.Object{
+					extTeleClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + clusterName + `"`),
+						ContentType: "application/json",
+					},
+					extKubeClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + kubeCluster + `"`),
+						ContentType: "application/json",
+					},
+				},
 			}
-			wantConfig.AuthInfos[authInfoName] = &clientcmdapi.AuthInfo{
-				LocationOfOrigin:  kubeconfigPath,
-				Extensions:        map[string]runtime.Object{},
+			wantConfig.AuthInfos[authAndClusterName] = &clientcmdapi.AuthInfo{
+				LocationOfOrigin: kubeconfigPath,
+				Extensions: map[string]runtime.Object{
+					extTeleClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + clusterName + `"`),
+						ContentType: "application/json",
+					},
+					extKubeClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + kubeCluster + `"`),
+						ContentType: "application/json",
+					},
+				},
 				Impersonate:       tt.impersonatedUser,
 				ImpersonateGroups: tt.impersonatedGroups,
 				Exec: &clientcmdapi.ExecConfig{
@@ -317,12 +350,16 @@ func TestUpdateWithExec(t *testing.T) {
 				},
 			}
 			wantConfig.Contexts[contextName] = &clientcmdapi.Context{
-				Cluster:          clusterName,
-				AuthInfo:         authInfoName,
+				Cluster:          contextName,
+				AuthInfo:         contextName,
 				LocationOfOrigin: kubeconfigPath,
 				Extensions: map[string]runtime.Object{
-					teleportKubeClusterNameExtension: &runtime.Unknown{
-						Raw:         fmt.Appendf(nil, "%q", kubeCluster),
+					extTeleClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + clusterName + `"`),
+						ContentType: "application/json",
+					},
+					extKubeClusterName: &runtime.Unknown{
+						Raw:         []byte(`"` + kubeCluster + `"`),
 						ContentType: "application/json",
 					},
 				},
@@ -340,7 +377,8 @@ func TestUpdateWithExecAndProxy(t *testing.T) {
 	const (
 		clusterName = "teleport-cluster"
 		clusterAddr = "https://1.2.3.6:3080"
-		proxy       = "my-teleport-proxy:3080"
+		proxyHost   = "my-teleport-proxy"
+		proxy       = proxyHost + ":3080"
 		tshPath     = "/path/to/tsh"
 		kubeCluster = "my-cluster"
 		homeEnvVar  = "TELEPORT_HOME"
@@ -366,15 +404,41 @@ func TestUpdateWithExecAndProxy(t *testing.T) {
 
 	wantConfig := initialConfig.DeepCopy()
 	contextName := ContextName(clusterName, kubeCluster)
-	wantConfig.Clusters[clusterName] = &clientcmdapi.Cluster{
+	wantConfig.Clusters[contextName] = &clientcmdapi.Cluster{
 		Server:                   clusterAddr,
 		CertificateAuthorityData: caCertPEM,
 		LocationOfOrigin:         kubeconfigPath,
-		Extensions:               map[string]runtime.Object{},
+		Extensions: map[string]runtime.Object{
+			extProfileName: &runtime.Unknown{
+				Raw:         []byte(`"` + proxyHost + `"`),
+				ContentType: "application/json",
+			},
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+			extKubeClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + kubeCluster + `"`),
+				ContentType: "application/json",
+			},
+		},
 	}
 	wantConfig.AuthInfos[contextName] = &clientcmdapi.AuthInfo{
 		LocationOfOrigin: kubeconfigPath,
-		Extensions:       map[string]runtime.Object{},
+		Extensions: map[string]runtime.Object{
+			extProfileName: &runtime.Unknown{
+				Raw:         []byte(`"` + proxyHost + `"`),
+				ContentType: "application/json",
+			},
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+			extKubeClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + kubeCluster + `"`),
+				ContentType: "application/json",
+			},
+		},
 		Exec: &clientcmdapi.ExecConfig{
 			APIVersion: "client.authentication.k8s.io/v1beta1",
 			Command:    tshPath,
@@ -389,12 +453,20 @@ func TestUpdateWithExecAndProxy(t *testing.T) {
 		},
 	}
 	wantConfig.Contexts[contextName] = &clientcmdapi.Context{
-		Cluster:          clusterName,
+		Cluster:          contextName,
 		AuthInfo:         contextName,
 		LocationOfOrigin: kubeconfigPath,
 		Extensions: map[string]runtime.Object{
-			teleportKubeClusterNameExtension: &runtime.Unknown{
-				Raw:         fmt.Appendf(nil, "%q", kubeCluster),
+			extProfileName: &runtime.Unknown{
+				Raw:         []byte(`"` + proxyHost + `"`),
+				ContentType: "application/json",
+			},
+			extTeleClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + clusterName + `"`),
+				ContentType: "application/json",
+			},
+			extKubeClusterName: &runtime.Unknown{
+				Raw:         []byte(`"` + kubeCluster + `"`),
 				ContentType: "application/json",
 			},
 		},
@@ -464,7 +536,7 @@ func TestRemoveByClusterName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove those generated entries from kubeconfig.
-	err = RemoveByClusterName(kubeconfigPath, clusterName)
+	err = RemoveByServerAddr(kubeconfigPath, clusterAddr)
 	require.NoError(t, err)
 
 	// Verify that kubeconfig changed back to the initial state.
@@ -485,8 +557,9 @@ func TestRemoveByClusterName(t *testing.T) {
 	}, false)
 	require.NoError(t, err)
 
-	// This time, explicitly switch CurrentContext to "prod".
-	// Remove should preserve this CurrentContext!
+	// This time, explicitly switch CurrentContext to "prod" as if the user did
+	// so by editing the config file or with "kubectl config set". Remove should
+	// preserve this CurrentContext!
 	config, err = Load(kubeconfigPath)
 	require.NoError(t, err)
 	config.CurrentContext = "prod"
@@ -494,7 +567,7 @@ func TestRemoveByClusterName(t *testing.T) {
 	require.NoError(t, err)
 
 	// Remove teleport-generated entries from kubeconfig.
-	err = RemoveByClusterName(kubeconfigPath, clusterName)
+	err = RemoveByServerAddr(kubeconfigPath, clusterAddr)
 	require.NoError(t, err)
 
 	wantConfig = initialConfig.DeepCopy()
@@ -502,6 +575,9 @@ func TestRemoveByClusterName(t *testing.T) {
 	// it above and Remove shouldn't touch it unless it matches the cluster
 	// being removed.
 	wantConfig.CurrentContext = "prod"
+	wantConfig.Contexts["dev"].Extensions = map[string]runtime.Object{
+		extPreviousSelectedContext: nil,
+	}
 	config, err = Load(kubeconfigPath)
 	require.NoError(t, err)
 	require.Equal(t, wantConfig, config)
@@ -616,7 +692,7 @@ func TestKubeClusterFromContext(t *testing.T) {
 			name: "context name is {teleport-cluster}-cluster name",
 			args: args{
 				contextName:     "telecluster-cluster1",
-				ctx:             &clientcmdapi.Context{Cluster: "cluster1"},
+				ctx:             &clientcmdapi.Context{Cluster: "telecluster"},
 				teleportCluster: "telecluster",
 			},
 			want: "cluster1",
@@ -637,8 +713,8 @@ func TestKubeClusterFromContext(t *testing.T) {
 				ctx: &clientcmdapi.Context{
 					Cluster: "telecluster",
 					Extensions: map[string]runtime.Object{
-						teleportKubeClusterNameExtension: &runtime.Unknown{
-							Raw: []byte("\"another\""),
+						extKubeClusterName: &runtime.Unknown{
+							Raw: []byte(`"another"`),
 						},
 					},
 				},

--- a/lib/kube/kubeconfig/localproxy.go
+++ b/lib/kube/kubeconfig/localproxy.go
@@ -169,6 +169,7 @@ func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, pro
 		}
 
 		if p, ok := getStringExtensionFromContext(context, extProfileName); ok {
+			// the context has the new extensions, no need to match by clusterAddr
 			if p != profileName {
 				continue
 			}
@@ -186,6 +187,8 @@ func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, pro
 			continue
 		}
 
+		// the context was created by an older version, match by clusterAddr and
+		// try to guess at the kube cluster name
 		if cluster.Server != clusterAddr {
 			continue
 		}

--- a/lib/kube/kubeconfig/localproxy.go
+++ b/lib/kube/kubeconfig/localproxy.go
@@ -68,6 +68,8 @@ func (s LocalProxyClusters) TeleportClusters() []string {
 
 // LocalProxyValues contains values for generating local proxy kubeconfig
 type LocalProxyValues struct {
+	// TeleportProfileName is the name of the profile used for credentials.
+	TeleportProfileName string
 	// TeleportKubeClusterAddr is the Teleport Kubernetes access address.
 	TeleportKubeClusterAddr string
 	// LocalProxyURL is the local forward proxy's URL.
@@ -104,6 +106,7 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 	// entries before adding the ones for local proxy.
 	config := originalKubeConfig.DeepCopy()
 	config.CurrentContext = ""
+	removeByProfileName(config, localProxyValues.TeleportProfileName)
 	removeByServerAddr(config, localProxyValues.TeleportKubeClusterAddr)
 
 	for _, cluster := range localProxyValues.Clusters {
@@ -120,17 +123,28 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 			CertificateAuthorityData: localProxyValues.LocalProxyCAs[cluster.TeleportCluster],
 			TLSServerName:            common.KubeLocalProxySNI(cluster.TeleportCluster, cluster.KubeCluster),
 		}
+		setStringExtensionInCluster(config.Clusters[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInCluster(config.Clusters[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInCluster(config.Clusters[contextName], extKubeClusterName, cluster.KubeCluster)
+
 		config.Contexts[contextName] = &clientcmdapi.Context{
 			Namespace: cluster.Namespace,
 			Cluster:   contextName,
 			AuthInfo:  contextName,
 		}
+		setStringExtensionInContext(config.Contexts[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInContext(config.Contexts[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInContext(config.Contexts[contextName], extKubeClusterName, cluster.KubeCluster)
+
 		config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{
 			ClientCertificateData: localProxyValues.LocalProxyCAs[cluster.TeleportCluster],
 			ClientKeyData:         localProxyValues.ClientKeyData,
 			Impersonate:           cluster.Impersonate,
 			ImpersonateGroups:     cluster.ImpersonateGroups,
 		}
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extKubeClusterName, cluster.KubeCluster)
 
 		// Set the first as current context or if matching the one from default
 		// kubeconfig.
@@ -143,40 +157,60 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 
 // LocalProxyClustersFromDefaultConfig loads Teleport kube clusters data saved
 // by `tsh kube login` in the default kubeconfig.
-func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, clusterAddr string) (clusters LocalProxyClusters) {
-	for teleportClusterName, cluster := range defaultConfig.Clusters {
+func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, profileName, clusterAddr string) (clusters LocalProxyClusters) {
+	for contextName, context := range defaultConfig.Contexts {
+		cluster, found := defaultConfig.Clusters[context.Cluster]
+		if !found {
+			continue
+		}
+		auth, found := defaultConfig.AuthInfos[context.AuthInfo]
+		if !found {
+			continue
+		}
+
+		if p, ok := getStringExtensionFromContext(context, extProfileName); ok {
+			if p != profileName {
+				continue
+			}
+
+			teleportCluster, _ := getStringExtensionFromContext(context, extTeleClusterName)
+			kubeCluster, _ := getStringExtensionFromContext(context, extKubeClusterName)
+
+			clusters = append(clusters, LocalProxyCluster{
+				TeleportCluster:   teleportCluster,
+				KubeCluster:       kubeCluster,
+				Namespace:         context.Namespace,
+				Impersonate:       auth.Impersonate,
+				ImpersonateGroups: auth.ImpersonateGroups,
+			})
+			continue
+		}
+
 		if cluster.Server != clusterAddr {
 			continue
 		}
 
-		for contextName, ctx := range defaultConfig.Contexts {
-			if ctx.Cluster != teleportClusterName {
-				continue
-			}
-			auth, found := defaultConfig.AuthInfos[contextName]
-			if !found {
-				continue
-			}
-
-			clusters = append(clusters, LocalProxyCluster{
-				TeleportCluster:   teleportClusterName,
-				KubeCluster:       KubeClusterFromContext(contextName, ctx, teleportClusterName),
-				Namespace:         ctx.Namespace,
-				Impersonate:       auth.Impersonate,
-				ImpersonateGroups: auth.ImpersonateGroups,
-			})
-		}
+		clusters = append(clusters, LocalProxyCluster{
+			TeleportCluster:   context.Cluster,
+			KubeCluster:       KubeClusterFromContext(contextName, context, context.Cluster),
+			Namespace:         context.Namespace,
+			Impersonate:       auth.Impersonate,
+			ImpersonateGroups: auth.ImpersonateGroups,
+		})
 	}
+
 	return clusters
 }
 
-// FindTeleportClusterForLocalProxy finds the Teleport kube cluster based on
-// provided cluster address and context name, and prepares a LocalProxyCluster.
+// FindTeleportClusterForLocalProxy finds the Kube cluster name for a given
+// context (or the current context), and prepares a LocalProxyCluster if the
+// context is for the given Teleport cluster name or if the server addr matches
+// the expected one.
 //
 // When the cluster has a ProxyURL set, it means the provided kubeconfig is
 // already pointing to a local proxy through this ProxyURL and thus can be
 // skipped as there is no need to create a new local proxy.
-func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, clusterAddr, contextName string) (LocalProxyCluster, bool) {
+func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, contextName, profileName, serverAddr string) (LocalProxyCluster, bool) {
 	if contextName == "" {
 		contextName = defaultConfig.CurrentContext
 	}
@@ -185,8 +219,9 @@ func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, cluste
 	if !found {
 		return LocalProxyCluster{}, false
 	}
+
 	cluster, found := defaultConfig.Clusters[context.Cluster]
-	if !found || cluster.Server != clusterAddr || cluster.ProxyURL != "" {
+	if !found {
 		return LocalProxyCluster{}, false
 	}
 	auth, found := defaultConfig.AuthInfos[context.AuthInfo]
@@ -194,9 +229,36 @@ func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, cluste
 		return LocalProxyCluster{}, false
 	}
 
+	if cluster.ProxyURL != "" {
+		// a proxy is already set, it's either an existing local proxy or
+		// something we don't understand is going on, and either way we should
+		// skip this
+		return LocalProxyCluster{}, false
+	}
+
+	var teleportCluster, kubeCluster string
+	if c, ok := getStringExtensionFromCluster(cluster, extProfileName); ok {
+		// we have found the profile name extension, this is a modern
+		// configuration and we can just work by extensions without having to
+		// make guesses based on URLs and context names
+		if c != profileName {
+			return LocalProxyCluster{}, false
+		}
+		teleportCluster, _ = getStringExtensionFromCluster(cluster, extTeleClusterName)
+		kubeCluster, _ = getStringExtensionFromCluster(cluster, extKubeClusterName)
+	} else {
+		// this kubeconfig is old, match by server URL and try to guess what the
+		// kube cluster name is
+		if cluster.Server != serverAddr {
+			return LocalProxyCluster{}, false
+		}
+		teleportCluster = context.Cluster
+		kubeCluster = KubeClusterFromContext(contextName, context, context.Cluster)
+	}
+
 	return LocalProxyCluster{
-		TeleportCluster:   context.Cluster,
-		KubeCluster:       KubeClusterFromContext(contextName, context, context.Cluster),
+		TeleportCluster:   teleportCluster,
+		KubeCluster:       kubeCluster,
 		Namespace:         context.Namespace,
 		Impersonate:       auth.Impersonate,
 		ImpersonateGroups: auth.ImpersonateGroups,

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -213,26 +213,20 @@ func (k *kube) writeKubeconfig(key *keys.PrivateKey, cas map[string]tls.Certific
 		return trace.BadParameter("could not parse CA certificate for cluster %q", k.cfg.ClusterName)
 	}
 
+	// XXX(espadolini): just like [kubeconfig.UpdateConfig], this assumes that
+	// the profile name is exactly the same as the hostname of the Proxy web
+	// address
+	profileName, err := utils.Host(k.cfg.WebProxyAddr)
+	if err != nil {
+		profileName = k.cfg.WebProxyAddr
+	}
 	values := &kubeconfig.LocalProxyValues{
-		// Ideally tc.KubeClusterAddr() should be used for
-		// TeleportKubeClusterAddr here.
-		//
-		// Kube cluster address is used as server address when `tsh kube login`
-		// adds cluster entries in the default kubeconfig. When creating
-		// kubeconfig for a local proxy, TeleportKubeClusterAddr is mainly used
-		// to identify which clusters in the kubeconfig belong to the current
-		// tsh profile, in case the default kubeconfig has other clusters. It
-		// also serves as a reference so that the server address of a cluster
-		// in the kubeconfig of `tsh proxy kube` and `tsh kube login` are the
-		// same.
-		//
-		// In this case here, since the kubeconfig for the local proxy is only
-		// for a single kube cluster and it is not created from the default
-		// kubeconfig, specifying the correct kube cluster address is not
-		// necessary.
-		//
-		// In most cases, tc.KubeClusterAddr() is the same as
-		// k.cfg.WebProxyAddr anyway.
+		TeleportProfileName: profileName,
+		// Ideally TeleportKubeClusterAddr would be set to tc.KubeClusterAddr()
+		// here, but this is for the local proxy and it's only used for
+		// compatibility with older versions of tsh to keep track of and clean
+		// up kubeconfig items associated to a given profile, which should not
+		// be needed since the introduction of the profile name extension.
 		TeleportKubeClusterAddr: "https://" + k.cfg.WebProxyAddr,
 		LocalProxyURL:           "http://" + k.forwardProxy.GetAddr(),
 		ClientKeyData:           key.PrivateKeyPEM(),

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -218,8 +218,9 @@ func (k *kube) writeKubeconfig(key *keys.PrivateKey, cas map[string]tls.Certific
 	// address
 	profileName, err := utils.Host(k.cfg.WebProxyAddr)
 	if err != nil {
-		profileName = k.cfg.WebProxyAddr
+		return trace.Wrap(err)
 	}
+
 	values := &kubeconfig.LocalProxyValues{
 		TeleportProfileName: profileName,
 		// Ideally TeleportKubeClusterAddr would be set to tc.KubeClusterAddr()

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -250,7 +250,7 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 	}
 
 	// Use logged-in clusters.
-	clusters := kubeconfig.LocalProxyClustersFromDefaultConfig(defaultConfig, tc.KubeClusterAddr())
+	clusters := kubeconfig.LocalProxyClustersFromDefaultConfig(defaultConfig, tc.WebProxyHost(), tc.KubeClusterAddr())
 	if len(clusters) == 0 {
 		return nil, nil, trace.BadParameter("%s", errorMsg)
 	}
@@ -434,6 +434,7 @@ func (k *kubeLocalProxy) createKubeConfig(defaultConfig *clientcmdapi.Config, ov
 		return nil, trace.BadParameter("empty default config")
 	}
 	values := &kubeconfig.LocalProxyValues{
+		TeleportProfileName:     k.tc.WebProxyHost(),
 		TeleportKubeClusterAddr: k.tc.KubeClusterAddr(),
 		LocalProxyURL:           "http://" + k.GetAddr(),
 		LocalProxyCAs:           map[string][]byte{},

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -480,7 +480,7 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	}
 
 	// Prepare Teleport kube cluster based on selected context.
-	kubeCluster, found := kubeconfig.FindTeleportClusterForLocalProxy(defaultConfig, kubeClusterAddrFromProfile(profile), selectedContext)
+	kubeCluster, found := kubeconfig.FindTeleportClusterForLocalProxy(defaultConfig, selectedContext, profile.Name(), kubeClusterAddrFromProfile(profile))
 	if !found {
 		return nil, nil, false
 	}

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -282,6 +282,7 @@ func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {
 				TLSCertificates: [][]byte{[]byte(fixtures.TLSCACertPEM)},
 			}},
 		},
+		ProxyAddr:     "localhost:443",
 		SelectCluster: kubeCluster,
 	}, false)
 	require.NoError(t, err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2632,6 +2632,16 @@ func onLogout(cf *CLIConf) error {
 		}
 
 		// Remove Teleport related entries from kubeconfig.
+
+		if profile != nil {
+			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "profile", profile.Name)
+			err = kubeconfig.RemoveByProfileName("", profile.Name)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		// TODO(espadolini): DELETE IN v20 (maybe, files could be left over from really old versions)
 		logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
 		err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
 		if err != nil {
@@ -2645,6 +2655,8 @@ func onLogout(cf *CLIConf) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		// TODO(espadolini): DELETE IN v20 (maybe, files could be left over from really old versions)
 		logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
 		if err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr()); err != nil {
 			return trace.Wrap(err)
@@ -2652,8 +2664,8 @@ func onLogout(cf *CLIConf) error {
 
 		// Remove Teleport related entries from kubeconfig for all clusters.
 		for _, profile := range profiles {
-			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster", profile.Cluster)
-			err = kubeconfig.RemoveByClusterName("", profile.Cluster)
+			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "profile", profile.Name)
+			err = kubeconfig.RemoveByProfileName("", profile.Name)
 			if err != nil {
 				return trace.Wrap(err)
 			}


### PR DESCRIPTION
Currently, `kubeconfig` files generated or updated by `tsh kube` define a "cluster" for each needed Teleport cluster, and a "context" and "authinfo" for each Kube cluster, pointing at the appropriate "cluster". Implicitly, the "cluster" also tangentially defines the `tsh` profile in use, by pointing the server address at the Kube listener of the proxy of the root cluster for the profile. During logout, the `kubeconfig` file gets scanned for various bits and pieces to identify which configuration elements are associated with the profile or profiles that are logging out, and thus need to be removed from the file. When launching a local kube proxy, the file is scanned by server address to figure out which Kube clusters were implicitly selected (by virtue of having logged into them) and should thus be prepared for forwarding.

Both [path-based Kubernetes routing](https://github.com/gravitational/teleport/issues/40405) and [Kubernetes access through the Relay service](https://github.com/gravitational/teleport/pull/60974) require a different "cluster" for each Kube cluster. To support that in the future, this PR changes the way `kubeconfig` files are manipulated: each Kube cluster gets a context, authinfo and cluster, and for all those three we include the existing `teleport.kube.name` extension to store the name of the Kube cluster (as defined in Teleport), and add the `kubeconfig.teleport.dev/teleport-cluster-name` and `kubeconfig.teleport.dev/profile-name` extensions for the Teleport cluster name (among the clusters available in a given profile) and profile name.

This PR also fixes the encoding of the `teleport.kube.name` extension for bizarre scenarios in which the Kube cluster name is not a valid json string object after `strconv.Quote`.