### PR TITLE
Switch client for browser/proxy where appropriate

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -254,7 +254,7 @@ func (c *Client) readClientSize() error {
 		s, err := c.cfg.Conn.ReadClientScreenSpec()
 		if err != nil {
 			if trace.IsBadParameter(err) {
-				c.cfg.Logger.DebugContext(context.Background(), "Failed to read client screen spec", "error", err)
+				c.cfg.Logger.DebugContext(context.Background(), "Failed to read browser screen spec", "error", err)
 				continue
 			} else {
 				return err
@@ -296,7 +296,7 @@ func (c *Client) readClientKeyboardLayout() error {
 		return trace.Wrap(err)
 	}
 	if msgType != tdp.TypeClientKeyboardLayout {
-		c.cfg.Logger.DebugContext(context.Background(), "Client did not send keyboard layout")
+		c.cfg.Logger.DebugContext(context.Background(), "Proxy did not send keyboard layout")
 		return nil
 	}
 	msg, err := c.cfg.Conn.ReadMessage()
@@ -487,7 +487,7 @@ func (c *Client) startInputStreaming(stopCh chan struct{}) error {
 				// Withhold the latest screen size until the client is ready for input. This ensures
 				// that the client receives the correct screen size when it is ready.
 				withheldResize = &m
-				c.cfg.Logger.DebugContext(context.Background(), "Withholding screen size until client is ready for input", "width", m.Width, "height", m.Height)
+				c.cfg.Logger.DebugContext(context.Background(), "Withholding screen size until proxy is ready for input", "width", m.Width, "height", m.Height)
 			default:
 				// Ignore all messages except ClientScreenSpec until the client is ready for input.
 				c.cfg.Logger.DebugContext(context.Background(), "Dropping TDP input message, not ready for input")
@@ -534,7 +534,7 @@ func (c *Client) handleTDPInput(msg tdp.Message) error {
 			return nil
 		}
 
-		c.cfg.Logger.DebugContext(context.Background(), "Client changed screen size", "width", m.Width, "height", m.Height)
+		c.cfg.Logger.DebugContext(context.Background(), "Browser changed screen size", "width", m.Width, "height", m.Height)
 		if errCode := C.client_write_screen_resize(
 			C.uintptr_t(c.handle),
 			C.uint32_t(m.Width),

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -129,7 +129,7 @@ func (h *Handler) createDesktopConnection(
 	}
 	screenSpec, ok := msg.(tdp.ClientScreenSpec)
 	if !ok {
-		return sendTDPError(trace.BadParameter("client sent unexpected message %T", msg))
+		return sendTDPError(trace.BadParameter("browser sent unexpected message %T", msg))
 	}
 
 	width, height := screenSpec.Width, screenSpec.Height
@@ -152,7 +152,7 @@ func (h *Handler) createDesktopConnection(
 	}
 	keyboardLayout, gotKeyboardLayout := msg.(tdp.ClientKeyboardLayout)
 	if !gotKeyboardLayout {
-		log.InfoContext(ctx, "client did not send keyboard layout", "message_type", logutils.TypeAttr(msg))
+		log.InfoContext(ctx, "Browser did not send keyboard layout", "message_type", logutils.TypeAttr(msg))
 		withheld = append(withheld, msg)
 	}
 
@@ -228,7 +228,7 @@ func (h *Handler) createDesktopConnection(
 			return sendTDPError(err)
 		}
 	} else {
-		log.DebugContext(ctx, "Client sent keyboard layout but agent is too old", "agent_version", version)
+		log.DebugContext(ctx, "Browser sent keyboard layout but agent is too old", "agent_version", version)
 	}
 
 	for _, msg := range withheld {
@@ -609,7 +609,7 @@ func handleProxyWebsocketConnErr(ctx context.Context, proxyWsConnErr error, log 
 			switch closeErr.Code {
 			case websocket.CloseNormalClosure, // when the user hits "disconnect" from the menu
 				websocket.CloseGoingAway: // when the user closes the tab
-				log.DebugContext(ctx, "Web socket closed by client", "close_code", closeErr.Code)
+				log.DebugContext(ctx, "Web socket closed by browser", "close_code", closeErr.Code)
 				return
 			}
 			return


### PR DESCRIPTION
When logging in desktop service, we refer to "client" in `desktop.go` which handles Browser to Proxy connections and `client.go` which handles Proxy to Windows Desktop Service connections. "Client" means different things in these contexts, so this PR specifies either browser or proxy where necessary.