### PR TITLE
Support updating existing Azure OIDC integration with `tctl`

### DIFF
--- a/api/types/integration.go
+++ b/api/types/integration.go
@@ -76,6 +76,8 @@ type Integration interface {
 
 	// GetAzureOIDCIntegrationSpec returns the `azure-oidc` spec fields.
 	GetAzureOIDCIntegrationSpec() *AzureOIDCIntegrationSpecV1
+	// SetAzureOIDCIntegrationSpec sets the `azure-oidc` spec fields.
+	SetAzureOIDCIntegrationSpec(*AzureOIDCIntegrationSpecV1)
 
 	// GetGitHubIntegrationSpec returns the GitHub spec.
 	GetGitHubIntegrationSpec() *GitHubIntegrationSpecV1
@@ -399,6 +401,13 @@ func (ig *IntegrationV1) SetAWSOIDCIssuerS3URI(issuerS3URI string) {
 // GetAzureOIDCIntegrationSpec returns the specific spec fields for `azure-oidc` subkind integrations.
 func (ig *IntegrationV1) GetAzureOIDCIntegrationSpec() *AzureOIDCIntegrationSpecV1 {
 	return ig.Spec.GetAzureOIDC()
+}
+
+// SetAzureOIDCIntegrationSpec sets the `azure-oidc` spec fields.
+func (ig *IntegrationV1) SetAzureOIDCIntegrationSpec(spec *AzureOIDCIntegrationSpecV1) {
+	ig.Spec.SubKindSpec = &IntegrationSpecV1_AzureOIDC{
+		AzureOIDC: spec,
+	}
 }
 
 // GetGitHubIntegrationSpec returns the GitHub spec.

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -858,6 +858,8 @@ func (rc *ResourceCommand) createIntegration(ctx context.Context, client *authcl
 			existingIntegration.SetGitHubIntegrationSpec(integration.GetGitHubIntegrationSpec())
 		case types.IntegrationSubKindAWSRolesAnywhere:
 			existingIntegration.SetAWSRolesAnywhereIntegrationSpec(integration.GetAWSRolesAnywhereIntegrationSpec())
+		case types.IntegrationSubKindAzureOIDC:
+			existingIntegration.SetAzureOIDCIntegrationSpec(integration.GetAzureOIDCIntegrationSpec())
 		default:
 			return trace.BadParameter("subkind %q is not supported", integration.GetSubKind())
 		}


### PR DESCRIPTION
changelog: Added ability to update existing Azure OIDC integration with `tctl`