### PR TITLE
[v18] Add `saml` and `oidc` resource reference pages

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/oidc-connector-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/oidc-connector-v3.mdx
@@ -1,0 +1,223 @@
+---
+title: OIDC Connector V3 Reference
+description: Provides a reference of fields within the OIDC Connector V3 resource, which you can manage with tctl.
+sidebar_label: OIDC Connector V3
+---
+{/* vale 3rd-party-products.former-names = NO */}
+{/* vale messaging.capitalization = NO */}
+
+**Kind**: `oidc`<br/>
+**Version**: `v3`
+
+Represents an OIDC connector.
+
+Example:
+
+```yaml
+kind: "string"
+sub_kind: "string"
+version: "string"
+metadata: # [...]
+spec: # [...]
+```
+|Field Name|Description|Type|
+|---|---|---|
+|kind|A resource kind.|string|
+|metadata|Holds resource metadata.|[Metadata](#metadata)|
+|spec|An OIDC connector specification.|[OIDC Connector Spec V3](#oidc-connector-spec-v3)|
+|sub_kind|An optional resource sub kind, used in some resources.|string|
+|version|The resource version. It must be specified. Supported values are: `v3`.|string|
+
+## Claim Mapping
+
+Maps a claim to teleport roles.
+
+
+Example:
+
+```yaml
+claim: "string"
+value: "string"
+roles: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|claim|A claim name.|string|
+|roles|A list of static teleport roles to match.|[]string|
+|value|A claim value to match.|string|
+
+## Duration
+
+A wrapper around duration to set up custom marshal/unmarshal
+
+
+## Entra ID Groups Provider
+
+Configures out-of-band user groups provider. It works by following through the groups claim source, which is sent for "groups" claim when the user's group membership exceeds 200 max item limit.
+
+
+Example:
+
+```yaml
+disabled: true
+group_type: "string"
+graph_endpoint: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|disabled|Specifies that the groups provider should be disabled even when Entra ID responds with a groups claim source. User may choose to disable it if they are using integrations such as SCIM or similar groups importer as connector based role mapping may be not needed in such a scenario.|Boolean|
+|graph_endpoint|A Microsoft Graph API endpoint. The groups claim source endpoint provided by Entra ID points to the now-retired Azure AD Graph endpoint ("https://graph.windows.net"). To convert it to the newer Microsoft Graph API endpoint, Teleport defaults to the Microsoft Graph global service endpoint ("https://graph.microsoft.com"). Update GraphEndpoint to point to a different Microsoft Graph national cloud deployment endpoint.|string|
+|group_type|A user group type filter. Defaults to "security-groups". Value can be "security-groups", "directory-roles", "all-groups".|string|
+
+## Metadata
+
+Resource metadata
+
+
+Example:
+
+```yaml
+name: "string"
+description: "string"
+labels: 
+  "string": "string"
+  "string": "string"
+  "string": "string"
+expires: # See description
+revision: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|description|Object description|string|
+|expires|A global expiry time header can be set on any resource in the system.||
+|labels|A set of labels|map[string]string|
+|name|An object name|string|
+|revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
+
+## OIDC Connector MFA Settings
+
+Contains OIDC MFA settings.
+
+
+Example:
+
+```yaml
+enabled: true
+client_id: "string"
+client_secret: "string"
+acr_values: "string"
+prompt: "string"
+max_age: # [...]
+request_object_mode: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|acr_values|Authentication Context Class Reference values. The meaning of the ACR value is context-specific and varies for identity providers. Some identity providers support MFA specific contexts, such Okta with its "phr" (phishing-resistant) ACR.|string|
+|client_id|ClientID is the OIDC OAuth app client ID.|string|
+|client_secret|The OIDC OAuth app client secret.|string|
+|enabled|Specified whether this OIDC connector supports MFA checks. Defaults to false.|Boolean|
+|max_age|The amount of time in nanoseconds that an IdP session is valid for. Defaults to 0 to always force re-authentication for MFA checks. This should only be set to a non-zero value if the IdP is setup to perform MFA checks on top of active user sessions.|[Duration](#duration)|
+|prompt|An optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.|string|
+|request_object_mode|Determines how JWT-Secured Authorization Requests will be used for authorization requests. JARs, or request objects, can provide integrity protection, source authentication, and confidentiality for authorization request parameters. If omitted, MFA flows will default to the `RequestObjectMode` behavior specified in the base OIDC connector. Set this property to 'none' to explicitly disable request objects for the MFA client.|string|
+
+## OIDC Connector Spec V3
+
+An OIDC connector specification.  It specifies configuration for Open ID Connect compatible external identity provider: https://openid.net/specs/openid-connect-core-1_0.html
+
+
+Example:
+
+```yaml
+issuer_url: "string"
+client_id: "string"
+client_secret: "string"
+acr_values: "string"
+provider: "string"
+display: "string"
+scope: 
+  - "string"
+  - "string"
+  - "string"
+prompt: "string"
+claims_to_roles: 
+  - # [...]
+  - # [...]
+  - # [...]
+google_service_account_uri: "string"
+google_service_account: "string"
+google_admin_email: "string"
+redirect_url: # [...]
+allow_unverified_email: true
+username_claim: "string"
+max_age: # [...]
+client_redirect_settings: # [...]
+mfa: # [...]
+pkce_mode: "string"
+user_matchers: 
+  - "string"
+  - "string"
+  - "string"
+request_object_mode: "string"
+entra_id_groups_provider: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|acr_values|An Authentication Context Class Reference value. The meaning of the ACR value is context-specific and varies for identity providers.|string|
+|allow_unverified_email|Tells the connector to accept OIDC users with unverified emails.|Boolean|
+|claims_to_roles|Specifies a dynamic mapping from claims to roles.|[][Claim Mapping](#claim-mapping)|
+|client_id|The id of the authentication client (Teleport Auth Service).|string|
+|client_redirect_settings|Defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|[SSO Client Redirect Settings](#sso-client-redirect-settings)|
+|client_secret|Used to authenticate the client.|string|
+|display|The friendly name for this provider.|string|
+|entra_id_groups_provider|EntraIDGroupsProvider configures out-of-band user groups provider. It works by following through the groups claim source, which is sent for the "groups" claim when the user's group membership exceeds 200 max item limit.|[Entra ID Groups Provider](#entra-id-groups-provider)|
+|google_admin_email|The email of a google admin to impersonate.|string|
+|google_service_account|A string containing google service account credentials.|string|
+|google_service_account_uri|A path to a google service account uri.|string|
+|issuer_url|The endpoint of the provider, e.g. https://accounts.google.com.|string|
+|max_age||[Duration](#duration)|
+|mfa|Contains settings to enable SSO MFA checks through this auth connector.|[OIDC Connector MFA Settings](#oidc-connector-mfa-settings)|
+|pkce_mode|Represents the configuration state for PKCE (Proof Key for Code Exchange). It can be "enabled" or "disabled"|string|
+|prompt|An optional OIDC prompt. An empty string omits prompt. If not specified, it defaults to select_account for backwards compatibility.|string|
+|provider|The external identity provider.|string|
+|redirect_url|A list of callback URLs which the identity provider can use to redirect the client back to the Teleport Proxy to complete authentication. This list should match the URLs on the provider's side. The URL used for a given auth request will be chosen to match the requesting Proxy's public address. If there is no match, the first url in the list will be used.|[Strings](#strings)|
+|request_object_mode|Determines how JWT-Secured Authorization Requests will be used for authorization requests. JARs, or request objects, can provide integrity protection, source authentication, and confidentiality for authorization request parameters.|string|
+|scope|Specifies additional scopes set by provider.|[]string|
+|user_matchers|A set of glob patterns to narrow down which username(s) this auth connector should match for identifier-first login.|[]string|
+|username_claim|Specifies the name of the claim from the OIDC connector to be used as the user's username.|string|
+
+## SSO Client Redirect Settings
+
+Contains settings to define which additional client redirect URLs should be allowed for non-browser SSO logins.
+
+
+Example:
+
+```yaml
+allowed_https_hostnames: 
+  - "string"
+  - "string"
+  - "string"
+insecure_allowed_cidr_ranges: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|allowed_https_hostnames|A list of hostnames allowed for https client redirect URLs|[]string|
+|insecure_allowed_cidr_ranges|A list of CIDRs allowed for HTTP or HTTPS client redirect URLs|[]string|
+
+## Strings
+
+A list of string that can unmarshal from list of strings or a scalar string from scalar yaml or json property
+
+

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/saml-connector-v2.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/saml-connector-v2.mdx
@@ -1,0 +1,209 @@
+---
+title: SAML Connector V2 Reference
+description: Provides a reference of fields within the SAML Connector V2 resource, which you can manage with tctl.
+sidebar_label: SAML Connector V2
+---
+{/* vale 3rd-party-products.former-names = NO */}
+{/* vale messaging.capitalization = NO */}
+
+**Kind**: `saml`<br/>
+**Version**: `v2`
+
+Represents a SAML connector.
+
+Example:
+
+```yaml
+kind: "string"
+sub_kind: "string"
+version: "string"
+metadata: # [...]
+spec: # [...]
+```
+|Field Name|Description|Type|
+|---|---|---|
+|kind|A resource kind.|string|
+|metadata|Holds resource metadata.|[Metadata](#metadata)|
+|spec|An SAML connector specification.|[SAML Connector Spec V2](#saml-connector-spec-v2)|
+|sub_kind|An optional resource sub kind, used in some resources.|string|
+|version|The resource version. It must be specified. Supported values are: `v2`.|string|
+
+## Asymmetric Key Pair
+
+A combination of a public certificate and private key that can be used for encryption and signing.
+
+
+Example:
+
+```yaml
+private_key: "string"
+cert: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|cert|A PEM-encoded x509 certificate.|string|
+|private_key|A PEM encoded x509 private key.|string|
+
+## Attribute Mapping
+
+Maps a SAML attribute statement to teleport roles.
+
+
+Example:
+
+```yaml
+name: "string"
+value: "string"
+roles: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|name|An attribute statement name.|string|
+|roles|A list of static teleport roles to map to.|[]string|
+|value|An attribute statement value to match.|string|
+
+## Metadata
+
+Resource metadata
+
+
+Example:
+
+```yaml
+name: "string"
+description: "string"
+labels: 
+  "string": "string"
+  "string": "string"
+  "string": "string"
+expires: # See description
+revision: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|description|Object description|string|
+|expires|A global expiry time header can be set on any resource in the system.||
+|labels|A set of labels|map[string]string|
+|name|An object name|string|
+|revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
+
+## SAML Connector MFA Settings
+
+Contains SAML MFA settings.
+
+
+Example:
+
+```yaml
+enabled: true
+entity_descriptor: "string"
+entity_descriptor_url: "string"
+force_authn: # [...]
+issuer: "string"
+sso: "string"
+cert: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|cert|The identity provider certificate PEM. IDP signs `\<Response\>` responses using this certificate.|string|
+|enabled|Specified whether this SAML connector supports MFA checks. Defaults to false.|Boolean|
+|entity_descriptor|XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements. Usually set from EntityDescriptorUrl.|string|
+|entity_descriptor_url|A URL that supplies a configuration XML.|string|
+|force_authn|Specified whether re-authentication should be forced for MFA checks. UNSPECIFIED is treated as YES to always re-authentication for MFA checks. This should only be set to NO if the IdP is setup to perform MFA checks on top of active user sessions.|[SAML Force Authn](#saml-force-authn)|
+|issuer|The identity provider issuer. Usually set from EntityDescriptor.|string|
+|sso|SSO is the URL of the identity provider's SSO service. Usually set from EntityDescriptor.|string|
+
+## SAML Connector Spec V2
+
+A SAML connector specification.
+
+
+Example:
+
+```yaml
+issuer: "string"
+sso: "string"
+cert: "string"
+display: "string"
+acs: "string"
+audience: "string"
+service_provider_issuer: "string"
+entity_descriptor: "string"
+entity_descriptor_url: "string"
+attributes_to_roles: 
+  - # [...]
+  - # [...]
+  - # [...]
+signing_key_pair: # [...]
+provider: "string"
+assertion_key_pair: # [...]
+allow_idp_initiated: true
+client_redirect_settings: # [...]
+single_logout_url: "string"
+mfa: # [...]
+force_authn: # [...]
+preferred_request_binding: "string"
+user_matchers: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|acs|A URL for assertion consumer service on the service provider (Teleport's side).|string|
+|allow_idp_initiated|A flag that indicates if the connector can be used for IdP-initiated logins.|Boolean|
+|assertion_key_pair|A key pair used for decrypting SAML assertions.|[Asymmetric Key Pair](#asymmetric-key-pair)|
+|attributes_to_roles|A list of mappings of attribute statements to roles.|[][Attribute Mapping](#attribute-mapping)|
+|audience|Uniquely identifies our service provider.|string|
+|cert|The identity provider certificate PEM. IDP signs `\<Response\>` responses using this certificate.|string|
+|client_redirect_settings|Defines which client redirect URLs are allowed for non-browser SSO logins other than the standard localhost ones.|[SSO Client Redirect Settings](#sso-client-redirect-settings)|
+|display|Controls how this connector is displayed.|string|
+|entity_descriptor|XML with descriptor. It can be used to supply configuration parameters in one XML file rather than supplying them in the individual elements.|string|
+|entity_descriptor_url|A URL that supplies a configuration XML.|string|
+|force_authn|Specified whether re-authentication should be forced on login. UNSPECIFIED is treated as NO.|[SAML Force Authn](#saml-force-authn)|
+|issuer|The identity provider issuer.|string|
+|mfa|Contains settings to enable SSO MFA checks through this auth connector.|[SAML Connector MFA Settings](#saml-connector-mfa-settings)|
+|preferred_request_binding|A preferred SAML request binding method. Value must be either "http-post" or "http-redirect". In general, the SAML identity provider lists request binding methods it supports. And the SAML service provider uses one of the IdP supported request binding method that it prefers. But we never honored request binding value provided by the IdP and always used http-redirect binding as a default. Setting up PreferredRequestBinding value lets us preserve existing auth connector behavior and only use http-post binding if it is explicitly configured.|string|
+|provider|The external identity provider.|string|
+|service_provider_issuer|The issuer of the service provider (Teleport).|string|
+|signing_key_pair|An x509 key pair used to sign AuthnRequest.|[Asymmetric Key Pair](#asymmetric-key-pair)|
+|single_logout_url|The SAML Single log-out URL to initiate SAML SLO (single log-out). If this is not provided, SLO is disabled.|string|
+|sso|The URL of the identity provider's SSO service.|string|
+|user_matchers|A set of glob patterns to narrow down which username(s) this auth connector should match for identifier-first login.|[]string|
+
+## SAML Force Authn
+
+Specified whether existing SAML sessions should be accepted or re-authentication should be forced.
+
+
+## SSO Client Redirect Settings
+
+Contains settings to define which additional client redirect URLs should be allowed for non-browser SSO logins.
+
+
+Example:
+
+```yaml
+allowed_https_hostnames: 
+  - "string"
+  - "string"
+  - "string"
+insecure_allowed_cidr_ranges: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|allowed_https_hostnames|A list of hostnames allowed for https client redirect URLs|[]string|
+|insecure_allowed_cidr_ranges|A list of CIDRs allowed for HTTP or HTTPS client redirect URLs|[]string|
+


### PR DESCRIPTION
These pages are generated from the `OIDCConnectorV3` and `SAMLConnectorV2` type declarations in the `teleport` source. The generator will be added in a separate change.