### PR TITLE
docs: adding Agent hardware guidelines

### DIFF
--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -32,7 +32,6 @@ Set up Teleport with a [High Availability configuration](../../../zero-trust-acc
 
 ### Agent resource requirements
 
-Resource requirements for Teleport Agents vary significantly based on workload, enabled features, and recording configuration.
 The following provides baseline guidance for production deployments.
 
 ### Baseline specifications
@@ -47,19 +46,21 @@ For production agents, we recommend:
 
 Agent resource consumption depends on:
 
-#### Connection volume
+- **Connection volume**
 
-A mostly dormant agent handling infrequent connections requires far fewer resources than an actively used agent with high concurrent session counts.
+A mostly dormant agent handling infrequent, lightweight connections requires far fewer resources than an actively used agent 
+supporting high concurrent sessions, or a smaller number of resource-intensive sessions. Overall you should consider workload 
+intensity driving resource consumption, and not just connection count.
 
-#### Recording mode
+- **Node recording mode**: 
 
-- **Node recording mode**: Requires substantially more disk space (100+ GB) as session recordings are stored locally before upload to the Auth Service.
+Requires substantially more disk space than proxy recording mode, because session recordings are stored locally on the agent before upload to the Auth Service. 
+Actual disk requirements depend on session volume, duration, and retention.
 
-#### Session types
+- **Session types**
 
-- SSH sessions require approximately 100 MB of memory per active session
-- Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below)
-- Database and application sessions have varying profiles based on connection patterns
+- SSH sessions require approximately 100 MB of memory per active session. Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below). 
+Database and application sessions have varying profiles based on connection patterns
 
 #### Enabled features
 
@@ -70,12 +71,11 @@ or performing dynamic resource discovery.
 
 Increase resources when the agent:
 - Handles high connection volumes (>100 concurrent sessions)
-- Uses node recording mode with frequent or long-running sessions  
 - Provides desktop access
 - Performs auto-discovery of many resources
 
-Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../../management/external-audit-storage.mdx) 
-to minimize agent disk requirements by storing recordings in your own cloud storage.
+Monitor CPU, memory, and disk usage to detect when scaling is needed. 
+Consider using external storage to minimize agent disk requirements by storing recordings in your own cloud storage.
 
 ## Auth Service and Proxy Service Configuration
 

--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -59,10 +59,10 @@ Actual disk requirements depend on session volume, duration, and retention.
 
 - **Session types**
 
-- SSH sessions require approximately 100 MB of memory per active session. Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below). 
+SSH sessions require approximately 100 MB of memory per active session. Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below). 
 Database and application sessions have varying profiles based on connection patterns
 
-#### Enabled features
+- **Enabled features**
 
 Agents running multiple services simultaneously (e.g., the SSH Service and Database Service) 
 or performing dynamic resource discovery.

--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -49,7 +49,8 @@ Agent resource consumption depends on:
 - Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below)
 - Database and application sessions have varying profiles based on connection patterns
 
-**Enabled features**: Agents running multiple access types simultaneously (SSH + Database + Applications) or performing dynamic resource discovery require additional resources.
+**Enabled features**: Agents running multiple access types simultaneously (SSH + Database + Applications) or performing dynamic resource discovery 
+require additional resources.
 
 ### Scaling beyond baseline
 
@@ -59,7 +60,7 @@ Increase resources when the agent:
 - Provides desktop access
 - Performs auto-discovery of many resources
 
-Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../zero-trust-access/management/external-audit-storage.mdx) to minimize agent disk requirements by storing recordings in your own cloud storage.
+Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../../management/external-audit-storage.mdx) to minimize agent disk requirements by storing recordings in your own cloud storage.
 
 ## Auth Service and Proxy Service Configuration
 

--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -13,6 +13,15 @@ self-hosted deployments of Teleport.
 
 ## Hardware recommendations
 
+The hardware and resource recommendations in this guide are general guidelines based on common deployment patterns and load testing. 
+Actual requirements will vary depending on your specific environment, workload characteristics, enabled features, and usage patterns. 
+We recommend monitoring your deployment's resource utilization and adjusting specifications based on observed performance.
+
+### Auth Service and Proxy Service
+
+The following recommendations apply to the **Auth Service and Proxy Service** for large-scale deployments. 
+For agent resource requirements, see the [Agent resource requirements](#agent-resource-requirements) section below.
+
 Set up Teleport with a [High Availability configuration](../../../zero-trust-access/deploy-a-cluster/high-availability.mdx).
 
 | Scenario                                                              | Max Recommended Count | Proxy Service         | Auth Service          | AWS Instance Types |
@@ -21,7 +30,7 @@ Set up Teleport with a [High Availability configuration](../../../zero-trust-acc
 | Teleport SSH Nodes connected to Auth Service                          | 50,000                | 2x  4 vCPUs, 16GB RAM | 2x 8 vCPUs, 16GB RAM  | m4.2xlarge         |
 | Teleport SSH Nodes connected to Proxy Service through reverse tunnels | 10,000                | 2x 4 vCPUs, 8GB RAM   | 2x 8 vCPUs, 16+GB RAM | m4.2xlarge         |
 
-## Agent resource requirements
+### Agent resource requirements
 
 Resource requirements for Teleport Agents vary significantly based on workload, enabled features, and recording configuration.
 The following provides baseline guidance for production deployments.
@@ -38,19 +47,24 @@ For production agents, we recommend:
 
 Agent resource consumption depends on:
 
-**Connection volume**: A mostly dormant agent handling infrequent connections requires far fewer resources than an actively used agent with high concurrent session counts.
+#### Connection volume
 
-**Recording mode**: 
-- **Proxy recording mode** (recommended): Minimal disk space required on agents as recordings happen at the Proxy Service, typically 10-50 GB is sufficient.
+A mostly dormant agent handling infrequent connections requires far fewer resources than an actively used agent with high concurrent session counts.
+
+#### Recording mode
+
 - **Node recording mode**: Requires substantially more disk space (100+ GB) as session recordings are stored locally before upload to the Auth Service.
 
-**Session types**:
+#### Session types
+
 - SSH sessions require approximately 100 MB of memory per active session
 - Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below)
 - Database and application sessions have varying profiles based on connection patterns
 
-**Enabled features**: Agents running multiple access types simultaneously (SSH + Database + Applications) or performing dynamic resource discovery 
-require additional resources.
+#### Enabled features
+
+Agents running multiple services simultaneously (e.g., the SSH Service and Database Service) 
+or performing dynamic resource discovery.
 
 ### Scaling beyond baseline
 
@@ -60,7 +74,8 @@ Increase resources when the agent:
 - Provides desktop access
 - Performs auto-discovery of many resources
 
-Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../../management/external-audit-storage.mdx) to minimize agent disk requirements by storing recordings in your own cloud storage.
+Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../../management/external-audit-storage.mdx) 
+to minimize agent disk requirements by storing recordings in your own cloud storage.
 
 ## Auth Service and Proxy Service Configuration
 
@@ -110,14 +125,14 @@ $ cat /proc/$(pidof teleport)/limits
 ## DynamoDB configuration
 
 When using Teleport with DynamoDB, we recommend using on-demand provisioning.
-This allow DynamoDB to scale with cluster load.
+This allows DynamoDB to scale with cluster load.
 
-For customers that can not use on-demand provisioning, we recommend at least
+For customers that cannot use on-demand provisioning, we recommend at least
 250 WCU and 100 RCU for 10k clusters.
 
 ## etcd
 
-When using Teleport with etcd, we recommend you do the following.
+When using Teleport with etcd, we recommend you do the following:
 
 - For performance, use the fastest SSDs available and ensure low-latency network connectivity
   between etcd peers. See the [etcd Hardware
@@ -141,12 +156,12 @@ etcdctl \
     endpoint status
 ```
 
-## Supported Load
+## Supported load
 
 The tests below were performed against a Teleport Cloud tenant which runs on instances with 8 vCPU and 32 GiB memory and
 has default limits of 4CPU and 4Gi memory.
 
-### Concurrent Logins
+### Concurrent logins
 
 | Resource Type | Login Command                          | Logins | Failure                  |
 |---------------|----------------------------------------|--------|--------------------------|
@@ -156,7 +171,7 @@ has default limits of 4CPU and 4Gi memory.
 | Kubernetes    | tsh kube login && tsh kube credentials | 2000   | Auth CPU Limits exceeded |
 
 
-### Sessions Per Second
+### Sessions per second
 
 | Resource Type | Sessions | Failure                   |
 |---------------|----------|---------------------------|

--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -21,6 +21,46 @@ Set up Teleport with a [High Availability configuration](../../../zero-trust-acc
 | Teleport SSH Nodes connected to Auth Service                          | 50,000                | 2x  4 vCPUs, 16GB RAM | 2x 8 vCPUs, 16GB RAM  | m4.2xlarge         |
 | Teleport SSH Nodes connected to Proxy Service through reverse tunnels | 10,000                | 2x 4 vCPUs, 8GB RAM   | 2x 8 vCPUs, 16+GB RAM | m4.2xlarge         |
 
+## Agent resource requirements
+
+Resource requirements for Teleport Agents vary significantly based on workload, enabled features, and recording configuration.
+The following provides baseline guidance for production deployments.
+
+### Baseline specifications
+
+For production agents, we recommend:
+
+- **Instance type**: AWS t3.small or equivalent (2 vCPUs, 2 GB RAM)
+- **Disk space**: 50-100 GB
+- **High Availability**: Deploy at least two agents for redundancy
+
+### Factors affecting requirements
+
+Agent resource consumption depends on:
+
+**Connection volume**: A mostly dormant agent handling infrequent connections requires far fewer resources than an actively used agent with high concurrent session counts.
+
+**Recording mode**: 
+- **Proxy recording mode** (recommended): Minimal disk space required on agents as recordings happen at the Proxy Service, typically 10-50 GB is sufficient.
+- **Node recording mode**: Requires substantially more disk space (100+ GB) as session recordings are stored locally before upload to the Auth Service.
+
+**Session types**:
+- SSH sessions require approximately 100 MB of memory per active session
+- Desktop sessions require significantly more resources (see [Windows Desktop Service](#windows-desktop-service) below)
+- Database and application sessions have varying profiles based on connection patterns
+
+**Enabled features**: Agents running multiple access types simultaneously (SSH + Database + Applications) or performing dynamic resource discovery require additional resources.
+
+### Scaling beyond baseline
+
+Increase resources when the agent:
+- Handles high connection volumes (>100 concurrent sessions)
+- Uses node recording mode with frequent or long-running sessions  
+- Provides desktop access
+- Performs auto-discovery of many resources
+
+Monitor CPU, memory, and disk usage to detect when scaling is needed. Consider using [External Audit Storage](../zero-trust-access/management/external-audit-storage.mdx) to minimize agent disk requirements by storing recordings in your own cloud storage.
+
 ## Auth Service and Proxy Service Configuration
 
 Upgrade Teleport's connection limits from the default connection limit of `15000`


### PR DESCRIPTION
We’ve had several user questions come through Inkeep AI search asking for clearer guidance on how much disk space and memory a Teleport Agent typically needs. (We do have general hardware guidelines for the Auth Service, but nothing comparable for Agents.)

While resource usage varies significantly based on workload and configuration, since we currently provide no documentation that helps users size Agent resources, we want to provide useful guidance and a response to this search query.

(I compiled this based on discussions with Steven M. and some folks in Support.)

Closes #3044