### PR TITLE
add --roles flag to tsh request search, that allows listing requestable roles

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -1078,7 +1078,7 @@ $ tsh request review [<flags>] <request-id>
 
 ## tsh request search
 
-Search for resources to request access to
+Search for resources to request access to, or list requestable roles.
 
 ```code
 $ tsh request search [<flags>]
@@ -1088,7 +1088,8 @@ $ tsh request search [<flags>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--kind` | none | `node`, `kube_cluster`, `kube_resource`, `db`, `app`, `windows_desktop` | Resource kind to search for (required) |
+| `--roles` | false | boolean | List requestable roles instead of searching for resources. Mutually exclusive with --kind. |
+| `--kind` | none | `node`, `kube_cluster`, `kube_resource`, `db`, `app`, `windows_desktop` | Resource kind to search for. Mutually exclusive with --roles. |
 | `--kube-kind` | none | string | Plural name of the kube resource (required when --kind is `kube_resource`) |
 | `--kube-api-group` | none | string | API group of the kube resource (required when --kind is `kube_resource` depending on the resource) |
 | `--search` | none | Comma-separated strings | List of comma-separated search keywords or phrases enclosed in single quotes |

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -68,6 +68,11 @@ const (
 	// `request.kubernetes_resources` config. It's also used to determine if a returned error
 	// contains this string (in tests and tsh) to customize error messages shown to user.
 	InvalidKubernetesKindAccessRequest = `your Teleport role's "request.kubernetes_resources" field`
+
+	// CannotRequestRole is used in error messages when a user attempts to request
+	// a role they are not allowed to use. It is also checked in returned errors
+	// (in tests and tsh) to customize the error message shown to the user.
+	CannotRequestRole = "can not request role"
 )
 
 // ValidateAccessRequest validates the AccessRequest and sets default values
@@ -1272,11 +1277,11 @@ func (m *RequestValidator) validate(ctx context.Context, req types.AccessRequest
 				// Roles are normally determined automatically for resource
 				// access requests, this role must have been explicitly
 				// requested, or a new deny rule has since been added.
-				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
+				return trace.BadParameter("user %q %s %q", req.GetUser(), CannotRequestRole, roleName)
 			}
 		} else {
 			if !m.CanRequestRole(roleName) {
-				return trace.BadParameter("user %q can not request role %q", req.GetUser(), roleName)
+				return trace.BadParameter("user %q %s %q", req.GetUser(), CannotRequestRole, roleName)
 			}
 		}
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -190,6 +190,8 @@ type CLIConf struct {
 	AssumeStartTimeRaw string
 	// ResourceKind is the resource kind to search for
 	ResourceKind string
+	// RequestableRoles allows users to search for requestable roles.
+	RequestableRoles bool
 	// Username is the Teleport user's username (to login into proxies)
 	Username string
 	// ExplicitUsername is true if Username was initially set by the end-user
@@ -1358,10 +1360,23 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	reqReview.Flag("assume-start-time", "Sets time roles can be assumed by requestor (RFC3339 e.g 2023-12-12T23:20:50.52Z).").StringVar(&cf.AssumeStartTimeRaw)
 
 	reqSearch := req.Command("search", "Search for resources to request access to.")
-	reqSearch.Flag("kind", fmt.Sprintf("Resource kind to search for (%s).", strings.Join(types.RequestableResourceKinds, ", "))).Required().StringVar(&cf.ResourceKind)
+	reqSearch.Flag("kind", fmt.Sprintf("Resource kind to search for (%s).  Mutually exclusive with --roles.", strings.Join(types.RequestableResourceKinds, ", "))).StringVar(&cf.ResourceKind)
+	reqSearch.Flag("roles", "List requestable roles instead of searching for resources. Mutually exclusive with --kind.").BoolVar(&cf.RequestableRoles)
 	reqSearch.Flag("kube-kind", fmt.Sprintf("Kubernetes resource kind name (plural) to search for. Required with --kind=%q Ex: pods, deployments, namespaces, etc.", types.KindKubernetesResource)).StringVar(&cf.kubeResourceKind)
 	reqSearch.Flag("kube-api-group", "Kubernetes API group to search for resources.").StringVar(&cf.kubeAPIGroup)
 	reqSearch.PreAction(func(*kingpin.ParseContext) error {
+		if cf.RequestableRoles && cf.ResourceKind != "" {
+			return trace.BadParameter("only one of --kind and --roles may be specified")
+		}
+		if !cf.RequestableRoles && cf.ResourceKind == "" {
+			return trace.BadParameter("one of --kind and --roles is required")
+		}
+
+		// in --roles mode we don't care about resource kinds or kube flags.
+		if cf.RequestableRoles {
+			return nil
+		}
+
 		// TODO(@creack): DELETE IN v20.0.0. Allow legacy kinds with a warning for now.
 		if slices.Contains(types.LegacyRequestableKubeResourceKinds, cf.ResourceKind) {
 			cf.kubeAPIGroup = types.KubernetesResourcesV7KindGroups[cf.ResourceKind]
@@ -3082,6 +3097,9 @@ func executeAccessRequest(cf *CLIConf, tc *client.TeleportClient) error {
 		}); err != nil {
 			if strings.Contains(err.Error(), services.InvalidKubernetesKindAccessRequest) {
 				return trace.BadParameter("%s\nTry searching for specific kinds with:\n> tsh request search --kube-cluster=KUBE_CLUSTER_NAME --kind=KIND", err.Error())
+			}
+			if strings.Contains(err.Error(), services.CannotRequestRole) {
+				return trace.BadParameter("%s\nHint: run \"tsh request search --roles\" to list requestable roles.", err.Error())
 			}
 			return trace.Wrap(err)
 		}


### PR DESCRIPTION
# What 
Resolves: #7693

tsh now supports listing requestable roles via `tsh request search --roles`, enforces mutual exclusivity between `--roles` and `--kind` flags, and adds a hint to `tsh request new --roles`, that suggests using `tsh request search --roles` when the requested role is not allowed.

changelog: Added `--roles` flag for `tsh request search`, allowing users to list all requestable roles. This flag is mutually exclusive with `--kind`

# Manual Tests

A local test cluster was created with a requester role that is allowed to request several other roles.
A test user with the requester role was created.

The following tests were performed:

* `tsh request search` returns an error 

* `tsh request search --roles` succeeds, lists requestable roles

* `tsh request search --kind` returns an error

* `tsh request search --kind=db` succeeds

* `tsh request search --roles --kind=db` returns error

* `tsh request search --roles --kind` returns error

* `tsh request new --roles` confirmed the new hint suggesting `tsh request search --roles`