### PR TITLE
[chore] fix race in TwoClustersTunnel

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2463,6 +2463,10 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	})
 	require.NoError(t, err)
 	tc.Stdout = &outputB
+
+	// Wait for the target host to appear in the inventory before connecting to it.
+	b.WaitForNodeCount(ctx, b.Secrets.SiteName, 1)
+
 	err = tc.SSH(ctx, cmd)
 	require.NoError(t, err)
 	require.Equal(t, outputA.String(), outputB.String())


### PR DESCRIPTION
This test previously passed in CI, relying
on slower machines and fails locally on both
Mac and in buildbox on macbook pro m3 with:

```
cluster site-A is offline
```

Adding the wait resolves the issue.