### PR TITLE
Connect: refresh resources when access changes and add tests for `ClusterLifecycleManager`

### DIFF
--- a/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
+++ b/web/packages/teleterm/src/mainProcess/awaitableSender/awaitableSender.ts
@@ -40,6 +40,11 @@ function isMessageAck(v: unknown): v is MessageAck {
   return typeof v === 'object' && 'type' in v && v.type === 'ack';
 }
 
+export interface IAwaitableSender<T> {
+  send(payload: T, options?: { signal?: AbortSignal }): Promise<void>;
+  whenDisposed(): Promise<void>;
+}
+
 /**
  * Enables sending messages from the main process to the renderer
  * and awaiting delivery confirmation.
@@ -48,7 +53,7 @@ function isMessageAck(v: unknown): v is MessageAck {
  * `AwaitableSender` is pull-based — the renderer must explicitly subscribe
  * to receive messages.
  */
-export class AwaitableSender<T> {
+export class AwaitableSender<T> implements IAwaitableSender<T> {
   private messages = new Map<
     string,
     { resolve(): void; reject(reason: unknown): void }

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { enablePatches } from 'immer';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { IAwaitableSender } from 'teleterm/mainProcess/awaitableSender';
+import { ClusterStore } from 'teleterm/mainProcess/clusterStore';
+import { ProfileChangeSet } from 'teleterm/mainProcess/profileWatcher';
+import { RendererIpc } from 'teleterm/mainProcess/types';
+import { MockedUnaryCall } from 'teleterm/services/tshd/cloneableClient';
+import { MockTshClient } from 'teleterm/services/tshd/fixtures/mocks';
+import {
+  makeLoggedInUser,
+  makeRootCluster,
+} from 'teleterm/services/tshd/testHelpers';
+
+import {
+  ClusterLifecycleEvent,
+  ClusterLifecycleManager,
+} from './clusterLifecycleManager';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+enablePatches();
+
+const cluster = makeRootCluster();
+
+const tests: {
+  name: string;
+  setup(opts: { tshdClient: MockTshClient }): Promise<{
+    profileWatcher: () => AsyncGenerator<ProfileChangeSet, void, void>;
+    throwInRendererHandler?: boolean;
+  }>;
+  expect(opts: {
+    clusterStore: ClusterStore;
+    tshdClient: MockTshClient;
+    rendererHandler: IAwaitableSender<ClusterLifecycleEvent>;
+    globalErrorHandler: jest.Mock;
+  }): void;
+}[] = [
+  {
+    name: 'when cluster is added, it updates state and notifies renderer',
+    setup: async () => {
+      return {
+        profileWatcher: makeWatcher([{ op: 'added', cluster }]),
+      };
+    },
+    expect: ({ clusterStore, rendererHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri)).toBeDefined();
+      expect(rendererHandler.send).toHaveBeenCalledWith({
+        op: 'did-add-cluster',
+        uri: cluster.uri,
+      });
+    },
+  },
+  {
+    name: 'when cluster is added and renderer fails, it updates state and reports an error',
+    setup: async () => {
+      return {
+        throwInRendererHandler: true,
+        profileWatcher: makeWatcher([{ op: 'added', cluster }]),
+      };
+    },
+    expect: ({ clusterStore, globalErrorHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri)).toBeDefined();
+      expect(globalErrorHandler).toHaveBeenCalledWith(
+        RendererIpc.ProfileWatcherError,
+        {
+          error: new Error('Error in renderer'),
+          reason: 'processing-error',
+        }
+      );
+    },
+  },
+  {
+    name: 'when cluster is removed, it removes it and notifies renderer',
+    setup: async ({ tshdClient }) => {
+      jest.spyOn(tshdClient, 'logout');
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      return {
+        profileWatcher: makeWatcher([{ op: 'removed', cluster }]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, rendererHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri)).toBeUndefined();
+      expect(tshdClient.logout).toHaveBeenCalledWith({
+        clusterUri: cluster.uri,
+        removeProfile: true,
+      });
+      expect(rendererHandler.send).toHaveBeenCalledWith({
+        op: 'will-logout-and-remove',
+        uri: cluster.uri,
+      });
+    },
+  },
+  {
+    name: 'when cluster is removed and renderer fails, it keeps the cluster and reports an error',
+    setup: async ({ tshdClient }) => {
+      jest.spyOn(tshdClient, 'logout');
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      return {
+        throwInRendererHandler: true,
+        profileWatcher: makeWatcher([{ op: 'removed', cluster }]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, globalErrorHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri)).toBeDefined();
+      expect(tshdClient.logout).not.toHaveBeenCalled();
+      expect(globalErrorHandler).toHaveBeenCalledWith(
+        RendererIpc.ProfileWatcherError,
+        {
+          error: new Error('Error in renderer'),
+          reason: 'processing-error',
+        }
+      );
+    },
+  },
+  {
+    name: 'when cluster becomes logged-out, it logs out and notifies renderer',
+    setup: async ({ tshdClient }) => {
+      const next = makeRootCluster({
+        connected: false,
+        loggedInUser: makeLoggedInUser({ name: '' }),
+      });
+      jest.spyOn(tshdClient, 'logout');
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      return {
+        profileWatcher: makeWatcher([
+          { op: 'changed', next, previous: cluster },
+        ]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, rendererHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri).loggedInUser.name).toBe(
+        ''
+      );
+      expect(tshdClient.logout).toHaveBeenCalledWith({
+        clusterUri: cluster.uri,
+        removeProfile: false,
+      });
+      expect(rendererHandler.send).toHaveBeenCalledWith({
+        op: 'will-logout',
+        uri: cluster.uri,
+      });
+    },
+  },
+  {
+    name: 'when cluster becomes logged-out and renderer fails, it keeps logged-in state and reports an error',
+    setup: async ({ tshdClient }) => {
+      const next = makeRootCluster({
+        connected: false,
+        loggedInUser: makeLoggedInUser({ name: '' }),
+      });
+      jest.spyOn(tshdClient, 'logout');
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      return {
+        throwInRendererHandler: true,
+        profileWatcher: makeWatcher([
+          { op: 'changed', next, previous: cluster },
+        ]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, globalErrorHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri).loggedInUser.name).toBe(
+        cluster.loggedInUser.name
+      );
+      expect(tshdClient.logout).not.toHaveBeenCalled();
+      expect(globalErrorHandler).toHaveBeenCalledWith(
+        RendererIpc.ProfileWatcherError,
+        {
+          error: new Error('Error in renderer'),
+          reason: 'processing-error',
+        }
+      );
+    },
+  },
+  {
+    name: 'when cluster changes, it updates state and clears stale clients',
+    setup: async ({ tshdClient }) => {
+      const next = makeRootCluster({
+        connected: false,
+      });
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      jest.spyOn(tshdClient, 'clearStaleClusterClients');
+      return {
+        profileWatcher: makeWatcher([
+          { op: 'changed', next, previous: cluster },
+        ]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, rendererHandler }) => {
+      expect(clusterStore.getState().get(cluster.uri).connected).toBe(false);
+      expect(tshdClient.clearStaleClusterClients).toHaveBeenCalledWith({
+        rootClusterUri: cluster.uri,
+      });
+      expect(rendererHandler.send).not.toHaveBeenCalled();
+    },
+  },
+  {
+    name: 'when access of logged in user changes, it updates state, clears stale clients, and notifies renderer',
+    setup: async ({ tshdClient }) => {
+      const next = makeRootCluster({
+        loggedInUser: makeLoggedInUser({ activeRequests: ['abcd'] }),
+      });
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      jest.spyOn(tshdClient, 'clearStaleClusterClients');
+      return {
+        profileWatcher: makeWatcher([
+          { op: 'changed', next, previous: cluster },
+        ]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, rendererHandler }) => {
+      expect(
+        clusterStore.getState().get(cluster.uri).loggedInUser.activeRequests
+      ).toEqual(['abcd']);
+      expect(tshdClient.clearStaleClusterClients).toHaveBeenCalledWith({
+        rootClusterUri: cluster.uri,
+      });
+      expect(rendererHandler.send).toHaveBeenCalledWith({
+        op: 'did-change-access',
+        uri: cluster.uri,
+      });
+    },
+  },
+  {
+    name: 'when access of logged in user changes and renderer fails, it updates state, clears stale clients and reports error',
+    setup: async ({ tshdClient }) => {
+      const next = makeRootCluster({
+        loggedInUser: makeLoggedInUser({ activeRequests: ['abcd'] }),
+      });
+      jest
+        .spyOn(tshdClient, 'listRootClusters')
+        .mockResolvedValue(new MockedUnaryCall({ clusters: [cluster] }));
+      jest.spyOn(tshdClient, 'clearStaleClusterClients');
+      return {
+        throwInRendererHandler: true,
+        profileWatcher: makeWatcher([
+          { op: 'changed', next, previous: cluster },
+        ]),
+      };
+    },
+    expect: ({ clusterStore, tshdClient, globalErrorHandler }) => {
+      expect(
+        clusterStore.getState().get(cluster.uri).loggedInUser.activeRequests
+      ).toEqual(['abcd']);
+      expect(tshdClient.clearStaleClusterClients).toHaveBeenCalledWith({
+        rootClusterUri: cluster.uri,
+      });
+      expect(globalErrorHandler).toHaveBeenCalledWith(
+        RendererIpc.ProfileWatcherError,
+        {
+          error: new Error('Error in renderer'),
+          reason: 'processing-error',
+        }
+      );
+    },
+  },
+];
+
+// eslint-disable-next-line jest/expect-expect
+test.each(tests)('$name', async ({ setup, expect: testExpect }) => {
+  const mockTshdClient = new MockTshClient();
+  const mockAppUpdater = {
+    maybeRemoveManagingCluster: jest.fn().mockResolvedValue(undefined),
+  };
+  const clusterStore = new ClusterStore(async () => mockTshdClient, {
+    crashWindow: async () => {},
+  });
+  const globalErrorHandler = jest.fn();
+  const windowsManager = {
+    getWindow: () => ({
+      webContents: {
+        send: globalErrorHandler,
+      },
+    }),
+  };
+  const { profileWatcher, throwInRendererHandler } = await setup({
+    tshdClient: mockTshdClient,
+  });
+
+  const done = Promise.withResolvers<void>();
+  const consumer = (async function* () {
+    try {
+      for await (const value of profileWatcher()) {
+        yield value;
+      }
+    } finally {
+      done.resolve();
+    }
+  })();
+
+  const manager = new ClusterLifecycleManager(
+    clusterStore,
+    async () => mockTshdClient,
+    mockAppUpdater,
+    windowsManager,
+    consumer
+  );
+  const mockRendererHandler = {
+    send: throwInRendererHandler
+      ? jest.fn().mockRejectedValue(new Error('Error in renderer'))
+      : jest.fn().mockResolvedValue(undefined),
+    whenDisposed: () => new Promise<void>(() => {}),
+  };
+  manager.setRendererEventHandler(mockRendererHandler);
+  await manager.syncRootClustersAndStartProfileWatcher();
+  await done.promise;
+
+  testExpect({
+    globalErrorHandler,
+    clusterStore,
+    tshdClient: mockTshdClient,
+    rendererHandler: mockRendererHandler,
+  });
+});
+
+function makeWatcher(...events: ProfileChangeSet[]) {
+  return async function* () {
+    yield* events;
+  };
+}

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.test.ts
@@ -91,7 +91,7 @@ const tests: {
     },
   },
   {
-    name: 'when cluster is removed, it removes it and notifies renderer',
+    name: 'when cluster is removed, it updates state and notifies renderer',
     setup: async ({ tshdClient }) => {
       jest.spyOn(tshdClient, 'logout');
       jest
@@ -138,7 +138,7 @@ const tests: {
     },
   },
   {
-    name: 'when cluster becomes logged-out, it logs out and notifies renderer',
+    name: 'when cluster becomes logged-out, it updates state and notifies renderer',
     setup: async ({ tshdClient }) => {
       const next = makeRootCluster({
         connected: false,

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -43,6 +43,14 @@ export interface ClusterLifecycleEvent {
    *
    * Operations prefixed with `did-` occur after the action has already happened
    * in the main process, so they cannot prevent it.
+   *
+   * Operation meanings:
+   * * did-add-cluster - A cluster has been successfully added.
+   * * did-change-access - The logged-in user has changed, or their roles,
+   * or access requests have been updated.
+   * * will-logout - The user is about to be logged out.
+   * * will-logout-and-remove - The user is about to be logged out
+   * and their profile (cluster) will be removed.
    */
   op:
     | 'did-add-cluster'

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -708,7 +708,7 @@ export default class MainProcess {
     );
 
     ipcMain.handle(MainProcessIpc.SyncCluster, (_, args) =>
-      this.clusterStore.sync(args.clusterUri)
+      this.clusterLifecycleManager.syncCluster(args.clusterUri)
     );
 
     ipcMain.handle(MainProcessIpc.Logout, async (_, args) => {

--- a/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequests/SelectorMenu.tsx
@@ -44,7 +44,6 @@ import {
   MenuListItem,
   Separator,
 } from 'teleterm/ui/components/Menu';
-import { useResourcesContext } from 'teleterm/ui/DocumentCluster/resourcesContext';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { useLoggedInUser } from 'teleterm/ui/hooks/useLoggedInUser';
 import { TopBarButton } from 'teleterm/ui/TopBar/TopBarButton';
@@ -83,7 +82,6 @@ export function SelectorMenu() {
   const ctx = useAppContext();
   const { clustersService } = ctx;
   const selectorRef = useRef<HTMLButtonElement>(null);
-  const { requestResourcesRefresh } = useResourcesContext(rootClusterUri);
   const loggedInUser = useLoggedInUser();
   const username = loggedInUser?.name;
 
@@ -210,7 +208,6 @@ export function SelectorMenu() {
         await clustersService.assumeRoles(rootClusterUri, [requestId]);
       }
     });
-    requestResourcesRefresh();
   }
 
   const isResourceRequestAssumed = sortedRequests

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAssumeAccess.ts
@@ -35,8 +35,6 @@ export function useAssumeAccess() {
   const [assumeRoleAttempt, runAssumeRole] = useAsync((requestId: string) =>
     retryWithRelogin(ctx, clusterUri, async () => {
       await ctx.clustersService.assumeRoles(rootClusterUri, [requestId]);
-      // Refresh the current resource tabs in the workspace.
-      requestResourcesRefresh();
     })
   );
 

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.test.tsx
@@ -19,6 +19,7 @@
 import { renderHook } from '@testing-library/react';
 
 import { rootClusterUri } from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
 import {
   ResourcesContextProvider,
@@ -28,7 +29,9 @@ import {
 describe('requestResourcesRefresh', () => {
   it('calls listener registered with onResourcesRefreshRequest', () => {
     const wrapper = ({ children }) => (
-      <ResourcesContextProvider>{children}</ResourcesContextProvider>
+      <MockAppContextProvider>
+        <ResourcesContextProvider>{children}</ResourcesContextProvider>
+      </MockAppContextProvider>
     );
     const { result } = renderHook(
       () => ({
@@ -58,7 +61,9 @@ describe('requestResourcesRefresh', () => {
 describe('onResourcesRefreshRequest cleanup function', () => {
   it('removes the listener', () => {
     const wrapper = ({ children }) => (
-      <ResourcesContextProvider>{children}</ResourcesContextProvider>
+      <MockAppContextProvider>
+        <ResourcesContextProvider>{children}</ResourcesContextProvider>
+      </MockAppContextProvider>
     );
     const { result } = renderHook(() => useResourcesContext(rootClusterUri), {
       wrapper,

--- a/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/resourcesContext.tsx
@@ -24,9 +24,11 @@ import {
   PropsWithChildren,
   useCallback,
   useContext,
+  useEffect,
   useRef,
 } from 'react';
 
+import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 export interface ResourcesContext {
@@ -54,6 +56,7 @@ export interface ResourcesContext {
 const ResourcesContext = createContext<ResourcesContext>(null);
 
 export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
+  const appCtx = useAppContext();
   const emitterRef = useRef<EventEmitter>(undefined);
   if (!emitterRef.current) {
     emitterRef.current = new EventEmitter();
@@ -85,6 +88,12 @@ export const ResourcesContextProvider: FC<PropsWithChildren> = props => {
     },
     []
   );
+
+  useEffect(() => {
+    return appCtx.addResourceRefreshListener(uri => {
+      requestResourcesRefresh(uri);
+    });
+  }, [appCtx, requestResourcesRefresh]);
 
   return (
     <ResourcesContext.Provider

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -230,7 +230,11 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     }
   }
 
-  /** Assumes roles for the given requests. */
+  /**
+   * Assumes roles for the given requests.
+   * After it's done, resources refresh is requested in
+   * ClusterLifecycleManager.syncCluster.
+   */
   async assumeRoles(
     rootClusterUri: uri.RootClusterUri,
     requestIds: string[]
@@ -244,7 +248,11 @@ export class ClustersService extends ImmutableStore<ClustersServiceState> {
     await this.syncRootCluster(rootClusterUri);
   }
 
-  /** Drops roles for the given requests. */
+  /**
+   * Drops roles for the given requests.
+   * After it's done, resources refresh is requested in
+   * ClusterLifecycleManager.syncCluster.
+   */
   async dropRoles(
     rootClusterUri: uri.RootClusterUri,
     requestIds: string[]

--- a/web/packages/teleterm/src/ui/types.ts
+++ b/web/packages/teleterm/src/ui/types.ts
@@ -39,6 +39,7 @@ import { TerminalsService } from 'teleterm/ui/services/terminals';
 import { TshdNotificationsService } from 'teleterm/ui/services/tshdNotifications/tshdNotificationService';
 import { UsageService } from 'teleterm/ui/services/usage';
 import { WorkspacesService } from 'teleterm/ui/services/workspacesService';
+import { RootClusterUri } from 'teleterm/ui/uri';
 
 export interface IAppContext {
   clustersService: ClustersService;
@@ -83,8 +84,15 @@ export interface IAppContext {
    * process (renderer).
    */
   unexpectedVnetShutdownListener: UnexpectedVnetShutdownListener | undefined;
+
+  /** Sets the listener and returns a cleanup function which removes the listener. */
+  addResourceRefreshListener: (listener: ResourceRefreshListener) => () => void;
+  /** Gets called when `ClusterLifecycleManager` requests resource refresh. */
+  resourceRefreshListener: ResourceRefreshListener | undefined;
 }
 
 export type UnexpectedVnetShutdownListener = (
   request: tshdEventsApi.ReportUnexpectedVnetShutdownRequest
 ) => void;
+
+export type ResourceRefreshListener = (uri: RootClusterUri) => void;


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/25806

Currently, when the user assumes or drops a request through the UI, we send that request to tshd, synchronize the root cluster, and request a refresh of resource tabs.
It would be great to have the same behavior (refreshing the resources) when a request is assumed through tsh.

My initial idea was to check if active requests of the logged in user has changed. This approach would work, but it would be prone to false positives. For example, this property would change when the user logs in as a different user, who doesn't have any assumed requests.

This wouldn't be a major issue, but I thought we could turn this bug into a feature. Instead of comparing only the active requests, we also check the username and roles of the logged-in user. When we detect that any of these have changed, we can assume with high probability that the user should see different resources.

I also added tests for `ClusterLifecycleManager`.

