### PR TITLE
[v18] Bloat Check Instance runner upgrade

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   bloat_check:
     name: Bloat Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-4core
     outputs:
       base_stats_file: ${{ steps.build_base.outputs.base_stats_file }}
       current_build_dir: ${{ steps.build_branch.outputs.build_dir }}


### PR DESCRIPTION
backport: https://github.com/gravitational/teleport/pull/61451
upgrading bloat check runner instance