### PR TITLE
Fix "invalid name syntax" connection error for PostgreSQL auto-provisioned users with email usernames

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -81,10 +81,11 @@ func testRDS(t *testing.T) {
 
 	// use random names so we can test auto provisioning these users with these
 	// roles via Teleport, without tests colliding with eachother across
-	// parallel test runs.
-	autoUserFineGrain := "auto_fine_grain_" + randASCII(t)
-	autoUserKeep := "auto_keep_" + randASCII(t)
-	autoUserDrop := "auto_drop_" + randASCII(t)
+	// parallel test runs. use email addresses in some tests to test out
+	// special characters.
+	autoUserFineGrain := "auto_fine_grain_" + randASCII(t) + "@teleport.com"
+	autoUserKeep := "auto_keep_" + randASCII(t) + "@teleport.com"
+	autoUserDrop := "auto_drop_" + randASCII(t) + "@teleport.com"
 	autoUserFineGrain2 := "auto_fine_grain2_" + randASCII(t)
 	autoUserKeep2 := "auto_keep2_" + randASCII(t)
 	autoUserDrop2 := "auto_drop2_" + randASCII(t)

--- a/lib/srv/db/postgres/sql/deactivate-user.sql
+++ b/lib/srv/db/postgres/sql/deactivate-user.sql
@@ -13,7 +13,7 @@ BEGIN
         SELECT r.rolname
         FROM pg_roles r
         WHERE r.rolname NOT IN (username, 'teleport-auto-user') AND
-              r.oid IN (select m.roleid from pg_auth_members m where m.member = to_regrole(username)::oid)
+              r.oid IN (select m.roleid from pg_auth_members m where m.member = to_regrole(QUOTE_IDENT(username))::oid)
         LOOP
             EXECUTE FORMAT('REVOKE %I FROM %I', role_, username);
         END LOOP;


### PR DESCRIPTION
closes #61448 
- #61448 

changelog: Fix "invalid name syntax" connection error for PostgreSQL auto-provisioned users with email usernames.