### PR TITLE
Fix AWS Console (w/ integration) access when using IP Pinning

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -361,7 +361,21 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 		appIntegration := appServer.GetApp().GetIntegration()
 		if appIntegration != "" {
 			src, dst := net.Pipe()
-			go t.c.integrationAppHandler.HandleConnection(src)
+
+			// Creating the connection using `net.Pipe()` results in both ends having the same local/remote address: "pipe".
+			// This causes IP Pinning checks to fail when validating that the connection remote address matches the certificate pinned IP.
+			//
+			// To fix this, we need to wrap the `src` connection to return the client source address as the remote address.
+			// The client source address is extracted from the context, the same way as in `dialAppServer`.
+			srcWithClientSrcAddr, err := wrapConnWithClientSrcAddrFromContext(ctx, src)
+			if err != nil {
+				// Log a warning and use the original remote address if we fail to extract the client source address from context.
+				// This will result in an error if the flow has pinned IP restrictions.
+				t.c.log.WarnContext(ctx, "Failed to extract client source address from context when proxying access to Application with integration credentials. IP Pinning checks will fail.", "error", err)
+				srcWithClientSrcAddr = src
+			}
+
+			go t.c.integrationAppHandler.HandleConnection(srcWithClientSrcAddr)
 			return dst, nil
 		}
 
@@ -384,6 +398,27 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 	}
 
 	return nil, trace.ConnectionProblem(nil, "no application servers remaining to connect")
+}
+
+type connWithCustomRemoteAddr struct {
+	net.Conn
+	remoteAddr net.Addr
+}
+
+func (w *connWithCustomRemoteAddr) RemoteAddr() net.Addr {
+	return w.remoteAddr
+}
+
+func wrapConnWithClientSrcAddrFromContext(ctx context.Context, conn net.Conn) (net.Conn, error) {
+	clientSrcAddr, err := authz.ClientSrcAddrFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &connWithCustomRemoteAddr{
+		Conn:       conn,
+		remoteAddr: clientSrcAddr,
+	}, nil
 }
 
 // DialWebsocket dials a websocket connection over the transport's reverse

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
@@ -494,12 +495,19 @@ func Test_transport_with_integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	conn, err := tr.DialContext(context.Background(), "", "")
+	ctxWithClientSrcAddr := authz.ContextWithClientSrcAddr(t.Context(), &utils.NetAddr{
+		AddrNetwork: "tcp",
+		Addr:        net.JoinHostPort("127.0.0.1", "55555"),
+	})
+
+	conn, err := tr.DialContext(ctxWithClientSrcAddr, "", "")
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		return integrationAppHandler.getConnection() != nil
 	}, 100*time.Millisecond, 10*time.Millisecond)
+
+	require.Equal(t, "127.0.0.1:55555", integrationAppHandler.getConnection().RemoteAddr().String())
 
 	message := "hello world"
 	messageSize := len(message)


### PR DESCRIPTION
When IP Pinning is enabled, the certificate's pinned IP and the IP presented by the client in the connection must be the same.

For AWS Console access which uses an integration, we don't use an Application Service to proxy connections, the Proxy Service is used instead.

In this situation, it uses a `net.Pipe` which sets both Local/Remote addrs to `pipe`.

When validating whether that's the same IP as the one present in the certificate's pinned IP, it fails because that's the address of an intermediate connection.

This PR fixes this by wrapping the connection with an overrided `RemoteAddr` method which returns the true client's IP extracted from the context.

Backporting to v17 because, even tho Roles Anywhere is v18, this also affects AWS OIDC integration which is present in v17.

Fixes #61437

Changelog: Fixed AWS Console access when using AWS IAM Roles Anywhere or AWS OIDC integrations, when IP Pinning is enabled.
