### PR TITLE
Add InsertAccessListCollection to services.AccessListsInternal

### DIFF
--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	"github.com/gravitational/teleport/lib/services"
 )
 
 // RelationshipKind represents the type of relationship: member or owner.
@@ -48,6 +47,14 @@ type AccessListAndMembersGetter interface {
 	ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) (members []*accesslist.AccessListMember, nextToken string, err error)
 	GetAccessList(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
 	GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error)
+}
+
+// lockGetter is a service that gets locks.
+type lockGetter interface {
+	// GetLocks is here for compatibility with older Teleport versions.
+	// TODO(okraport): DELETE IN v21
+	GetLocks(ctx context.Context, inForceOnly bool, targets ...types.LockTarget) ([]types.Lock, error)
+	ListLocks(ctx context.Context, limit int, startKey string, filter *types.LockFilter) ([]types.Lock, string, error)
 }
 
 // GetMembersFor returns a flattened list of Members for an Access List, including inherited Members.
@@ -271,7 +278,7 @@ func IsAccessListOwner(
 	user types.User,
 	accessList *accesslist.AccessList,
 	g AccessListAndMembersGetter,
-	lockGetter services.LockGetter,
+	lockGetter lockGetter,
 	clock clockwork.Clock,
 ) (accesslistv1.AccessListUserAssignmentType, error) {
 	if lockGetter != nil {
@@ -350,7 +357,7 @@ func IsAccessListMember(
 	user types.User,
 	accessList *accesslist.AccessList,
 	g AccessListAndMembersGetter,
-	lockGetter services.LockGetter,
+	lockGetter lockGetter,
 	clock clockwork.Clock,
 ) (accesslistv1.AccessListUserAssignmentType, error) {
 	if lockGetter != nil {

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -32,6 +32,7 @@ import (
 	accesslistclient "github.com/gravitational/teleport/api/client/accesslist"
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/accesslists"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -93,6 +94,26 @@ type AccessListsInternal interface {
 	// UpdateAccessListAndOverwriteMembers conditionally updates the access list,
 	// overwriting the list's members if successful.
 	UpdateAccessListAndOverwriteMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
+
+	// InsertAccessListCollection inserts a complete collection of access lists and their members from a single
+	// upstream source (e.g. EntraID) using a batch operation for improved performance.
+	//
+	// This method is designed for bulk import scenarios where an entire access list collection needs to be
+	// synchronized from an external source. All access lists and members in the collection are
+	// inserted using chunked batch operations, minimizing memory allocation while still reducing
+	// the number of write operations. Due to the batch nature of this operation (access list hierarchy
+	// is known upfront), we can avoid per-access-list locking and global locks to improve performance.
+	//
+	// Important: This method assumes the collection is self-contained. Access lists in the collection
+	// cannot reference access lists outside the collection as members or owners. This is intentional for
+	// collections representing a complete snapshot from a single upstream source.
+	// The function should be used only once during initial import where
+	// we are sure that Teleport doesn't have any pre-existing access lists from the upstream and the
+	// internal relation between upstream access lists and internal access lists doesn't exist yet.
+	//
+	// Operation can fail due to backend shutdown. In that case, if partial state was created,
+	// use UpsertAccessListWithMembers/DeleteAccessListMember to reconcile to the desired state.
+	InsertAccessListCollection(ctx context.Context, collection *accesslists.Collection) error
 }
 
 // MarshalAccessList marshals the access list resource to JSON.


### PR DESCRIPTION
This PR adds the`InsertAccessListCollection` function (introduced in https://github.com/gravitational/teleport/pull/61315) to the AL service internal interface so teleport.e code can use it. This created an import cycle that I broke by adding local lock getter interface instead of importing the one from the bloated `services` package.

Required by: https://github.com/gravitational/teleport.e/pull/7572