### PR TITLE
Skip client tools auto updates for dev builds

### DIFF
--- a/lib/autoupdate/tools/updater.go
+++ b/lib/autoupdate/tools/updater.go
@@ -150,6 +150,10 @@ func NewUpdater(toolsDir, localVersion string, options ...Option) *Updater {
 // Returns the version needs to be updated and re-executed, by re-execution flag we
 // understand that update and re-execute is required.
 func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *UpdateResponse, err error) {
+	if shouldSkipDevVersion() {
+		return &UpdateResponse{Version: "", ReExec: false}, nil
+	}
+
 	// Check if the user has requested a specific version of client tools.
 	requestedVersion := os.Getenv(teleportToolsVersionEnv)
 	switch requestedVersion {
@@ -212,6 +216,10 @@ func (u *Updater) CheckLocal(ctx context.Context, profileName string) (resp *Upd
 // operate with this cluster. It returns the semantic version that needs updating and whether
 // re-execution is necessary, by re-execution flag we understand that update and re-execute is required.
 func (u *Updater) CheckRemote(ctx context.Context, proxyAddr string, insecure bool) (response *UpdateResponse, err error) {
+	if shouldSkipDevVersion() {
+		return &UpdateResponse{Version: "", ReExec: false}, nil
+	}
+
 	proxyHost := utils.TryHost(proxyAddr)
 	// Check if the user has requested a specific version of client tools.
 	requestedVersion := os.Getenv(teleportToolsVersionEnv)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -841,6 +841,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		DTAutoEnroll:       dtenroll.AutoEnroll,
 	}
 
+	// run early to enable debug logging if env var is set.
+	// this makes it possible to debug early startup functionality, particularly command aliases.
+	if _, err := initLogger(&cf, utils.LoggingForCLI, parseLoggingOptsFromEnv()); err != nil {
+		printInitLoggerError(err)
+	}
+
 	// We need to parse the arguments before executing managed updates to identify
 	// the profile name and the required version for the current cluster.
 	// All other commands and flags may change between versions, so full parsing
@@ -856,12 +862,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	name := utils.TryHost(strings.TrimPrefix(strings.ToLower(proxyArg), "https://"))
 	if err := autoupdatetools.CheckAndUpdateLocal(ctx, name, args); err != nil {
 		return trace.Wrap(err)
-	}
-
-	// run early to enable debug logging if env var is set.
-	// this makes it possible to debug early startup functionality, particularly command aliases.
-	if _, err := initLogger(&cf, utils.LoggingForCLI, parseLoggingOptsFromEnv()); err != nil {
-		printInitLoggerError(err)
 	}
 
 	moduleCfg := modules.GetModules()


### PR DESCRIPTION
Often dev builds, with particular patches, are sent to customers for testing of said patch. Having the dev builds auto-update create a confusing situation and asking customers to set TELEPORT_TOOLS_VERSION=off is noisy and error prone.

#61495