### PR TITLE
Fix duplicated "name" field in MWI reference docs

### DIFF
--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -603,10 +603,6 @@ audiences:
  - foo.example.com
 (!docs/pages/includes/machine-id/workload-identity-selector-config.yaml!)
 (!docs/pages/includes/machine-id/common-output-config.yaml!)
-# name optionally overrides the name of the service used in logs and the `/readyz`
-# endpoint. It must only contain letters, numbers, hyphens, underscores, and plus
-# symbols.
-name: my-service-name
 ```
 
 ### `workload-identity-aws-roles-anywhere`


### PR DESCRIPTION
This field is already described within the `docs/pages/includes/machine-id/common-output-config.yaml` include - so appeared duplicated in the documentation.