### PR TITLE
use a map of strings to empty structs instead of bools for ESR configured events map

### DIFF
--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -174,10 +174,10 @@ func TestRootWatch(t *testing.T) {
 		User:           "foo@example.com",
 		PID:            cmd.Process.Pid,
 		Emitter:        emitter,
-		Events: map[string]bool{
-			constants.EnhancedRecordingCommand: true,
-			constants.EnhancedRecordingDisk:    true,
-			constants.EnhancedRecordingNetwork: true,
+		Events: map[string]struct{}{
+			constants.EnhancedRecordingCommand: {},
+			constants.EnhancedRecordingDisk:    {},
+			constants.EnhancedRecordingNetwork: {},
 		},
 	})
 	require.NoError(t, err)
@@ -277,8 +277,8 @@ func TestRootScripts(t *testing.T) {
 				User:           "foo@example.com",
 				PID:            os.Getpid(),
 				Emitter:        emitter,
-				Events: map[string]bool{
-					constants.EnhancedRecordingCommand: true,
+				Events: map[string]struct{}{
+					constants.EnhancedRecordingCommand: {},
 				},
 			}
 			_, err := service.OpenSession(scx)

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -84,7 +84,7 @@ type SessionContext struct {
 
 	// Events is the set of events (command, disk, or network) to record for
 	// this session.
-	Events map[string]bool
+	Events map[string]struct{}
 
 	// UserRoles are the roles assigned to the user.
 	UserRoles []string
@@ -93,8 +93,7 @@ type SessionContext struct {
 }
 
 // NOP is used on either non-Linux systems or when BPF support is not enabled.
-type NOP struct {
-}
+type NOP struct{}
 
 // Close closes the NOP service. Note this function does nothing.
 func (s *NOP) Close(bool) error {

--- a/lib/srv/bpf_test.go
+++ b/lib/srv/bpf_test.go
@@ -70,10 +70,10 @@ var (
 	longArg    = strings.Repeat(longArgBase, (maxArgLength/4)/len(longArgBase))
 	overMaxArg = strings.Repeat(longArgBase, (maxArgLength)/len(longArgBase)+1)
 
-	recordAllEvents = map[string]bool{
-		constants.EnhancedRecordingCommand: true,
-		constants.EnhancedRecordingDisk:    true,
-		constants.EnhancedRecordingNetwork: true,
+	recordAllEvents = map[string]struct{}{
+		constants.EnhancedRecordingCommand: {},
+		constants.EnhancedRecordingDisk:    {},
+		constants.EnhancedRecordingNetwork: {},
 	}
 )
 
@@ -657,42 +657,42 @@ func TestBPFRoleOptions(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		events map[string]bool
+		events map[string]struct{}
 	}{
 		{
 			name: "no events",
 		},
 		{
 			name:   "command events",
-			events: map[string]bool{constants.EnhancedRecordingCommand: true},
+			events: map[string]struct{}{constants.EnhancedRecordingCommand: {}},
 		},
 		{
 			name:   "disk events",
-			events: map[string]bool{constants.EnhancedRecordingDisk: true},
+			events: map[string]struct{}{constants.EnhancedRecordingDisk: {}},
 		},
 		{
 			name:   "network events",
-			events: map[string]bool{constants.EnhancedRecordingNetwork: true},
+			events: map[string]struct{}{constants.EnhancedRecordingNetwork: {}},
 		},
 		{
 			name: "command and disk events",
-			events: map[string]bool{
-				constants.EnhancedRecordingCommand: true,
-				constants.EnhancedRecordingDisk:    true,
+			events: map[string]struct{}{
+				constants.EnhancedRecordingCommand: {},
+				constants.EnhancedRecordingDisk:    {},
 			},
 		},
 		{
 			name: "command and network events",
-			events: map[string]bool{
-				constants.EnhancedRecordingCommand: true,
-				constants.EnhancedRecordingNetwork: true,
+			events: map[string]struct{}{
+				constants.EnhancedRecordingCommand: {},
+				constants.EnhancedRecordingNetwork: {},
 			},
 		},
 		{
 			name: "disk and network events",
-			events: map[string]bool{
-				constants.EnhancedRecordingDisk:    true,
-				constants.EnhancedRecordingNetwork: true,
+			events: map[string]struct{}{
+				constants.EnhancedRecordingDisk:    {},
+				constants.EnhancedRecordingNetwork: {},
 			},
 		},
 	}
@@ -799,7 +799,7 @@ func handleConnections(l net.Listener) {
 
 // runCommand runs the given command with Enhanced Session Recording
 // enabled and returns the recorded events.
-func runCommand(t *testing.T, srv Server, bpfSrv bpf.BPF, command string, expectedCmdFail bool, recordEvents map[string]bool) []apievents.AuditEvent {
+func runCommand(t *testing.T, srv Server, bpfSrv bpf.BPF, command string, expectedCmdFail bool, recordEvents map[string]struct{}) []apievents.AuditEvent {
 	scx := newExecServerContext(t, srv)
 	scx.Identity.AccessPermit = &decisionpb.SSHAccessPermit{}
 	scx.execRequest.SetCommand(command)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1427,7 +1427,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		return trace.Wrap(err)
 	}
 
-	var eventsMap map[string]bool
+	var eventsMap map[string]struct{}
 	if scx.Identity.AccessPermit != nil {
 		eventsMap = eventsMapFromSSHAccessPermit(scx.Identity.AccessPermit)
 	} else if scx.srv.GetBPF().Enabled() {
@@ -1645,7 +1645,7 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 		scx.SendExecResult(ctx, *result)
 	}
 
-	var eventsMap map[string]bool
+	var eventsMap map[string]struct{}
 	if scx.Identity.AccessPermit != nil {
 		eventsMap = eventsMapFromSSHAccessPermit(scx.Identity.AccessPermit)
 	} else if scx.srv.GetBPF().Enabled() {
@@ -2502,10 +2502,10 @@ func (s *session) onWriteErrorCallback(sessionRecordingMode constants.SessionRec
 	}
 }
 
-func eventsMapFromSSHAccessPermit(permit *decisionpb.SSHAccessPermit) map[string]bool {
-	eventsMap := make(map[string]bool, len(permit.BpfEvents))
+func eventsMapFromSSHAccessPermit(permit *decisionpb.SSHAccessPermit) map[string]struct{} {
+	eventsMap := make(map[string]struct{}, len(permit.BpfEvents))
 	for _, event := range permit.BpfEvents {
-		eventsMap[event] = true
+		eventsMap[event] = struct{}{}
 	}
 
 	return eventsMap


### PR DESCRIPTION
The bools in the map were meaningless, the existence of keys is all anything ever checks for.

Follow up from https://github.com/gravitational/teleport/pull/61450.