### PR TITLE
[chore] disable debug service in integration tests

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -67,6 +67,7 @@ func newNodeConfig(t *testing.T, tokenName string, joinMethod types.JoinMethod) 
 	config.Logger = slog.New(slog.DiscardHandler)
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	config.InstanceMetadataClient = cloudimds.NewDisabledIMDSClient()
+	config.DebugService.Enabled = false
 	return config
 }
 
@@ -77,6 +78,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, tokenName string, join
 	config.JoinMethod = joinMethod
 	config.SSH.Enabled = false
 	config.Auth.Enabled = false
+	config.DebugService.Enabled = false
 
 	proxyAddr := helpers.NewListener(t, service.ListenerProxyWeb, &config.FileDescriptors)
 	config.Proxy.Enabled = true
@@ -123,6 +125,7 @@ func newAuthConfig(t *testing.T, clock clockwork.Clock) *servicecfg.Config {
 	config.Logger = slog.New(slog.DiscardHandler)
 	config.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	config.InstanceMetadataClient = cloudimds.NewDisabledIMDSClient()
+	config.DebugService.Enabled = false
 	return config
 }
 

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -377,6 +377,7 @@ func MakeTestServers(t *testing.T) (auth *service.TeleportProcess, proxy *servic
 	// We need this to get a random port assigned to it and allow parallel
 	// execution of this test.
 	cfg := servicecfg.MakeDefaultConfig()
+	cfg.DebugService.Enabled = false
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	cfg.Hostname = "localhost"
@@ -418,6 +419,7 @@ func MakeTestServers(t *testing.T) (auth *service.TeleportProcess, proxy *servic
 
 	// Set up a test proxy service.
 	cfg = servicecfg.MakeDefaultConfig()
+	cfg.DebugService.Enabled = false
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	cfg.Hostname = "localhost"
@@ -459,6 +461,7 @@ func MakeTestDatabaseServer(t *testing.T, proxyAddr utils.NetAddr, token string,
 	lib.SetInsecureDevMode(true)
 
 	cfg := servicecfg.MakeDefaultConfig()
+	cfg.DebugService.Enabled = false
 	cfg.Hostname = "localhost"
 	cfg.DataDir = t.TempDir()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8837,6 +8837,7 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 			nodeCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 			nodeCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 			nodeCfg.Auth.Enabled = false
+			nodeCfg.DebugService.Enabled = false
 			// Configure Proxy.
 			nodeCfg.Proxy.Enabled = true
 			nodeCfg.Proxy.DisableWebService = false
@@ -8845,7 +8846,6 @@ func TestConnectivityWithoutAuth(t *testing.T) {
 			nodeCfg.Proxy.SSHAddr.Addr = node.SSHProxy
 			nodeCfg.Proxy.WebAddr.Addr = node.Web
 			nodeCfg.Proxy.ReverseTunnelListenAddr.Addr = node.Secrets.TunnelAddr
-
 			// Configure Node.
 			nodeCfg.SSH.Enabled = true
 			nodeCfg.SSH.Addr.Addr = node.SSH
@@ -8977,6 +8977,7 @@ func TestConnectivityDuringAuthRestart(t *testing.T) {
 	nodeCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 	nodeCfg.DiagnosticAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerType("diag"), &node.Fds))
 	nodeCfg.Auth.Enabled = false
+	nodeCfg.DebugService.Enabled = false
 	// Configure Proxy.
 	nodeCfg.Proxy.Enabled = true
 	nodeCfg.Proxy.DisableWebService = false

--- a/integration/joinopenssh_test.go
+++ b/integration/joinopenssh_test.go
@@ -87,6 +87,7 @@ func TestJoinOpenSSH(t *testing.T) {
 	openSSHCfg := servicecfg.MakeDefaultConfig()
 
 	openSSHCfg.OpenSSH.Enabled = true
+	openSSHCfg.DebugService.Enabled = false
 	err = config.ConfigureOpenSSH(&config.CommandLineFlags{
 		DataDir:           teleportDataDir,
 		ProxyServer:       rc.Web,

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -211,6 +211,7 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			nodeCfg.SSH.Enabled = true
 			nodeCfg.SSH.AllowTCPForwarding = tt.portForwardingAllowed
 			nodeCfg.SSH.Labels = map[string]string{"foo": "bar"}
+			nodeCfg.DebugService.Enabled = false
 
 			err = node.CreateWithConf(t, nodeCfg)
 			require.NoError(t, err)

--- a/integration/proxy/proxy_tunnel_strategy_test.go
+++ b/integration/proxy/proxy_tunnel_strategy_test.go
@@ -349,6 +349,7 @@ func (p *proxyTunnelStrategy) makeProxy(t *testing.T) {
 	authAddr := utils.MustParseAddr(p.auth.Auth)
 
 	conf := servicecfg.MakeDefaultConfig()
+	conf.DebugService.Enabled = false
 	conf.SetAuthServerAddress(*authAddr)
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()
@@ -399,6 +400,7 @@ func (p *proxyTunnelStrategy) makeNode(t *testing.T) {
 	conf.DataDir = t.TempDir()
 	conf.Logger = node.Log
 	conf.InstanceMetadataClient = imds.NewDisabledIMDSClient()
+	conf.DebugService.Enabled = false
 
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
@@ -440,6 +442,7 @@ func (p *proxyTunnelStrategy) makeDatabase(t *testing.T) {
 	})
 
 	conf := servicecfg.MakeDefaultConfig()
+	conf.DebugService.Enabled = false
 	conf.Version = types.V3
 	conf.SetToken("token")
 	conf.DataDir = t.TempDir()


### PR DESCRIPTION
The datadir in this test consists of TempDir
and typically suffix which exceeds the
BSD socket limits causing the test to fail on MacOS.

This commit disables the debug service in the failing tests,
for testing the debug service specifically it should be
enabled in the test itself