### PR TITLE
Don't modify source slice in RemoveFromSlice

### DIFF
--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/constants"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/utils/set"
 )
 
 // WriteContextCloser provides close method with context
@@ -402,8 +401,12 @@ func GetFreeTCPPorts(n int, offset ...int) (PortList, error) {
 
 // RemoveFromSlice makes a copy of the slice and removes the passed in values from the copy.
 func RemoveFromSlice(slice []string, values ...string) []string {
-	remove := set.New(values...)
-	return slices.DeleteFunc(slice, func(s string) bool { return remove.Contains(s) })
+	return slices.DeleteFunc(
+		slices.Clone(slice),
+		func(s string) bool {
+			return slices.Contains(values, s)
+		},
+	)
 }
 
 // ChooseRandomString returns a random string from the given slice.


### PR DESCRIPTION
This change modifies `RemoveFromSlice` so it doesn't modify source slice. It brings back behavior from before sets refactoring.

changelog: Fix rotation after modifying proxy public address