### PR TITLE
Clean up docs sidebar labels

### DIFF
--- a/docs/pages/reference/agent-services/application-access.mdx
+++ b/docs/pages/reference/agent-services/application-access.mdx
@@ -1,6 +1,6 @@
 ---
 title: Application Access Reference Documentation
-sidebar_label: Application Access
+sidebar_label: Applications
 description: Configuration and CLI reference documentation for Teleport application access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/database-access-reference/audit.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/audit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Audit Events Reference
-sidebar_label: Database Access Audit Events
+sidebar_label: Audit Events
 description: Audit events reference for Teleport database access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/database-access-reference/aws.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access AWS IAM Reference
-sidebar_label: Database Access AWS IAM
+sidebar_label: AWS IAM Policies
 description: AWS IAM policies for Teleport database access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/database-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access CLI Reference
-sidebar_label: Database Access CLI
+sidebar_label: CLI Commands
 description: CLI reference for Teleport database access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/database-access-reference/configuration.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Configuration Reference
-sidebar_label: Database Access Configuration
+sidebar_label: Configuration
 description: Configuration reference for Teleport database access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/database-access-reference/database-access-reference.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/database-access-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Reference
-sidebar_label: Database Access
+sidebar_label: Databases
 description: Configuration and CLI reference for the Teleport Database Service.
 tags:
  - zero-trust

--- a/docs/pages/reference/agent-services/database-access-reference/labels.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/labels.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Labels Reference
-sidebar_label: Database Labels
+sidebar_label: Labels
 description: Database labels reference for Teleport database access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/desktop-access-reference/audit.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/audit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desktop Access Audit Events Reference
-sidebar_label: Desktop Access Audit Events
+sidebar_label: Audit Events
 description: Audit events reference for Teleport desktop access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/desktop-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desktop Access CLI Reference
-sidebar_label: Desktop Access CLI
+sidebar_label: CLI Commands
 description: CLI reference for Teleport desktop access.
 tags:
  - reference

--- a/docs/pages/reference/agent-services/desktop-access-reference/configuration.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desktop Access Configuration Reference
-sidebar_label: Desktop Access Configuration
+sidebar_label: Configuration
 description: Configuration reference for Teleport desktop access.
 tags:
  - conceptual

--- a/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
+++ b/docs/pages/reference/agent-services/desktop-access-reference/desktop-access-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desktop Access Reference
-sidebar_label: Desktop Access
+sidebar_label: Remote Desktops
 description: Comprehensive guides to configuring and auditing desktop access.
 template: "no-toc"
 tags:

--- a/docs/pages/reference/agent-services/mcp-access.mdx
+++ b/docs/pages/reference/agent-services/mcp-access.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Access Reference
-sidebar_label: MCP Access
+sidebar_label: MCP Servers
 description: Configuration and CLI reference for Teleport MCP access.
 tags:
 - reference

--- a/docs/pages/reference/architecture/agents.mdx
+++ b/docs/pages/reference/architecture/agents.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Agent Architecture
+sidebar_label: Agents
 description: Describes the architecture that enables Teleport to securely proxy client traffic to infrastructure resources. 
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/api-architecture.mdx
+++ b/docs/pages/reference/architecture/api-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Architecture
+sidebar_label: API
 description: Architectural overview of the Teleport gRPC API.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/architecture.mdx
+++ b/docs/pages/reference/architecture/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Architecture
+sidebar_label: Architecture
 description: Provides detailed information about how Teleport works.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/authentication.mdx
+++ b/docs/pages/reference/architecture/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authentication
+sidebar_label: Authentication
 description: This chapter explains how Teleport uses certificate authorities to authenticate users and services.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/authorization.mdx
+++ b/docs/pages/reference/architecture/authorization.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Authorization
+sidebar_label: Authorization
 description: This chapter explains how Teleport authorizes users and roles.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/kubernetes-applications-architecture.mdx
+++ b/docs/pages/reference/architecture/kubernetes-applications-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes App Discovery Architecture
+sidebar_label: Kubernetes App Discovery
 description: Learn how Teleport automatically discovers applications running on Kubernetes.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/machine-id-architecture.mdx
+++ b/docs/pages/reference/architecture/machine-id-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Machine & Workload Identity Architecture
+sidebar_label: Machine & Workload Identity
 description: How Teleport Machine & Workload Identity works.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/proxy.mdx
+++ b/docs/pages/reference/architecture/proxy.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Proxy Service
+sidebar_label: Proxy Service
 description: Architecture of Teleport's identity-aware proxy service
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/relay.mdx
+++ b/docs/pages/reference/architecture/relay.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Relay Service
+sidebar_label: Relay Service
 description: Architecture of Teleport's Relay service
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Session Recording
+sidebar_label: Session Recording
 description: An overview of Teleport's session recording and its configuration
 tags:
  - session-recording

--- a/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
+++ b/docs/pages/reference/architecture/teleport-cloud-architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Enterprise Cloud Architecture
+sidebar_label: Enterprise Cloud
 description: Cloud security, availability, and networking details.
 tags:
  - conceptual

--- a/docs/pages/reference/architecture/trustedclusters.mdx
+++ b/docs/pages/reference/architecture/trustedclusters.mdx
@@ -1,5 +1,6 @@
 ---
 title: Trusted Clusters Architecture
+sidebar_label: Trusted Clusters
 description: Deep dive into design of Teleport Trusted Clusters.
 tags:
  - conceptual

--- a/docs/pages/reference/cli/cli.mdx
+++ b/docs/pages/reference/cli/cli.mdx
@@ -1,5 +1,6 @@
 ---
 title: Command-Line Tool References
+sidebar_label: Command-Line Tools
 description: Detailed guide and reference documentation for Teleport's command line interface (CLI) tools.
 tags:
  - reference

--- a/docs/pages/reference/deployment/config.mdx
+++ b/docs/pages/reference/deployment/config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Configuration Reference
+sidebar_label: Teleport Configuration
 description: The detailed guide and reference documentation for configuring Teleport for SSH and Kubernetes access.
 keywords: [config, file, reference, yaml, etc]
 tags:

--- a/docs/pages/reference/deployment/deployment.mdx
+++ b/docs/pages/reference/deployment/deployment.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport Deployment References
-sidebar_label: Teleport Deployment
+sidebar_label: Deploying Teleport
 description: Provides reference information for running Teleport on your infrastructure.
 ---
 

--- a/docs/pages/reference/deployment/identity-security-config.mdx
+++ b/docs/pages/reference/deployment/identity-security-config.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Identity Security Configuration
+sidebar_label: Identity Security Configuration
 description: The detailed guide and reference documentation for configuring Teleport Identity Security.
 keywords: [config, file, reference, yaml, etc]
 tags:

--- a/docs/pages/reference/deployment/monitoring/monitoring.mdx
+++ b/docs/pages/reference/deployment/monitoring/monitoring.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Monitoring References
+sidebar_label: Monitoring
 description: Provides comprehensive guides to monitoring data available from Teleport.
 tags:
  - platform-wide

--- a/docs/pages/reference/deployment/signals.mdx
+++ b/docs/pages/reference/deployment/signals.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Signals
+sidebar_label: Signals
 description: "Signals you can send to a running teleport process."
 tags:
  - reference

--- a/docs/pages/reference/helm-reference/helm-reference.mdx
+++ b/docs/pages/reference/helm-reference/helm-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Helm Chart References
+sidebar_label: Helm Charts
 description: Comprehensive lists of configuration values in Teleport's Helm charts
 template: "no-toc"
 tags:

--- a/docs/pages/reference/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/reference/machine-workload-identity/machine-workload-identity.mdx
@@ -1,5 +1,6 @@
 ---
 title: 'Machine & Workload Identity References'
+sidebar_label: Machine & Workload Identity
 description: 'Includes comprehensive guides to tools for managing Teleport Machine & Workload Identity'
 ---
 

--- a/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/attributes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Workload Identity Attributes
+sidebar_label: Attributes
 description: Information about the attributes that can be used in templating and rules in the WorkloadIdentity resource.
 tags:
  - reference

--- a/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
@@ -1,5 +1,6 @@
 ---
 title: Workload Identity X.509 Issuer Override Resource
+sidebar_label: X.509 Issuer Override Resource
 description: Provides information about the `workload_identity_x509_issuer_override` resource.
 tags:
  - conceptual

--- a/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/revocations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Workload Identity Revocations
+sidebar_label: Revocations
 description: Information about performing revocations for issued workload identity credentials
 tags:
  - conceptual

--- a/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Workload Identity API & Workload Attestation
+sidebar_label: API Service
 description: Information about the `tbot` Workload Identity API service and Workload Attestation functionality
 tags:
  - conceptual

--- a/docs/pages/reference/reference.mdx
+++ b/docs/pages/reference/reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Reference Guides
+sidebar_label: References
 description: Provides comprehensive information on configuration fields, Teleport commands, and other ways of interacting with Teleport.
 tags:
  - platform-wide


### PR DESCRIPTION
Reduce repetition in order to make the sidebar easier to read. This change edits labels in the following sidebar sections:

- reference/agent-services/database-access-reference
- reference/agent-services/desktop-access-reference
- reference/agent-services
- reference/architecture
- reference/deployment
- reference/machine-workload-identity/workload-identity
- reference