### PR TITLE
Use flexible matching on sync stamp rendering

### DIFF
--- a/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
+++ b/web/packages/design/src/SyncStamp/SyncStamp.test.tsx
@@ -22,7 +22,7 @@ import { SyncStamp } from './SyncStamp';
 
 test('renders time since date', () => {
   render(<SyncStamp date={new Date()} />);
-  expect(screen.getByText('Last Sync: 0 seconds ago')).toBeInTheDocument();
+  expect(screen.getByText(/Last Sync: \d+ seconds? ago/)).toBeInTheDocument();
 });
 
 test('renders empty state text', () => {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/AwsOidcDashboard.test.tsx
@@ -118,7 +118,7 @@ test('renders header and stats cards', async () => {
 
   const ec2 = screen.getByTestId('ec2-stats');
   expect(within(ec2).getByTestId('sync')).toHaveTextContent(
-    'Last Sync: 0 seconds ago'
+    /Last Sync: \d+ seconds? ago/
   );
   expect(within(ec2).getByTestId('rules')).toHaveTextContent(
     'Enrollment Rules 24'


### PR DESCRIPTION
Per don't test what you don't own; we really only care that the stamp is rendering, not with a specific time difference. This check should resolve the flaky outcome where sometimes the result is `0 seconds ago` and sometimes `1 second ago` by  using flexible matching on the count and plural s.

- Closes #61279 
