### PR TITLE
Allow byte export of PTY session recordings via `tsh play`

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1192,8 +1192,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	play.Flag("speed", "Playback speed, applicable when streaming SSH or Kubernetes sessions.").Default("1x").EnumVar(&cf.PlaySpeed, "0.5x", "1x", "2x", "4x", "8x")
 	play.Flag("skip-idle-time", "Quickly skip over idle time, applicable when streaming SSH or Kubernetes sessions.").BoolVar(&cf.NoWait)
 	play.Flag("format", defaults.FormatFlagDescription(
-		teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text,
-	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text)
+		teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text, "json-data",
+	)).Short('f').Default(teleport.PTY).EnumVar(&cf.Format, teleport.PTY, teleport.JSON, teleport.YAML, teleport.Text, "json-data")
 	play.Arg("session-id", "ID or path to session file to play.").Required().StringVar(&cf.SessionID)
 
 	// scp


### PR DESCRIPTION
Adds `tsh play -f json-data` to include session recording bytes in the JSON output.

That means this event:

```json
{"ei":3,"event":"print","time":"2025-11-18T20:48:39.487Z","cluster_name":"teleport.example.com","ci":2,"bytes":300,"ms":1,"offset":105}
```

would be printed like this:

```json
{"ei":3,"event":"print","time":"2025-11-18T20:48:39.487Z","cluster_name":"teleport.example.com","ci":2,"bytes":300,"ms":1,"offset":105,"data":"\r\r\nThe programs included with the Debian GNU/Linux system are free software;\r\r\nthe exact distribution terms for each program are described in the\r\r\nindividual files in /usr/share/doc/*/copyright.\r\r\n\r\r\nDebian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent\r\r\npermitted by applicable law.\r\r\n"}
```

I'm marking this as a draft because I'm sure I missed something and welcome feedback!