### PR TITLE
Web: support internal link w/ Alert.tsx and neutral intent w/ SlideTabs.tsx

### DIFF
--- a/web/packages/design/src/Alert/Alert.test.tsx
+++ b/web/packages/design/src/Alert/Alert.test.tsx
@@ -16,7 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MemoryRouter } from 'react-router';
+import { createMemoryHistory } from 'history';
+import { MemoryRouter, Router } from 'react-router';
 
 import { render, screen, theme, userEvent } from 'design/utils/testing';
 
@@ -140,18 +141,26 @@ describe('Banner', () => {
   });
 
   test('action buttons as internal links', async () => {
+    const user = userEvent.setup();
+    const history = createMemoryHistory({
+      initialEntries: ['/'],
+    });
+    const push = jest.spyOn(history, 'push');
+
     render(
       <MemoryRouter>
-        <Banner
-          primaryAction={{
-            content: 'Primary Link',
-            internalLink: 'primary-route',
-          }}
-          secondaryAction={{
-            content: 'Secondary Link',
-            internalLink: 'secondary-route',
-          }}
-        />
+        <Router history={history}>
+          <Banner
+            primaryAction={{
+              content: 'Primary Link',
+              linkTo: 'primary-route',
+            }}
+            secondaryAction={{
+              content: 'Secondary Link',
+              linkTo: 'secondary-route',
+            }}
+          />
+        </Router>
       </MemoryRouter>
     );
 
@@ -162,12 +171,17 @@ describe('Banner', () => {
     expect(
       screen.getByRole('link', { name: 'Primary Link' })
     ).not.toHaveAttribute('target');
+    await user.click(screen.getByRole('link', { name: 'Primary Link' }));
+    expect(push).toHaveBeenCalledWith('primary-route');
+
     expect(
       screen.getByRole('link', { name: 'Secondary Link' })
     ).toHaveAttribute('href', '/secondary-route');
     expect(
       screen.getByRole('link', { name: 'Secondary Link' })
     ).not.toHaveAttribute('target');
+    await user.click(screen.getByRole('link', { name: 'Secondary Link' }));
+    expect(push).toHaveBeenCalledWith('secondary-route');
   });
 
   test('dismiss button', async () => {

--- a/web/packages/design/src/Alert/Alert.test.tsx
+++ b/web/packages/design/src/Alert/Alert.test.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { MemoryRouter } from 'react-router';
+
 import { render, screen, theme, userEvent } from 'design/utils/testing';
 
 import { Alert, Banner } from '.';
@@ -107,7 +109,7 @@ describe('Banner', () => {
     expect(primaryCallback).toHaveBeenCalled();
   });
 
-  test('action buttons as links', async () => {
+  test('action buttons as external links', async () => {
     render(
       <Banner
         primaryAction={{
@@ -125,9 +127,47 @@ describe('Banner', () => {
       'href',
       'https://goteleport.com/1'
     );
+    expect(screen.getByRole('link', { name: 'Primary Link' })).toHaveAttribute(
+      'target',
+      '_blank'
+    );
     expect(
       screen.getByRole('link', { name: 'Secondary Link' })
     ).toHaveAttribute('href', 'https://goteleport.com/2');
+    expect(
+      screen.getByRole('link', { name: 'Secondary Link' })
+    ).toHaveAttribute('target', '_blank');
+  });
+
+  test('action buttons as internal links', async () => {
+    render(
+      <MemoryRouter>
+        <Banner
+          primaryAction={{
+            content: 'Primary Link',
+            internalLink: 'primary-route',
+          }}
+          secondaryAction={{
+            content: 'Secondary Link',
+            internalLink: 'secondary-route',
+          }}
+        />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'Primary Link' })).toHaveAttribute(
+      'href',
+      '/primary-route'
+    );
+    expect(
+      screen.getByRole('link', { name: 'Primary Link' })
+    ).not.toHaveAttribute('target');
+    expect(
+      screen.getByRole('link', { name: 'Secondary Link' })
+    ).toHaveAttribute('href', '/secondary-route');
+    expect(
+      screen.getByRole('link', { name: 'Secondary Link' })
+    ).not.toHaveAttribute('target');
   });
 
   test('dismiss button', async () => {

--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -17,6 +17,7 @@
  */
 
 import React, { useState } from 'react';
+import { Link as InternalLink } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 import { color, ColorProps, style } from 'styled-system';
 
@@ -137,7 +138,14 @@ interface Props<K> {
  */
 export interface Action {
   content: React.ReactNode;
+  /**
+   * a link that takes user out of the app (new tab)
+   */
   href?: string;
+  /**
+   * a link that takes you to a different route within the app
+   */
+  internalLink?: string;
   onClick?: (event: React.MouseEvent) => void;
 }
 
@@ -398,7 +406,7 @@ const ActionButtons = ({
 
 /** Renders either a regular or a link button, depending on the action. */
 export const ActionButton = ({
-  action: { href, content, onClick },
+  action: { href, content, onClick, internalLink },
   fill,
   intent,
   inputAlignment = false,
@@ -411,33 +419,36 @@ export const ActionButton = ({
   inputAlignment?: boolean;
   disabled?: boolean;
   title?: string;
-}) =>
-  href ? (
-    <Button
-      as="a"
-      href={href}
-      target="_blank"
-      fill={fill}
-      intent={intent}
-      onClick={onClick}
-      inputAlignment={inputAlignment}
-      disabled={disabled}
-      title={title}
-    >
-      {content}
-    </Button>
-  ) : (
-    <Button
-      fill={fill}
-      intent={intent}
-      onClick={onClick}
-      inputAlignment={inputAlignment}
-      disabled={disabled}
-      title={title}
-    >
-      {content}
-    </Button>
-  );
+}) => {
+  const sharedProps = {
+    fill,
+    intent,
+    onClick,
+    disabled,
+    title,
+    // Prevent props being passed to underlying React element
+    // and removes "React does not recognize <field> on a DOM element"
+    // error.
+    $inputAlignment: inputAlignment,
+  };
+
+  if (href) {
+    return (
+      <Button {...sharedProps} as="a" href={href} target="_blank">
+        {content}
+      </Button>
+    );
+  }
+
+  if (internalLink) {
+    return (
+      <Button {...sharedProps} as={InternalLink} to={internalLink}>
+        {content}
+      </Button>
+    );
+  }
+  return <Button {...sharedProps}>{content}</Button>;
+};
 
 export const Danger = (props: AlertProps) => <Alert kind="danger" {...props} />;
 export const Info = (props: AlertProps) => <Alert kind="info" {...props} />;

--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -17,7 +17,7 @@
  */
 
 import React, { useState } from 'react';
-import { Link as InternalLink } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
 import { color, ColorProps, style } from 'styled-system';
 
@@ -145,7 +145,7 @@ export interface Action {
   /**
    * a link that takes you to a different route within the app
    */
-  internalLink?: string;
+  linkTo?: string;
   onClick?: (event: React.MouseEvent) => void;
 }
 
@@ -406,7 +406,7 @@ const ActionButtons = ({
 
 /** Renders either a regular or a link button, depending on the action. */
 export const ActionButton = ({
-  action: { href, content, onClick, internalLink },
+  action: { href, content, onClick, linkTo },
   fill,
   intent,
   inputAlignment = false,
@@ -440,9 +440,9 @@ export const ActionButton = ({
     );
   }
 
-  if (internalLink) {
+  if (linkTo) {
     return (
-      <Button {...sharedProps} as={InternalLink} to={internalLink}>
+      <Button {...sharedProps} as={Link} to={linkTo}>
         {content}
       </Button>
     );

--- a/web/packages/design/src/Button/Button.tsx
+++ b/web/packages/design/src/Button/Button.tsx
@@ -63,7 +63,7 @@ export type ButtonProps<E extends React.ElementType> =
        * size of input margins, thus allowing alignment between input text and
        * button labels.
        */
-      inputAlignment?: boolean;
+      $inputAlignment?: boolean;
 
       /**
        * If set to true, renders a button with the smallest horizontal paddings.
@@ -359,7 +359,7 @@ const horizontalPadding = <E extends React.ElementType>(
   if (props.compact) {
     return 4;
   }
-  if (props.inputAlignment) {
+  if (props.$inputAlignment) {
     return 16;
   }
   if (props.size === 'small') {

--- a/web/packages/design/src/Button/buttons.story.tsx
+++ b/web/packages/design/src/Button/buttons.story.tsx
@@ -107,16 +107,16 @@ export const Buttons = () => {
           defaultValue="Padding of buttons below should match padding of this input"
           width="480px"
         />
-        <Button size="extra-large" inputAlignment>
+        <Button size="extra-large" $inputAlignment>
           Extra large with input alignment
         </Button>
-        <Button size="large" inputAlignment>
+        <Button size="large" $inputAlignment>
           Large with input alignment
         </Button>
-        <Button size="medium" inputAlignment>
+        <Button size="medium" $inputAlignment>
           Medium with input alignment
         </Button>
-        <Button size="small" inputAlignment>
+        <Button size="small" $inputAlignment>
           Small with input alignment
         </Button>
       </Flex>

--- a/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.story.tsx
@@ -246,3 +246,45 @@ export const DisabledTab = () => {
     />
   );
 };
+
+export const NeutralTabs = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  return (
+    <SlideTabs
+      tabs={threeSimpleTabs}
+      onChange={setActiveIndex}
+      activeIndex={activeIndex}
+      intent="neutral"
+    />
+  );
+};
+
+export const NeutralTabsDisabled = () => {
+  const [activeIndex, setActiveIndex] = useState(1);
+  return (
+    <SlideTabs
+      tabs={threeSimpleTabs}
+      onChange={setActiveIndex}
+      activeIndex={activeIndex}
+      intent="neutral"
+      disabled={true}
+    />
+  );
+};
+
+export const NeutralWithDisabledTab = () => {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const tabs = [
+    { key: 'aws', title: 'aws' },
+    { key: 'automatically', title: 'automatically', disabled: true },
+    { key: 'manually', title: 'manually' },
+  ];
+  return (
+    <SlideTabs
+      tabs={tabs}
+      activeIndex={activeIndex}
+      onChange={setActiveIndex}
+      intent="neutral"
+    />
+  );
+};

--- a/web/packages/design/src/SlideTabs/SlideTabs.tsx
+++ b/web/packages/design/src/SlideTabs/SlideTabs.tsx
@@ -35,6 +35,7 @@ export function SlideTabs({
   disabled = false,
   fitContent = false,
   hideStatusIconOnActiveTab,
+  intent = 'primary',
 }: SlideTabsProps) {
   const theme = useTheme();
   const activeTab = useRef<HTMLButtonElement>(null);
@@ -118,6 +119,7 @@ export function SlideTabs({
                 disabled={resolvedDisabled}
                 aria-selected={selected}
                 size={size}
+                intent={intent}
                 aria-label={ariaLabel}
               >
                 {/* We need a separate tab content component, since the status
@@ -152,7 +154,7 @@ export function SlideTabs({
           activeIndex={activeIndex}
           size={size}
         >
-          <TabSliderInner appearance={appearance} />
+          <TabSliderInner appearance={appearance} intent={intent} />
         </TabSlider>
       </TabList>
     </Wrapper>
@@ -160,6 +162,11 @@ export function SlideTabs({
 }
 
 export type SlideTabsProps = {
+  /**
+   * Specifies the selected tab button purpose class
+   * and affects its color palette.
+   */
+  intent?: Intent;
   /**
    * The style to render the selector in.
    */
@@ -216,7 +223,7 @@ export type SlideTabsProps = {
  */
 export type TabSpec = string | FullTabSpec;
 
-type FullTabSpec = TabContentSpec & {
+export type FullTabSpec = TabContentSpec & {
   /** Iteration key for the tab. */
   key: React.Key;
   /**
@@ -311,9 +318,12 @@ function StatusIconOrSpinner({
   );
 }
 
-const TabSliderInner = styled.div<{ appearance: Appearance }>`
+const TabSliderInner = styled.div<{ appearance: Appearance; intent: Intent }>`
   height: 100%;
-  background-color: ${({ theme }) => theme.colors.brand};
+  background-color: ${p =>
+    p.intent === 'primary'
+      ? p.theme.colors.brand
+      : p.theme.colors.interactive.tonal.neutral[2]};
   border-radius: ${props => (props.appearance === 'square' ? '8px' : '60px')};
 `;
 
@@ -420,6 +430,7 @@ const TabButton = styled.button<{
   disabled?: boolean;
   selected?: boolean;
   size: Size;
+  intent: Intent;
 }>`
   /* Reset the button styles. */
   font-family: inherit;
@@ -444,7 +455,7 @@ const TabButton = styled.button<{
    */
   ${buttonMargin}
   color: ${props =>
-    props.selected
+    props.selected && props.intent === 'primary'
       ? props.theme.colors.text.primaryInverse
       : props.theme.colors.text.main};
 
@@ -453,6 +464,7 @@ const TabButton = styled.button<{
 
 type Appearance = 'square' | 'round';
 type Size = 'large' | 'medium' | 'small';
+type Intent = 'primary' | 'neutral';
 
 const TabSlider = styled.div<{
   itemCount: number;

--- a/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
+++ b/web/packages/shared/components/FieldMultiInput/FieldMultiInput.tsx
@@ -194,7 +194,7 @@ export function FieldMultiInput({
           <ButtonSecondary
             alignSelf="start"
             size="small"
-            inputAlignment
+            $inputAlignment
             onClick={() => insertItem(value.length)}
             disabled={disabled}
           >

--- a/web/packages/shared/components/ScheduleEditor/ScheduleEditor.tsx
+++ b/web/packages/shared/components/ScheduleEditor/ScheduleEditor.tsx
@@ -82,7 +82,7 @@ export const ScheduleEditor = ({
             key={weekday.value}
             size="large"
             width={40}
-            inputAlignment={true}
+            $inputAlignment={true}
             intent={schedule.shifts[weekday.value] ? 'primary' : 'neutral'}
             onClick={() => toggleWeekday(weekday.value)}
           >

--- a/web/packages/shared/components/ToastNotification/ToastNotification.tsx
+++ b/web/packages/shared/components/ToastNotification/ToastNotification.tsx
@@ -258,6 +258,7 @@ const NotificationBody = ({
           <ActionButton
             intent="neutral"
             action={{
+              internalLink: action.internalLink,
               href: action.href,
               content: action.content,
               onClick: event => {

--- a/web/packages/shared/components/ToastNotification/ToastNotification.tsx
+++ b/web/packages/shared/components/ToastNotification/ToastNotification.tsx
@@ -258,7 +258,7 @@ const NotificationBody = ({
           <ActionButton
             intent="neutral"
             action={{
-              internalLink: action.internalLink,
+              linkTo: action.linkTo,
               href: action.href,
               content: action.content,
               onClick: event => {

--- a/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
+++ b/web/packages/shared/components/TraitsEditor/TraitsEditor.tsx
@@ -255,7 +255,7 @@ export function TraitsEditor({
         size="small"
         pr={3}
         compact={false}
-        inputAlignment
+        $inputAlignment
       />
     </Fieldset>
   );

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -440,7 +440,7 @@ export function KubernetesAccessSection({
                   })
                 }
                 size="small"
-                inputAlignment
+                $inputAlignment
               >
                 <Add disabled={isProcessing} size="small" />
                 {value.resources.length > 0

--- a/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
+++ b/web/packages/teleport/src/components/LabelsInput/LabelsInput.tsx
@@ -318,7 +318,7 @@ export function LabelsInput({
           size="small"
           pr={3}
           compact={false}
-          inputAlignment
+          $inputAlignment
         />
       )}
     </Fieldset>


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

two minor commits:

- Alert.tsx now supports internal linking for internal routes (used to be just external linking)
  - renaming `inputAlignment` prop to `$inputAlignment` was required b/c of react error about passing invalid props down to DOM element ([transient props](https://styled-components.com/docs/api#transient-props))
- SlideTabs.tsx now supports neutral intent where the tab buttons take on neutral coloring (with image below)

<img width="1075" height="115" alt="image" src="https://github.com/user-attachments/assets/4f24cb90-45ab-4e78-bc12-4804528f0459" />

<img width="1063" height="92" alt="image" src="https://github.com/user-attachments/assets/5f8ad9bf-b92c-4a6d-87ac-1503fdf85ebc" />

