### PR TITLE
Expand Teleport Identity Activity Center Examples

### DIFF
--- a/docs/pages/identity-security/access-graph/identity-activity-center.mdx
+++ b/docs/pages/identity-security/access-graph/identity-activity-center.mdx
@@ -117,7 +117,9 @@ for transient and long-term storage, and AWS Glue table and database.
 
 `policy.tf` includes the declaration of the AWS IAM policy that must
 be attached to the AWS identity that the Identity Security service runs as,
-enabling it to access the resources and execute queries.
+enabling it to access the resources and execute queries. If using an E2 instance
+for Identity Security, attach the policy to the instance role. If using ECS or EKS,
+attach the policy to the task or pod role.
 
 ```hcl
 (!examples/identity-activity-center/policy.tf!)
@@ -179,7 +181,10 @@ To configure it for self-hosted clusters, update the Identity Security configura
 append the following section:
 
 ```yaml
-
+# Configuration for Teleport Access Graph service.
+# Example: /etc/access_graph/config.yaml
+# Add the following section to enable Identity Activity Center.
+# ...
 identity_activity_center:
   region: <Var name="eu-central-1"/>
   database: <Var name="example-db"/>
@@ -190,7 +195,7 @@ identity_activity_center:
   workgroup: <Var name="example-workgroup"/>
   sqs_queue_url: https://sqs.<Var name="eu-central-1"/>.amazonaws.com/<Var name="aws-account-id"/>/<Var name="example-sqs-queue"/>
   maxmind_geoip_city_db_path: /path/to/geoIp-city.mmdb # optional
-
+# ...
 ```
 
 </TabItem>

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -97,14 +97,14 @@ address: ":50051"
 
 # Example Identity Activity Center configuration.
 # identity_activity_center:
-#   region: <Var name="eu-central-1"/>
-#   database: <Var name="example-db"/>
-#   table: <Var name="example-table"/>
-#   s3: s3://<Var name="example-long-term-bucket"/>/data/
-#   s3_results: s3://<Var name="example-transient-bucket"/>/results/
-#   s3_large_files: s3://<Var name="example-transient-bucket"/>/large_files
-#   workgroup: <Var name="example-workgroup"/>
-#   sqs_queue_url: https://sqs.<Var name="eu-central-1"/>.amazonaws.com/<Var name="aws-account-id"/>/<Var name="example-sqs-queue"/>
+#   region: eu-central-1
+#   database: example-db
+#   table: example-table
+#   s3: s3://example-long-term-bucket/data/
+#   s3_results: s3://example-transient-bucket/results/
+#   s3_large_files: s3://example-transient-bucket/large_files
+#   workgroup: example-workgroup
+#   sqs_queue_url: https://sqs.eu-central-1.amazonaws.com/aws-account-id/example-sqs-queue
 #   maxmind_geoip_city_db_path: "/etc/maxmindGeoIP/GeoLite2-City.mmdb" # optional
 
 tls:

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -77,6 +77,8 @@ $ tctl get cert_authorities --format=json \
 Then, on the same machine, create a configuration file for the Access Graph service, similar to this:
 
 ```yaml
+# Configuration for Teleport Access Graph service.
+# Example: /etc/access_graph/config.yaml
 backend:
   postgres:
     # This uses the PostgreSQL connection URI format, see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
@@ -92,6 +94,18 @@ backend:
 # IP address (optional) and port for the Access Graph service to listen to.
 # This is the default value. This key can be omitted to listen on port 50051 on all interfaces.
 address: ":50051"
+
+# Example Identity Activity Center configuration.
+# identity_activity_center:
+#   region: <Var name="eu-central-1"/>
+#   database: <Var name="example-db"/>
+#   table: <Var name="example-table"/>
+#   s3: s3://<Var name="example-long-term-bucket"/>/data/
+#   s3_results: s3://<Var name="example-transient-bucket"/>/results/
+#   s3_large_files: s3://<Var name="example-transient-bucket"/>/large_files
+#   workgroup: <Var name="example-workgroup"/>
+#   sqs_queue_url: https://sqs.<Var name="eu-central-1"/>.amazonaws.com/<Var name="aws-account-id"/>/<Var name="example-sqs-queue"/>
+#   maxmind_geoip_city_db_path: "/etc/maxmindGeoIP/GeoLite2-City.mmdb" # optional
 
 tls:
   # File paths of PEM-encoded TLS certificate and private key for the Access Graph server.


### PR DESCRIPTION
I've been helping a couple of customer that have ran into issues setting up Teleport Identity Activity Center. This provides a few more examples ( where to place this yaml and where/how to attach the IAM instance profile ) 