### PR TITLE
chore: integration test improvements

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -672,7 +672,7 @@ func (i *TeleInstance) createTeleportProcess(tconf *servicecfg.Config) (*service
 }
 
 // CreateWithConf creates a new instance of Teleport using the supplied config
-func (i *TeleInstance) CreateWithConf(_ *testing.T, tconf *servicecfg.Config) error {
+func (i *TeleInstance) CreateWithConf(t *testing.T, tconf *servicecfg.Config) error {
 	i.Config = tconf
 	var err error
 	i.Process, err = i.createTeleportProcess(tconf)
@@ -689,7 +689,7 @@ func (i *TeleInstance) CreateWithConf(_ *testing.T, tconf *servicecfg.Config) er
 	// create users and roles if they don't exist, or sign their keys if they're
 	// already present
 	auth := i.Process.GetAuthServer()
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	for _, user := range i.Secrets.Users {
 		teleUser, err := types.NewUser(user.Username)
@@ -1379,6 +1379,18 @@ func (i *TeleInstance) Start() error {
 		"received_events_count", len(receivedEvents),
 	)
 
+	// Wait for any SSH instances to be visible in the inventory before returning
+	// to prevent any immediate connection attempts from failing because the host
+	// has not yet been propagated to the caches.
+	expectedNodes := len(i.Nodes)
+	if i.Config.SSH.Enabled {
+		expectedNodes++
+	}
+
+	if err := i.WaitForNodeCount(context.Background(), i.Secrets.SiteName, expectedNodes); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return nil
 }
 
@@ -1956,6 +1968,10 @@ func (i *TeleInstance) WaitForNodeCount(ctx context.Context, clusterName string,
 		deadline     = time.Second * 30
 		iterWaitTime = time.Second
 	)
+
+	if count <= 0 || i.Config == nil || !i.Config.Auth.Enabled || !i.Config.Proxy.Enabled {
+		return nil
+	}
 
 	err := retryutils.RetryStaticFor(deadline, iterWaitTime, func() error {
 		cluster, err := i.Tunnel.Cluster(ctx, clusterName)

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -680,8 +680,6 @@ func TestRootLoginAsHostUser(t *testing.T) {
 		require.NoError(t, instance.StopAll())
 	})
 
-	instance.WaitForNodeCount(context.Background(), helpers.Site, 1)
-
 	tests := []struct {
 		name      string
 		command   []string
@@ -759,6 +757,7 @@ func TestRootStaticHostUsers(t *testing.T) {
 		require.NoError(t, instance.StopAll())
 	})
 	nodeCfg := servicecfg.MakeDefaultConfig()
+	nodeCfg.SSH.DisableCreateHostUser = false
 	nodeCfg.SSH.Labels = map[string]string{
 		"foo": "bar",
 	}


### PR DESCRIPTION
The changes here are meant to reduce resources consumed by integration tests and eliminate the footgun of connecting to a host before its been populated in the appropriate caches.

`(integrationTestSuite) defaultServiceConfig` now disables more services by default. Host user creation, the Web UI and Web Service, and the Database Proxy are all now turned off by default. The tests that require them can opt into turning them on.

`(TeleInstance) Start` now blocks until the processes SSH server is present in caches before returning. Most tests were already calling this manually after Start, however, not all of them were. This is frequently forgotten in new tests and causes flakes if client connections are attempted as soon as Start returns. There are still cases where calling WaitForNodeCount directly applies - tests that spin up additional nodes or tests that create nodes in a leaf cluster.

context.Background was also replaced with t.Context in some places.