### PR TITLE
Prevent chdir race condition in hasAccessibleHomeDir

### DIFF
--- a/lib/srv/reexec_test.go
+++ b/lib/srv/reexec_test.go
@@ -416,6 +416,10 @@ func testX11Forward(ctx context.Context, t *testing.T, proc *networking.Process,
 func TestRootCheckHomeDir(t *testing.T) {
 	testutils.RequireRoot(t)
 
+	// this test manipulates global state, ensure we're not going to run it in
+	// parallel with something else
+	t.Setenv("foo", "bar")
+
 	tmp := t.TempDir()
 	require.NoError(t, os.Chmod(filepath.Dir(tmp), 0777))
 	require.NoError(t, os.Chmod(tmp, 0777))


### PR DESCRIPTION
`srv.hasAccessibleHomeDir` can end up being called, even concurrently, by virtue of `homeDirSubsys` and file transfer `~` expansion when logging in as the user running Teleport. This PR adds a lock around changing and reverting the current directory, and makes the revert operation use a file rather than assuming that it's possible to go back to the original directory by absolute path, which is a little safer; the implementation follows the implementation of `(*testing.T).Chdir`.

In addition, this PR removes the change of directory to the self-discovered directory of the Teleport executable when executing Teleport for reexec purposes.