### PR TITLE
Avoid staleness race condition in `genericCollector`

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -776,18 +776,30 @@ func (g *genericCollector[T, R]) refreshStaleResources(ctx context.Context) erro
 	}
 
 	_, err := utils.FnCacheGet(ctx, g.cache, g.GenericWatcherConfig.ResourceKind, func(ctx context.Context) (any, error) {
-		current, err := g.getResources(ctx)
+		newCurrent, err := g.getResources(ctx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		// There is a chance that the watcher reinitialized while
-		// getting resources happened above. Check if we are still stale
-		if g.stale.CompareAndSwap(true, false) {
-			g.rw.Lock()
-			g.current = current
-			g.rw.Unlock()
+		// as an optimization, we can check if the collector is still stale
+		// before grabbing the write lock
+		if !g.stale.Load() {
+			// the view is no longer stale, discard newCurrent and proceed with
+			// the data in g.current
+			return nil, nil
 		}
+
+		g.rw.Lock()
+		defer g.rw.Unlock()
+
+		// check the staleness again since it might've changed since we were not
+		// holding the lock
+		if !g.stale.Load() {
+			return nil, nil
+		}
+
+		g.current = newCurrent
+		g.stale.Store(false)
 
 		return nil, nil
 	})


### PR DESCRIPTION
This PR fixes a rare race condition that can happen if a `GenericResourceWatcher` runs a fallback fetch due to staleness right when the watcher successfully reinitializes, as well as a race condition that could let a reader read stale data before said fallback fetch has a chance to swap new data in place. The latter might result in old data being returned from the watcher, the former might result in inconsistent data stored in the watcher essentially forever, since the fallback data is not synchronized with the watcher stream and might leave missing data around.