### PR TITLE
[v18] Don't populate the domain field when heartbeating non-AD desktops

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"os"
 	"strconv"
@@ -1119,10 +1120,10 @@ func (s *WindowsService) staticHostHeartbeatInfo(host servicecfg.WindowsHost,
 ) func() (types.Resource, error) {
 	return func() (types.Resource, error) {
 		addr := host.Address.String()
+
 		labels := getHostLabels(addr)
-		for k, v := range host.Labels {
-			labels[k] = v
-		}
+		maps.Copy(labels, host.Labels)
+
 		name := host.Name
 		if name == "" {
 			var err error
@@ -1131,14 +1132,21 @@ func (s *WindowsService) staticHostHeartbeatInfo(host servicecfg.WindowsHost,
 				return nil, trace.Wrap(err)
 			}
 		}
+
 		labels[types.OriginLabel] = types.OriginConfigFile
 		labels[types.ADLabel] = strconv.FormatBool(host.AD)
+
+		var domain string
+		if host.AD {
+			domain = s.cfg.Domain
+		}
+
 		desktop, err := types.NewWindowsDesktopV3(
 			name,
 			labels,
 			types.WindowsDesktopSpecV3{
 				Addr:   addr,
-				Domain: s.cfg.Domain,
+				Domain: domain,
 				HostID: s.cfg.Heartbeat.HostUUID,
 				NonAD:  !host.AD,
 			})


### PR DESCRIPTION
The domain field doesn't cause any problems, since we ignore it when `ad: false`, but it's technically incorrect so we shouldn't be setting the field at all.

Backports #61490 