### PR TITLE
Web: allow customizations to unified resource component

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -35,6 +35,7 @@ export function CardsView({
   onPinResource,
   isProcessing,
   pinningSupport,
+  visibleInputFields,
 }: ResourceViewProps) {
   return (
     <CardsContainer className="CardsContainer" gap={2}>
@@ -51,6 +52,7 @@ export function CardsView({
             pinResource={() => onPinResource(key)}
             onShowStatusInfo={onShowStatusInfo}
             showingStatusInfo={showingStatusInfo}
+            visibleInputFields={visibleInputFields}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router';
 import styled from 'styled-components';
 
@@ -87,10 +87,28 @@ const additionalResources = [
   }),
 ];
 
-const meta: Meta<typeof ResourceCard> = {
-  component: ResourceCard,
-  title: 'Shared/UnifiedResources/Items',
+type StoryProps = {
+  withoutCheckbox: boolean;
+  withoutPin: boolean;
 };
+
+const meta: Meta<StoryProps> = {
+  title: 'Shared/UnifiedResources/Items',
+  argTypes: {
+    withoutCheckbox: {
+      control: { type: 'boolean' },
+    },
+    withoutPin: {
+      control: { type: 'boolean' },
+    },
+  },
+  // default
+  args: {
+    withoutCheckbox: false,
+    withoutPin: false,
+  },
+};
+export default meta;
 
 const Grid = styled.div<GapProps>`
   display: grid;
@@ -98,58 +116,57 @@ const Grid = styled.div<GapProps>`
   ${gap}
 `;
 
-export default meta;
-type Story = StoryObj<typeof ResourceCard>;
-
 const ActionButton = <ButtonBorder size="small">Action</ButtonBorder>;
 
-export const Cards: Story = {
-  render() {
-    return (
-      <MemoryRouter>
-        <SamlAppActionProvider>
-          <Grid gap={2}>
-            {[
-              ...apps.map(resource =>
-                makeUnifiedResourceViewItemApp(resource, {
-                  ActionButton: <ResourceActionButton resource={resource} />,
-                })
-              ),
-              ...databases.map(resource =>
-                makeUnifiedResourceViewItemDatabase(resource, {
-                  ActionButton,
-                })
-              ),
-              ...kubes.map(resource =>
-                makeUnifiedResourceViewItemKube(resource, { ActionButton })
-              ),
-              ...nodes.map(resource =>
-                makeUnifiedResourceViewItemNode(resource, {
-                  ActionButton,
-                })
-              ),
-              ...additionalResources.map(resource =>
-                makeUnifiedResourceViewItemApp(resource, { ActionButton })
-              ),
-              ...desktops.map(resource =>
-                makeUnifiedResourceViewItemDesktop(resource, { ActionButton })
-              ),
-            ].map((res, i) => (
-              <ResourceCard
-                key={i}
-                pinned={false}
-                pinResource={() => {}}
-                selectResource={() => {}}
-                selected={false}
-                pinningSupport={PinningSupport.Supported}
-                onShowStatusInfo={() => null}
-                showingStatusInfo={false}
-                viewItem={res}
-              />
-            ))}
-          </Grid>
-        </SamlAppActionProvider>
-      </MemoryRouter>
-    );
-  },
-};
+export function Cards(props: StoryProps) {
+  return (
+    <MemoryRouter>
+      <SamlAppActionProvider>
+        <Grid gap={2}>
+          {[
+            ...apps.map(resource =>
+              makeUnifiedResourceViewItemApp(resource, {
+                ActionButton: <ResourceActionButton resource={resource} />,
+              })
+            ),
+            ...databases.map(resource =>
+              makeUnifiedResourceViewItemDatabase(resource, {
+                ActionButton,
+              })
+            ),
+            ...kubes.map(resource =>
+              makeUnifiedResourceViewItemKube(resource, { ActionButton })
+            ),
+            ...nodes.map(resource =>
+              makeUnifiedResourceViewItemNode(resource, {
+                ActionButton,
+              })
+            ),
+            ...additionalResources.map(resource =>
+              makeUnifiedResourceViewItemApp(resource, { ActionButton })
+            ),
+            ...desktops.map(resource =>
+              makeUnifiedResourceViewItemDesktop(resource, { ActionButton })
+            ),
+          ].map((res, i) => (
+            <ResourceCard
+              key={i}
+              pinned={false}
+              pinResource={() => {}}
+              selectResource={() => {}}
+              selected={false}
+              pinningSupport={PinningSupport.Supported}
+              onShowStatusInfo={() => null}
+              showingStatusInfo={false}
+              viewItem={res}
+              visibleInputFields={{
+                checkbox: !props.withoutCheckbox,
+                pin: !props.withoutPin,
+              }}
+            />
+          ))}
+        </Grid>
+      </SamlAppActionProvider>
+    </MemoryRouter>
+  );
+}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -88,24 +88,24 @@ const additionalResources = [
 ];
 
 type StoryProps = {
-  withoutCheckbox: boolean;
-  withoutPin: boolean;
+  withCheckbox: boolean;
+  withPin: boolean;
 };
 
 const meta: Meta<StoryProps> = {
   title: 'Shared/UnifiedResources/Items',
   argTypes: {
-    withoutCheckbox: {
+    withCheckbox: {
       control: { type: 'boolean' },
     },
-    withoutPin: {
+    withPin: {
       control: { type: 'boolean' },
     },
   },
   // default
   args: {
-    withoutCheckbox: false,
-    withoutPin: false,
+    withCheckbox: true,
+    withPin: true,
   },
 };
 export default meta;
@@ -160,8 +160,8 @@ export function Cards(props: StoryProps) {
               showingStatusInfo={false}
               viewItem={res}
               visibleInputFields={{
-                checkbox: !props.withoutCheckbox,
-                pin: !props.withoutPin,
+                checkbox: props.withCheckbox,
+                pin: props.withPin,
               }}
             />
           ))}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -37,7 +37,7 @@ import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { SingleLineBox } from '../shared/SingleLineBox';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
-import { ResourceItemProps } from '../types';
+import { ResourceItemProps, VisibleResourceItemFields } from '../types';
 import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
 
 // Since we do a lot of manual resizing and some absolute positioning, we have
@@ -66,7 +66,14 @@ export function ResourceCard({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
+  visibleInputFields,
 }: Omit<ResourceItemProps, 'expandAllLabels'>) {
+  // Conditionally render input fields.
+  const show: VisibleResourceItemFields = visibleInputFields ?? {
+    pin: true,
+    checkbox: true,
+  };
+
   const {
     name,
     primaryIconName,
@@ -186,7 +193,7 @@ export function ResourceCard({
           p={3}
           // we set padding left a bit larger so we can have space to absolutely
           // position the pin/checkbox buttons
-          pl={6}
+          pl={show.pin || show.checkbox ? 6 : 2}
           alignItems="start"
           onMouseLeave={onMouseLeave}
           pinned={pinned}
@@ -199,27 +206,31 @@ export function ResourceCard({
           {...(shouldDisplayStatusWarning && !showAllLabels && { pr: '35px' })}
           {...(shouldDisplayStatusWarning && showAllLabels && { pr: '7px' })}
         >
-          <CheckboxInput
-            checked={selected}
-            onChange={selectResource}
-            style={{ position: 'absolute', top: '16px', left: '16px' }}
-          />
-          <Box
-            css={`
-              position: absolute;
-              // we position far from the top so the layout of the pin doesn't change if we expand the card
-              top: ${props => props.theme.space[9]}px;
-              transition: none;
-              left: 16px;
-            `}
-          >
-            <PinButton
-              setPinned={pinResource}
-              pinned={pinned}
-              pinningSupport={pinningSupport}
-              hovered={hovered}
+          {show.checkbox && (
+            <CheckboxInput
+              checked={selected}
+              onChange={selectResource}
+              style={{ position: 'absolute', top: '16px', left: '16px' }}
             />
-          </Box>
+          )}
+          {show.pin && (
+            <Box
+              css={`
+                position: absolute;
+                // we position far from the top so the layout of the pin doesn't change if we expand the card
+                top: ${props => props.theme.space[9]}px;
+                transition: none;
+                left: 16px;
+              `}
+            >
+              <PinButton
+                setPinned={pinResource}
+                pinned={pinned}
+                pinningSupport={pinningSupport}
+                hovered={hovered}
+              />
+            </Box>
+          )}
           <ResourceIcon
             name={primaryIconName}
             width="45px"

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -37,7 +37,7 @@ import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { SingleLineBox } from '../shared/SingleLineBox';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
-import { ResourceItemProps, VisibleResourceItemFields } from '../types';
+import { ResourceItemProps } from '../types';
 import { WarningRightEdgeBadgeSvg } from './WarningRightEdgeBadgeSvg';
 
 // Since we do a lot of manual resizing and some absolute positioning, we have
@@ -66,14 +66,8 @@ export function ResourceCard({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
-  visibleInputFields,
+  visibleInputFields = { pin: true, checkbox: true },
 }: Omit<ResourceItemProps, 'expandAllLabels'>) {
-  // Conditionally render input fields.
-  const show: VisibleResourceItemFields = visibleInputFields ?? {
-    pin: true,
-    checkbox: true,
-  };
-
   const {
     name,
     primaryIconName,
@@ -193,7 +187,7 @@ export function ResourceCard({
           p={3}
           // we set padding left a bit larger so we can have space to absolutely
           // position the pin/checkbox buttons
-          pl={show.pin || show.checkbox ? 6 : 2}
+          pl={visibleInputFields.pin || visibleInputFields.checkbox ? 6 : 2}
           alignItems="start"
           onMouseLeave={onMouseLeave}
           pinned={pinned}
@@ -206,14 +200,14 @@ export function ResourceCard({
           {...(shouldDisplayStatusWarning && !showAllLabels && { pr: '35px' })}
           {...(shouldDisplayStatusWarning && showAllLabels && { pr: '7px' })}
         >
-          {show.checkbox && (
+          {visibleInputFields.checkbox && (
             <CheckboxInput
               checked={selected}
               onChange={selectResource}
               style={{ position: 'absolute', top: '16px', left: '16px' }}
             />
           )}
-          {show.pin && (
+          {visibleInputFields.pin && (
             <Box
               css={`
                 position: absolute;

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -34,6 +34,7 @@ export function ListView({
   pinningSupport,
   isProcessing,
   expandAllLabels,
+  visibleInputFields,
 }: ResourceViewProps) {
   return (
     <Flex className="ListContainer">
@@ -51,6 +52,7 @@ export function ListView({
             expandAllLabels={expandAllLabels}
             onShowStatusInfo={onShowStatusInfo}
             showingStatusInfo={showingStatusInfo}
+            visibleInputFields={visibleInputFields}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta } from '@storybook/react-vite';
 
 import { ButtonBorder, Flex } from 'design';
 
@@ -80,56 +80,73 @@ const additionalResources = [
   }),
 ];
 
-const meta: Meta<typeof ResourceListItem> = {
-  component: ResourceListItem,
-  title: 'Shared/UnifiedResources/Items',
+type StoryProps = {
+  withoutCheckbox: boolean;
+  withoutPin: boolean;
 };
 
+const meta: Meta<StoryProps> = {
+  title: 'Shared/UnifiedResources/Items',
+  argTypes: {
+    withoutCheckbox: {
+      control: { type: 'boolean' },
+    },
+    withoutPin: {
+      control: { type: 'boolean' },
+    },
+  },
+  // default
+  args: {
+    withoutCheckbox: false,
+    withoutPin: false,
+  },
+};
 export default meta;
-type Story = StoryObj<typeof ResourceListItem>;
 
 const ActionButton = <ButtonBorder size="small">Action</ButtonBorder>;
 
-export const ListItems: Story = {
-  render() {
-    return (
-      <Flex flexDirection="column">
-        {[
-          ...apps.map(resource =>
-            makeUnifiedResourceViewItemApp(resource, { ActionButton })
-          ),
-          ...databases.map(resource =>
-            makeUnifiedResourceViewItemDatabase(resource, {
-              ActionButton,
-            })
-          ),
-          ...kubes.map(resource =>
-            makeUnifiedResourceViewItemKube(resource, { ActionButton })
-          ),
-          ...nodes.map(resource =>
-            makeUnifiedResourceViewItemNode(resource, { ActionButton })
-          ),
-          ...additionalResources.map(resource =>
-            makeUnifiedResourceViewItemApp(resource, { ActionButton })
-          ),
-          ...desktops.map(resource =>
-            makeUnifiedResourceViewItemDesktop(resource, { ActionButton })
-          ),
-        ].map((res, i) => (
-          <ResourceListItem
-            key={i}
-            pinned={false}
-            pinResource={() => {}}
-            selectResource={() => {}}
-            selected={false}
-            pinningSupport={PinningSupport.Supported}
-            expandAllLabels={false}
-            onShowStatusInfo={() => null}
-            showingStatusInfo={false}
-            viewItem={res}
-          />
-        ))}
-      </Flex>
-    );
-  },
-};
+export function ListItems(props: StoryProps) {
+  return (
+    <Flex flexDirection="column">
+      {[
+        ...apps.map(resource =>
+          makeUnifiedResourceViewItemApp(resource, { ActionButton })
+        ),
+        ...databases.map(resource =>
+          makeUnifiedResourceViewItemDatabase(resource, {
+            ActionButton,
+          })
+        ),
+        ...kubes.map(resource =>
+          makeUnifiedResourceViewItemKube(resource, { ActionButton })
+        ),
+        ...nodes.map(resource =>
+          makeUnifiedResourceViewItemNode(resource, { ActionButton })
+        ),
+        ...additionalResources.map(resource =>
+          makeUnifiedResourceViewItemApp(resource, { ActionButton })
+        ),
+        ...desktops.map(resource =>
+          makeUnifiedResourceViewItemDesktop(resource, { ActionButton })
+        ),
+      ].map((res, i) => (
+        <ResourceListItem
+          key={i}
+          pinned={false}
+          pinResource={() => {}}
+          selectResource={() => {}}
+          selected={false}
+          pinningSupport={PinningSupport.Supported}
+          expandAllLabels={false}
+          onShowStatusInfo={() => null}
+          showingStatusInfo={false}
+          viewItem={res}
+          visibleInputFields={{
+            checkbox: !props.withoutCheckbox,
+            pin: !props.withoutPin,
+          }}
+        />
+      ))}
+    </Flex>
+  );
+}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -81,24 +81,24 @@ const additionalResources = [
 ];
 
 type StoryProps = {
-  withoutCheckbox: boolean;
-  withoutPin: boolean;
+  withCheckbox: boolean;
+  withPin: boolean;
 };
 
 const meta: Meta<StoryProps> = {
   title: 'Shared/UnifiedResources/Items',
   argTypes: {
-    withoutCheckbox: {
+    withCheckbox: {
       control: { type: 'boolean' },
     },
-    withoutPin: {
+    withPin: {
       control: { type: 'boolean' },
     },
   },
   // default
   args: {
-    withoutCheckbox: false,
-    withoutPin: false,
+    withCheckbox: true,
+    withPin: true,
   },
 };
 export default meta;
@@ -142,8 +142,8 @@ export function ListItems(props: StoryProps) {
           showingStatusInfo={false}
           viewItem={res}
           visibleInputFields={{
-            checkbox: !props.withoutCheckbox,
-            pin: !props.withoutPin,
+            checkbox: props.withCheckbox,
+            pin: props.withPin,
           }}
         />
       ))}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -37,7 +37,7 @@ import {
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
-import { ResourceItemProps } from '../types';
+import { ResourceItemProps, VisibleResourceItemFields } from '../types';
 
 export function ResourceListItem({
   onLabelClick,
@@ -50,7 +50,14 @@ export function ResourceListItem({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
+  visibleInputFields,
 }: ResourceItemProps) {
+  // Conditionally render input fields.
+  const show: VisibleResourceItemFields = visibleInputFields ?? {
+    checkbox: true,
+    pin: true,
+  };
+
   const {
     name,
     primaryIconName,
@@ -102,29 +109,35 @@ export function ResourceListItem({
         selected={selected}
         shouldDisplayWarning={shouldDisplayStatusWarning}
         showingStatusInfo={showingStatusInfo}
+        hideCheckbox={!show.checkbox}
+        hidePin={!show.pin}
       >
         {/* checkbox */}
-        <HoverTooltip tipContent={selected ? 'Deselect' : 'Select'}>
-          <CheckboxInput
-            checked={selected}
-            onChange={selectResource}
-            css={`
-              grid-area: checkbox;
-            `}
-          />
-        </HoverTooltip>
+        {show.checkbox && (
+          <HoverTooltip tipContent={selected ? 'Deselect' : 'Select'}>
+            <CheckboxInput
+              checked={selected}
+              onChange={selectResource}
+              css={`
+                grid-area: checkbox;
+              `}
+            />
+          </HoverTooltip>
+        )}
 
         {/* pin button */}
-        <PinButton
-          setPinned={pinResource}
-          pinned={pinned}
-          pinningSupport={pinningSupport}
-          hovered={hovered}
-          css={`
-            grid-area: pin;
-            place-self: center center;
-          `}
-        />
+        {show.pin && (
+          <PinButton
+            setPinned={pinResource}
+            pinned={pinned}
+            pinningSupport={pinningSupport}
+            hovered={hovered}
+            css={`
+              grid-area: pin;
+              place-self: center center;
+            `}
+          />
+        )}
 
         {/* icon */}
         <ResourceIcon
@@ -356,12 +369,8 @@ const RowContainer = styled(Box)<{
 
 const RowInnerContainer = styled(Flex)<BackgroundColorProps>`
   display: grid;
-  grid-template-columns: 22px 24px 36px 2fr 1fr 1fr 32px min-content;
   column-gap: ${props => props.theme.space[3]}px;
   grid-template-rows: 56px min-content;
-  grid-template-areas:
-    'checkbox pin icon name type address labels-btn warning-icon button'
-    '. . labels labels labels labels labels labels labels';
   align-items: center;
   height: 100%;
   min-width: 100%;
@@ -377,6 +386,33 @@ const RowInnerContainer = styled(Flex)<BackgroundColorProps>`
     // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
     border-bottom: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
   }
+
+  grid-template-columns: 22px 24px 36px 2fr 1fr 1fr 32px min-content;
+  grid-template-areas:
+    'checkbox pin icon name type address labels-btn warning-icon button'
+    '. . labels labels labels labels labels labels labels';
+
+  ${p =>
+    p.hideCheckbox &&
+    `grid-template-columns: 24px 36px 2fr 1fr 1fr 32px min-content;
+    grid-template-areas:
+    'pin icon name type address labels-btn warning-icon button'
+    '. labels labels labels labels labels labels labels';`}
+
+  ${p =>
+    p.hidePin &&
+    `grid-template-columns: 22px 36px 2fr 1fr 1fr 32px min-content;
+    grid-template-areas:
+    'checkbox icon name type address labels-btn warning-icon button'
+    '. labels labels labels labels labels labels labels';`}
+
+  ${p =>
+    p.hideCheckbox &&
+    p.hidePin &&
+    `grid-template-columns: 36px 2fr 1fr 1fr 32px min-content;
+    grid-template-areas:
+    'icon name type address labels-btn warning-icon button'
+    'labels labels labels labels labels labels labels';`}
 `;
 
 const Name = styled(Text)`

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -37,7 +37,7 @@ import {
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
-import { ResourceItemProps, VisibleResourceItemFields } from '../types';
+import { ResourceItemProps } from '../types';
 
 export function ResourceListItem({
   onLabelClick,
@@ -50,14 +50,8 @@ export function ResourceListItem({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
-  visibleInputFields,
+  visibleInputFields = { pin: true, checkbox: true },
 }: ResourceItemProps) {
-  // Conditionally render input fields.
-  const show: VisibleResourceItemFields = visibleInputFields ?? {
-    checkbox: true,
-    pin: true,
-  };
-
   const {
     name,
     primaryIconName,
@@ -109,11 +103,11 @@ export function ResourceListItem({
         selected={selected}
         shouldDisplayWarning={shouldDisplayStatusWarning}
         showingStatusInfo={showingStatusInfo}
-        hideCheckbox={!show.checkbox}
-        hidePin={!show.pin}
+        hideCheckbox={!visibleInputFields.checkbox}
+        hidePin={!visibleInputFields.pin}
       >
         {/* checkbox */}
-        {show.checkbox && (
+        {visibleInputFields.checkbox && (
           <HoverTooltip tipContent={selected ? 'Deselect' : 'Select'}>
             <CheckboxInput
               checked={selected}
@@ -126,7 +120,7 @@ export function ResourceListItem({
         )}
 
         {/* pin button */}
-        {show.pin && (
+        {visibleInputFields.pin && (
           <PinButton
             setPinned={pinResource}
             pinned={pinned}

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -26,7 +26,7 @@ import React, {
   useState,
   type JSX,
 } from 'react';
-import styled from 'styled-components';
+import styled, { CSSProp } from 'styled-components';
 
 import { Box, ButtonBorder, ButtonSecondary, Flex, Text } from 'design';
 import { Danger } from 'design/Alert';
@@ -57,7 +57,7 @@ import {
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
 // eslint-disable-next-line no-restricted-imports -- FIXME
-import { ResourcesResponse } from 'teleport/services/agents';
+import { ResourceLabel, ResourcesResponse } from 'teleport/services/agents';
 
 import { useInfoGuide } from '../SlidingSidePanel/InfoGuide';
 import { CardsView } from './CardsView/CardsView';
@@ -73,6 +73,8 @@ import {
   UnifiedResourceDefinition,
   UnifiedResourcesPinning,
   UnifiedResourcesQueryParams,
+  VisibleFilterPanelFields,
+  VisibleResourceItemFields,
 } from './types';
 
 // get 48 resources to start
@@ -181,6 +183,11 @@ export interface UnifiedResourcesProps {
    * */
   NoResources: React.ReactElement;
   /**
+   * If true, it will render the "NoResources" component
+   * without doing other internal "no result" checks.
+   */
+  overrideNoResultsCheck?: boolean;
+  /**
    * If pinning is supported, the functions to get and update pinned resources
    * can be passed here.
    */
@@ -212,6 +219,32 @@ export interface UnifiedResourcesProps {
    * with selected resources status info.
    */
   onShowStatusInfo(resource: UnifiedResourceDefinition): void;
+
+  /**
+   * onLabelClick is a custom label click handler.
+   *
+   * Default behavior is to append clicked label to
+   * the query string (aka predicate expression).
+   */
+  onLabelClick?(label: ResourceLabel): void;
+  /**
+   * Provide custom CSS to this components container.
+   */
+  cssStyle?: CSSProp;
+  /**
+   * Defaults to showing all fields.
+   * When specified, only fields with `true` value are shown.
+   *
+   * Applies to FilterPanel component.
+   */
+  visibleFilterPanelFields?: VisibleFilterPanelFields;
+  /**
+   * Defaults to showing all fields.
+   * When specified, only fields with `true` value are shown.
+   *
+   * Applies to row item elements (CardView or ListView).
+   */
+  visibleResourceItemFields?: VisibleResourceItemFields;
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -230,6 +263,11 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     ClusterDropdown,
     bulkActions = [],
     onShowStatusInfo,
+    visibleFilterPanelFields,
+    visibleResourceItemFields,
+    onLabelClick,
+    cssStyle,
+    overrideNoResultsCheck,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -472,17 +510,34 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
       ? CardsView
       : ListView;
 
+  let footerElement: JSX.Element;
+  if (overrideNoResultsCheck) {
+    footerElement = props.NoResources;
+  } else if (noResults) {
+    if (isSearchEmpty && !params.pinnedOnly) {
+      footerElement = props.NoResources;
+    }
+    if (params.pinnedOnly && isSearchEmpty) {
+      footerElement = <NoPinned />;
+    }
+    if (!isSearchEmpty) {
+      footerElement = (
+        <NoResults
+          isPinnedTab={params.pinnedOnly}
+          query={params?.query || params?.search}
+        />
+      );
+    }
+  }
+
+  if (resourcesFetchAttempt.status === 'failed' && resources.length > 0) {
+    footerElement = (
+      <ButtonSecondary onClick={onRetryClicked}>Load more</ButtonSecondary>
+    );
+  }
+
   return (
-    <div
-      className="ContainerContext"
-      css={`
-        width: 100%;
-        max-width: 1800px;
-        margin: 0 auto;
-        min-width: 450px;
-      `}
-      ref={containerRef}
-    >
+    <Container className="ContainerContext" ref={containerRef} css={cssStyle}>
       <ErrorsContainer>
         {resourcesFetchAttempt.status === 'failed' && (
           <Danger
@@ -532,6 +587,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
 
       {props.Header}
       <FilterPanel
+        visibleInputFields={visibleFilterPanelFields}
         availabilityFilter={availabilityFilter}
         changeAvailableResourceMode={changeAvailableResourceMode}
         params={params}
@@ -605,12 +661,15 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         </Flex>
       )}
       <ViewComponent
-        onLabelClick={label =>
-          setParams({
-            ...params,
-            search: '',
-            query: makeAdvancedSearchQueryForLabel(label, params),
-          })
+        onLabelClick={
+          onLabelClick
+            ? onLabelClick
+            : label =>
+                setParams({
+                  ...params,
+                  search: '',
+                  query: makeAdvancedSearchQueryForLabel(label, params),
+                })
         }
         pinnedResources={pinnedResources}
         selectedResources={selectedResources}
@@ -656,22 +715,11 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
             : []
         }
         expandAllLabels={expandAllLabels}
+        visibleInputFields={visibleResourceItemFields}
       />
       <div ref={setTrigger} />
-      <ListFooter>
-        {resourcesFetchAttempt.status === 'failed' && resources.length > 0 && (
-          <ButtonSecondary onClick={onRetryClicked}>Load more</ButtonSecondary>
-        )}
-        {noResults && isSearchEmpty && !params.pinnedOnly && props.NoResources}
-        {noResults && params.pinnedOnly && isSearchEmpty && <NoPinned />}
-        {noResults && !isSearchEmpty && (
-          <NoResults
-            isPinnedTab={params.pinnedOnly}
-            query={params?.query || params?.search}
-          />
-        )}
-      </ListFooter>
-    </div>
+      <ListFooter>{footerElement}</ListFooter>
+    </Container>
   );
 }
 
@@ -840,3 +888,10 @@ export function getResourceAvailabilityFilter(
       availableResourceMode satisfies never;
   }
 }
+
+const Container = styled.div`
+  width: 100%;
+  max-width: 1800px;
+  margin: 0 auto;
+  min-width: 450px;
+`;

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -26,7 +26,7 @@ import React, {
   useState,
   type JSX,
 } from 'react';
-import styled, { CSSProp } from 'styled-components';
+import styled from 'styled-components';
 
 import { Box, ButtonBorder, ButtonSecondary, Flex, Text } from 'design';
 import { Danger } from 'design/Alert';
@@ -57,7 +57,7 @@ import {
 import { makeAdvancedSearchQueryForLabel } from 'shared/utils/advancedSearchLabelQuery';
 
 // eslint-disable-next-line no-restricted-imports -- FIXME
-import { ResourceLabel, ResourcesResponse } from 'teleport/services/agents';
+import { ResourcesResponse } from 'teleport/services/agents';
 
 import { useInfoGuide } from '../SlidingSidePanel/InfoGuide';
 import { CardsView } from './CardsView/CardsView';
@@ -119,6 +119,11 @@ export type BulkAction = {
    */
   tooltip?: string;
   action: (selectedResources: SelectedResource[]) => void;
+};
+
+export type ResourceLabel = {
+  name: string;
+  value: string;
 };
 
 export type SelectedResource = {
@@ -184,9 +189,9 @@ export interface UnifiedResourcesProps {
   NoResources: React.ReactElement;
   /**
    * If true, it will render the "NoResources" component
-   * without doing other internal "no result" checks.
+   * regardless of internal "no result" checks.
    */
-  overrideNoResultsCheck?: boolean;
+  forceNoResources?: boolean;
   /**
    * If pinning is supported, the functions to get and update pinned resources
    * can be passed here.
@@ -228,9 +233,9 @@ export interface UnifiedResourcesProps {
    */
   onLabelClick?(label: ResourceLabel): void;
   /**
-   * Provide custom CSS to this components container.
+   *  className support so that UnifiedResources works with the css prop.
    */
-  cssStyle?: CSSProp;
+  className?: string;
   /**
    * Defaults to showing all fields.
    * When specified, only fields with `true` value are shown.
@@ -266,8 +271,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     visibleFilterPanelFields,
     visibleResourceItemFields,
     onLabelClick,
-    cssStyle,
-    overrideNoResultsCheck,
+    className,
+    forceNoResources,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -511,7 +516,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
       : ListView;
 
   let footerElement: JSX.Element;
-  if (overrideNoResultsCheck) {
+  if (forceNoResources) {
     footerElement = props.NoResources;
   } else if (noResults) {
     if (isSearchEmpty && !params.pinnedOnly) {
@@ -537,7 +542,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
   }
 
   return (
-    <Container className="ContainerContext" ref={containerRef} css={cssStyle}>
+    <Container className={`ContainerContext ${className}`} ref={containerRef}>
       <ErrorsContainer>
         {resourcesFetchAttempt.status === 'failed' && (
           <Danger
@@ -587,7 +592,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
 
       {props.Header}
       <FilterPanel
-        visibleInputFields={visibleFilterPanelFields}
+        visibleFilterPanelFields={visibleFilterPanelFields}
         availabilityFilter={availabilityFilter}
         changeAvailableResourceMode={changeAvailableResourceMode}
         params={params}

--- a/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
+++ b/web/packages/shared/components/UnifiedResources/shared/getBackgroundColor.ts
@@ -25,6 +25,8 @@ export interface BackgroundColorProps {
   theme: Theme;
   shouldDisplayWarning: boolean;
   showingStatusInfo: boolean;
+  hidePin?: boolean;
+  hideCheckbox?: boolean;
 }
 
 export const getBackgroundColor = (props: BackgroundColorProps) => {

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -196,6 +196,19 @@ export interface UnifiedResourceViewItem {
   status?: ResourceHealthStatus;
 }
 
+export type VisibleFilterPanelFields = {
+  checkbox: boolean;
+  clusterOpts: boolean;
+  healthStatusOpts: boolean;
+  resourceTypeOpts: boolean;
+  resourceAvailabilityOpts: boolean;
+};
+
+export type VisibleResourceItemFields = {
+  checkbox: boolean;
+  pin: boolean;
+};
+
 export enum PinningSupport {
   Supported = 'Supported',
   /**
@@ -230,6 +243,11 @@ export type ResourceItemProps = {
    * Used as a flag to render different styling.
    */
   showingStatusInfo: boolean;
+  /**
+   * Defaults to showing all fields.
+   * When specified, only fields with `true` value are shown.
+   */
+  visibleInputFields?: VisibleResourceItemFields;
 };
 
 // Props that are needed for the Card view.
@@ -273,6 +291,11 @@ export type ResourceViewProps = {
     showingStatusInfo: boolean;
   }[];
   expandAllLabels: boolean;
+  /**
+   * Defaults to showing all fields.
+   * When specified, only fields with `true` value are shown.
+   */
+  visibleInputFields?: VisibleResourceItemFields;
 };
 
 /**

--- a/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
+++ b/web/packages/shared/hooks/useInfiniteScroll/useKeyBasedPagination.ts
@@ -207,7 +207,7 @@ export type KeyBasedPaginationOptions<T> = {
   dataKey?: string;
 };
 
-type KeyBasedPagination<T> = {
+export type KeyBasedPagination<T> = {
   /**
    * Attempts to fetch a new batch of data, unless one is already being fetched,
    * or the previous fetch resulted with an error. It is intended to be called
@@ -229,6 +229,10 @@ type KeyBasedPagination<T> = {
   clear(): void;
   attempt: Attempt;
   resources: T[];
+  /**
+   * True if there is no next page.
+   * Means all pages were fetched.
+   */
   finished: boolean;
   /**
    * Used in conjunction with create/delete/update operations

--- a/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
+++ b/web/packages/teleport/src/components/hooks/useUrlFiltering/useUrlFiltering.ts
@@ -43,7 +43,7 @@ export interface UrlFilteringState {
   search: string;
 }
 
-type URLResourceFilter = Omit<ResourceFilter, 'includedResourceMode'>;
+export type URLResourceFilter = Omit<ResourceFilter, 'includedResourceMode'>;
 
 export function useUrlFiltering(
   initialParams: URLResourceFilter,


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Allows customizing unified resources view:
- provide custom css styling
- selectively hiding input fields
- provide custom label click func
- render `NoResources` component bypassing internal no result checks