### PR TITLE
MWI: Fix static keypair creation with `--static-key-path`

### DIFF
--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -44,7 +44,7 @@ func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreate
 	cmd.Flag("proxy-server", "The proxy server, which will be pinged to determine the current cryptographic suite in use").Required().StringVar(&c.ProxyServer)
 	cmd.Flag("overwrite", "If set, overwrite any existing keypair. If unset and a keypair already exists, its key will be printed for use.").BoolVar(&c.Overwrite)
 	cmd.Flag("format", "Output format, one of: text, json").Default(teleport.Text).EnumVar(&c.Format, teleport.Text, teleport.JSON)
-	cmd.Flag("static", "If set, create a static private key instead of writing a mutable key into bot storage. If --static-path is unset, the key will be printed to the terminal.").BoolVar(&c.Static)
+	cmd.Flag("static", "If set, create a static private key instead of writing a mutable key into bot storage. If --static-key-path is unset, the key will be printed to the terminal.").BoolVar(&c.Static)
 	cmd.Flag("static-key-path", "If set, writes the static private key to a file.").StringVar(&c.StaticKeyPath)
 
 	return c

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -18,7 +18,12 @@
 
 package cli
 
-import "github.com/gravitational/teleport"
+import (
+	"io"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+)
 
 // KeypairCreateCommand handles `tbot keypair create`
 type KeypairCreateCommand struct {
@@ -30,6 +35,14 @@ type KeypairCreateCommand struct {
 	Format        string
 	Static        bool
 	StaticKeyPath string
+
+	// GetSuite is an optional function to fetch crypto suites. Used to override
+	// in tests, may be nil.
+	GetSuite cryptosuites.GetSuiteFunc
+
+	// Writer is an optional writer to which output from this command should be
+	// written. If nil, stdout is used. Used in tests.
+	Writer io.Writer
 }
 
 // NewKeypairCreateCommand initializes the `keypair create` command and returns

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -24,6 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/template"
@@ -161,7 +162,7 @@ func generateExampleToken(params KeypairMessageParams, indent string) (string, e
 	return indented.String(), nil
 }
 
-func printKeypair(params KeypairMessageParams, format string) error {
+func printKeypair(w io.Writer, params KeypairMessageParams, format string) error {
 	example, err := generateExampleToken(params, "\t")
 	if err != nil {
 		return trace.Wrap(err)
@@ -171,7 +172,7 @@ func printKeypair(params KeypairMessageParams, format string) error {
 
 	switch format {
 	case teleport.Text:
-		if err := keypairMessageTemplate.Execute(os.Stdout, params); err != nil {
+		if err := keypairMessageTemplate.Execute(w, params); err != nil {
 			return trace.Wrap(err)
 		}
 	case teleport.JSON:
@@ -183,7 +184,7 @@ func printKeypair(params KeypairMessageParams, format string) error {
 			return trace.Wrap(err, "generating json")
 		}
 
-		fmt.Printf("%s\n", string(bytes))
+		fmt.Fprintf(w, "%s\n", string(bytes))
 	default:
 		return trace.BadParameter("unsupported output format %s; keypair has not been generated", format)
 	}
@@ -193,14 +194,14 @@ func printKeypair(params KeypairMessageParams, format string) error {
 
 // printKeypairFromState prints the current keypair from the given client state using the
 // specified format.
-func printKeypairFromState(state *boundkeypair.FSClientState, format string) error {
+func printKeypairFromState(w io.Writer, state *boundkeypair.FSClientState, format string) error {
 	publicKeyBytes, err := state.ToPublicKeyBytes()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	keyString := strings.TrimSpace(string(publicKeyBytes))
-	return trace.Wrap(printKeypair(KeypairMessageParams{
+	return trace.Wrap(printKeypair(w, KeypairMessageParams{
 		PublicKey: keyString,
 	}, format))
 }
@@ -246,9 +247,14 @@ func generateStaticKeypair(ctx context.Context, globals *cli.GlobalArgs, cmd *cl
 			)
 		}
 
+		getSuite := cmd.GetSuite
+		if getSuite == nil {
+			getSuite = getSuiteFromProxy(cmd.ProxyServer, globals.Insecure)
+		}
+
 		key, err = cryptosuites.GenerateKey(
 			ctx,
-			getSuiteFromProxy(cmd.ProxyServer, globals.Insecure),
+			getSuite,
 			cryptosuites.BoundKeypairJoining,
 		)
 		if err != nil {
@@ -285,7 +291,12 @@ func generateStaticKeypair(ctx context.Context, globals *cli.GlobalArgs, cmd *cl
 		)
 	}
 
-	return trace.Wrap(printKeypair(KeypairMessageParams{
+	w := cmd.Writer
+	if w == nil {
+		w = os.Stdout
+	}
+
+	return trace.Wrap(printKeypair(w, KeypairMessageParams{
 		PublicKey:         publicKeyString,
 		EnvName:           onboarding.BoundKeypairStaticKeyEnv,
 		EncodedPrivateKey: encodedPrivateKey,
@@ -313,23 +324,28 @@ func onKeypairCreateCommand(ctx context.Context, globals *cli.GlobalArgs, cmd *c
 	}
 
 	fsAdapter := destination.NewBoundkeypairDestinationAdapter(dest)
+	w := cmd.Writer
+	if w == nil {
+		w = os.Stdout
+	}
 
 	// Check for existing client state.
 	state, err := boundkeypair.LoadClientState(ctx, fsAdapter)
 	if err == nil {
 		if !cmd.Overwrite {
 			log.InfoContext(ctx, "Existing client state found, printing existing public key. To generate a new key, pass --overwrite")
-			return trace.Wrap(printKeypairFromState(state, cmd.Format))
+			return trace.Wrap(printKeypairFromState(w, state, cmd.Format))
 		} else {
 			log.WarnContext(ctx, "Overwriting existing client state and generating a new keypair.")
 		}
 	}
 
-	state, err = boundkeypair.NewUnboundClientState(
-		ctx,
-		fsAdapter,
-		getSuiteFromProxy(cmd.ProxyServer, globals.Insecure),
-	)
+	getSuite := cmd.GetSuite
+	if getSuite == nil {
+		getSuite = getSuiteFromProxy(cmd.ProxyServer, globals.Insecure)
+	}
+
+	state, err = boundkeypair.NewUnboundClientState(ctx, fsAdapter, getSuite)
 	if err != nil {
 		return trace.Wrap(err, "initializing new client state")
 	}
@@ -344,5 +360,5 @@ func onKeypairCreateCommand(ctx context.Context, globals *cli.GlobalArgs, cmd *c
 		"storage", dest.String(),
 	)
 
-	return trace.Wrap(printKeypairFromState(state, cmd.Format))
+	return trace.Wrap(printKeypairFromState(w, state, cmd.Format))
 }

--- a/tool/tbot/keypair_test.go
+++ b/tool/tbot/keypair_test.go
@@ -1,0 +1,111 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/cli"
+	"github.com/stretchr/testify/require"
+)
+
+func dummyGetSuite(ctx context.Context) (types.SignatureAlgorithmSuite, error) {
+	return types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1, nil
+}
+
+// TestGenerateStaticKeypairAtPath
+func TestGenerateStaticKeypairAtPath(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "test.key")
+
+	// Try creating a new key
+	firstBuf := bytes.Buffer{}
+	require.NoError(t, generateStaticKeypair(t.Context(), &cli.GlobalArgs{}, &cli.KeypairCreateCommand{
+		GetSuite:      dummyGetSuite,
+		Format:        teleport.JSON,
+		StaticKeyPath: dest,
+		Overwrite:     false,
+		Writer:        &firstBuf,
+	}))
+
+	// It should be readable and nonempty
+	require.FileExists(t, dest)
+	firstFileBytes, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.NotEmpty(t, firstFileBytes)
+
+	firstParseResult := KeypairDocument{}
+	require.NoError(t, json.Unmarshal(firstBuf.Bytes(), &firstParseResult))
+
+	decodedFirstKey, err := base64.StdEncoding.DecodeString(firstParseResult.PrivateKey)
+	require.NoError(t, err)
+
+	// Defer to bytes.Equal instead of require.Equal(), since otherwise it'll
+	// print very unhelpful debugging info if the check fails.
+	require.True(t, bytes.Equal(firstFileBytes, decodedFirstKey))
+
+	// Try again, but overwrite
+	secondBuf := bytes.Buffer{}
+	require.NoError(t, generateStaticKeypair(t.Context(), &cli.GlobalArgs{}, &cli.KeypairCreateCommand{
+		GetSuite:      dummyGetSuite,
+		Format:        teleport.JSON,
+		StaticKeyPath: dest,
+		Overwrite:     true,
+		Writer:        &secondBuf,
+	}))
+
+	secondFileBytes, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.NotEmpty(t, secondFileBytes)
+
+	// Content should be different
+	require.False(t, bytes.Equal(firstFileBytes, secondFileBytes))
+
+	// Try once more, but don't overwrite
+	thirdBuf := bytes.Buffer{}
+	require.NoError(t, generateStaticKeypair(t.Context(), &cli.GlobalArgs{}, &cli.KeypairCreateCommand{
+		GetSuite:      dummyGetSuite,
+		Format:        teleport.JSON,
+		StaticKeyPath: dest,
+		Overwrite:     false,
+		Writer:        &thirdBuf,
+	}))
+
+	thirdFileBytes, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.NotEmpty(t, thirdFileBytes)
+
+	thirdParseResult := KeypairDocument{}
+	require.NoError(t, json.Unmarshal(thirdBuf.Bytes(), &thirdParseResult))
+
+	decodedThirdKey, err := base64.StdEncoding.DecodeString(thirdParseResult.PrivateKey)
+	require.NoError(t, err)
+
+	// These values should all match the file from the 2nd try
+	require.True(t, bytes.Equal(secondFileBytes, thirdFileBytes))
+	require.True(t, bytes.Equal(secondFileBytes, decodedThirdKey))
+}

--- a/tool/tbot/keypair_test.go
+++ b/tool/tbot/keypair_test.go
@@ -27,10 +27,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/tbot/cli"
-	"github.com/stretchr/testify/require"
 )
 
 func dummyGetSuite(ctx context.Context) (types.SignatureAlgorithmSuite, error) {


### PR DESCRIPTION
Passing the `--static-key-path` flag was broken due to an improper error check that was intended to allow nonexistent files, but then incorrectly tried to extract a key from an empty byte array.

This fix skips parsing if the file is not found (which is allowed) and allows it to simply generate a new key.

Additionally, this fixes a reference to `--static-key` in the CLI help text, which was renamed to `--static-key-path`.

changelog: Fixed static keypair creation in `tbot keypair create` when the `--static-key-path` flag is used