### PR TITLE
Expose instance inventory to client and add web endpoint

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -83,6 +83,7 @@ import (
 	gitserverpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/gitserver/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	kubewaitingcontainerpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/kubewaitingcontainer/v1"
@@ -917,6 +918,11 @@ func (c *Client) SigstorePolicyResourceServiceClient() workloadidentityv1pb.Sigs
 // PresenceServiceClient returns an unadorned client for the presence service.
 func (c *Client) PresenceServiceClient() presencepb.PresenceServiceClient {
 	return presencepb.NewPresenceServiceClient(c.conn)
+}
+
+// InventoryServiceClient returns an unadorned client for the inventory service.
+func (c *Client) InventoryServiceClient() inventoryv1.InventoryServiceClient {
+	return inventoryv1.NewInventoryServiceClient(c.conn)
 }
 
 // NotificationServiceClient returns a notification service client that can be used to fetch notifications.

--- a/api/client/inventory.go
+++ b/api/client/inventory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 )
@@ -245,6 +246,15 @@ func (c *Client) GetInstances(ctx context.Context, filter types.InstanceFilter) 
 		}
 		return instance, nil
 	}, cancel)
+}
+
+// ListUnifiedInstances returns a paginated list of unified instances (teleport instances and bot instances).
+func (c *Client) ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error) {
+	rsp, err := c.InventoryServiceClient().ListUnifiedInstances(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return rsp, nil
 }
 
 func newDownstreamInventoryControlStream(stream proto.AuthService_InventoryControlStreamClient, cancel context.CancelFunc) DownstreamInventoryControlStream {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -46,6 +46,7 @@ import (
 	dbobjectimportrulev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/dbobjectimportrule/v1"
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	integrationv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
+	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
@@ -1617,6 +1618,9 @@ type ClientI interface {
 	services.AppAuthConfig
 	types.Events
 	services.ScopedAccessClientGetter
+
+	// ListUnifiedInstances returns a paginated list of unified instances (teleport instances and bot instances).
+	ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error)
 
 	types.WebSessionsGetter
 	services.WebToken

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cache"
+	inventorycache "github.com/gravitational/teleport/lib/cache/inventory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
@@ -592,6 +593,19 @@ func InitAuthCache(p AuthCacheParams) error {
 		return trace.Wrap(err)
 	}
 	p.AuthServer.Cache = c
+
+	// Create and set the inventory cache
+	invCache, err := inventorycache.NewInventoryCache(inventorycache.InventoryCacheConfig{
+		PrimaryCache:       c,
+		Events:             p.AuthServer.Services,
+		Inventory:          p.AuthServer.Services,
+		BotInstanceBackend: p.AuthServer.Services,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	p.AuthServer.SetInventoryCache(invCache)
+
 	return nil
 }
 

--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -76,6 +76,7 @@ func instanceTypeToKind(instanceType inventoryv1.InstanceType) (string, error) {
 	}
 }
 
+// bytestring contains binary data (encoded keys) and is not intended to be printable.
 type bytestring = string
 
 type inventoryIndex string

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -859,6 +859,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/nodes", h.WithClusterAuth(h.clusterNodesGet))
 	h.POST("/webapi/sites/:site/nodes", h.WithClusterAuth(h.handleNodeCreate))
 
+	h.GET("/webapi/sites/:site/instances", h.WithClusterAuth(h.clusterUnifiedInstancesGet))
+
 	// get login alerts
 	h.GET("/webapi/sites/:site/alerts", h.WithClusterAuth(h.clusterLoginAlertsGet))
 

--- a/lib/web/inventory.go
+++ b/lib/web/inventory.go
@@ -1,0 +1,140 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"maps"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/web/ui"
+)
+
+func splitQuery(value string) []string {
+	values := map[string]struct{}{}
+	for v := range strings.SplitSeq(value, ",") {
+		if trimmed := strings.TrimSpace(v); trimmed != "" {
+			values[trimmed] = struct{}{}
+		}
+	}
+	return slices.Collect(maps.Keys(values))
+}
+
+// listUnifiedInstancesResponse is the response for listing unified instances
+type listUnifiedInstancesResponse struct {
+	// Instances is the list of unified instances (both instances and bot instances)
+	Instances []ui.UnifiedInstance `json:"instances"`
+	// StartKey is the next page token
+	StartKey string `json:"startKey"`
+}
+
+// clusterUnifiedInstancesGet returns a paginated list of unified instances
+func (h *Handler) clusterUnifiedInstancesGet(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, cluster reversetunnelclient.Cluster) (any, error) {
+	clt, err := sctx.GetUserClient(r.Context(), cluster)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	values := r.URL.Query()
+
+	limit, err := QueryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	startKey := values.Get("startKey")
+
+	// Default values
+	sort := inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME
+	order := inventoryv1.SortOrder_SORT_ORDER_ASCENDING
+	if sortParam := values.Get("sort"); sortParam != "" {
+		parts := strings.SplitN(sortParam, ":", 2)
+		fieldName := strings.ToLower(parts[0])
+		switch fieldName {
+		case "name", "hostname":
+			sort = inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME
+		case "type":
+			sort = inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_TYPE
+		case "version":
+			sort = inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_VERSION
+		}
+		if len(parts) == 2 {
+			direction := strings.ToLower(parts[1])
+			if direction == "desc" || direction == "descending" {
+				order = inventoryv1.SortOrder_SORT_ORDER_DESCENDING
+			}
+		}
+	}
+
+	filter := &inventoryv1.ListUnifiedInstancesFilter{
+		Search:              values.Get("search"),
+		PredicateExpression: values.Get("query"),
+		Services:            splitQuery(values.Get("services")),
+		Upgraders:           splitQuery(values.Get("upgraders")),
+		UpdaterGroups:       splitQuery(values.Get("updaterGroups")),
+	}
+
+	var hasInstance, hasBotInstance bool
+	for t := range strings.SplitSeq(values.Get("types"), ",") {
+		switch strings.ToLower(strings.TrimSpace(t)) {
+		case "instance":
+			hasInstance = true
+		case "bot_instance":
+			hasBotInstance = true
+		}
+
+		if hasInstance && hasBotInstance {
+			break
+		}
+	}
+	if hasInstance {
+		filter.InstanceTypes = append(filter.InstanceTypes, inventoryv1.InstanceType_INSTANCE_TYPE_INSTANCE)
+	}
+	if hasBotInstance {
+		filter.InstanceTypes = append(filter.InstanceTypes, inventoryv1.InstanceType_INSTANCE_TYPE_BOT_INSTANCE)
+	}
+
+	resp, err := clt.ListUnifiedInstances(r.Context(), &inventoryv1.ListUnifiedInstancesRequest{
+		PageSize:  limit,
+		PageToken: startKey,
+		Sort:      sort,
+		Order:     order,
+		Filter:    filter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	uiInstances := make([]ui.UnifiedInstance, 0, len(resp.Items))
+	for _, item := range resp.Items {
+		uiInstances = append(uiInstances, ui.MakeUnifiedInstance(item))
+	}
+
+	return &listUnifiedInstancesResponse{
+		Instances: uiInstances,
+		StartKey:  resp.NextPageToken,
+	}, nil
+}

--- a/lib/web/inventory_test.go
+++ b/lib/web/inventory_test.go
@@ -1,0 +1,244 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"encoding/json"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+func TestListUnifiedInstances(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	env := newWebPack(t, 1, func(cfg *WebPackOptions) {
+		cfg.enableAuthCache = true
+	})
+	clusterName := env.server.ClusterName()
+
+	// Create mock instances
+	instances := []*types.InstanceV1{
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-1"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-1",
+				Version:  "18.1.0",
+				Services: []types.SystemRole{types.RoleNode},
+			},
+		},
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-2"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-2",
+				Version:  "18.2.0",
+				Services: []types.SystemRole{types.RoleProxy, types.RoleAuth},
+			},
+		},
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-3"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-3",
+				Version:  "18.3.0",
+				Services: []types.SystemRole{types.RoleDatabase},
+			},
+		},
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-4"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-4",
+				Version:  "18.4.0",
+				Services: []types.SystemRole{types.RoleNode},
+			},
+		},
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-5"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-5",
+				Version:  "18.5.0",
+				Services: []types.SystemRole{types.RoleProxy},
+			},
+		},
+		{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{Name: "instance-6"},
+			},
+			Spec: types.InstanceSpecV1{
+				Hostname: "host-6",
+				Version:  "18.6.0",
+				Services: []types.SystemRole{types.RoleAuth},
+			},
+		},
+	}
+	for _, instance := range instances {
+		require.NoError(t, env.server.Auth().UpsertInstance(ctx, instance))
+	}
+
+	// Create mock bot instances
+	bots := []*machineidv1.BotInstance{
+		{
+			Metadata: &headerv1.Metadata{Name: "bot-1"},
+			Spec: &machineidv1.BotInstanceSpec{
+				BotName:    "bot-1",
+				InstanceId: "bot-1",
+			},
+			Status: &machineidv1.BotInstanceStatus{
+				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+					{
+						RecordedAt: timestamppb.Now(),
+						Version:    "18.7.0",
+					},
+				},
+			},
+		},
+		{
+			Metadata: &headerv1.Metadata{Name: "bot-2"},
+			Spec: &machineidv1.BotInstanceSpec{
+				BotName:    "bot-2",
+				InstanceId: "bot-2",
+			},
+			Status: &machineidv1.BotInstanceStatus{
+				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+					{
+						RecordedAt: timestamppb.Now(),
+						Version:    "18.8.0",
+					},
+				},
+			},
+		},
+		{
+			Metadata: &headerv1.Metadata{Name: "bot-3"},
+			Spec: &machineidv1.BotInstanceSpec{
+				BotName:    "bot-3",
+				InstanceId: "bot-3",
+			},
+			Status: &machineidv1.BotInstanceStatus{
+				LatestHeartbeats: []*machineidv1.BotInstanceStatusHeartbeat{
+					{
+						RecordedAt: timestamppb.Now(),
+						Version:    "18.9.0",
+					},
+				},
+			},
+		},
+	}
+	for _, bot := range bots {
+		_, err := env.server.Auth().BotInstance.CreateBotInstance(ctx, bot)
+		require.NoError(t, err)
+	}
+
+	// Create user with required permissions
+	username := "test-user"
+	role, err := types.NewRole(services.RoleNameForUser(username), types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Rules: []types.Rule{
+				types.NewRule(types.KindInstance, []string{types.VerbRead, types.VerbList}),
+				types.NewRule(types.KindBotInstance, []string{types.VerbRead, types.VerbList}),
+			},
+		},
+	})
+	require.NoError(t, err)
+	pack := env.proxies[0].authPack(t, username, []types.Role{role})
+
+	endpoint := pack.clt.Endpoint("webapi", "sites", clusterName, "instances")
+
+	// The initial requests are in the eventually to ensure that the inventory
+	// cache is healthy, has processed all put events, and that all the instances
+	// are present.
+	var listResp listUnifiedInstancesResponse
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		// Test listing with no params
+		resp, err := pack.clt.Get(ctx, endpoint, url.Values{})
+		require.NoError(t, err)
+
+		require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+		require.Len(t, listResp.Instances, 9, "should have 9 items (6 instances + 3 bots)")
+	}, 10*time.Second, 100*time.Millisecond, "inventory cache failed to become healthy and populated")
+
+	// Test pagination
+	// Get page of 4
+	resp, err := pack.clt.Get(ctx, endpoint, url.Values{
+		"limit": []string{"4"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 4, "should have 4 items")
+	require.NotEmpty(t, listResp.StartKey, "should have a startKey in the response")
+
+	// Get page of 5
+	resp, err = pack.clt.Get(ctx, endpoint, url.Values{
+		"limit":    []string{"5"},
+		"startKey": []string{listResp.StartKey},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 5, "should have 5 items in second page")
+	// First item on the second page should be instance-2
+	require.Equal(t, "instance-2", listResp.Instances[0].ID)
+	require.Empty(t, listResp.StartKey, "should not have a startKey in the response")
+
+	// Test sorting by version descending
+	resp, err = pack.clt.Get(ctx, endpoint, url.Values{
+		"sort": []string{"version:desc"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 9)
+	require.Equal(t, "bot-3", listResp.Instances[0].ID)      // 18.9.0
+	require.Equal(t, "bot-2", listResp.Instances[1].ID)      // 18.8.0
+	require.Equal(t, "instance-4", listResp.Instances[5].ID) // 18.4.0
+	require.Equal(t, "instance-1", listResp.Instances[8].ID) // 18.1.0
+
+	// Test searching
+	resp, err = pack.clt.Get(ctx, endpoint, url.Values{
+		"search": []string{"host-1"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Len(t, listResp.Instances, 1, "should find 1 item matching 'host-1' search")
+	require.Equal(t, "instance-1", listResp.Instances[0].ID)
+
+	// Test a search with no matches
+	resp, err = pack.clt.Get(ctx, endpoint, url.Values{
+		"search": []string{"nonexistentinstance"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(resp.Bytes(), &listResp))
+	require.Empty(t, listResp.Instances, "should find no items matching the search")
+}

--- a/lib/web/ui/instance.go
+++ b/lib/web/ui/instance.go
@@ -1,0 +1,125 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ui
+
+import (
+	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// UnifiedInstance represents either a Teleport instance or a bot instance for the WebUI.
+type UnifiedInstance struct {
+	// ID is the unique identifier for this item
+	ID string `json:"id"`
+	// Type is the type of instance, either "instance" or "bot_instance"
+	Type string `json:"type"`
+	// Instance contains the instance data if type is "instance"
+	Instance *InstanceData `json:"instance,omitempty"`
+	// BotInstance contains the bot instance data if type is "bot_instance"
+	BotInstance *BotInstanceData `json:"botInstance,omitempty"`
+}
+
+// InstanceData represents a teleport instance item for the WebUI
+type InstanceData struct {
+	// Name is the hostname of the instance
+	Name string `json:"name"`
+	// Version is the version
+	Version string `json:"version"`
+	// Services is the list of services running on this instance
+	Services []string `json:"services"`
+	// Upgrader contains information about the external upgrader
+	Upgrader *UpgraderInfo `json:"upgrader,omitempty"`
+}
+
+// BotInstanceData represents a bot instance item for the WebUI
+type BotInstanceData struct {
+	// Name is the name of the bot
+	Name string `json:"name"`
+	// Version is the bot version
+	Version string `json:"version"`
+}
+
+// UpgraderInfo contains information about an external upgrader
+type UpgraderInfo struct {
+	// Type is the upgrader type
+	Type string `json:"type"`
+	// Version is the upgrader version
+	Version string `json:"version"`
+	// Group is the updater group
+	Group string `json:"group"`
+}
+
+// MakeUnifiedInstance creates a UnifiedInstance from a UnifiedInstanceItem proto
+func MakeUnifiedInstance(item *inventoryv1.UnifiedInstanceItem) UnifiedInstance {
+	if instance := item.GetInstance(); instance != nil {
+		return makeInstanceUnifiedItem(instance)
+	}
+	if botInstance := item.GetBotInstance(); botInstance != nil {
+		return makeBotInstanceUnifiedItem(botInstance)
+	}
+	return UnifiedInstance{}
+}
+
+func makeInstanceUnifiedItem(instance *types.InstanceV1) UnifiedInstance {
+	services := make([]string, 0, len(instance.Spec.Services))
+	for _, service := range instance.Spec.Services {
+		services = append(services, string(service))
+	}
+
+	instanceData := &InstanceData{
+		Name:     instance.Spec.Hostname,
+		Version:  instance.Spec.Version,
+		Services: services,
+	}
+
+	if instance.Spec.ExternalUpgrader != "" || instance.Spec.UpdaterInfo != nil {
+		instanceData.Upgrader = &UpgraderInfo{
+			Type: instance.Spec.ExternalUpgrader,
+		}
+		if instance.Spec.UpdaterInfo != nil {
+			instanceData.Upgrader.Group = instance.Spec.UpdaterInfo.UpdateGroup
+			// UpdaterV2Info doesn't have a version field so we hardcode "v2"
+			instanceData.Upgrader.Version = "v2"
+		}
+	}
+
+	return UnifiedInstance{
+		ID:       instance.Metadata.Name,
+		Type:     "instance",
+		Instance: instanceData,
+	}
+}
+
+func makeBotInstanceUnifiedItem(botInstance *machineidv1.BotInstance) UnifiedInstance {
+	botData := &BotInstanceData{
+		Name: botInstance.Spec.BotName,
+	}
+
+	if botInstance.Status != nil && len(botInstance.Status.LatestHeartbeats) > 0 {
+		heartbeat := botInstance.Status.LatestHeartbeats[0]
+		botData.Version = heartbeat.Version
+	}
+
+	return UnifiedInstance{
+		ID:          botInstance.Metadata.Name,
+		Type:        "bot_instance",
+		BotInstance: botData,
+	}
+}


### PR DESCRIPTION
## Purpose

This PR is part of https://github.com/gravitational/teleport/issues/60528

This PR exposes the instance inventory to the client and adds the webapi endpoint so that the frontend can make requests.

Required merges:
- https://github.com/gravitational/teleport/pull/60535
- https://github.com/gravitational/teleport/pull/61089
- https://github.com/gravitational/teleport/pull/61857