### PR TITLE
Add `lib/tfgen` package for generating resource Terraform code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -162,6 +162,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/guptarohit/asciigraph v0.7.3
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/yamux v0.1.2
 	github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02
 	github.com/icza/mjpeg v0.0.0-20230330134156-38318e5ab8f4
@@ -229,6 +230,7 @@ require (
 	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb
 	github.com/vulcand/predicate v1.2.0 // replaced
 	github.com/yusufpapurcu/wmi v1.2.4
+	github.com/zclconf/go-cty v1.16.3
 	github.com/zitadel/oidc/v3 v3.45.0
 	gitlab.com/gitlab-org/api/client-go v0.159.0
 	go.etcd.io/etcd/api/v3 v3.6.5
@@ -309,9 +311,11 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/squirrel v1.5.4 // indirect
+	github.com/agext/levenshtein v1.2.1 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/apache/arrow-go/v18 v18.4.0 // indirect
 	github.com/apache/thrift v0.22.0 // indirect
+	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aws/aws-sdk-go v1.55.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -757,6 +757,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
+github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
+github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -778,6 +780,8 @@ github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4x
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
 github.com/apache/thrift v0.22.0 h1:r7mTJdj51TMDe6RtcmNdQxgn9XcyfGDOzegMDRg47uc=
 github.com/apache/thrift v0.22.0/go.mod h1:1e7J/O1Ae6ZQMTYdy9xa3w9k+XHWPfRvdPyJeynQ+/g=
+github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
+github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -1591,6 +1595,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
 github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
@@ -2255,6 +2261,10 @@ github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
+github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
+github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -283,7 +283,7 @@ require (
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
-	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.23.0 // indirect
 	github.com/hashicorp/terraform-json v0.25.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -1550,8 +1550,8 @@ github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+O
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/hcl/v2 v2.23.0 h1:Fphj1/gCylPxHutVSEOf2fBOh1VE4AuLV7+kbJf3qos=
-github.com/hashicorp/hcl/v2 v2.23.0/go.mod h1:62ZYHrXgPoX8xBnzl8QzbWq4dyDsDtfCRgIq1rbJEvA=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.23.0 h1:MUiBM1s0CNlRFsCLJuM5wXZrzA3MnPYEsiXmzATMW/I=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -82,7 +82,6 @@ require (
 	github.com/alecthomas/kingpin/v2 v2.4.0 // indirect
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
-	github.com/apparentlymart/go-textseg v1.0.0 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
@@ -285,7 +284,7 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hashicorp/hc-install v0.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
-	github.com/hashicorp/hcl/v2 v2.3.0 // indirect
+	github.com/hashicorp/hcl/v2 v2.24.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
@@ -464,7 +463,7 @@ require (
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	github.com/yuin/goldmark v1.7.4 // indirect
 	github.com/yuin/goldmark-meta v1.1.0 // indirect
-	github.com/zclconf/go-cty v1.14.4 // indirect
+	github.com/zclconf/go-cty v1.16.3 // indirect
 	github.com/zitadel/logging v0.6.2 // indirect
 	github.com/zitadel/oidc/v3 v3.45.0 // indirect
 	github.com/zitadel/schema v1.3.1 // indirect
@@ -503,6 +502,7 @@ require (
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.30.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
+	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/api v0.255.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -796,7 +796,6 @@ github.com/apparentlymart/go-cidr v1.0.1/go.mod h1:EBcsNrHc3zQeuaeCeCtQruQm+n9/Y
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0 h1:MzVXffFUye+ZcSR6opIgz9Co7WcDx6ZcY+RjfFHoA0I=
 github.com/apparentlymart/go-dump v0.0.0-20190214190832-042adf3cf4a0/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
-github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -1595,8 +1594,9 @@ github.com/hashicorp/hc-install v0.7.0 h1:Uu9edVqjKQxxuD28mR5TikkKDd/p55S8vzPC16
 github.com/hashicorp/hc-install v0.7.0/go.mod h1:ELmmzZlGnEcqoUMKUuykHaPCIR1sYLYX+KSggWSKZuA=
 github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31RPDgJM=
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
-github.com/hashicorp/hcl/v2 v2.3.0 h1:iRly8YaMwTBAKhn1Ybk7VSdzbnopghktCD031P8ggUE=
 github.com/hashicorp/hcl/v2 v2.3.0/go.mod h1:d+FwDBbOLvpAM3Z6J7gPj/VoAGkNe/gm352ZhjJ/Zv8=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/terraform-exec v0.15.0/go.mod h1:H4IG8ZxanU+NW0ZpDRNsvh9f0ul7C0nHP+rUR/CHs7I=
@@ -2280,9 +2280,11 @@ github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH8
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.14.4 h1:uXXczd9QDGsgu0i/QFR/hzI5NYCHLf6NQw/atrbnhq8=
-github.com/zclconf/go-cty v1.14.4/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
+github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
+github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
+github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=

--- a/lib/tfgen/internal/reflect_legacy.go
+++ b/lib/tfgen/internal/reflect_legacy.go
@@ -72,10 +72,15 @@ func reflectMessageLegacy(value reflect.Value) (*Message, error) {
 			continue
 		}
 
-		msg.Attributes = append(msg.Attributes, Attribute{
-			Name:  fieldName,
-			Value: fieldValue,
-		})
+		if fieldType.Anonymous {
+			// Handle embedded struct fields.
+			msg.Attributes = append(msg.Attributes, fieldValue.Message().Attributes...)
+		} else {
+			msg.Attributes = append(msg.Attributes, Attribute{
+				Name:  fieldName,
+				Value: fieldValue,
+			})
+		}
 	}
 
 	return &msg, nil

--- a/lib/tfgen/internal/reflect_legacy.go
+++ b/lib/tfgen/internal/reflect_legacy.go
@@ -33,7 +33,7 @@ import (
 type LegacyProtoMessage interface{ ProtoMessage() }
 
 // ReflectLegacy uses Go's reflect package to walk the given message and
-// discover its attributes.
+// discover its attributes. This is suitable for legacy/gogo-proto resources.
 func ReflectLegacy(message LegacyProtoMessage) (*Message, error) {
 	msg := reflect.ValueOf(message)
 	if msg.Kind() == reflect.Pointer {

--- a/lib/tfgen/internal/reflect_legacy.go
+++ b/lib/tfgen/internal/reflect_legacy.go
@@ -28,12 +28,13 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+// LegacyProtoMessage is the interface satisfied by protobuf v1 and gogo-proto
+// structs.
+type LegacyProtoMessage interface{ ProtoMessage() }
+
 // ReflectLegacy uses Go's reflect package to walk the given message and
 // discover its attributes.
-func ReflectLegacy(message any) (*Message, error) {
-	if _, ok := message.(interface{ ProtoMessage() }); !ok {
-		return nil, trace.BadParameter("must be a protobuf message")
-	}
+func ReflectLegacy(message LegacyProtoMessage) (*Message, error) {
 	msg := reflect.ValueOf(message)
 	if msg.Kind() == reflect.Pointer {
 		msg = msg.Elem()

--- a/lib/tfgen/internal/reflect_legacy.go
+++ b/lib/tfgen/internal/reflect_legacy.go
@@ -1,0 +1,202 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// ReflectLegacy uses Go's reflect package to walk the given message and
+// discover its attributes.
+func ReflectLegacy(message any) (*Message, error) {
+	if _, ok := message.(interface{ ProtoMessage() }); !ok {
+		return nil, trace.BadParameter("must be a protobuf message")
+	}
+	msg := reflect.ValueOf(message)
+	if msg.Kind() == reflect.Pointer {
+		msg = msg.Elem()
+	}
+	return reflectMessageLegacy(msg)
+}
+
+func reflectMessageLegacy(value reflect.Value) (*Message, error) {
+	msgType := value.Type()
+
+	var msg Message
+	for i := range msgType.NumField() {
+		fieldType := msgType.Field(i)
+		fieldName := fieldType.Name
+
+		// Skip over protobuf internal fields.
+		if strings.HasPrefix(fieldName, "XXX_") {
+			continue
+		}
+
+		// Derive the field name from the JSON tag.
+		jsonTag := fieldType.Tag.Get("json")
+		if jsonTag != "" {
+			fieldName, _, _ = strings.Cut(jsonTag, ",")
+			if fieldName == "-" {
+				continue
+			}
+		}
+
+		fieldValue, err := reflectValueLegacy(value.Field(i))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if fieldValue == nil {
+			continue
+		}
+
+		msg.Attributes = append(msg.Attributes, Attribute{
+			Name:  fieldName,
+			Value: fieldValue,
+		})
+	}
+
+	return &msg, nil
+}
+
+func reflectValueLegacy(value reflect.Value) (*Value, error) {
+	if value.Kind() == reflect.Pointer {
+		// Special case: if field is not populated at all, we simply don't emit
+		// it as an attribute.
+		if value.IsNil() {
+			return nil, nil
+		}
+
+		// Dereference pointer.
+		value = value.Elem()
+	}
+
+	// Handle custom types.
+	switch v := value.Interface().(type) {
+	case []byte:
+		return &Value{
+			Type:  TypeBytes,
+			Value: v,
+		}, nil
+	case time.Time:
+		return &Value{
+			Type:  TypeTimestamp,
+			Value: v,
+		}, nil
+	case types.Duration:
+		return &Value{
+			Type:  TypeDuration,
+			Value: time.Duration(v),
+		}, nil
+	case types.BoolOption:
+		return &Value{
+			Type:  TypeBool,
+			Value: v.Value,
+		}, nil
+	}
+
+	switch value.Kind() {
+	case reflect.Struct:
+		message, err := reflectMessageLegacy(value)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &Value{
+			Type:  TypeMessage,
+			Value: message,
+		}, nil
+	case reflect.Map:
+		return reflectMapLegacy(value)
+	case reflect.Slice:
+		return reflectSliceLegacy(value)
+	case reflect.String:
+		return &Value{
+			Type:  TypeString,
+			Value: value.String(),
+		}, nil
+	case reflect.Bool:
+		return &Value{
+			Type:  TypeBool,
+			Value: value.Bool(),
+		}, nil
+	case reflect.Int32, reflect.Int64:
+		return &Value{
+			Type:  TypeInt,
+			Value: int(value.Int()),
+		}, nil
+	case reflect.Uint32, reflect.Uint64:
+		return &Value{
+			Type:  TypeInt,
+			Value: int(value.Uint()),
+		}, nil
+	case reflect.Float32, reflect.Float64:
+		return &Value{
+			Type:  TypeFloat,
+			Value: value.Float(),
+		}, nil
+	}
+
+	return nil, trace.NotImplemented("field type %s not supported", value.Kind())
+}
+
+func reflectSliceLegacy(value reflect.Value) (*Value, error) {
+	elems := make([]*Value, value.Len())
+	for i := range value.Len() {
+		val, err := reflectValueLegacy(value.Index(i))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		elems[i] = val
+	}
+
+	return &Value{
+		Type: TypeList,
+		Value: &ListValue{
+			Elems: elems,
+		},
+	}, nil
+}
+
+func reflectMapLegacy(value reflect.Value) (*Value, error) {
+	elems := make(map[any]*Value)
+	iter := value.MapRange()
+	for iter.Next() {
+		key, err := reflectValueLegacy(iter.Key())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		val, err := reflectValueLegacy(iter.Value())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		elems[key.Value] = val
+	}
+
+	return &Value{
+		Type: TypeMap,
+		Value: &MapValue{
+			Elems: elems,
+		},
+	}, nil
+}

--- a/lib/tfgen/internal/reflect_legacy_test.go
+++ b/lib/tfgen/internal/reflect_legacy_test.go
@@ -1,0 +1,114 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tfgen/internal"
+)
+
+func TestReflectLegacy(t *testing.T) {
+	now := time.Now().UTC()
+
+	token, err := types.NewProvisionTokenFromSpec(
+		"my-token",
+		now,
+		types.ProvisionTokenSpecV2{
+			Roles:      []types.SystemRole{types.RoleBot},
+			BotName:    "my-bot",
+			JoinMethod: types.JoinMethodGitHub,
+			GitHub: &types.ProvisionTokenSpecV2GitHub{
+				Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+					{
+						Repository: "gravitational/teleport",
+					},
+				},
+			},
+			SuggestedLabels: types.Labels{
+				"foo": {"bar", "baz"},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	expected := &internal.Message{
+		Attributes: []internal.Attribute{
+			attribute("kind", stringVal(types.KindToken)),
+			attribute("sub_kind", stringVal("")),
+			attribute("version", stringVal(types.V2)),
+			attribute("metadata",
+				messageVal(
+					attribute("name", stringVal("my-token")),
+					attribute("description", stringVal("")),
+					attribute("labels", mapVal(nil)),
+					attribute("expires", timestampVal(now)),
+					attribute("revision", stringVal("")),
+				),
+			),
+			attribute("spec",
+				messageVal(
+					attribute("roles", listVal(stringVal("Bot"))),
+					attribute("allow", listVal()),
+					attribute("aws_iid_ttl", durationVal(0)),
+					attribute("join_method", stringVal("github")),
+					attribute("bot_name", stringVal("my-bot")),
+					attribute("suggested_labels",
+						mapVal(
+							map[any]*internal.Value{
+								"foo": listVal(stringVal("bar"), stringVal("baz")),
+							},
+						),
+					),
+					attribute("github",
+						messageVal(
+							attribute("allow",
+								listVal(
+									messageVal(
+										attribute("sub", stringVal("")),
+										attribute("repository", stringVal("gravitational/teleport")),
+										attribute("repository_owner", stringVal("")),
+										attribute("workflow", stringVal("")),
+										attribute("environment", stringVal("")),
+										attribute("actor", stringVal("")),
+										attribute("ref", stringVal("")),
+										attribute("ref_type", stringVal("")),
+									),
+								),
+							),
+							attribute("enterprise_server_host", stringVal("")),
+							attribute("enterprise_slug", stringVal("")),
+							attribute("static_jwks", stringVal("")),
+						),
+					),
+					attribute("suggested_agent_matcher_labels", mapVal(nil)),
+				),
+			),
+		},
+	}
+
+	output, err := internal.ReflectLegacy(token)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, output))
+}

--- a/lib/tfgen/internal/reflect_legacy_test.go
+++ b/lib/tfgen/internal/reflect_legacy_test.go
@@ -108,7 +108,7 @@ func TestReflectLegacy(t *testing.T) {
 		},
 	}
 
-	output, err := internal.ReflectLegacy(token)
+	output, err := internal.ReflectLegacy(token.(internal.LegacyProtoMessage))
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expected, output))
 }

--- a/lib/tfgen/internal/reflect_modern.go
+++ b/lib/tfgen/internal/reflect_modern.go
@@ -1,0 +1,212 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import (
+	"time"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ReflectModern uses the modern protoreflect package to walk the given message
+// and discover its attributes.
+func ReflectModern(message proto.Message) (*Message, error) {
+	return reflectMessageModern(message.ProtoReflect())
+}
+
+func reflectMessageModern(
+	value protoreflect.Message,
+) (*Message, error) {
+	desc := value.Descriptor()
+	fields := desc.Fields()
+
+	var msg Message
+	for i := range fields.Len() {
+		fieldDesc := fields.Get(i)
+		fieldValue := value.Get(fieldDesc)
+
+		value, err := reflectValueModern(fieldValue, fieldDesc)
+		if err != nil {
+			return nil, trace.Wrap(err, "reflecting field: %s", fieldDesc.Name())
+		}
+
+		msg.Attributes = append(msg.Attributes, Attribute{
+			Name:  fieldDesc.TextName(),
+			Value: value,
+		})
+	}
+
+	return &msg, nil
+}
+
+func reflectValueModern(
+	value protoreflect.Value,
+	desc protoreflect.FieldDescriptor,
+) (*Value, error) {
+	if desc.IsList() {
+		return reflectListModern(value.List(), desc)
+	}
+	if desc.IsMap() {
+		return reflectMapModern(value.Map(), desc)
+	}
+	return reflectValueInnerModern(value, desc)
+}
+
+func reflectValueInnerModern(
+	value protoreflect.Value,
+	desc protoreflect.FieldDescriptor,
+) (*Value, error) {
+	switch desc.Kind() {
+	case protoreflect.BoolKind:
+		return &Value{
+			Type:  TypeBool,
+			Value: value.Bool(),
+		}, nil
+	case protoreflect.StringKind, protoreflect.EnumKind:
+		return &Value{
+			Type:  TypeString,
+			Value: value.String(),
+		}, nil
+	case protoreflect.Int32Kind, protoreflect.Int64Kind,
+		protoreflect.Sint32Kind, protoreflect.Sint64Kind,
+		protoreflect.Sfixed32Kind, protoreflect.Sfixed64Kind:
+		return &Value{
+			Type:  TypeInt,
+			Value: int(value.Int()),
+		}, nil
+	case protoreflect.Uint32Kind, protoreflect.Uint64Kind,
+		protoreflect.Fixed32Kind, protoreflect.Fixed64Kind:
+		return &Value{
+			Type:  TypeInt,
+			Value: int(value.Uint()),
+		}, nil
+	case protoreflect.FloatKind, protoreflect.DoubleKind:
+		return &Value{
+			Type:  TypeFloat,
+			Value: value.Float(),
+		}, nil
+	case protoreflect.BytesKind:
+		return &Value{
+			Type:  TypeBytes,
+			Value: value.Bytes(),
+		}, nil
+	case protoreflect.MessageKind:
+		switch desc.Message().FullName() {
+		case googleProtobufTimestamp:
+			return reflectTimestampModern(value.Message())
+		case googleProtobufDuration:
+			return reflectDurationModern(value.Message())
+		}
+
+		message, err := reflectMessageModern(value.Message())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &Value{
+			Type:  TypeMessage,
+			Value: message,
+		}, nil
+	}
+	return nil, trace.NotImplemented("unsupported field kind: %s", desc.Kind())
+}
+
+func reflectListModern(
+	value protoreflect.List,
+	desc protoreflect.FieldDescriptor,
+) (*Value, error) {
+	elems := make([]*Value, value.Len())
+	for i := range value.Len() {
+		val, err := reflectValueInnerModern(value.Get(i), desc)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		elems[i] = val
+	}
+
+	return &Value{
+		Type: TypeList,
+		Value: &ListValue{
+			Elems: elems,
+		},
+	}, nil
+}
+
+func reflectMapModern(
+	value protoreflect.Map,
+	desc protoreflect.FieldDescriptor,
+) (*Value, error) {
+	elems := make(map[any]*Value, value.Len())
+
+	var err error
+	value.Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
+		var v *Value
+		if v, err = reflectValueModern(value, desc.MapValue()); err != nil {
+			return false
+		}
+		elems[key.Interface()] = v
+		return true
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &Value{
+		Type: TypeMap,
+		Value: &MapValue{
+			Elems: elems,
+		},
+	}, nil
+}
+
+func reflectTimestampModern(value protoreflect.Message) (*Value, error) {
+	ts, ok := value.Interface().(*timestamppb.Timestamp)
+	if !ok {
+		return nil, trace.BadParameter("expected timestamp, got: %T", value)
+	}
+
+	t := ts.AsTime()
+	if !ts.IsValid() {
+		t = time.Time{}
+	}
+
+	return &Value{
+		Type:  TypeTimestamp,
+		Value: t,
+	}, nil
+}
+
+func reflectDurationModern(value protoreflect.Message) (*Value, error) {
+	dur, ok := value.Interface().(*durationpb.Duration)
+	if !ok {
+		return nil, trace.BadParameter("expected duration, got: %T", value)
+	}
+	return &Value{
+		Type:  TypeDuration,
+		Value: dur.AsDuration(),
+	}, nil
+}
+
+var (
+	googleProtobufTimestamp = protoreflect.FullName("google.protobuf.Timestamp")
+	googleProtobufDuration  = protoreflect.FullName("google.protobuf.Duration")
+)

--- a/lib/tfgen/internal/reflect_modern.go
+++ b/lib/tfgen/internal/reflect_modern.go
@@ -29,7 +29,7 @@ import (
 )
 
 // ReflectModern uses the modern protoreflect package to walk the given message
-// and discover its attributes.
+// and discover its attributes. This is suitable for RFD 153-style resources.
 func ReflectModern(message proto.Message) (*Message, error) {
 	return reflectMessageModern(message.ProtoReflect())
 }

--- a/lib/tfgen/internal/reflect_modern_test.go
+++ b/lib/tfgen/internal/reflect_modern_test.go
@@ -1,0 +1,112 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tfgen/internal"
+)
+
+func TestReflectModern(t *testing.T) {
+	now := time.Now().UTC()
+
+	input := &machineidv1.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:        "my-bot",
+			Description: "hello",
+			Expires:     timestamppb.New(now),
+			Labels:      map[string]string{"foo": "bar"},
+		},
+		Spec: &machineidv1.BotSpec{
+			Roles: []string{"foo"},
+			Traits: []*machineidv1.Trait{
+				{
+					Name:   "logins",
+					Values: []string{"root", "ubuntu"},
+				},
+			},
+			MaxSessionTtl: durationpb.New(1 * time.Hour),
+		},
+	}
+
+	expected := &internal.Message{
+		Attributes: []internal.Attribute{
+			attribute("kind", stringVal("bot")),
+			attribute("sub_kind", stringVal("")),
+			attribute("version", stringVal(types.V1)),
+			attribute("metadata",
+				messageVal(
+					attribute("name", stringVal("my-bot")),
+					attribute("namespace", stringVal("")),
+					attribute("description", stringVal("hello")),
+					attribute("labels",
+						mapVal(
+							map[any]*internal.Value{
+								"foo": stringVal("bar"),
+							},
+						),
+					),
+					attribute("expires", timestampVal(now)),
+					attribute("revision", stringVal("")),
+				),
+			),
+			attribute("spec",
+				messageVal(
+					attribute("roles", listVal(stringVal("foo"))),
+					attribute("traits",
+						listVal(
+							messageVal(
+								attribute("name", stringVal("logins")),
+								attribute("values",
+									listVal(
+										stringVal("root"),
+										stringVal("ubuntu"),
+									),
+								),
+							),
+						),
+					),
+					attribute("max_session_ttl", durationVal(1*time.Hour)),
+				),
+			),
+			attribute("status",
+				messageVal(
+					attribute("user_name", stringVal("")),
+					attribute("role_name", stringVal("")),
+				),
+			),
+		},
+	}
+
+	output, err := internal.ReflectModern(input)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, output))
+}

--- a/lib/tfgen/internal/types.go
+++ b/lib/tfgen/internal/types.go
@@ -1,0 +1,209 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal
+
+import "time"
+
+// Type is our internal representation of a field value data type.
+type Type uint16
+
+const (
+	TypeUnknown Type = iota
+	TypeMessage
+	TypeList
+	TypeMap
+	TypeBool
+	TypeString
+	TypeInt
+	TypeFloat
+	TypeBytes
+	TypeTimestamp
+	TypeDuration
+)
+
+// String implements fmt.Stringer.
+func (t Type) String() string {
+	switch t {
+	case TypeMessage:
+		return "message"
+	case TypeList:
+		return "list"
+	case TypeMap:
+		return "map"
+	case TypeBool:
+		return "bool"
+	case TypeString:
+		return "string"
+	case TypeInt:
+		return "int"
+	case TypeFloat:
+		return "float"
+	case TypeBytes:
+		return "bytes"
+	case TypeTimestamp:
+		return "timestamp"
+	case TypeDuration:
+		return "duration"
+	default:
+		return "<unknown>"
+	}
+}
+
+// Message represents a protobuf message/struct.
+type Message struct {
+	// Attributes of the message.
+	Attributes []Attribute
+}
+
+// Attribute of a message.
+type Attribute struct {
+	// Name of the attribute.
+	Name string
+
+	// Value of the attribute.
+	Value *Value
+}
+
+// Value is a tuple of data type and value.
+type Value struct {
+	// Type of value.
+	Type Type
+
+	// Value itself (check Type before casting).
+	Value any
+}
+
+// ListValue represents a list/slice.
+type ListValue struct {
+	// Elems contains the list values.
+	Elems []*Value
+}
+
+// MapValue represents a map.
+type MapValue struct {
+	// Elems contains the map values.
+	Elems map[any]*Value
+}
+
+// List returns the value as a ListValue, or an empty ListValue if it isn't one.
+func (v *Value) List() *ListValue {
+	if v.Type != TypeList {
+		return &ListValue{}
+	}
+	if l, ok := v.Value.(*ListValue); ok {
+		return l
+	}
+	return &ListValue{}
+}
+
+// Map returns the value as a MapValue, or an empty MapValue if it isn't one.
+func (v *Value) Map() *MapValue {
+	if v.Type != TypeMap {
+		return &MapValue{}
+	}
+	if m, ok := v.Value.(*MapValue); ok {
+		return m
+	}
+	return &MapValue{}
+}
+
+// Message returns the value as a Message, or an empty Message if it isn't one.
+func (v *Value) Message() *Message {
+	if v.Type != TypeMessage {
+		return &Message{}
+	}
+	if m, ok := v.Value.(*Message); ok {
+		return m
+	}
+	return &Message{}
+}
+
+// Bool returns the value as a boolean, or false if it isn't one.
+func (v *Value) Bool() bool {
+	if v.Type != TypeBool {
+		return false
+	}
+	b, _ := v.Value.(bool)
+	return b
+}
+
+// Int returns the value as a integer, or 0 if it isn't one.
+func (v *Value) Int() int {
+	if v.Type != TypeInt {
+		return 0
+	}
+	i, _ := v.Value.(int)
+	return i
+}
+
+// Float returns the value as a float64, or 0 if it isn't one.
+func (v *Value) Float() float64 {
+	if v.Type != TypeFloat {
+		return 0
+	}
+	f, _ := v.Value.(float64)
+	return f
+}
+
+// String returns the value as a string, or "" if it isn't one.
+func (v *Value) String() string {
+	if v.Type != TypeString {
+		return ""
+	}
+	s, _ := v.Value.(string)
+	return s
+}
+
+// Bytes returns the value as a []byte, or nil if it isn't one.
+func (v *Value) Bytes() []byte {
+	if v.Type != TypeBytes {
+		return nil
+	}
+	b, _ := v.Value.([]byte)
+	return b
+}
+
+// Timestamp returns the value as a time.Time, or the zero value if it isn't one.
+func (v *Value) Timestamp() time.Time {
+	if v.Type != TypeTimestamp {
+		return time.Time{}
+	}
+	t, _ := v.Value.(time.Time)
+	return t
+}
+
+// Duration returns the value as a time.Duration, or the zero value if it isn't one.
+func (v *Value) Duration() time.Duration {
+	if v.Type != TypeDuration {
+		return 0
+	}
+	d, _ := v.Value.(time.Duration)
+	return d
+}
+
+// AttributeNamed returns a message attribute with the given name, or nil if no
+// such attribute exists.
+func (m *Message) AttributeNamed(name string) *Attribute {
+	for _, a := range m.Attributes {
+		if a.Name == name {
+			return &a
+		}
+	}
+	return nil
+}

--- a/lib/tfgen/internal/types_test.go
+++ b/lib/tfgen/internal/types_test.go
@@ -1,0 +1,86 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package internal_test
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/lib/tfgen/internal"
+)
+
+func attribute(name string, value *internal.Value) internal.Attribute {
+	return internal.Attribute{
+		Name:  name,
+		Value: value,
+	}
+}
+
+func messageVal(attributes ...internal.Attribute) *internal.Value {
+	return &internal.Value{
+		Type: internal.TypeMessage,
+		Value: &internal.Message{
+			Attributes: attributes,
+		},
+	}
+}
+
+func stringVal(s string) *internal.Value {
+	return &internal.Value{
+		Type:  internal.TypeString,
+		Value: s,
+	}
+}
+
+func timestampVal(t time.Time) *internal.Value {
+	return &internal.Value{
+		Type:  internal.TypeTimestamp,
+		Value: t,
+	}
+}
+
+func durationVal(t time.Duration) *internal.Value {
+	return &internal.Value{
+		Type:  internal.TypeDuration,
+		Value: t,
+	}
+}
+
+func mapVal(elems map[any]*internal.Value) *internal.Value {
+	if elems == nil {
+		elems = make(map[any]*internal.Value)
+	}
+	return &internal.Value{
+		Type: internal.TypeMap,
+		Value: &internal.MapValue{
+			Elems: elems,
+		},
+	}
+}
+
+func listVal(elems ...*internal.Value) *internal.Value {
+	if elems == nil {
+		elems = []*internal.Value{}
+	}
+	return &internal.Value{
+		Type: internal.TypeList,
+		Value: &internal.ListValue{
+			Elems: elems,
+		},
+	}
+}

--- a/lib/tfgen/options.go
+++ b/lib/tfgen/options.go
@@ -1,0 +1,79 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tfgen
+
+import "github.com/gravitational/teleport/lib/tfgen/internal"
+
+// GenerateOpt is an optional argument that can be passed to customize the
+// behavior of Generate.
+type GenerateOpt func(*generateOpts)
+
+// WithFieldTransform applies a transformation to the given field. It is used
+// when our Terraform representation of the field diverges from the protobuf
+// structure (see: transform.BotTraits for an example).
+//
+// name is the dot-syntax path to the field (e.g. `spec.traits`).
+func WithFieldTransform(name string, transform Transform) GenerateOpt {
+	return func(o *generateOpts) { o.fieldTransforms[name] = transform }
+}
+
+// Transform that can be used to change the Terraform representation of a field.
+type Transform func(*internal.Value) (*internal.Value, error)
+
+// WithFieldComment adds a comment above the given field.
+//
+// If the field is unpopulated, its zero value will be emitted so that the
+// comment is preserved.
+//
+// name is the dot-syntax path to the field (e.g. `spec.traits`).
+//
+// Note: currently only single-line comments on fields within the spec and
+// metadata objects are supported. You cannot add comments to top-level fields
+// such as version, sub_kind, or the metadata and spec fields themselves. You
+// also cannot add comments to objects within a list or map.
+func WithFieldComment(name, comment string) GenerateOpt {
+	return func(o *generateOpts) { o.fieldComments[name] = comment }
+}
+
+// WithResourceType overrides the Terraform resource type. By default, the type
+// will be "teleport_<kind>".
+func WithResourceType(typeName string) GenerateOpt {
+	return func(o *generateOpts) { o.resourceType = typeName }
+}
+
+// WithResourceName overrides the Terraform resource name. By default, the name
+// will be taken from the resource's metadata.
+func WithResourceName(name string) GenerateOpt {
+	return func(o *generateOpts) { o.resourceName = name }
+}
+
+type generateOpts struct {
+	resourceType string
+	resourceName string
+
+	fieldTransforms map[string]Transform
+	fieldComments   map[string]string
+}
+
+func newGenerateOpts() *generateOpts {
+	return &generateOpts{
+		fieldTransforms: make(map[string]Transform),
+		fieldComments:   make(map[string]string),
+	}
+}

--- a/lib/tfgen/testdata/TestGenerate_AccessMonitoringRule.golden
+++ b/lib/tfgen/testdata/TestGenerate_AccessMonitoringRule.golden
@@ -1,0 +1,37 @@
+resource "teleport_access_monitoring_rule" "monitoring-rule" {
+  version = "v1"
+
+  metadata = {
+    name = "monitoring-rule"
+  }
+
+  spec = {
+    subjects  = ["access_request"]
+    condition = "access_request.spec.roles.contains(\"your_role_name\")"
+    notification = {
+      name       = "slack"
+      recipients = ["#your-slack-channel"]
+    }
+    automatic_review = {
+      integration = "builtin"
+      decision    = "APPROVED"
+    }
+    desired_state = "reviewed"
+    schedules = {
+      default = {
+        time = {
+          shifts = [{
+            end     = "23:59"
+            start   = "00:00"
+            weekday = "Monday"
+            }, {
+            end     = "23:59"
+            start   = "00:00"
+            weekday = "Tuesday"
+          }]
+          timezone = "America/Los_Angeles"
+        }
+      }
+    }
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_Bot.golden
+++ b/lib/tfgen/testdata/TestGenerate_Bot.golden
@@ -1,0 +1,14 @@
+resource "teleport_bot" "gha-gravitational-teleport" {
+  version = "v1"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    roles = ["gravitational-teleport-kube-access"]
+    traits = {
+      kubernetes_groups = ["system:masters", "viewers"]
+    }
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_OIDCConnector.golden
+++ b/lib/tfgen/testdata/TestGenerate_OIDCConnector.golden
@@ -1,0 +1,19 @@
+resource "teleport_oidc" "connector" {
+  version = "v3"
+
+  metadata = {
+    name = "connector"
+  }
+
+  spec = {
+    client_id     = "some-client"
+    client_secret = "some-secret"
+    claims_to_roles = [{
+      claim = "foo"
+      roles = ["baz"]
+      value = "bar"
+    }]
+    redirect_url = ["https://some-url"]
+    max_age      = "1s"
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_Role.golden
+++ b/lib/tfgen/testdata/TestGenerate_Role.golden
@@ -1,0 +1,20 @@
+resource "teleport_role" "gravitational-teleport-kube-access" {
+  version = "v8"
+
+  metadata = {
+    name = "gravitational-teleport-kube-access"
+    # Remember to add some labels!
+    labels = {}
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
+      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      kubernetes_labels = {
+        env    = ["staging", "dev"]
+        region = ["eu-west-1"]
+      }
+    }
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_Role.golden
+++ b/lib/tfgen/testdata/TestGenerate_Role.golden
@@ -9,6 +9,10 @@ resource "teleport_role" "gravitational-teleport-kube-access" {
 
   spec = {
     allow = {
+      node_labels = {
+        bar  = ["baz"]
+        team = ["a", "b", "c"]
+      }
       kubernetes_groups = ["{{internal.kubernetes_groups}}"]
       kubernetes_users  = ["{{internal.kubernetes_users}}"]
       kubernetes_labels = {

--- a/lib/tfgen/testdata/TestGenerate_Token.golden
+++ b/lib/tfgen/testdata/TestGenerate_Token.golden
@@ -1,0 +1,19 @@
+resource "teleport_provision_token" "github-gravitational-teleport" {
+  version = "v2"
+
+  metadata = {
+    name = "github-gravitational-teleport"
+  }
+
+  spec = {
+    roles       = ["Bot"]
+    join_method = "github"
+    bot_name    = "gha-gravitational-teleport"
+    github = {
+      allow = [{
+        repository       = "graviational/teleport"
+        repository_owner = "gravitational"
+      }]
+    }
+  }
+}

--- a/lib/tfgen/testdata/TestGenerate_User.golden
+++ b/lib/tfgen/testdata/TestGenerate_User.golden
@@ -1,0 +1,13 @@
+resource "teleport_user" "bob" {
+  version = "v2"
+
+  metadata = {
+    name = "bob"
+  }
+
+  spec = {
+    traits = {
+      kubernetes_groups = ["viewers"]
+    }
+  }
+}

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -317,18 +317,22 @@ func valueToCty(
 		listVal := val.List()
 		if len(listVal.Elems) == 0 {
 			if emitZeroVal {
-				return cty.MapValEmpty(cty.NilType)
+				return cty.ListValEmpty(cty.NilType)
 			}
 			return cty.NilVal
 		}
-		elems := make([]cty.Value, len(listVal.Elems))
+		elems := make([]cty.Value, 0, len(listVal.Elems))
 		for idx, elem := range listVal.Elems {
-			elems[idx] = valueToCty(
+			value := valueToCty(
 				append(path, fmt.Sprintf("[%d]", idx)),
 				elem,
 				opts,
 				false, /* emitZeroVal */
 			)
+			if value == cty.NilVal {
+				continue
+			}
+			elems = append(elems, value)
 		}
 		return cty.ListVal(elems)
 
@@ -343,12 +347,16 @@ func valueToCty(
 		elems := make(map[string]cty.Value, len(mapVal.Elems))
 		for k, v := range mapVal.Elems {
 			key := fmt.Sprintf("%v", k)
-			elems[fmt.Sprintf("%v", k)] = valueToCty(
+			value := valueToCty(
 				append(path, fmt.Sprintf("[%q]", key)),
 				v,
 				opts,
-				false,
+				false, /* emitZeroVal */
 			)
+			if value == cty.NilVal {
+				continue
+			}
+			elems[key] = value
 		}
 		return cty.MapVal(elems)
 

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -1,0 +1,388 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tfgen
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tfgen/internal"
+)
+
+// Resource for which Terraform configuration can be generated. It's a subset of
+// the common methods between types.Resource and types.Resource153.
+type Resource interface {
+	GetKind() string
+	GetSubKind() string
+	GetVersion() string
+}
+
+// Generate Terraform configuration for the given resource protobuf message, so
+// that it can be used in IaC-first wizards. You can pass opts to customize the
+// output (e.g to add field comments, or change the Terraform resource type).
+//
+// This method broadly tries to match the behavior of our protoc-gen-terraform
+// plugin.
+//
+// If the resource uses the modern protobuf package (google.golang.org/protobuf)
+// we will use the protoreflect method to discover its fields. Field names will
+// be taken from the field's TextName.
+//
+// If the resource uses the legacy protobuf package and github.com/gogo/protobuf
+// extensions, we will use Go's reflect package to discover its fields. Field
+// names will be taken from the struct member's JSON tag.
+//
+// Note: This method may be incomplete! Especially for legacy structs that use
+// custom field types. If you find a resource for which the generated Terraform
+// isn't valid, please reach out to @boxofrad.
+func Generate(resource Resource, opts ...GenerateOpt) ([]byte, error) {
+	o := newGenerateOpts()
+	for _, fn := range opts {
+		fn(o)
+	}
+	file := hclwrite.NewEmptyFile()
+	if err := generateResource(resource, file, o); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return hclwrite.Format(file.Bytes()), nil
+}
+
+func generateResource(
+	resource Resource,
+	file *hclwrite.File,
+	opts *generateOpts,
+) error {
+	resourceType := opts.resourceType
+	if resourceType == "" {
+		resourceType = fmt.Sprintf("teleport_%s", resource.GetKind())
+	}
+
+	resourceName := opts.resourceName
+	if resourceName == "" {
+		if v, ok := resource.(interface {
+			GetMetadata() *headerv1.Metadata
+		}); ok {
+			resourceName = v.GetMetadata().GetName()
+		}
+		if v, ok := resource.(interface {
+			GetMetadata() types.Metadata
+		}); ok {
+			resourceName = v.GetMetadata().Name
+		}
+	}
+
+	resourceBlock := file.Body().AppendNewBlock(
+		"resource",
+		[]string{resourceType, resourceName},
+	)
+
+	// Top level fields: version and sub_kind.
+	if v := resource.GetVersion(); v != "" {
+		resourceBlock.Body().SetAttributeValue("version", cty.StringVal(v))
+	}
+	if v := resource.GetSubKind(); v != "" {
+		resourceBlock.Body().SetAttributeValue("sub_kind", cty.StringVal(v))
+	}
+	resourceBlock.Body().AppendNewline()
+
+	msg, err := reflectMessage(resource)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Metadata object.
+	if v := msg.AttributeNamed("metadata"); v != nil {
+		tokens := messageToTokens(fieldPath{"metadata"}, v.Value, opts)
+		if tokens != nil {
+			resourceBlock.Body().SetAttributeRaw("metadata", tokens)
+		}
+	}
+	resourceBlock.Body().AppendNewline()
+
+	// Spec object.
+	if v := msg.AttributeNamed("spec"); v != nil {
+		tokens := messageToTokens(fieldPath{"spec"}, v.Value, opts)
+		if tokens != nil {
+			resourceBlock.Body().SetAttributeRaw("spec", tokens)
+		}
+	}
+	return nil
+}
+
+func reflectMessage(msg any) (*internal.Message, error) {
+	if pm, ok := msg.(proto.Message); ok {
+		return internal.ReflectModern(pm)
+	}
+	return internal.ReflectLegacy(msg)
+}
+
+// messageToTokens converts a message/struct to a collection of HCL tokens.
+//
+// We operate directly on tokens here, rather than converting the message to a
+// cty object and allowing hclwrite to generate the tokens, because we want to
+// be able to inject comments above fields.
+func messageToTokens(
+	path fieldPath,
+	val *internal.Value,
+	opts *generateOpts,
+) hclwrite.Tokens {
+	var tokens hclwrite.Tokens
+	for _, attr := range val.Message().Attributes {
+		fieldPath := append(path, attr.Name)
+		comment, hasComment := opts.fieldComments[fieldPath.String()]
+
+		valueTokens := valueToTokens(
+			fieldPath,
+			attr.Value,
+			opts,
+			hasComment, /* emitZeroValue - render the zero value if there's comment on the field */
+		)
+
+		if valueTokens == nil {
+			continue
+		}
+
+		if hasComment {
+			tokens = append(tokens, commentToTokens(comment)...)
+		}
+		tokens = append(tokens, assignmentToTokens(attr.Name, valueTokens)...)
+		tokens = append(tokens, newlineToken())
+	}
+
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	return braceTokens(tokens)
+}
+
+// commentToTokens converts a comment string to a set of HCL tokens.
+func commentToTokens(comment string) hclwrite.Tokens {
+	return hclwrite.Tokens{
+		&hclwrite.Token{
+			Type:  hclsyntax.TokenComment,
+			Bytes: append([]byte(`# `), []byte(comment)...),
+		},
+		newlineToken(),
+	}
+}
+
+// newlineToken represent a single newline character.
+func newlineToken() *hclwrite.Token {
+	return &hclwrite.Token{
+		Type:  hclsyntax.TokenNewline,
+		Bytes: []byte("\n"),
+	}
+}
+
+// assignmentToTokens generates tokens for a field assignment statement.
+func assignmentToTokens(name string, valueTokens hclwrite.Tokens) hclwrite.Tokens {
+	var tokens hclwrite.Tokens
+	tokens = append(tokens, hclwrite.TokensForIdentifier(name)...)
+	tokens = append(tokens, &hclwrite.Token{
+		Type:  hclsyntax.TokenEqual,
+		Bytes: []byte(` = `),
+	})
+	return append(tokens, valueTokens...)
+}
+
+// braceTokens wraps the given set of tokens in a set of curly braces (e.g. for
+// an object body).
+func braceTokens(inner hclwrite.Tokens) hclwrite.Tokens {
+	return append(
+		hclwrite.Tokens{
+			&hclwrite.Token{
+				Type:  hclsyntax.TokenOBrace,
+				Bytes: []byte(`{`),
+			},
+			newlineToken(),
+		},
+		append(
+			inner,
+			&hclwrite.Token{
+				Type:  hclsyntax.TokenCBrace,
+				Bytes: []byte("}"),
+			},
+		)...,
+	)
+}
+
+// valueToTokens converts the given value to a set of HCL tokens.
+//
+// If the value is a message, we will call messageToTokens so we can inject
+// comments above the message fields.
+func valueToTokens(
+	path fieldPath,
+	val *internal.Value,
+	opts *generateOpts,
+	emitZeroVal bool,
+) hclwrite.Tokens {
+	if val.Type == internal.TypeMessage {
+		return messageToTokens(path, val, opts)
+	}
+
+	ctyVal := valueToCty(path, val, opts, emitZeroVal)
+	if ctyVal == cty.NilVal {
+		return nil
+	}
+	return hclwrite.TokensForValue(ctyVal)
+}
+
+// valueToCty converts a given value to cty so that we can generate HCL tokens
+// from it.
+func valueToCty(
+	path fieldPath,
+	val *internal.Value,
+	opts *generateOpts,
+	emitZeroVal bool,
+) cty.Value {
+	// If there's a transformation on this field, apply it.
+	if transform, ok := opts.fieldTransforms[path.String()]; ok {
+		var err error
+		if val, err = transform(val); err != nil {
+			return cty.StringVal(fmt.Sprintf("<transformation failed, error: %v>", err))
+		}
+	}
+
+	switch val.Type {
+	case internal.TypeBool:
+		boolVal := val.Bool()
+		if !boolVal && !emitZeroVal {
+			return cty.NilVal
+		}
+		return cty.BoolVal(boolVal)
+
+	case internal.TypeString:
+		stringVal := val.String()
+		if stringVal == "" && !emitZeroVal {
+			return cty.NilVal
+		}
+		return cty.StringVal(stringVal)
+
+	case internal.TypeBytes:
+		bytesVal := val.Bytes()
+		if bytesVal == nil && !emitZeroVal {
+			return cty.NilVal
+		}
+		// protoc-gen-terraform naively converts bytes into strings without
+		// validating the contents is UTF-8, so we'll copy that behavior for
+		// compatibility - but really we should base64 encode it instead.
+		return cty.StringVal(string(bytesVal))
+
+	case internal.TypeInt:
+		intVal := val.Int()
+		if intVal == 0 && !emitZeroVal {
+			return cty.NilVal
+		}
+		// Note: we may truncate large uint64 values, but we don't use them!
+		return cty.NumberIntVal(int64(intVal))
+
+	case internal.TypeFloat:
+		floatVal := val.Float()
+		if floatVal == 0 && !emitZeroVal {
+			return cty.NilVal
+		}
+		return cty.NumberFloatVal(floatVal)
+
+	case internal.TypeList:
+		listVal := val.List()
+		if len(listVal.Elems) == 0 {
+			if emitZeroVal {
+				return cty.MapValEmpty(cty.NilType)
+			}
+			return cty.NilVal
+		}
+		elems := make([]cty.Value, len(listVal.Elems))
+		for idx, elem := range listVal.Elems {
+			elems[idx] = valueToCty(
+				append(path, fmt.Sprintf("[%d]", idx)),
+				elem,
+				opts,
+				false, /* emitZeroVal */
+			)
+		}
+		return cty.ListVal(elems)
+
+	case internal.TypeMap:
+		mapVal := val.Map()
+		if len(mapVal.Elems) == 0 {
+			if emitZeroVal {
+				return cty.MapValEmpty(cty.NilType)
+			}
+			return cty.NilVal
+		}
+		elems := make(map[string]cty.Value, len(mapVal.Elems))
+		for k, v := range mapVal.Elems {
+			key := fmt.Sprintf("%v", k)
+			elems[fmt.Sprintf("%v", k)] = valueToCty(
+				append(path, fmt.Sprintf("[%q]", key)),
+				v,
+				opts,
+				false,
+			)
+		}
+		return cty.MapVal(elems)
+
+	case internal.TypeDuration:
+		durVal := val.Duration()
+		if durVal == 0 && !emitZeroVal {
+			return cty.NilVal
+		}
+		return cty.StringVal(durVal.String())
+
+	case internal.TypeTimestamp:
+		tsVal := val.Timestamp()
+		if tsVal.IsZero() && !emitZeroVal {
+			return cty.NilVal
+		}
+		return cty.StringVal(tsVal.Format(time.RFC3339))
+
+	case internal.TypeMessage:
+		// Note: this branch will only be reached for messages inside a list or
+		// map, other messages will be handled by messageToTokens.
+		messageVal := val.Message()
+		attrs := make(map[string]cty.Value)
+		for _, attr := range messageVal.Attributes {
+			if val := valueToCty(
+				append(path, attr.Name),
+				attr.Value,
+				opts,
+				false, /* emitZeroVal */
+			); val != cty.NilVal {
+				attrs[attr.Name] = val
+			}
+		}
+		return cty.ObjectVal(attrs)
+	default:
+		return cty.StringVal(fmt.Sprintf("<unknown value type: %s>", val.Type))
+	}
+}
+
+type fieldPath []string
+
+func (p fieldPath) String() string { return strings.Join(p, ".") }

--- a/lib/tfgen/tfgen.go
+++ b/lib/tfgen/tfgen.go
@@ -135,10 +135,14 @@ func generateResource(
 }
 
 func reflectMessage(msg any) (*internal.Message, error) {
-	if pm, ok := msg.(proto.Message); ok {
-		return internal.ReflectModern(pm)
+	switch m := msg.(type) {
+	case proto.Message:
+		return internal.ReflectModern(m)
+	case internal.LegacyProtoMessage:
+		return internal.ReflectLegacy(m)
+	default:
+		return nil, trace.BadParameter("resource must be a protobuf message, was a %T", msg)
 	}
-	return internal.ReflectLegacy(msg)
 }
 
 // messageToTokens converts a message/struct to a collection of HCL tokens.

--- a/lib/tfgen/tfgen_test.go
+++ b/lib/tfgen/tfgen_test.go
@@ -1,0 +1,172 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tfgen_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tfgen"
+	"github.com/gravitational/teleport/lib/tfgen/transform"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestGenerate_Role(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t, &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V8,
+		Metadata: types.Metadata{
+			Name: "gravitational-teleport-kube-access",
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubernetesLabels: types.Labels{
+					"env":    []string{"staging", "dev"},
+					"region": []string{"eu-west-1"},
+				},
+				KubeGroups: []string{"{{internal.kubernetes_groups}}"},
+				KubeUsers:  []string{"{{internal.kubernetes_users}}"},
+			},
+		},
+	},
+		tfgen.WithFieldComment("metadata.labels", "Remember to add some labels!"))
+}
+
+func TestGenerate_Bot(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t,
+		&machineidv1.Bot{
+			Kind:    types.KindBot,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "gha-gravitational-teleport",
+			},
+			Spec: &machineidv1.BotSpec{
+				Roles: []string{"gravitational-teleport-kube-access"},
+				Traits: []*machineidv1.Trait{
+					{
+						Name:   "kubernetes_groups",
+						Values: []string{"system:masters", "viewers"},
+					},
+				},
+			},
+		},
+		tfgen.WithFieldTransform("spec.traits", transform.BotTraits),
+	)
+}
+
+func TestGenerate_Token(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t,
+		&types.ProvisionTokenV2{
+			Kind:    types.KindToken,
+			Version: types.V2,
+			Metadata: types.Metadata{
+				Name: "github-gravitational-teleport",
+			},
+			Spec: types.ProvisionTokenSpecV2{
+				BotName:    "gha-gravitational-teleport",
+				Roles:      []types.SystemRole{types.RoleBot},
+				JoinMethod: types.JoinMethodGitHub,
+				GitHub: &types.ProvisionTokenSpecV2GitHub{
+					Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+						{
+							Repository:      "graviational/teleport",
+							RepositoryOwner: "gravitational",
+						},
+					},
+				},
+			},
+		},
+		tfgen.WithResourceType("teleport_provision_token"),
+	)
+}
+
+func TestGenerate_AccessMonitoringRule(t *testing.T) {
+	t.Parallel()
+
+	goldenTest(t,
+		&accessmonitoringrulesv1.AccessMonitoringRule{
+			Kind:    types.KindAccessMonitoringRule,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: "monitoring-rule",
+			},
+			Spec: &accessmonitoringrulesv1.AccessMonitoringRuleSpec{
+				Subjects:     []string{"access_request"},
+				Condition:    `access_request.spec.roles.contains("your_role_name")`,
+				DesiredState: types.AccessMonitoringRuleStateReviewed,
+				Notification: &accessmonitoringrulesv1.Notification{
+					Name:       "slack",
+					Recipients: []string{"#your-slack-channel"},
+				},
+				AutomaticReview: &accessmonitoringrulesv1.AutomaticReview{
+					Integration: "builtin",
+					Decision:    "APPROVED",
+				},
+				Schedules: map[string]*accessmonitoringrulesv1.Schedule{
+					"default": {
+						Time: &accessmonitoringrulesv1.TimeSchedule{
+							Timezone: "America/Los_Angeles",
+							Shifts: []*accessmonitoringrulesv1.TimeSchedule_Shift{
+								{
+									Weekday: "Monday",
+									Start:   "00:00",
+									End:     "23:59",
+								},
+								{
+									Weekday: "Tuesday",
+									Start:   "00:00",
+									End:     "23:59",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func goldenTest(t *testing.T, resource tfgen.Resource, opts ...tfgen.GenerateOpt) {
+	t.Helper()
+
+	tf, err := tfgen.Generate(resource, opts...)
+	require.NoError(t, err)
+
+	if golden.ShouldSet() {
+		golden.Set(t, tf)
+	}
+	require.Empty(t,
+		cmp.Diff(
+			string(golden.Get(t)),
+			string(tf),
+		),
+	)
+}

--- a/lib/tfgen/transform/machineid.go
+++ b/lib/tfgen/transform/machineid.go
@@ -1,0 +1,59 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package transform
+
+import "github.com/gravitational/teleport/lib/tfgen/internal"
+
+// BotTraits transforms the standard representation of a slice of
+// machineidv1.Trait values into the map[string][]string form we
+// expect in the Terraform provider.
+//
+// Before:
+//
+//	[{name = "logins", values = ["root", "ubuntu"]}]
+//
+// After:
+//
+//	{logins = ["root", "ubuntu"]}
+//
+// Example usage:
+//
+//	tfgen.Generate(bot, tfgen.WithFieldTransform("spec.traits", transform.BotTraits))
+func BotTraits(value *internal.Value) (*internal.Value, error) {
+	traitsMap := make(map[any]*internal.Value)
+
+	for _, elem := range value.List().Elems {
+		message := elem.Message()
+
+		name := message.AttributeNamed("name").Value.String()
+		values := message.AttributeNamed("values").Value.List()
+
+		traitsMap[name] = &internal.Value{
+			Type:  internal.TypeList,
+			Value: values,
+		}
+	}
+
+	return &internal.Value{
+		Type: internal.TypeMap,
+		Value: &internal.MapValue{
+			Elems: traitsMap,
+		},
+	}, nil
+}


### PR DESCRIPTION
### Background

There are a number of folks working on features that will improve our IaC (Infrastructure-as-Code) story. For example, the Machine & Workload Identity team plan to build a set of wizards to enable the user to deploy `tbot` for various CI/CD use-cases, the output of which will be a set of Terraform resources.

Our Terraform resource schemas are generated from protobuf definitions using the [`protoc-gen-terraform`](https://github.com/gravitational/protoc-gen-terraform) plugin. As they can be arbitrarily complex (e.g. messages inside lists inside messages inside maps), using simple text templating can be cumbersome and error-prone, and you need to carefully escape strings, etc.

### Overview

This PR introduces a new package `lib/tfgen` which can generate Terraform code programatically from resource structs (think `json.Marshal` but for Terraform code).

**Example usage:**

```go
tfgen.Generate(
	&machineidv1.Bot{
		Kind:    types.KindBot,
		Version: types.V1,
		Metadata: &headerv1.Metadata{
			Name: "gha-gravitational-teleport",
		},
		Spec: &machineidv1.BotSpec{
			Roles: []string{"gravitational-teleport-kube-access"},
			Traits: []*machineidv1.Trait{
				{
					Name:   "kubernetes_groups",
					Values: []string{"system:masters", "viewers"},
				},
			},
		},
	},
	tfgen.WithFieldTransform("spec.traits", transform.BotTraits),
)
```

**Output:**

```terraform
resource "teleport_bot" "gha-gravitational-teleport" {
  version = "v1"

  metadata = {
    name = "gha-gravitational-teleport"
  }

  spec = {
    roles = ["gravitational-teleport-kube-access"]
    traits = {
      kubernetes_groups = ["system:masters", "viewers"]
    }
  }
}
```

You can even inject comments on specific fields:

```go
terraformCode, err := tfgen.Generate(
    bot,
    tfgen.WithFieldComment("spec.allow", "Add your rules here..."),
)
```

For full examples of the output, see the golden files in `lib/tfgen/testdata`.

### How it works

It uses reflection - `protoreflect` for "modern" resources and Go's `reflect` package for legacy/gogo-proto resources - to walk the message structure and extract the fields into an intermediate representation. Then it walks this intermediate representation and uses the Go HCL library to emit Terraform code (ensuring proper escaping and formatting).