### PR TITLE
[v18] Fix EC2 SSM set up script used in Discover

### DIFF
--- a/lib/integrations/awsoidc/ec2_ssm_iam_config.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config.go
@@ -182,9 +182,10 @@ func ConfigureEC2SSM(ctx context.Context, clt EC2SSMConfigureClient, req EC2SSMI
 
 	actions := []provisioning.Action{*putRolePolicy}
 
-	// If using an existing document, the SSMDocumentName is empty.
-	// If using the pre-existing Document AWS-RunShellScript, the SSM Document already exists, so no need to create it.
-	if req.SSMDocumentName != "" || req.SSMDocumentName == types.AWSSSMDocumentRunShellScript {
+	// SSM Document creation only happens when the user specifies a custom name.
+	// The AWSSSMDocumentRunShellScript SSM Document (AWS-RunShellScript) already exists in all accounts.
+	mustCreateDoc := req.SSMDocumentName != "" && req.SSMDocumentName != types.AWSSSMDocumentRunShellScript
+	if mustCreateDoc {
 		content := awslib.EC2DiscoverySSMDocument(req.ProxyPublicURL,
 			awslib.WithInsecureSkipInstallPathRandomization(req.insecureSkipInstallPathRandomization),
 		)

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config_test.go
@@ -191,6 +191,7 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 		mockExistingSSMDocs []string
 		req                 func() EC2SSMIAMConfigureRequest
 		errCheck            require.ErrorAssertionFunc
+		validateDocs        func(t *testing.T, docs map[string][]ssmtypes.Tag)
 	}{
 		{
 			name:                "valid",
@@ -199,6 +200,14 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 			mockExistingRoles:   []string{"integrationrole"},
 			mockExistingSSMDocs: []string{},
 			errCheck:            require.NoError,
+			validateDocs: func(t *testing.T, docs map[string][]ssmtypes.Tag) {
+				require.Contains(t, docs, "MyDoc")
+				require.ElementsMatch(t, []ssmtypes.Tag{
+					{Key: aws.String("teleport.dev/cluster"), Value: aws.String("my-cluster")},
+					{Key: aws.String("teleport.dev/integration"), Value: aws.String("my-integration")},
+					{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+				}, docs["MyDoc"])
+			},
 		},
 		{
 			name:                "integration role does not exist",
@@ -224,6 +233,36 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 			mockExistingSSMDocs: []string{},
 			errCheck:            badParameterCheck,
 		},
+		{
+			name: "skips doc creation when document is not set",
+			req: func() EC2SSMIAMConfigureRequest {
+				baseReq := baseReq()
+				baseReq.SSMDocumentName = ""
+				return baseReq
+			},
+			mockAccountID:       "123456789012",
+			mockExistingRoles:   []string{"integrationrole"},
+			mockExistingSSMDocs: []string{},
+			errCheck:            require.NoError,
+			validateDocs: func(t *testing.T, docs map[string][]ssmtypes.Tag) {
+				require.Empty(t, docs)
+			},
+		},
+		{
+			name: "skips doc creation when document is well known pre-defined document (it exists already in the account)",
+			req: func() EC2SSMIAMConfigureRequest {
+				baseReq := baseReq()
+				baseReq.SSMDocumentName = "AWS-RunShellScript"
+				return baseReq
+			},
+			mockAccountID:       "123456789012",
+			mockExistingRoles:   []string{"integrationrole"},
+			mockExistingSSMDocs: []string{},
+			errCheck:            require.NoError,
+			validateDocs: func(t *testing.T, docs map[string][]ssmtypes.Tag) {
+				require.Empty(t, docs)
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			clt := mockEC2SSMIAMConfigClient{
@@ -233,13 +272,8 @@ func TestEC2SSMIAMConfig(t *testing.T) {
 
 			err := ConfigureEC2SSM(ctx, &clt, tt.req())
 			tt.errCheck(t, err)
-			if err == nil {
-				require.Contains(t, clt.existingDocs, tt.req().SSMDocumentName)
-				require.ElementsMatch(t, []ssmtypes.Tag{
-					{Key: aws.String("teleport.dev/cluster"), Value: aws.String("my-cluster")},
-					{Key: aws.String("teleport.dev/integration"), Value: aws.String("my-integration")},
-					{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
-				}, clt.existingDocs[tt.req().SSMDocumentName])
+			if tt.validateDocs != nil {
+				tt.validateDocs(t, clt.existingDocs)
 			}
 		})
 	}
@@ -294,6 +328,9 @@ func (m *mockEC2SSMIAMConfigClient) PutRolePolicy(ctx context.Context, params *i
 func (m *mockEC2SSMIAMConfigClient) CreateDocument(ctx context.Context, params *ssm.CreateDocumentInput, optFns ...func(*ssm.Options)) (*ssm.CreateDocumentOutput, error) {
 	if m.existingDocs == nil {
 		m.existingDocs = make(map[string][]ssmtypes.Tag)
+	}
+	if aws.ToString(params.Name) == "AWS-RunShellScript" {
+		return nil, &ssmtypes.ValidationException{}
 	}
 	if _, ok := m.existingDocs[aws.ToString(params.Name)]; ok {
 		return nil, &ssmtypes.DocumentAlreadyExists{}


### PR DESCRIPTION
Backport #61663 to branch/v18

changelog: Fixed EC2 SSM Document set up script used in Enroll New Resource.
