### PR TITLE
Add username_claim instructions to OIDC guides

### DIFF
--- a/docs/pages/includes/sso/username-claim.mdx
+++ b/docs/pages/includes/sso/username-claim.mdx
@@ -1,0 +1,24 @@
+By default, Teleport expects an `email` claim to be present in the OIDC claim. 
+The value from the `email` claim is used as a username in Teleport. If you wish 
+to use another claim to configure username, you can override the 
+default expected `email` claim with the `username_claim` field in the auth 
+connector spec. 
+
+The example below shows configuring the `username_claim` field with `preferred_username`
+value. This will configure Teleport to query `preferred_username` claim instead 
+of the `email` claim.:
+
+```yaml
+kind: oidc
+metadata:
+  # ...
+spec:
+  # ...
+  username_claim: preferred_username
+```
+
+<Admonition type="warning" title="Username claim">
+  Ensure that the claim value you use to configure `username_claim` is a uniquely
+  identifiable value for the user. 
+</Admonition>
+

--- a/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/entra-id-oidc.mdx
@@ -277,6 +277,8 @@ version: v3
 
 </details>
 
+(!docs/pages/includes/sso/username-claim.mdx!)
+
 ### Test the connector
 
 Now test the connector resource by piping the file to `tctl sso test` command:
@@ -286,29 +288,6 @@ $ cat entraid-oidc-connector.yaml | tctl sso test
 ```
 If the configuration test fails, the `tctl sso test` command will print helpful 
 information to debug the issue.
-
-By default, Teleport expects an `email` claim to be present in the OIDC claim. 
-The value from the `email` claim is used as a username in Teleport. If you wish 
-to use another claim to configure username, you can override the 
-default expected `email` claim with the `username_claim` field in the Auth 
-Connector spec. 
-
-The example below shows configuring the `username_claim` field with `preferred_username`
-value. This will configure Teleport to query `preferred_username` claim instead 
-of the `email` claim. 
-```yaml
-kind: oidc
-metadata:
-  name: entra-id
-spec:
-  ... # other fields not displayed for brevity
-  username_claim: preferred_username
-```
-
-<Admonition type="warning" title="Username claim">
-  Ensure that the claim value you use to configure `username_claim` is a uniquely
-  identifiable value for the user. 
-</Admonition>
 
 ### Create the connector
 

--- a/docs/pages/zero-trust-access/sso/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/gitlab.mdx
@@ -141,6 +141,8 @@ version: v3
 
 ```
 
+(!docs/pages/includes/sso/username-claim.mdx!)
+
 ### Test the connector
 
 Test the connector resource by piping the file to `tctl sso test`:

--- a/docs/pages/zero-trust-access/sso/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/google-workspace.mdx
@@ -463,6 +463,8 @@ credentials for scopes [...]" in audit log messages, change the `client_id` sett
 resource configuration file. For more information about viewing audit logs, see 
 [Troubleshooting](#troubleshooting).
 
+(!docs/pages/includes/sso/username-claim.mdx!)
+
 ### Test the connector
 
 To test the connector, run the following command:
@@ -474,6 +476,8 @@ $ cat gworkspace-connector.yaml | tctl sso test
 This command opens the browser and attempts to sign you in to your Teleport cluster
 using Google. If it fails, review the command output for troubleshooting
 information.
+
+### Create the connector 
 
 To create the connector using the `tctl` tool, run the following command:
 

--- a/docs/pages/zero-trust-access/sso/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/oidc.mdx
@@ -268,20 +268,7 @@ spec:
 
 ### Optional: Specify a claim to use as the username
 
-By default, Teleport will use the user's email as their Teleport username.
-
-You can define a `username_claim` to specify the claim that should be used as
-the username instead:
-
-```yaml
-kind: oidc
-version: v2
-metadata:
-  name: connector
-spec:
-  # Use the `preferred_username` claim as the user's Teleport username.
-  username_claim: preferred_username
-```
+(!docs/pages/includes/sso/username-claim.mdx!)
 
 ### Optional: Request object mode
 


### PR DESCRIPTION
OIDC how-to guides are inconsistent in how much detail they include about the `username_claim` field. Extract the most complete instructions in the SSO section - from the Entra ID guide - into a partial and include the partial in all how-to guides for creating an OIDC authentication connector.