### PR TITLE
Bump macOS runner version in GitHub workflows

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -4,22 +4,22 @@ run-name: Build on Mac OS
 on:
   merge_group:
     paths:
-      - '.github/workflows/build-macos.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '**.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
+      - ".github/workflows/build-macos.yaml"
+      - "**.go"
+      - "go.mod"
+      - "go.sum"
+      - "**.rs"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "build.assets/Makefile"
+      - "build.assets/Dockerfile*"
+      - "Makefile"
 
 jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-13-xlarge
+    runs-on: macos-15-xlarge
 
     permissions:
       contents: read


### PR DESCRIPTION
This bumps the macOS runner version from 13 to 15, ahead of the macOS 13 runner removal scheduled for December 4th.

This has been tested via dev build `v19.0.0-dev.fred-macos15-1`.

This will include an e ref bump once https://github.com/gravitational/teleport.e/pull/7629 has merged.

---

Goal issue: https://github.com/gravitational/cloud/issues/15376