### PR TITLE
Fix minor SEO issues in the docs

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/encrypted-session-recordings/rotating-manual-keys.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rotating Manual Session Recording Encryption Keys
-description: How to rotate automatically provisioned session recording encryption keys.
+description: How to rotate private keys for encrypted session recordings while designating certain keys only for decryption.
 tags:
   - session-recording
   - how-to

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the AWS CLI tools with Teleport and AWS IAM Identity Center
-description: Provides an overview of the Teleport AWS IAM Identity Center integration.
+description: Explains how to use the AWS IAM Identity Center integration to protect AWS CLI tools with Teleport.
 tags:
  - how-to
  - identity-governance

--- a/docs/pages/machine-workload-identity/introduction.mdx
+++ b/docs/pages/machine-workload-identity/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Introduction to Machine & Workload Identity"
-description: "Replace static secrets with secure, short-lived identities for machines and workloads."
+description: "Explains concepts and use cases for Machine & Workload Identity, which replaces static secrets with secure, short-lived identities for machines and workloads."
 sidebar_label: "Introduction"
 sidebar_position: 1
 videoBanner: "ZDWRt105tBg"

--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Teleport Machine & Workload Identity"
-description: "Replace static secrets with secure, short-lived identities for machines and workloads."
+description: "Includes guides for for Machine & Workload Identity, which replaces static secrets with secure, short-lived identities for machines and workloads."
 template: "landing-page"
 tags:
  - mwi

--- a/docs/pages/reference/architecture/device-trust.mdx
+++ b/docs/pages/reference/architecture/device-trust.mdx
@@ -1,5 +1,6 @@
 ---
-title: Device Trust
+title: Device Trust Architecture
+sidebar_label: Device Trust
 description: How Teleport Device Trust works.
 tags:
  - conceptual

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Teleport Terraform Provider"
+title: "Teleport Terraform Provider Reference"
+sidebar_label: Terraform Provider
 description: Reference documentation of the Teleport Terraform provider.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -1,5 +1,5 @@
 ---
-title: Teleport Terraform Provider
+title: Using the Teleport Terraform Provider
 sidebar_label: Terraform Provider
 description: How to manage dynamic resources using the Teleport Terraform provider.
 videoBanner: YgNHD4SS8dg

--- a/integrations/terraform/templates/index.md.tmpl
+++ b/integrations/terraform/templates/index.md.tmpl
@@ -1,5 +1,6 @@
 ---
-title: "Teleport Terraform Provider"
+title: "Teleport Terraform Provider Reference"
+sidebar_label: Terraform Provider
 description: Reference documentation of the Teleport Terraform provider.
 tags:
  - infrastructure-as-code


### PR DESCRIPTION
Fix duplicate meta descriptions and titles in the following guides:
- Encrypted session recording
- AWS IAM Identity Center
- MWI introduction and index page
- Terraform provider reference and how-to guide index pages
- Device Trust guides