### PR TITLE
Fix PAM Auth for exec sessions with allocated TTY

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -299,13 +299,13 @@ func RunCommand() (errw io.Writer, code int, err error) {
 	// launch the shell under.
 	var pamEnvironment []string
 	if c.PAMConfig != nil {
-		// Connect std{in,out,err} to the TTY if it's a shell request, otherwise
-		// discard std{out,err}. If this was not done, things like MOTD would be
-		// printed for "exec" requests.
+		// Connect std{in,out,err} to the TTY if a terminal has been allocated,
+		// otherwise discard std{out,err}. If this was not done, things like MOTD
+		// would be printed for non-interactive "exec" requests.
 		var stdin io.Reader
 		var stdout io.Writer
 		var stderr io.Writer
-		if c.RequestType == sshutils.ShellRequest {
+		if tty != nil {
 			stdin = tty
 			stdout = tty
 			stderr = tty


### PR DESCRIPTION
Changelog: Fix an issue in the Teleport SSH Service where interactive PAM Auth modules always fail when trying to run exec sessions with tty allocated. e.g. `tsh ssh --tty <node> ls`.

Fixes https://github.com/gravitational/teleport/issues/61689

Manual Testing (8cd5232ad5b969b99098b8a4d0ba77f6fa20c91b):
- Set up a custom interactive PAM auth module as described in https://github.com/gravitational/teleport/issues/49028.
- [x] `tsh ssh --tty <node> ls` prompts for authentication and succeeds.
- [x] `tsh ssh <node>` prompts for authentication and succeeds.
- [x] Starting an interactive session in the WebUI prompts for authentication and succeeds.

Note: `tsh ssh <node> ls` without `-tty` and with interactive PAM auth fails both before and after this PR, as expected. Unfortunately, this failure manifests as a stalled connection which eventually times out or is canceled by the user, and it's unclear whether this is improvable within this boundaries of PAM. Either way, that issue is out of scope of this PR.