### PR TITLE
Fix sftp server not evaluating '.' correctly

### DIFF
--- a/lib/sshutils/sftp/local.go
+++ b/lib/sshutils/sftp/local.go
@@ -144,13 +144,19 @@ func (l localFS) Getwd() (string, error) {
 }
 
 func (l localFS) RealPath(path string) (string, error) {
+	return Realpath(path)
+}
+
+func (l localFS) Close() error {
+	return nil
+}
+
+// RealPath canonicalizes a path name, including resolving ".." and
+// following symlinks.
+func Realpath(path string) (string, error) {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return "", err
 	}
 	return filepath.EvalSymlinks(path)
-}
-
-func (l localFS) Close() error {
-	return nil
 }

--- a/lib/sshutils/sftp/local_test.go
+++ b/lib/sshutils/sftp/local_test.go
@@ -1,0 +1,84 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package sftp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRealpath(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	dir := filepath.Join(root, "a")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	file := filepath.Join(dir, "foo.txt")
+	require.NoError(t, os.WriteFile(file, []byte("foo"), 0o644))
+	symlink := filepath.Join(dir, "sym")
+	require.NoError(t, os.Symlink(root, symlink))
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	fileRelativeToHere, err := filepath.Rel(wd, file)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "absolute path",
+			path:     file,
+			expected: file,
+		},
+		{
+			name:     "relative path",
+			path:     fileRelativeToHere,
+			expected: file,
+		},
+		{
+			name:     "follow symlink",
+			path:     filepath.Join(symlink, "a", "foo.txt"),
+			expected: file,
+		},
+		{
+			name:     "current dir",
+			path:     ".",
+			expected: wd,
+		},
+		{
+			name:     "empty",
+			path:     "",
+			expected: wd,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// On Mac, temp dirs are under an extra hidden /private dir.
+			expected, err := filepath.EvalSymlinks(tc.expected)
+			require.NoError(t, err)
+			out, err := Realpath(tc.path)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, out)
+		})
+	}
+}

--- a/tool/teleport/common/sftp.go
+++ b/tool/teleport/common/sftp.go
@@ -30,7 +30,6 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -235,7 +234,7 @@ func (s *sftpHandler) Filelist(req *sftp.Request) (_ sftp.ListerAt, retErr error
 // RealPath canonicalizes a path name, including resolving ".." and
 // following symlinks. Required to implement [sftp.RealPathFileLister].
 func (s *sftpHandler) RealPath(path string) (string, error) {
-	return filepath.EvalSymlinks(path)
+	return sftputils.Realpath(path)
 }
 
 func (s *sftpHandler) sendSFTPEvent(req *sftp.Request, reqErr error) {


### PR DESCRIPTION
This change fixes a bug where the local Teleport sftp server (from `teleport sftp`) would not correctly evaluate the realpath for `"."` to the current directory. This caused the forwarding server to report the wrong working directory (which it determines by calling `Realpath(".")` and appending to `"/"`).

Fixes #61265.

Changelog: Fixed relative path evaluation for SFTP in proxy recording mode

# Test Plan
- [x] sftp with a relative path works in proxy recording mode
- [x] The following are unaffected:
  - [x] absolute path in proxy recording mode
  - [x] relative path in node recording mode
  - [x] absolute path in node recording mode