### PR TITLE
Add paginated `ListAuthServers`/`ListProxies`

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3694,6 +3694,38 @@ func (c *Client) DeleteAllApps(ctx context.Context) error {
 	return trace.Wrap(err)
 }
 
+// ListAuthServers returns a paginated list of auth servers registered in the cluster.
+func (c *Client) ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	resp, err := c.PresenceServiceClient().ListAuthServers(ctx, &presencepb.ListAuthServersRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	servers := make([]types.Server, 0, len(resp.Servers))
+	for _, server := range resp.Servers {
+		servers = append(servers, server)
+	}
+	return servers, resp.NextPageToken, nil
+}
+
+// ListProxyServers returns a paginated list of proxy servers registered in the cluster.
+func (c *Client) ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	resp, err := c.PresenceServiceClient().ListProxyServers(ctx, &presencepb.ListProxyServersRequest{
+		PageSize:  int32(pageSize),
+		PageToken: pageToken,
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	servers := make([]types.Server, 0, len(resp.Servers))
+	for _, server := range resp.Servers {
+		servers = append(servers, server)
+	}
+	return servers, resp.NextPageToken, nil
+}
+
 // CreateKubernetesCluster creates a new kubernetes cluster resource.
 func (c *Client) CreateKubernetesCluster(ctx context.Context, cluster types.KubeCluster) error {
 	kubeClusterV3, ok := cluster.(*types.KubernetesClusterV3)

--- a/api/gen/proto/go/teleport/presence/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service.pb.go
@@ -788,6 +788,230 @@ func (*DeleteRelayServerResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_presence_v1_service_proto_rawDescGZIP(), []int{14}
 }
 
+// Request message for the PresenceService.ListAuthServers rpc.
+type ListAuthServersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuthServersRequest) Reset() {
+	*x = ListAuthServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuthServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuthServersRequest) ProtoMessage() {}
+
+func (x *ListAuthServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuthServersRequest.ProtoReflect.Descriptor instead.
+func (*ListAuthServersRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_presence_v1_service_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ListAuthServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListAuthServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+// Response message for the PresenceService.ListAuthServers rpc.
+type ListAuthServersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of auth server resources.
+	Servers []*types.ServerV2 `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListAuthServersResponse) Reset() {
+	*x = ListAuthServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListAuthServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListAuthServersResponse) ProtoMessage() {}
+
+func (x *ListAuthServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListAuthServersResponse.ProtoReflect.Descriptor instead.
+func (*ListAuthServersResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_presence_v1_service_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *ListAuthServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		return x.Servers
+	}
+	return nil
+}
+
+func (x *ListAuthServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
+// Request message for the PresenceService.ListProxyServers rpc.
+type ListProxyServersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The maximum number of items to return.
+	// The server may impose a different page size at its discretion.
+	PageSize int32 `protobuf:"varint,1,opt,name=page_size,json=pageSize,proto3" json:"page_size,omitempty"`
+	// The next_page_token value returned from a previous List request, if any.
+	PageToken     string `protobuf:"bytes,2,opt,name=page_token,json=pageToken,proto3" json:"page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProxyServersRequest) Reset() {
+	*x = ListProxyServersRequest{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProxyServersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProxyServersRequest) ProtoMessage() {}
+
+func (x *ListProxyServersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProxyServersRequest.ProtoReflect.Descriptor instead.
+func (*ListProxyServersRequest) Descriptor() ([]byte, []int) {
+	return file_teleport_presence_v1_service_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *ListProxyServersRequest) GetPageSize() int32 {
+	if x != nil {
+		return x.PageSize
+	}
+	return 0
+}
+
+func (x *ListProxyServersRequest) GetPageToken() string {
+	if x != nil {
+		return x.PageToken
+	}
+	return ""
+}
+
+// Response message for the PresenceService.ListProxyServers rpc.
+type ListProxyServersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of proxy server resources.
+	Servers []*types.ServerV2 `protobuf:"bytes,1,rep,name=servers,proto3" json:"servers,omitempty"`
+	// Token to retrieve the next page of results, or empty if there are no
+	// more results in the list.
+	NextPageToken string `protobuf:"bytes,2,opt,name=next_page_token,json=nextPageToken,proto3" json:"next_page_token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListProxyServersResponse) Reset() {
+	*x = ListProxyServersResponse{}
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListProxyServersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListProxyServersResponse) ProtoMessage() {}
+
+func (x *ListProxyServersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_presence_v1_service_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListProxyServersResponse.ProtoReflect.Descriptor instead.
+func (*ListProxyServersResponse) Descriptor() ([]byte, []int) {
+	return file_teleport_presence_v1_service_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *ListProxyServersResponse) GetServers() []*types.ServerV2 {
+	if x != nil {
+		return x.Servers
+	}
+	return nil
+}
+
+func (x *ListProxyServersResponse) GetNextPageToken() string {
+	if x != nil {
+		return x.NextPageToken
+	}
+	return ""
+}
+
 var File_teleport_presence_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_presence_v1_service_proto_rawDesc = "" +
@@ -832,7 +1056,22 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\".\n" +
 	"\x18DeleteRelayServerRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\"\x1b\n" +
-	"\x19DeleteRelayServerResponse2\xb8\b\n" +
+	"\x19DeleteRelayServerResponse\"T\n" +
+	"\x16ListAuthServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"l\n" +
+	"\x17ListAuthServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken\"U\n" +
+	"\x17ListProxyServersRequest\x12\x1b\n" +
+	"\tpage_size\x18\x01 \x01(\x05R\bpageSize\x12\x1d\n" +
+	"\n" +
+	"page_token\x18\x02 \x01(\tR\tpageToken\"m\n" +
+	"\x18ListProxyServersResponse\x12)\n" +
+	"\aservers\x18\x01 \x03(\v2\x0f.types.ServerV2R\aservers\x12&\n" +
+	"\x0fnext_page_token\x18\x02 \x01(\tR\rnextPageToken2\x9b\n" +
+	"\n" +
 	"\x0fPresenceService\x12Y\n" +
 	"\x10GetRemoteCluster\x12-.teleport.presence.v1.GetRemoteClusterRequest\x1a\x16.types.RemoteClusterV3\x12w\n" +
 	"\x12ListRemoteClusters\x12/.teleport.presence.v1.ListRemoteClustersRequest\x1a0.teleport.presence.v1.ListRemoteClustersResponse\x12_\n" +
@@ -843,7 +1082,9 @@ const file_teleport_presence_v1_service_proto_rawDesc = "" +
 	"\x13DeleteReverseTunnel\x120.teleport.presence.v1.DeleteReverseTunnelRequest\x1a\x16.google.protobuf.Empty\x12k\n" +
 	"\x0eGetRelayServer\x12+.teleport.presence.v1.GetRelayServerRequest\x1a,.teleport.presence.v1.GetRelayServerResponse\x12q\n" +
 	"\x10ListRelayServers\x12-.teleport.presence.v1.ListRelayServersRequest\x1a..teleport.presence.v1.ListRelayServersResponse\x12t\n" +
-	"\x11DeleteRelayServer\x12..teleport.presence.v1.DeleteRelayServerRequest\x1a/.teleport.presence.v1.DeleteRelayServerResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
+	"\x11DeleteRelayServer\x12..teleport.presence.v1.DeleteRelayServerRequest\x1a/.teleport.presence.v1.DeleteRelayServerResponse\x12n\n" +
+	"\x0fListAuthServers\x12,.teleport.presence.v1.ListAuthServersRequest\x1a-.teleport.presence.v1.ListAuthServersResponse\x12q\n" +
+	"\x10ListProxyServers\x12-.teleport.presence.v1.ListProxyServersRequest\x1a..teleport.presence.v1.ListProxyServersResponseBTZRgithub.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1;presencev1b\x06proto3"
 
 var (
 	file_teleport_presence_v1_service_proto_rawDescOnce sync.Once
@@ -857,7 +1098,7 @@ func file_teleport_presence_v1_service_proto_rawDescGZIP() []byte {
 	return file_teleport_presence_v1_service_proto_rawDescData
 }
 
-var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_teleport_presence_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*GetRemoteClusterRequest)(nil),    // 0: teleport.presence.v1.GetRemoteClusterRequest
 	(*ListRemoteClustersRequest)(nil),  // 1: teleport.presence.v1.ListRemoteClustersRequest
@@ -874,45 +1115,56 @@ var file_teleport_presence_v1_service_proto_goTypes = []any{
 	(*ListRelayServersResponse)(nil),   // 12: teleport.presence.v1.ListRelayServersResponse
 	(*DeleteRelayServerRequest)(nil),   // 13: teleport.presence.v1.DeleteRelayServerRequest
 	(*DeleteRelayServerResponse)(nil),  // 14: teleport.presence.v1.DeleteRelayServerResponse
-	(*types.RemoteClusterV3)(nil),      // 15: types.RemoteClusterV3
-	(*fieldmaskpb.FieldMask)(nil),      // 16: google.protobuf.FieldMask
-	(*types.ReverseTunnelV2)(nil),      // 17: types.ReverseTunnelV2
-	(*RelayServer)(nil),                // 18: teleport.presence.v1.RelayServer
-	(*emptypb.Empty)(nil),              // 19: google.protobuf.Empty
+	(*ListAuthServersRequest)(nil),     // 15: teleport.presence.v1.ListAuthServersRequest
+	(*ListAuthServersResponse)(nil),    // 16: teleport.presence.v1.ListAuthServersResponse
+	(*ListProxyServersRequest)(nil),    // 17: teleport.presence.v1.ListProxyServersRequest
+	(*ListProxyServersResponse)(nil),   // 18: teleport.presence.v1.ListProxyServersResponse
+	(*types.RemoteClusterV3)(nil),      // 19: types.RemoteClusterV3
+	(*fieldmaskpb.FieldMask)(nil),      // 20: google.protobuf.FieldMask
+	(*types.ReverseTunnelV2)(nil),      // 21: types.ReverseTunnelV2
+	(*RelayServer)(nil),                // 22: teleport.presence.v1.RelayServer
+	(*types.ServerV2)(nil),             // 23: types.ServerV2
+	(*emptypb.Empty)(nil),              // 24: google.protobuf.Empty
 }
 var file_teleport_presence_v1_service_proto_depIdxs = []int32{
-	15, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
-	15, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
-	16, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
-	17, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
-	17, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
-	18, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
-	18, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
-	0,  // 7: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
-	1,  // 8: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
-	3,  // 9: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
-	4,  // 10: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
-	5,  // 11: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
-	7,  // 12: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
-	8,  // 13: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
-	9,  // 14: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
-	11, // 15: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
-	13, // 16: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
-	15, // 17: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
-	2,  // 18: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
-	15, // 19: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
-	19, // 20: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
-	6,  // 21: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
-	17, // 22: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
-	19, // 23: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
-	10, // 24: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
-	12, // 25: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
-	14, // 26: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
-	17, // [17:27] is the sub-list for method output_type
-	7,  // [7:17] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	19, // 0: teleport.presence.v1.ListRemoteClustersResponse.remote_clusters:type_name -> types.RemoteClusterV3
+	19, // 1: teleport.presence.v1.UpdateRemoteClusterRequest.remote_cluster:type_name -> types.RemoteClusterV3
+	20, // 2: teleport.presence.v1.UpdateRemoteClusterRequest.update_mask:type_name -> google.protobuf.FieldMask
+	21, // 3: teleport.presence.v1.ListReverseTunnelsResponse.reverse_tunnels:type_name -> types.ReverseTunnelV2
+	21, // 4: teleport.presence.v1.UpsertReverseTunnelRequest.reverse_tunnel:type_name -> types.ReverseTunnelV2
+	22, // 5: teleport.presence.v1.GetRelayServerResponse.relay_server:type_name -> teleport.presence.v1.RelayServer
+	22, // 6: teleport.presence.v1.ListRelayServersResponse.relays:type_name -> teleport.presence.v1.RelayServer
+	23, // 7: teleport.presence.v1.ListAuthServersResponse.servers:type_name -> types.ServerV2
+	23, // 8: teleport.presence.v1.ListProxyServersResponse.servers:type_name -> types.ServerV2
+	0,  // 9: teleport.presence.v1.PresenceService.GetRemoteCluster:input_type -> teleport.presence.v1.GetRemoteClusterRequest
+	1,  // 10: teleport.presence.v1.PresenceService.ListRemoteClusters:input_type -> teleport.presence.v1.ListRemoteClustersRequest
+	3,  // 11: teleport.presence.v1.PresenceService.UpdateRemoteCluster:input_type -> teleport.presence.v1.UpdateRemoteClusterRequest
+	4,  // 12: teleport.presence.v1.PresenceService.DeleteRemoteCluster:input_type -> teleport.presence.v1.DeleteRemoteClusterRequest
+	5,  // 13: teleport.presence.v1.PresenceService.ListReverseTunnels:input_type -> teleport.presence.v1.ListReverseTunnelsRequest
+	7,  // 14: teleport.presence.v1.PresenceService.UpsertReverseTunnel:input_type -> teleport.presence.v1.UpsertReverseTunnelRequest
+	8,  // 15: teleport.presence.v1.PresenceService.DeleteReverseTunnel:input_type -> teleport.presence.v1.DeleteReverseTunnelRequest
+	9,  // 16: teleport.presence.v1.PresenceService.GetRelayServer:input_type -> teleport.presence.v1.GetRelayServerRequest
+	11, // 17: teleport.presence.v1.PresenceService.ListRelayServers:input_type -> teleport.presence.v1.ListRelayServersRequest
+	13, // 18: teleport.presence.v1.PresenceService.DeleteRelayServer:input_type -> teleport.presence.v1.DeleteRelayServerRequest
+	15, // 19: teleport.presence.v1.PresenceService.ListAuthServers:input_type -> teleport.presence.v1.ListAuthServersRequest
+	17, // 20: teleport.presence.v1.PresenceService.ListProxyServers:input_type -> teleport.presence.v1.ListProxyServersRequest
+	19, // 21: teleport.presence.v1.PresenceService.GetRemoteCluster:output_type -> types.RemoteClusterV3
+	2,  // 22: teleport.presence.v1.PresenceService.ListRemoteClusters:output_type -> teleport.presence.v1.ListRemoteClustersResponse
+	19, // 23: teleport.presence.v1.PresenceService.UpdateRemoteCluster:output_type -> types.RemoteClusterV3
+	24, // 24: teleport.presence.v1.PresenceService.DeleteRemoteCluster:output_type -> google.protobuf.Empty
+	6,  // 25: teleport.presence.v1.PresenceService.ListReverseTunnels:output_type -> teleport.presence.v1.ListReverseTunnelsResponse
+	21, // 26: teleport.presence.v1.PresenceService.UpsertReverseTunnel:output_type -> types.ReverseTunnelV2
+	24, // 27: teleport.presence.v1.PresenceService.DeleteReverseTunnel:output_type -> google.protobuf.Empty
+	10, // 28: teleport.presence.v1.PresenceService.GetRelayServer:output_type -> teleport.presence.v1.GetRelayServerResponse
+	12, // 29: teleport.presence.v1.PresenceService.ListRelayServers:output_type -> teleport.presence.v1.ListRelayServersResponse
+	14, // 30: teleport.presence.v1.PresenceService.DeleteRelayServer:output_type -> teleport.presence.v1.DeleteRelayServerResponse
+	16, // 31: teleport.presence.v1.PresenceService.ListAuthServers:output_type -> teleport.presence.v1.ListAuthServersResponse
+	18, // 32: teleport.presence.v1.PresenceService.ListProxyServers:output_type -> teleport.presence.v1.ListProxyServersResponse
+	21, // [21:33] is the sub-list for method output_type
+	9,  // [9:21] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_teleport_presence_v1_service_proto_init() }
@@ -927,7 +1179,7 @@ func file_teleport_presence_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_presence_v1_service_proto_rawDesc), len(file_teleport_presence_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   15,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/presence/v1/service_grpc.pb.go
@@ -45,6 +45,8 @@ const (
 	PresenceService_GetRelayServer_FullMethodName      = "/teleport.presence.v1.PresenceService/GetRelayServer"
 	PresenceService_ListRelayServers_FullMethodName    = "/teleport.presence.v1.PresenceService/ListRelayServers"
 	PresenceService_DeleteRelayServer_FullMethodName   = "/teleport.presence.v1.PresenceService/DeleteRelayServer"
+	PresenceService_ListAuthServers_FullMethodName     = "/teleport.presence.v1.PresenceService/ListAuthServers"
+	PresenceService_ListProxyServers_FullMethodName    = "/teleport.presence.v1.PresenceService/ListProxyServers"
 )
 
 // PresenceServiceClient is the client API for PresenceService service.
@@ -73,6 +75,10 @@ type PresenceServiceClient interface {
 	ListRelayServers(ctx context.Context, in *ListRelayServersRequest, opts ...grpc.CallOption) (*ListRelayServersResponse, error)
 	// DeleteRelayServer deletes a relay_server resource by name.
 	DeleteRelayServer(ctx context.Context, in *DeleteRelayServerRequest, opts ...grpc.CallOption) (*DeleteRelayServerResponse, error)
+	// ListAuthServers returns a page of Auth servers.
+	ListAuthServers(ctx context.Context, in *ListAuthServersRequest, opts ...grpc.CallOption) (*ListAuthServersResponse, error)
+	// ListProxyServers returns a page of Proxy servers.
+	ListProxyServers(ctx context.Context, in *ListProxyServersRequest, opts ...grpc.CallOption) (*ListProxyServersResponse, error)
 }
 
 type presenceServiceClient struct {
@@ -183,6 +189,26 @@ func (c *presenceServiceClient) DeleteRelayServer(ctx context.Context, in *Delet
 	return out, nil
 }
 
+func (c *presenceServiceClient) ListAuthServers(ctx context.Context, in *ListAuthServersRequest, opts ...grpc.CallOption) (*ListAuthServersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListAuthServersResponse)
+	err := c.cc.Invoke(ctx, PresenceService_ListAuthServers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *presenceServiceClient) ListProxyServers(ctx context.Context, in *ListProxyServersRequest, opts ...grpc.CallOption) (*ListProxyServersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ListProxyServersResponse)
+	err := c.cc.Invoke(ctx, PresenceService_ListProxyServers_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // PresenceServiceServer is the server API for PresenceService service.
 // All implementations must embed UnimplementedPresenceServiceServer
 // for forward compatibility.
@@ -209,6 +235,10 @@ type PresenceServiceServer interface {
 	ListRelayServers(context.Context, *ListRelayServersRequest) (*ListRelayServersResponse, error)
 	// DeleteRelayServer deletes a relay_server resource by name.
 	DeleteRelayServer(context.Context, *DeleteRelayServerRequest) (*DeleteRelayServerResponse, error)
+	// ListAuthServers returns a page of Auth servers.
+	ListAuthServers(context.Context, *ListAuthServersRequest) (*ListAuthServersResponse, error)
+	// ListProxyServers returns a page of Proxy servers.
+	ListProxyServers(context.Context, *ListProxyServersRequest) (*ListProxyServersResponse, error)
 	mustEmbedUnimplementedPresenceServiceServer()
 }
 
@@ -248,6 +278,12 @@ func (UnimplementedPresenceServiceServer) ListRelayServers(context.Context, *Lis
 }
 func (UnimplementedPresenceServiceServer) DeleteRelayServer(context.Context, *DeleteRelayServerRequest) (*DeleteRelayServerResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteRelayServer not implemented")
+}
+func (UnimplementedPresenceServiceServer) ListAuthServers(context.Context, *ListAuthServersRequest) (*ListAuthServersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListAuthServers not implemented")
+}
+func (UnimplementedPresenceServiceServer) ListProxyServers(context.Context, *ListProxyServersRequest) (*ListProxyServersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListProxyServers not implemented")
 }
 func (UnimplementedPresenceServiceServer) mustEmbedUnimplementedPresenceServiceServer() {}
 func (UnimplementedPresenceServiceServer) testEmbeddedByValue()                         {}
@@ -450,6 +486,42 @@ func _PresenceService_DeleteRelayServer_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
+func _PresenceService_ListAuthServers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListAuthServersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).ListAuthServers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_ListAuthServers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).ListAuthServers(ctx, req.(*ListAuthServersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _PresenceService_ListProxyServers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListProxyServersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(PresenceServiceServer).ListProxyServers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: PresenceService_ListProxyServers_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(PresenceServiceServer).ListProxyServers(ctx, req.(*ListProxyServersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // PresenceService_ServiceDesc is the grpc.ServiceDesc for PresenceService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -496,6 +568,14 @@ var PresenceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteRelayServer",
 			Handler:    _PresenceService_DeleteRelayServer_Handler,
+		},
+		{
+			MethodName: "ListAuthServers",
+			Handler:    _PresenceService_ListAuthServers_Handler,
+		},
+		{
+			MethodName: "ListProxyServers",
+			Handler:    _PresenceService_ListProxyServers_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/api/proto/teleport/presence/v1/service.proto
+++ b/api/proto/teleport/presence/v1/service.proto
@@ -47,6 +47,11 @@ service PresenceService {
   rpc ListRelayServers(ListRelayServersRequest) returns (ListRelayServersResponse);
   // DeleteRelayServer deletes a relay_server resource by name.
   rpc DeleteRelayServer(DeleteRelayServerRequest) returns (DeleteRelayServerResponse);
+
+  // ListAuthServers returns a page of Auth servers.
+  rpc ListAuthServers(ListAuthServersRequest) returns (ListAuthServersResponse);
+  // ListProxyServers returns a page of Proxy servers.
+  rpc ListProxyServers(ListProxyServersRequest) returns (ListProxyServersResponse);
 }
 
 // Request for GetRemoteCluster
@@ -161,3 +166,39 @@ message DeleteRelayServerRequest {
 
 // Response message for the PresenceService.DeleteRelayServer rpc.
 message DeleteRelayServerResponse {}
+
+// Request message for the PresenceService.ListAuthServers rpc.
+message ListAuthServersRequest {
+  // The maximum number of items to return.
+  // The server may impose a different page size at its discretion.
+  int32 page_size = 1;
+  // The next_page_token value returned from a previous List request, if any.
+  string page_token = 2;
+}
+
+// Response message for the PresenceService.ListAuthServers rpc.
+message ListAuthServersResponse {
+  // A list of auth server resources.
+  repeated types.ServerV2 servers = 1;
+  // Token to retrieve the next page of results, or empty if there are no
+  // more results in the list.
+  string next_page_token = 2;
+}
+
+// Request message for the PresenceService.ListProxyServers rpc.
+message ListProxyServersRequest {
+  // The maximum number of items to return.
+  // The server may impose a different page size at its discretion.
+  int32 page_size = 1;
+  // The next_page_token value returned from a previous List request, if any.
+  string page_token = 2;
+}
+
+// Response message for the PresenceService.ListProxyServers rpc.
+message ListProxyServersResponse {
+  // A list of proxy server resources.
+  repeated types.ServerV2 servers = 1;
+  // Token to retrieve the next page of results, or empty if there are no
+  // more results in the list.
+  string next_page_token = 2;
+}

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/backend"
@@ -46,6 +47,7 @@ import (
 	cloudimds "github.com/gravitational/teleport/lib/cloud/imds"
 	cloudaws "github.com/gravitational/teleport/lib/cloud/imds/aws"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -260,7 +262,7 @@ func TestIAMNodeJoin(t *testing.T) {
 	require.NoError(t, err)
 
 	// sanity check there are no proxies to start with
-	proxies, err := authServer.GetProxies()
+	proxies, err := stream.Collect(clientutils.Resources(ctx, authServer.ListProxyServers))
 	require.NoError(t, err)
 	require.Empty(t, proxies)
 
@@ -274,7 +276,7 @@ func TestIAMNodeJoin(t *testing.T) {
 
 	// the proxy should eventually join the cluster and heartbeat
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		proxies, err := authServer.GetProxies()
+		proxies, err := stream.Collect(clientutils.Resources(ctx, authServer.ListProxyServers))
 		require.NoError(t, err)
 		require.NotEmpty(t, proxies)
 	}, 10*time.Second, 50*time.Millisecond, "waiting for proxy to join cluster")

--- a/lib/auth/accountrecovery_test.go
+++ b/lib/auth/accountrecovery_test.go
@@ -1032,7 +1032,7 @@ func TestGetAccountRecoveryToken(t *testing.T) {
 			name:    "invalid token type",
 			wantErr: true,
 			getRequest: func() *proto.GetAccountRecoveryTokenRequest {
-				wrongTokenType, err := srv.Auth().NewUserToken(authclient.CreateUserTokenRequest{
+				wrongTokenType, err := srv.Auth().NewUserToken(ctx, authclient.CreateUserTokenRequest{
 					Name: "llama",
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -123,8 +123,10 @@ func NewAPIServer(config *APIConfig) (http.Handler, error) {
 	// Servers and presence heartbeat
 	srv.POST("/:version/namespaces/:namespace/nodes/keepalive", srv.WithAuth(srv.keepAliveNode))
 	srv.POST("/:version/authservers", srv.WithAuth(srv.upsertAuthServer))
+	// TODO(kiosion) DELETE IN 21.0.0
 	srv.GET("/:version/authservers", srv.WithScopedAuth(srv.getAuthServers))
 	srv.POST("/:version/proxies", srv.WithAuth(srv.upsertProxy))
+	// TODO(kiosion) DELETE IN 21.0.0
 	srv.GET("/:version/proxies", srv.WithScopedAuth(srv.getProxies))
 	srv.DELETE("/:version/proxies", srv.WithAuth(srv.deleteAllProxies))
 	srv.DELETE("/:version/proxies/:name", srv.WithAuth(srv.deleteProxy))
@@ -306,7 +308,10 @@ func (s *APIServer) upsertProxy(auth *ServerWithRoles, w http.ResponseWriter, r 
 }
 
 // getProxies returns registered proxies
+//
+// TODO(kiosion) DELETE IN 21.0.0
 func (s *APIServer) getProxies(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	servers, err := auth.GetProxies()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -342,7 +347,10 @@ func (s *APIServer) upsertAuthServer(auth *ServerWithRoles, w http.ResponseWrite
 }
 
 // getAuthServers returns registered auth servers
+//
+// TODO(kiosion) DELETE IN 21.0.0
 func (s *APIServer) getAuthServers(auth *ServerWithRoles, w http.ResponseWriter, r *http.Request, p httprouter.Params, version string) (any, error) {
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	servers, err := auth.GetAuthServers()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/apiserver_test.go
+++ b/lib/auth/apiserver_test.go
@@ -133,8 +133,10 @@ func TestUpsertServer(t *testing.T) {
 				require.NoError(t, err)
 				allServers = append(allServers, servers...)
 			}
+			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 			addServers(s.GetAuthServers())
 			addServers(s.GetNodes(ctx, apidefaults.Namespace))
+			//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 			addServers(s.GetProxies())
 			require.Empty(t, cmp.Diff(allServers, []types.Server{tt.wantServer}, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 		})

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -3211,7 +3211,7 @@ func TestDeleteMFADeviceSync(t *testing.T) {
 
 	deleteReqUsingToken := func(tokenReq authclient.CreateUserTokenRequest) func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
 		return func(t *testing.T) *proto.DeleteMFADeviceSyncRequest {
-			token, err := authServer.NewUserToken(tokenReq)
+			token, err := authServer.NewUserToken(ctx, tokenReq)
 			require.NoError(t, err, "newUserToken")
 
 			_, err = authServer.CreateUserToken(ctx, token)
@@ -3416,7 +3416,7 @@ func TestDeleteMFADeviceSync_WithErrors(t *testing.T) {
 			deleteReq := test.deleteReq
 
 			if test.tokenRequest != nil {
-				token, err := authServer.NewUserToken(*test.tokenRequest)
+				token, err := authServer.NewUserToken(ctx, *test.tokenRequest)
 				require.NoError(t, err)
 				_, err = authServer.CreateUserToken(context.Background(), token)
 				require.NoError(t, err)
@@ -3634,7 +3634,7 @@ func TestAddMFADeviceSync(t *testing.T) {
 			wantErr: true,
 			getReq: func(t *testing.T, deviceName string) *proto.AddMFADeviceSyncRequest {
 				// Obtain a non privilege token.
-				token, err := authServer.NewUserToken(authclient.CreateUserTokenRequest{
+				token, err := authServer.NewUserToken(ctx, authclient.CreateUserTokenRequest{
 					Name: u.username,
 					TTL:  5 * time.Minute,
 					Type: authclient.UserTokenTypeResetPassword,
@@ -3823,7 +3823,7 @@ func TestGetMFADevices_WithToken(t *testing.T) {
 			tokenID := "test-token-not-found"
 
 			if tc.tokenRequest != nil {
-				token, err := srv.Auth().NewUserToken(*tc.tokenRequest)
+				token, err := srv.Auth().NewUserToken(ctx, *tc.tokenRequest)
 				require.NoError(t, err)
 				_, err = srv.Auth().CreateUserToken(context.Background(), token)
 				require.NoError(t, err)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -51,6 +51,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -2403,6 +2404,9 @@ func (a *ServerWithRoles) UpsertAuthServer(ctx context.Context, s types.Server) 
 	return a.authServer.UpsertAuthServer(ctx, s)
 }
 
+// Deprecated: Prefer paginated variant [ListAuthServers].
+//
+// TODO(kiosion) DELETE IN 21.0.0
 func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 	if a.scopedContext != nil {
 		ruleCtx := a.scopedContext.RuleContext()
@@ -2416,13 +2420,39 @@ func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		return a.authServer.GetAuthServers()
+		out, err := iterstream.Collect(clientutils.Resources(context.TODO(), a.authServer.ListAuthServers))
+		return out, trace.Wrap(err)
 	}
 
 	if err := a.authorizeAction(types.KindAuthServer, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetAuthServers()
+
+	out, err := iterstream.Collect(clientutils.Resources(context.TODO(), a.authServer.ListAuthServers))
+	return out, trace.Wrap(err)
+}
+
+func (a *ServerWithRoles) ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	if a.scopedContext != nil {
+		ruleCtx := a.scopedContext.RuleContext()
+		// For auth server reads we do not enforce scope pinning. This ensures that auths are readable for
+		// all scoped identities regardless of their current scope pinning. This pattern should not
+		// be used for any checks save essential global configuration reads that are necessary for basic
+		// teleport functionality.
+		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CheckAccessToRules(&ruleCtx, types.KindAuthServer, types.VerbList, types.VerbRead)
+		}); err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		return a.authServer.ListAuthServers(ctx, pageSize, pageToken)
+	}
+
+	if err := a.authorizeAction(types.KindAuthServer, types.VerbList, types.VerbRead); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return a.authServer.ListAuthServers(ctx, pageSize, pageToken)
 }
 
 // DeleteAuthServer deletes auth server by name
@@ -2440,6 +2470,9 @@ func (a *ServerWithRoles) UpsertProxy(ctx context.Context, s types.Server) error
 	return a.authServer.UpsertProxy(ctx, s)
 }
 
+// Deprecated: Prefer paginated variant [ListProxyServers].
+//
+// TODO(kiosion) DELETE IN 21.0.0
 func (a *ServerWithRoles) GetProxies() ([]types.Server, error) {
 	if a.scopedContext != nil {
 		ruleCtx := a.scopedContext.RuleContext()
@@ -2453,13 +2486,39 @@ func (a *ServerWithRoles) GetProxies() ([]types.Server, error) {
 			return nil, trace.Wrap(err)
 		}
 
-		return a.authServer.GetProxies()
+		out, err := iterstream.Collect(clientutils.Resources(context.TODO(), a.authServer.ListProxyServers))
+		return out, trace.Wrap(err)
 	}
 
 	if err := a.authorizeAction(types.KindProxy, types.VerbList, types.VerbRead); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return a.authServer.GetProxies()
+
+	out, err := iterstream.Collect(clientutils.Resources(context.TODO(), a.authServer.ListProxyServers))
+	return out, trace.Wrap(err)
+}
+
+func (a *ServerWithRoles) ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	if a.scopedContext != nil {
+		ruleCtx := a.scopedContext.RuleContext()
+		// For proxy reads we do not enforce scope pinning. This ensures that proxies are readable for
+		// all scoped identities regardless of their current scope pinning. This pattern should not
+		// be used for any checks save essential global configuration reads that are necessary for basic
+		// teleport functionality.
+		if err := a.scopedContext.CheckerContext.RiskyUnpinnedDecision(a.CloseContext(), scopes.Root, func(checker *services.SplitAccessChecker) error {
+			return checker.Common().CheckAccessToRules(&ruleCtx, types.KindProxy, types.VerbList, types.VerbRead)
+		}); err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+
+		return a.authServer.ListProxyServers(ctx, pageSize, pageToken)
+	}
+
+	if err := a.authorizeAction(types.KindProxy, types.VerbList, types.VerbRead); err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
+	return a.authServer.ListProxyServers(ctx, pageSize, pageToken)
 }
 
 // DeleteAllProxies deletes all proxies

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -224,10 +224,24 @@ type ReadProxyAccessPoint interface {
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
 
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
+
 	// GetAuthServers returns a list of auth servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListAuthServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetAuthServers() ([]types.Server, error)
+
+	// ListAuthServers returns a paginated list of auth servers registered in the cluster
+	ListAuthServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
 
 	// ListReverseTunnels returns a list of reverse tunnels with pagination.
 	ListReverseTunnels(ctx context.Context, pageSize int, nextToken string) ([]types.ReverseTunnel, string, error)
@@ -445,10 +459,24 @@ type ReadRemoteProxyAccessPoint interface {
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
 
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
+
 	// GetAuthServers returns a list of auth servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListAuthServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetAuthServers() ([]types.Server, error)
+
+	// ListAuthServers returns a paginated list of auth servers registered in the cluster
+	ListAuthServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
 
 	// GetAllTunnelConnections returns all tunnel connections
 	GetAllTunnelConnections(opts ...services.MarshalOption) ([]types.TunnelConnection, error)
@@ -622,7 +650,14 @@ type ReadAppsAccessPoint interface {
 	GetRoles(ctx context.Context) ([]types.Role, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
 
 	// GetApps returns all application resources.
 	GetApps(ctx context.Context) ([]types.Application, error)
@@ -851,7 +886,14 @@ type ReadDiscoveryAccessPoint interface {
 	GetIntegration(ctx context.Context, name string) (types.Integration, error)
 
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
 
 	// GetUserTask gets a single User Task by its name.
 	GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error)
@@ -937,7 +979,14 @@ type ReadOktaAccessPoint interface {
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, nextToken string) ([]types.Server, string, error)
 
 	// GetAuthPreference returns the cluster authentication configuration.
 	GetAuthPreference(ctx context.Context) (types.AuthPreference, error)
@@ -1098,10 +1147,24 @@ type Cache interface {
 	GetNodes(ctx context.Context, namespace string) ([]types.Server, error)
 
 	// GetProxies returns a list of proxy servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
 
+	// ListProxyServers returns a paginated list of proxy servers registered in the cluster
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
+
 	// GetAuthServers returns a list of auth servers registered in the cluster
+	//
+	// Deprecated: Prefer paginated variant [ListAuthServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetAuthServers() ([]types.Server, error)
+
+	// ListAuthServers returns a paginated list of auth servers registered in the cluster
+	ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 
 	// GetCertAuthority returns cert authority by id
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)

--- a/lib/auth/authclient/http_client.go
+++ b/lib/auth/authclient/http_client.go
@@ -423,27 +423,6 @@ func (c *HTTPClient) UpsertAuthServer(ctx context.Context, s types.Server) error
 	return trace.Wrap(err)
 }
 
-// GetAuthServers returns the list of auth servers registered in the cluster.
-func (c *HTTPClient) GetAuthServers() ([]types.Server, error) {
-	out, err := c.Get(context.TODO(), c.Endpoint("authservers"), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var items []json.RawMessage
-	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	re := make([]types.Server, len(items))
-	for i, raw := range items {
-		server, err := services.UnmarshalServer(raw, types.KindAuthServer)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		re[i] = server
-	}
-	return re, nil
-}
-
 // UpsertProxy is used by proxies to report their presence
 // to other auth servers in form of heartbeat expiring after ttl period.
 func (c *HTTPClient) UpsertProxy(ctx context.Context, s types.Server) error {
@@ -456,27 +435,6 @@ func (c *HTTPClient) UpsertProxy(ctx context.Context, s types.Server) error {
 	}
 	_, err = c.PostJSON(ctx, c.Endpoint("proxies"), args)
 	return trace.Wrap(err)
-}
-
-// GetProxies returns the list of auth servers registered in the cluster.
-func (c *HTTPClient) GetProxies() ([]types.Server, error) {
-	out, err := c.Get(context.TODO(), c.Endpoint("proxies"), url.Values{})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var items []json.RawMessage
-	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	re := make([]types.Server, len(items))
-	for i, raw := range items {
-		server, err := services.UnmarshalServer(raw, types.KindProxy)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		re[i] = server
-	}
-	return re, nil
 }
 
 // DeleteAllProxies deletes all proxies

--- a/lib/auth/authclient/httpfallback.go
+++ b/lib/auth/authclient/httpfallback.go
@@ -21,8 +21,12 @@ package authclient
 import (
 	"context"
 	"encoding/json"
+	"net/url"
 
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
 )
 
 // httpfallback.go holds endpoints that have been converted to gRPC
@@ -69,4 +73,54 @@ func (c *HTTPClient) validateTrustedCluster(ctx context.Context, validateRequest
 	}
 
 	return validateResponse, nil
+}
+
+// GetAuthServers returns the list of auth servers registered in the cluster.
+//
+// Deprecated: Prefer paginated variant [APIClient.ListAuthServers].
+//
+// TODO(kiosion): DELETE IN 21.0.0
+func (c *HTTPClient) GetAuthServers() ([]types.Server, error) {
+	out, err := c.Get(context.TODO(), c.Endpoint("authservers"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	re := make([]types.Server, len(items))
+	for i, raw := range items {
+		server, err := services.UnmarshalServer(raw, types.KindAuthServer)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		re[i] = server
+	}
+	return re, nil
+}
+
+// GetProxies returns the list of auth servers registered in the cluster.
+//
+// Deprecated: Prefer paginated variant [APIClient.ListProxyServers].
+//
+// TODO(kiosion): DELETE IN 21.0.0
+func (c *HTTPClient) GetProxies() ([]types.Server, error) {
+	out, err := c.Get(context.TODO(), c.Endpoint("proxies"), url.Values{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(out.Bytes(), &items); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	re := make([]types.Server, len(items))
+	for i, raw := range items {
+		server, err := services.UnmarshalServer(raw, types.KindProxy)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		re[i] = server
+	}
+	return re, nil
 }

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -96,8 +96,8 @@ func (a *Server) CreateRecoveryToken(ctx context.Context, username, tokenType st
 	return a.createRecoveryToken(ctx, username, tokenType, usage)
 }
 
-func (a *Server) NewUserToken(req authclient.CreateUserTokenRequest) (types.UserToken, error) {
-	return a.newUserToken(req)
+func (a *Server) NewUserToken(ctx context.Context, req authclient.CreateUserTokenRequest) (types.UserToken, error) {
+	return a.newUserToken(ctx, req)
 }
 
 func CreatePrivilegeToken(ctx context.Context, srv *Server, username, tokenKind string) (*types.UserTokenV3, error) {
@@ -246,7 +246,7 @@ func ValidServerHostname(hostname string) bool {
 }
 
 func FormatAccountName(s proxyDomainGetter, username string, authHostname string) (string, error) {
-	return formatAccountName(s, username, authHostname)
+	return formatAccountName(context.TODO(), s, username, authHostname)
 }
 
 func ConfigureCAsForTrustedCluster(tc types.TrustedCluster, cas []types.CertAuthority) {

--- a/lib/auth/gitserver/gitserverv1/github.go
+++ b/lib/auth/gitserver/gitserverv1/github.go
@@ -124,7 +124,7 @@ func (s *Service) makeGithubConnectorSpec(ctx context.Context, uuid, org, integr
 	return &types.GithubConnectorSpecV3{
 		ClientID:       clientID,
 		ClientSecret:   clientSecret,
-		RedirectURL:    fmt.Sprintf("https://%s/v1/webapi/github/callback", s.cfg.ProxyPublicAddrGetter()),
+		RedirectURL:    fmt.Sprintf("https://%s/v1/webapi/github/callback", s.cfg.ProxyPublicAddrGetter(ctx)),
 		EndpointURL:    types.GithubURL,
 		APIEndpointURL: types.GithubAPIURL,
 		// TODO(greedy52) the GitHub OAuth flow for authenticated user does not

--- a/lib/auth/gitserver/gitserverv1/service.go
+++ b/lib/auth/gitserver/gitserverv1/service.go
@@ -56,7 +56,7 @@ type Config struct {
 	// Log is the slog logger.
 	Log *slog.Logger
 	// ProxyPublicAddrGetter gets the public proxy address.
-	ProxyPublicAddrGetter func() string
+	ProxyPublicAddrGetter func(context.Context) string
 	// GitHubAuthRequestCreator is a callback to create the prepared request in
 	// the backend.
 	GitHubAuthRequestCreator GitHubAuthRequestCreator

--- a/lib/auth/gitserver/gitserverv1/service_test.go
+++ b/lib/auth/gitserver/gitserverv1/service_test.go
@@ -345,7 +345,7 @@ func newService(t *testing.T, checker services.AccessChecker, existing ...*types
 		Backend: testBackend{
 			GitServers: gitServersService,
 		},
-		ProxyPublicAddrGetter: func() string {
+		ProxyPublicAddrGetter: func(context.Context) string {
 			return fakeProxyAddr
 		},
 		GitHubAuthRequestCreator: func(_ context.Context, req types.GithubAuthRequest) (*types.GithubAuthRequest, error) {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3638,6 +3638,60 @@ func (g *GRPCServer) DeleteToken(ctx context.Context, req *types.ResourceRequest
 	return &emptypb.Empty{}, nil
 }
 
+// ListAuthServers returns a paginated list of auth servers.
+func (g *GRPCServer) ListAuthServers(ctx context.Context, req *presencev1pb.ListAuthServersRequest) (*presencev1pb.ListAuthServersResponse, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, next, err := auth.ListAuthServers(ctx, int(req.PageSize), req.PageToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	serverV2s := make([]*types.ServerV2, 0, len(servers))
+	for _, server := range servers {
+		srv, ok := server.(*types.ServerV2)
+		if !ok {
+			return nil, trace.Errorf("encountered unexpected server type: %T", server)
+		}
+		serverV2s = append(serverV2s, srv)
+	}
+
+	return &presencev1pb.ListAuthServersResponse{
+		Servers:       serverV2s,
+		NextPageToken: next,
+	}, nil
+}
+
+// ListProxyServers returns a paginated list of proxy servers.
+func (g *GRPCServer) ListProxyServers(ctx context.Context, req *presencev1pb.ListProxyServersRequest) (*presencev1pb.ListProxyServersResponse, error) {
+	auth, err := g.authenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, next, err := auth.ListProxyServers(ctx, int(req.PageSize), req.PageToken)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	serverV2s := make([]*types.ServerV2, 0, len(servers))
+	for _, server := range servers {
+		srv, ok := server.(*types.ServerV2)
+		if !ok {
+			return nil, trace.Errorf("encountered unexpected server type: %T", server)
+		}
+		serverV2s = append(serverV2s, srv)
+	}
+
+	return &presencev1pb.ListProxyServersResponse{
+		Servers:       serverV2s,
+		NextPageToken: next,
+	}, nil
+}
+
 // GetNode retrieves a node by name and namespace.
 func (g *GRPCServer) GetNode(ctx context.Context, req *types.ResourceInNamespaceRequest) (*types.ServerV2, error) {
 	if req.Namespace == "" {

--- a/lib/auth/integration/integrationv1/awsoidc.go
+++ b/lib/auth/integration/integrationv1/awsoidc.go
@@ -86,7 +86,7 @@ type AWSOIDCServiceConfig struct {
 	Cache                 CacheAWSOIDC
 	TokenCreator          TokenCreator
 	Clock                 clockwork.Clock
-	ProxyPublicAddrGetter func() string
+	ProxyPublicAddrGetter func(context.Context) string
 	Logger                *slog.Logger
 }
 
@@ -225,7 +225,7 @@ type AWSOIDCService struct {
 	authorizer            authz.Authorizer
 	logger                *slog.Logger
 	clock                 clockwork.Clock
-	proxyPublicAddrGetter func() string
+	proxyPublicAddrGetter func(context.Context) string
 	cache                 CacheAWSOIDC
 	tokenCreator          TokenCreator
 }
@@ -669,7 +669,7 @@ func (s *AWSOIDCService) EnrollEKSClusters(ctx context.Context, req *integration
 		return nil, trace.Wrap(err)
 	}
 
-	publicProxyAddr := s.proxyPublicAddrGetter()
+	publicProxyAddr := s.proxyPublicAddrGetter(ctx)
 	if publicProxyAddr == "" {
 		return nil, trace.BadParameter("could not get public proxy address.")
 	}

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -19,6 +19,7 @@
 package integrationv1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -221,7 +222,7 @@ func TestRBAC(t *testing.T) {
 	awsoidService, err := NewAWSOIDCService(&AWSOIDCServiceConfig{
 		IntegrationService:    resourceSvc,
 		Authorizer:            resourceSvc.authorizer,
-		ProxyPublicAddrGetter: func() string { return "128.0.0.1" },
+		ProxyPublicAddrGetter: func(context.Context) string { return "128.0.0.1" },
 		Cache:                 backend,
 		TokenCreator:          backend,
 	})

--- a/lib/auth/integration/integrationv1/service.go
+++ b/lib/auth/integration/integrationv1/service.go
@@ -54,7 +54,14 @@ type Cache interface {
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadSigningKeys bool) (types.CertAuthority, error)
 
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of registered proxies.
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 
 	// IntegrationsGetter defines methods to access Integration resources.
 	services.IntegrationsGetter

--- a/lib/auth/integration/integrationv1/service_test.go
+++ b/lib/auth/integration/integrationv1/service_test.go
@@ -1074,6 +1074,13 @@ func (m *mockCache) GetProxies() ([]types.Server, error) {
 	return m.proxies, nil
 }
 
+func (m *mockCache) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	if m.returnErr != nil {
+		return nil, "", m.returnErr
+	}
+	return m.proxies, "", nil
+}
+
 func (m *mockCache) GetToken(ctx context.Context, token string) (types.ProvisionToken, error) {
 	return nil, nil
 }

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -73,7 +73,11 @@ type WorkloadIdentityServiceConfig struct {
 type WorkloadIdentityCacher interface {
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 }
 
 // KeyStorer is an interface that provides methods to retrieve keys and

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -82,7 +82,11 @@ func (OSSSigstorePolicyEvaluator) Evaluate(_ context.Context, policyNames []stri
 
 type issuerCache interface {
 	workloadIdentityReader
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+	ListProxyServers(context.Context, int, string) ([]types.Server, string, error)
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 }
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1588,6 +1588,7 @@ func TestServersCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	// Proxy service.
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetProxies()
 	require.NoError(t, err)
 	require.Empty(t, out)
@@ -1596,6 +1597,7 @@ func TestServersCRUD(t *testing.T) {
 	proxy.Spec.Hostname = "proxy.llama"
 	require.NoError(t, clt.UpsertProxy(ctx, proxy))
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetProxies()
 	require.NoError(t, err)
 	require.Len(t, out, 1)
@@ -1604,11 +1606,13 @@ func TestServersCRUD(t *testing.T) {
 	err = clt.DeleteProxy(ctx, proxy.GetName())
 	require.NoError(t, err)
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetProxies()
 	require.NoError(t, err)
 	require.Empty(t, out)
 
 	// Auth service.
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetAuthServers()
 	require.NoError(t, err)
 	require.Empty(t, out)
@@ -1617,6 +1621,7 @@ func TestServersCRUD(t *testing.T) {
 	auth.Spec.Hostname = "auth.llama"
 	require.NoError(t, clt.UpsertAuthServer(ctx, auth))
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = clt.GetAuthServers()
 	require.NoError(t, err)
 	require.Len(t, out, 1)
@@ -4576,6 +4581,7 @@ func TestEvents(t *testing.T) {
 				err := testSrv.Auth().UpsertProxy(ctx, srv)
 				require.NoError(t, err)
 
+				//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 				out, err := testSrv.Auth().GetProxies()
 				require.NoError(t, err)
 

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -265,6 +265,7 @@ func TestUserTokenSecretsCreationSettings(t *testing.T) {
 func TestUserTokenCreationSettings(t *testing.T) {
 	t.Parallel()
 	srv := newTestTLSServer(t)
+	ctx := t.Context()
 
 	username := "joe@example.com"
 	_, _, err := authtest.CreateUserAndRole(srv.Auth(), username, []string{username}, nil)
@@ -276,7 +277,7 @@ func TestUserTokenCreationSettings(t *testing.T) {
 		Type: authclient.UserTokenTypeResetPasswordInvite,
 	}
 
-	token, err := srv.Auth().NewUserToken(req)
+	token, err := srv.Auth().NewUserToken(ctx, req)
 	require.NoError(t, err)
 	require.Equal(t, req.Name, token.GetUser())
 	require.Equal(t, req.Type, token.GetSubKind())
@@ -458,6 +459,13 @@ func (s *debugAuth) GetProxies() ([]types.Server, error) {
 		return nil, trace.BadParameter("failed to fetch proxies")
 	}
 	return s.proxies, nil
+}
+
+func (s *debugAuth) ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	if s.proxiesError {
+		return nil, "", trace.BadParameter("failed to fetch proxies")
+	}
+	return s.proxies, "", nil
 }
 
 func (s *debugAuth) GetDomainName() (string, error) {

--- a/lib/cache/auth_server_test.go
+++ b/lib/cache/auth_server_test.go
@@ -43,11 +43,11 @@ func TestAuthServers(t *testing.T) {
 			}, nil
 		},
 		create:    p.presenceS.UpsertAuthServer,
-		list:      getAllAdapter(func(context.Context) ([]types.Server, error) { return p.presenceS.GetAuthServers() }),
-		cacheList: getAllAdapter(func(context.Context) ([]types.Server, error) { return p.cache.GetAuthServers() }),
+		list:      p.presenceS.ListAuthServers,
+		cacheList: p.cache.ListAuthServers,
 		update:    p.presenceS.UpsertAuthServer,
 		deleteAll: func(_ context.Context) error {
 			return p.presenceS.DeleteAllAuthServers()
 		},
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/cache/proxy_server_test.go
+++ b/lib/cache/proxy_server_test.go
@@ -44,11 +44,11 @@ func TestProxies(t *testing.T) {
 			}, nil
 		},
 		create:    p.presenceS.UpsertProxy,
-		list:      getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.presenceS.GetProxies() }),
-		cacheList: getAllAdapter(func(_ context.Context) ([]types.Server, error) { return p.cache.GetProxies() }),
+		list:      p.presenceS.ListProxyServers,
+		cacheList: p.cache.ListProxyServers,
 		update:    p.presenceS.UpsertProxy,
 		deleteAll: func(_ context.Context) error {
 			return p.presenceS.DeleteAllProxies()
 		},
-	}, withSkipPaginationTest())
+	})
 }

--- a/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
+++ b/lib/integrations/awsoidc/credprovider/integration_config_provider_test.go
@@ -92,6 +92,10 @@ func (d *depsMock) GetProxies() ([]types.Server, error) {
 	return d.proxies, nil
 }
 
+func (d *depsMock) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return d.proxies, "", nil
+}
+
 func (d *depsMock) GetClusterName(_ context.Context) (types.ClusterName, error) {
 	return types.NewClusterName(types.ClusterNameSpecV2{ClusterName: "teleport.example.com", ClusterID: "cluster-id"})
 }

--- a/lib/integrations/awsoidc/token_generator.go
+++ b/lib/integrations/awsoidc/token_generator.go
@@ -47,7 +47,14 @@ type Cache interface {
 	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of registered proxies.
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 }
 
 // KeyStoreManager defines methods to get signers using the server's keystore.

--- a/lib/integrations/awsra/generate_credentials_test.go
+++ b/lib/integrations/awsra/generate_credentials_test.go
@@ -138,6 +138,14 @@ func (m *mockCache) GetProxies() ([]types.Server, error) {
 	}}, nil
 }
 
+func (m *mockCache) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return []types.Server{&types.ServerV2{
+		Spec: types.ServerSpecV2{
+			PublicAddrs: []string{"proxy.example.com"},
+		},
+	}}, "", nil
+}
+
 func (m *mockCache) ListIntegrations(ctx context.Context, pageSize int, nextKey string) ([]types.Integration, string, error) {
 	if m.integrations == nil {
 		m.integrations = map[string]types.Integration{}

--- a/lib/integrations/azureoidc/token_generator.go
+++ b/lib/integrations/azureoidc/token_generator.go
@@ -52,7 +52,14 @@ type Cache interface {
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+
+	// ListProxyServers returns a paginated list of registered proxies.
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 }
 
 // GenerateEntraOIDCToken returns a JWT suitable for OIDC authentication to MS Graph API.

--- a/lib/reversetunnel/local_cluster_test.go
+++ b/lib/reversetunnel/local_cluster_test.go
@@ -355,6 +355,10 @@ func (m *mockLocalClusterClient) GetProxies() ([]types.Server, error) {
 	return m.proxies, nil
 }
 
+func (m *mockLocalClusterClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return m.proxies, "", nil
+}
+
 type mockWatcher struct {
 	events chan types.Event
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6575,7 +6575,7 @@ func (process *TeleportProcess) initApps() {
 		// Loop over each application and create a server.
 		var applications types.Apps
 		for _, app := range process.Config.Apps.Apps {
-			publicAddr, err := getPublicAddr(accessPoint, app)
+			publicAddr, err := getPublicAddr(process.ExitContext(), accessPoint, app)
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -7114,7 +7114,7 @@ func dumperHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // getPublicAddr waits for a proxy to be registered with Teleport.
-func getPublicAddr(authClient authclient.ReadAppsAccessPoint, a servicecfg.App) (string, error) {
+func getPublicAddr(ctx context.Context, authClient authclient.ReadAppsAccessPoint, a servicecfg.App) (string, error) {
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 	timeout := time.NewTimer(5 * time.Second)
@@ -7123,7 +7123,7 @@ func getPublicAddr(authClient authclient.ReadAppsAccessPoint, a servicecfg.App) 
 	for {
 		select {
 		case <-ticker.C:
-			publicAddr, err := app.FindPublicAddr(authClient, a.PublicAddr, a.Name)
+			publicAddr, err := app.FindPublicAddr(ctx, authClient, a.PublicAddr, a.Name)
 			if err == nil {
 				return publicAddr, nil
 			}

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -92,7 +93,10 @@ func ValidateApp(app types.Application, proxyGetter ProxyGetter) error {
 		return trace.Wrap(err, "app %q has an invalid IDN hostname %q", app.GetName(), appAddr.Host())
 	}
 
-	proxyServers, err := proxyGetter.GetProxies()
+	proxyServers, err := clientutils.CollectWithFallback(context.TODO(), proxyGetter.ListProxyServers, func(context.Context) ([]types.Server, error) {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		return proxyGetter.GetProxies()
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -19,6 +19,7 @@
 package services
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -201,6 +202,23 @@ func (m *mockProxyGetter) GetProxies() ([]types.Server, error) {
 	}
 
 	return servers, nil
+}
+
+func (m *mockProxyGetter) ListProxyServers(_ context.Context, _ int, _ string) ([]types.Server, string, error) {
+	servers := make([]types.Server, 0, len(m.addrs))
+
+	for _, addr := range m.addrs {
+		servers = append(
+			servers,
+			&types.ServerV2{
+				Spec: types.ServerSpecV2{
+					PublicAddrs: []string{addr},
+				},
+			},
+		)
+	}
+
+	return servers, "", nil
 }
 
 // TestApplicationUnmarshal verifies an app resource can be unmarshaled.

--- a/lib/services/local/suite_test.go
+++ b/lib/services/local/suite_test.go
@@ -384,6 +384,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	require.Empty(t, out)
 
 	// Proxy service.
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = s.PresenceS.GetProxies()
 	require.NoError(t, err)
 	require.Empty(t, out)
@@ -392,6 +393,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	proxy.Spec.Hostname = "proxy.llama"
 	require.NoError(t, s.PresenceS.UpsertProxy(ctx, proxy))
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = s.PresenceS.GetProxies()
 	require.NoError(t, err)
 	require.Len(t, out, 1)
@@ -400,11 +402,13 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	err = s.PresenceS.DeleteProxy(ctx, proxy.GetName())
 	require.NoError(t, err)
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = s.PresenceS.GetProxies()
 	require.NoError(t, err)
 	require.Empty(t, out)
 
 	// Auth service.
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = s.PresenceS.GetAuthServers()
 	require.NoError(t, err)
 	require.Empty(t, out)
@@ -413,6 +417,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	auth.Spec.Hostname = "auth.llama"
 	require.NoError(t, s.PresenceS.UpsertAuthServer(ctx, auth))
 
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	out, err = s.PresenceS.GetAuthServers()
 	require.NoError(t, err)
 	require.Len(t, out, 1)
@@ -2162,6 +2167,7 @@ func (s *ServicesTestSuite) Events(t *testing.T) {
 				err := s.PresenceS.UpsertProxy(ctx, srv)
 				require.NoError(t, err)
 
+				//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 				out, err := s.PresenceS.GetProxies()
 				require.NoError(t, err)
 

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -31,7 +31,13 @@ import (
 // ProxyGetter is a service that gets proxies.
 type ProxyGetter interface {
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+	// ListProxyServers returns a paginated list of registered Proxy servers.
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 }
 
 // NodesGetter is a service that gets nodes.
@@ -83,7 +89,14 @@ type Presence interface {
 	UpsertNode(ctx context.Context, server types.Server) (*types.KeepAlive, error)
 
 	// GetAuthServers returns a list of registered servers
+	//
+	// Deprecated: Prefer paginated variant [ListAuthServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetAuthServers() ([]types.Server, error)
+
+	// ListAuthServers returns a paginated list of registered auth servers.
+	ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 
 	// UpsertAuthServer registers auth server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -409,7 +409,10 @@ func NewProxyWatcher(ctx context.Context, cfg ProxyWatcherConfig) (*GenericWatch
 		ResourceKind:          types.KindProxy,
 		ResourceKey:           types.Server.GetName,
 		ResourceGetter: func(ctx context.Context) ([]types.Server, error) {
-			return proxyGetter.GetProxies()
+			return clientutils.CollectWithFallback(ctx, proxyGetter.ListProxyServers, func(context.Context) ([]types.Server, error) {
+				//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+				return proxyGetter.GetProxies()
+			})
 		},
 		ResourcesC:                          cfg.ProxiesC,
 		ResourceDiffer:                      cfg.ProxyDiffer,

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -70,6 +70,10 @@ func (n nopProxyGetter) GetProxies() ([]types.Server, error) {
 	return nil, nil
 }
 
+func (n nopProxyGetter) ListProxyServers(_ context.Context, _ int, _ string) ([]types.Server, string, error) {
+	return nil, "", nil
+}
+
 func TestResourceWatcher_Backoff(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
@@ -296,7 +297,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 	c.tlsConfig = CopyAndConfigureTLS(c.log, c.cfg.AccessPoint, c.cfg.TLSConfig)
 
 	// Figure out the port the proxy is running on.
-	c.proxyPort = c.getProxyPort()
+	c.proxyPort = c.getProxyPort(c.closeContext)
 
 	return c, nil
 }
@@ -458,8 +459,11 @@ func (c *ConnectionsHandler) serveHTTP(w http.ResponseWriter, r *http.Request) e
 }
 
 // getProxyPort tries to figure out the address the proxy is running at.
-func (c *ConnectionsHandler) getProxyPort() string {
-	servers, err := c.cfg.AccessPoint.GetProxies()
+func (c *ConnectionsHandler) getProxyPort(ctx context.Context) string {
+	servers, err := clientutils.CollectWithFallback(ctx, c.cfg.AccessPoint.ListProxyServers, func(context.Context) ([]types.Server, error) {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		return c.cfg.AccessPoint.GetProxies()
+	})
 	if err != nil {
 		return strconv.Itoa(defaults.HTTPListenPort)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -586,6 +586,7 @@ func (s *Server) startDynamicMatchersWatcher(ctx context.Context) error {
 // This is only used if the matcher does not specify a ProxyAddress.
 // Example: proxy.example.com:3080 or proxy.example.com
 func (s *Server) publicProxyAddress(ctx context.Context) (string, error) {
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	proxies, err := s.AccessPoint.GetProxies()
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -521,6 +521,11 @@ func (m *mockIntegrationsTokenGenerator) GetProxies() ([]types.Server, error) {
 	return m.proxies, nil
 }
 
+// ListProxyServers returns a paginated list of registered proxies.
+func (m *mockIntegrationsTokenGenerator) ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	return m.proxies, "", nil
+}
+
 // GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
 func (m *mockIntegrationsTokenGenerator) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
 	return uuid.NewString(), nil

--- a/lib/utils/oidc/issuer.go
+++ b/lib/utils/oidc/issuer.go
@@ -26,19 +26,29 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 )
 
-// ProxyGetter is a service that gets proxies.
+// ProxiesGetter is a service that gets proxies.
 type ProxiesGetter interface {
 	// GetProxies returns a list of registered proxies.
+	//
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
+	// ListProxyServers returns a paginated list of registered proxies.
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
 }
 
 // IssuerForCluster returns the issuer URL using the Cluster state.
 // Path is an optional element to append to the issuer to distinguish a
 // separate CA within the same cluster.
 func IssuerForCluster(ctx context.Context, clt ProxiesGetter, path string) (string, error) {
-	proxies, err := clt.GetProxies()
+	proxies, err := clientutils.CollectWithFallback(ctx, clt.ListProxyServers, func(context.Context) ([]types.Server, error) {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		return clt.GetProxies()
+	})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/utils/oidc/issuer_test.go
+++ b/lib/utils/oidc/issuer_test.go
@@ -94,6 +94,13 @@ func (m *mockProxyGetter) GetProxies() ([]types.Server, error) {
 	return m.proxies, nil
 }
 
+func (m *mockProxyGetter) ListProxyServers(_ context.Context, _ int, _ string) ([]types.Server, string, error) {
+	if m.returnErr != nil {
+		return nil, "", m.returnErr
+	}
+	return m.proxies, "", nil
+}
+
 func TestIssuerForCluster(t *testing.T) {
 	ctx := context.Background()
 	for _, tt := range []struct {

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -581,6 +581,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 
 	// Wait for proxy to fully register before starting the test.
 	for start := time.Now(); ; {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 		proxies, err := s.proxyClient.GetProxies()
 		require.NoError(t, err)
 		if len(proxies) != 0 {
@@ -8403,6 +8404,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 
 	// Wait for proxies to fully register before starting the test.
 	for start := time.Now(); ; {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 		proxies, err := proxies[0].client.GetProxies()
 		require.NoError(t, err)
 		if len(proxies) == numProxies {

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -576,6 +576,10 @@ func (c *mockAuthClient) GetProxies() ([]types.Server, error) {
 	return []types.Server{}, nil
 }
 
+func (c *mockAuthClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return []types.Server{}, "", nil
+}
+
 // fakeClusterListener Implements a `net.Listener` that return `net.Conn` from
 // the `FakeCluster`.
 type fakeClusterListener struct {

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -178,9 +178,19 @@ func (m *mockAccessPoint) GetNodes(ctx context.Context, namespace string) ([]typ
 }
 
 func (m *mockAccessPoint) GetProxies() ([]types.Server, error) {
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	return m.presence.GetProxies()
 }
 
+func (m *mockAccessPoint) ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	return m.presence.ListProxyServers(ctx, pageSize, pageToken)
+}
+
 func (m *mockAccessPoint) GetAuthServers() ([]types.Server, error) {
+	//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
 	return m.presence.GetAuthServers()
+}
+
+func (m *mockAccessPoint) ListAuthServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error) {
+	return m.presence.ListAuthServers(ctx, pageSize, pageToken)
 }

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -42,6 +42,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
@@ -341,6 +342,10 @@ type certificateSigner interface {
 	GetClusterName(ctx context.Context) (types.ClusterName, error)
 	GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error)
 	GetDatabaseServers(ctx context.Context, namespace string, opts ...services.MarshalOption) ([]types.DatabaseServer, error)
+	ListProxyServers(ctx context.Context, pageSize int, pageToken string) ([]types.Server, string, error)
+	// Deprecated: Prefer paginated variant [ListProxyServers].
+	//
+	// TODO(kiosion): DELETE IN 21.0.0
 	GetProxies() ([]types.Server, error)
 	GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error)
 	TrustClient() trustpb.TrustServiceClient
@@ -474,7 +479,12 @@ func (a *AuthCommand) generateSnowflakeKey(ctx context.Context, clusterAPI certi
 
 // ListAuthServers prints a list of connected auth servers
 func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI authCommandClient) error {
-	servers, err := clusterAPI.GetAuthServers()
+	servers, err := clientutils.CollectWithFallback(
+		ctx,
+		clusterAPI.ListAuthServers,
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		func(context.Context) ([]types.Server, error) { return clusterAPI.GetAuthServers() },
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1233,7 +1243,10 @@ func (a *AuthCommand) checkProxyAddr(ctx context.Context, clusterAPI certificate
 		return trace.WrapWithMessage(err, "couldn't load cluster network configuration, try setting --proxy manually")
 	}
 	// Fetch proxies known to auth server and try to find a public address.
-	proxies, err := clusterAPI.GetProxies()
+	proxies, err := clientutils.CollectWithFallback(ctx, clusterAPI.ListProxyServers, func(context.Context) ([]types.Server, error) {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		return clusterAPI.GetProxies()
+	})
 	if err != nil {
 		return trace.WrapWithMessage(err, "couldn't load registered proxies, try setting --proxy manually")
 	}

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -437,6 +437,10 @@ func (c *mockClient) GetProxies() ([]types.Server, error) {
 	return c.proxies, nil
 }
 
+func (c *mockClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return c.proxies, "", nil
+}
+
 func (c *mockClient) GetRemoteClusters(ctx context.Context) ([]types.RemoteCluster, error) {
 	return c.remoteClusters, nil
 }

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -186,7 +187,12 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 		return trace.Wrap(err)
 	}
 
-	authServers, err := client.GetAuthServers()
+	authServers, err := clientutils.CollectWithFallback(
+		ctx,
+		client.ListAuthServers,
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		func(context.Context) ([]types.Server, error) { return client.GetAuthServers() },
+	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -207,7 +213,10 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 			}
 
 			if err == nil && pingResponse.GetServerFeatures().Cloud {
-				proxies, err := client.GetProxies()
+				proxies, err := clientutils.CollectWithFallback(ctx, client.ListProxyServers, func(context.Context) ([]types.Server, error) {
+					//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+					return client.GetProxies()
+				})
 				if err != nil {
 					return trace.Wrap(err)
 				}


### PR DESCRIPTION
- Add new paginated replacements for `GetAuthServers`/`GetProxies`
- Deprecate non-paginated funcs
- Implement replacements, update tests

Required for https://github.com/gravitational/teleport.e/pull/7709