### PR TITLE
[refactoring][mcp] sdk migration part2: replace protocol

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -189,6 +189,7 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/moby/term v0.5.2
+	github.com/modelcontextprotocol/go-sdk v1.1.0
 	github.com/ohler55/ojg v1.27.0
 	github.com/okta/okta-sdk-golang/v2 v2.20.0
 	github.com/openai/openai-go/v3 v3.8.1
@@ -433,6 +434,7 @@ require (
 	github.com/google/certificate-transparency-go v1.3.2 // indirect
 	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/jsonschema-go v0.3.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1425,6 +1425,8 @@ github.com/google/go-tpm-tools v0.4.7/go.mod h1:gSyXTZHe3fgbzb6WEGd90QucmsnT1SRd
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonschema-go v0.3.0 h1:6AH2TxVNtk3IlvkkhjrtbUc4S8AvO0Xii0DxIygDg+Q=
+github.com/google/jsonschema-go v0.3.0/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=
 github.com/google/logger v1.1.1/go.mod h1:BkeJZ+1FhQ+/d087r4dzojEg1u2ZX+ZqG1jTUrLM+zQ=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
@@ -1863,6 +1865,8 @@ github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=
 github.com/moby/term v0.5.2/go.mod h1:d3djjFCrjnB+fl8NJux+EJzu0msscUP+f8it8hPkFLc=
+github.com/modelcontextprotocol/go-sdk v1.1.0 h1:Qjayg53dnKC4UZ+792W21e4BpwEZBzwgRW6LrjLWSwA=
+github.com/modelcontextprotocol/go-sdk v1.1.0/go.mod h1:6fM3LCm3yV7pAs8isnKLn07oKtB0MP9LHd3DfAcKw10=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/integration/appaccess/mcp_test.go
+++ b/integration/appaccess/mcp_test.go
@@ -76,6 +76,8 @@ func testMCPDialStdio(t *testing.T, pack *Pack) {
 	serverConn, err := dialer.DialALPN(t.Context())
 	require.NoError(t, err)
 
+	// TODO(greedy52) replace all MCP client, server usage before backporting
+	// migration to a release.
 	ctx := t.Context()
 	stdioClient := mcptest.NewStdioClientFromConn(t, serverConn)
 

--- a/lib/client/mcp/errors.go
+++ b/lib/client/mcp/errors.go
@@ -25,7 +25,7 @@ import (
 	"syscall"
 
 	"github.com/gravitational/trace"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 const (
@@ -75,8 +75,8 @@ func IsServerInfoChangedError(err error) bool {
 }
 
 type serverInfoChangedError struct {
-	expectedInfo mcp.Implementation
-	currentInfo  mcp.Implementation
+	expectedInfo *mcp.Implementation
+	currentInfo  *mcp.Implementation
 }
 
 func (e *serverInfoChangedError) Error() string {

--- a/lib/client/mcp/errors_test.go
+++ b/lib/client/mcp/errors_test.go
@@ -21,17 +21,17 @@ package mcp
 import (
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsServerInfoChangedError(t *testing.T) {
 	err := &serverInfoChangedError{
-		expectedInfo: mcp.Implementation{
+		expectedInfo: &mcp.Implementation{
 			Name:    "i-am-mcp",
 			Version: "1.0.0",
 		},
-		currentInfo: mcp.Implementation{
+		currentInfo: &mcp.Implementation{
 			Name:    "i-am-mcp",
 			Version: "1.1.0",
 		},

--- a/lib/srv/mcp/stdio_test.go
+++ b/lib/srv/mcp/stdio_test.go
@@ -27,7 +27,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/mark3labs/mcp-go/mcp"
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/mcptest"
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
 )
 
 func Test_handleAuthErrStdio(t *testing.T) {
@@ -109,16 +110,21 @@ func Test_handleStdio(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "teleport-demo", resp.ServerInfo.Name)
 
-	listToolsResult, err := stdioClient.ListTools(ctx, mcp.ListToolsRequest{})
+	listToolsResult, err := stdioClient.ListTools(ctx, mcpgo.ListToolsRequest{})
 	require.NoError(t, err)
-	checkToolsListResult(t, listToolsResult, []string{
-		"teleport_user_info",
-		"teleport_session_info",
-		"teleport_demo_info",
-	})
+	require.ElementsMatch(t,
+		[]string{
+			"teleport_user_info",
+			"teleport_session_info",
+			"teleport_demo_info",
+		},
+		sliceutils.Map(listToolsResult.Tools, func(t mcpgo.Tool) string {
+			return t.Name
+		}),
+	)
 
-	callToolResult, err := stdioClient.CallTool(ctx, mcp.CallToolRequest{
-		Params: mcp.CallToolParams{
+	callToolResult, err := stdioClient.CallTool(ctx, mcpgo.CallToolRequest{
+		Params: mcpgo.CallToolParams{
 			Name: "teleport_user_info",
 		},
 	})

--- a/lib/utils/mcputils/id_tracker_test.go
+++ b/lib/utils/mcputils/id_tracker_test.go
@@ -23,7 +23,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,25 +33,25 @@ func TestIDTracker(t *testing.T) {
 	require.Empty(t, tracker.Len())
 
 	t.Run("request missing ID not tracked", func(t *testing.T) {
-		require.False(t, tracker.PushRequest(&JSONRPCRequest{
+		require.False(t, tracker.PushRequest(&jsonrpc.Request{
 			Method: "bad",
 		}))
 		require.Empty(t, tracker.Len())
 	})
 
 	t.Run("request tracked", func(t *testing.T) {
-		require.True(t, tracker.PushRequest(&JSONRPCRequest{
-			ID:     mcp.NewRequestId(0),
+		require.True(t, tracker.PushRequest(&jsonrpc.Request{
+			ID:     mustMakeIntID(t, 0),
 			Method: MethodToolsList,
 		}))
 		require.Equal(t, 1, tracker.Len())
 	})
 
 	t.Run("pop unknown id", func(t *testing.T) {
-		unknownIDs := []mcp.RequestId{
-			mcp.NewRequestId(5),
-			mcp.NewRequestId("0"),
-			mcp.NewRequestId(nil),
+		unknownIDs := []jsonrpc.ID{
+			mustMakeIntID(t, 5),
+			mustMakeID(t, "0"),
+			mustMakeID(t, nil),
 		}
 		for id := range slices.Values(unknownIDs) {
 			t.Run(fmt.Sprintf("%T", id), func(t *testing.T) {
@@ -63,7 +63,7 @@ func TestIDTracker(t *testing.T) {
 	})
 
 	t.Run("pop tracked id", func(t *testing.T) {
-		method, ok := tracker.PopByID(mcp.NewRequestId(0))
+		method, ok := tracker.PopByID(mustMakeIntID(t, 0))
 		require.True(t, ok)
 		require.Equal(t, MethodToolsList, method)
 		require.Empty(t, tracker.Len())
@@ -71,14 +71,14 @@ func TestIDTracker(t *testing.T) {
 
 	t.Run("track last 5", func(t *testing.T) {
 		for i := range 20 {
-			tracker.PushRequest(&JSONRPCRequest{
-				ID:     mcp.NewRequestId(i + 1),
+			tracker.PushRequest(&jsonrpc.Request{
+				ID:     mustMakeIntID(t, i+1),
 				Method: MethodToolsCall,
 			})
 			require.LessOrEqual(t, tracker.Len(), 10)
 		}
 		for i := range 5 {
-			method, ok := tracker.PopByID(mcp.NewRequestId(20 - i))
+			method, ok := tracker.PopByID(mustMakeIntID(t, 20-i))
 			require.True(t, ok)
 			require.Equal(t, MethodToolsCall, method)
 		}
@@ -86,24 +86,37 @@ func TestIDTracker(t *testing.T) {
 	})
 }
 
+func mustMakeID(t testing.TB, id any) jsonrpc.ID {
+	t.Helper()
+	ret, err := jsonrpc.MakeID(id)
+	require.NoError(t, err)
+	return ret
+}
+
+func mustMakeIntID(t testing.TB, id int) jsonrpc.ID {
+	t.Helper()
+	return mustMakeID(t, float64(id))
+}
+
 func BenchmarkIDTracker(b *testing.B) {
 	idTracker, err := NewIDTracker(100)
 	require.NoError(b, err)
 
 	for i := range 100 {
-		idTracker.PushRequest(&JSONRPCRequest{
-			ID:     mcp.NewRequestId(i),
+		idTracker.PushRequest(&jsonrpc.Request{
+			ID:     mustMakeIntID(b, i),
 			Method: MethodToolsList,
 		})
 	}
+	testID := mustMakeIntID(b, 2000)
 
 	// cpu: Apple M3 Pro
 	// BenchmarkIDTracker-12    	12267649	        81.85 ns/op
 	for b.Loop() {
-		idTracker.PushRequest(&JSONRPCRequest{
-			ID:     mcp.NewRequestId(2000),
+		idTracker.PushRequest(&jsonrpc.Request{
+			ID:     testID,
 			Method: MethodToolsList,
 		})
-		idTracker.PopByID(mcp.NewRequestId(2000))
+		idTracker.PopByID(testID)
 	}
 }

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -19,172 +19,33 @@
 package mcputils
 
 import (
-	"encoding/json"
+	"fmt"
 
 	"github.com/gravitational/trace"
-	"github.com/mark3labs/mcp-go/mcp"
-
-	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 )
 
-// Type definitions from both mcp-go/client/transport or mcp-go are not suitable
-// for our reverse proxy use, thus this file redefines them.
-//
-// TODO(greedy52) switch to official golang lib or official go SDK if they offer
-// the level of handling we need. Same goes for other helpers like StdioXXX.
-
-// JSONRPCParams defines params for request or notification.
-// TODO(greedy52) handle metadata
-type JSONRPCParams map[string]any
-
-// GetEventParams returns the apievents.Struct for auditing.
-func (p JSONRPCParams) GetEventParams() *apievents.Struct {
-	if p == nil {
-		return nil
-	}
-
-	eventParams, _ := apievents.EncodeMap(p)
-	return eventParams
-}
-
-// GetName returns the "name" param.
-func (p JSONRPCParams) GetName() (string, bool) {
-	if p == nil {
-		return "", false
-	}
-	name, ok := p["name"].(string)
-	return name, ok
-}
-
-// BaseJSONRPCMessage is a base message that includes all fields for MCP
-// protocol.
-//
-// Note that json.RawMessage is used to keep the original content when
-// marshaling it again. json.RawMessage can also be easily unmarshalled to user
-// defined types when needed. Same applies to other types in this file.
-type BaseJSONRPCMessage struct {
-	// JSONRPC specifies the version of JSONRPC.
-	JSONRPC string `json:"jsonrpc"`
-	// ID is the ID for request and response. ID is nil for notification.
-	ID mcp.RequestId `json:"id"`
-	// Method is the request or notification method. Method is empty for response.
-	Method string `json:"method,omitempty"`
-	// Params is the params for request and notification.
-	Params JSONRPCParams `json:"params,omitempty"`
-	// Result is the response result.
-	Result json.RawMessage `json:"result,omitempty"`
-	// Error is the response error.
-	Error json.RawMessage `json:"error,omitempty"`
-}
-
-// IsNotification returns true if the message is a notification.
-func (m *BaseJSONRPCMessage) IsNotification() bool {
-	return m.ID.IsNil()
-}
-
-// IsRequest returns true if the message is a request.
-func (m *BaseJSONRPCMessage) IsRequest() bool {
-	return !m.ID.IsNil() && m.Method != ""
-}
-
-// IsResponse returns if the message is a response.
-func (m *BaseJSONRPCMessage) IsResponse() bool {
-	return !m.ID.IsNil() && (m.Result != nil || m.Error != nil)
-}
-
-// MakeNotification converts the base message to JSONRPCNotification.
-func (m *BaseJSONRPCMessage) MakeNotification() *JSONRPCNotification {
-	return &JSONRPCNotification{
-		JSONRPC: m.JSONRPC,
-		Method:  m.Method,
-		Params:  m.Params,
-	}
-}
-
-// MakeRequest converts the base message to JSONRPCRequest.
-func (m *BaseJSONRPCMessage) MakeRequest() *JSONRPCRequest {
-	return &JSONRPCRequest{
-		JSONRPC: m.JSONRPC,
-		ID:      m.ID,
-		Method:  m.Method,
-		Params:  m.Params,
-	}
-}
-
-// MakeResponse converts the base message to JSONRPCResponse.
-func (m *BaseJSONRPCMessage) MakeResponse() *JSONRPCResponse {
-	return &JSONRPCResponse{
-		JSONRPC: m.JSONRPC,
-		ID:      m.ID,
-		Result:  m.Result,
-		Error:   m.Error,
-	}
-}
-
-// JSONRPCNotification defines a MCP notification.
-//
-// https://modelcontextprotocol.io/specification/2025-03-26/basic#notifications
-type JSONRPCNotification struct {
-	JSONRPC string        `json:"jsonrpc"`
-	Method  string        `json:"method"`
-	Params  JSONRPCParams `json:"params,omitempty"`
-}
-
-// JSONRPCRequest defines a MCP request.
-//
-// https://modelcontextprotocol.io/specification/2025-03-26/basic#requests
-type JSONRPCRequest struct {
-	JSONRPC string        `json:"jsonrpc"`
-	Method  string        `json:"method"`
-	ID      mcp.RequestId `json:"id"`
-	Params  JSONRPCParams `json:"params,omitempty"`
-}
-
-// JSONRPCResponse defines an MCP response.
-//
-// By protocol spec, responses are further sub-categorized as either successful
-// results or errors. Either a result or an error MUST be set. A response MUST
-// NOT set both.
-//
-// https://modelcontextprotocol.io/specification/2025-03-26/basic#responses
-type JSONRPCResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	ID      mcp.RequestId   `json:"id"`
-	Result  json.RawMessage `json:"result,omitempty"`
-	Error   json.RawMessage `json:"error,omitempty"`
-}
-
-// GetListToolResult assumes the result is for MethodToolsList and returns
-// the corresponding go object.
-func (r *JSONRPCResponse) GetListToolResult() (*mcp.ListToolsResult, error) {
-	var listResult mcp.ListToolsResult
-	if err := json.Unmarshal([]byte(r.Result), &listResult); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &listResult, nil
-}
-
-// GetInitializeResult assumes the result is for MethodInitialize and
-// returns the corresponding go object.
-func (r *JSONRPCResponse) GetInitializeResult() (*mcp.InitializeResult, error) {
-	var result mcp.InitializeResult
-	if err := json.Unmarshal(r.Result, &result); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return &result, nil
-}
-
 // unmarshalResponse is a helper that unmarshalls a raw message to an
-// JSONRPCResponse.
-func unmarshalResponse(rawMessage string) (*JSONRPCResponse, error) {
-	var base BaseJSONRPCMessage
-	if err := json.Unmarshal([]byte(rawMessage), &base); err != nil {
+// jsonrpc.Response.
+func unmarshalResponse(rawMessage string) (*jsonrpc.Response, error) {
+	message, err := jsonrpc.DecodeMessage([]byte(rawMessage))
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !base.IsResponse() {
+
+	response, ok := message.(*jsonrpc.Response)
+	if !ok {
 		return nil, trace.BadParameter("message is not a response")
 	}
-	return base.MakeResponse(), nil
+	return response, nil
+}
+
+// IDString returns the string representation of the ID.
+func IDString(id jsonrpc.ID) string {
+	if !id.IsValid() {
+		return ""
+	}
+	return fmt.Sprintf("%v", id.Raw())
 }
 
 const (

--- a/lib/utils/mcputils/reader_test.go
+++ b/lib/utils/mcputils/reader_test.go
@@ -20,8 +20,11 @@ package mcputils
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +47,7 @@ func TestReadOneResponse(t *testing.T) {
 		name          string
 		rawMessage    string
 		checkError    require.ErrorAssertionFunc
-		checkResponse func(*testing.T, *JSONRPCResponse)
+		checkResponse func(*testing.T, *jsonrpc.Response)
 	}{
 		{
 			name:       "bad json",
@@ -65,10 +68,13 @@ func TestReadOneResponse(t *testing.T) {
 			name:       "response",
 			rawMessage: string(sampleResponseJSON),
 			checkError: require.NoError,
-			checkResponse: func(t *testing.T, response *JSONRPCResponse) {
+			checkResponse: func(t *testing.T, response *jsonrpc.Response) {
 				require.NotNil(t, response)
-				_, err := response.GetListToolResult()
-				require.NoError(t, err)
+				require.Empty(t, response.Error)
+				var result mcp.ListToolsResult
+				require.NoError(t, json.Unmarshal(response.Result, &result))
+				require.Len(t, result.Tools, 1)
+				require.Equal(t, "get_weather", result.Tools[0].Name)
 			},
 		},
 	}

--- a/lib/utils/mcputils/sse.go
+++ b/lib/utils/mcputils/sse.go
@@ -22,7 +22,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,7 +30,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -103,8 +102,8 @@ func (w *SSERequestWriter) GetEndpointURL() string {
 //
 // Note that the HTTP response does not contain the MCP response. MCP response
 // is sent through the SSE stream ¯\(ツ)/¯.
-func (w *SSERequestWriter) WriteMessage(ctx context.Context, msg mcp.JSONRPCMessage) error {
-	data, err := json.Marshal(msg)
+func (w *SSERequestWriter) WriteMessage(ctx context.Context, msg jsonrpc.Message) error {
+	data, err := jsonrpc.EncodeMessage(msg)
 	if err != nil {
 		return trace.Wrap(err, "marshaling MCP request")
 	}

--- a/lib/utils/mcputils/stdio.go
+++ b/lib/utils/mcputils/stdio.go
@@ -22,13 +22,12 @@ import (
 	"bufio"
 	"cmp"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 
 	"github.com/gravitational/trace"
-	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -72,8 +71,8 @@ func NewStdioMessageWriter(w io.Writer) *StdioMessageWriter {
 }
 
 // WriteMessage writes a JSONRPC message in stdio transport.
-func (w *StdioMessageWriter) WriteMessage(_ context.Context, resp mcp.JSONRPCMessage) error {
-	bytes, err := json.Marshal(resp)
+func (w *StdioMessageWriter) WriteMessage(_ context.Context, resp jsonrpc.Message) error {
+	bytes, err := jsonrpc.EncodeMessage(resp)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
part of
- #61426

This PR replaces old protocol messages defined in `mcputils` with the `jsonrpc` package from the SDK and updates logic where touches it.

This PR hasn't replaced "end" MCP client and server used for testing which ensures the protocol still passes all the original tests.

Only thing breaks so far is the streamble-HTTP transport from the official SDK does not expose way to listen notifications from the server SSE stream. Will tackle that separately.