### PR TITLE
Improve reliability of waitForSessionToBeEstablished

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -415,7 +415,7 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 				tconf.Auth.AuditConfig = auditConfig
 				tconf.Auth.SessionRecordingConfig = recConfig
 				tconf.Proxy.Enabled = true
-				tconf.SSH.Enabled = true
+				tconf.SSH.Enabled = false
 				return t, nil, nil, tconf
 			}
 			teleport := suite.NewTeleportWithConfig(makeConfig())
@@ -438,9 +438,9 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 
 			ctx := t.Context()
 
-			// wait for both nodes to show up, otherwise
-			// we'll have trouble connecting to the node below.
-			err = teleport.WaitForNodeCount(ctx, helpers.Site, 2)
+			// wait for the node to show up, otherwise
+			// we'll have trouble connecting below.
+			err = teleport.WaitForNodeCount(ctx, helpers.Site, 1)
 			require.NoError(t, err)
 
 			// should have no sessions:
@@ -466,32 +466,15 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 				cl.Stdout = myTerm
 				cl.Stdin = myTerm
 
-				err = cl.SSH(context.TODO(), []string{})
+				err = cl.SSH(ctx, nil)
 				endC <- err
 			}()
 
-			// wait until we've found the session in the audit log
-			getSession := func(site authclient.ClientI) (types.SessionTracker, error) {
-				timeout, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-				defer cancel()
-				sessions, err := waitForSessionToBeEstablished(timeout, defaults.Namespace, site)
-				if err != nil {
-					return nil, trace.Wrap(err)
-				}
-				return sessions[0], nil
-			}
-			tracker, err := getSession(site)
-			require.NoError(t, err)
-			sessionID := tracker.GetSessionID()
-
-			// wait for the user to join this session:
-			for len(tracker.GetParticipants()) == 0 {
-				time.Sleep(time.Millisecond * 5)
-				tracker, err = site.GetSessionTracker(ctx, tracker.GetSessionID())
-				require.NoError(t, err)
-			}
+			// wait until the session tracker exists.
+			tracker := waitForSessionToBeEstablished(t, site, 1)
 			// make sure it's us who joined! :)
 			require.Equal(t, suite.Me.Username, tracker.GetParticipants()[0].User)
+			sessionID := tracker.GetSessionID()
 
 			// let's type "echo hi" followed by "enter" and then "exit" + "enter":
 			myTerm.Type("echo hi\n\rexit\n\r")
@@ -510,15 +493,15 @@ func testAuditOn(t *testing.T, suite *integrationTestSuite) {
 			for {
 				select {
 				case event := <-teleport.UploadEventsC:
-					if event.SessionID != tracker.GetSessionID() {
-						t.Logf("Skipping mismatching session %v, expecting upload of %v.", event.SessionID, tracker.GetSessionID())
+					if event.SessionID != sessionID {
+						t.Logf("Skipping mismatching session %v, expecting upload of %v.", event.SessionID, sessionID)
 						continue
 					}
 					break loop
 				case <-timeoutC:
 					dumpGoroutineProfile()
 					t.Fatalf("%s: Timeout waiting for upload of session %v to complete to %v",
-						tt.comment, tracker.GetSessionID(), tt.auditSessionsURI)
+						tt.comment, sessionID, tt.auditSessionsURI)
 				}
 			}
 
@@ -1618,15 +1601,9 @@ func verifySessionJoin(t *testing.T, username string, teleport *helpers.TeleInst
 	// PersonB: wait for a session to become available, then join:
 	sessionB := make(chan error)
 	joinSession := func() {
-		sessionTimeoutCtx, sessionTimeoutCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer sessionTimeoutCancel()
-		sessions, err := waitForSessionToBeEstablished(sessionTimeoutCtx, defaults.Namespace, site)
-		if err != nil {
-			sessionB <- trace.Wrap(err)
-			return
-		}
+		tracker := waitForSessionToBeEstablished(t, site, 1)
 
-		sessionID := sessions[0].GetSessionID()
+		sessionID := tracker.GetSessionID()
 		cl, err := teleport.NewClient(helpers.ClientConfig{
 			Login:   username,
 			Cluster: helpers.Site,
@@ -2036,12 +2013,9 @@ func testDisconnectScenarios(t *testing.T, suite *integrationTestSuite) {
 
 				}, 2*time.Second, 100*time.Millisecond)
 
-				timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-				defer cancel()
-
-				ss, err := waitForSessionToBeEstablished(timeoutCtx, defaults.Namespace, site)
-				require.NoError(t, err)
-				require.Len(t, ss, 1)
+				tracker := waitForSessionToBeEstablished(t, site, 1)
+				// make sure it's us who joined! :)
+				require.Equal(t, suite.Me.Username, tracker.GetParticipants()[0].User)
 				require.NoError(t, teleport.StopAuth(false))
 			},
 		},
@@ -4981,19 +4955,8 @@ func testAuditOff(t *testing.T, suite *integrationTestSuite) {
 		endCh <- err
 	}()
 
-	// wait until there's a session in there:
-	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	sessions, err = waitForSessionToBeEstablished(timeoutCtx, defaults.Namespace, site)
-	require.NoError(t, err)
-	tracker := sessions[0]
-
 	// wait for the user to join this session
-	for len(tracker.GetParticipants()) == 0 {
-		time.Sleep(time.Millisecond * 5)
-		tracker, err = site.GetSessionTracker(ctx, sessions[0].GetSessionID())
-		require.NoError(t, err)
-	}
+	tracker := waitForSessionToBeEstablished(t, site, 1)
 	// make sure it's us who joined! :)
 	require.Equal(t, suite.Me.Username, tracker.GetParticipants()[0].User)
 
@@ -5862,11 +5825,8 @@ func testWindowChange(t *testing.T, suite *integrationTestSuite) {
 	// joinSession will join the existing session on a server.
 	joinSession := func() {
 		// Find the existing session in the backend.
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		sessions, err := waitForSessionToBeEstablished(timeoutCtx, defaults.Namespace, site)
-		require.NoError(t, err)
-		sessionID := sessions[0].GetSessionID()
+		tracker := waitForSessionToBeEstablished(t, site, 1)
+		sessionID := tracker.GetSessionID()
 
 		cl, err := teleport.NewClient(helpers.ClientConfig{
 			Login:   suite.Me.Username,
@@ -9139,15 +9099,10 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 
 	// PersonB: wait for a session to become available, then join:
 	joinSession := func() {
-		sessionTimeoutCtx, sessionTimeoutCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer sessionTimeoutCancel()
-		sessions, err := waitForSessionToBeEstablished(sessionTimeoutCtx, defaults.Namespace, site)
-		if err != nil {
-			cancel(trace.Wrap(err, "failed waiting for peer session to be established"))
-			return
-		}
+		// Wait for the session initiator to have created and join the session.
+		tracker := waitForSessionToBeEstablished(t, site, 1)
 
-		sessionID := sessions[0].GetSessionID()
+		sessionID := tracker.GetSessionID()
 		cl, err := instance.NewClient(helpers.ClientConfig{
 			TeleportUser: "moderator",
 			Login:        suite.Me.Username,
@@ -9170,18 +9125,8 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 	go openSession()
 	go joinSession()
 
-	require.Eventually(t, func() bool {
-		ss, err := site.GetActiveSessionTrackers(ctx)
-		if err != nil {
-			return false
-		}
-
-		if len(ss) != 1 {
-			return false
-		}
-
-		return len(ss[0].GetParticipants()) == 2
-	}, 5*time.Second, 100*time.Millisecond)
+	// Wait for both parties to have joined the session before proceeding.
+	waitForSessionToBeEstablished(t, site, 2)
 
 	peerTerminal.Type("echo llamas\n\r")
 

--- a/integration/port_forwarding_test.go
+++ b/integration/port_forwarding_test.go
@@ -31,9 +31,9 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -56,44 +56,24 @@ func extractPort(svr *httptest.Server) (int, error) {
 	return n, nil
 }
 
-func waitForSessionToBeEstablished(ctx context.Context, namespace string, site authclient.ClientI) ([]types.SessionTracker, error) {
+// waitForSessionToBeEstablished waits for a session tracker to exist in the backend
+// with the provided number of participants present.
+func waitForSessionToBeEstablished(t *testing.T, clt authclient.ClientI, participants int) types.SessionTracker {
+	t.Helper()
+	ctx := t.Context()
 
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
+	var tracker types.SessionTracker
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		trackers, err := clt.GetActiveSessionTrackers(ctx)
+		require.NoError(t, err, "getting session trackers")
+		require.Len(t, trackers, 1, "no active sessions found")
 
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
+		require.Len(t, trackers[0].GetParticipants(), participants, "got %d participants, expected %d", len(trackers[0].GetParticipants()), participants)
 
-		case <-ticker.C:
-			ss, err := site.GetActiveSessionTrackers(ctx)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if len(ss) > 0 {
-				return ss, nil
-			}
-		}
-	}
-}
+		tracker = trackers[0]
+	}, 30*time.Second, 250*time.Millisecond)
 
-// testPingLocalServer checks whether or not an HTTP server is serving on
-// localhost at the given port.
-func testPingLocalServer(t *testing.T, port int, expectSuccess bool) {
-	addr := fmt.Sprintf("http://%s:%d/", "localhost", port)
-	r, err := http.Get(addr)
-
-	if r != nil {
-		r.Body.Close()
-	}
-
-	if expectSuccess {
-		require.NoError(t, err)
-		require.NotNil(t, r)
-	} else {
-		require.Error(t, err)
-	}
+	return tracker
 }
 
 func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
@@ -221,7 +201,8 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 				require.NoError(t, node.StopAll())
 			})
 
-			site := instance.GetSiteAPI(helpers.Site)
+			// Wait for the node to be present in the inventory.
+			instance.WaitForNodeCount(t.Context(), helpers.Site, 2)
 
 			// ...and a pair of running dummy servers
 			handler := http.HandlerFunc(
@@ -253,11 +234,15 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 
 			nodeSSHPort := helpers.Port(t, instance.SSH)
+			term := NewTerminal(250)
 			cl, err := instance.NewClient(helpers.ClientConfig{
 				Login:   tt.login,
 				Cluster: helpers.Site,
 				Host:    Host,
 				Port:    nodeSSHPort,
+				Stdout:  term,
+				Stdin:   term,
+				Labels:  tt.labels,
 			})
 			require.NoError(t, err)
 			cl.Config.LocalForwardPorts = []client.ForwardedPort{
@@ -276,26 +261,45 @@ func testPortForwarding(t *testing.T, suite *integrationTestSuite) {
 					DestPort: localServerPort,
 				},
 			}
-			term := NewTerminal(250)
-			cl.Stdout = term
-			cl.Stdin = term
-			cl.Labels = tt.labels
 
-			go cl.SSH(t.Context(), []string{})
+			// Create a session that is terminated when the context is canceled.
+			ctx, cancel := context.WithCancel(t.Context())
+			t.Cleanup(cancel)
+			go func() {
+				_ = cl.SSH(ctx, nil)
+			}()
 
-			timeout, cancel := context.WithTimeout(t.Context(), 15*time.Second)
-			defer cancel()
-			_, err = waitForSessionToBeEstablished(timeout, apidefaults.Namespace, site)
-			require.NoError(t, err)
+			cases := []struct {
+				name string
+				port int
+			}{
+				{
+					name: "local forwarding",
+					port: localClientPort,
+				},
+				{
+					name: "remote forwarding",
+					port: remoteClientPort,
+				},
+			}
+			for _, test := range cases {
+				t.Run(test.name, func(t *testing.T) {
+					require.EventuallyWithT(t, func(t *assert.CollectT) {
+						addr := fmt.Sprintf("http://localhost:%d/", test.port)
+						r, err := http.Get(addr)
+						if r != nil {
+							r.Body.Close()
+						}
 
-			// When everything is *finally* set up, and I attempt to use the
-			// forwarded connections
-			t.Run("local forwarding", func(t *testing.T) {
-				testPingLocalServer(t, localClientPort, tt.expectSuccess)
-			})
-			t.Run("remote forwarding", func(t *testing.T) {
-				testPingLocalServer(t, remoteClientPort, tt.expectSuccess)
-			})
+						if tt.expectSuccess {
+							require.NoError(t, err)
+							require.NotNil(t, r)
+						} else {
+							require.Error(t, err)
+						}
+					}, 20*time.Second, 250*time.Millisecond)
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
Several integration tests make use of the function to know that a session was created, a SessionTracker was created in the backend, and to retrieve the session id.

The function polled the backend for session trackers until the context deadline set in individual tests was exceeded. In an effort to reduce flakiness and make the API easier for callers the helper has been rewritten. It now leverages a require.Eventually internally, has a hardcoded limit of 30s instead of allowing each test to define their own, and validates the number of expected participants in a session.


Closes https://github.com/gravitational/teleport/issues/17224. 
Closes https://github.com/gravitational/teleport/issues/36959.