### PR TITLE
[v18] Fix Workload Identity templating not correctly handling uint values

### DIFF
--- a/lib/auth/machineid/workloadidentityv1/expression/proto.go
+++ b/lib/auth/machineid/workloadidentityv1/expression/proto.go
@@ -146,9 +146,9 @@ func protoMessageVariables[TMessage proto.Message, TEnv messageEnv[TMessage]](ze
 					}
 				})
 			case protoreflect.Uint32Kind, protoreflect.Uint64Kind:
-				vars[name] = typical.DynamicVariable(func(env TEnv) (uint64, error) {
+				vars[name] = typical.DynamicVariable(func(env TEnv) (uint, error) {
 					if v, err := get(env); err == nil {
-						return v.Uint(), nil
+						return uint(v.Uint()), nil
 					} else {
 						return 0, err
 					}

--- a/lib/auth/machineid/workloadidentityv1/expression/template.go
+++ b/lib/auth/machineid/workloadidentityv1/expression/template.go
@@ -135,8 +135,10 @@ func (t *Template) Render(env *Environment) (string, error) {
 				_, _ = b.WriteString(strconv.FormatBool(t))
 			case int:
 				_, _ = b.WriteString(strconv.Itoa(t))
+			case uint:
+				_, _ = b.WriteString(strconv.Itoa(int(t)))
 			default:
-				return "", trace.Errorf("expression did not evaluate to a string: %s", frag.text)
+				return "", trace.Errorf("expression did not evaluate to a string: %q, %T", frag.text, result)
 			}
 		}
 	}

--- a/lib/auth/machineid/workloadidentityv1/expression/template_test.go
+++ b/lib/auth/machineid/workloadidentityv1/expression/template_test.go
@@ -98,6 +98,28 @@ func TestTemplate_Success(t *testing.T) {
 			attrs:  &workloadidentityv1.Attrs{},
 			output: "1234",
 		},
+		"int interpolation": {
+			tmpl: `{{ workload.unix.pid }}`,
+			attrs: &workloadidentityv1.Attrs{
+				Workload: &workloadidentityv1.WorkloadAttrs{
+					Unix: &workloadidentityv1.WorkloadAttrsUnix{
+						Pid: 1337,
+					},
+				},
+			},
+			output: "1337",
+		},
+		"uint interpolation": {
+			tmpl: `{{ workload.unix.uid }}`,
+			attrs: &workloadidentityv1.Attrs{
+				Workload: &workloadidentityv1.WorkloadAttrs{
+					Unix: &workloadidentityv1.WorkloadAttrsUnix{
+						Uid: 1337,
+					},
+				},
+			},
+			output: "1337",
+		},
 		"user traits": {
 			tmpl: `{{user.traits.skill}}`,
 			attrs: &workloadidentityv1.Attrs{


### PR DESCRIPTION
Backport #61735 to branch/v18

changelog: Fixed workload identity templating to support certain numeric values that previously gave a "expression did not evaluate to a string" error.
