### PR TITLE
Refactor lib/srv/db/endpoints package

### DIFF
--- a/lib/healthcheck/net.go
+++ b/lib/healthcheck/net.go
@@ -28,8 +28,19 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+// Resolver resolves database endpoints.
+type Resolver interface {
+	// Resolve resolves database endpoints.
+	Resolve(ctx context.Context) ([]string, error)
+}
+
 // EndpointsResolverFunc is callback func that returns endpoints for a target.
 type EndpointsResolverFunc func(ctx context.Context) ([]string, error)
+
+// Resolve resolves database endpoints.
+func (f EndpointsResolverFunc) Resolve(ctx context.Context) ([]string, error) {
+	return f(ctx)
+}
 
 // dialFunc dials an address on the given network.
 type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)

--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -36,7 +36,6 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/cassandra/protocol"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -321,12 +320,4 @@ func (e *Engine) getAuth(sessionCtx *common.Session) (handshakeHandler, error) {
 
 func getEndpoint(db types.Database) string {
 	return db.GetURI()
-}
-
-// NewEndpointsResolver returns an endpoint resolver.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	uri := getEndpoint(db)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{uri}, nil
-	}), nil
 }

--- a/lib/srv/db/cassandra/healthcheck.go
+++ b/lib/srv/db/cassandra/healthcheck.go
@@ -1,0 +1,34 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cassandra
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker returns an endpoint health checker.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	uri := getEndpoint(cfg.Database)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{uri}, nil
+	}), nil
+}

--- a/lib/srv/db/clickhouse/engine_native.go
+++ b/lib/srv/db/clickhouse/engine_native.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -65,15 +64,4 @@ func getNativeEndpoint(db types.Database) (string, error) {
 		return "", trace.Wrap(err, "failed to parse database URI")
 	}
 	return u.Host, nil
-}
-
-// NewNativeEndpointsResolver resolves a ClickHouse native endpoint from DB URI.
-func NewNativeEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	endpoint, err := getNativeEndpoint(db)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{endpoint}, nil
-	}), nil
 }

--- a/lib/srv/db/clickhouse/healthcheck.go
+++ b/lib/srv/db/clickhouse/healthcheck.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package clickhouse
+
+import (
+	"cmp"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/net/http/httpproxy"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHTTPEndpointHealthChecker resolves a ClickHouse HTTP endpoint from DB URI.
+func NewHTTPEndpointHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	dbURL, err := getURL(cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Not all of our DB engines respect http proxy env vars, but this one does.
+	// The endpoint resolved for TCP health checks should be the one that the
+	// agent will actually connect to, since often proxy env vars are set to
+	// accommodate self-imposed network restrictions that force external traffic
+	// to go through a proxy.
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+	proxyURL, err := proxyFunc(dbURL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if proxyURL != nil {
+		dbURL = proxyURL
+	}
+	host := dbURL.Hostname()
+	port := cmp.Or(dbURL.Port(), "443")
+	hostPort := net.JoinHostPort(host, port)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{hostPort}, nil
+	}), nil
+}
+
+// NewNativeEndpointHealthChecker resolves a ClickHouse native endpoint from DB URI.
+func NewNativeEndpointHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	endpoint, err := getNativeEndpoint(cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{endpoint}, nil
+	}), nil
+}

--- a/lib/srv/db/dynamodb/healthcheck.go
+++ b/lib/srv/db/dynamodb/healthcheck.go
@@ -1,0 +1,79 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dynamodb
+
+import (
+	"cmp"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/net/http/httpproxy"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+	"github.com/gravitational/teleport/lib/utils/aws/dynamodbutils"
+)
+
+// NewHealthChecker resolves endpoints from DB URI.
+func NewHealthChecker(ctx context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	resolver, err := NewEndpointsResolver(ctx, cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return healthcheck.NewTargetDialer(resolver.Resolve), nil
+}
+
+// NewEndpointsResolver resolves endpoints from DB URI.
+func NewEndpointsResolver(_ context.Context, db types.Database) (healthcheck.Resolver, error) {
+	aws := db.GetAWS()
+	fips := dynamodbutils.IsFIPSEnabled()
+	resolverFns := []resolverFn{
+		resolveDynamoDBEndpoint,
+		resolveDynamoDBStreamsEndpoint,
+	}
+	return healthcheck.EndpointsResolverFunc(func(ctx context.Context) ([]string, error) {
+		addrs := make([]string, 0, len(resolverFns))
+		for _, resolve := range resolverFns {
+			re, err := resolve(ctx, aws.Region, aws.AccountID, fips)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			// Not all of our DB engines respect http proxy env vars, but this one does.
+			// The endpoint resolved for TCP health checks should be the one that the
+			// agent will actually connect to, since often proxy env vars are set to
+			// accommodate self-imposed network restrictions that force external traffic
+			// to go through a proxy.
+			proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+			proxyURL, err := proxyFunc(re.URL)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if proxyURL != nil {
+				re.URL = proxyURL
+			}
+			host := re.URL.Hostname()
+			port := cmp.Or(re.URL.Port(), "443")
+			addrs = append(addrs, net.JoinHostPort(host, port))
+		}
+		return addrs, nil
+	}), nil
+}

--- a/lib/srv/db/elasticsearch/engine.go
+++ b/lib/srv/db/elasticsearch/engine.go
@@ -21,7 +21,6 @@ package elasticsearch
 import (
 	"bufio"
 	"bytes"
-	"cmp"
 	"context"
 	"encoding/json"
 	"io"
@@ -35,13 +34,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -310,18 +307,4 @@ func parseURI(uri string) (*url.URL, error) {
 	// force HTTPS
 	u.Scheme = "https"
 	return u, nil
-}
-
-// NewEndpointsResolver resolves an endpoint from DB URI.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	dbURL, err := parseURI(db.GetURI())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	host := dbURL.Hostname()
-	port := cmp.Or(dbURL.Port(), "443")
-	hostPort := net.JoinHostPort(host, port)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{hostPort}, nil
-	}), nil
 }

--- a/lib/srv/db/elasticsearch/healthcheck.go
+++ b/lib/srv/db/elasticsearch/healthcheck.go
@@ -1,0 +1,44 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package elasticsearch
+
+import (
+	"cmp"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker resolves an endpoint from DB URI.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	dbURL, err := parseURI(cfg.Database.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	host := dbURL.Hostname()
+	port := cmp.Or(dbURL.Port(), "443")
+	hostPort := net.JoinHostPort(host, port)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{hostPort}, nil
+	}), nil
+}

--- a/lib/srv/db/endpoints/endpoints.go
+++ b/lib/srv/db/endpoints/endpoints.go
@@ -16,21 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// TODO(gavin): delete this package after updating e to not depend on it.
 package endpoints
 
 import (
 	"context"
-	"sync"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
-)
-
-var (
-	resolverBuilders   = make(map[string]ResolverBuilder)
-	resolverBuildersMu sync.RWMutex
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
 )
 
 // ResolverBuilder constructs a [Resolver].
@@ -66,50 +63,11 @@ type GCPClients interface {
 
 // RegisterResolver registers a new database endpoint resolver.
 func RegisterResolver(builder ResolverBuilder, names ...string) {
-	resolverBuildersMu.Lock()
-	defer resolverBuildersMu.Unlock()
-	for _, name := range names {
-		resolverBuilders[name] = builder
-	}
-}
-
-// GetResolverBuilders is used in tests to cleanup after overriding a resolver.
-func GetResolverBuilders(names ...string) (map[string]ResolverBuilder, error) {
-	resolverBuildersMu.RLock()
-	defer resolverBuildersMu.RUnlock()
-	out := map[string]ResolverBuilder{}
-	for _, name := range names {
-		builder, ok := resolverBuilders[name]
-		if !ok {
-			return nil, trace.NotFound("database endpoint resolver builder %q is not registered", name)
+	healthchecks.RegisterHealthChecker(func(ctx context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+		resolver, err := builder(ctx, cfg.Database, ResolverBuilderConfig{GCPClients: cfg.GCPClients})
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-		out[name] = builder
-	}
-	return out, nil
-}
-
-// GetResolver returns a resolver for the given database.
-func GetResolver(ctx context.Context, db types.Database, cfg ResolverBuilderConfig) (Resolver, error) {
-	name := db.GetProtocol()
-	resolverBuildersMu.RLock()
-	builder, ok := resolverBuilders[name]
-	resolverBuildersMu.RUnlock()
-	if !ok {
-		return nil, trace.NotFound("database endpoint resolver %q is not registered", name)
-	}
-
-	resolver, err := builder(ctx, db, cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return resolver, nil
-}
-
-// IsRegistered returns true if the given database protocol has been registered.
-func IsRegistered(db types.Database) bool {
-	name := db.GetProtocol()
-	resolverBuildersMu.RLock()
-	defer resolverBuildersMu.RUnlock()
-	_, ok := resolverBuilders[name]
-	return ok
+		return healthcheck.NewTargetDialer(resolver.Resolve), nil
+	}, names...)
 }

--- a/lib/srv/db/healthchecks/healthchecks.go
+++ b/lib/srv/db/healthchecks/healthchecks.go
@@ -1,0 +1,147 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package healthchecks
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+)
+
+var (
+	healthCheckerBuilders   = make(map[string]HealthCheckerBuilder)
+	healthCheckerBuildersMu sync.RWMutex
+)
+
+// RegisterHealthChecker registers a new database health checker.
+func RegisterHealthChecker(builder HealthCheckerBuilder, names ...string) {
+	healthCheckerBuildersMu.Lock()
+	defer healthCheckerBuildersMu.Unlock()
+	for _, name := range names {
+		healthCheckerBuilders[name] = builder
+	}
+}
+
+// GetHealthCheckBuilders is used in tests to cleanup after overriding a resolver.
+func GetHealthCheckBuilders(names ...string) (map[string]HealthCheckerBuilder, error) {
+	healthCheckerBuildersMu.RLock()
+	defer healthCheckerBuildersMu.RUnlock()
+	out := map[string]HealthCheckerBuilder{}
+	for _, name := range names {
+		builder, ok := healthCheckerBuilders[name]
+		if !ok {
+			return nil, trace.NotFound("database endpoint resolver builder %q is not registered", name)
+		}
+		out[name] = builder
+	}
+	return out, nil
+}
+
+// GetHealthChecker returns a health checker for the given database.
+func GetHealthChecker(ctx context.Context, cfg HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	name := cfg.Database.GetProtocol()
+	healthCheckerBuildersMu.RLock()
+	builder, ok := healthCheckerBuilders[name]
+	healthCheckerBuildersMu.RUnlock()
+	if !ok {
+		return nil, trace.NotFound("database endpoint resolver %q is not registered", name)
+	}
+
+	checker, err := builder(ctx, cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return checker, nil
+}
+
+// IsRegistered returns true if the given database protocol has been registered.
+func IsRegistered(db types.Database) bool {
+	name := db.GetProtocol()
+	healthCheckerBuildersMu.RLock()
+	defer healthCheckerBuildersMu.RUnlock()
+	_, ok := healthCheckerBuilders[name]
+	return ok
+}
+
+// HealthCheckerBuilder builds a database [healthcheck.HealthChecker].
+type HealthCheckerBuilder func(ctx context.Context, cfg HealthCheckerConfig) (healthcheck.HealthChecker, error)
+
+// HealthCheckerConfig is the config for a database [healthcheck.HealthChecker].
+type HealthCheckerConfig struct {
+	// Auth handles database access authentication.
+	Auth common.Auth
+	// AuthClient is the cluster auth server client.
+	AuthClient *authclient.Client
+	// Clock is an optional clock to use
+	Clock clockwork.Clock
+	// Database is the database to health check.
+	Database types.Database
+	// GCPClients are used to access GCP API for health checks.
+	GCPClients GCPClients
+	// Log is an optional logger.
+	Log *slog.Logger
+	// UpdateProxiedDatabase finds the proxied database by name and uses the
+	// provided function to update the database's status. Returns
+	// trace.NotFound if the name is not found otherwise forwards the error
+	// from the provided callback function.
+	UpdateProxiedDatabase func(string, func(types.Database) error) error
+}
+
+func (cfg *HealthCheckerConfig) checkAndSetDefaults() error {
+	switch {
+	case cfg.Auth == nil:
+		return trace.BadParameter("missing Auth")
+	case cfg.AuthClient == nil:
+		return trace.BadParameter("missing AuthClient")
+	case cfg.Database == nil:
+		return trace.BadParameter("missing Database")
+	case cfg.GCPClients == nil:
+		return trace.BadParameter("missing GCPClients")
+	case cfg.UpdateProxiedDatabase == nil:
+		return trace.BadParameter("missing UpdateProxiedDatabase")
+	}
+
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
+	}
+	if cfg.Log == nil {
+		cfg.Log = slog.Default()
+	}
+	return nil
+}
+
+// GCPClients are clients used to resolve GCP endpoints.
+type GCPClients interface {
+	// GetGCPSQLAdminClient returns GCP Cloud SQL Admin client.
+	GetGCPSQLAdminClient(context.Context) (gcp.SQLAdminClient, error)
+	// GetGCPAlloyDBClient returns GCP AlloyDB Admin client.
+	GetGCPAlloyDBClient(context.Context) (gcp.AlloyDBAdminClient, error)
+}

--- a/lib/srv/db/mongodb/connect.go
+++ b/lib/srv/db/mongodb/connect.go
@@ -41,7 +41,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/srv/db/mongodb/protocol"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
@@ -235,27 +234,6 @@ func makeClientOptionsFromDatabaseURI(uri string) (*options.ClientOptions, error
 		return nil, trace.Wrap(err)
 	}
 	return clientCfg, nil
-}
-
-// NewEndpointsResolver returns a health check target endpoint resolver.
-// SRV URI (mongodb+srv://) is resolved to a seed list from DNS SRV record
-// https://www.mongodb.com/docs/manual/reference/connection-string/#srv-connection-format
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	return newEndpointsResolver(db.GetURI()), nil
-}
-
-func newEndpointsResolver(uri string) endpoints.Resolver {
-	return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
-		clientCfg, err := makeClientOptionsFromDatabaseURI(uri)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		endpoints := make([]string, 0, len(clientCfg.Hosts))
-		for _, host := range clientCfg.Hosts {
-			endpoints = append(endpoints, address.Address(host).String())
-		}
-		return endpoints, nil
-	})
 }
 
 // getServerSelector returns selector for picking the server to connect to,

--- a/lib/srv/db/mongodb/healthcheck.go
+++ b/lib/srv/db/mongodb/healthcheck.go
@@ -1,0 +1,51 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mongodb
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"go.mongodb.org/mongo-driver/mongo/address"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker returns an endpoint health checker.
+// SRV URI (mongodb+srv://) is resolved to a seed list from DNS SRV record
+// https://www.mongodb.com/docs/manual/reference/connection-string/#srv-connection-format
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	resolver := newEndpointsResolver(cfg.Database.GetURI())
+	return healthcheck.NewTargetDialer(resolver.Resolve), nil
+}
+
+func newEndpointsResolver(uri string) healthcheck.EndpointsResolverFunc {
+	return func(ctx context.Context) ([]string, error) {
+		clientCfg, err := makeClientOptionsFromDatabaseURI(uri)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		endpoints := make([]string, 0, len(clientCfg.Hosts))
+		for _, host := range clientCfg.Hosts {
+			endpoints = append(endpoints, address.Address(host).String())
+		}
+		return endpoints, nil
+	}
+}

--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -277,7 +277,7 @@ func (e *Engine) setupDatabaseForAutoUsers(conn *clientConn, sessionCtx *common.
 	}
 
 	// If update is necessary, do a transaction.
-	e.Log.DebugContext(e.Context, "Updating stored procedures for MySQL server.", "database", sessionCtx.Database.GetName())
+	e.Log.DebugContext(e.Context, "Updating stored procedures for MySQL server.")
 	return trace.Wrap(doTransaction(conn, func() error {
 		for _, procedureName := range allProcedureNames {
 			dropCommand := fmt.Sprintf("DROP PROCEDURE IF EXISTS %s", procedureName)

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -30,16 +30,13 @@ import (
 	"github.com/go-mysql-org/go-mysql/mysql"
 	"github.com/go-mysql-org/go-mysql/server"
 	"github.com/gravitational/trace"
-	"golang.org/x/time/rate"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
 	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
@@ -558,54 +555,3 @@ const (
 	// gcpSQLProxyListenPort is the port used by Cloud Proxy for MySQL instances.
 	gcpSQLProxyListenPort = "3307"
 )
-
-// resolverClients are API clients needed to resolve MySQL endpoints.
-type resolverClients interface {
-	// GetGCPSQLAdminClient returns GCP Cloud SQL Admin client.
-	GetGCPSQLAdminClient(context.Context) (gcp.SQLAdminClient, error)
-}
-
-// NewEndpointsResolver returns a database target endpoint resolver.
-func NewEndpointsResolver(_ context.Context, db types.Database, cfg endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	return newEndpointsResolver(db, cfg.GCPClients)
-}
-
-func newEndpointsResolver(db types.Database, clients resolverClients) (endpoints.Resolver, error) {
-	switch {
-	case db.IsCloudSQL():
-		return newCloudSQLEndpointResolver(db, clients), nil
-	default:
-		return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
-			return []string{db.GetURI()}, nil
-		}), nil
-	}
-}
-
-func newCloudSQLEndpointResolver(db types.Database, clients resolverClients) endpoints.Resolver {
-	// avoid checking the ssl mode more than once every 15 minutes.
-	sometimes := rate.Sometimes{Interval: 15 * time.Minute}
-	var requireSSL bool
-	return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
-		var requireSSLErr error
-		sometimes.Do(func() {
-			clt, err := clients.GetGCPSQLAdminClient(ctx)
-			if err != nil {
-				requireSSLErr = trace.Wrap(err)
-				return
-			}
-
-			requireSSL, err = cloud.GetGCPRequireSSL(ctx, db, clt)
-			if err != nil && !trace.IsAccessDenied(err) {
-				requireSSLErr = trace.Wrap(err)
-				return
-			}
-		})
-		if requireSSLErr != nil {
-			return nil, trace.Wrap(requireSSLErr)
-		}
-		if requireSSL {
-			return []string{getGCPTLSAddress(db.GetURI())}, nil
-		}
-		return []string{db.GetURI()}, nil
-	})
-}

--- a/lib/srv/db/mysql/healthcheck.go
+++ b/lib/srv/db/mysql/healthcheck.go
@@ -1,0 +1,89 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysql
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/time/rate"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/cloud"
+	"github.com/gravitational/teleport/lib/srv/db/endpoints"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker creates a new MySQL endpoint health checker.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	resolver, err := newEndpointsResolver(cfg.Database, cfg.GCPClients)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return healthcheck.NewTargetDialer(resolver.Resolve), nil
+}
+
+// resolverClients are API clients needed to resolve MySQL endpoints.
+type resolverClients interface {
+	// GetGCPSQLAdminClient returns GCP Cloud SQL Admin client.
+	GetGCPSQLAdminClient(context.Context) (gcp.SQLAdminClient, error)
+}
+
+func newEndpointsResolver(db types.Database, clients resolverClients) (endpoints.Resolver, error) {
+	switch {
+	case db.IsCloudSQL():
+		return newCloudSQLEndpointResolver(db, clients), nil
+	default:
+		return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
+			return []string{db.GetURI()}, nil
+		}), nil
+	}
+}
+
+func newCloudSQLEndpointResolver(db types.Database, clients resolverClients) endpoints.Resolver {
+	// avoid checking the ssl mode more than once every 15 minutes.
+	sometimes := rate.Sometimes{Interval: 15 * time.Minute}
+	var requireSSL bool
+	return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
+		var requireSSLErr error
+		sometimes.Do(func() {
+			clt, err := clients.GetGCPSQLAdminClient(ctx)
+			if err != nil {
+				requireSSLErr = trace.Wrap(err)
+				return
+			}
+
+			requireSSL, err = cloud.GetGCPRequireSSL(ctx, db, clt)
+			if err != nil && !trace.IsAccessDenied(err) {
+				requireSSLErr = trace.Wrap(err)
+				return
+			}
+		})
+		if requireSSLErr != nil {
+			return nil, trace.Wrap(requireSSLErr)
+		}
+		if requireSSL {
+			return []string{getGCPTLSAddress(db.GetURI())}, nil
+		}
+		return []string{db.GetURI()}, nil
+	})
+}

--- a/lib/srv/db/opensearch/healthcheck.go
+++ b/lib/srv/db/opensearch/healthcheck.go
@@ -1,0 +1,60 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package opensearch
+
+import (
+	"cmp"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/net/http/httpproxy"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker resolves an endpoint from DB URI.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	dbURL, err := parseURI(cfg.Database.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Not all of our DB engines respect http proxy env vars, but this one does.
+	// The endpoint resolved for TCP health checks should be the one that the
+	// agent will actually connect to, since often proxy env vars are set to
+	// accommodate self-imposed network restrictions that force external traffic
+	// to go through a proxy.
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+	proxyURL, err := proxyFunc(dbURL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if proxyURL != nil {
+		dbURL = proxyURL
+	}
+	host := dbURL.Hostname()
+	port := cmp.Or(dbURL.Port(), "443")
+	hostPort := net.JoinHostPort(host, port)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{hostPort}, nil
+	}), nil
+}

--- a/lib/srv/db/postgres/connector.go
+++ b/lib/srv/db/postgres/connector.go
@@ -25,7 +25,6 @@ import (
 	"io"
 	"log/slog"
 	"net"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -41,7 +40,6 @@ import (
 	libcloud "github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
@@ -55,67 +53,6 @@ type connector struct {
 	databaseUser  string
 	databaseName  string
 	startupParams map[string]string
-}
-
-// NewEndpointsResolver returns a health check target endpoint resolver.
-func NewEndpointsResolver(_ context.Context, db types.Database, config endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	// special handling for AlloyDB
-	if db.GetType() == types.DatabaseTypeAlloyDB {
-		return newAlloyDBEndpointsResolver(db, config.GCPClients)
-	}
-
-	return newEndpointsResolver(db.GetURI())
-}
-
-func newAlloyDBEndpointsResolver(db types.Database, clients endpoints.GCPClients) (endpoints.Resolver, error) {
-	serverPort := strconv.Itoa(alloyDBServerProxyPort)
-
-	info, err := gcputils.ParseAlloyDBConnectionURI(db.GetURI())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if db.GetGCP().AlloyDB.EndpointOverride != "" {
-		addr := net.JoinHostPort(db.GetGCP().AlloyDB.EndpointOverride, serverPort)
-		return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-			return []string{addr}, nil
-		}), nil
-	}
-
-	resolveFun := endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
-		adminClient, err := clients.GetGCPAlloyDBClient(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		addr, err := adminClient.GetEndpointAddress(ctx, *info, db.GetGCP().AlloyDB.EndpointType)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return []string{net.JoinHostPort(addr, serverPort)}, nil
-	})
-
-	return resolveFun, nil
-}
-
-func newEndpointsResolver(uri string) (endpoints.Resolver, error) {
-	config, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%s", uri))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	addrs := make([]string, 0, len(config.Fallbacks)+1)
-	hostPort := net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port)))
-	addrs = append(addrs, hostPort)
-	for _, fb := range config.Fallbacks {
-		hostPort := net.JoinHostPort(fb.Host, strconv.Itoa(int(fb.Port)))
-		// pgconn duplicates the host/port in its fallbacks for some reason, so
-		// we de-duplicate and preserve the fallback order
-		if !slices.Contains(addrs, hostPort) {
-			addrs = append(addrs, hostPort)
-		}
-	}
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return addrs, nil
-	}), nil
 }
 
 // alloyDBServerProxyPort is the non-configurable port on which the AlloyDB server-side proxy is listening.

--- a/lib/srv/db/postgres/healthcheck.go
+++ b/lib/srv/db/postgres/healthcheck.go
@@ -1,0 +1,96 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"strconv"
+
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+
+	"github.com/gravitational/teleport/api/types"
+	gcputils "github.com/gravitational/teleport/api/utils/gcp"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker returns an endpoint health checker.
+func NewHealthChecker(_ context.Context, config healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	// special handling for AlloyDB
+	if config.Database.GetType() == types.DatabaseTypeAlloyDB {
+		return newAlloyDBEndpointsResolver(config.Database, config.GCPClients)
+	}
+
+	resolver, err := newEndpointsResolver(config.Database.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return healthcheck.NewTargetDialer(resolver.Resolve), nil
+}
+
+func newAlloyDBEndpointsResolver(db types.Database, clients healthchecks.GCPClients) (healthcheck.HealthChecker, error) {
+	serverPort := strconv.Itoa(alloyDBServerProxyPort)
+
+	info, err := gcputils.ParseAlloyDBConnectionURI(db.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if db.GetGCP().AlloyDB.EndpointOverride != "" {
+		addr := net.JoinHostPort(db.GetGCP().AlloyDB.EndpointOverride, serverPort)
+		return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+			return []string{addr}, nil
+		}), nil
+	}
+
+	return healthcheck.NewTargetDialer(func(ctx context.Context) ([]string, error) {
+		adminClient, err := clients.GetGCPAlloyDBClient(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		addr, err := adminClient.GetEndpointAddress(ctx, *info, db.GetGCP().AlloyDB.EndpointType)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return []string{net.JoinHostPort(addr, serverPort)}, nil
+	}), nil
+}
+
+func newEndpointsResolver(uri string) (healthcheck.EndpointsResolverFunc, error) {
+	config, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%s", uri))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	addrs := make([]string, 0, len(config.Fallbacks)+1)
+	hostPort := net.JoinHostPort(config.Host, strconv.Itoa(int(config.Port)))
+	addrs = append(addrs, hostPort)
+	for _, fb := range config.Fallbacks {
+		hostPort := net.JoinHostPort(fb.Host, strconv.Itoa(int(fb.Port)))
+		// pgconn duplicates the host/port in its fallbacks for some reason, so
+		// we de-duplicate and preserve the fallback order
+		if !slices.Contains(addrs, hostPort) {
+			addrs = append(addrs, hostPort)
+		}
+	}
+	return func(context.Context) ([]string, error) {
+		return addrs, nil
+	}, nil
+}

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -47,7 +47,6 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/iam"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/srv/db/redis/connection"
 	"github.com/gravitational/teleport/lib/srv/db/redis/protocol"
 	"github.com/gravitational/teleport/lib/utils"
@@ -662,16 +661,4 @@ func getConnectionOptions(db types.Database) (*connection.Options, error) {
 
 func getHostPort(connOpts *connection.Options) string {
 	return net.JoinHostPort(connOpts.Address, connOpts.Port)
-}
-
-// NewEndpointsResolver resolves an endpoint from DB URI.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	connOpts, err := getConnectionOptions(db)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	hostPort := getHostPort(connOpts)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{hostPort}, nil
-	}), nil
 }

--- a/lib/srv/db/redis/healthcheck.go
+++ b/lib/srv/db/redis/healthcheck.go
@@ -1,0 +1,40 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package redis
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker resolves an endpoint from DB URI.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	connOpts, err := getConnectionOptions(cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	hostPort := getHostPort(connOpts)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{hostPort}, nil
+	}), nil
+}

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -64,7 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/dynamodb"
 	"github.com/gravitational/teleport/lib/srv/db/elasticsearch"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
 	"github.com/gravitational/teleport/lib/srv/db/mongodb"
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
 	"github.com/gravitational/teleport/lib/srv/db/objects"
@@ -82,37 +82,36 @@ import (
 
 func init() {
 	common.RegisterEngine(cassandra.NewEngine, defaults.ProtocolCassandra)
+	common.RegisterEngine(clickhouse.NewEngine, defaults.ProtocolClickHouse)
+	common.RegisterEngine(clickhouse.NewEngine, defaults.ProtocolClickHouseHTTP)
+	common.RegisterEngine(dynamodb.NewEngine, defaults.ProtocolDynamoDB)
 	common.RegisterEngine(elasticsearch.NewEngine, defaults.ProtocolElasticsearch)
-	common.RegisterEngine(opensearch.NewEngine, defaults.ProtocolOpenSearch)
 	common.RegisterEngine(mongodb.NewEngine, defaults.ProtocolMongoDB)
 	common.RegisterEngine(mysql.NewEngine, defaults.ProtocolMySQL)
+	common.RegisterEngine(opensearch.NewEngine, defaults.ProtocolOpenSearch)
 	common.RegisterEngine(postgres.NewEngine, defaults.ProtocolPostgres, defaults.ProtocolCockroachDB)
 	common.RegisterEngine(redis.NewEngine, defaults.ProtocolRedis)
 	common.RegisterEngine(snowflake.NewEngine, defaults.ProtocolSnowflake)
-	common.RegisterEngine(sqlserver.NewEngine, defaults.ProtocolSQLServer)
-	common.RegisterEngine(dynamodb.NewEngine, defaults.ProtocolDynamoDB)
-	common.RegisterEngine(clickhouse.NewEngine, defaults.ProtocolClickHouse)
-	common.RegisterEngine(clickhouse.NewEngine, defaults.ProtocolClickHouseHTTP)
 	common.RegisterEngine(spanner.NewEngine, defaults.ProtocolSpanner)
+	common.RegisterEngine(sqlserver.NewEngine, defaults.ProtocolSQLServer)
 
 	objects.RegisterObjectFetcher(postgres.NewObjectFetcher, defaults.ProtocolPostgres)
 
-	endpoints.RegisterResolver(postgres.NewEndpointsResolver, defaults.ProtocolPostgres, defaults.ProtocolCockroachDB)
+	healthchecks.RegisterHealthChecker(cassandra.NewHealthChecker, defaults.ProtocolCassandra)
+	healthchecks.RegisterHealthChecker(clickhouse.NewHTTPEndpointHealthChecker, defaults.ProtocolClickHouseHTTP)
+	healthchecks.RegisterHealthChecker(clickhouse.NewNativeEndpointHealthChecker, defaults.ProtocolClickHouse)
+	healthchecks.RegisterHealthChecker(dynamodb.NewHealthChecker, defaults.ProtocolDynamoDB)
+	healthchecks.RegisterHealthChecker(elasticsearch.NewHealthChecker, defaults.ProtocolElasticsearch)
+	healthchecks.RegisterHealthChecker(mongodb.NewHealthChecker, defaults.ProtocolMongoDB)
 	if isMySQLHealthCheckEnabled() {
-		endpoints.RegisterResolver(mysql.NewEndpointsResolver, defaults.ProtocolMySQL)
+		healthchecks.RegisterHealthChecker(mysql.NewHealthChecker, defaults.ProtocolMySQL)
 	}
-	endpoints.RegisterResolver(mongodb.NewEndpointsResolver, defaults.ProtocolMongoDB)
-
-	endpoints.RegisterResolver(cassandra.NewEndpointsResolver, defaults.ProtocolCassandra)
-	endpoints.RegisterResolver(clickhouse.NewNativeEndpointsResolver, defaults.ProtocolClickHouse)
-	endpoints.RegisterResolver(clickhouse.NewHTTPEndpointsResolver, defaults.ProtocolClickHouseHTTP)
-	endpoints.RegisterResolver(dynamodb.NewEndpointsResolver, defaults.ProtocolDynamoDB)
-	endpoints.RegisterResolver(elasticsearch.NewEndpointsResolver, defaults.ProtocolElasticsearch)
-	endpoints.RegisterResolver(opensearch.NewEndpointsResolver, defaults.ProtocolOpenSearch)
-	endpoints.RegisterResolver(redis.NewEndpointsResolver, defaults.ProtocolRedis)
-	endpoints.RegisterResolver(snowflake.NewEndpointsResolver, defaults.ProtocolSnowflake)
-	endpoints.RegisterResolver(spanner.NewEndpointsResolver, defaults.ProtocolSpanner)
-	endpoints.RegisterResolver(sqlserver.NewEndpointsResolver, defaults.ProtocolSQLServer)
+	healthchecks.RegisterHealthChecker(opensearch.NewHealthChecker, defaults.ProtocolOpenSearch)
+	healthchecks.RegisterHealthChecker(postgres.NewHealthChecker, defaults.ProtocolPostgres, defaults.ProtocolCockroachDB)
+	healthchecks.RegisterHealthChecker(redis.NewHealthChecker, defaults.ProtocolRedis)
+	healthchecks.RegisterHealthChecker(snowflake.NewHealthChecker, defaults.ProtocolSnowflake)
+	healthchecks.RegisterHealthChecker(spanner.NewHealthChecker, defaults.ProtocolSpanner)
+	healthchecks.RegisterHealthChecker(sqlserver.NewHealthChecker, defaults.ProtocolSQLServer)
 }
 
 // isMySQLHealthCheckEnabled returns true if MySQL health checks are enabled.
@@ -528,7 +527,7 @@ func New(ctx context.Context, config Config) (*Server, error) {
 // startDatabase performs initialization actions for the provided database
 // such as starting dynamic labels and initializing CA certificate.
 func (s *Server) startDatabase(ctx context.Context, database types.Database) error {
-	if err := s.startHealthCheck(ctx, database); err != nil && endpoints.IsRegistered(database) {
+	if err := s.startHealthCheck(ctx, database); err != nil && healthchecks.IsRegistered(database) {
 		s.log.DebugContext(ctx, "Failed to start database health checker",
 			"db", database.GetName(),
 			"error", err,
@@ -748,6 +747,16 @@ func (s *Server) getProxiedDatabase(name string) (types.Database, error) {
 			name, s.proxiedDatabases)
 	}
 	return s.copyDatabaseWithUpdatedLabelsLocked(db), nil
+}
+
+func (s *Server) updateProxiedDatabase(name string, doUpdate func(types.Database) error) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	db, found := s.proxiedDatabases[name]
+	if !found {
+		return trace.NotFound("%q not found among registered databases", name)
+	}
+	return trace.Wrap(doUpdate(db))
 }
 
 // copyDatabaseWithUpdatedLabelsLocked will inject updated dynamic and cloud labels into
@@ -1339,15 +1348,7 @@ func (s *Server) createEngine(sessionCtx *common.Session, audit common.Audit) (c
 				Clock:      s.cfg.Clock,
 			}
 		},
-		UpdateProxiedDatabase: func(name string, doUpdate func(types.Database) error) error {
-			s.mu.Lock()
-			defer s.mu.Unlock()
-			db, found := s.proxiedDatabases[name]
-			if !found {
-				return trace.NotFound("%q not found among registered databases", name)
-			}
-			return trace.Wrap(doUpdate(db))
-		},
+		UpdateProxiedDatabase: s.updateProxiedDatabase,
 	})
 }
 
@@ -1482,12 +1483,12 @@ func (s *Server) trackSession(ctx context.Context, sessionCtx *common.Session) e
 
 // startHealthCheck starts health checks for the database.
 func (s *Server) startHealthCheck(ctx context.Context, db types.Database) error {
-	resolver, err := s.getEndpointsResolver(ctx, db)
+	checker, err := s.getHealthChecker(ctx, db)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	err = s.cfg.healthCheckManager.AddTarget(healthcheck.Target{
-		HealthChecker: healthcheck.NewTargetDialer(resolver),
+		HealthChecker: checker,
 		GetResource: func() types.ResourceWithLabels {
 			s.mu.RLock()
 			defer s.mu.RUnlock()
@@ -1541,22 +1542,32 @@ func (s *Server) getTargetHealth(ctx context.Context, db types.Database) types.T
 	}
 }
 
-// getEndpointsResolver gets a health check endpoint resolver for the database.
-func (s *Server) getEndpointsResolver(ctx context.Context, db types.Database) (healthcheck.EndpointsResolverFunc, error) {
-	resolver, err := endpoints.GetResolver(ctx, db, endpoints.ResolverBuilderConfig{
-		GCPClients: s.cfg.GCPClients,
+func (s *Server) getHealthChecker(ctx context.Context, db types.Database) (healthcheck.HealthChecker, error) {
+	if err := checkSupportsHealthChecks(db); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	s.mu.RLock()
+	db = s.copyDatabaseWithUpdatedLabelsLocked(db)
+	s.mu.RUnlock()
+	checker, err := healthchecks.GetHealthChecker(ctx, healthchecks.HealthCheckerConfig{
+		Auth:                  s.cfg.Auth,
+		AuthClient:            s.cfg.AuthClient,
+		Clock:                 s.cfg.Clock,
+		Database:              db,
+		GCPClients:            s.cfg.GCPClients,
+		Log:                   s.log,
+		UpdateProxiedDatabase: s.updateProxiedDatabase,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return resolver.Resolve, nil
+	return checker, nil
 }
 
 // checkSupportsHealthChecks returns nil if the database supports health checks.
-// TODO(gavin): add resolvers for all database protocols that we support, then
-// remove this helper.
 func checkSupportsHealthChecks(db types.Database) error {
-	if !endpoints.IsRegistered(db) {
+	if !healthchecks.IsRegistered(db) {
 		return trace.NotImplemented("endpoint health checks for database protocol %q are not supported", db.GetProtocol())
 	}
 	return nil

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -49,23 +49,24 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/healthcheck"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/dynamodb"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
 	"github.com/gravitational/teleport/lib/srv/db/snowflake"
 )
 
-func registerTestEndpointResolver(t *testing.T, builder endpoints.ResolverBuilder, names ...string) {
+func registerTestEndpointResolver(t *testing.T, builder healthchecks.HealthCheckerBuilder, names ...string) {
 	// prevent parallel tests from running with the modified endpoint resolver.
 	t.Setenv("registerTestEndpointResolver", "NO PARALLEL ALLOWED")
-	origBuilders, err := endpoints.GetResolverBuilders(names...)
+	origBuilders, err := healthchecks.GetHealthCheckBuilders(names...)
 	require.NoError(t, err, "trying to override a resolver that isn't registered")
-	endpoints.RegisterResolver(builder, names...)
+	healthchecks.RegisterHealthChecker(builder, names...)
 	t.Cleanup(func() {
 		for name, origBuilder := range origBuilders {
-			endpoints.RegisterResolver(origBuilder, name)
+			healthchecks.RegisterHealthChecker(origBuilder, name)
 		}
 	})
 }
@@ -705,10 +706,10 @@ func TestHealthCheck(t *testing.T) {
 	}
 	for _, db := range databases {
 		if db.GetProtocol() == defaults.ProtocolMySQL {
-			require.False(t, endpoints.IsRegistered(db), "health checks for MySQL protocol should be disabled")
+			require.False(t, healthchecks.IsRegistered(db), "health checks for MySQL protocol should be disabled")
 			continue
 		}
-		require.True(t, endpoints.IsRegistered(db), "database %v does not have a registered endpoint resolver", db.GetName())
+		require.True(t, healthchecks.IsRegistered(db), "database %v does not have a registered endpoint resolver", db.GetName())
 	}
 	dynamoListenAddr := net.JoinHostPort("localhost", testCtx.dynamodb["dynamodb"].db.Port())
 	dynamoResolver := &fakeEndpointResolver{
@@ -727,8 +728,8 @@ func TestHealthCheck(t *testing.T) {
 			testCtx.snowflake["snowflake"].resource.GetURI(): snowflakeListenAddr,
 		},
 	}
-	registerTestEndpointResolver(t, dynamoResolver.build, defaults.ProtocolDynamoDB)
-	registerTestEndpointResolver(t, snowflakeResolver.build, defaults.ProtocolSnowflake)
+	registerTestEndpointResolver(t, dynamoResolver.newHealthChecker, defaults.ProtocolDynamoDB)
+	registerTestEndpointResolver(t, snowflakeResolver.newHealthChecker, defaults.ProtocolSnowflake)
 
 	testCtx.server = testCtx.setupDatabaseServer(ctx, t, agentParams{
 		Databases: databases,
@@ -786,19 +787,19 @@ func newHealthCheckConfig(t *testing.T, name string) *healthcheckconfigv1.Health
 type fakeEndpointResolver struct {
 	t *testing.T
 	// builder is the builder that this fake resolver wraps.
-	builder endpoints.ResolverBuilder
+	builder func(ctx context.Context, db types.Database) (healthcheck.Resolver, error)
 	// rewrite is a map of host:port addresses to rewrite.
 	// The resolver asserts an error if an address is not found in this map.
 	rewrite map[string]string
 }
 
-func (f *fakeEndpointResolver) build(ctx context.Context, db types.Database, cfg endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
+func (f *fakeEndpointResolver) newHealthChecker(ctx context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
 	f.t.Helper()
-	resolver, err := f.builder(ctx, db, cfg)
+	resolver, err := f.builder(ctx, cfg.Database)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return endpoints.ResolverFn(func(ctx context.Context) ([]string, error) {
+	return healthcheck.NewTargetDialer(func(ctx context.Context) ([]string, error) {
 		f.t.Helper()
 		addrs, err := resolver.Resolve(ctx)
 		if err != nil {

--- a/lib/srv/db/snowflake/engine.go
+++ b/lib/srv/db/snowflake/engine.go
@@ -21,7 +21,6 @@ package snowflake
 import (
 	"bufio"
 	"bytes"
-	"cmp"
 	"compress/gzip"
 	"context"
 	"crypto/tls"
@@ -42,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -684,18 +682,4 @@ func parseURI(uri string) (*url.URL, error) {
 	}
 	snowflakeURL, err := url.Parse(uri)
 	return snowflakeURL, trace.Wrap(err)
-}
-
-// NewEndpointsResolver resolves an endpoint from DB URI.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	dbURL, err := parseURI(db.GetURI())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	host := dbURL.Hostname()
-	port := cmp.Or(dbURL.Port(), "443")
-	hostPort := net.JoinHostPort(host, port)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{hostPort}, nil
-	}), nil
 }

--- a/lib/srv/db/snowflake/healthcheck.go
+++ b/lib/srv/db/snowflake/healthcheck.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package snowflake
+
+import (
+	"cmp"
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewEndpointsResolver resolves an endpoint from DB URI.
+func NewEndpointsResolver(_ context.Context, db types.Database) (healthcheck.Resolver, error) {
+	dbURL, err := parseURI(db.GetURI())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	host := dbURL.Hostname()
+	port := cmp.Or(dbURL.Port(), "443")
+	hostPort := net.JoinHostPort(host, port)
+	return healthcheck.EndpointsResolverFunc(func(context.Context) ([]string, error) {
+		return []string{hostPort}, nil
+	}), nil
+}
+
+// NewHealthChecker resolves an endpoint from DB URI.
+func NewHealthChecker(ctx context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	resolver, err := NewEndpointsResolver(ctx, cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return healthcheck.NewTargetDialer(resolver.Resolve), nil
+}

--- a/lib/srv/db/spanner/grpcserver.go
+++ b/lib/srv/db/spanner/grpcserver.go
@@ -41,7 +41,6 @@ import (
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 )
 
 type upstream[T any] interface {
@@ -523,12 +522,4 @@ func (s *messageStatsHandler) HandleConn(_ context.Context, _ stats.ConnStats) {
 // resolver logic.
 func getEndpoint(db types.Database) string {
 	return db.GetURI()
-}
-
-// NewEndpointsResolver returns an endpoint resolver.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	uri := getEndpoint(db)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{uri}, nil
-	}), nil
 }

--- a/lib/srv/db/spanner/healthcheck.go
+++ b/lib/srv/db/spanner/healthcheck.go
@@ -1,0 +1,34 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package spanner
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker returns an endpoint health checker.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	uri := getEndpoint(cfg.Database)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{uri}, nil
+	}), nil
+}

--- a/lib/srv/db/sqlserver/connect.go
+++ b/lib/srv/db/sqlserver/connect.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/kerberos"
-	"github.com/gravitational/teleport/lib/srv/db/endpoints"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver/protocol"
 )
 
@@ -175,16 +174,4 @@ func getHostPort(db types.Database) (string, string, error) {
 		return "", "", trace.Wrap(err, "failed to parse database URI")
 	}
 	return host, port, nil
-}
-
-// NewEndpointsResolver returns an endpoint resolver.
-func NewEndpointsResolver(_ context.Context, db types.Database, _ endpoints.ResolverBuilderConfig) (endpoints.Resolver, error) {
-	host, port, err := getHostPort(db)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	addr := net.JoinHostPort(host, port)
-	return endpoints.ResolverFn(func(context.Context) ([]string, error) {
-		return []string{addr}, nil
-	}), nil
 }

--- a/lib/srv/db/sqlserver/healthcheck.go
+++ b/lib/srv/db/sqlserver/healthcheck.go
@@ -1,0 +1,41 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package sqlserver
+
+import (
+	"context"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/srv/db/healthchecks"
+)
+
+// NewHealthChecker returns an endpoint health checker.
+func NewHealthChecker(_ context.Context, cfg healthchecks.HealthCheckerConfig) (healthcheck.HealthChecker, error) {
+	host, port, err := getHostPort(cfg.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	addr := net.JoinHostPort(host, port)
+	return healthcheck.NewTargetDialer(func(context.Context) ([]string, error) {
+		return []string{addr}, nil
+	}), nil
+}


### PR DESCRIPTION
The endpoints package couples database health checkers together. This refactor is to register health checkers instead of endpoint resolvers, to decouple the database health checkers from each other.

Related issue:
- https://github.com/gravitational/teleport/issues/58118 

This refactor is part of the fix for that.
This was also split out of the fix PR because it was doing too many things:
- https://github.com/gravitational/teleport/pull/61409

The only major difference after splitting it out into a separate PR is that I moved each engine's health check function into its own healthcheck.go file.

Backporting because the health check fix needs to be backported and it depends on these changes.