### PR TITLE
Refactor mysql package

### DIFF
--- a/lib/srv/db/mysql/autousers.go
+++ b/lib/srv/db/mysql/autousers.go
@@ -147,7 +147,7 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 
 	// Use "tp-<hash>" in case DatabaseUser is over max username length.
 	sessionCtx.DatabaseUser = maybeHashUsername(sessionCtx.DatabaseUser, conn.maxUsernameLength())
-	e.Log.InfoContext(e.Context, "Activating MySQL user.", "user", sessionCtx.DatabaseUser, "roles", sessionCtx.DatabaseRoles, "identity", sessionCtx.Identity.Username)
+	e.Log.InfoContext(e.Context, "Activating MySQL user", "user", sessionCtx.DatabaseUser, "roles", sessionCtx.DatabaseRoles, "identity", sessionCtx.Identity.Username)
 
 	// Prep JSON.
 	details, err := makeActivateUserDetails(sessionCtx, sessionCtx.Identity.Username)
@@ -162,7 +162,7 @@ func (e *Engine) ActivateUser(ctx context.Context, sessionCtx *common.Session) e
 		details,
 	)
 	if err != nil {
-		e.Log.DebugContext(e.Context, "Call teleport_activate_user failed.", "error", err)
+		e.Log.DebugContext(e.Context, "Call teleport_activate_user failed", "error", err)
 		err = convertActivateError(sessionCtx, err)
 		e.Audit.OnDatabaseUserCreate(ctx, sessionCtx, err)
 		return trace.Wrap(err)
@@ -183,7 +183,7 @@ func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session)
 	}
 	defer conn.Close()
 
-	e.Log.InfoContext(e.Context, "Deactivating MySQL user.", "user", sessionCtx.DatabaseUser, "identity", sessionCtx.Identity.Username)
+	e.Log.InfoContext(e.Context, "Deactivating MySQL user", "user", sessionCtx.DatabaseUser, "identity", sessionCtx.Identity.Username)
 
 	err = conn.executeAndCloseResult(
 		fmt.Sprintf("CALL %s(?)", deactivateUserProcedureName),
@@ -191,7 +191,7 @@ func (e *Engine) DeactivateUser(ctx context.Context, sessionCtx *common.Session)
 	)
 
 	if getSQLState(err) == common.SQLStateActiveUser {
-		e.Log.DebugContext(e.Context, "Failed to deactivate user.", "user", sessionCtx.DatabaseUser, "error", err)
+		e.Log.DebugContext(e.Context, "Failed to deactivate user", "user", sessionCtx.DatabaseUser, "error", err)
 		return nil
 	}
 
@@ -211,12 +211,12 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 	}
 	defer conn.Close()
 
-	e.Log.InfoContext(e.Context, "Deleting MySQL user.", "database_user", sessionCtx.DatabaseUser, "identity", sessionCtx.Identity.Username)
+	e.Log.InfoContext(e.Context, "Deleting MySQL user", "database_user", sessionCtx.DatabaseUser, "identity", sessionCtx.Identity.Username)
 
 	result, err := conn.Execute(fmt.Sprintf("CALL %s(?)", deleteUserProcedureName), sessionCtx.DatabaseUser)
 	if err != nil {
 		if getSQLState(err) == common.SQLStateActiveUser {
-			e.Log.DebugContext(e.Context, "Failed to delete user.", "user", sessionCtx.DatabaseUser, "error", err)
+			e.Log.DebugContext(e.Context, "Failed to delete user", "user", sessionCtx.DatabaseUser, "error", err)
 			return nil
 		}
 
@@ -228,12 +228,12 @@ func (e *Engine) DeleteUser(ctx context.Context, sessionCtx *common.Session) err
 	deleted := true
 	switch readDeleteUserResult(result) {
 	case common.SQLStateUserDropped:
-		e.Log.DebugContext(e.Context, "User deleted successfully.", "user", sessionCtx.DatabaseUser)
+		e.Log.DebugContext(e.Context, "User deleted successfully", "user", sessionCtx.DatabaseUser)
 	case common.SQLStateUserDeactivated:
-		e.Log.InfoContext(e.Context, "Unable to delete user, it was disabled instead.", "user", sessionCtx.DatabaseUser)
+		e.Log.InfoContext(e.Context, "Unable to delete user, it was disabled instead", "user", sessionCtx.DatabaseUser)
 		deleted = false
 	default:
-		e.Log.WarnContext(e.Context, "Unable to determine user deletion state.", "user", sessionCtx.DatabaseUser)
+		e.Log.WarnContext(e.Context, "Unable to determine user deletion state", "user", sessionCtx.DatabaseUser)
 	}
 	e.Audit.OnDatabaseUserDeactivate(ctx, sessionCtx, deleted, nil)
 
@@ -277,7 +277,7 @@ func (e *Engine) setupDatabaseForAutoUsers(conn *clientConn, sessionCtx *common.
 	}
 
 	// If update is necessary, do a transaction.
-	e.Log.DebugContext(e.Context, "Updating stored procedures for MySQL server.")
+	e.Log.DebugContext(e.Context, "Updating stored procedures for MySQL server")
 	return trace.Wrap(doTransaction(conn, func() error {
 		for _, procedureName := range allProcedureNames {
 			dropCommand := fmt.Sprintf("DROP PROCEDURE IF EXISTS %s", procedureName)
@@ -376,7 +376,7 @@ func checkMySQLSupportedVersion(ctx context.Context, log *slog.Logger, serverVer
 	ver, err := semver.NewVersion(serverVersion)
 	switch {
 	case err != nil:
-		log.DebugContext(ctx, "Invalid MySQL server version. Assuming role management is supported.", "server_version", serverVersion)
+		log.DebugContext(ctx, "Invalid MySQL server version. Assuming role management is supported", "server_version", serverVersion)
 		return nil
 
 	// Reference:
@@ -406,7 +406,7 @@ func checkMariaDBSupportedVersion(ctx context.Context, log *slog.Logger, serverV
 	ver, err := semver.NewVersion(serverVersion)
 	switch {
 	case err != nil:
-		log.DebugContext(ctx, "Invalid MariaDB server version. Assuming role management is supported.", "server_version", serverVersion)
+		log.DebugContext(ctx, "Invalid MariaDB server version. Assuming role management is supported", "server_version", serverVersion)
 		return nil
 
 	case ver.Major > 10:

--- a/lib/srv/db/mysql/connector.go
+++ b/lib/srv/db/mysql/connector.go
@@ -1,0 +1,217 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mysql
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/go-mysql-org/go-mysql/client"
+	"github.com/go-mysql-org/go-mysql/mysql"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/time/rate"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
+)
+
+func newConnector(cfg connectorConfig) (*connector, error) {
+	if err := cfg.checkAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &connector{
+		connectorConfig: cfg,
+		gcpAuth: &gcpAuth{
+			auth:         cfg.auth,
+			authClient:   cfg.authClient,
+			clients:      cfg.gcpClients,
+			clock:        cfg.clock,
+			database:     cfg.database,
+			databaseUser: cfg.databaseUser,
+			log:          cfg.log,
+			// avoid checking the ssl mode more than once every 30 minutes
+			sometimes: &rate.Sometimes{Interval: 30 * time.Minute},
+		},
+	}, nil
+}
+
+type connectorConfig struct {
+	auth       common.Auth
+	authClient *authclient.Client
+	clock      clockwork.Clock
+	gcpClients gcpClients
+	log        *slog.Logger
+
+	database     types.Database
+	databaseName string
+	databaseUser string
+}
+
+func (cfg *connectorConfig) checkAndSetDefaults() error {
+	if cfg.auth == nil {
+		return trace.BadParameter("missing auth")
+	}
+	if cfg.authClient == nil {
+		return trace.BadParameter("missing authClient")
+	}
+	if cfg.gcpClients == nil {
+		return trace.BadParameter("missing gcpClients")
+	}
+	if cfg.database == nil {
+		return trace.BadParameter("missing database")
+	}
+	if cfg.databaseUser == "" {
+		return trace.BadParameter("missing databaseUser")
+	}
+
+	if cfg.clock == nil {
+		cfg.clock = clockwork.NewRealClock()
+	}
+	if cfg.log == nil {
+		cfg.log = slog.Default()
+	}
+	return nil
+}
+
+// connector connects to MySQL databases.
+type connector struct {
+	connectorConfig
+
+	gcpAuth *gcpAuth
+}
+
+// connect establishes connection to MySQL database.
+func (c *connector) connect(ctx context.Context, certExpiry time.Time) (*client.Conn, error) {
+	tlsConfig, err := c.auth.GetTLSConfig(ctx, certExpiry, c.database, c.databaseUser)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	user := c.databaseUser
+	connectOpt := func(conn *client.Conn) error {
+		conn.SetTLSConfig(tlsConfig)
+		return nil
+	}
+
+	var dialer client.Dialer
+	var password string
+	switch {
+	case c.database.IsRDS(), c.database.IsRDSProxy():
+		password, err = c.auth.GetRDSAuthToken(ctx, c.database, c.databaseUser)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	case c.database.IsCloudSQL():
+		user, password, err = c.gcpAuth.getGCPUserAndPassword(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		requireSSL, err := c.gcpAuth.checkSSLRequired(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Create ephemeral certificate and append to TLS config when
+		// the instance requires SSL. Also use a TLS dialer instead of
+		// the default net dialer when GCP requires SSL.
+		if requireSSL {
+			if err := c.gcpAuth.appendGCPClientCert(ctx, certExpiry, tlsConfig); err != nil {
+				return nil, trace.Wrap(err)
+			}
+			connectOpt = func(*client.Conn) error {
+				return nil
+			}
+			dialer = newGCPTLSDialer(tlsConfig)
+		}
+	case c.database.IsAzure():
+		password, err = c.auth.GetAzureAccessToken(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		user = discoverycommon.MakeAzureDatabaseLoginUsername(c.database, user)
+	}
+
+	// Use default net dialer unless it is already initialized.
+	if dialer == nil {
+		var nd net.Dialer
+		dialer = nd.DialContext
+	}
+
+	c.log.DebugContext(ctx, "Connecting to database")
+	// TODO(r0mant): Set CLIENT_INTERACTIVE flag on the client?
+	conn, err := client.ConnectWithDialer(ctx, "tcp", c.database.GetURI(),
+		user,
+		password,
+		c.databaseName,
+		func(ctx context.Context, network, address string) (net.Conn, error) {
+			conn, err := dialer(ctx, network, address)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return conn, nil
+		},
+		connectOpt,
+		// client-set capabilities only.
+		// TODO(smallinsky) Forward "real" capabilities from mysql client to mysql server.
+		withClientCapabilities(
+			mysql.CLIENT_MULTI_RESULTS,
+			mysql.CLIENT_MULTI_STATEMENTS,
+		),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return conn, nil
+}
+
+// updateServerVersion updates the server runtime version if the version
+// reported by the database is different from the version in status
+// configuration.
+func updateServerVersion(
+	ctx context.Context,
+	log *slog.Logger,
+	db types.Database,
+	serverVersion string,
+	updateProxiedDatabase func(string, func(types.Database) error) error,
+) error {
+	statusVersion := db.GetMySQLServerVersion()
+
+	// Update only when needed.
+	if serverVersion == "" || serverVersion == statusVersion {
+		return nil
+	}
+
+	// Note that db may be a copy of the database cached by database service.
+	// Call updateProxiedDatabase to update the original as well.
+	db.SetMySQLServerVersion(serverVersion)
+	doUpdate := func(db types.Database) error {
+		db.SetMySQLServerVersion(serverVersion)
+		return nil
+	}
+
+	log.DebugContext(ctx, "Updated MySQL server version",
+		"old_version", statusVersion,
+		"version", serverVersion,
+	)
+	return trace.Wrap(updateProxiedDatabase(db.GetName(), doUpdate))
+}

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -21,10 +21,8 @@ package mysql
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"io"
 	"net"
-	"time"
 
 	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/go-mysql-org/go-mysql/mysql"
@@ -32,13 +30,9 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/retryutils"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/common/role"
 	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
-	discoverycommon "github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -85,7 +79,7 @@ func makeProxyConn(clientConn net.Conn) *server.Conn {
 // SendError sends an error to connected client in the MySQL understandable format.
 func (e *Engine) SendError(err error) {
 	if writeErr := e.proxyConn.WriteError(trace.Unwrap(err)); writeErr != nil {
-		e.Log.DebugContext(e.Context, "Failed to send error to MySQL client.", "client_error", err, "write_error", writeErr)
+		e.Log.DebugContext(e.Context, "Failed to send error to MySQL client", "client_error", err, "write_error", writeErr)
 	}
 }
 
@@ -112,7 +106,7 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	defer func() {
 		err := e.GetUserProvisioner(e).Teardown(ctx, sessionCtx)
 		if err != nil {
-			e.Log.ErrorContext(e.Context, "Failed to teardown the user.", "error", err)
+			e.Log.ErrorContext(e.Context, "Failed to teardown the user", "error", err)
 		}
 	}()
 
@@ -128,7 +122,7 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	defer func() {
 		err := serverConn.Quit()
 		if err != nil {
-			e.Log.ErrorContext(ctx, "Failed to close connection to MySQL server.", "error", err)
+			e.Log.ErrorContext(ctx, "Failed to close connection to MySQL server", "error", err)
 		}
 	}()
 
@@ -137,11 +131,7 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 
 	// Internally, updateServerVersion() updates databases only when database version
 	// is not set, or it has changed since previous call.
-	if err := e.updateServerVersion(sessionCtx, serverConn); err != nil {
-		// Log but do not fail connection if the version update fails.
-		e.Log.WarnContext(ctx, "Failed to update the MySQL server version.", "error", err)
-
-	}
+	e.updateServerVersion(ctx, sessionCtx.Database, serverConn)
 
 	// notify proxy of auth/connect success. At this point the original client
 	// should consider the connection phase completed.
@@ -170,40 +160,24 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	go e.receiveFromServer(serverConn, e.proxyConn.Conn, serverErrCh, sessionCtx)
 	select {
 	case err := <-clientErrCh:
-		e.Log.DebugContext(e.Context, "Client done.", "error", err)
+		e.Log.DebugContext(e.Context, "Client done", "error", err)
 	case err := <-serverErrCh:
-		e.Log.DebugContext(e.Context, "Server done.", "error", err)
+		e.Log.DebugContext(e.Context, "Server done", "error", err)
 	case <-ctx.Done():
-		e.Log.DebugContext(e.Context, "Context canceled.")
+		e.Log.DebugContext(e.Context, "Context canceled")
 	}
 	return nil
 }
 
-// updateServerVersion updates the server runtime version if the version reported by the database is different from
-// the version in status configuration.
-func (e *Engine) updateServerVersion(sessionCtx *common.Session, serverConn *client.Conn) error {
-	serverVersion := serverConn.GetServerVersion()
-	statusVersion := sessionCtx.Database.GetMySQLServerVersion()
-
-	// Update only when needed.
-	if serverVersion == "" || serverVersion == statusVersion {
-		return nil
+// updateServerVersion updates the server runtime version if the version
+// reported by the database is different from the version in status
+// configuration.
+func (e *Engine) updateServerVersion(ctx context.Context, db types.Database, serverConn *client.Conn) {
+	err := updateServerVersion(ctx, e.Log, db, serverConn.GetServerVersion(), e.UpdateProxiedDatabase)
+	if err != nil {
+		// Log but do not fail connection if the version update fails.
+		e.Log.WarnContext(ctx, "Failed to update the MySQL server version", "error", err)
 	}
-
-	// Note that sessionCtx.Database is a copy of the database cached by
-	// database service. Call e.UpdateProxiedDatabase to do the update instead of
-	// setting the copy.
-	doUpdate := func(db types.Database) error {
-		db.SetMySQLServerVersion(serverVersion)
-		return nil
-	}
-
-	if err := e.UpdateProxiedDatabase(sessionCtx.Database.GetName(), doUpdate); err != nil {
-		return trace.Wrap(err)
-	}
-
-	e.Log.DebugContext(e.Context, "Updated MySQL server version.", "version", serverVersion)
-	return nil
 }
 
 // checkAccess does authorization check for MySQL connection about to be established.
@@ -238,93 +212,29 @@ func (e *Engine) checkAccess(ctx context.Context, sessionCtx *common.Session) er
 
 // connect establishes connection to MySQL database.
 func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*client.Conn, error) {
-	tlsConfig, err := e.Auth.GetTLSConfig(ctx, sessionCtx.GetExpiry(), sessionCtx.Database, sessionCtx.DatabaseUser)
+	connector, err := e.newConnector(sessionCtx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	user := sessionCtx.DatabaseUser
-	connectOpt := func(conn *client.Conn) error {
-		conn.SetTLSConfig(tlsConfig)
-		return nil
-	}
-
-	var dialer client.Dialer
-	var password string
-	switch {
-	case sessionCtx.Database.IsRDS(), sessionCtx.Database.IsRDSProxy():
-		password, err = e.Auth.GetRDSAuthToken(ctx, sessionCtx.Database, sessionCtx.DatabaseUser)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	case sessionCtx.Database.IsCloudSQL():
-		// Get the client once for subsequent calls (it acquires a read lock).
-		gcpClient, err := e.GCPClients.GetSQLAdminClient(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		user, password, err = e.getGCPUserAndPassword(ctx, sessionCtx, gcpClient)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		// Detect whether the instance is set to require SSL.
-		// Fallback to not requiring SSL for access denied errors.
-		requireSSL, err := cloud.GetGCPRequireSSL(ctx, sessionCtx.Database, gcpClient)
-		if err != nil && !trace.IsAccessDenied(err) {
-			return nil, trace.Wrap(err)
-		}
-		// Create ephemeral certificate and append to TLS config when
-		// the instance requires SSL. Also use a TLS dialer instead of
-		// the default net dialer when GCP requires SSL.
-		if requireSSL {
-			err = cloud.AppendGCPClientCert(ctx, &cloud.AppendGCPClientCertRequest{
-				GCPClient:   gcpClient,
-				GenerateKey: e.Auth.GenerateDatabaseClientKey,
-				Expiry:      sessionCtx.GetExpiry(),
-				Database:    sessionCtx.Database,
-				TLSConfig:   tlsConfig,
-			})
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			connectOpt = func(*client.Conn) error {
-				return nil
-			}
-			dialer = newGCPTLSDialer(tlsConfig)
-		}
-	case sessionCtx.Database.IsAzure():
-		password, err = e.Auth.GetAzureAccessToken(ctx)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		user = discoverycommon.MakeAzureDatabaseLoginUsername(sessionCtx.Database, user)
-	}
-
-	// Use default net dialer unless it is already initialized.
-	if dialer == nil {
-		var nd net.Dialer
-		dialer = nd.DialContext
-	}
-
-	// TODO(r0mant): Set CLIENT_INTERACTIVE flag on the client?
-	conn, err := client.ConnectWithDialer(ctx, "tcp", sessionCtx.Database.GetURI(),
-		user,
-		password,
-		sessionCtx.DatabaseName,
-		dialer,
-		connectOpt,
-		// client-set capabilities only.
-		// TODO(smallinsky) Forward "real" capabilities from mysql client to mysql server.
-		withClientCapabilities(
-			mysql.CLIENT_MULTI_RESULTS,
-			mysql.CLIENT_MULTI_STATEMENTS,
-		),
-	)
+	conn, err := connector.connect(ctx, sessionCtx.GetExpiry())
 	if err != nil {
 		return nil, common.ConvertConnectError(err, sessionCtx)
 	}
 	return conn, nil
+}
+
+func (e *Engine) newConnector(sessionCtx *common.Session) (*connector, error) {
+	return newConnector(connectorConfig{
+		auth:       e.Auth,
+		authClient: e.AuthClient,
+		clock:      e.Clock,
+		gcpClients: e.GCPClients,
+		log:        e.Log,
+
+		database:     sessionCtx.Database,
+		databaseName: sessionCtx.DatabaseName,
+		databaseUser: sessionCtx.DatabaseUser,
+	})
 }
 
 func withClientCapabilities(caps ...uint32) func(conn *client.Conn) error {
@@ -345,7 +255,7 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 		"server", serverConn.RemoteAddr(),
 	)
 	defer func() {
-		log.DebugContext(e.Context, "Stop receiving from client.")
+		log.DebugContext(e.Context, "Stop receiving from client")
 		close(clientErrCh)
 	}()
 
@@ -355,10 +265,10 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 		packet, err := protocol.ParsePacket(clientConn)
 		if err != nil {
 			if utils.IsOKNetworkError(err) {
-				log.DebugContext(e.Context, "Client connection closed.")
+				log.DebugContext(e.Context, "Client connection closed")
 				return
 			}
-			log.ErrorContext(e.Context, "Failed to read client packet.", "error", err)
+			log.ErrorContext(e.Context, "Failed to read client packet", "error", err)
 			clientErrCh <- err
 			return
 		}
@@ -377,7 +287,7 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 			// We do not want to allow changing the connection user and instead
 			// force users to go through normal reconnect flow so log the
 			// attempt and close the client connection.
-			log.WarnContext(e.Context, "Rejecting attempt to change user.", "user", pkt.User(), "session", sessionCtx)
+			log.WarnContext(e.Context, "Rejecting attempt to change user", "user", pkt.User(), "session", sessionCtx)
 			return
 		case *protocol.Quit:
 			return
@@ -427,7 +337,7 @@ func (e *Engine) receiveFromClient(clientConn, serverConn net.Conn, clientErrCh 
 		}
 		_, err = protocol.WritePacket(packet.Bytes(), serverConn)
 		if err != nil {
-			log.ErrorContext(e.Context, "Failed to write server packet.", "error", err)
+			log.ErrorContext(e.Context, "Failed to write server packet", "error", err)
 			clientErrCh <- err
 			return
 		}
@@ -454,7 +364,7 @@ func (e *Engine) receiveFromServer(serverConn, clientConn net.Conn, serverErrCh 
 
 		var count int64
 		defer func() {
-			log.DebugContext(e.Context, "Stopped parsing messages from server.", "parsed_total", count)
+			log.DebugContext(e.Context, "Stopped parsing messages from server", "parsed_total", count)
 		}()
 
 		for {
@@ -474,64 +384,14 @@ func (e *Engine) receiveFromServer(serverConn, clientConn net.Conn, serverErrCh 
 	total, err := io.Copy(clientConn, io.TeeReader(serverConn, copyWriter))
 	if err != nil {
 		if utils.IsOKNetworkError(err) {
-			log.DebugContext(e.Context, "Server connection closed.")
+			log.DebugContext(e.Context, "Server connection closed")
 		} else {
-			log.WarnContext(e.Context, "Server -> Client copy finished with unexpected error.", "error", err)
+			log.WarnContext(e.Context, "Server -> Client copy finished with unexpected error", "error", err)
 		}
 	}
 
-	log.DebugContext(e.Context, "Stopped receiving from server.", "total_bytes", total)
+	log.DebugContext(e.Context, "Stopped receiving from server", "total_bytes", total)
 	serverErrCh <- trace.Wrap(err)
-}
-
-// makeAcquireSemaphoreConfig builds parameters for acquiring a semaphore
-// for connecting to a MySQL Cloud SQL instance for this session.
-func (e *Engine) makeAcquireSemaphoreConfig(sessionCtx *common.Session) services.AcquireSemaphoreWithRetryConfig {
-	return services.AcquireSemaphoreWithRetryConfig{
-		Service: e.AuthClient,
-		// The semaphore will serialize connections to the database as specific
-		// user. If we fail to release the lock for some reason, it will expire
-		// in a minute anyway.
-		Request: types.AcquireSemaphoreRequest{
-			SemaphoreKind: "gcp-mysql-token",
-			SemaphoreName: fmt.Sprintf("%v-%v", sessionCtx.Database.GetName(), sessionCtx.DatabaseUser),
-			MaxLeases:     1,
-		},
-		// If multiple connections are being established simultaneously to the
-		// same database as the same user, retry for a few seconds.
-		Retry: retryutils.LinearConfig{
-			Step:  time.Second,
-			Max:   time.Second,
-			Clock: e.Clock,
-		},
-		TTL: time.Minute,
-		Now: e.Clock.Now,
-	}
-}
-
-// newGCPTLSDialer returns a TLS dialer configured to connect to the Cloud Proxy
-// port rather than the default MySQL port.
-func newGCPTLSDialer(tlsConfig *tls.Config) client.Dialer {
-	return func(ctx context.Context, network, address string) (net.Conn, error) {
-		// Workaround issue generating ephemeral certificates for secure connections
-		// by creating a TLS connection to the Cloud Proxy port overriding the
-		// MySQL client's connection. MySQL on the default port does not trust
-		// the ephemeral certificate's CA but Cloud Proxy does.
-		address = getGCPTLSAddress(address)
-		tlsDialer := tls.Dialer{Config: tlsConfig}
-		return tlsDialer.DialContext(ctx, network, address)
-	}
-}
-
-// getGCPTLSAddress returns the appropriate address for a Cloud SQL MySQL
-// instance, possibly overriding the default port to instead use the Cloud Proxy
-// port.
-func getGCPTLSAddress(address string) string {
-	host, port, err := net.SplitHostPort(address)
-	if err == nil && port == gcpSQLListenPort {
-		return net.JoinHostPort(host, gcpSQLProxyListenPort)
-	}
-	return address
 }
 
 // FetchMySQLVersion connects to MySQL database and tries to read the handshake packet and return the version.
@@ -548,10 +408,3 @@ func FetchMySQLVersion(ctx context.Context, database types.Database) (string, er
 
 	return protocol.FetchMySQLVersionInternal(ctx, dialer, database.GetURI())
 }
-
-const (
-	// gcpSQLListenPort is the port used by Cloud SQL MySQL instances.
-	gcpSQLListenPort = "3306"
-	// gcpSQLProxyListenPort is the port used by Cloud Proxy for MySQL instances.
-	gcpSQLProxyListenPort = "3307"
-)

--- a/lib/srv/db/mysql/gcp.go
+++ b/lib/srv/db/mysql/gcp.go
@@ -20,15 +20,46 @@ package mysql
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"log/slog"
+	"net"
 	"strings"
+	"time"
 
+	"github.com/go-mysql-org/go-mysql/client"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/time/rate"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/db/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/common"
+)
+
+const (
+	// gcpMySQLDBUserTypeBuiltIn indicates the database's built-in user type.
+	gcpMySQLDBUserTypeBuiltIn = "BUILT_IN"
+	// gcpMySQLDBUserTypeServiceAccount indicates a Cloud IAM service account.
+	gcpMySQLDBUserTypeServiceAccount = "CLOUD_IAM_SERVICE_ACCOUNT"
+	//  gcpMySQLDBUserTypeGroupServiceAccount indicates a Cloud IAM group service account.
+	gcpMySQLDBUserTypeGroupServiceAccount = "CLOUD_IAM_GROUP_SERVICE_ACCOUNT"
+	// gcpMySQLDBUserTypeUser indicates a Cloud IAM user.
+	gcpMySQLDBUserTypeUser = "CLOUD_IAM_USER"
+	// gcpMySQLDBUserTypeGroupUser indicates a Cloud IAM group login user.
+	gcpMySQLDBUserTypeGroupUser = "CLOUD_IAM_GROUP_USER"
+)
+
+const (
+	// gcpSQLListenPort is the port used by Cloud SQL MySQL instances.
+	gcpSQLListenPort = "3306"
+	// gcpSQLProxyListenPort is the port used by Cloud Proxy for MySQL instances.
+	gcpSQLProxyListenPort = "3307"
 )
 
 func isDBUserFullGCPServerAccountID(dbUser string) bool {
@@ -48,15 +79,37 @@ func gcpServiceAccountToDatabaseUser(serviceAccountName string) string {
 	return user
 }
 
-func databaseUserToGCPServiceAccount(sessionCtx *common.Session) string {
-	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sessionCtx.DatabaseUser, sessionCtx.Database.GetGCP().ProjectID)
+func databaseUserToGCPServiceAccount(database types.Database, dbUser string) string {
+	return fmt.Sprintf("%s@%s.iam.gserviceaccount.com", dbUser, database.GetGCP().ProjectID)
 }
 
-func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.Session, gcpClient gcp.SQLAdminClient) (string, string, error) {
+type gcpClients interface {
+	GetSQLAdminClient(context.Context) (gcp.SQLAdminClient, error)
+}
+
+type gcpAuth struct {
+	auth         common.Auth
+	authClient   *authclient.Client
+	clients      gcpClients
+	clock        clockwork.Clock
+	database     types.Database
+	databaseUser string
+	log          *slog.Logger
+
+	requireSSL    bool
+	requireSSLErr error
+	sometimes     *rate.Sometimes
+}
+
+func (a *gcpAuth) getGCPUserAndPassword(ctx context.Context) (string, string, error) {
+	gcpClient, err := a.clients.GetSQLAdminClient(ctx)
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
 	// If `--db-user` is the full service account email ID, use IAM Auth.
-	if isDBUserFullGCPServerAccountID(sessionCtx.DatabaseUser) {
-		user := gcpServiceAccountToDatabaseUser(sessionCtx.DatabaseUser)
-		password, err := e.getGCPIAMAuthToken(ctx, sessionCtx)
+	if isDBUserFullGCPServerAccountID(a.databaseUser) {
+		user := gcpServiceAccountToDatabaseUser(a.databaseUser)
+		password, err := a.getGCPIAMAuthToken(ctx, a.databaseUser)
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}
@@ -67,18 +120,20 @@ func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.S
 	// for GCP MySQL. For GCP Postgres, "user@my-project-id.iam" is the actual
 	// mapped in-database username. However, the mapped in-database username
 	// for GCP MySQL does not have the "@my-project-id.iam" part.
-	if isDBUserShortGCPServiceAccountID(sessionCtx.DatabaseUser) {
-		return "", "", trace.BadParameter("username %q is not accepted for GCP MySQL. Please use the in-database username or the full service account Email ID.", sessionCtx.DatabaseUser)
+	if isDBUserShortGCPServiceAccountID(a.databaseUser) {
+		return "", "", trace.BadParameter("username %q is not accepted for GCP MySQL. Please use the in-database username or the full service account Email ID.", a.databaseUser)
 	}
 
 	// Get user info to decide how to authenticate.
-	user := sessionCtx.DatabaseUser
-	dbUserInfo, err := gcpClient.GetUser(ctx, sessionCtx.Database, sessionCtx.DatabaseUser)
+	user := a.databaseUser
+	dbUserInfo, err := gcpClient.GetUser(ctx, a.database, a.databaseUser)
 	switch {
 	// GetUser permission is new for IAM auth. If no permission, assume legacy password user.
 	case trace.IsAccessDenied(err):
-		e.Log.DebugContext(e.Context, "Access denied to get GCP MySQL database user info. Continue with password auth.", "user", sessionCtx.DatabaseUser)
-		password, err := e.getGCPOneTimePassword(ctx, sessionCtx)
+		a.log.DebugContext(ctx, "Access denied to get GCP MySQL database user info, continuing with password auth",
+			"user", a.databaseUser,
+		)
+		password, err := a.getGCPOneTimePassword(ctx)
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}
@@ -88,7 +143,7 @@ func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.S
 	// that catching not found here also prevents Google creating a new
 	// database user during OTP generation.
 	case trace.IsNotFound(err):
-		return "", "", trace.NotFound("database user %q does not exist in database %q", sessionCtx.DatabaseUser, sessionCtx.Database.GetName())
+		return "", "", trace.NotFound("database user %q does not exist in database %q", a.databaseUser, a.database.GetName())
 
 	// Report any other error.
 	case err != nil:
@@ -100,7 +155,7 @@ func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.S
 	switch dbUserInfo.Type {
 	case "",
 		gcpMySQLDBUserTypeBuiltIn:
-		password, err := e.getGCPOneTimePassword(ctx, sessionCtx)
+		password, err := a.getGCPOneTimePassword(ctx)
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}
@@ -108,8 +163,8 @@ func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.S
 
 	case gcpMySQLDBUserTypeServiceAccount,
 		gcpMySQLDBUserTypeGroupServiceAccount:
-		serviceAccountName := databaseUserToGCPServiceAccount(sessionCtx)
-		password, err := e.getGCPIAMAuthToken(ctx, sessionCtx.WithUser(serviceAccountName))
+		serviceAccountName := databaseUserToGCPServiceAccount(a.database, a.databaseUser)
+		password, err := a.getGCPIAMAuthToken(ctx, serviceAccountName)
 		if err != nil {
 			return "", "", trace.Wrap(err)
 		}
@@ -124,16 +179,16 @@ func (e *Engine) getGCPUserAndPassword(ctx context.Context, sessionCtx *common.S
 	}
 }
 
-func (e *Engine) getGCPIAMAuthToken(ctx context.Context, sessionCtx *common.Session) (string, error) {
-	e.Log.DebugContext(ctx, "Authenticating GCP MySQL with IAM auth.", "session", sessionCtx)
+func (a *gcpAuth) getGCPIAMAuthToken(ctx context.Context, dbUser string) (string, error) {
+	a.log.DebugContext(ctx, "Authenticating GCP MySQL with IAM auth", "db_user", dbUser)
 
 	// Note that sessionCtx.DatabaseUser is the service account.
-	password, err := e.Auth.GetCloudSQLAuthToken(ctx, sessionCtx.DatabaseUser)
+	password, err := a.auth.GetCloudSQLAuthToken(ctx, dbUser)
 	return password, trace.Wrap(err)
 }
 
-func (e *Engine) getGCPOneTimePassword(ctx context.Context, sessionCtx *common.Session) (string, error) {
-	e.Log.DebugContext(ctx, "Authenticating GCP MySQL with password auth.", "session", sessionCtx)
+func (a *gcpAuth) getGCPOneTimePassword(ctx context.Context) (string, error) {
+	a.log.DebugContext(ctx, "Authenticating GCP MySQL with password auth")
 
 	// For Cloud SQL MySQL legacy auth, we use one-time passwords by resetting
 	// the database user password for each connection. Thus, acquire a lock to
@@ -141,7 +196,7 @@ func (e *Engine) getGCPOneTimePassword(ctx context.Context, sessionCtx *common.S
 	// serialized.
 	retryCtx, cancel := context.WithTimeout(ctx, defaults.DatabaseConnectTimeout)
 	defer cancel()
-	lease, err := services.AcquireSemaphoreWithRetry(retryCtx, e.makeAcquireSemaphoreConfig(sessionCtx))
+	lease, err := services.AcquireSemaphoreWithRetry(retryCtx, a.makeAcquireSemaphoreConfig())
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -149,27 +204,104 @@ func (e *Engine) getGCPOneTimePassword(ctx context.Context, sessionCtx *common.S
 	// below. If the semaphore fails to release for some reason, it will
 	// expire in a minute on its own.
 	defer func() {
-		err := e.AuthClient.CancelSemaphoreLease(ctx, *lease)
+		err := a.authClient.CancelSemaphoreLease(ctx, *lease)
 		if err != nil {
-			e.Log.ErrorContext(ctx, "Failed to cancel lease.", "lease", lease, "error", err)
+			a.log.ErrorContext(ctx, "Failed to cancel lease", "lease", lease, "error", err)
 		}
 	}()
-	password, err := e.Auth.GetCloudSQLPassword(ctx, sessionCtx.Database, sessionCtx.DatabaseUser)
+	password, err := a.auth.GetCloudSQLPassword(ctx, a.database, a.databaseUser)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 	return password, nil
 }
 
-const (
-	// gcpMySQLDBUserTypeBuiltIn indicates the database's built-in user type.
-	gcpMySQLDBUserTypeBuiltIn = "BUILT_IN"
-	// gcpMySQLDBUserTypeServiceAccount indicates a Cloud IAM service account.
-	gcpMySQLDBUserTypeServiceAccount = "CLOUD_IAM_SERVICE_ACCOUNT"
-	//  gcpMySQLDBUserTypeGroupServiceAccount indicates a Cloud IAM group service account.
-	gcpMySQLDBUserTypeGroupServiceAccount = "CLOUD_IAM_GROUP_SERVICE_ACCOUNT"
-	// gcpMySQLDBUserTypeUser indicates a Cloud IAM user.
-	gcpMySQLDBUserTypeUser = "CLOUD_IAM_USER"
-	// gcpMySQLDBUserTypeGroupUser indicates a Cloud IAM group login user.
-	gcpMySQLDBUserTypeGroupUser = "CLOUD_IAM_GROUP_USER"
-)
+// makeAcquireSemaphoreConfig builds parameters for acquiring a semaphore
+// for connecting to a MySQL Cloud SQL instance for this session.
+func (a *gcpAuth) makeAcquireSemaphoreConfig() services.AcquireSemaphoreWithRetryConfig {
+	return services.AcquireSemaphoreWithRetryConfig{
+		Service: a.authClient,
+		// The semaphore will serialize connections to the database as specific
+		// user. If we fail to release the lock for some reason, it will expire
+		// in a minute anyway.
+		Request: types.AcquireSemaphoreRequest{
+			SemaphoreKind: "gcp-mysql-token",
+			SemaphoreName: fmt.Sprintf("%v-%v", a.database.GetName(), a.databaseUser),
+			MaxLeases:     1,
+		},
+		// If multiple connections are being established simultaneously to the
+		// same database as the same user, retry for a few seconds.
+		Retry: retryutils.LinearConfig{
+			Step:  time.Second,
+			Max:   time.Second,
+			Clock: a.clock,
+		},
+		TTL: time.Minute,
+		Now: a.clock.Now,
+	}
+}
+
+func (a *gcpAuth) checkSSLRequired(ctx context.Context) (bool, error) {
+	a.sometimes.Do(func() {
+		client, err := a.clients.GetSQLAdminClient(ctx)
+		if err != nil {
+			a.requireSSL = false
+			a.requireSSLErr = err
+			return
+		}
+		a.requireSSL, a.requireSSLErr = checkGCPRequireSSL(ctx, a.database, client)
+	})
+	return a.requireSSL, trace.Wrap(a.requireSSLErr)
+}
+
+func checkGCPRequireSSL(ctx context.Context, database types.Database, client gcp.SQLAdminClient) (bool, error) {
+	// Detect whether the instance is set to require SSL.
+	// Fallback to not requiring SSL for access denied errors.
+	requireSSL, err := cloud.GetGCPRequireSSL(ctx, database, client)
+	if err != nil {
+		if trace.IsAccessDenied(err) {
+			return false, nil
+		}
+		return false, trace.Wrap(err)
+	}
+	return requireSSL, nil
+}
+
+func (a *gcpAuth) appendGCPClientCert(ctx context.Context, certExpiry time.Time, tlsConfig *tls.Config) error {
+	gcpClient, err := a.clients.GetSQLAdminClient(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return trace.Wrap(cloud.AppendGCPClientCert(ctx, &cloud.AppendGCPClientCertRequest{
+		GCPClient:   gcpClient,
+		GenerateKey: a.auth.GenerateDatabaseClientKey,
+		Expiry:      certExpiry,
+		Database:    a.database,
+		TLSConfig:   tlsConfig,
+	}))
+}
+
+// newGCPTLSDialer returns a TLS dialer configured to connect to the Cloud Proxy
+// port rather than the default MySQL port.
+func newGCPTLSDialer(tlsConfig *tls.Config) client.Dialer {
+	return func(ctx context.Context, network, address string) (net.Conn, error) {
+		// Workaround issue generating ephemeral certificates for secure connections
+		// by creating a TLS connection to the Cloud Proxy port overriding the
+		// MySQL client's connection. MySQL on the default port does not trust
+		// the ephemeral certificate's CA but Cloud Proxy does.
+		address = getGCPTLSAddress(address)
+		tlsDialer := tls.Dialer{Config: tlsConfig}
+		return tlsDialer.DialContext(ctx, network, address)
+	}
+}
+
+// getGCPTLSAddress returns the appropriate address for a Cloud SQL MySQL
+// instance, possibly overriding the default port to instead use the Cloud Proxy
+// port.
+func getGCPTLSAddress(address string) string {
+	host, port, err := net.SplitHostPort(address)
+	if err == nil && port == gcpSQLListenPort {
+		return net.JoinHostPort(host, gcpSQLProxyListenPort)
+	}
+	return address
+}

--- a/lib/srv/db/mysql/gcp_test.go
+++ b/lib/srv/db/mysql/gcp_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/cloud/gcp/gcptest"
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -155,9 +156,12 @@ func Test_getGCPUserAndPassword(t *testing.T) {
 				Context:    ctx,
 				Clock:      clockwork.NewRealClock(),
 				Log:        slog.Default(),
+				GCPClients: &gcptest.Clients{GCPSQL: test.mockGCPClient},
 			}).(*Engine)
 
-			databaseUser, password, err := engine.getGCPUserAndPassword(ctx, sessionCtx, test.mockGCPClient)
+			connector, err := engine.newConnector(sessionCtx)
+			require.NoError(t, err)
+			databaseUser, password, err := connector.gcpAuth.getGCPUserAndPassword(ctx)
 			if test.wantError {
 				require.Error(t, err)
 			} else {

--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -81,12 +81,12 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	// has a chance to close the connection from its side.
 	defer func() {
 		if r := recover(); r != nil {
-			p.Log.WarnContext(ctx, "Recovered in MySQL proxy while handling connection.", "from", clientConn.RemoteAddr(), "problem", r, "stack", debug.Stack())
+			p.Log.WarnContext(ctx, "Recovered in MySQL proxy while handling connection", "from", clientConn.RemoteAddr(), "problem", r, "stack", debug.Stack())
 			err = trace.BadParameter("failed to handle MySQL client connection")
 		}
 		if err != nil {
 			if writeErr := mysqlServer.WriteError(trace.Unwrap(err)); writeErr != nil {
-				p.Log.DebugContext(ctx, "Failed to send error to MySQL client.", "original_err", err.Error(), "error", writeErr)
+				p.Log.DebugContext(ctx, "Failed to send error to MySQL client", "original_err", err.Error(), "error", writeErr)
 			}
 		}
 	}()
@@ -256,7 +256,7 @@ func (p *Proxy) maybeReadProxyLine(ctx context.Context, conn *multiplexer.Conn) 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	p.Log.DebugContext(ctx, "MySQL listener proxy-line.", "proxy_line", proxyLine)
+	p.Log.DebugContext(ctx, "MySQL listener proxy-line", "proxy_line", proxyLine)
 	return nil
 }
 


### PR DESCRIPTION
* Add a connector to abstract away connecting to the database.
* Move GCP code into gcp.go, with a new type gcpAuth for handling GCP auth logic.
* Removing punctuation in log lines

Related issue:
- https://github.com/gravitational/teleport/issues/58118 

This refactor is part of the fix for that.
This was also split out of the fix PR because it was doing too many things:
- https://github.com/gravitational/teleport/pull/61409

Stacked on top of another PR:
- https://github.com/gravitational/teleport/pull/61752

Backporting because the health check fix needs to be backported and it depends on these changes.