### PR TITLE
Fix `tsh db connect` failing to connect to database on separate ports

### DIFF
--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -768,14 +768,13 @@ func (c *CLICommandBuilder) getSpannerCommand(ctx context.Context) (*exec.Cmd, e
 	)
 
 	db, err := c.getDatabase(ctx)
-	if err != nil {
-		// default placeholders for a print command if not all info is available
-		if c.options.printFormat {
-			project, instance, database = "<project>", "<instance>", "<database>"
-		} else {
-			return nil, trace.Wrap(err)
-		}
-	} else {
+	switch {
+	case err != nil && c.options.printFormat:
+		// OK to continue in this case, we'll print the placeholders instead.
+		project, instance, database = "<project>", "<instance>", "<database>"
+	case err != nil:
+		return nil, trace.Wrap(err)
+	default:
 		gcp = db.GetGCP()
 	}
 

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -121,16 +121,22 @@ type CLICommandBuilder struct {
 	// --cluster flag. Therefore profile.Cluster is not suitable for
 	// determining the target cluster or the root cluster. Use tc.SiteName for
 	// the target cluster and rootCluster for root cluster.
-	profile *client.ProfileStatus
-	db      *tlsca.RouteToDatabase
-	host    string
-	port    int
-	options connectionCommandOpts
-	uid     utils.UID
+	profile         *client.ProfileStatus
+	db              *tlsca.RouteToDatabase
+	host            string
+	port            int
+	options         connectionCommandOpts
+	uid             utils.UID
+	getDatabaseFunc GetDatabaseFunc
 }
 
-func NewCmdBuilder(tc *client.TeleportClient, profile *client.ProfileStatus,
-	db tlsca.RouteToDatabase, rootClusterName string, opts ...ConnectCommandFunc,
+func NewCmdBuilder(
+	tc *client.TeleportClient,
+	profile *client.ProfileStatus,
+	db tlsca.RouteToDatabase,
+	rootClusterName string,
+	getDatabaseFunc GetDatabaseFunc,
+	opts ...ConnectCommandFunc,
 ) (*CLICommandBuilder, error) {
 	var options connectionCommandOpts
 	for _, opt := range opts {
@@ -152,19 +158,20 @@ func NewCmdBuilder(tc *client.TeleportClient, profile *client.ProfileStatus,
 		options.exe = &SystemExecer{}
 	}
 
-	if options.getDatabase == nil {
-		return nil, trace.BadParameter("WithGetDatabaseFunc option is required")
+	if getDatabaseFunc == nil {
+		return nil, trace.BadParameter("GetDatabaseFunc is required and cannot be nil")
 	}
 
 	return &CLICommandBuilder{
-		tc:          tc,
-		profile:     profile,
-		db:          &db,
-		host:        host,
-		port:        port,
-		options:     options,
-		rootCluster: rootClusterName,
-		uid:         utils.NewRealUID(),
+		tc:              tc,
+		profile:         profile,
+		db:              &db,
+		host:            host,
+		port:            port,
+		options:         options,
+		rootCluster:     rootClusterName,
+		getDatabaseFunc: getDatabaseFunc,
+		uid:             utils.NewRealUID(),
 	}, nil
 }
 
@@ -554,7 +561,7 @@ func (c *CLICommandBuilder) getMongoCommand(ctx context.Context) (*exec.Cmd, err
 }
 
 func (c *CLICommandBuilder) getDatabase(ctx context.Context) (types.Database, error) {
-	db, err := c.options.getDatabase(ctx, c.tc, c.db.ServiceName)
+	db, err := c.getDatabaseFunc(ctx, c.tc, c.db.ServiceName)
 	return db, trace.Wrap(err)
 }
 
@@ -965,7 +972,6 @@ type connectionCommandOpts struct {
 	exe                      Execer
 	password                 string
 	oracle                   oracleOpts
-	getDatabase              GetDatabaseFunc
 }
 
 // ConnectCommandFunc is a type for functions returned by the "With*" functions in this package.
@@ -1070,13 +1076,6 @@ func WithOracleOpts(canUseTCP bool, hasTCPServers bool) ConnectCommandFunc {
 
 // GetDatabaseFunc is a callback to retrieve types.Database.
 type GetDatabaseFunc func(context.Context, *client.TeleportClient, string) (types.Database, error)
-
-// WithGetDatabaseFunc provides a callback to retrieve types.Database.
-func WithGetDatabaseFunc(f GetDatabaseFunc) ConnectCommandFunc {
-	return func(opts *connectionCommandOpts) {
-		opts.getDatabase = f
-	}
-}
 
 const (
 	// envVarMongoServerSelectionTimeoutMS is the environment variable that

--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -131,7 +131,7 @@ type CLICommandBuilder struct {
 
 func NewCmdBuilder(tc *client.TeleportClient, profile *client.ProfileStatus,
 	db tlsca.RouteToDatabase, rootClusterName string, opts ...ConnectCommandFunc,
-) *CLICommandBuilder {
+) (*CLICommandBuilder, error) {
 	var options connectionCommandOpts
 	for _, opt := range opts {
 		opt(&options)
@@ -152,6 +152,10 @@ func NewCmdBuilder(tc *client.TeleportClient, profile *client.ProfileStatus,
 		options.exe = &SystemExecer{}
 	}
 
+	if options.getDatabase == nil {
+		return nil, trace.BadParameter("WithGetDatabaseFunc option is required")
+	}
+
 	return &CLICommandBuilder{
 		tc:          tc,
 		profile:     profile,
@@ -161,7 +165,7 @@ func NewCmdBuilder(tc *client.TeleportClient, profile *client.ProfileStatus,
 		options:     options,
 		rootCluster: rootClusterName,
 		uid:         utils.NewRealUID(),
-	}
+	}, nil
 }
 
 // GetConnectCommand returns a command that can connect the user directly to the given database
@@ -220,7 +224,7 @@ func (c *CLICommandBuilder) GetConnectCommand(ctx context.Context) (*exec.Cmd, e
 		return c.getClickhouseNativeCommand()
 
 	case defaults.ProtocolSpanner:
-		return c.getSpannerCommand()
+		return c.getSpannerCommand(ctx)
 	}
 
 	return nil, trace.BadParameter("unsupported database protocol: %v", c.db)
@@ -550,11 +554,6 @@ func (c *CLICommandBuilder) getMongoCommand(ctx context.Context) (*exec.Cmd, err
 }
 
 func (c *CLICommandBuilder) getDatabase(ctx context.Context) (types.Database, error) {
-	// Technically, we can just use tc to get the database. But caller may have
-	// extra logic so rely on the callback for now.
-	if c.options.getDatabase == nil {
-		return nil, trace.NotFound("missing GetDatabaseFunc")
-	}
 	db, err := c.options.getDatabase(ctx, c.tc, c.db.ServiceName)
 	return db, trace.Wrap(err)
 }
@@ -756,25 +755,35 @@ func (c *CLICommandBuilder) getDynamoDBCommand() (*exec.Cmd, error) {
 	return exec.Command(awsBin, args...), nil
 }
 
-func (c *CLICommandBuilder) getSpannerCommand() (*exec.Cmd, error) {
+func (c *CLICommandBuilder) getSpannerCommand(ctx context.Context) (*exec.Cmd, error) {
 	if err := c.checkLocalProxyTunnelOnly(false); err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	var (
+		gcp types.GCPCloudSQL
 		project,
 		instance,
 		database string
 	)
-	if c.options.printFormat {
+
+	db, err := c.getDatabase(ctx)
+	if err != nil {
 		// default placeholders for a print command if not all info is available
-		project, instance, database = "<project>", "<instance>", "<database>"
+		if c.options.printFormat {
+			project, instance, database = "<project>", "<instance>", "<database>"
+		} else {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		gcp = db.GetGCP()
 	}
 
-	if c.options.gcp.ProjectID != "" {
-		project = c.options.gcp.ProjectID
+	if gcp.ProjectID != "" {
+		project = gcp.ProjectID
 	}
-	if c.options.gcp.InstanceID != "" {
-		instance = c.options.gcp.InstanceID
+	if gcp.InstanceID != "" {
+		instance = gcp.InstanceID
 	}
 	if c.db.Database != "" {
 		database = c.db.Database
@@ -956,7 +965,6 @@ type connectionCommandOpts struct {
 	logger                   *slog.Logger
 	exe                      Execer
 	password                 string
-	gcp                      types.GCPCloudSQL
 	oracle                   oracleOpts
 	getDatabase              GetDatabaseFunc
 }
@@ -1058,14 +1066,6 @@ func WithOracleOpts(canUseTCP bool, hasTCPServers bool) ConnectCommandFunc {
 	return func(opts *connectionCommandOpts) {
 		opts.oracle.canUseTCP = canUseTCP
 		opts.oracle.hasTCPServers = hasTCPServers
-	}
-}
-
-// WithGCP adds GCP metadata for the database command to access.
-// TODO(greedy52) use GetDatabaseFunc instead.
-func WithGCP(gcp types.GCPCloudSQL) ConnectCommandFunc {
-	return func(opts *connectionCommandOpts) {
-		opts.gcp = gcp
 	}
 }
 

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -79,13 +79,14 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		opts         []ConnectCommandFunc
-		dbProtocol   string
-		databaseName string
-		execer       *fakeExec
-		cmd          []string
-		wantErr      bool
+		name            string
+		opts            []ConnectCommandFunc
+		dbProtocol      string
+		databaseName    string
+		execer          *fakeExec
+		cmd             []string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:         "postgres",
@@ -327,10 +328,10 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongodb (legacy)",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{withMongoDBAtlasDatabase()},
+			name:            "mongodb (legacy)",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongo": []byte("legacy"),
@@ -344,10 +345,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongodb no TLS (legacy)",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongodb no TLS (legacy)",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongo": []byte("legacy"),
@@ -359,10 +361,10 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongosh no CA",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{withMongoDBAtlasDatabase()},
+			name:            "mongosh no CA",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -376,12 +378,12 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
+			name:            "mongosh",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, "/tmp/keys/example.com/cas/example.com.pem"),
-				withMongoDBAtlasDatabase(),
 			},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
@@ -396,10 +398,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh no TLS",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongosh no TLS",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -410,10 +413,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh preferred",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongosh preferred",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{}, // Cannot find either bin.
 			},
@@ -422,10 +426,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "DocumentDB",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "docdb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withDocumentDBDatabase()},
+			name:            "DocumentDB",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "docdb",
+			getDatabaseFunc: withDocumentDBDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					// When both are available, legacy mongo is preferred.
@@ -439,10 +444,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "DocumentDB mongosh",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "docdb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withDocumentDBDatabase()},
+			name:            "DocumentDB mongosh",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "docdb",
+			getDatabaseFunc: withDocumentDBDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -678,12 +684,12 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner for exec is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -691,13 +697,13 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner with print format is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner with print format is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -705,13 +711,13 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner with print format and placeholders is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner with print format and placeholders is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: getDatabaseFuncWithError, // When format is set the command can accept error when fetching the database.
 			opts: []ConnectCommandFunc{
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withErrorGetDatabaseFunc(), // When format is set the command can accept error when fetching the database.
 			},
 			execer:       &fakeExec{},
 			databaseName: "",
@@ -719,48 +725,48 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner for exec without GCP project is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without GCP project is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner for exec without GCP instance is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without GCP instance is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner for exec without database name is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without database name is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner without a local proxy is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner without a local proxy is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("", 0, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -789,10 +795,14 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetConnectCommand(context.Background())
@@ -826,13 +836,14 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		opts         []ConnectCommandFunc
-		dbProtocol   string
-		databaseName string
-		execer       *fakeExec
-		cmd          map[string][]string
-		wantErr      bool
+		name            string
+		opts            []ConnectCommandFunc
+		dbProtocol      string
+		databaseName    string
+		execer          *fakeExec
+		cmd             map[string][]string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:         "postgres no TLS",
@@ -953,10 +964,14 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
@@ -997,12 +1012,13 @@ func TestConvertCommandError(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc       string
-		dbProtocol string
-		execer     *fakeExec
-		stderr     []byte
-		wantBin    string
-		wantStdErr string
+		desc            string
+		dbProtocol      string
+		execer          *fakeExec
+		stderr          []byte
+		wantBin         string
+		wantStdErr      string
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			desc:       "converts access denied to helpful message",
@@ -1041,9 +1057,14 @@ func TestConvertCommandError(t *testing.T) {
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
@@ -1063,8 +1084,8 @@ func TestConvertCommandError(t *testing.T) {
 	}
 }
 
-func withMongoDBAtlasDatabase() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withMongoDBAtlasDatabase() GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "mongodb-atlas",
@@ -1075,11 +1096,11 @@ func withMongoDBAtlasDatabase() ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-func withDocumentDBDatabase() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withDocumentDBDatabase() GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "docdb",
@@ -1090,11 +1111,11 @@ func withDocumentDBDatabase() ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-func withSpannerDatabase(gcp types.GCPCloudSQL) ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withSpannerDatabase(gcp types.GCPCloudSQL) GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "docdb",
@@ -1106,14 +1127,12 @@ func withSpannerDatabase(gcp types.GCPCloudSQL) ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-// withErrorGetDatabaseFunc provides a non-nil function that returns error when
+// getDatabaseFuncWithError provides a non-nil function that returns error when
 // retrieving the database. This can be used in tests that don't retrieve
 // databases.
-func withErrorGetDatabaseFunc() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(ctx context.Context, tc *client.TeleportClient, s string) (types.Database, error) {
-		return nil, trace.NotImplemented("unexpected call to getDatabase function")
-	})
+func getDatabaseFuncWithError(ctx context.Context, tc *client.TeleportClient, s string) (types.Database, error) {
+	return nil, trace.NotImplemented("unexpected call to getDatabase function")
 }

--- a/lib/client/db/dbcmd/exec_test.go
+++ b/lib/client/db/dbcmd/exec_test.go
@@ -58,11 +58,12 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		opts     []ConnectCommandFunc
-		protocol string
-		cmd      []string
-		wantErr  bool
+		name            string
+		opts            []ConnectCommandFunc
+		protocol        string
+		cmd             []string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:     "not authenticated tunnel",
@@ -103,10 +104,14 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(fakeExec),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetExecCommand(context.Background(), "select 1")

--- a/lib/client/db/dbcmd/exec_test.go
+++ b/lib/client/db/dbcmd/exec_test.go
@@ -103,9 +103,11 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(fakeExec),
+				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c := NewCmdBuilder(tc, profile, database, "root", opts...)
+			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetExecCommand(context.Background(), "select 1")
 			if tt.wantErr {

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -180,7 +180,7 @@ type GetDatabaseServersResponse struct {
 
 // NewDBCLICmdBuilder creates a dbcmd.CLICommandBuilder with provided cluster,
 // db route, and options.
-func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
+func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, getDatabaseFunc dbcmd.GetDatabaseFunc, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
 	return dbcmd.NewCmdBuilder(
 		cluster.clusterClient,
 		&cluster.status,
@@ -192,6 +192,7 @@ func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, optio
 		// generating correct CA paths. We use dbcmd.WithNoTLS here which means that the CA paths aren't
 		// included in the returned CLI command.
 		cluster.Name,
+		getDatabaseFunc,
 		options...,
 	)
 }

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -180,7 +180,7 @@ type GetDatabaseServersResponse struct {
 
 // NewDBCLICmdBuilder creates a dbcmd.CLICommandBuilder with provided cluster,
 // db route, and options.
-func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) *dbcmd.CLICommandBuilder {
+func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
 	return dbcmd.NewCmdBuilder(
 		cluster.clusterClient,
 		&cluster.status,

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -91,12 +91,20 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 
 	previewOpts := append(opts, dbcmd.WithPrintFormat())
 
-	execCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...).GetConnectCommand(ctx)
+	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...)
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+	execCmd, err := execCmdBuilder.GetConnectCommand(ctx)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}
 
-	previewCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...).GetConnectCommand(ctx)
+	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...)
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+	previewCmd, err := previewCmdBuilder.GetConnectCommand(ctx)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -65,6 +65,13 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 	var getDatabaseError error
 	var database types.Database
 
+	getDatabaseFunc := func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
+		getDatabaseOnce.Do(func() {
+			database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())
+		})
+		return database, trace.Wrap(getDatabaseError)
+	}
+
 	opts := []dbcmd.ConnectCommandFunc{
 		dbcmd.WithLogger(gateway.Log()),
 		dbcmd.WithLocalProxy(gateway.LocalAddress(), gateway.LocalPortInt(), ""),
@@ -72,12 +79,6 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		dbcmd.WithTolerateMissingCLIClient(),
 		dbcmd.WithExecer(execer),
 		dbcmd.WithOracleOpts(true /* can use TCP */, true /* has TCP servers */),
-		dbcmd.WithGetDatabaseFunc(func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
-			getDatabaseOnce.Do(func() {
-				database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())
-			})
-			return database, trace.Wrap(getDatabaseError)
-		}),
 	}
 
 	switch gateway.Protocol() {
@@ -91,7 +92,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 
 	previewOpts := append(opts, dbcmd.WithPrintFormat())
 
-	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...)
+	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, getDatabaseFunc, opts...)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}
@@ -100,7 +101,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		return Cmds{}, trace.Wrap(err)
 	}
 
-	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...)
+	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, getDatabaseFunc, previewOpts...)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -536,10 +536,9 @@ func onDatabaseConfig(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case dbFormatCommand:
-		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster, getDatabase,
 			dbcmd.WithPrintFormat(),
 			dbcmd.WithLogger(logger),
-			dbcmd.WithGetDatabaseFunc(getDatabase),
 		)
 		if err != nil {
 			return trace.Wrap(err)
@@ -794,7 +793,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, dbInfo.getDatabaseForDBCmd, opts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -536,11 +536,15 @@ func onDatabaseConfig(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case dbFormatCommand:
-		cmd, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
 			dbcmd.WithPrintFormat(),
 			dbcmd.WithLogger(logger),
 			dbcmd.WithGetDatabaseFunc(getDatabase),
-		).GetConnectCommand(cf.Context)
+		)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cmd, err := cb.GetConnectCommand(cf.Context)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -607,7 +611,10 @@ func maybeStartLocalProxy(ctx context.Context, cf *CLIConf,
 	requires *dbLocalProxyRequirement,
 ) ([]dbcmd.ConnectCommandFunc, error) {
 	if !requires.localProxy {
-		return nil, nil
+		// Even when local proxy is not required, we need to build the base
+		// options for database command.
+		baseOpts, err := makeDatabaseCommandOptions(ctx, tc, dbInfo)
+		return baseOpts, trace.Wrap(err)
 	}
 	if requires.tunnel {
 		logger.DebugContext(ctx, "Starting local proxy tunnel", "reasons", requires.tunnelReasons)
@@ -787,7 +794,10 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	bb := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	cmd, err := bb.GetConnectCommand(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
@@ -803,7 +813,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 	peakStderr := utils.NewCaptureNBytesWriter(dbcmd.PeakStderrSize)
 	cmd.Stderr = io.MultiWriter(os.Stderr, peakStderr)
 
-	err = cmd.Run()
+	err = cf.RunCommand(cmd)
 	if err != nil {
 		return dbcmd.ConvertCommandError(cmd, err, string(peakStderr.Bytes()))
 	}

--- a/tool/tsh/common/db_exec.go
+++ b/tool/tsh/common/db_exec.go
@@ -516,7 +516,7 @@ func (m *databaseExecCommandMaker) makeCommand(ctx context.Context, dbInfo *data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...)
+	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, dbInfo.getDatabaseForDBCmd, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/db_exec.go
+++ b/tool/tsh/common/db_exec.go
@@ -516,8 +516,11 @@ func (m *databaseExecCommandMaker) makeCommand(ctx context.Context, dbInfo *data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...).
-		GetExecCommand(ctx, command)
+	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cb.GetExecCommand(ctx, command)
 }
 
 // ensureEachDatabase ensures one to one mapping between the provided database

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -24,8 +24,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -53,6 +55,7 @@ import (
 	dbcommon "github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func registerFakeEnterpriseDBEngines(t *testing.T) {
@@ -2227,4 +2230,68 @@ func TestDatabaseInfo(t *testing.T) {
 			require.Equal(t, tt.routeOut, dbInfo.RouteToDatabase)
 		})
 	}
+}
+
+// TestMongoDBSeparatePortCommandError given a MongoDB database with cluster
+// using separate port mode ensures `tsh` generates the connect command without
+// errors.
+//
+// See https://github.com/gravitational/teleport/issues/47895
+func TestMongoDBSeparatePortCommandError(t *testing.T) {
+	t.Parallel()
+
+	connector := mockConnector(t)
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetDatabaseUsers([]string{"admin"})
+	alice.SetDatabaseNames([]string{"default"})
+	alice.SetRoles([]string{"access"})
+
+	process, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithClusterName("root"),
+		testserver.WithBootstrap(connector, alice),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			mongoPublicAddr := localListenerAddr()
+			cfg.Proxy.MongoAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: mongoPublicAddr}
+			cfg.Proxy.MongoPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: mongoPublicAddr}}
+			cfg.Databases.Enabled = true
+			cfg.Databases.Databases = []servicecfg.Database{
+				{
+					Name:     "mongo",
+					Protocol: defaults.ProtocolMongoDB,
+					URI:      "external-mongo:27017",
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	tshHome, _ := mustLogin(t, process, alice, connector.GetName())
+
+	// cmdExecuted tracks that the MongoDB command was executed.
+	var cmdExecuted atomic.Bool
+
+	// noopCmdRunner is a command runner that does nothing. For this test, we
+	// only need to ensure the command is generated without actually validating
+	// it. This task should be handled in the dbcmd package.
+	noopCmdRunner := func(_ *exec.Cmd) error {
+		cmdExecuted.Store(true)
+		return nil
+	}
+
+	err = Run(context.Background(), []string{
+		"db",
+		"connect",
+		"mongo",
+		"--insecure",
+		"--db-name=test",
+		"--db-user=alice",
+	}, setHomePath(tshHome), setCmdRunner(noopCmdRunner))
+	require.NoError(t, err)
+	require.True(t, cmdExecuted.Load(), "expected the MongoDB command to have executed")
 }

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -2267,8 +2268,8 @@ func TestMongoDBSeparatePortCommandError(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, process.Close())
-		require.NoError(t, process.Wait())
+		assert.NoError(t, process.Close())
+		assert.NoError(t, process.Wait())
 	})
 
 	tshHome, _ := mustLogin(t, process, alice, connector.GetName())

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -240,7 +240,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		cb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootCluster, opts...)
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootCluster, dbInfo.getDatabaseForDBCmd, opts...)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -316,7 +316,6 @@ func makeDatabaseCommandOptions(ctx context.Context, tc *libclient.TeleportClien
 	var err error
 	opts := append([]dbcmd.ConnectCommandFunc{
 		dbcmd.WithLogger(logger),
-		dbcmd.WithGetDatabaseFunc(dbInfo.getDatabaseForDBCmd),
 	}, extraOpts...)
 
 	if opts, err = maybeAddDBUserPassword(ctx, tc, dbInfo, opts); err != nil {


### PR DESCRIPTION
Closes #47895 by consistently generating the `dbcmd` options even when the local proxy is disabled. A test case was added for this specific issue.

In addition, this PR also has some other refactors:
- Make the `WithGetDatabaseFunc` option a requirement, allowing us to catch such an error in tests if/when another database type uses the function and it was not correctly set up.
- Remove `WithGCP` `dbcmd` option in favor of the get database function. This required a small refactor on the Spanner command generation.

changelog: Fix `tsh db connect` failing to connect to databases using separate ports configuration (non-TLS routing mode).