### PR TITLE
Fixing documented KMS policy for v18+

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/aws-kms.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/aws-kms.mdx
@@ -62,7 +62,7 @@ Start by creating the following AWS IAM policy in your account.
             "Resource": "*"
         },
         {
-            "Sid": "CreateKeys",
+            "Sid": "CreateSigningKeys",
             "Effect": "Allow",
             "Action": [
                 "kms:CreateKey",
@@ -72,25 +72,55 @@ Start by creating the following AWS IAM policy in your account.
             "Condition": {
                 "StringEquals": {
                     "aws:RequestTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>",
+                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
+                }
+            }
+        },
+        {
+            "Sid": "CreateEncryptionKeys",
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateKey",
+                "kms:TagResource"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:RequestTag/TeleportClusterEncryption": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>",
                     "aws:ResourceTag/TeleportClusterEncryption": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
                 }
             }
         },
         {
-            "Sid": "UseKeys",
+            "Sid": "UseSigningKeys",
             "Effect": "Allow",
             "Action": [
                 "kms:GetPublicKey",
                 "kms:ScheduleKeyDeletion",
                 "kms:DescribeKey",
                 "kms:ListResourceTags",
-                "kms:Sign",
-                "kms:Decrypt",
+                "kms:Sign"
             ],
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
-                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>",
+                    "aws:ResourceTag/TeleportCluster": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
+                }
+            }
+        },
+        {
+            "Sid": "UseEncryptionKeys",
+            "Effect": "Allow",
+            "Action": [
+                "kms:GetPublicKey",
+                "kms:ScheduleKeyDeletion",
+                "kms:DescribeKey",
+                "kms:ListResourceTags",
+                "kms:Decrypt"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
                     "aws:ResourceTag/TeleportClusterEncryption": "<Var name="teleport.example.com" description="Your Teleport cluster name"/>"
                 }
             }


### PR DESCRIPTION
This PR fixes the malformed IAM policy documented for providing Teleport with the necessary permissions to interact with KMS. The intended behavior is:
- New keys can be provisioned with both the `TeleportCluster` and `TeleportEncryptionCluster` keys. Both do not have to be present at the same time.
- Keys marked with the `TeleportCluster` tag should allow for signing.
- Keys marked with the `TeleportEncryptionCluster` tag should allow for encryption.

Manual testing steps:
- [x] Create a role with the documented policy
- [x] Assume role in AWS CLI
- [x] Confirm signing and encryption keys cannot be created without one of the relevant tags
- [x] Confirm signing and encryption keys can be generated with either of the relevant tags
- [x] Confirm signing keys can sign data when tagged with the `TeleportCluster` tag
- [x] Confirm encryption keys can decrypt data when tagged with the `TeleportClusterEncryption` tag

I temporarily added the `aws:Encrypt` action to the policy just to make testing easier, but this shouldn't be required for Teleport's usage