### PR TITLE
Fix flaky test `TestIntegrations/ControlMaster`

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -92,8 +92,8 @@ func ExternalSSHCommand(o CommandOptions) (*exec.Cmd, error) {
 	// ControlMaster is often used by applications like Ansible.
 	if o.ControlPath != "" {
 		execArgs = append(execArgs, "-oControlMaster=auto")
-		execArgs = append(execArgs, "-oControlPersist=1s")
-		execArgs = append(execArgs, "-oConnectTimeout=2")
+		execArgs = append(execArgs, "-oControlPersist=0")
+		execArgs = append(execArgs, "-oConnectTimeout=10")
 		execArgs = append(execArgs, fmt.Sprintf("-oControlPath=%v", o.ControlPath))
 	}
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4586,10 +4586,9 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 			inRecordLocation: types.RecordAtNode,
 		},
 		// Run tests when Teleport is recording sessions at the proxy
-		// (temporarily disabled, see https://github.com/gravitational/teleport/issues/16224)
-		// {
-		// 	inRecordLocation: types.RecordAtProxy,
-		// },
+		{
+			inRecordLocation: types.RecordAtProxy,
+		},
 	}
 
 	for _, tt := range tests {
@@ -4631,10 +4630,10 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 			require.NoError(t, err)
 			defer helpers.CloseAgent(teleAgent, socketDirPath)
 
-			// Create and run an exec command twice with the passed in ControlPath. This
-			// will cause re-use of the connection and creation of two sessions within
-			// the connection.
-			for range 2 {
+			testConnection := func(t *testing.T) {
+				// Create and run an exec command twice with the passed in ControlPath. This
+				// will cause re-use of the connection and creation of two sessions within
+				// the connection.
 				execCmd, err := helpers.ExternalSSHCommand(helpers.CommandOptions{
 					ForcePTY:     true,
 					ForwardAgent: true,
@@ -4658,6 +4657,13 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 				require.NoError(t, err, "stderr=%q", stderr)
 				require.True(t, strings.HasSuffix(strings.TrimSpace(string(output)), "hello"))
 			}
+
+			t.Run("first connection", func(t *testing.T) {
+				testConnection(t)
+			})
+			t.Run("second connection", func(t *testing.T) {
+				testConnection(t)
+			})
 		})
 	}
 }


### PR DESCRIPTION
This test was either failing because the `ConnectTimeout` was too short at 2s, or because `ControlPersist` was set to 1s, meaning the shared ssh connection was only retained for 1s after the initial connection. Changing those values to 10 (seconds) and 0 (no persist limit, until file removed by test) respectively fixed the flake.

I confirmed that both the proxy and node recording modes tests passed 1500+ times with this fix, while I could usually repro the flake with ~300-500 concurrent runs.

I was only able to reproduce the `Connection closed by UNKNOWN port 65535` error, not the `signal: broken pipe`, but they're likely caused by the same underlying issue.

Closes https://github.com/gravitational/teleport/issues/16224