### PR TITLE
Update pinned Azure attested metadata CA certs

### DIFF
--- a/lib/auth/azure_certs.go
+++ b/lib/auth/azure_certs.go
@@ -104,32 +104,13 @@ func getAzureRootCerts() ([]*x509.Certificate, error) {
 
 // These certificates can be found at
 // https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-ca-details.
-// Pinned on 2023-01-25.
+// Pinned on 2025-11-25.
 var rawAzureCerts = [][]byte{
-	// Baltimore CyberTrust Root
-	[]byte(`-----BEGIN CERTIFICATE-----
-MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ
-RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD
-VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX
-DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y
-ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy
-VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr
-mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr
-IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK
-mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu
-XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy
-dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye
-jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1
-BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3
-DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92
-9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx
-jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0
-Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz
-ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS
-R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp
------END CERTIFICATE-----`),
-
 	// DigiCert Global Root CA
+	//
+	// Note(Noah): It looks like the days of this CA may be numbered, according
+	// to https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/azure-instance-metadata-service-attested-data-tls-2025-critical-changes/2888953
+	// we can expect this to be removed in April 2026.
 	[]byte(`-----BEGIN CERTIFICATE-----
 MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
 MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3


### PR DESCRIPTION
I received an email yesterday notifying me of an upcoming rotation to some of the CAs used by Azure to sign the attested metadata document we use for the Azure join method. More information can be found at https://techcommunity.microsoft.com/blog/azuregovernanceandmanagementblog/azure-instance-metadata-service-attested-data-tls-2025-critical-changes/2888953

My understanding from this blog post is that we are not impacted since we do not pin the sub CAs, we only pin the root CAs. 

However, I did take the opportunity to review our pin list against https://learn.microsoft.com/en-us/azure/security/fundamentals/azure-ca-details?tabs=root-and-subordinate-cas-list - I noticed here that we were still pinning to Baltimore CyberTrust Root. This was removed from the list by msft on October 8th 2024, and, the CA itself expired 12th May 2025.