### PR TITLE
Add endpoint for MWI GitHub + Kubernetes wizard

### DIFF
--- a/integrations/event-handler/go.sum
+++ b/integrations/event-handler/go.sum
@@ -733,6 +733,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/ThalesIgnite/crypto11 v1.2.5 h1:1IiIIEqYmBvUYFeMnHqRft4bwf/O36jryEUpY+9ef8E=
 github.com/ThalesIgnite/crypto11 v1.2.5/go.mod h1:ILDKtnCKiQ7zRoNxcp36Y1ZR8LBPmR2E23+wTQe/MlE=
+github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
+github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -752,6 +754,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/arrow/go/v10 v10.0.1/go.mod h1:YvhnlEePVnBS4+0z3fhPfUy7W1Ikj0Ih0vcRo/gZ1M0=
 github.com/apache/arrow/go/v11 v11.0.0/go.mod h1:Eg5OsL5H+e299f7u5ssuXsuHQVEGC4xei5aX110hRiI=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
+github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
@@ -1371,6 +1375,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQxvE=
+github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/hashicorp/vault/api v1.16.0 h1:nbEYGJiAPGzT9U4oWgaaB0g+Rj8E59QuHKyA5LhwQN4=
 github.com/hashicorp/vault/api v1.16.0/go.mod h1:KhuUhzOD8lDSk29AtzNjgAu2kxRA9jL9NAbkFlqvkBA=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
@@ -1800,6 +1806,8 @@ github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zalando/go-keyring v0.2.6 h1:r7Yc3+H+Ux0+M72zacZoItR3UDxeWfKTcabvkI8ua9s=
 github.com/zalando/go-keyring v0.2.6/go.mod h1:2TCrxYrbUNYfNS/Kgy/LSrkSQzZ5UPVH85RwfczwvcI=
+github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk=
+github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 github.com/zitadel/logging v0.6.2 h1:MW2kDDR0ieQynPZ0KIZPrh9ote2WkxfBif5QoARDQcU=

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1219,7 +1219,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/sessionrecording/:session_id/playback/ws", h.WithClusterAuthWebSocket(h.recordingPlaybackWS))
 
 	// MWI IaC Wizards
-	h.POST("/webapi/machine-id/wizards/ci-cd", h.WithAuth(h.machineIDWizardGenerateIaC))
+	h.POST("/webapi/sites/:site/machine-id/wizards/ci-cd", h.WithClusterAuth(h.machineIDWizardGenerateIaC))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1219,7 +1219,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/sessionrecording/:session_id/playback/ws", h.WithClusterAuthWebSocket(h.recordingPlaybackWS))
 
 	// MWI IaC Wizards
-	h.POST("/webapi/machine-id/wizards/ci-cd", h.WithAuth(h.machineIDWizard))
+	h.POST("/webapi/machine-id/wizards/ci-cd", h.WithAuth(h.machineIDWizardGenerateIaC))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1217,6 +1217,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/sites/:site/sessionthumbnail/:session_id", h.WithClusterAuth(h.getSessionRecordingThumbnail))
 	h.GET("/webapi/sites/:site/sessionrecording/:session_id/metadata/ws", h.WithClusterAuthWebSocket(h.getSessionRecordingMetadata))
 	h.GET("/webapi/sites/:site/sessionrecording/:session_id/playback/ws", h.WithClusterAuthWebSocket(h.recordingPlaybackWS))
+
+	// MWI IaC Wizards
+	h.POST("/webapi/machine-id/wizards/ci-cd", h.WithAuth(h.machineIDWizard))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -17,9 +17,9 @@ import (
 	"github.com/gravitational/teleport/lib/tfgen/transform"
 )
 
-// machineIDWizard generates IaC code for the Machine Identity CI/CD wizards.
-func (h *Handler) machineIDWizard(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext) (any, error) {
-	var req machineIDWizardRequest
+// machineIDWizardGenerateIaC generates IaC code for the Machine Identity CI/CD wizards.
+func (h *Handler) machineIDWizardGenerateIaC(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext) (any, error) {
+	var req machineIDWizardGenerateIaCRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -142,7 +142,7 @@ func (h *Handler) machineIDWizard(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	return machineIDGHAK8sWizardResponse{
+	return machineIDGHAK8sWizardGenerateIaCResponse{
 		Terraform: fmt.Sprintf(
 			machineIDGHAK8sWizardTerraformTemplate,
 			roleTF,
@@ -169,7 +169,7 @@ func (h *Handler) terraformProviderConfig() string {
 //go:embed templates/machine-id-gha-k8s-wizard.tf.tmpl
 var machineIDGHAK8sWizardTerraformTemplate string
 
-type machineIDWizardRequest struct {
+type machineIDWizardGenerateIaCRequest struct {
 	SourceType      string                            `json:"source_type"`
 	DestinationType string                            `json:"destination_type"`
 	GitHub          *machineIDWizardRequestGitHub     `json:"github"`
@@ -196,6 +196,6 @@ type machineIDWizardRequestKubernetes struct {
 	Resources []types.KubernetesResource `json:"resources"`
 }
 
-type machineIDGHAK8sWizardResponse struct {
+type machineIDGHAK8sWizardGenerateIaCResponse struct {
 	Terraform string `json:"terraform"`
 }

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -170,7 +170,7 @@ type machineIDWizardGenerateIaCRequest struct {
 	SourceType      string                            `json:"source_type"`
 	DestinationType string                            `json:"destination_type"`
 	GitHub          *machineIDWizardRequestGitHub     `json:"github"`
-	Kubernetes      *machineIDWizardRequestKubernetes `json:"kubernetes`
+	Kubernetes      *machineIDWizardRequestKubernetes `json:"kubernetes"`
 }
 
 type machineIDWizardRequestGitHub struct {

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -142,11 +143,30 @@ func (h *Handler) machineIDWizard(w http.ResponseWriter, r *http.Request, p http
 	}
 
 	return machineIDGHAK8sWizardResponse{
-		Terraform: fmt.Sprintf(machineIDGHAK8sWizardTerraformTemplate, roleTF, botTF, tokenTF),
+		Terraform: fmt.Sprintf(
+			machineIDGHAK8sWizardTerraformTemplate,
+			roleTF,
+			botTF,
+			tokenTF,
+			h.terraformProviderConfig(),
+		),
 	}, nil
 }
 
-//go:embed templates/machine-id-gha-k8s-wizard-terraform.tmpl
+//go:embed templates/terraform-provider.tf.tmpl
+var terraformProviderTemplate string
+
+// terraformProviderConfig returns base configuration for the Teleport terraform
+// provider.
+func (h *Handler) terraformProviderConfig() string {
+	return fmt.Sprintf(
+		terraformProviderTemplate,
+		teleport.SemVer().Major,
+		h.PublicProxyAddr(),
+	)
+}
+
+//go:embed templates/machine-id-gha-k8s-wizard.tf.tmpl
 var machineIDGHAK8sWizardTerraformTemplate string
 
 type machineIDWizardRequest struct {

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -13,13 +13,14 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tfgen"
 	"github.com/gravitational/teleport/lib/tfgen/transform"
 	"github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // machineIDWizardGenerateIaC generates IaC code for the Machine Identity CI/CD wizards.
-func (h *Handler) machineIDWizardGenerateIaC(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext) (any, error) {
+func (h *Handler) machineIDWizardGenerateIaC(_ http.ResponseWriter, r *http.Request, _ httprouter.Params, _ *SessionContext, _ reversetunnelclient.Cluster) (any, error) {
 	var req machineIDWizardGenerateIaCRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -1,0 +1,181 @@
+package web
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tfgen"
+	"github.com/gravitational/teleport/lib/tfgen/transform"
+)
+
+// machineIDWizard generates IaC code for the Machine Identity CI/CD wizards.
+func (h *Handler) machineIDWizard(w http.ResponseWriter, r *http.Request, p httprouter.Params, ctx *SessionContext) (any, error) {
+	var req machineIDWizardRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Note: we currently only support deploying from GitHub Actions to Kubernetes
+	// but this endpoint will support other sources and destinations in the future.
+	switch {
+	case req.SourceType != "github":
+		return nil, trace.BadParameter("source_type must be one of: [github]")
+	case req.DestinationType != "kubernetes":
+		return nil, trace.BadParameter("destination_type must be one of: [kubernetes]")
+	}
+
+	if req.GitHub == nil {
+		// Default to *something* so the generated code isn't completely broken.
+		req.GitHub = &machineIDWizardRequestGitHub{
+			Repository: "repository",
+			Owner:      "organization",
+		}
+	}
+
+	namePrefix := fmt.Sprintf("gha-%s-%s", req.GitHub.Owner, req.GitHub.Repository)
+
+	// Role resource.
+	role := &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V7,
+		Metadata: types.Metadata{
+			Name: fmt.Sprintf("%s-kube-access", namePrefix),
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubeGroups: []string{"{{internal.kubernetes_groups}}"},
+				KubeUsers:  []string{"{{internal.kubernetes_users}}"},
+			},
+		},
+	}
+	var roleOpts []tfgen.GenerateOpt
+	if req.Kubernetes != nil {
+		role.Spec.Allow.KubernetesLabels = req.Kubernetes.Labels
+		role.Spec.Allow.KubernetesResources = req.Kubernetes.Resources
+	} else {
+		roleOpts = append(roleOpts, tfgen.WithFieldComment("spec.allow.kubernetes_labels", "kubernetes_labels will be added in the next steps."))
+	}
+
+	// Bot resource.
+	bot := &machineidv1.Bot{
+		Kind:    types.KindBot,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: namePrefix,
+		},
+		Spec: &machineidv1.BotSpec{},
+	}
+	botOpts := []tfgen.GenerateOpt{
+		tfgen.WithFieldTransform("spec.traits", transform.BotTraits),
+	}
+
+	if req.Kubernetes == nil {
+		botOpts = append(botOpts,
+			tfgen.WithFieldComment("spec.traits", "kubernetes_groups and kubernetes_users will be added in the next step."),
+		)
+	} else {
+		if len(req.Kubernetes.Groups) != 0 {
+			bot.Spec.Traits = append(bot.Spec.Traits, &machineidv1.Trait{
+				Name:   "kubernetes_groups",
+				Values: req.Kubernetes.Groups,
+			})
+		}
+		if len(req.Kubernetes.Users) != 0 {
+			bot.Spec.Traits = append(bot.Spec.Traits, &machineidv1.Trait{
+				Name:   "kubernetes_users",
+				Values: req.Kubernetes.Users,
+			})
+		}
+	}
+
+	// Join token resource.
+	token := &types.ProvisionTokenV2{
+		Kind:    types.KindToken,
+		Version: types.V2,
+		Metadata: types.Metadata{
+			Name: namePrefix,
+		},
+		Spec: types.ProvisionTokenSpecV2{
+			Roles:      []types.SystemRole{types.RoleBot},
+			JoinMethod: types.JoinMethodGitHub,
+			BotName:    namePrefix,
+			GitHub: &types.ProvisionTokenSpecV2GitHub{
+				Allow: []*types.ProvisionTokenSpecV2GitHub_Rule{
+					{
+						Repository:      fmt.Sprintf("%s/%s", req.GitHub.Owner, req.GitHub.Repository),
+						RepositoryOwner: req.GitHub.Owner,
+						Workflow:        req.GitHub.Workflow,
+						Environment:     req.GitHub.Environment,
+						Actor:           req.GitHub.Actor,
+						Ref:             req.GitHub.Ref,
+						RefType:         req.GitHub.RefType,
+					},
+				},
+				EnterpriseServerHost: req.GitHub.EnterpriseServerHost,
+				EnterpriseSlug:       req.GitHub.EnterpriseSlug,
+				StaticJWKS:           req.GitHub.StaticJWKS,
+			},
+		},
+	}
+
+	roleTF, err := tfgen.Generate(role, roleOpts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	botTF, err := tfgen.Generate(bot, botOpts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tokenTF, err := tfgen.Generate(token, tfgen.WithResourceType("teleport_provision_token"))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return machineIDGHAK8sWizardResponse{
+		Terraform: fmt.Sprintf(machineIDGHAK8sWizardTerraformTemplate, roleTF, botTF, tokenTF),
+	}, nil
+}
+
+//go:embed templates/machine-id-gha-k8s-wizard-terraform.tmpl
+var machineIDGHAK8sWizardTerraformTemplate string
+
+type machineIDWizardRequest struct {
+	SourceType      string                            `json:"source_type"`
+	DestinationType string                            `json:"destination_type"`
+	GitHub          *machineIDWizardRequestGitHub     `json:"github"`
+	Kubernetes      *machineIDWizardRequestKubernetes `json:"kubernetes`
+}
+
+type machineIDWizardRequestGitHub struct {
+	Repository           string `json:"repository"`
+	Owner                string `json:"owner"`
+	Workflow             string `json:"workflow"`
+	Environment          string `json:"environment"`
+	Actor                string `json:"actor"`
+	Ref                  string `json:"ref"`
+	RefType              string `json:"ref_type"`
+	EnterpriseServerHost string `json:"enterprise_server_host"`
+	EnterpriseSlug       string `json:"enterprise_slug"`
+	StaticJWKS           string `json:"static_jwks"`
+}
+
+type machineIDWizardRequestKubernetes struct {
+	Labels    types.Labels               `json:"labels"`
+	Groups    []string                   `json:"groups"`
+	Users     []string                   `json:"users"`
+	Resources []types.KubernetesResource `json:"resources"`
+}
+
+type machineIDGHAK8sWizardResponse struct {
+	Terraform string `json:"terraform"`
+}

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package web
 
 import (

--- a/lib/web/mwi_wizards.go
+++ b/lib/web/mwi_wizards.go
@@ -72,7 +72,9 @@ func (h *Handler) machineIDWizardGenerateIaC(w http.ResponseWriter, r *http.Requ
 		Metadata: &headerv1.Metadata{
 			Name: namePrefix,
 		},
-		Spec: &machineidv1.BotSpec{},
+		Spec: &machineidv1.BotSpec{
+			Roles: []string{role.GetName()},
+		},
 	}
 	botOpts := []tfgen.GenerateOpt{
 		tfgen.WithFieldTransform("spec.traits", transform.BotTraits),

--- a/lib/web/mwi_wizards_test.go
+++ b/lib/web/mwi_wizards_test.go
@@ -1,3 +1,21 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package web
 
 import (

--- a/lib/web/mwi_wizards_test.go
+++ b/lib/web/mwi_wizards_test.go
@@ -42,16 +42,24 @@ func TestMachineIDWizard(t *testing.T) {
 			SourceType:      "github",
 			DestinationType: "kubernetes",
 			GitHub: &machineIDWizardRequestGitHub{
-				Repository: "teleport",
-				Owner:      "gravitational",
+				Allow: []machineIDWizardRequestGitHubAllow{
+					{
+						Repository: "teleport",
+						Owner:      "gravitational",
+					},
+				},
 			},
 		},
 		"github+kubernetes-step2-terraform": {
 			SourceType:      "github",
 			DestinationType: "kubernetes",
 			GitHub: &machineIDWizardRequestGitHub{
-				Repository: "teleport",
-				Owner:      "gravitational",
+				Allow: []machineIDWizardRequestGitHubAllow{
+					{
+						Repository: "teleport",
+						Owner:      "gravitational",
+					},
+				},
 			},
 			Kubernetes: &machineIDWizardRequestKubernetes{
 				Labels: types.Labels{"department": []string{"engineering"}},
@@ -62,13 +70,17 @@ func TestMachineIDWizard(t *testing.T) {
 			SourceType:      "github",
 			DestinationType: "kubernetes",
 			GitHub: &machineIDWizardRequestGitHub{
-				Repository:           "teleport",
-				Owner:                "gravitational",
-				Workflow:             "deploy",
-				Environment:          "production",
-				Actor:                "deployinator",
-				Ref:                  "main",
-				RefType:              "branch",
+				Allow: []machineIDWizardRequestGitHubAllow{
+					{
+						Repository:  "teleport",
+						Owner:       "gravitational",
+						Workflow:    "deploy",
+						Environment: "production",
+						Actor:       "deployinator",
+						Ref:         "main",
+						RefType:     "branch",
+					},
+				},
 				EnterpriseServerHost: "github.corp.internal",
 				EnterpriseSlug:       "sluggy",
 				StaticJWKS:           testJWKS,

--- a/lib/web/mwi_wizards_test.go
+++ b/lib/web/mwi_wizards_test.go
@@ -31,7 +31,7 @@ func TestMachineIDWizard(t *testing.T) {
 
 	env := newWebPack(t, 1)
 	pack := env.proxies[0].authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
-	endpoint := pack.clt.Endpoint("webapi", "machine-id", "wizards", "ci-cd")
+	endpoint := pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "machine-id", "wizards", "ci-cd")
 
 	testCases := map[string]machineIDWizardGenerateIaCRequest{
 		"github+kubernetes-empty-terraform": {

--- a/lib/web/mwi_wizards_test.go
+++ b/lib/web/mwi_wizards_test.go
@@ -1,0 +1,110 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
+)
+
+func TestMachineIDWizard(t *testing.T) {
+	t.Parallel()
+
+	const testJWKS = `{
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "P9Zd",
+      "alg": "RS256",
+      "n": "kWp2zRA23Z3vTL4uoe8kTFptxBVFunIoP4t_8TDYJrOb7D1iZNDXVeEsYKp6ppmrTZDAgd-cNOTKLd4M39WJc5FN0maTAVKJc7NxklDeKc4dMe1BGvTZNG4MpWBo-taKULlYUu0ltYJuLzOjIrTHfarucrGoRWqM0sl3z2-fv9k",
+      "e": "AQAB"
+    }
+  ]
+}`
+
+	env := newWebPack(t, 1)
+	pack := env.proxies[0].authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
+	endpoint := pack.clt.Endpoint("webapi", "machine-id", "wizards", "ci-cd")
+
+	testCases := map[string]machineIDWizardRequest{
+		"github+kubernetes-empty-terraform": {
+			SourceType:      "github",
+			DestinationType: "kubernetes",
+		},
+		"github+kubernetes-step1-terraform": {
+			SourceType:      "github",
+			DestinationType: "kubernetes",
+			GitHub: &machineIDWizardRequestGitHub{
+				Repository: "teleport",
+				Owner:      "gravitational",
+			},
+		},
+		"github+kubernetes-step2-terraform": {
+			SourceType:      "github",
+			DestinationType: "kubernetes",
+			GitHub: &machineIDWizardRequestGitHub{
+				Repository: "teleport",
+				Owner:      "gravitational",
+			},
+			Kubernetes: &machineIDWizardRequestKubernetes{
+				Labels: types.Labels{"department": []string{"engineering"}},
+				Groups: []string{"system:masters"},
+			},
+		},
+		"github+kubernetes-complex-terraform": {
+			SourceType:      "github",
+			DestinationType: "kubernetes",
+			GitHub: &machineIDWizardRequestGitHub{
+				Repository:           "teleport",
+				Owner:                "gravitational",
+				Workflow:             "deploy",
+				Environment:          "production",
+				Actor:                "deployinator",
+				Ref:                  "main",
+				RefType:              "branch",
+				EnterpriseServerHost: "github.corp.internal",
+				EnterpriseSlug:       "sluggy",
+				StaticJWKS:           testJWKS,
+			},
+			Kubernetes: &machineIDWizardRequestKubernetes{
+				Labels: types.Labels{"department": []string{"engineering"}},
+				Groups: []string{"viewers"},
+				Users:  []string{"serviceAccount:deployment-sa"},
+				Resources: []types.KubernetesResource{
+					{
+						Kind:      "deployment",
+						APIGroup:  "apps",
+						Name:      "billing-service",
+						Namespace: "default",
+					},
+				},
+			},
+		},
+	}
+	for name, req := range testCases {
+		t.Run(name, func(t *testing.T) {
+			rsp, err := pack.clt.PostJSON(t.Context(), endpoint, req)
+			require.NoError(t, err)
+
+			var body machineIDGHAK8sWizardResponse
+			require.NoError(t, json.Unmarshal(rsp.Bytes(), &body))
+
+			if golden.ShouldSet() {
+				golden.Set(t, []byte(body.Terraform))
+			}
+
+			require.Empty(t,
+				cmp.Diff(
+					string(golden.Get(t)),
+					body.Terraform,
+				),
+			)
+		})
+	}
+}

--- a/lib/web/mwi_wizards_test.go
+++ b/lib/web/mwi_wizards_test.go
@@ -33,7 +33,7 @@ func TestMachineIDWizard(t *testing.T) {
 	pack := env.proxies[0].authPack(t, "admin", []types.Role{services.NewPresetEditorRole()})
 	endpoint := pack.clt.Endpoint("webapi", "machine-id", "wizards", "ci-cd")
 
-	testCases := map[string]machineIDWizardRequest{
+	testCases := map[string]machineIDWizardGenerateIaCRequest{
 		"github+kubernetes-empty-terraform": {
 			SourceType:      "github",
 			DestinationType: "kubernetes",
@@ -93,7 +93,7 @@ func TestMachineIDWizard(t *testing.T) {
 			rsp, err := pack.clt.PostJSON(t.Context(), endpoint, req)
 			require.NoError(t, err)
 
-			var body machineIDGHAK8sWizardResponse
+			var body machineIDGHAK8sWizardGenerateIaCResponse
 			require.NoError(t, json.Unmarshal(rsp.Bytes(), &body))
 
 			// Cut the provider configuration out of the golden file, as this

--- a/lib/web/templates/machine-id-gha-k8s-wizard-terraform.tmpl
+++ b/lib/web/templates/machine-id-gha-k8s-wizard-terraform.tmpl
@@ -1,0 +1,20 @@
+# This file contains definitions for resources required to allow a GitHub
+# Actions workflow to enroll with Teleport and connect to allowed Kubernetes
+# clusters protected by Teleport.
+
+# See the Teleport Terraform Provider docs for more information about using
+# Terraform to manage Teleport resources:
+# https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/
+
+# A role defines which Kubernetes clusters can be accessed, and the level of
+# access granted. Fine tune the access using the `kubernetes_*` attributes.
+# All available options can be found in the Teleport Terraform Provider
+# reference:
+# https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
+%[1]s
+# A bot is a Machine & Workload ID user which is granted access to enrolled
+# Kubernetes clusters using the role above.
+%[2]s
+# A provision token allows a GitHub Actions workflow to enroll with Teleport and
+# assume the identity of the bot defined above and its access.
+%[3]s

--- a/lib/web/templates/machine-id-gha-k8s-wizard.tf.tmpl
+++ b/lib/web/templates/machine-id-gha-k8s-wizard.tf.tmpl
@@ -18,3 +18,4 @@
 # A provision token allows a GitHub Actions workflow to enroll with Teleport and
 # assume the identity of the bot defined above and its access.
 %[3]s
+%[4]s

--- a/lib/web/templates/machine-id-gha-k8s-wizard.tf.tmpl
+++ b/lib/web/templates/machine-id-gha-k8s-wizard.tf.tmpl
@@ -11,11 +11,11 @@
 # All available options can be found in the Teleport Terraform Provider
 # reference:
 # https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
-%[1]s
+{{ .RoleConfig }}
 # A bot is a Machine & Workload ID user which is granted access to enrolled
 # Kubernetes clusters using the role above.
-%[2]s
+{{ .BotConfig }}
 # A provision token allows a GitHub Actions workflow to enroll with Teleport and
 # assume the identity of the bot defined above and its access.
-%[3]s
-%[4]s
+{{ .TokenConfig }}
+{{ template "terraform-provider.tf.tmpl" . }}

--- a/lib/web/templates/terraform-provider.tf.tmpl
+++ b/lib/web/templates/terraform-provider.tf.tmpl
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = "~> %[1]d.0"
+    }
+  }
+}
+
+provider "teleport" {
+  addr = %[2]q
+}

--- a/lib/web/templates/terraform-provider.tf.tmpl
+++ b/lib/web/templates/terraform-provider.tf.tmpl
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     teleport = {
       source  = "terraform.releases.teleport.dev/gravitational/teleport"
-      version = "~> %[1]d.0"
+      version = "~> {{ .MajorVersion }}.0"
     }
   }
 }
 
 provider "teleport" {
-  addr = %[2]q
+  addr = "{{ .ProxyAddr }}"
 }

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
@@ -1,0 +1,84 @@
+# This file contains definitions for resources required to allow a GitHub
+# Actions workflow to enroll with Teleport and connect to allowed Kubernetes
+# clusters protected by Teleport.
+
+# See the Teleport Terraform Provider docs for more information about using
+# Terraform to manage Teleport resources:
+# https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/
+
+# A role defines which Kubernetes clusters can be accessed, and the level of
+# access granted. Fine tune the access using the `kubernetes_*` attributes.
+# All available options can be found in the Teleport Terraform Provider
+# reference:
+# https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
+resource "teleport_role" "gha-gravitational-teleport-kube-access" {
+  version = "v7"
+
+  metadata = {
+    name = "gha-gravitational-teleport-kube-access"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
+      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      kubernetes_labels = {
+        department = ["engineering"]
+      }
+      kubernetes_resources = [{
+        api_group = "apps"
+        kind      = "deployment"
+        name      = "billing-service"
+        namespace = "default"
+      }]
+    }
+  }
+}
+
+# A bot is a Machine & Workload ID user which is granted access to enrolled
+# Kubernetes clusters using the role above.
+resource "teleport_bot" "gha-gravitational-teleport" {
+  version = "v1"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    traits = {
+      kubernetes_groups = ["viewers"]
+      kubernetes_users  = ["serviceAccount:deployment-sa"]
+    }
+  }
+}
+
+# A provision token allows a GitHub Actions workflow to enroll with Teleport and
+# assume the identity of the bot defined above and its access.
+resource "teleport_provision_token" "gha-gravitational-teleport" {
+  version = "v2"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    roles       = ["Bot"]
+    join_method = "github"
+    bot_name    = "gha-gravitational-teleport"
+    github = {
+      allow = [{
+        actor            = "deployinator"
+        environment      = "production"
+        ref              = "main"
+        ref_type         = "branch"
+        repository       = "gravitational/teleport"
+        repository_owner = "gravitational"
+        workflow         = "deploy"
+      }]
+      enterprise_server_host = "github.corp.internal"
+      enterprise_slug        = "sluggy"
+      static_jwks            = "{\n  \"keys\": [\n    {\n      \"kty\": \"RSA\",\n      \"use\": \"sig\",\n      \"kid\": \"P9Zd\",\n      \"alg\": \"RS256\",\n      \"n\": \"kWp2zRA23Z3vTL4uoe8kTFptxBVFunIoP4t_8TDYJrOb7D1iZNDXVeEsYKp6ppmrTZDAgd-cNOTKLd4M39WJc5FN0maTAVKJc7NxklDeKc4dMe1BGvTZNG4MpWBo-taKULlYUu0ltYJuLzOjIrTHfarucrGoRWqM0sl3z2-fv9k\",\n      \"e\": \"AQAB\"\n    }\n  ]\n}"
+    }
+  }
+}
+

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
@@ -45,6 +45,7 @@ resource "teleport_bot" "gha-gravitational-teleport" {
   }
 
   spec = {
+    roles = ["gha-gravitational-teleport-kube-access"]
     traits = {
       kubernetes_groups = ["viewers"]
       kubernetes_users  = ["serviceAccount:deployment-sa"]

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-complex-terraform.golden
@@ -20,8 +20,8 @@ resource "teleport_role" "gha-gravitational-teleport-kube-access" {
 
   spec = {
     allow = {
-      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
-      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      kubernetes_groups = ["viewers"]
+      kubernetes_users  = ["serviceAccount:deployment-sa"]
       kubernetes_labels = {
         department = ["engineering"]
       }
@@ -46,10 +46,6 @@ resource "teleport_bot" "gha-gravitational-teleport" {
 
   spec = {
     roles = ["gha-gravitational-teleport-kube-access"]
-    traits = {
-      kubernetes_groups = ["viewers"]
-      kubernetes_users  = ["serviceAccount:deployment-sa"]
-    }
   }
 }
 

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
@@ -38,6 +38,7 @@ resource "teleport_bot" "gha-organization-repository" {
   }
 
   spec = {
+    roles = ["gha-organization-repository-kube-access"]
     # kubernetes_groups and kubernetes_users will be added in the next step.
     traits = {}
   }

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
@@ -20,9 +20,9 @@ resource "teleport_role" "gha-organization-repository-kube-access" {
 
   spec = {
     allow = {
-      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
-      kubernetes_users  = ["{{internal.kubernetes_users}}"]
-      # kubernetes_labels will be added in the next steps.
+      # kubernetes_groups will be added in the next step.
+      kubernetes_groups = []
+      # kubernetes_labels will be added in the next step.
       kubernetes_labels = {}
     }
   }
@@ -39,8 +39,6 @@ resource "teleport_bot" "gha-organization-repository" {
 
   spec = {
     roles = ["gha-organization-repository-kube-access"]
-    # kubernetes_groups and kubernetes_users will be added in the next step.
-    traits = {}
   }
 }
 

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-empty-terraform.golden
@@ -1,0 +1,67 @@
+# This file contains definitions for resources required to allow a GitHub
+# Actions workflow to enroll with Teleport and connect to allowed Kubernetes
+# clusters protected by Teleport.
+
+# See the Teleport Terraform Provider docs for more information about using
+# Terraform to manage Teleport resources:
+# https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/
+
+# A role defines which Kubernetes clusters can be accessed, and the level of
+# access granted. Fine tune the access using the `kubernetes_*` attributes.
+# All available options can be found in the Teleport Terraform Provider
+# reference:
+# https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
+resource "teleport_role" "gha-organization-repository-kube-access" {
+  version = "v7"
+
+  metadata = {
+    name = "gha-organization-repository-kube-access"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
+      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      # kubernetes_labels will be added in the next steps.
+      kubernetes_labels = {}
+    }
+  }
+}
+
+# A bot is a Machine & Workload ID user which is granted access to enrolled
+# Kubernetes clusters using the role above.
+resource "teleport_bot" "gha-organization-repository" {
+  version = "v1"
+
+  metadata = {
+    name = "gha-organization-repository"
+  }
+
+  spec = {
+    # kubernetes_groups and kubernetes_users will be added in the next step.
+    traits = {}
+  }
+}
+
+# A provision token allows a GitHub Actions workflow to enroll with Teleport and
+# assume the identity of the bot defined above and its access.
+resource "teleport_provision_token" "gha-organization-repository" {
+  version = "v2"
+
+  metadata = {
+    name = "gha-organization-repository"
+  }
+
+  spec = {
+    roles       = ["Bot"]
+    join_method = "github"
+    bot_name    = "gha-organization-repository"
+    github = {
+      allow = [{
+        repository       = "organization/repository"
+        repository_owner = "organization"
+      }]
+    }
+  }
+}
+

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
@@ -38,6 +38,7 @@ resource "teleport_bot" "gha-gravitational-teleport" {
   }
 
   spec = {
+    roles = ["gha-gravitational-teleport-kube-access"]
     # kubernetes_groups and kubernetes_users will be added in the next step.
     traits = {}
   }

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
@@ -1,0 +1,67 @@
+# This file contains definitions for resources required to allow a GitHub
+# Actions workflow to enroll with Teleport and connect to allowed Kubernetes
+# clusters protected by Teleport.
+
+# See the Teleport Terraform Provider docs for more information about using
+# Terraform to manage Teleport resources:
+# https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/
+
+# A role defines which Kubernetes clusters can be accessed, and the level of
+# access granted. Fine tune the access using the `kubernetes_*` attributes.
+# All available options can be found in the Teleport Terraform Provider
+# reference:
+# https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
+resource "teleport_role" "gha-gravitational-teleport-kube-access" {
+  version = "v7"
+
+  metadata = {
+    name = "gha-gravitational-teleport-kube-access"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
+      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      # kubernetes_labels will be added in the next steps.
+      kubernetes_labels = {}
+    }
+  }
+}
+
+# A bot is a Machine & Workload ID user which is granted access to enrolled
+# Kubernetes clusters using the role above.
+resource "teleport_bot" "gha-gravitational-teleport" {
+  version = "v1"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    # kubernetes_groups and kubernetes_users will be added in the next step.
+    traits = {}
+  }
+}
+
+# A provision token allows a GitHub Actions workflow to enroll with Teleport and
+# assume the identity of the bot defined above and its access.
+resource "teleport_provision_token" "gha-gravitational-teleport" {
+  version = "v2"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    roles       = ["Bot"]
+    join_method = "github"
+    bot_name    = "gha-gravitational-teleport"
+    github = {
+      allow = [{
+        repository       = "gravitational/teleport"
+        repository_owner = "gravitational"
+      }]
+    }
+  }
+}
+

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step1-terraform.golden
@@ -20,9 +20,9 @@ resource "teleport_role" "gha-gravitational-teleport-kube-access" {
 
   spec = {
     allow = {
-      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
-      kubernetes_users  = ["{{internal.kubernetes_users}}"]
-      # kubernetes_labels will be added in the next steps.
+      # kubernetes_groups will be added in the next step.
+      kubernetes_groups = []
+      # kubernetes_labels will be added in the next step.
       kubernetes_labels = {}
     }
   }
@@ -39,8 +39,6 @@ resource "teleport_bot" "gha-gravitational-teleport" {
 
   spec = {
     roles = ["gha-gravitational-teleport-kube-access"]
-    # kubernetes_groups and kubernetes_users will be added in the next step.
-    traits = {}
   }
 }
 

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
@@ -39,6 +39,7 @@ resource "teleport_bot" "gha-gravitational-teleport" {
   }
 
   spec = {
+    roles = ["gha-gravitational-teleport-kube-access"]
     traits = {
       kubernetes_groups = ["system:masters"]
     }

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
@@ -20,8 +20,7 @@ resource "teleport_role" "gha-gravitational-teleport-kube-access" {
 
   spec = {
     allow = {
-      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
-      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      kubernetes_groups = ["system:masters"]
       kubernetes_labels = {
         department = ["engineering"]
       }
@@ -40,9 +39,6 @@ resource "teleport_bot" "gha-gravitational-teleport" {
 
   spec = {
     roles = ["gha-gravitational-teleport-kube-access"]
-    traits = {
-      kubernetes_groups = ["system:masters"]
-    }
   }
 }
 

--- a/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
+++ b/lib/web/testdata/TestMachineIDWizard/github+kubernetes-step2-terraform.golden
@@ -1,0 +1,69 @@
+# This file contains definitions for resources required to allow a GitHub
+# Actions workflow to enroll with Teleport and connect to allowed Kubernetes
+# clusters protected by Teleport.
+
+# See the Teleport Terraform Provider docs for more information about using
+# Terraform to manage Teleport resources:
+# https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/
+
+# A role defines which Kubernetes clusters can be accessed, and the level of
+# access granted. Fine tune the access using the `kubernetes_*` attributes.
+# All available options can be found in the Teleport Terraform Provider
+# reference:
+# https://goteleport.com/docs/reference/infrastructure-as-code/terraform-provider/
+resource "teleport_role" "gha-gravitational-teleport-kube-access" {
+  version = "v7"
+
+  metadata = {
+    name = "gha-gravitational-teleport-kube-access"
+  }
+
+  spec = {
+    allow = {
+      kubernetes_groups = ["{{internal.kubernetes_groups}}"]
+      kubernetes_users  = ["{{internal.kubernetes_users}}"]
+      kubernetes_labels = {
+        department = ["engineering"]
+      }
+    }
+  }
+}
+
+# A bot is a Machine & Workload ID user which is granted access to enrolled
+# Kubernetes clusters using the role above.
+resource "teleport_bot" "gha-gravitational-teleport" {
+  version = "v1"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    traits = {
+      kubernetes_groups = ["system:masters"]
+    }
+  }
+}
+
+# A provision token allows a GitHub Actions workflow to enroll with Teleport and
+# assume the identity of the bot defined above and its access.
+resource "teleport_provision_token" "gha-gravitational-teleport" {
+  version = "v2"
+
+  metadata = {
+    name = "gha-gravitational-teleport"
+  }
+
+  spec = {
+    roles       = ["Bot"]
+    join_method = "github"
+    bot_name    = "gha-gravitational-teleport"
+    github = {
+      allow = [{
+        repository       = "gravitational/teleport"
+        repository_owner = "gravitational"
+      }]
+    }
+  }
+}
+


### PR DESCRIPTION
Adds an HTTP endpoint for the GitHub Actions + Kubernetes wizard, that generates Terraform configuration for a role, bot, and join token resource using the new `lib/tfgen` package.
