### PR TITLE
Fix syntax issue in Access Monitoring reference

### DIFF
--- a/docs/pages/reference/access-controls/access-monitoring-events.mdx
+++ b/docs/pages/reference/access-controls/access-monitoring-events.mdx
@@ -5,7 +5,7 @@ description: Provides a comprehensive list of Access Monitoring events, their fi
 ---
 
 The Access Monitoring event reference includes a list of Access Monitoring
-events that you can query and view in reports, along with examples of @tctl@
+events that you can query and view in reports, along with examples of `tctl`
 commands you can run to query each event.
 
 Access Monitoring tracks a subset of Teleport audit events that are relevant to


### PR DESCRIPTION
In #61632, the Access Monitoring event reference generator originally replaced `@` characters in a template with backticks before executing it, and the frontmatter and introduction of the guide were part of the template.

While this change took a different approach, extracting the frontmatter and introduction into a separate file, and no longer replacing `@` characters, the `@` characters weren't removed from the file. This change fixes the stray `@` characters.