### PR TITLE
[v18] Fixing blocking behavior when an encrypted recording upload fails

### DIFF
--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -583,7 +583,9 @@ func (m *Manager) FindDecryptersByLabels(ctx context.Context, labels ...*types.K
 		for _, label := range labels {
 			decs, err := backend.findDecryptersByLabel(ctx, label)
 			if err != nil {
-				m.logger.DebugContext(ctx, "could not find key for label", "backend", backend.name(), "label_type", label.Type, "label", label.Label, "error", err)
+				if !trace.IsNotImplemented(err) {
+					m.logger.DebugContext(ctx, "could not find key for label", "backend", backend.name(), "label_type", label.Type, "label", label.Label, "error", err)
+				}
 				continue
 			}
 

--- a/lib/events/eventstest/generate.go
+++ b/lib/events/eventstest/generate.go
@@ -19,6 +19,7 @@
 package eventstest
 
 import (
+	"cmp"
 	"fmt"
 	"strings"
 	"time"
@@ -43,6 +44,10 @@ type SessionParams struct {
 	// PrintData is optional data to use for print events. Each element of the
 	// slice represents data for one print event.
 	PrintData []string
+	// PrintUntilBytes works similarly to PrintEvents, but instead of generating
+	// a fixed number of events, it generates events until the total size of the
+	// the generated events exceeds PrintUntilBytes.
+	PrintUntilBytes int64
 	// Clock is an optional clock setting start
 	// and offset time of the event
 	Clock clockwork.Clock
@@ -54,6 +59,32 @@ type SessionParams struct {
 	ClusterName string
 	// UserName is name of the user interacting with the session
 	UserName string
+}
+
+// genPrintData generates print events based on the given SessionParams. It
+// prioritizes generating events by count if specified. Otherwise it will
+// attempt to generate enough event to reach a total byte size.
+func (p *SessionParams) genPrintData() {
+	var i int64
+	var bytesEmitted int64
+	shouldContinue := func() bool {
+		if p.PrintEvents > 0 {
+			return i < p.PrintEvents
+		}
+
+		if p.PrintUntilBytes > 0 {
+			return bytesEmitted < p.PrintUntilBytes
+		}
+
+		return false
+	}
+
+	p.PrintData = make([]string, 0, int(cmp.Or(p.PrintEvents, 500)))
+	for shouldContinue() {
+		p.PrintData = append(p.PrintData, strings.Repeat("hello", int(i%177+1)))
+		bytesEmitted += int64(len(p.PrintData[i]))
+		i++
+	}
 }
 
 // SetDefaults sets parameters defaults
@@ -69,10 +100,7 @@ func (p *SessionParams) SetDefaults() {
 		p.SessionID = uuid.New().String()
 	}
 	if p.PrintData == nil {
-		p.PrintData = make([]string, p.PrintEvents)
-		for i := range p.PrintEvents {
-			p.PrintData[i] = strings.Repeat("hello", int(i%177+1))
-		}
+		p.genPrintData()
 	}
 	if p.UserName == "" {
 		p.UserName = "alice@example.com"

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -296,6 +296,10 @@ func (u *Uploader) Scan(ctx context.Context) (*ScanStats, error) {
 				u.log.DebugContext(ctx, "Recording was uploaded by another process.", "recording", fi.Name())
 				continue
 			}
+			if errors.Is(err, errNoEncryptedUploader) {
+				u.log.ErrorContext(ctx, "Skipped encrypted session recording due to missing uploader", "recording", fi.Name())
+				continue
+			}
 			if isSessionError(err) || trace.IsBadParameter(err) {
 				u.log.WarnContext(ctx, "Skipped session recording.", "recording", fi.Name(), "error", err)
 				stats.Corrupted++
@@ -366,8 +370,7 @@ func (u *upload) writeStatus(status apievents.StreamStatus) error {
 	return nil
 }
 
-// releaseFile releases file and associated resources
-// in a correct order
+// Close an upload's proto stream, files, and release it's file lock in the correct order.
 func (u *upload) Close() error {
 	return trace.NewAggregate(
 		u.reader.Close(),
@@ -392,40 +395,6 @@ func (u *upload) removeFiles() error {
 
 var errSkipEncryptedUpload = errors.New("skip encrypted upload")
 
-func (u *Uploader) uploadEncryptedRecording(ctx context.Context, sessionID string, in io.ReadSeeker) error {
-	if u.cfg.EncryptedRecordingUploader == nil {
-		return trace.Wrap(errSkipEncryptedUpload, "no encrypted uploader configured")
-	}
-
-	header, err := events.ParsePartHeader(in)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	if header.Flags&events.ProtoStreamFlagEncrypted == 0 {
-		return trace.Wrap(errSkipEncryptedUpload, "recording not encrypted")
-	}
-
-	if _, err := in.Seek(0, 0); err != nil {
-		return trace.Wrap(err, "resetting recording for plaintext upload")
-	}
-
-	// The upload parts in the given reader are each ~128KB. Usually these parts are consumed and reconstructed
-	// by Auth in 5MB chunks to meet the minimum upload size of upload providers like S3. Since these uploads
-	// are proxied directly to the uploader from the agent here (see link below), this agent needs to combine
-	// these upload parts into larger, aggregated upload parts.
-	//
-	// https://github.com/gravitational/teleport/blob/master/rfd/0127-encrypted-session-recordings.md#session-recording-modes
-	partIter := encryptedUploadAggregateIter(in, u.cfg.EncryptedRecordingUploadTargetSize, u.cfg.EncryptedRecordingUploadMaxSize)
-
-	u.log.DebugContext(ctx, "uploading encrypted recording", "session_id", sessionID)
-	if err := u.cfg.EncryptedRecordingUploader.UploadEncryptedRecording(ctx, sessionID, partIter); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
-}
-
 // encryptedUploadAggregateIter returns an iterator that aggregates upload parts from the given reader
 // into larger upload with size greater than targetSize, or as near targetSize as possible without exceeding
 // the maxSize.
@@ -440,7 +409,7 @@ func encryptedUploadAggregateIter(in io.Reader, targetSize int, maxSize int) ite
 		}
 
 		if header.Flags&events.ProtoStreamFlagEncrypted == 0 {
-			return events.PartHeader{}, trace.Wrap(errSkipEncryptedUpload, "recording not encrypted")
+			return events.PartHeader{}, trace.Wrap(errSkipEncryptedUpload, "recording part not encrypted")
 		}
 
 		// Ensure that the individual file upload parts are not larger than the max size allowed here (e.g. 4MB gRPC max message size).
@@ -486,7 +455,16 @@ func encryptedUploadAggregateIter(in io.Reader, targetSize int, maxSize int) ite
 		return nil
 	}
 
-	return func(yield func([]byte, error) bool) {
+	return func(yieldFn func([]byte, error) bool) {
+		// wrap any yielded errors with sessionError since any failure to
+		// read the file itself should be treated as a corrupted recording
+		yield := func(b []byte, err error) bool {
+			if err != nil {
+				return yieldFn(b, sessionError{err})
+			}
+			return yieldFn(b, nil)
+		}
+
 		// yield the current aggregated upload part and reset the buffer.
 		yieldCurrent := func() bool {
 			// Copy the buffer to a new []byte so that the next
@@ -596,22 +574,23 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 		return trace.Wrap(err, "uploader could not acquire file lock for %q", sessionFilePath)
 	}
 
-	if err := u.uploadEncryptedRecording(ctx, sessionID.String(), sessionFile); !errors.Is(err, errSkipEncryptedUpload) {
-		if err != nil {
-			log.WarnContext(ctx, "Encrypted upload failed.", "error", err)
+	upload := &upload{
+		sessionID:    sessionID,
+		file:         sessionFile,
+		fileUnlockFn: unlock,
+		reader:       nil,
+	}
+
+	if err := u.uploadEncrypted(ctx, upload); err != nil {
+		if !errors.Is(err, errSkipEncryptedUpload) {
 			u.emitEvent(events.UploadEvent{
 				SessionID: sessionID.String(),
-				Error:     sessionError{err},
+				Error:     err,
 				Created:   u.cfg.Clock.Now().UTC(),
 			})
-
 			return trace.Wrap(err)
 		}
-
-		if err := os.Remove(sessionFile.Name()); err != nil {
-			return trace.Wrap(err)
-		}
-
+	} else {
 		return nil
 	}
 
@@ -621,14 +600,8 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 		return trace.Wrap(err)
 	}
 
-	protoReader := events.NewProtoReader(sessionFile, nil)
+	upload.reader = events.NewProtoReader(sessionFile, nil)
 
-	upload := &upload{
-		sessionID:    sessionID,
-		reader:       protoReader,
-		file:         sessionFile,
-		fileUnlockFn: unlock,
-	}
 	upload.checkpointFile, err = os.OpenFile(u.checkpointFilePath(sessionID), os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		if err := upload.Close(); err != nil {
@@ -655,6 +628,64 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) (err error)
 			Created:   u.cfg.Clock.Now().UTC(),
 		})
 	}()
+	return nil
+}
+
+var errNoEncryptedUploader = &trace.BadParameterError{Message: "no encrypted uploader configured while uploading encrypted recording"}
+
+func (u *Uploader) uploadEncrypted(ctx context.Context, up *upload) error {
+	log := u.log.With(fieldSessionID, up.sessionID)
+	header, err := events.ParsePartHeader(up.file)
+	if err != nil {
+		return trace.Wrap(sessionError{err})
+	}
+
+	if header.Flags&events.ProtoStreamFlagEncrypted == 0 {
+		return trace.Wrap(errSkipEncryptedUpload, "recording not encrypted")
+	}
+
+	if u.cfg.EncryptedRecordingUploader == nil {
+		return trace.Wrap(errNoEncryptedUploader)
+	}
+
+	if _, err := up.file.Seek(0, io.SeekStart); err != nil {
+		return trace.Wrap(err, "resetting recording for plaintext upload")
+	}
+
+	// The upload parts in the given reader are each ~128KB. Usually these parts are consumed and reconstructed
+	// by Auth in 5MB chunks to meet the minimum upload size of upload providers like S3. Since these uploads
+	// are proxied directly to the uploader from the agent here (see link below), this agent needs to combine
+	// these upload parts into larger, aggregated upload parts.
+	//
+	// https://github.com/gravitational/teleport/blob/master/rfd/0127-encrypted-session-recordings.md#session-recording-modes
+	partIter := encryptedUploadAggregateIter(up.file, u.cfg.EncryptedRecordingUploadTargetSize, u.cfg.EncryptedRecordingUploadMaxSize)
+
+	u.wg.Add(1)
+	go func() {
+		defer u.wg.Done()
+		defer u.releaseSemaphore(ctx)
+		defer up.Close()
+		log.DebugContext(ctx, "uploading encrypted recording")
+		if err := u.cfg.EncryptedRecordingUploader.UploadEncryptedRecording(ctx, up.sessionID.String(), partIter); err != nil {
+			log.ErrorContext(ctx, "Encrypted upload failed", "error", err)
+			u.emitEvent(events.UploadEvent{
+				SessionID: up.sessionID.String(),
+				Error:     err,
+				Created:   u.cfg.Clock.Now().UTC(),
+			})
+			return
+		}
+
+		u.emitEvent(events.UploadEvent{
+			SessionID: up.sessionID.String(),
+			Created:   u.cfg.Clock.Now().UTC(),
+		})
+
+		if err := os.Remove(up.file.Name()); err != nil {
+			log.ErrorContext(ctx, "failed to remove session file after successful upload", "error", err)
+		}
+	}()
+
 	return nil
 }
 

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -39,12 +39,14 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 // TestUploadOK tests async file uploads scenarios
@@ -54,8 +56,10 @@ func TestUploadOK(t *testing.T) {
 
 	p := newUploaderPack(ctx, t, uploaderPackConfig{})
 
+	clock, ok := p.clock.(*clockwork.FakeClock)
+	require.True(t, ok, "fake clock expected")
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntilContext(ctx, 1)
+	clock.BlockUntilContext(ctx, 1)
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 1024})
 	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
@@ -64,7 +68,7 @@ func TestUploadOK(t *testing.T) {
 
 	// initiate the scan by advancing clock past
 	// block period
-	p.clock.Advance(p.scanPeriod + time.Second)
+	clock.Advance(p.scanPeriod + time.Second)
 
 	var event events.UploadEvent
 	select {
@@ -93,8 +97,11 @@ func TestUploadParallel(t *testing.T) {
 
 	p := newUploaderPack(ctx, t, uploaderPackConfig{})
 
+	clock, ok := p.clock.(*clockwork.FakeClock)
+	require.True(t, ok, "fake clock expected")
+
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntilContext(ctx, 1)
+	clock.BlockUntilContext(ctx, 1)
 
 	sessions := make(map[string][]apievents.AuditEvent)
 
@@ -109,7 +116,7 @@ func TestUploadParallel(t *testing.T) {
 
 	// initiate the scan by advancing the clock past
 	// block period
-	p.clock.Advance(p.scanPeriod + time.Second)
+	clock.Advance(p.scanPeriod + time.Second)
 
 	for range sessions {
 		var event events.UploadEvent
@@ -378,7 +385,7 @@ func TestUploadResume(t *testing.T) {
 // and makes sure that the uploader starts backing off.
 func TestUploadBackoff(t *testing.T) {
 	var terminateConnectionAt atomic.Int64
-	terminateConnectionAt.Store(700)
+	terminateConnectionAt.Store(256)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
@@ -400,28 +407,21 @@ func TestUploadBackoff(t *testing.T) {
 		},
 	})
 
+	clock, ok := p.clock.(*clockwork.FakeClock)
+	require.True(t, ok, "fake clock expected")
+
 	// wait until uploader blocks on the clock before creating the stream
-	p.clock.BlockUntilContext(ctx, 1)
+	clock.BlockUntilContext(ctx, 1)
 
-	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 4096})
-	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
-
-	stream, err := p.fileStreamer.CreateAuditStream(ctx, session.ID(sid))
-	require.NoError(t, err)
-
-	for _, event := range inEvents {
-		err := stream.RecordEvent(ctx, eventstest.PrepareEvent(event))
-		require.NoError(t, err)
-	}
-	err = stream.Complete(ctx)
-	require.NoError(t, err)
+	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 512})
+	p.emitEvents(ctx, t, inEvents)
 
 	// initiate the scan by advancing clock past
 	// block period
-	p.clock.Advance(p.scanPeriod + time.Second)
+	clock.Advance(p.scanPeriod + time.Second)
 
 	// initiate several scan attempts and increase the scan period
-	attempts := 10
+	attempts := 5
 	var prev time.Time
 	var diffs []time.Duration
 	for i := 0; i < attempts; i++ {
@@ -443,8 +443,8 @@ func TestUploadBackoff(t *testing.T) {
 		// Block until Scan has been called two times,
 		// first time after doing the scan, and second
 		// on receiving the event to <- eventsCh
-		p.clock.BlockUntilContext(ctx, 2)
-		p.clock.Advance(p.scanPeriod*time.Duration(i+2) + time.Second)
+		clock.BlockUntilContext(ctx, 2)
+		clock.Advance(p.scanPeriod*time.Duration(i+2) + time.Second)
 	}
 
 	// Make sure that durations between retries are increasing
@@ -456,8 +456,8 @@ func TestUploadBackoff(t *testing.T) {
 
 	// Fix the streamer, make sure the upload succeeds
 	terminateConnectionAt.Store(0)
-	p.clock.BlockUntilContext(ctx, 2)
-	p.clock.Advance(time.Hour)
+	clock.BlockUntilContext(ctx, 2)
+	clock.Advance(time.Hour)
 	select {
 	case event := <-p.eventsC:
 		require.NoError(t, event.Error)
@@ -466,43 +466,43 @@ func TestUploadBackoff(t *testing.T) {
 	}
 }
 
-// TestUploadBadSession creates a corrupted session file
-// and makes sure the uploader marks it as faulty
-func TestUploadBadSession(t *testing.T) {
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
+// TestUploadCorruptSession creates a corrupted session file
+// and makes sure the uploader marks it as faulty and moves it
+// to the corrupted directory
+func TestUploadCorruptSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		p := newUploaderPack(ctx, t, uploaderPackConfig{
+			clock: clockwork.NewRealClock(),
+		})
+		sessionID := session.NewID()
+		fileName := filepath.Join(p.scanDir, string(sessionID)+tarExt)
 
-	p := newUploaderPack(ctx, t, uploaderPackConfig{})
+		err := os.WriteFile(fileName, []byte("this session is corrupted"), 0o600)
+		require.NoError(t, err)
 
-	// wait until uploader blocks on the clock
-	p.clock.BlockUntilContext(ctx, 1)
-
-	sessionID := session.NewID()
-	fileName := filepath.Join(p.scanDir, string(sessionID)+tarExt)
-
-	err := os.WriteFile(fileName, []byte("this session is corrupted"), 0o600)
-	require.NoError(t, err)
-
-	// initiate the scan by advancing clock past
-	// block period
-	p.clock.Advance(p.scanPeriod + time.Second)
-
-	// wait for the upload event, make sure
-	// the error is the problem error
-	var event events.UploadEvent
-	select {
-	case event = <-p.eventsC:
+		// wait for the upload event, make sure
+		// the error is the problem error
+		event := <-p.eventsC
 		require.Error(t, event.Error)
 		require.True(t, isSessionError(event.Error))
-	case <-ctx.Done():
-		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
-	}
 
-	stats, err := p.uploader.Scan(ctx)
-	require.NoError(t, err)
-	// Bad records have been scanned, but uploads have not started
-	require.Equal(t, 1, stats.Scanned)
-	require.Equal(t, 0, stats.Started)
+		stats, err := p.uploader.Scan(ctx)
+		require.NoError(t, err)
+		// Bad records have been scanned, but uploads have not started
+		require.Equal(t, 1, stats.Scanned)
+		require.Equal(t, 1, stats.Corrupted)
+		require.Equal(t, 0, stats.Started)
+
+		// wait for the upload to picked up again and moved to the corrupted
+		// directory
+		synctest.Wait()
+
+		// make sure the file has been moved from the scan dir to the corrupted dir
+		require.NoFileExists(t, fileName)
+		require.FileExists(t, filepath.Join(p.uploader.cfg.CorruptedDir, string(sessionID)+tarExt))
+
+	})
 }
 
 // TestMinimumUpload tests that the minimum upload values for files and final uploads are respected.
@@ -525,10 +525,12 @@ func TestMinimumUpload(t *testing.T) {
 		minimumUploadBytes:     int64(minUploadBytes),
 	})
 
+	clock, ok := p.clock.(*clockwork.FakeClock)
+	require.True(t, ok, "fake clock expected")
 	// wait until uploader blocks on the clock
-	p.clock.BlockUntilContext(ctx, 1)
+	clock.BlockUntilContext(ctx, 1)
 
-	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(mathrand.IntN(5000) + 5000)})
+	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintUntilBytes: int64(maxUploadBytes + 512 + mathrand.IntN(512))})
 	sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
 	stream, err := p.fileStreamer.CreateAuditStream(ctx, session.ID(sid))
 	require.NoError(t, err)
@@ -582,7 +584,8 @@ func TestMinimumUpload(t *testing.T) {
 	// Complete the file stream and advance the clock to unblock the uploader scanner.
 	err = stream.Complete(ctx)
 	require.NoError(t, err)
-	p.clock.Advance(p.scanPeriod + time.Second)
+
+	clock.Advance(p.scanPeriod + time.Second)
 
 	var event events.UploadEvent
 	select {
@@ -650,12 +653,14 @@ func TestUploadEncryptedRecording(t *testing.T) {
 			encryptedTargetSize: 8192 * 4 * 2,
 			minUploadBytes:      8192 * 4,
 		}, {
-			name:                "target size equals min upload size",
+			name: "target size equals min upload size",
+			// this test becomes flaky at lower sizes
 			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			minUploadBytes:      8192 * 4,
 		}, {
-			name:                "target size smaller than min upload size",
+			name: "target size smaller than min upload size",
+			// this test becomes flaky at lower sizes
 			minFileSize:         8192,
 			encryptedTargetSize: 8192 * 4,
 			minUploadBytes:      8192 * 4 * 2,
@@ -757,19 +762,21 @@ func TestUploadEncryptedRecording(t *testing.T) {
 				encryptedRecordingUploadMaxSize:    tc.encryptedMaxSize,
 			})
 
+			clock, ok := p.clock.(*clockwork.FakeClock)
+			require.True(t, ok, "fake clock expected")
+
 			// wait until uploader blocks on the clock
-			err := p.clock.BlockUntilContext(ctx, 1)
+			err := clock.BlockUntilContext(ctx, 1)
 			require.NoError(t, err)
 
 			// Here we ensure at least 5 final upload parts so that we amply test the test case values, + some variance.
-			eventsCount := expectFinalSizeCeil*5/64 + mathrand.IntN(1000)
-			inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(eventsCount)})
+			inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintUntilBytes: int64(expectFinalSizeCeil*5 + mathrand.IntN(512))})
 			sid := inEvents[0].(events.SessionMetadataGetter).GetSessionID()
 			p.emitEvents(ctx, t, inEvents)
 
 			// initiate the scan by advancing clock past
 			// block period
-			p.clock.Advance(p.scanPeriod + time.Second)
+			clock.Advance(p.scanPeriod + time.Second)
 
 			var event events.UploadEvent
 			select {
@@ -814,6 +821,94 @@ func TestUploadEncryptedRecording(t *testing.T) {
 	}
 }
 
+// TestUploadCorruptEncryptedRecording ensures that a single failed upload does not cause failures to upload
+// other well-formed recordings. It also ensures that the affected file is moved into the corrupted directory.
+func TestUploadCorruptEncryptedRecording(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+
+		var corruptSessionID string
+		var failedSessionID string
+		wrapUploaderFn := func(uploader events.EncryptedRecordingUploader) events.EncryptedRecordingUploader {
+			return encryptedUploaderFn(func(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
+				if sessionID == corruptSessionID {
+					return sessionError{errors.New("corrupted session")}
+				}
+
+				if sessionID == failedSessionID {
+					return errors.New("upload failure")
+				}
+
+				return uploader.UploadEncryptedRecording(ctx, sessionID, parts)
+			})
+		}
+
+		concurrentUploads := 3
+		// we need to generate enough sessions to saturate the concurrent uploads and
+		// ensure we're releasing the semaphore properly
+		sessionCount := concurrentUploads * 3
+
+		p := newUploaderPack(ctx, t, uploaderPackConfig{
+			minimumFileUploadBytes:             64,
+			encrypter:                          &fakeEncryptedIO{},
+			encryptedRecordingUploadTargetSize: 128,
+			wrapEncryptedUploader:              wrapUploaderFn,
+			concurrentUploads:                  concurrentUploads,
+		})
+
+		// clean up the scan dir because the tests are flaky otherwise
+		t.Cleanup(func() { os.RemoveAll(p.scanDir) })
+
+		// generate a few recordings
+		eventsCount := 100
+		sessionIDs := make([]string, sessionCount)
+		failedIdx := mathrand.IntN(len(sessionIDs))
+		corruptIdx := mathrand.IntN(len(sessionIDs))
+		for corruptIdx == failedIdx {
+			corruptIdx = mathrand.IntN(len(sessionIDs))
+		}
+		for i := range sessionCount {
+			inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: int64(eventsCount)})
+			sessionIDs[i] = inEvents[0].(events.SessionMetadataGetter).GetSessionID()
+			if i == failedIdx {
+				failedSessionID = sessionIDs[i]
+			}
+			if i == corruptIdx {
+				corruptSessionID = sessionIDs[i]
+			}
+			p.emitEvents(ctx, t, inEvents)
+		}
+
+		// Due to issues with determinism in running the uploader, we opt to scan/wait
+		// in a loop to ensure all uploads are fully processed and then assert on the
+		// final state of recording files on disk.
+		for range 10 {
+			_, err := p.uploader.Scan(ctx)
+			require.NoError(t, err)
+			synctest.Wait()
+		}
+
+		// assert corrupt file is moved to the corrupted dir
+		assert.NoFileExists(t, filepath.Join(p.scanDir, corruptSessionID+tarExt))
+		assert.FileExists(t, filepath.Join(p.uploader.cfg.CorruptedDir, corruptSessionID+tarExt))
+		assert.FileExists(t, filepath.Join(p.uploader.cfg.CorruptedDir, corruptSessionID+errorExt))
+
+		// assert file that failed to upload still exists in the scan dir to be retried
+		assert.FileExists(t, filepath.Join(p.scanDir, failedSessionID+tarExt))
+		assert.NoFileExists(t, filepath.Join(p.uploader.cfg.CorruptedDir, failedSessionID+tarExt))
+
+		// assert that successfully uploaded files are removed
+		for _, sid := range sessionIDs {
+			switch sid {
+			case failedSessionID, corruptSessionID:
+				continue
+			}
+			assert.NoFileExists(t, filepath.Join(p.scanDir, sid+tarExt))
+			assert.NoFileExists(t, filepath.Join(p.uploader.cfg.CorruptedDir, sid+tarExt))
+		}
+	})
+}
+
 type uploaderPackConfig struct {
 	minimumFileUploadBytes             int64
 	minimumUploadBytes                 int64
@@ -822,6 +917,8 @@ type uploaderPackConfig struct {
 	wrapEncryptedUploader              wrapEncryptedUploaderFn
 	encryptedRecordingUploadTargetSize int
 	encryptedRecordingUploadMaxSize    int
+	clock                              clockwork.Clock
+	concurrentUploads                  int
 }
 
 // uploaderPack reduces boilerplate required
@@ -829,7 +926,7 @@ type uploaderPackConfig struct {
 type uploaderPack struct {
 	scanPeriod       time.Duration
 	initialScanDelay time.Duration
-	clock            *clockwork.FakeClock
+	clock            clockwork.Clock
 	// fileStreamer streams events to upload parts on disk.
 	scanDir      string
 	fileStreamer events.Streamer
@@ -849,8 +946,12 @@ func newUploaderPack(ctx context.Context, t *testing.T, cfg uploaderPackConfig) 
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
+	clock := cfg.clock
+	if clock == nil {
+		clock = clockwork.NewFakeClock()
+	}
 	pack := uploaderPack{
-		clock:            clockwork.NewFakeClock(),
+		clock:            clock,
 		eventsC:          make(chan events.UploadEvent, 100),
 		memEventsC:       make(chan events.UploadEvent, 100),
 		scanDir:          scanDir,
@@ -889,11 +990,12 @@ func newUploaderPack(ctx context.Context, t *testing.T, cfg uploaderPackConfig) 
 		InitialScanDelay:                   pack.initialScanDelay,
 		ScanPeriod:                         pack.scanPeriod,
 		Streamer:                           pack.protoStreamer,
-		Clock:                              pack.clock,
+		Clock:                              clock,
 		EventsC:                            pack.eventsC,
 		EncryptedRecordingUploader:         pack.memUploader,
 		EncryptedRecordingUploadTargetSize: cfg.encryptedRecordingUploadTargetSize,
 		EncryptedRecordingUploadMaxSize:    cfg.encryptedRecordingUploadMaxSize,
+		ConcurrentUploads:                  cfg.concurrentUploads,
 	}
 	if cfg.wrapEncryptedUploader != nil {
 		uploaderCfg.EncryptedRecordingUploader = cfg.wrapEncryptedUploader(pack.memUploader)
@@ -1031,6 +1133,12 @@ func emitStream(ctx context.Context, t *testing.T, streamer events.Streamer, inE
 	require.NoError(t, err)
 }
 
+type encryptedUploaderFn func(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error
+
+func (e encryptedUploaderFn) UploadEncryptedRecording(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
+	return e(ctx, sessionID, parts)
+}
+
 // readStream reads and decodes the audit stream from uploadID
 func readStream(ctx context.Context, t *testing.T, uploadID string, uploader *eventstest.MemoryUploader) []apievents.AuditEvent {
 	t.Helper()
@@ -1085,10 +1193,4 @@ func (f *fakeEncryptedIO) WithEncryption(ctx context.Context, writer io.WriteClo
 
 func (f *fakeEncryptedIO) WithDecryption(ctx context.Context, reader io.Reader) (io.Reader, error) {
 	return hex.NewDecoder(reader), f.err
-}
-
-type encryptedUploaderFn func(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error
-
-func (e encryptedUploaderFn) UploadEncryptedRecording(ctx context.Context, sessionID string, parts iter.Seq2[[]byte, error]) error {
-	return e(ctx, sessionID, parts)
 }

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -1177,7 +1177,7 @@ func (p ProtoReaderStats) ToFields() map[string]any {
 
 // Close releases reader resources
 func (r *ProtoReader) Close() error {
-	if r.gzipReader != nil {
+	if r != nil && r.gzipReader != nil {
 		return r.gzipReader.Close()
 	}
 	return nil

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3851,6 +3851,7 @@ func (process *TeleportProcess) initUploaderService() error {
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,
 		EncryptedRecordingUploadMaxSize: encryptedRecordingMaxUploadSize,
+		ConcurrentUploads:               2,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #61579 to branch/v18

changelog: Fixed an issue that caused a failed upload of an encrypted session recording to block other recordings from uploading
