### PR TITLE
[v18] Kubernetes Access support for the Relay Service

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -41,6 +41,21 @@ Here are a few examples:
 | Teleport Cloud cluster        | `example.teleport.sh:443`           |
 | `teleport-cluster` Helm chart | `teleport.example.com:443`          |
 
+## `relayAddr`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`relayAddr` defines the optional address of the Teleport Relay
+Service tunnel endpoint that this agent should use.
+
+If set, the agent will open reverse tunnels to the specified Relay in addition
+to the tunnels to the control plane, for the protocols supported by the Relay.
+
+relayAddr is available starting from Teleport v18.5.0, taking effect for the
+Kubernetes service.
+
 ## `enterprise`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/.lint/all-v6.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/all-v6.yaml
@@ -1,5 +1,6 @@
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
+relayAddr: relay.example.com:3024
 roles: kube,app,db,jamf
 kubeClusterName: test-kube-cluster-name
 labels:

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -15,6 +15,9 @@ teleport:
   {{- else }}
   auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
   {{- end }}
+  {{- with .Values.relayAddr }}
+  relay_server: {{ . | quote }}
+  {{- end }}
   {{- if .Values.caPin }}
   ca_pin: {{- toYaml .Values.caPin | nindent 4 }}
   {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -268,6 +268,7 @@ matches snapshot for all-v6.yaml:
             output: stderr
             severity: INFO
           proxy_server: proxy.example.com:3080
+          relay_server: relay.example.com:3024
         version: v3
     kind: ConfigMap
     metadata:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -3,6 +3,7 @@
     "type": "object",
     "required": [
         "proxyAddr",
+        "relayAddr",
         "roles",
         "joinParams",
         "kubeClusterName",
@@ -47,6 +48,11 @@
         },
         "proxyAddr": {
             "$id": "#/properties/proxyAddr",
+            "type": "string",
+            "default": ""
+        },
+        "relayAddr": {
+            "$id": "#/properties/relayAddr",
             "type": "string",
             "default": ""
         },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -32,6 +32,16 @@ roles: "kube"
 # | `teleport-cluster` Helm chart | `teleport.example.com:443`          |
 proxyAddr: ""
 
+# relayAddr(string) -- defines the optional address of the Teleport Relay
+# Service tunnel endpoint that this agent should use.
+#
+# If set, the agent will open reverse tunnels to the specified Relay in addition
+# to the tunnels to the control plane, for the protocols supported by the Relay.
+#
+# relayAddr is available starting from Teleport v18.5.0, taking effect for the
+# Kubernetes service.
+relayAddr: ""
+
 # enterprise(bool) -- controls if the `teleport-kube-agent` chart should deploy
 # the OSS version or the enterprise version of the container image.
 # This must be set to `true` when connecting to Teleport Cloud or self-hosted
@@ -903,7 +913,7 @@ adminClusterRoleBinding:
 # You can override this to use your own Teleport image rather than a
 # Teleport-published image.
 #
-# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater"> 
+# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater">
 # When using the Teleport Kube Agent Updater, you must ensure the
 # image is available before the updater version target gets updated and
 # Kubernetes tries to pull the image.

--- a/gen/proto/go/teleport/relaytunnel/v1alpha/discovery_service.pb.go
+++ b/gen/proto/go/teleport/relaytunnel/v1alpha/discovery_service.pb.go
@@ -79,8 +79,11 @@ type DiscoverResponse struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	RelayGroup            string                 `protobuf:"bytes,1,opt,name=relay_group,json=relayGroup,proto3" json:"relay_group,omitempty"`
 	TargetConnectionCount int32                  `protobuf:"varint,2,opt,name=target_connection_count,json=targetConnectionCount,proto3" json:"target_connection_count,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// the list of api/types.TunnelTypes supported by this Relay group; if empty,
+	// it should be treated as containing only types.NodeTunnel ("node")
+	SupportedTunnelTypes []string `protobuf:"bytes,3,rep,name=supported_tunnel_types,json=supportedTunnelTypes,proto3" json:"supported_tunnel_types,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *DiscoverResponse) Reset() {
@@ -127,16 +130,24 @@ func (x *DiscoverResponse) GetTargetConnectionCount() int32 {
 	return 0
 }
 
+func (x *DiscoverResponse) GetSupportedTunnelTypes() []string {
+	if x != nil {
+		return x.SupportedTunnelTypes
+	}
+	return nil
+}
+
 var File_teleport_relaytunnel_v1alpha_discovery_service_proto protoreflect.FileDescriptor
 
 const file_teleport_relaytunnel_v1alpha_discovery_service_proto_rawDesc = "" +
 	"\n" +
 	"4teleport/relaytunnel/v1alpha/discovery_service.proto\x12\x1cteleport.relaytunnel.v1alpha\"\x11\n" +
-	"\x0fDiscoverRequest\"k\n" +
+	"\x0fDiscoverRequest\"\xa1\x01\n" +
 	"\x10DiscoverResponse\x12\x1f\n" +
 	"\vrelay_group\x18\x01 \x01(\tR\n" +
 	"relayGroup\x126\n" +
-	"\x17target_connection_count\x18\x02 \x01(\x05R\x15targetConnectionCount2}\n" +
+	"\x17target_connection_count\x18\x02 \x01(\x05R\x15targetConnectionCount\x124\n" +
+	"\x16supported_tunnel_types\x18\x03 \x03(\tR\x14supportedTunnelTypes2}\n" +
 	"\x10DiscoveryService\x12i\n" +
 	"\bDiscover\x12-.teleport.relaytunnel.v1alpha.DiscoverRequest\x1a..teleport.relaytunnel.v1alpha.DiscoverResponseB`Z^github.com/gravitational/teleport/gen/proto/go/teleport/relaytunnel/v1alpha;relaytunnelv1alphab\x06proto3"
 

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -389,6 +389,8 @@ type ReadRelayAccessPoint interface {
 	GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error)
 
 	GetUser(ctx context.Context, name string, withSecrets bool) (types.User, error)
+
+	GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error)
 }
 
 // ReadRemoteProxyAccessPoint is a read only API interface implemented by a certificate authority (CA) to be

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -284,6 +284,7 @@ func ForRelay(cfg Config) Config {
 		{Kind: types.KindCertAuthority, Filter: makeAllKnownCAsFilter().IntoMap()},
 		{Kind: types.KindClusterAuthPreference},
 		{Kind: types.KindClusterNetworkingConfig},
+		{Kind: types.KindKubeServer},
 		{Kind: types.KindNode},
 		{Kind: types.KindRelayServer},
 		{Kind: types.KindRole},

--- a/lib/client/identityfile/identity.go
+++ b/lib/client/identityfile/identity.go
@@ -474,7 +474,7 @@ func Write(ctx context.Context, cfg WriteConfig) (filesWritten []string, err err
 			TeleportClusterName: cfg.KeyRing.ClusterName,
 			ClusterAddr:         cfg.KubeProxyAddr,
 			Credentials:         cfg.KeyRing,
-			TLSServerName:       cfg.KubeTLSServerName,
+			TLSServerNameFunc:   func(teleportClusterName, kubeClusterName string) string { return cfg.KubeTLSServerName },
 			KubeClusters:        kubeCluster,
 		}, cfg.KubeStoreAllCAs, writer); err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/kube/kubeconfig/localproxy.go
+++ b/lib/kube/kubeconfig/localproxy.go
@@ -68,6 +68,8 @@ func (s LocalProxyClusters) TeleportClusters() []string {
 
 // LocalProxyValues contains values for generating local proxy kubeconfig
 type LocalProxyValues struct {
+	// TeleportProfileName is the name of the profile used for credentials.
+	TeleportProfileName string
 	// TeleportKubeClusterAddr is the Teleport Kubernetes access address.
 	TeleportKubeClusterAddr string
 	// LocalProxyURL is the local forward proxy's URL.
@@ -104,6 +106,7 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 	// entries before adding the ones for local proxy.
 	config := originalKubeConfig.DeepCopy()
 	config.CurrentContext = ""
+	removeByProfileName(config, localProxyValues.TeleportProfileName)
 	removeByServerAddr(config, localProxyValues.TeleportKubeClusterAddr)
 
 	for _, cluster := range localProxyValues.Clusters {
@@ -120,17 +123,28 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 			CertificateAuthorityData: localProxyValues.LocalProxyCAs[cluster.TeleportCluster],
 			TLSServerName:            common.KubeLocalProxySNI(cluster.TeleportCluster, cluster.KubeCluster),
 		}
+		setStringExtensionInCluster(config.Clusters[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInCluster(config.Clusters[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInCluster(config.Clusters[contextName], extKubeClusterName, cluster.KubeCluster)
+
 		config.Contexts[contextName] = &clientcmdapi.Context{
 			Namespace: cluster.Namespace,
 			Cluster:   contextName,
 			AuthInfo:  contextName,
 		}
+		setStringExtensionInContext(config.Contexts[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInContext(config.Contexts[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInContext(config.Contexts[contextName], extKubeClusterName, cluster.KubeCluster)
+
 		config.AuthInfos[contextName] = &clientcmdapi.AuthInfo{
 			ClientCertificateData: localProxyValues.LocalProxyCAs[cluster.TeleportCluster],
 			ClientKeyData:         localProxyValues.ClientKeyData,
 			Impersonate:           cluster.Impersonate,
 			ImpersonateGroups:     cluster.ImpersonateGroups,
 		}
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extProfileName, localProxyValues.TeleportProfileName)
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extTeleClusterName, cluster.TeleportCluster)
+		setStringExtensionInAuthInfo(config.AuthInfos[contextName], extKubeClusterName, cluster.KubeCluster)
 
 		// Set the first as current context or if matching the one from default
 		// kubeconfig.
@@ -143,40 +157,63 @@ func CreateLocalProxyConfig(originalKubeConfig *clientcmdapi.Config, localProxyV
 
 // LocalProxyClustersFromDefaultConfig loads Teleport kube clusters data saved
 // by `tsh kube login` in the default kubeconfig.
-func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, clusterAddr string) (clusters LocalProxyClusters) {
-	for teleportClusterName, cluster := range defaultConfig.Clusters {
+func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, profileName, clusterAddr string) (clusters LocalProxyClusters) {
+	for contextName, context := range defaultConfig.Contexts {
+		cluster, found := defaultConfig.Clusters[context.Cluster]
+		if !found {
+			continue
+		}
+		auth, found := defaultConfig.AuthInfos[context.AuthInfo]
+		if !found {
+			continue
+		}
+
+		if p, ok := getStringExtensionFromContext(context, extProfileName); ok {
+			// the context has the new extensions, no need to match by clusterAddr
+			if p != profileName {
+				continue
+			}
+
+			teleportCluster, _ := getStringExtensionFromContext(context, extTeleClusterName)
+			kubeCluster, _ := getStringExtensionFromContext(context, extKubeClusterName)
+
+			clusters = append(clusters, LocalProxyCluster{
+				TeleportCluster:   teleportCluster,
+				KubeCluster:       kubeCluster,
+				Namespace:         context.Namespace,
+				Impersonate:       auth.Impersonate,
+				ImpersonateGroups: auth.ImpersonateGroups,
+			})
+			continue
+		}
+
+		// the context was created by an older version, match by clusterAddr and
+		// try to guess at the kube cluster name
 		if cluster.Server != clusterAddr {
 			continue
 		}
 
-		for contextName, ctx := range defaultConfig.Contexts {
-			if ctx.Cluster != teleportClusterName {
-				continue
-			}
-			auth, found := defaultConfig.AuthInfos[contextName]
-			if !found {
-				continue
-			}
-
-			clusters = append(clusters, LocalProxyCluster{
-				TeleportCluster:   teleportClusterName,
-				KubeCluster:       KubeClusterFromContext(contextName, ctx, teleportClusterName),
-				Namespace:         ctx.Namespace,
-				Impersonate:       auth.Impersonate,
-				ImpersonateGroups: auth.ImpersonateGroups,
-			})
-		}
+		clusters = append(clusters, LocalProxyCluster{
+			TeleportCluster:   context.Cluster,
+			KubeCluster:       KubeClusterFromContext(contextName, context, context.Cluster),
+			Namespace:         context.Namespace,
+			Impersonate:       auth.Impersonate,
+			ImpersonateGroups: auth.ImpersonateGroups,
+		})
 	}
+
 	return clusters
 }
 
-// FindTeleportClusterForLocalProxy finds the Teleport kube cluster based on
-// provided cluster address and context name, and prepares a LocalProxyCluster.
+// FindTeleportClusterForLocalProxy finds the Kube cluster name for a given
+// context (or the current context), and prepares a LocalProxyCluster if the
+// context is for the given Teleport cluster name or if the server addr matches
+// the expected one.
 //
 // When the cluster has a ProxyURL set, it means the provided kubeconfig is
 // already pointing to a local proxy through this ProxyURL and thus can be
 // skipped as there is no need to create a new local proxy.
-func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, clusterAddr, contextName string) (LocalProxyCluster, bool) {
+func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, contextName, profileName, serverAddr string) (LocalProxyCluster, bool) {
 	if contextName == "" {
 		contextName = defaultConfig.CurrentContext
 	}
@@ -185,8 +222,9 @@ func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, cluste
 	if !found {
 		return LocalProxyCluster{}, false
 	}
+
 	cluster, found := defaultConfig.Clusters[context.Cluster]
-	if !found || cluster.Server != clusterAddr || cluster.ProxyURL != "" {
+	if !found {
 		return LocalProxyCluster{}, false
 	}
 	auth, found := defaultConfig.AuthInfos[context.AuthInfo]
@@ -194,9 +232,36 @@ func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, cluste
 		return LocalProxyCluster{}, false
 	}
 
+	if cluster.ProxyURL != "" {
+		// a proxy is already set, it's either an existing local proxy or
+		// something we don't understand is going on, and either way we should
+		// skip this
+		return LocalProxyCluster{}, false
+	}
+
+	var teleportCluster, kubeCluster string
+	if c, ok := getStringExtensionFromCluster(cluster, extProfileName); ok {
+		// we have found the profile name extension, this is a modern
+		// configuration and we can just work by extensions without having to
+		// make guesses based on URLs and context names
+		if c != profileName {
+			return LocalProxyCluster{}, false
+		}
+		teleportCluster, _ = getStringExtensionFromCluster(cluster, extTeleClusterName)
+		kubeCluster, _ = getStringExtensionFromCluster(cluster, extKubeClusterName)
+	} else {
+		// this kubeconfig is old, match by server URL and try to guess what the
+		// kube cluster name is
+		if cluster.Server != serverAddr {
+			return LocalProxyCluster{}, false
+		}
+		teleportCluster = context.Cluster
+		kubeCluster = KubeClusterFromContext(contextName, context, context.Cluster)
+	}
+
 	return LocalProxyCluster{
-		TeleportCluster:   context.Cluster,
-		KubeCluster:       KubeClusterFromContext(contextName, context, context.Cluster),
+		TeleportCluster:   teleportCluster,
+		KubeCluster:       kubeCluster,
 		Namespace:         context.Namespace,
 		Impersonate:       auth.Impersonate,
 		ImpersonateGroups: auth.ImpersonateGroups,

--- a/lib/kube/relay/hash.go
+++ b/lib/kube/relay/hash.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relay
+
+import (
+	"crypto/sha256"
+	"encoding/base32"
+)
+
+// base32hex is the "Extended Hex Alphabet" defined in RFC 4648 but with
+// lowercase letters and no padding.
+var base32hex = base32.NewEncoding("0123456789abcdefghijklmnopqrstuv").WithPadding(base32.NoPadding)
+
+const (
+	hashLen = sha256.Size
+	// encodedHashLen is the length of the base32 encoding of [hashLen] bytes,
+	// without padding.
+	encodedHashLen = hashLen/5*8 + (hashLen%5*8+4)/5
+)
+
+func hashForTarget(teleportClusterName, kubeClusterName string) [hashLen]byte {
+	h := sha256.New()
+	var buf [hashLen]byte
+	buf = sha256.Sum256([]byte(teleportClusterName))
+	h.Write(buf[:])
+	buf = sha256.Sum256([]byte(kubeClusterName))
+	h.Write(buf[:])
+	h.Sum(buf[:0])
+	return buf
+}
+
+// SNILabelForKubeCluster returns the domain label used in front of [SNISuffix]
+// to identify a Kubernetes cluster as the target for a passively routed Relay
+// connection. It consists of [SNIPrefixForKubeCluster] ("cluster-") followed by
+// the base32hex encoding of the SHA256 hash of Teleport cluster name and
+// Kubernetes cluster name, for a total of 60 ASCII lowercase characters.
+func SNILabelForKubeCluster(teleportClusterName, kubeClusterName string) string {
+	h := hashForTarget(teleportClusterName, kubeClusterName)
+	return SNIPrefixForKubeCluster + base32hex.EncodeToString(h[:])
+}

--- a/lib/kube/relay/hash.go
+++ b/lib/kube/relay/hash.go
@@ -52,3 +52,10 @@ func SNILabelForKubeCluster(teleportClusterName, kubeClusterName string) string 
 	h := hashForTarget(teleportClusterName, kubeClusterName)
 	return SNIPrefixForKubeCluster + base32hex.EncodeToString(h[:])
 }
+
+// FullSNIForKubeCluster returns the full server name used to identify a
+// Kubernetes cluster as the target for a passively routed Relay connection,
+// i.e. the same value as [SNILabelForKubeCluster] followed by [SNISuffix].
+func FullSNIForKubeCluster(teleportClusterName, kubeClusterName string) string {
+	return SNILabelForKubeCluster(teleportClusterName, kubeClusterName) + SNISuffix
+}

--- a/lib/kube/relay/hash_test.go
+++ b/lib/kube/relay/hash_test.go
@@ -1,0 +1,69 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodedHashLen(t *testing.T) {
+	//nolint:staticcheck // the explicit type in the declaration is the entire
+	// point of this statement
+	var _ [hashLen]byte = hashForTarget("", "")
+
+	//nolint:testifylint // the parameter order is deliberate,
+	// b32hex.EncodedLen(hashLen) is the source of truth and we are testing the
+	// value of the const
+	require.Equal(t, base32hex.EncodedLen(hashLen), encodedHashLen)
+}
+
+func TestHashForTarget(t *testing.T) {
+	testCases := []struct {
+		teleportClusterName    string
+		kubeClusterName        string
+		hash                   string
+		sniLabelForKubeCluster string
+	}{
+		{
+			teleportClusterName:    "",
+			kubeClusterName:        "",
+			hash:                   "-\xba]\xbc3\x9es\x16\xae\xa2h?\xaf\x83\x9c\x1b{\x1e\xe21=\xb7\x92\x11%\x88\x11\x8d\xf0f\xaa5",
+			sniLabelForKubeCluster: "cluster-5mt5rf1jjpphdbl2d0vqv0ss3dthtohh7mrp4495h08ors36l8qg",
+		},
+		{
+			teleportClusterName:    "teleport.example.com",
+			kubeClusterName:        "prod-1",
+			hash:                   "%0\x86\x19\x99\x17\x97\xf9uX~\x00\xe4?\xf4aPO\v\xde%gq\xc7\xdf\xc6\x05|\xd1y\xd7r",
+			sniLabelForKubeCluster: "cluster-4ko8c6cp2ubvitaofo0e8fvkc584u2uu4ljn3huvoo2npkbpqtp0",
+		},
+
+		{
+			teleportClusterName:    "8701ae5eecf94a25adc7a90e3f373a25",
+			kubeClusterName:        "3929312bc0c74cd491a882f7abd7edbd",
+			hash:                   "\x0f\x12\xae\xf8\x83\xc2\xd3 j-\xe9\x87\xea\xdf\x18s\xd7\f\xb6\xcf\xcd\xce\x17\x89\x19c\r\xa2\x99\xd8A\xdd",
+			sniLabelForKubeCluster: "cluster-1s9atu43ob9i0qhdt63ulnooefbgpdmfpn71f28pcc6q56eo87eg",
+		},
+	}
+
+	for _, tc := range testCases {
+		hft := hashForTarget(tc.teleportClusterName, tc.kubeClusterName)
+		require.Equal(t, tc.hash, string(hft[:]))
+		require.Equal(t, tc.sniLabelForKubeCluster, SNILabelForKubeCluster(tc.teleportClusterName, tc.kubeClusterName))
+	}
+}

--- a/lib/kube/relay/passive_forwarder.go
+++ b/lib/kube/relay/passive_forwarder.go
@@ -1,0 +1,407 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relay
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/gravitational/trace"
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	apiconstants "github.com/gravitational/teleport/api/constants"
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/healthcheck"
+	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/utils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// SNISuffix is the suffix of the server name that signals that a connection is
+// intended for Kubernetes Access through a relay. The format of the domain
+// label in front of SNISuffix depends on the desired target for the connection.
+// For now, the only supported class of targets is identified by a prefix of
+// [SNIPrefixForKubeCluster] ("cluster-") to signify a connection for a given
+// Kubernetes cluster by name.
+const SNISuffix = ".kuberelay." + apiconstants.APIDomain
+
+// SNIPrefixForKubeCluster is the prefix of the domain label used to identify a
+// Kubernetes cluster as the target for a passively routed Relay connection.
+const SNIPrefixForKubeCluster = "cluster-"
+
+// When adding more target types (for example "session-") keep in mind that the
+// entire reason for the hashing scheme in [SNILabelForKubeCluster] is that
+// individual labels are limited to 63 characters (and the total FQDN is limited
+// to 253 characters, but that's not relevant for us since Kube agents can only
+// have one wildcard label in front of [SNISuffix]), so mind the total length of
+// the data you need to encode.
+
+type RelayTunnelDialFunc = func(ctx context.Context, hostID string, tunnelType apitypes.TunnelType, src, dst net.Addr) (net.Conn, error)
+type RelayPeerDialFunc = func(ctx context.Context, hostID string, tunnelType apitypes.TunnelType, relayIDs []string, src, dst net.Addr) (net.Conn, error)
+
+type GetKubeServersWithFilterFunc = func(ctx context.Context, filter func(readonly.KubeServer) bool) ([]apitypes.KubeServer, error)
+
+// PassiveForwarderConfig contains the parameters for [NewPassiveForwarder].
+type PassiveForwarderConfig struct {
+	Log *slog.Logger
+
+	ClusterName string
+	GroupName   string
+
+	// GetKubeServersWithFilter should return the Kube server resources known to
+	// the cluster that pass the given filter function.
+	GetKubeServersWithFilter GetKubeServersWithFilterFunc
+
+	// LocalDial should dial the given target if it's available as a reverse
+	// tunnel attached to the local instance.
+	LocalDial RelayTunnelDialFunc
+	// PeerDial should dial the given target through a known list of relay IDs.
+	// It will only be called for targets that are advertising the same relay
+	// group, but the function should check that any given relay in the list
+	// belongs to the correct group before attempting to use it.
+	PeerDial RelayPeerDialFunc
+}
+
+// NewPassiveForwarder returns a [PassiveForwarder] with the given config.
+func NewPassiveForwarder(cfg PassiveForwarderConfig) (*PassiveForwarder, error) {
+	if cfg.Log == nil {
+		return nil, trace.BadParameter("missing Log")
+	}
+	if cfg.ClusterName == "" {
+		return nil, trace.BadParameter("missing ClusterName")
+	}
+	if cfg.GroupName == "" {
+		return nil, trace.BadParameter("missing GroupName")
+	}
+	if cfg.GetKubeServersWithFilter == nil {
+		return nil, trace.BadParameter("missing GetKubeServersWithFilter")
+	}
+	if cfg.LocalDial == nil {
+		return nil, trace.BadParameter("missing LocalDial")
+	}
+	if cfg.PeerDial == nil {
+		return nil, trace.BadParameter("missing PeerDial")
+	}
+
+	resolvedNames, err := lru.New[[hashLen]byte, string](64)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// This context is owned by PassiveForwarder and it's used for operations
+	// that get synchronously canceled by Close.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return &PassiveForwarder{
+		log: cfg.Log,
+
+		clusterName: cfg.ClusterName,
+		groupName:   cfg.GroupName,
+
+		getKubeServersWithFilter: cfg.GetKubeServersWithFilter,
+
+		localDial: cfg.LocalDial,
+		peerDial:  cfg.PeerDial,
+
+		resolvedNames: resolvedNames,
+
+		ctx:    ctx,
+		cancel: cancel,
+	}, nil
+}
+
+// PassiveForwarder implements the logic to route and forward connections to
+// Kubernetes Service agents connected to a Relay.
+type PassiveForwarder struct {
+	log *slog.Logger
+
+	clusterName string
+	groupName   string
+
+	getKubeServersWithFilter GetKubeServersWithFilterFunc
+
+	localDial RelayTunnelDialFunc
+	peerDial  RelayPeerDialFunc
+
+	// resolvedNames contains (hash, name) pairs for which
+	// hash == hashForTarget(clusterName, name); pairs are only _added_ to the
+	// LRU if v is a kube cluster served by an agent connected to this relay
+	// group, but that doesn't guarantee that the cluster is still being served
+	// if the pair is looked up at a later time.
+	resolvedNames *lru.Cache[[hashLen]byte, string]
+
+	// ctx is used to signal that long running operations should unblock and
+	// return, especially operations that have added to wg because Close should
+	// wait until their end. It's owned by PassiveForwarder and should be
+	// canceled by calling Close; it does not belong to a context tree and does
+	// not outlive any call with a parent context. The intended operation of
+	// this object is almost entirely based on I/O and explicit closing, so
+	// there's no natural way to receive contexts associated with individual
+	// operations triggered by callers of its methods.
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu sync.Mutex
+	// wg synchronizes with ctx and mu: wg.Add must only be called while holding
+	// mu if ctx.Err == nil, wg.Wait must only be called after cancel is called
+	// while holding mu.
+	wg sync.WaitGroup
+}
+
+// Close closes all ongoing connections and blocks until the associated
+// resources are gone.
+func (p *PassiveForwarder) Close() error {
+	p.mu.Lock()
+	// we cancel the context while holding the lock to signal that nothing
+	// long-running should begin in the background, so nothing will add to wg
+	// and we can wait on it
+	p.cancel()
+	p.mu.Unlock()
+
+	p.wg.Wait()
+	return nil
+}
+
+// Dispatch checks if the given SNI refers to a connection for a Kubernetes
+// cluster through a Relay; if so, it returns true and the connection should be
+// ignored by the caller, otherwise the connection is left untouched and the
+// caller should handle it. The transcript contains data that was already sent
+// by the client (i.e. a TLS ClientHello) and will be sent to the agent before
+// forwarding more data from the connection. This method is intended to be used
+// with [relaytransport.SNIDispatchTransportCredentials].
+func (p *PassiveForwarder) Dispatch(serverName string, transcript *bytes.Buffer, rawConn net.Conn) (dispatched bool) {
+	sniPrefix, ok := strings.CutSuffix(serverName, SNISuffix)
+	if !ok {
+		return false
+	}
+
+	p.mu.Lock()
+	if p.ctx.Err() != nil {
+		p.mu.Unlock()
+		_ = rawConn.Close()
+		// the forwarder was closed and Close has potentially already returned,
+		// so we shouldn't spawn additional goroutines
+		return true
+	}
+	p.wg.Go(func() {
+		p.forward(sniPrefix, transcript, rawConn)
+	})
+	p.mu.Unlock()
+
+	return true
+}
+
+func (p *PassiveForwarder) forward(sniPrefix string, transcript *bytes.Buffer, clientConn net.Conn) {
+	ctx := p.ctx
+	log := p.log.With(
+		"client_addr", clientConn.RemoteAddr().String(),
+	)
+	// TODO(espadolini): there's no way to signal errors to the client, so the
+	// best we can do is to cut the connection abruptly - unfortunately, that
+	// will cause clients such as kubectl to treat requests as retriable, and
+	// it's only after a lengthy timeout that an error will actually be reported
+	// to the user. Then again, this same behavior also means that if the
+	// connection failure is caused by a temporary failure due to missing
+	// tunnels and the likes, the following retries have a chance of succeeding,
+	// so this behavior is not all bad.
+	defer clientConn.Close()
+
+	sniPrefix = strings.ToLower(sniPrefix)
+	encodedHash, ok := strings.CutPrefix(sniPrefix, SNIPrefixForKubeCluster)
+	if !ok || len(encodedHash) != encodedHashLen {
+		log.DebugContext(ctx,
+			"Received unsupported SNI for kube relay forwarding",
+			"sni_prefix", sniPrefix,
+		)
+		return
+	}
+	var desiredHash [hashLen]byte
+	if _, err := base32hex.Decode(desiredHash[:], []byte(encodedHash)); err != nil {
+		log.DebugContext(ctx,
+			"Received malformed hash in SNI for kube cluster relay forwarding",
+			"encoded_hash", encodedHash,
+		)
+		return
+	}
+
+	kubeClusterName, cached := p.resolvedNames.Get(desiredHash)
+	kubeServers, err := p.getKubeServersWithFilter(
+		ctx,
+		func(ks readonly.KubeServer) bool {
+			if ks.GetRelayGroup() != p.groupName {
+				return false
+			}
+
+			if kubeClusterName != "" {
+				return ks.GetCluster().GetName() == kubeClusterName
+			}
+
+			if desiredHash == hashForTarget(p.clusterName, ks.GetCluster().GetName()) {
+				kubeClusterName = ks.GetCluster().GetName()
+				if !cached {
+					p.resolvedNames.Add(desiredHash, kubeClusterName)
+				}
+				return true
+			}
+			return false
+		},
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.ErrorContext(ctx,
+			"Failed to retrieve kube servers for routing",
+			"encoded_hash", encodedHash,
+			"error", err,
+		)
+		return
+	}
+	if len(kubeServers) < 1 {
+		log.WarnContext(ctx,
+			"No kube server found for the desired hash in the local relay group",
+			"encoded_hash", encodedHash,
+		)
+		return
+	}
+
+	var agentConn net.Conn
+	var agentHostID string
+	for kubeServer := range healthcheck.OrderByTargetHealthStatus(kubeServers) {
+		target := kubeServer.GetHostID() + "." + p.clusterName
+
+		localTunnelConn, err := p.localDial(ctx,
+			target, apitypes.KubeTunnel,
+			clientConn.RemoteAddr(), clientConn.LocalAddr(),
+		)
+		if err == nil {
+			agentConn = localTunnelConn
+			agentHostID = kubeServer.GetHostID()
+			break
+		}
+
+		if !trace.IsNotFound(err) {
+			log.DebugContext(ctx,
+				"Failed to dial target in local relay tunnel server, trying peer dialing",
+				"agent_host_id", kubeServer.GetHostID(),
+				"error", err,
+			)
+		}
+
+		peerTunnelConn, err := p.peerDial(ctx,
+			target, apitypes.KubeTunnel,
+			slices.Clone(kubeServer.GetRelayIDs()),
+			clientConn.RemoteAddr(), clientConn.LocalAddr(),
+		)
+		if err == nil {
+			agentConn = peerTunnelConn
+			agentHostID = kubeServer.GetHostID()
+			break
+		}
+
+		log.DebugContext(ctx,
+			"Failed to dial target through relay peering, trying next target if any",
+			"agent_host_id", kubeServer.GetHostID(),
+			"error", err,
+		)
+	}
+	if agentConn == nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.WarnContext(ctx,
+			"Failed to open tunnel connection to any agent connected to this relay group serving the desired cluster",
+			"kube_cluster", kubeClusterName,
+		)
+		return
+	}
+	defer agentConn.Close()
+
+	defer context.AfterFunc(ctx, func() {
+		// this will unblock both sides of the copy (it's not sufficient to
+		// close just one, it might've already half-closed and the other
+		// direction might get stuck reading)
+		_ = agentConn.Close()
+		_ = clientConn.Close()
+	})()
+
+	log = log.With(
+		"kube_cluster", kubeClusterName,
+		"agent_host_id", agentHostID,
+	)
+	log.InfoContext(ctx,
+		"Forwarding kube connection to agent",
+	)
+	defer log.DebugContext(ctx,
+		"Done forwarding kube connection to agent",
+	)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	wg.Go(func() {
+		defer log.Log(ctx, logutils.TraceLevel,
+			"Done copying data from client to agent",
+		)
+		if _, err := io.Copy(agentConn, transcript); err != nil {
+			log.Log(ctx, traceIfOKNetworkError(err, slog.LevelDebug),
+				"Got an error copying data from client transcript to agent",
+				"error", err,
+			)
+			_ = clientConn.Close()
+			_ = agentConn.Close()
+			return
+		}
+		if _, err := io.Copy(agentConn, clientConn); err != nil {
+			log.Log(ctx, traceIfOKNetworkError(err, slog.LevelDebug),
+				"Got an error copying data from client to agent",
+				"error", err,
+			)
+			_ = clientConn.Close()
+			_ = agentConn.Close()
+			return
+		}
+	})
+
+	wg.Go(func() {
+		defer log.Log(ctx, logutils.TraceLevel,
+			"Done copying data from agent to client",
+		)
+		if _, err := io.Copy(clientConn, agentConn); err != nil {
+			log.Log(ctx, traceIfOKNetworkError(err, slog.LevelDebug),
+				"Got an error copying data from agent to client",
+				"error", err,
+			)
+			_ = clientConn.Close()
+			_ = agentConn.Close()
+			return
+		}
+	})
+}
+
+func traceIfOKNetworkError(err error, l slog.Level) slog.Level {
+	if err == nil || utils.IsOKNetworkError(err) {
+		return logutils.TraceLevel
+	}
+	return l
+}

--- a/lib/kube/relay/passive_forwarder.go
+++ b/lib/kube/relay/passive_forwarder.go
@@ -205,7 +205,7 @@ func (p *PassiveForwarder) Dispatch(serverName string, transcript *bytes.Buffer,
 	}
 	p.wg.Add(1)
 	go func() {
-		p.wg.Done()
+		defer p.wg.Done()
 		p.forward(sniPrefix, transcript, rawConn)
 	}()
 	p.mu.Unlock()

--- a/lib/kube/relay/passive_forwarder_test.go
+++ b/lib/kube/relay/passive_forwarder_test.go
@@ -1,0 +1,145 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relay
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	apitypes "github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services/readonly"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+func TestMain(m *testing.M) {
+	logtest.InitLogger(testing.Verbose)
+	os.Exit(m.Run())
+}
+
+func TestPassiveForwarder_Selection(t *testing.T) {
+	kubeServers := []*apitypes.KubernetesServerV3{
+		// not in any group
+		{
+			Spec: apitypes.KubernetesServerSpecV3{
+				RelayGroup: "",
+				HostID:     "host-a",
+				Cluster: &apitypes.KubernetesClusterV3{
+					Metadata: apitypes.Metadata{
+						Name: "cluster-a",
+					},
+				},
+			},
+		},
+		// in the group, unhealthy
+		{
+			Spec: apitypes.KubernetesServerSpecV3{
+				RelayGroup: "thisgroup",
+				HostID:     "host-b",
+				Cluster: &apitypes.KubernetesClusterV3{
+					Metadata: apitypes.Metadata{
+						Name: "cluster-b",
+					},
+				},
+			},
+			Status: &apitypes.KubernetesServerStatusV3{
+				TargetHealth: &apitypes.TargetHealth{
+					Status: "unhealthy",
+				},
+			},
+		},
+		// not in the correct group
+		{
+			Spec: apitypes.KubernetesServerSpecV3{
+				RelayGroup: "othergroup",
+				HostID:     "host-c",
+				Cluster: &apitypes.KubernetesClusterV3{
+					Metadata: apitypes.Metadata{
+						Name: "cluster-c",
+					},
+				},
+			},
+		},
+		// in the right group, healthy
+		{
+			Spec: apitypes.KubernetesServerSpecV3{
+				RelayGroup: "thisgroup",
+				HostID:     "host-b2",
+				Cluster: &apitypes.KubernetesClusterV3{
+					Metadata: apitypes.Metadata{
+						Name: "cluster-b",
+					},
+				},
+			},
+			Status: &apitypes.KubernetesServerStatusV3{
+				TargetHealth: &apitypes.TargetHealth{
+					Status: "healthy",
+				},
+			},
+		},
+	}
+
+	var localDialed []string
+	fwd, err := NewPassiveForwarder(PassiveForwarderConfig{
+		Log:         slog.Default(),
+		ClusterName: "clustername",
+		GroupName:   "thisgroup",
+		GetKubeServersWithFilter: func(ctx context.Context, filter func(readonly.KubeServer) bool) ([]apitypes.KubeServer, error) {
+			var out []apitypes.KubeServer
+			for _, s := range kubeServers {
+				if filter(s) {
+					out = append(out, s.Copy())
+				}
+			}
+			return out, nil
+		},
+		LocalDial: func(ctx context.Context, hostID string, tunnelType apitypes.TunnelType, src, dst net.Addr) (net.Conn, error) {
+			localDialed = append(localDialed, hostID)
+			return nil, trace.NotFound("no")
+		},
+		PeerDial: func(ctx context.Context, hostID string, tunnelType apitypes.TunnelType, relayIDs []string, src, dst net.Addr) (net.Conn, error) {
+			return nil, trace.ConnectionProblem(nil, "nope")
+		},
+	})
+	require.NoError(t, err)
+	defer fwd.Close()
+
+	fwd.forward(SNILabelForKubeCluster("clustername", "cluster-a"), new(bytes.Buffer), (*noopConn)(nil))
+	require.Empty(t, localDialed)
+	fwd.forward(SNILabelForKubeCluster("clustername", "cluster-c"), new(bytes.Buffer), (*noopConn)(nil))
+	require.Empty(t, localDialed)
+	// host-b2 is healthy so it will always be tried before the unhealthy host-b
+	for range 100 {
+		localDialed = []string{}
+		fwd.forward(SNILabelForKubeCluster("clustername", "cluster-b"), new(bytes.Buffer), (*noopConn)(nil))
+		require.Equal(t, []string{"host-b2.clustername", "host-b.clustername"}, localDialed)
+	}
+}
+
+type noopConn struct {
+	net.Conn
+}
+
+func (*noopConn) Close() error         { return nil }
+func (*noopConn) LocalAddr() net.Addr  { return &net.TCPAddr{} }
+func (*noopConn) RemoteAddr() net.Addr { return &net.TCPAddr{} }

--- a/lib/relaytransport/sni.go
+++ b/lib/relaytransport/sni.go
@@ -1,0 +1,158 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relaytransport
+
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"net"
+	"time"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc/credentials"
+)
+
+type SNIDispatchFunc = func(serverName string, transcript *bytes.Buffer, rawConn net.Conn) (dispatched bool)
+
+// SNIDispatchTransportCredentials is a wrapper around a
+// [credentials.TransportCredentials] that reads a TLS ClientHello from each
+// client connection and optionally dispatches the connection through a custom
+// function based on the Server Name Indication in the ClientHello, without
+// interacting with the connection otherwise.
+type SNIDispatchTransportCredentials struct {
+	_ struct{}
+
+	credentials.TransportCredentials
+
+	// DispatchFunc should return true if the connection with the given server
+	// name should not be handled by the gRPC server. The transcript buffer
+	// contains the data that was received from the connection (containing the
+	// TLS ClientHello and potentially more data).
+	DispatchFunc SNIDispatchFunc
+}
+
+var _ credentials.TransportCredentials = (*SNIDispatchTransportCredentials)(nil)
+
+// Clone implements [credentials.TransportCredentials].
+func (s *SNIDispatchTransportCredentials) Clone() credentials.TransportCredentials {
+	return &SNIDispatchTransportCredentials{
+		TransportCredentials: s.TransportCredentials.Clone(),
+		DispatchFunc:         s.DispatchFunc,
+	}
+}
+
+// ServerHandshake implements [credentials.TransportCredentials].
+func (s *SNIDispatchTransportCredentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	// the deadline for rawConn was set by the grpc server machinery based on
+	// the server connection timeout, we should not apply additional timeouts
+
+	transcript := new(bytes.Buffer)
+	var serverName string
+	var receivedHello bool
+	if err := tls.Server(
+		&transcripterConn{conn: rawConn, transcript: transcript},
+		&tls.Config{
+			GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+				serverName = chi.ServerName
+				receivedHello = true
+				return nil, io.EOF
+			},
+		},
+	).Handshake(); !receivedHello && err != nil {
+		_ = rawConn.Close()
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if s.DispatchFunc(serverName, transcript, rawConn) {
+		return nil, nil, credentials.ErrConnDispatched
+	}
+
+	if transcript.Len() > 0 {
+		rawConn = &transcriptedConn{
+			Conn:       rawConn,
+			transcript: transcript,
+		}
+	}
+
+	return s.TransportCredentials.ServerHandshake(rawConn)
+}
+
+// transcripterConn is a net.Conn that also stores the data that was read from a
+// real net.Conn in a transcript, and for which every other operation is a noop.
+type transcripterConn struct {
+	transcript *bytes.Buffer
+	conn       net.Conn
+}
+
+var _ net.Conn = (*transcripterConn)(nil)
+
+// Close implements [net.Conn].
+func (p *transcripterConn) Close() error { return nil }
+
+// Read implements [net.Conn].
+func (p *transcripterConn) Read(b []byte) (n int, err error) {
+	n, err = p.conn.Read(b)
+	_, _ = p.transcript.Write(b[:n])
+	return n, err
+}
+
+// LocalAddr implements [net.Conn].
+func (p *transcripterConn) LocalAddr() net.Addr { return p.conn.LocalAddr() }
+
+// RemoteAddr implements [net.Conn].
+func (p *transcripterConn) RemoteAddr() net.Addr { return p.conn.RemoteAddr() }
+
+// SetDeadline implements [net.Conn].
+func (p *transcripterConn) SetDeadline(t time.Time) error { return nil }
+
+// SetReadDeadline implements [net.Conn].
+func (p *transcripterConn) SetReadDeadline(t time.Time) error { return nil }
+
+// SetWriteDeadline implements [net.Conn].
+func (p *transcripterConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// Write implements [net.Conn].
+func (p *transcripterConn) Write(b []byte) (n int, err error) { return len(b), nil }
+
+// transcriptedConn is a net.Conn whose incoming data begins with the data in a
+// transcript.
+type transcriptedConn struct {
+	net.Conn
+	transcript *bytes.Buffer
+}
+
+var _ net.Conn = (*transcriptedConn)(nil)
+
+// Read implements [net.Conn].
+func (p *transcriptedConn) Read(b []byte) (n int, err error) {
+	if p.transcript == nil {
+		return p.Conn.Read(b)
+	}
+
+	// this is improper behavior since closing the Conn will not cause read
+	// errors until the transcript is exhausted and reads past the deadline will
+	// still succeed, but this net.Conn implementation is very much intended for
+	// a buffer containing a TLS ClientHello that gets fully read almost
+	// immediately anyway
+	n = copy(b, p.transcript.Next(len(b)))
+	if p.transcript.Len() < 1 {
+		p.transcript = nil
+	}
+
+	return n, nil
+}

--- a/lib/relaytransport/sni_test.go
+++ b/lib/relaytransport/sni_test.go
@@ -1,0 +1,264 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package relaytransport
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport/lib/utils/uds"
+)
+
+func TestSNIDispatch_NoDispatch(t *testing.T) {
+	caCert := requireExampleServerCert(t)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert.Leaf)
+
+	var eg errgroup.Group
+	defer eg.Wait()
+
+	// net.Pipe is unbuffered and crypto/tls doesn't work well with unbuffered
+	// connections (even though it should)
+	sc, cc, err := uds.NewSocketpair(uds.SocketTypeStream)
+	require.NoError(t, err)
+	defer sc.Close()
+	defer cc.Close()
+
+	// from the point of view of a client, the SNI dispatcher does not exist
+	eg.Go(func() error {
+		defer cc.Close()
+		tc := tls.Client(cc, &tls.Config{
+			ServerName: "foo.example.com",
+			RootCAs:    caPool,
+		})
+		if err := tc.Handshake(); err != nil {
+			return err
+		}
+		if _, err := tc.Write([]byte("a")); err != nil {
+			return err
+		}
+		if _, err := io.ReadFull(tc, make([]byte, 1)); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// a connection going through the dispatcher with the wrong SNI will not be
+	// dispatched, and it will be passed to the inner TransportCredentials
+	var transportCredentialsCalled, dispatchFuncCalled int
+	var dispatchErr error
+	returnedConn, _, err := (&SNIDispatchTransportCredentials{
+		DispatchFunc: func(serverName string, transcript *bytes.Buffer, rawConn net.Conn) (dispatched bool) {
+			dispatchFuncCalled++
+			if serverName != "foo.example.com" {
+				dispatchErr = fmt.Errorf("expected foo.example.com, got SNI %+q", serverName)
+			}
+			return false
+		},
+		TransportCredentials: transportCredentialsFunc(func(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+			transportCredentialsCalled++
+			return rawConn, nil, nil
+		}),
+	}).ServerHandshake(sc)
+	require.NoError(t, err)
+	require.NoError(t, dispatchErr)
+	require.Equal(t, 1, dispatchFuncCalled)
+	require.Equal(t, 1, transportCredentialsCalled)
+
+	// prove that we can use the non-dispatched conn as is
+	tc := tls.Server(returnedConn, &tls.Config{
+		Certificates: []tls.Certificate{caCert},
+	})
+	require.NoError(t, tc.Handshake())
+
+	_, err = tc.Write([]byte("a"))
+	require.NoError(t, err)
+	_, err = io.ReadFull(tc, make([]byte, 1))
+	require.NoError(t, err)
+
+	// the client is happy
+	require.NoError(t, eg.Wait())
+}
+
+func TestSNIDispatch_YesDispatch(t *testing.T) {
+	caCert := requireExampleServerCert(t)
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCert.Leaf)
+
+	var eg errgroup.Group
+	defer eg.Wait()
+
+	// net.Pipe is unbuffered and crypto/tls doesn't work well with unbuffered
+	// connections (even though it should)
+	sc, cc, err := uds.NewSocketpair(uds.SocketTypeStream)
+	require.NoError(t, err)
+	defer sc.Close()
+	defer cc.Close()
+
+	// from the point of view of a client, the SNI dispatcher does not exist
+	eg.Go(func() error {
+		defer cc.Close()
+		tc := tls.Client(cc, &tls.Config{
+			ServerName: "bar.example.com",
+			RootCAs:    caPool,
+		})
+		if err := tc.Handshake(); err != nil {
+			return err
+		}
+		if _, err := tc.Write([]byte("a")); err != nil {
+			return err
+		}
+		if _, err := io.ReadFull(tc, make([]byte, 1)); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	// a connection going through the dispatcher with the correct SNI will be
+	// dispatched and the inner TransportCredentials doesn't see it
+	var transportCredentialsCalled, dispatchFuncCalled int
+	var dispatchErr error
+	var dispatchedTranscript *bytes.Buffer
+	var dispatchedConn net.Conn
+	_, _, err = (&SNIDispatchTransportCredentials{
+		DispatchFunc: func(serverName string, transcript *bytes.Buffer, rawConn net.Conn) (dispatched bool) {
+			dispatchFuncCalled++
+			if serverName != "bar.example.com" {
+				dispatchErr = fmt.Errorf("expected bar.example.com, got SNI %+q", serverName)
+				return false
+			}
+			dispatchedTranscript = transcript
+			dispatchedConn = rawConn
+			return true
+		},
+		TransportCredentials: transportCredentialsFunc(func(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+			transportCredentialsCalled++
+			return rawConn, nil, nil
+		}),
+	}).ServerHandshake(sc)
+	require.ErrorIs(t, err, credentials.ErrConnDispatched)
+	require.NoError(t, dispatchErr)
+	require.Equal(t, 1, dispatchFuncCalled)
+	require.Equal(t, 0, transportCredentialsCalled)
+
+	// the DispatchFunc gets the actual connection object plus a transcript
+	require.Same(t, sc, dispatchedConn)
+
+	// a TLS ClientHello is in there
+	require.NotNil(t, dispatchedTranscript)
+	require.NotZero(t, dispatchedTranscript.Len())
+
+	type nestedConn struct {
+		net.Conn
+	}
+	type bypassReader struct {
+		io.Reader
+		nestedConn
+	}
+	// methods in the io.Reader will take priority over nestedConn
+	scWithTranscript := bypassReader{
+		Reader:     io.MultiReader(dispatchedTranscript, dispatchedConn),
+		nestedConn: nestedConn{dispatchedConn},
+	}
+
+	// prove that we can use the dispatched conn if it's preceded by the
+	// returned transcript
+	tc := tls.Server(scWithTranscript, &tls.Config{
+		Certificates: []tls.Certificate{caCert},
+	})
+	require.NoError(t, tc.Handshake())
+
+	_, err = tc.Write([]byte("a"))
+	require.NoError(t, err)
+	_, err = io.ReadFull(tc, make([]byte, 1))
+	require.NoError(t, err)
+
+	// the client is happy
+	require.NoError(t, eg.Wait())
+}
+
+type transportCredentialsFunc func(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error)
+
+var _ credentials.TransportCredentials = transportCredentialsFunc(nil)
+
+// ServerHandshake implements [credentials.TransportCredentials].
+func (fn transportCredentialsFunc) ServerHandshake(c net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	return fn(c)
+}
+
+// ClientHandshake implements [credentials.TransportCredentials].
+func (transportCredentialsFunc) ClientHandshake(context.Context, string, net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	panic("unimplemented")
+}
+
+// Clone implements [credentials.TransportCredentials].
+func (transportCredentialsFunc) Clone() credentials.TransportCredentials {
+	panic("unimplemented")
+}
+
+// Info implements [credentials.TransportCredentials].
+func (transportCredentialsFunc) Info() credentials.ProtocolInfo {
+	panic("unimplemented")
+}
+
+// OverrideServerName implements [credentials.TransportCredentials].
+func (transportCredentialsFunc) OverrideServerName(string) error {
+	panic("unimplemented")
+}
+
+func requireExampleServerCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	_, key, err := ed25519.GenerateKey(nil)
+	require.NoError(t, err)
+
+	cert := &x509.Certificate{
+		NotBefore:   time.Now().Add(-24 * time.Hour),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+
+		DNSNames: []string{"*.example.com"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, cert, cert, key.Public(), key)
+	require.NoError(t, err)
+
+	cert, err = x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        cert,
+	}
+}

--- a/lib/relaytunnel/discover.go
+++ b/lib/relaytunnel/discover.go
@@ -43,6 +43,7 @@ type StaticDiscoverServiceServer struct {
 
 	RelayGroup            string
 	TargetConnectionCount int32
+	SupportedTunnelTypes  []string
 }
 
 var _ relaytunnelv1alpha.DiscoveryServiceServer = (*StaticDiscoverServiceServer)(nil)
@@ -52,6 +53,7 @@ func (d *StaticDiscoverServiceServer) Discover(ctx context.Context, req *relaytu
 	return &relaytunnelv1alpha.DiscoverResponse{
 		RelayGroup:            d.RelayGroup,
 		TargetConnectionCount: d.TargetConnectionCount,
+		SupportedTunnelTypes:  d.SupportedTunnelTypes,
 	}, nil
 }
 

--- a/lib/relaytunnel/tunnel_client.go
+++ b/lib/relaytunnel/tunnel_client.go
@@ -244,7 +244,29 @@ func (c *Client) discoverOnce(ctx context.Context) error {
 		return trace.Wrap(err)
 	}
 
-	c.updateDiscovery(ctx, resp.GetRelayGroup(), resp.GetTargetConnectionCount())
+	effectiveConnectionCount := resp.GetTargetConnectionCount()
+
+	supportedTunnelTypes := resp.GetSupportedTunnelTypes()
+	if len(supportedTunnelTypes) < 1 {
+		supportedTunnelTypes = []string{string(types.NodeTunnel)}
+	}
+
+	if !slices.Contains(supportedTunnelTypes, string(c.tunnelType)) {
+		// the relay group is not advertising support for the tunnel type we
+		// want, so we just stay at a connection count of 0 to not attempt
+		// opening connections that would not work anyway; the next check will
+		// try again, so if the relay is upgraded and starts supporting our
+		// tunnel type we will begin opening connections
+		c.log.ErrorContext(ctx,
+			"The specified relay server does not currently support the required tunnel type and no tunnels will be opened, will check again later",
+			"relay_addr", c.relayAddr,
+			"tunnel_type", string(c.tunnelType),
+			"supported_tunnel_types", supportedTunnelTypes,
+		)
+		effectiveConnectionCount = 0
+	}
+
+	c.updateDiscovery(ctx, resp.GetRelayGroup(), effectiveConnectionCount)
 
 	return nil
 }

--- a/lib/relaytunnel/tunnel_server.go
+++ b/lib/relaytunnel/tunnel_server.go
@@ -133,18 +133,18 @@ func (*grpcServerCredentials) ClientHandshake(ctx context.Context, authority str
 	return nil, nil, trace.NotImplemented("these transport credentials can only be used as a server")
 }
 
-// OverrideServerName implements implements [credentials.TransportCredentials].
+// OverrideServerName implements [credentials.TransportCredentials].
 func (*grpcServerCredentials) OverrideServerName(string) error {
 	return nil
 }
 
-// Clone implements implements [credentials.TransportCredentials].
+// Clone implements [credentials.TransportCredentials].
 func (s *grpcServerCredentials) Clone() credentials.TransportCredentials {
 	// s is immutable so there's no need to copy anything
 	return s
 }
 
-// Info implements implements [credentials.TransportCredentials].
+// Info implements [credentials.TransportCredentials].
 func (s *grpcServerCredentials) Info() credentials.ProtocolInfo {
 	return credentials.ProtocolInfo{
 		SecurityProtocol: "tls",
@@ -152,7 +152,7 @@ func (s *grpcServerCredentials) Info() credentials.ProtocolInfo {
 	}
 }
 
-// ServerHandshake implements implements [credentials.TransportCredentials].
+// ServerHandshake implements [credentials.TransportCredentials].
 func (s *grpcServerCredentials) ServerHandshake(rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -332,6 +332,8 @@ func (s *Server) handleYamuxTunnel(c io.ReadWriteCloser, clientID *tlsca.Identit
 		switch tunnelType {
 		case types.NodeTunnel:
 			requiredRole = types.RoleNode
+		case types.KubeTunnel:
+			requiredRole = types.RoleKube
 		default:
 			return trace.BadParameter("unsupported tunnel type %q", tunnelType)
 		}

--- a/lib/service/relay.go
+++ b/lib/service/relay.go
@@ -46,9 +46,11 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/authz"
+	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	multiplexergrpc "github.com/gravitational/teleport/lib/multiplexer/grpc"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/relaypeer"
+	"github.com/gravitational/teleport/lib/relaytransport"
 	"github.com/gravitational/teleport/lib/relaytunnel"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
@@ -140,6 +142,20 @@ func (process *TeleportProcess) runRelayService() error {
 	}
 	defer nodeWatcher.Close()
 
+	kubeServerWatcher, err := services.NewKubeServerWatcher(process.ExitContext(), services.KubeServerWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component:    teleport.ComponentRelay,
+			Logger:       sublogger("kube_server_watcher"),
+			Client:       accessPoint,
+			MaxStaleness: time.Minute,
+		},
+		KubernetesServerGetter: accessPoint,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer kubeServerWatcher.Close()
+
 	tunnelServer, err := relaytunnel.NewServer(relaytunnel.ServerConfig{
 		Log: sublogger("tunnel_server"),
 		GetCertificate: func(ctx context.Context) (*tls.Certificate, error) {
@@ -178,6 +194,10 @@ func (process *TeleportProcess) runRelayService() error {
 	relaytunnelv1alpha.RegisterDiscoveryServiceServer(tunnelGRPCServer, &relaytunnel.StaticDiscoverServiceServer{
 		RelayGroup:            process.Config.Relay.RelayGroup,
 		TargetConnectionCount: process.Config.Relay.TargetConnectionCount,
+		SupportedTunnelTypes: []string{
+			string(apitypes.NodeTunnel),
+			string(apitypes.KubeTunnel),
+		},
 	})
 
 	peerServer, err := relaypeer.NewServer(relaypeer.ServerConfig{
@@ -220,6 +240,35 @@ func (process *TeleportProcess) runRelayService() error {
 		return c, nil
 	}
 
+	relayPeerClient, err := relaypeer.NewClient(relaypeer.ClientConfig{
+		HostID:      conn.hostID,
+		ClusterName: conn.clusterName,
+		GroupName:   process.Config.Relay.RelayGroup,
+
+		AccessPoint: accessPoint,
+		Log:         sublogger("peer_client"),
+
+		GetCertificate: conn.ClientGetCertificate,
+		GetPool:        conn.ClientGetPool,
+		Ciphersuites:   process.Config.CipherSuites,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	kubeForwarder, err := kuberelay.NewPassiveForwarder(kuberelay.PassiveForwarderConfig{
+		Log:                      sublogger("kube_forwarder"),
+		ClusterName:              conn.clusterName,
+		GroupName:                process.Config.Relay.RelayGroup,
+		GetKubeServersWithFilter: kubeServerWatcher.CurrentResourcesWithFilter,
+		LocalDial:                tunnelServer.Dial,
+		PeerDial:                 relayPeerClient.Dial,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer kubeForwarder.Close()
+
 	var transportCreds credentials.TransportCredentials
 	{
 		tc, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
@@ -235,24 +284,12 @@ func (process *TeleportProcess) runRelayService() error {
 		}
 		transportCreds = tc
 	}
+	transportCreds = &relaytransport.SNIDispatchTransportCredentials{
+		TransportCredentials: transportCreds,
+		DispatchFunc:         kubeForwarder.Dispatch,
+	}
 	if process.Config.Relay.TransportPROXYProtocol {
 		transportCreds = multiplexergrpc.PPV2ServerCredentials{TransportCredentials: transportCreds}
-	}
-
-	relayPeerClient, err := relaypeer.NewClient(relaypeer.ClientConfig{
-		HostID:      conn.hostID,
-		ClusterName: conn.clusterName,
-		GroupName:   process.Config.Relay.RelayGroup,
-
-		AccessPoint: accessPoint,
-		Log:         sublogger("relay_router"),
-
-		GetCertificate: conn.ClientGetCertificate,
-		GetPool:        conn.ClientGetPool,
-		Ciphersuites:   process.Config.CipherSuites,
-	})
-	if err != nil {
-		return trace.Wrap(err)
 	}
 
 	relayRouter, err := proxy.NewRelayRouter(proxy.RelayRouterConfig{

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -139,6 +139,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	kubegrpc "github.com/gravitational/teleport/lib/kube/grpc"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
+	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
@@ -4307,6 +4308,9 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole, h
 			utils.NetAddr{Addr: reversetunnelclient.LocalKubernetes},
 		)
 		addrs = append(addrs, process.Config.Kube.PublicAddrs...)
+		if process.Config.RelayServer != "" {
+			dnsNames = append(dnsNames, "*"+kuberelay.SNISuffix)
+		}
 	case types.RoleApp, types.RoleOkta:
 		principals = append(principals, hostUUID)
 	case types.RoleWindowsDesktop:

--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -272,6 +272,9 @@ type KubeServer interface {
 	GetCluster() types.KubeCluster
 	// GetProxyIDs returns a list of proxy ids this service is connected to.
 	GetProxyIDs() []string
+	// GetRelayGroup returns the name of the Relay group that the kube server is
+	// connected to.
+	GetRelayGroup() string
 }
 
 var _ KubeServer = types.KubeServer(nil)

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -236,7 +236,7 @@ func (l *LocalProxy) handleDownstreamConnection(ctx context.Context, downstreamC
 		return trace.Wrap(err)
 	}
 
-	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(l.cfg.SNI, cert))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -261,7 +261,7 @@ func (l *LocalProxy) HandleTCPConnector(ctx context.Context, connector func() (n
 		return trace.Wrap(err)
 	}
 
-	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(cert))
+	upstreamConn, err := dialALPNMaybePing(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(l.cfg.SNI, cert))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -299,20 +299,20 @@ func (l *LocalProxy) Close() error {
 	return nil
 }
 
-func (l *LocalProxy) getALPNDialerConfig(certs ...tls.Certificate) client.ALPNDialerConfig {
+func (l *LocalProxy) getALPNDialerConfig(serverName string, certs ...tls.Certificate) client.ALPNDialerConfig {
 	return client.ALPNDialerConfig{
 		ALPNConnUpgradeRequired: l.cfg.ALPNConnUpgradeRequired,
 		TLSConfig: &tls.Config{
 			NextProtos:         common.ProtocolsToString(l.cfg.Protocols),
 			InsecureSkipVerify: l.cfg.InsecureSkipVerify,
-			ServerName:         l.cfg.SNI,
+			ServerName:         serverName,
 			Certificates:       certs,
 			RootCAs:            l.cfg.RootCAs,
 		},
 	}
 }
 
-func (l *LocalProxy) makeHTTPReverseProxy(certs ...tls.Certificate) *httputil.ReverseProxy {
+func (l *LocalProxy) makeHTTPReverseProxy(serverName string, certs ...tls.Certificate) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Director: func(outReq *http.Request) {
 			outReq.URL.Scheme = "https"
@@ -341,7 +341,7 @@ func (l *LocalProxy) makeHTTPReverseProxy(certs ...tls.Certificate) *httputil.Re
 			http.Error(w, http.StatusText(code), code)
 		},
 		Transport: &http.Transport{
-			DialTLSContext: client.NewALPNDialer(l.getALPNDialerConfig(certs...)).DialContext,
+			DialTLSContext: client.NewALPNDialer(l.getALPNDialerConfig(serverName, certs...)).DialContext,
 		},
 	}
 }
@@ -404,15 +404,27 @@ func (l *LocalProxy) startHTTPAccessProxy(ctx context.Context) error {
 }
 
 func (l *LocalProxy) getHTTPReverseProxyForReq(req *http.Request) (*httputil.ReverseProxy, error) {
-	certs, err := l.cfg.HTTPMiddleware.OverwriteClientCerts(req)
-	if trace.IsNotImplemented(err) {
-		return l.makeHTTPReverseProxy(l.getCert()), nil
-	} else if err != nil {
+	serverName, ok, err := l.cfg.HTTPMiddleware.GetServerName(req)
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if ok {
+		l.cfg.Log.DebugContext(req.Context(), "got SNI from middleware", "server_name", serverName)
+	} else {
+		serverName = l.cfg.SNI
+	}
 
-	l.cfg.Log.DebugContext(req.Context(), "overwrote certs")
-	return l.makeHTTPReverseProxy(certs...), nil
+	certs, ok, err := l.cfg.HTTPMiddleware.GetClientCerts(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if ok {
+		l.cfg.Log.DebugContext(req.Context(), "got certs from middleware")
+	} else {
+		certs = []tls.Certificate{l.getCert()}
+	}
+
+	return l.makeHTTPReverseProxy(serverName, certs...), nil
 }
 
 // getCert returns the local proxy's configured TLS certificate.

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -546,8 +546,9 @@ func TestKubeMiddleware(t *testing.T) {
 			assert.Contains(t, rw.Buffer().String(), "context canceled")
 
 			// but certificate still was reissued.
-			certs, err := km.OverwriteClientCerts(req)
+			certs, ok, err := km.GetClientCerts(req)
 			assert.NoError(t, err)
+			assert.True(t, ok)
 			if !assert.Len(t, certs, 1) {
 				return
 			}
@@ -622,12 +623,13 @@ func TestKubeMiddleware(t *testing.T) {
 			// HandleRequest will reissue certificate if needed
 			km.HandleRequest(responsewriters.NewMemoryResponseWriter(), &req)
 
-			certs, err := km.OverwriteClientCerts(&req)
+			certs, ok, err := km.GetClientCerts(&req)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
+				require.True(t, ok)
 				require.Len(t, certs, 1)
 				require.Equal(t, tt.overwrittenCert, certs[0])
 			}

--- a/lib/tbot/services/k8s/output_v2_config.go
+++ b/lib/tbot/services/k8s/output_v2_config.go
@@ -68,6 +68,10 @@ type OutputV2Config struct {
 	//
 	// By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}".
 	ContextNameTemplate string `yaml:"context_name_template,omitempty"`
+
+	// RelayAddress specifies the address of a relay transport server to use in
+	// the generated Kubernetes config file.
+	RelayAddress string `yaml:"relay_server,omitempty"`
 }
 
 // GetName returns the user-given name of the service, used for validation purposes.

--- a/lib/tbot/services/k8s/output_v2_test.go
+++ b/lib/tbot/services/k8s/output_v2_test.go
@@ -303,13 +303,14 @@ func TestKubernetesV2OutputService_render(t *testing.T) {
 				[]types.CertAuthority{fakeCA(t, types.HostCA, mockClusterName)},
 			)
 			require.NoError(t, err)
+			mockSNI := client.GetKubeTLSServerName(mockClusterName)
 			status := &kubernetesStatusV2{
 				kubernetesClusterNames: []string{"a", "b", "c"},
 				defaultNamespaces: map[string]string{
 					"a": "namespace-a",
 				},
 				teleportClusterName: mockClusterName,
-				tlsServerName:       client.GetKubeTLSServerName(mockClusterName),
+				tlsServerNameFunc:   func(teleportClusterName, kubeClusterName string) string { return mockSNI },
 				credentials:         keyRing,
 				clusterAddr:         fmt.Sprintf("https://%s:443", mockClusterName),
 			}

--- a/lib/teleterm/clusters/cluster_gateways.go
+++ b/lib/teleterm/clusters/cluster_gateways.go
@@ -146,6 +146,7 @@ func (c *Cluster) createKubeGateway(ctx context.Context, params CreateGatewayPar
 		Cert:                          cert,
 		Insecure:                      c.clusterClient.InsecureSkipVerify,
 		WebProxyAddr:                  c.clusterClient.WebProxyAddr,
+		RelayAddr:                     c.clusterClient.RelayAddr,
 		Logger:                        c.Logger,
 		TCPPortAllocator:              params.TCPPortAllocator,
 		OnExpiredCert:                 params.OnExpiredCert,

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -69,6 +69,9 @@ type Config struct {
 	Username string
 	// WebProxyAddr
 	WebProxyAddr string
+	// RelayAddr, if set, is the address of the Relay service that should be
+	// used by protocols that support using a Relay.
+	RelayAddr string
 	// Logger is a component logger
 	Logger *slog.Logger
 	// TCPPortAllocator creates listeners on the given ports. This interface lets us avoid occupying

--- a/proto/teleport/relaytunnel/v1alpha/discovery_service.proto
+++ b/proto/teleport/relaytunnel/v1alpha/discovery_service.proto
@@ -35,4 +35,8 @@ message DiscoverResponse {
   string relay_group = 1;
 
   int32 target_connection_count = 2;
+
+  // the list of api/types.TunnelTypes supported by this Relay group; if empty,
+  // it should be treated as containing only types.NodeTunnel ("node")
+  repeated string supported_tunnel_types = 3;
 }

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -69,6 +69,7 @@ import (
 	kubeclient "github.com/gravitational/teleport/lib/client/kube"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	kuberelay "github.com/gravitational/teleport/lib/kube/relay"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -196,7 +197,11 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 		return trace.AccessDenied("this cluster does not support Kubernetes")
 	}
 
-	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	// TODO(espadolini): joining requires hitting the agent handling a specific
+	// session, which is not currently implemented through the relay, once it's
+	// possible we should probably get rid of the whole ignoreRelay parameter
+	const ignoreRelayTrue = true
+	kubeStatus, err := fetchKubeStatus(cf.Context, tc, ignoreRelayTrue)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -208,7 +213,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 	}
 
 	tlsConfig.InsecureSkipVerify = cf.InsecureSkipVerify
-	tlsConfig.ServerName = kubeStatus.tlsServerName
+	tlsConfig.ServerName = kubeStatus.tlsServerNameForCluster(cluster, kubeCluster)
 	session, err := client.NewKubeSession(cf.Context,
 		client.KubeSessionConfig{
 			KubeProxyAddr:                 tc.Config.KubeProxyAddr,
@@ -1276,7 +1281,8 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	err = retryWithAccessRequest(cf, tc, func() error {
 		err := client.RetryWithRelogin(cf.Context, tc, func() error {
 			var err error
-			kubeStatus, err = fetchKubeStatus(cf.Context, tc)
+			const ignoreRelayFalse = false
+			kubeStatus, err = fetchKubeStatus(cf.Context, tc, ignoreRelayFalse)
 			return trace.Wrap(err)
 		})
 		if err != nil {
@@ -1493,15 +1499,20 @@ type kubernetesStatus struct {
 	teleportClusterName string
 	kubeClusters        []types.KubeCluster
 	credentials         *client.KeyRing
-	tlsServerName       string
+	tlsServerNameFunc   func(teleportClusterName, kubeClusterName string) string
+}
+
+func (s *kubernetesStatus) tlsServerNameForCluster(teleportClusterName, kubeClusterName string) string {
+	if s.tlsServerNameFunc == nil {
+		return ""
+	}
+	return s.tlsServerNameFunc(teleportClusterName, kubeClusterName)
 }
 
 // fetchKubeStatus returns a kubernetesStatus populated from the given TeleportClient.
-func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernetesStatus, error) {
+func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient, ignoreRelay bool) (*kubernetesStatus, error) {
 	var err error
-	kubeStatus := &kubernetesStatus{
-		clusterAddr: tc.KubeClusterAddr(),
-	}
+	kubeStatus := &kubernetesStatus{}
 	kubeStatus.credentials, err = tc.LocalAgent().GetCoreKeyRing()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1511,9 +1522,22 @@ func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernete
 		return nil, trace.Wrap(err)
 	}
 
+	if !ignoreRelay && tc.RelayAddr != "" {
+		kubeStatus.clusterAddr = (&url.URL{
+			Scheme: "https",
+			Host:   tc.RelayAddr,
+		}).String()
+		kubeStatus.tlsServerNameFunc = kuberelay.FullSNIForKubeCluster
+		return kubeStatus, nil
+	}
+
+	kubeStatus.clusterAddr = tc.KubeClusterAddr()
 	if tc.TLSRoutingEnabled {
 		k8host, _ := tc.KubeProxyHostPort()
-		kubeStatus.tlsServerName = client.GetKubeTLSServerName(k8host)
+		tlsServerName := client.GetKubeTLSServerName(k8host)
+		kubeStatus.tlsServerNameFunc = func(teleportClusterName, kubeClusterName string) string {
+			return tlsServerName
+		}
 	}
 
 	return kubeStatus, nil
@@ -1527,7 +1551,7 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus, overrideCo
 		TeleportClusterName: kubeStatus.teleportClusterName,
 		Credentials:         kubeStatus.credentials,
 		ProxyAddr:           cf.Proxy,
-		TLSServerName:       kubeStatus.tlsServerName,
+		TLSServerNameFunc:   kubeStatus.tlsServerNameFunc,
 		Impersonate:         cf.kubernetesImpersonationConfig.kubernetesUser,
 		ImpersonateGroups:   cf.kubernetesImpersonationConfig.kubernetesGroups,
 		Namespace:           cf.kubeNamespace,
@@ -1592,7 +1616,7 @@ func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path, overrideCont
 	if _, err := tc.Ping(cf.Context); err != nil {
 		return trace.Wrap(err)
 	}
-	if tc.KubeProxyAddr == "" {
+	if tc.KubeProxyAddr == "" && tc.RelayAddr == "" {
 		// Kubernetes support disabled, don't touch kubeconfig.
 		return nil
 	}

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -250,7 +250,7 @@ func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*cli
 	}
 
 	// Use logged-in clusters.
-	clusters := kubeconfig.LocalProxyClustersFromDefaultConfig(defaultConfig, tc.KubeClusterAddr())
+	clusters := kubeconfig.LocalProxyClustersFromDefaultConfig(defaultConfig, tc.WebProxyHost(), tc.KubeClusterAddr())
 	if len(clusters) == 0 {
 		return nil, nil, trace.BadParameter("%s", errorMsg)
 	}
@@ -434,6 +434,7 @@ func (k *kubeLocalProxy) createKubeConfig(defaultConfig *clientcmdapi.Config, ov
 		return nil, trace.BadParameter("empty default config")
 	}
 	values := &kubeconfig.LocalProxyValues{
+		TeleportProfileName:     k.tc.WebProxyHost(),
 		TeleportKubeClusterAddr: k.tc.KubeClusterAddr(),
 		LocalProxyURL:           "http://" + k.GetAddr(),
 		LocalProxyCAs:           map[string][]byte{},

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -480,7 +480,7 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 	}
 
 	// Prepare Teleport kube cluster based on selected context.
-	kubeCluster, found := kubeconfig.FindTeleportClusterForLocalProxy(defaultConfig, kubeClusterAddrFromProfile(profile), selectedContext)
+	kubeCluster, found := kubeconfig.FindTeleportClusterForLocalProxy(defaultConfig, selectedContext, profile.Name(), kubeClusterAddrFromProfile(profile))
 	if !found {
 		return nil, nil, false
 	}

--- a/tool/tsh/common/kubectl.go
+++ b/tool/tsh/common/kubectl.go
@@ -458,6 +458,12 @@ func shouldUseKubeLocalProxy(cf *CLIConf, kubectlArgs []string) (*clientcmdapi.C
 		return nil, nil, false
 	}
 
+	// TODO(espadolini): we could skip the local proxy when using a relay, but
+	// we can only know if we are using a relay once we have a TeleportClient
+	// and we load the profile, which will only happen later; seeing as it's
+	// only a little wasteful to spin up a local proxy it's fine for now, but if
+	// we rework the flow we should add a way to skip the local proxy when using
+	// a relay even if a connection through the control plane would require it
 	if !profile.RequireKubeLocalProxy() {
 		return nil, nil, false
 	}

--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -282,6 +282,7 @@ func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {
 				TLSCertificates: [][]byte{[]byte(fixtures.TLSCACertPEM)},
 			}},
 		},
+		ProxyAddr:     "localhost:443",
 		SelectCluster: kubeCluster,
 	}, false)
 	require.NoError(t, err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -6224,7 +6224,8 @@ func updateKubeConfigOnLogin(cf *CLIConf, tc *client.TeleportClient) error {
 	if len(cf.KubernetesCluster) == 0 {
 		return nil
 	}
-	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
+	const ignoreRelayFalse = false
+	kubeStatus, err := fetchKubeStatus(cf.Context, tc, ignoreRelayFalse)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2647,6 +2647,16 @@ func onLogout(cf *CLIConf) error {
 		}
 
 		// Remove Teleport related entries from kubeconfig.
+
+		if profile != nil {
+			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "profile", profile.Name)
+			err = kubeconfig.RemoveByProfileName("", profile.Name)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
+		// TODO(espadolini): DELETE IN v20 (maybe, files could be left over from really old versions)
 		logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
 		err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr())
 		if err != nil {
@@ -2660,6 +2670,8 @@ func onLogout(cf *CLIConf) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		// TODO(espadolini): DELETE IN v20 (maybe, files could be left over from really old versions)
 		logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster_addr", tc.KubeClusterAddr())
 		if err = kubeconfig.RemoveByServerAddr("", tc.KubeClusterAddr()); err != nil {
 			return trace.Wrap(err)
@@ -2667,8 +2679,8 @@ func onLogout(cf *CLIConf) error {
 
 		// Remove Teleport related entries from kubeconfig for all clusters.
 		for _, profile := range profiles {
-			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "cluster", profile.Cluster)
-			err = kubeconfig.RemoveByClusterName("", profile.Cluster)
+			logger.DebugContext(cf.Context, "Removing Teleport related entries from kubeconfig", "profile", profile.Name)
+			err = kubeconfig.RemoveByProfileName("", profile.Name)
 			if err != nil {
 				return trace.Wrap(err)
 			}


### PR DESCRIPTION
This PR backports the Relay Kube access functionality to branch/v18. v18 docs will be added in a separate PR.

changelog: Added support for Kubernetes Access when using the Relay Service.