### PR TITLE
Fix WithUnauthenticatedLimiter and WithAccessDeniedLimiter rate limiters

### DIFF
--- a/lib/limiter/internal/ratelimit/ratelimit_test.go
+++ b/lib/limiter/internal/ratelimit/ratelimit_test.go
@@ -19,10 +19,12 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLimitExceededError(t *testing.T) {
+	t.Parallel()
 	err := &limitExceededError{delay: 3 * time.Second}
 
 	require.True(t, trace.IsLimitExceeded(err))
@@ -30,4 +32,91 @@ func TestLimitExceededError(t *testing.T) {
 	var le *trace.LimitExceededError
 	require.ErrorAs(t, err, &le)
 	require.Equal(t, err.Error(), le.Message)
+}
+
+func TestTokenBucketSet_IsRateLimited(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not rate limited when tokens available", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		rates := NewRateSet()
+		require.NoError(t, rates.Add(time.Minute, 10, 10))
+
+		tbs := NewTokenBucketSet(rates, clock)
+		require.False(t, tbs.IsRateLimited(), "should not be rate limited with full bucket")
+	})
+
+	t.Run("rate limited when no tokens available", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		rates := NewRateSet()
+		require.NoError(t, rates.Add(time.Minute, 10, 10))
+
+		tbs := NewTokenBucketSet(rates, clock)
+
+		// Consume all tokens
+		delay, err := tbs.Consume(10)
+		require.NoError(t, err)
+		require.Zero(t, delay)
+
+		// Now should be rate limited
+		require.True(t, tbs.IsRateLimited(), "should be rate limited after consuming all tokens")
+	})
+
+	t.Run("not rate limited after time passes", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		rates := NewRateSet()
+		require.NoError(t, rates.Add(time.Minute, 10, 10))
+
+		tbs := NewTokenBucketSet(rates, clock)
+
+		// Consume all tokens
+		delay, err := tbs.Consume(10)
+		require.NoError(t, err)
+		require.Zero(t, delay)
+
+		require.True(t, tbs.IsRateLimited(), "should be rate limited after consuming all tokens")
+
+		// Advance time to refill tokens
+		clock.Advance(time.Minute)
+
+		require.False(t, tbs.IsRateLimited())
+	})
+
+	t.Run("rate limited when any bucket is exhausted", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		rates := NewRateSet()
+		require.NoError(t, rates.Add(time.Minute, 10, 10))
+		require.NoError(t, rates.Add(time.Hour, 100, 100))
+
+		tbs := NewTokenBucketSet(rates, clock)
+
+		// Consume all tokens from the minute bucket
+		delay, err := tbs.Consume(10)
+		require.NoError(t, err)
+		require.Zero(t, delay)
+
+		// Should be rate limited even though hour bucket has tokens
+		require.True(t, tbs.IsRateLimited())
+	})
+
+	t.Run("does not consume tokens", func(t *testing.T) {
+		clock := clockwork.NewFakeClock()
+		rates := NewRateSet()
+		require.NoError(t, rates.Add(time.Minute, 10, 10))
+
+		tbs := NewTokenBucketSet(rates, clock)
+
+		// Check multiple times - should not consume tokens
+		require.False(t, tbs.IsRateLimited())
+		require.False(t, tbs.IsRateLimited())
+		require.False(t, tbs.IsRateLimited())
+
+		// Should still be able to consume all tokens
+		delay, err := tbs.Consume(10)
+		require.NoError(t, err)
+		require.Zero(t, delay)
+
+		// Now should be rate limited
+		require.True(t, tbs.IsRateLimited())
+	})
 }

--- a/lib/limiter/internal/ratelimit/tokenbucket.go
+++ b/lib/limiter/internal/ratelimit/tokenbucket.go
@@ -70,6 +70,18 @@ func (tbs *TokenBucketSet) Update(rates *RateSet) {
 	}
 }
 
+// IsRateLimited checks if the bucket is currently rate-limited (no tokens available)
+// without actually consuming any tokens. Returns true if rate-limited, false otherwise.
+func (tbs *TokenBucketSet) IsRateLimited() bool {
+	for _, tokenBucket := range tbs.buckets {
+		tokenBucket.updateAvailableTokens()
+		if tokenBucket.availableTokens < 1 {
+			return true
+		}
+	}
+	return false
+}
+
 // Consume makes an attempt to consume the specified number of tokens from the
 // bucket. If there are enough tokens available then (0, nil) is returned.
 // If tokens to consume is larger than the burst size, then an error is returned

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -5142,7 +5142,7 @@ func (h *Handler) WithSession(fn ContextHandler) httprouter.Handle {
 // This is a good default to use as both Cluster and User auth are checked here, but `WithLimiter` can be used if
 // you're certain that no authenticated requests will be made.
 func (h *Handler) WithUnauthenticatedLimiter(fn httplib.HandlerFunc) httprouter.Handle {
-	return h.unauthenticatedLimiterFunc(fn, h.WithLimiterHandlerFunc)
+	return h.unauthenticatedLimiterFunc(fn, h.limiter)
 }
 
 // WithUnauthenticatedHighLimiter adds a conditional IP-based rate limiting that will limit only unauthenticated
@@ -5150,21 +5150,39 @@ func (h *Handler) WithUnauthenticatedLimiter(fn httplib.HandlerFunc) httprouter.
 // This higher rate limit should only be used on endpoints which are only CPU constrained
 // (no file or other resources used).
 func (h *Handler) WithUnauthenticatedHighLimiter(fn httplib.HandlerFunc) httprouter.Handle {
-	return h.unauthenticatedLimiterFunc(fn, h.WithHighLimiterHandlerFunc)
+	return h.unauthenticatedLimiterFunc(fn, h.highLimiter)
 }
 
-func (h *Handler) unauthenticatedLimiterFunc(fn httplib.HandlerFunc, rateFunc func(fn httplib.HandlerFunc) httplib.HandlerFunc) httprouter.Handle {
+func (h *Handler) unauthenticatedLimiterFunc(fn httplib.HandlerFunc, limiter *limiter.RateLimiter) httprouter.Handle {
 	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+		// check if the request remote is rate limited before attempting authentication.
+		isLimited, err := isRequestRateLimited(r, limiter)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if isLimited {
+			return nil, trace.LimitExceeded("rate limit exceeded")
+		}
 		if _, _, err := h.authenticateRequestWithCluster(w, r, p); err != nil {
 			// retry with user auth
 			if _, err = h.AuthenticateRequest(w, r, true /* check token */); err != nil {
 				// no auth passed, limit request
-				return rateFunc(fn)(w, r, p)
+				return withLimiterHandlerFunc(fn, limiter)(w, r, p)
 			}
 		}
 		// auth passed, call directly
 		return fn(w, r, p)
 	})
+}
+
+func withLimiterHandlerFunc(fn httplib.HandlerFunc, limiter *limiter.RateLimiter) httplib.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+		err := rateLimitRequest(r, limiter)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return fn(w, r, p)
+	}
 }
 
 // WithAccessDeniedLimiter adds conditional IP-based rate limiting that only applies
@@ -5185,13 +5203,17 @@ func (h *Handler) WithAccessDeniedLimiter(fn httplib.HandlerFunc) httprouter.Han
 
 func (h *Handler) conditionalLimiterFunc(fn httplib.HandlerFunc, limiter *limiter.RateLimiter, shouldLimit func(error) bool) httprouter.Handle {
 	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
-		// TODO(smallinsky) Currently, the WithUnauthenticatedLimiter and the WithUnauthenticatedAccessDeniedLimiter perform
-		// rate limit change after the authentication check.
-		// Ideally if a client is rate limited it should be rate limited before any authentication check is preformed.
+		remoteAddr, err := getRemoteAddressFromRequest(r)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if limiter.IsRateLimited(remoteAddr) {
+			return nil, trace.LimitExceeded("rate limit exceeded")
+		}
 		result, err := fn(w, r, p)
 		if err != nil {
 			if shouldLimit(err) {
-				if err := rateLimitRequest(r, limiter); err != nil {
+				if err := limiter.RegisterRequest(remoteAddr, nil); err != nil {
 					return nil, trace.Wrap(err)
 				}
 			}
@@ -5220,34 +5242,39 @@ func (h *Handler) WithHighLimiter(fn httplib.HandlerFunc) httprouter.Handle {
 // WithLimiterHandlerFunc adds IP-based rate limiting to a HandlerFunc. This
 // should be used when you need to nest this inside another HandlerFunc.
 func (h *Handler) WithLimiterHandlerFunc(fn httplib.HandlerFunc) httplib.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
-		err := rateLimitRequest(r, h.limiter)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return fn(w, r, p)
-	}
+	return withLimiterHandlerFunc(fn, h.limiter)
 }
 
 // WithHighLimiterHandlerFunc adds IP-based rate limiting to a HandlerFunc. This is similar to WithLimiterHandlerFunc
 // but provides a higher rate limit.  This should only be used for requests which are only CPU bound (no disk or other
 // resources used).
 func (h *Handler) WithHighLimiterHandlerFunc(fn httplib.HandlerFunc) httplib.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
-		err := rateLimitRequest(r, h.highLimiter)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return fn(w, r, p)
+	return withLimiterHandlerFunc(fn, h.highLimiter)
+}
+
+// isRequestRateLimited checks if the request would be rate-limited without consuming any tokens.
+// Returns true if the request is rate-limited, false otherwise.
+func isRequestRateLimited(r *http.Request, limiter *limiter.RateLimiter) (bool, error) {
+	remote, err := getRemoteAddressFromRequest(r)
+	if err != nil {
+		return false, trace.Wrap(err)
 	}
+	return limiter.IsRateLimited(remote), nil
+}
+
+func getRemoteAddressFromRequest(r *http.Request) (string, error) {
+	remote, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return remote, nil
 }
 
 func rateLimitRequest(r *http.Request, limiter *limiter.RateLimiter) error {
-	remote, _, err := net.SplitHostPort(r.RemoteAddr)
+	remote, err := getRemoteAddressFromRequest(r)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	return trace.Wrap(limiter.RegisterRequest(remote, nil /* customRate */))
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -9320,24 +9320,79 @@ func TestWitWithAccessDeniedLimiter(t *testing.T) {
 	h := &Handler{limiter: rateLimiter}
 
 	callCount := 0
+	shouldFail := false
 	handle := h.WithAccessDeniedLimiter(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 		callCount++
-		return nil, trace.AccessDenied("invalid credentials")
+		if shouldFail {
+			return nil, trace.AccessDenied("invalid credentials")
+		}
+		return "success", nil
 	})
 
 	r := &http.Request{RemoteAddr: "192.168.1.1:1234"}
 
+	// Make some successful requests - these should not count toward rate limit
+	for i := 0; i < 5; i++ {
+		w := httptest.NewRecorder()
+		handle(w, r, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// Now make access denied requests - only these should count
+	shouldFail = true
 	for i := 0; i < 3; i++ {
 		w := httptest.NewRecorder()
 		handle(w, r, nil)
 		require.Equal(t, http.StatusForbidden, w.Code)
 	}
-	require.Equal(t, 3, callCount)
+	require.Equal(t, 8, callCount)
 
+	// Next request should be rate limited (handler not called)
 	w := httptest.NewRecorder()
 	handle(w, r, nil)
 	require.Equal(t, http.StatusTooManyRequests, w.Code)
-	require.Equal(t, 4, callCount)
+
+	require.Equal(t, 8, callCount)
+}
+
+func TestWithUnauthenticatedLimiter(t *testing.T) {
+	rateLimiter, err := limiter.NewRateLimiter(limiter.Config{
+		Rates: []limiter.Rate{
+			{Period: time.Minute, Average: 2, Burst: 3},
+		},
+		Clock: clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+
+	h := &Handler{limiter: rateLimiter}
+
+	callCount := 0
+	handle := h.WithUnauthenticatedLimiter(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+		callCount++
+		return "success", nil
+	})
+
+	r := &http.Request{RemoteAddr: "192.168.1.1:1234"}
+
+	// Request should return the error from handler
+	w := httptest.NewRecorder()
+	handle(w, r, nil)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, 1, callCount)
+
+	// Should be able to make more requests (they still count toward rate limit)
+	for range 2 {
+		w := httptest.NewRecorder()
+		handle(w, r, nil)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+	require.Equal(t, 3, callCount)
+
+	// Next request should be rate limited
+	w = httptest.NewRecorder()
+	handle(w, r, nil)
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+	require.Equal(t, 3, callCount)
 }
 
 // kubeClusterConfig defines the cluster to be created


### PR DESCRIPTION
### What  
 
 Fix rate limiting logic in `WithUnauthenticatedLimiter` and `WithAccessDeniedLimiter` middleware to check rate limits before performing authentication or executing the handler.

###   Problem

  Previously, these middleware functions would:
  1. Execute authentication checks (allow to guessing the token without rate limiting) 
  2. Only apply rate limiting after the auth operations completed



Requires https://github.com/gravitational/teleport/pull/61776

Address https://github.com/gravitational/teleport/issues/61510

Contributes to https://github.com/gravitational/teleport/issues/61511


changelog: Improve HTTP Unauthenticated rate limiter behavior