### PR TITLE
Flaky tests: reduce iteration count to 50

### DIFF
--- a/.github/actions/difftest/action.yml
+++ b/.github/actions/difftest/action.yml
@@ -12,7 +12,7 @@ inputs:
   attempts:
     description: Number of runs
     required: false
-    default: 100
+    default: 50
 
   bin:
     description: difftest binary location


### PR DESCRIPTION
The default timeout for flaky tests detector is 10 minutes, which isn't enough for tests which take longer or PRs touching multiple tests.

We could increase the timeout, but perhaps reducing the iteration count is an acceptable alternative.