### PR TITLE
[v18] Fix `tsh db connect` failing to connect to database on separate ports

### DIFF
--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -767,14 +767,13 @@ func (c *CLICommandBuilder) getSpannerCommand(ctx context.Context) (*exec.Cmd, e
 	)
 
 	db, err := c.getDatabase(ctx)
-	if err != nil {
-		// default placeholders for a print command if not all info is available
-		if c.options.printFormat {
-			project, instance, database = "<project>", "<instance>", "<database>"
-		} else {
-			return nil, trace.Wrap(err)
-		}
-	} else {
+	switch {
+	case err != nil && c.options.printFormat:
+		// OK to continue in this case, we'll print the placeholders instead.
+		project, instance, database = "<project>", "<instance>", "<database>"
+	case err != nil:
+		return nil, trace.Wrap(err)
+	default:
 		gcp = db.GetGCP()
 	}
 

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -79,13 +79,14 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		opts         []ConnectCommandFunc
-		dbProtocol   string
-		databaseName string
-		execer       *fakeExec
-		cmd          []string
-		wantErr      bool
+		name            string
+		opts            []ConnectCommandFunc
+		dbProtocol      string
+		databaseName    string
+		execer          *fakeExec
+		cmd             []string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:         "postgres",
@@ -327,10 +328,10 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongodb (legacy)",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{withMongoDBAtlasDatabase()},
+			name:            "mongodb (legacy)",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongo": []byte("legacy"),
@@ -344,10 +345,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongodb no TLS (legacy)",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongodb no TLS (legacy)",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongo": []byte("legacy"),
@@ -359,10 +361,10 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "mongosh no CA",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{withMongoDBAtlasDatabase()},
+			name:            "mongosh no CA",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -376,12 +378,12 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
+			name:            "mongosh",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, "/tmp/keys/example.com/cas/example.com.pem"),
-				withMongoDBAtlasDatabase(),
 			},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
@@ -396,10 +398,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh no TLS",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongosh no TLS",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -410,10 +413,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "mongosh preferred",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "mydb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withMongoDBAtlasDatabase()},
+			name:            "mongosh preferred",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "mydb",
+			getDatabaseFunc: withMongoDBAtlasDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{}, // Cannot find either bin.
 			},
@@ -422,10 +426,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			},
 		},
 		{
-			name:         "DocumentDB",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "docdb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withDocumentDBDatabase()},
+			name:            "DocumentDB",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "docdb",
+			getDatabaseFunc: withDocumentDBDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					// When both are available, legacy mongo is preferred.
@@ -439,10 +444,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:         "DocumentDB mongosh",
-			dbProtocol:   defaults.ProtocolMongoDB,
-			databaseName: "docdb",
-			opts:         []ConnectCommandFunc{WithNoTLS(), withDocumentDBDatabase()},
+			name:            "DocumentDB mongosh",
+			dbProtocol:      defaults.ProtocolMongoDB,
+			databaseName:    "docdb",
+			getDatabaseFunc: withDocumentDBDatabase(),
+			opts:            []ConnectCommandFunc{WithNoTLS()},
 			execer: &fakeExec{
 				execOutput: map[string][]byte{
 					"mongosh": []byte("1.1.6"),
@@ -678,12 +684,12 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner for exec is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -691,13 +697,13 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner with print format is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner with print format is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -705,13 +711,13 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner with print format and placeholders is ok",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner with print format and placeholders is ok",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: getDatabaseFuncWithError, // When format is set the command can accept error when fetching the database.
 			opts: []ConnectCommandFunc{
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withErrorGetDatabaseFunc(), // When format is set the command can accept error when fetching the database.
 			},
 			execer:       &fakeExec{},
 			databaseName: "",
@@ -719,48 +725,48 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:       "Spanner for exec without GCP project is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without GCP project is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner for exec without GCP instance is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without GCP instance is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner for exec without database name is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner for exec without database name is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
 			wantErr:      true,
 		},
 		{
-			name:       "Spanner without a local proxy is an error",
-			dbProtocol: defaults.ProtocolSpanner,
+			name:            "Spanner without a local proxy is an error",
+			dbProtocol:      defaults.ProtocolSpanner,
+			getDatabaseFunc: withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("", 0, ""),
 				WithNoTLS(),
-				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -790,10 +796,14 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetConnectCommand(context.Background())
@@ -827,13 +837,14 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 	}
 
 	tests := []struct {
-		name         string
-		opts         []ConnectCommandFunc
-		dbProtocol   string
-		databaseName string
-		execer       *fakeExec
-		cmd          map[string][]string
-		wantErr      bool
+		name            string
+		opts            []ConnectCommandFunc
+		dbProtocol      string
+		databaseName    string
+		execer          *fakeExec
+		cmd             map[string][]string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:         "postgres no TLS",
@@ -955,10 +966,14 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
@@ -999,12 +1014,13 @@ func TestConvertCommandError(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc       string
-		dbProtocol string
-		execer     *fakeExec
-		stderr     []byte
-		wantBin    string
-		wantStdErr string
+		desc            string
+		dbProtocol      string
+		execer          *fakeExec
+		stderr          []byte
+		wantBin         string
+		wantStdErr      string
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			desc:       "converts access denied to helpful message",
@@ -1044,9 +1060,14 @@ func TestConvertCommandError(t *testing.T) {
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
 				WithExecer(tt.execer),
-				withErrorGetDatabaseFunc(),
 			}
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
@@ -1066,8 +1087,8 @@ func TestConvertCommandError(t *testing.T) {
 	}
 }
 
-func withMongoDBAtlasDatabase() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withMongoDBAtlasDatabase() GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "mongodb-atlas",
@@ -1078,11 +1099,11 @@ func withMongoDBAtlasDatabase() ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-func withDocumentDBDatabase() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withDocumentDBDatabase() GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "docdb",
@@ -1093,11 +1114,11 @@ func withDocumentDBDatabase() ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-func withSpannerDatabase(gcp types.GCPCloudSQL) ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+func withSpannerDatabase(gcp types.GCPCloudSQL) GetDatabaseFunc {
+	return func(context.Context, *client.TeleportClient, string) (types.Database, error) {
 		db, err := types.NewDatabaseV3(
 			types.Metadata{
 				Name: "docdb",
@@ -1109,14 +1130,12 @@ func withSpannerDatabase(gcp types.GCPCloudSQL) ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
-	})
+	}
 }
 
-// withErrorGetDatabaseFunc provides a non-nil function that returns error when
+// getDatabaseFuncWithError provides a non-nil function that returns error when
 // retrieving the database. This can be used in tests that don't retrieve
 // databases.
-func withErrorGetDatabaseFunc() ConnectCommandFunc {
-	return WithGetDatabaseFunc(func(ctx context.Context, tc *client.TeleportClient, s string) (types.Database, error) {
-		return nil, trace.NotImplemented("unexpected call to getDatabase function")
-	})
+func getDatabaseFuncWithError(ctx context.Context, tc *client.TeleportClient, s string) (types.Database, error) {
+	return nil, trace.NotImplemented("unexpected call to getDatabase function")
 }

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -683,7 +683,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
+				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -697,7 +697,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
+				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -711,7 +711,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 				WithPrintFormat(),
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{}),
+				withErrorGetDatabaseFunc(), // When format is set the command can accept error when fetching the database.
 			},
 			execer:       &fakeExec{},
 			databaseName: "",
@@ -724,7 +724,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{InstanceID: "bar-instance"}),
+				withSpannerDatabase(types.GCPCloudSQL{InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -736,7 +736,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{ProjectID: "foo-proj"}),
+				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -748,7 +748,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{ProjectID: "foo-proj"}),
+				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -760,7 +760,7 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts: []ConnectCommandFunc{
 				WithLocalProxy("", 0, ""),
 				WithNoTLS(),
-				WithGCP(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
+				withSpannerDatabase(types.GCPCloudSQL{ProjectID: "foo-proj", InstanceID: "bar-instance"}),
 			},
 			execer:       &fakeExec{},
 			databaseName: "googlesql-db",
@@ -790,9 +790,11 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
+				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c := NewCmdBuilder(tc, profile, database, "root", opts...)
+			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetConnectCommand(context.Background())
 			if tt.wantErr {
@@ -953,9 +955,11 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(tt.execer),
+				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c := NewCmdBuilder(tc, profile, database, "root", opts...)
+			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
 			commandOptions, err := c.GetConnectCommandAlternatives(context.Background())
@@ -1040,8 +1044,10 @@ func TestConvertCommandError(t *testing.T) {
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
 				WithExecer(tt.execer),
+				withErrorGetDatabaseFunc(),
 			}
-			c := NewCmdBuilder(tc, profile, database, "root", opts...)
+			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 
 			cmd, err := c.GetConnectCommand(context.Background())
@@ -1087,5 +1093,30 @@ func withDocumentDBDatabase() ConnectCommandFunc {
 			},
 		)
 		return db, trace.Wrap(err)
+	})
+}
+
+func withSpannerDatabase(gcp types.GCPCloudSQL) ConnectCommandFunc {
+	return WithGetDatabaseFunc(func(context.Context, *client.TeleportClient, string) (types.Database, error) {
+		db, err := types.NewDatabaseV3(
+			types.Metadata{
+				Name: "docdb",
+			},
+			types.DatabaseSpecV3{
+				Protocol: types.DatabaseTypeSpanner,
+				URI:      "spanner.googleapis.com:443",
+				GCP:      gcp,
+			},
+		)
+		return db, trace.Wrap(err)
+	})
+}
+
+// withErrorGetDatabaseFunc provides a non-nil function that returns error when
+// retrieving the database. This can be used in tests that don't retrieve
+// databases.
+func withErrorGetDatabaseFunc() ConnectCommandFunc {
+	return WithGetDatabaseFunc(func(ctx context.Context, tc *client.TeleportClient, s string) (types.Database, error) {
+		return nil, trace.NotImplemented("unexpected call to getDatabase function")
 	})
 }

--- a/lib/client/db/dbcmd/exec_test.go
+++ b/lib/client/db/dbcmd/exec_test.go
@@ -58,11 +58,12 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 	}
 
 	tests := []struct {
-		name     string
-		opts     []ConnectCommandFunc
-		protocol string
-		cmd      []string
-		wantErr  bool
+		name            string
+		opts            []ConnectCommandFunc
+		protocol        string
+		cmd             []string
+		wantErr         bool
+		getDatabaseFunc GetDatabaseFunc
 	}{
 		{
 			name:     "not authenticated tunnel",
@@ -103,10 +104,14 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(fakeExec),
-				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			getDatabaseFunc := tt.getDatabaseFunc
+			if getDatabaseFunc == nil {
+				getDatabaseFunc = getDatabaseFuncWithError
+			}
+
+			c, err := NewCmdBuilder(tc, profile, database, "root", getDatabaseFunc, opts...)
 			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetExecCommand(context.Background(), "select 1")

--- a/lib/client/db/dbcmd/exec_test.go
+++ b/lib/client/db/dbcmd/exec_test.go
@@ -103,9 +103,11 @@ func TestCLICommandBuilderGetExecCommand(t *testing.T) {
 			opts := append([]ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithExecer(fakeExec),
+				withErrorGetDatabaseFunc(),
 			}, tt.opts...)
 
-			c := NewCmdBuilder(tc, profile, database, "root", opts...)
+			c, err := NewCmdBuilder(tc, profile, database, "root", opts...)
+			require.NoError(t, err)
 			c.uid = utils.NewFakeUID()
 			got, err := c.GetExecCommand(context.Background(), "select 1")
 			if tt.wantErr {

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -180,7 +180,7 @@ type GetDatabaseServersResponse struct {
 
 // NewDBCLICmdBuilder creates a dbcmd.CLICommandBuilder with provided cluster,
 // db route, and options.
-func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
+func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, getDatabaseFunc dbcmd.GetDatabaseFunc, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
 	return dbcmd.NewCmdBuilder(
 		cluster.clusterClient,
 		&cluster.status,
@@ -192,6 +192,7 @@ func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, optio
 		// generating correct CA paths. We use dbcmd.WithNoTLS here which means that the CA paths aren't
 		// included in the returned CLI command.
 		cluster.Name,
+		getDatabaseFunc,
 		options...,
 	)
 }

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -180,7 +180,7 @@ type GetDatabaseServersResponse struct {
 
 // NewDBCLICmdBuilder creates a dbcmd.CLICommandBuilder with provided cluster,
 // db route, and options.
-func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) *dbcmd.CLICommandBuilder {
+func NewDBCLICmdBuilder(cluster *Cluster, routeToDb tlsca.RouteToDatabase, options ...dbcmd.ConnectCommandFunc) (*dbcmd.CLICommandBuilder, error) {
 	return dbcmd.NewCmdBuilder(
 		cluster.clusterClient,
 		&cluster.status,

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -91,12 +91,20 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 
 	previewOpts := append(opts, dbcmd.WithPrintFormat())
 
-	execCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...).GetConnectCommand(ctx)
+	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...)
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+	execCmd, err := execCmdBuilder.GetConnectCommand(ctx)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}
 
-	previewCmd, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...).GetConnectCommand(ctx)
+	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...)
+	if err != nil {
+		return Cmds{}, trace.Wrap(err)
+	}
+	previewCmd, err := previewCmdBuilder.GetConnectCommand(ctx)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}

--- a/lib/teleterm/cmd/db.go
+++ b/lib/teleterm/cmd/db.go
@@ -65,6 +65,13 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 	var getDatabaseError error
 	var database types.Database
 
+	getDatabaseFunc := func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
+		getDatabaseOnce.Do(func() {
+			database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())
+		})
+		return database, trace.Wrap(getDatabaseError)
+	}
+
 	opts := []dbcmd.ConnectCommandFunc{
 		dbcmd.WithLogger(gateway.Log()),
 		dbcmd.WithLocalProxy(gateway.LocalAddress(), gateway.LocalPortInt(), ""),
@@ -72,12 +79,6 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		dbcmd.WithTolerateMissingCLIClient(),
 		dbcmd.WithExecer(execer),
 		dbcmd.WithOracleOpts(true /* can use TCP */, true /* has TCP servers */),
-		dbcmd.WithGetDatabaseFunc(func(ctx context.Context, _ *client.TeleportClient, _ string) (types.Database, error) {
-			getDatabaseOnce.Do(func() {
-				database, getDatabaseError = cluster.GetDatabase(ctx, authClient, gateway.TargetURI())
-			})
-			return database, trace.Wrap(getDatabaseError)
-		}),
 	}
 
 	switch gateway.Protocol() {
@@ -91,7 +92,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 
 	previewOpts := append(opts, dbcmd.WithPrintFormat())
 
-	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, opts...)
+	execCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, getDatabaseFunc, opts...)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}
@@ -100,7 +101,7 @@ func newDBCLICommandWithExecer(ctx context.Context, cluster *clusters.Cluster, g
 		return Cmds{}, trace.Wrap(err)
 	}
 
-	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, previewOpts...)
+	previewCmdBuilder, err := clusters.NewDBCLICmdBuilder(cluster, routeToDb, getDatabaseFunc, previewOpts...)
 	if err != nil {
 		return Cmds{}, trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -537,11 +537,15 @@ func onDatabaseConfig(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case dbFormatCommand:
-		cmd, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
 			dbcmd.WithPrintFormat(),
 			dbcmd.WithLogger(logger),
 			dbcmd.WithGetDatabaseFunc(getDatabase),
-		).GetConnectCommand(cf.Context)
+		)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		cmd, err := cb.GetConnectCommand(cf.Context)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -608,7 +612,10 @@ func maybeStartLocalProxy(ctx context.Context, cf *CLIConf,
 	requires *dbLocalProxyRequirement,
 ) ([]dbcmd.ConnectCommandFunc, error) {
 	if !requires.localProxy {
-		return nil, nil
+		// Even when local proxy is not required, we need to build the base
+		// options for database command.
+		baseOpts, err := makeDatabaseCommandOptions(ctx, tc, dbInfo)
+		return baseOpts, trace.Wrap(err)
 	}
 	if requires.tunnel {
 		logger.DebugContext(ctx, "Starting local proxy tunnel", "reasons", requires.tunnelReasons)
@@ -788,7 +795,10 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	bb := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 	cmd, err := bb.GetConnectCommand(cf.Context)
 	if err != nil {
 		return trace.Wrap(err)
@@ -804,7 +814,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 	peakStderr := utils.NewCaptureNBytesWriter(dbcmd.PeakStderrSize)
 	cmd.Stderr = io.MultiWriter(os.Stderr, peakStderr)
 
-	err = cmd.Run()
+	err = cf.RunCommand(cmd)
 	if err != nil {
 		return dbcmd.ConvertCommandError(cmd, err, string(peakStderr.Bytes()))
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -537,10 +537,9 @@ func onDatabaseConfig(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case dbFormatCommand:
-		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster,
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, *database, rootCluster, getDatabase,
 			dbcmd.WithPrintFormat(),
 			dbcmd.WithLogger(logger),
-			dbcmd.WithGetDatabaseFunc(getDatabase),
 		)
 		if err != nil {
 			return trace.Wrap(err)
@@ -795,7 +794,7 @@ func onDatabaseConnect(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, opts...)
+	bb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootClusterName, dbInfo.getDatabaseForDBCmd, opts...)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/db_exec.go
+++ b/tool/tsh/common/db_exec.go
@@ -516,7 +516,7 @@ func (m *databaseExecCommandMaker) makeCommand(ctx context.Context, dbInfo *data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...)
+	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, dbInfo.getDatabaseForDBCmd, opts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/db_exec.go
+++ b/tool/tsh/common/db_exec.go
@@ -516,8 +516,11 @@ func (m *databaseExecCommandMaker) makeCommand(ctx context.Context, dbInfo *data
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...).
-		GetExecCommand(ctx, command)
+	cb, err := dbcmd.NewCmdBuilder(m.tc, m.profile, dbInfo.RouteToDatabase, m.rootCluster, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cb.GetExecCommand(ctx, command)
 }
 
 // ensureEachDatabase ensures one to one mapping between the provided database

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -2274,8 +2275,8 @@ func TestMongoDBSeparatePortCommandError(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		require.NoError(t, process.Close())
-		require.NoError(t, process.Wait())
+		assert.NoError(t, process.Close())
+		assert.NoError(t, process.Wait())
 	})
 
 	tshHome, _ := mustLogin(t, process, alice, connector.GetName())

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -24,8 +24,10 @@ import (
 	"encoding/pem"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -53,6 +55,7 @@ import (
 	dbcommon "github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 func registerFakeEnterpriseDBEngines(t *testing.T) {
@@ -2234,4 +2237,68 @@ func TestDatabaseInfo(t *testing.T) {
 			require.Equal(t, tt.routeOut, dbInfo.RouteToDatabase)
 		})
 	}
+}
+
+// TestMongoDBSeparatePortCommandError given a MongoDB database with cluster
+// using separate port mode ensures `tsh` generates the connect command without
+// errors.
+//
+// See https://github.com/gravitational/teleport/issues/47895
+func TestMongoDBSeparatePortCommandError(t *testing.T) {
+	t.Parallel()
+
+	connector := mockConnector(t)
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetDatabaseUsers([]string{"admin"})
+	alice.SetDatabaseNames([]string{"default"})
+	alice.SetRoles([]string{"access"})
+
+	process, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithClusterName("root"),
+		testserver.WithBootstrap(connector, alice),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			mongoPublicAddr := localListenerAddr()
+			cfg.Proxy.MongoAddr = utils.NetAddr{AddrNetwork: "tcp", Addr: mongoPublicAddr}
+			cfg.Proxy.MongoPublicAddrs = []utils.NetAddr{{AddrNetwork: "tcp", Addr: mongoPublicAddr}}
+			cfg.Databases.Enabled = true
+			cfg.Databases.Databases = []servicecfg.Database{
+				{
+					Name:     "mongo",
+					Protocol: defaults.ProtocolMongoDB,
+					URI:      "external-mongo:27017",
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, process.Close())
+		require.NoError(t, process.Wait())
+	})
+
+	tshHome, _ := mustLogin(t, process, alice, connector.GetName())
+
+	// cmdExecuted tracks that the MongoDB command was executed.
+	var cmdExecuted atomic.Bool
+
+	// noopCmdRunner is a command runner that does nothing. For this test, we
+	// only need to ensure the command is generated without actually validating
+	// it. This task should be handled in the dbcmd package.
+	noopCmdRunner := func(_ *exec.Cmd) error {
+		cmdExecuted.Store(true)
+		return nil
+	}
+
+	err = Run(context.Background(), []string{
+		"db",
+		"connect",
+		"mongo",
+		"--insecure",
+		"--db-name=test",
+		"--db-user=alice",
+	}, setHomePath(tshHome), setCmdRunner(noopCmdRunner))
+	require.NoError(t, err)
+	require.True(t, cmdExecuted.Load(), "expected the MongoDB command to have executed")
 }

--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -240,7 +240,7 @@ func onProxyCommandDB(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 
-		cb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootCluster, opts...)
+		cb, err := dbcmd.NewCmdBuilder(tc, profile, dbInfo.RouteToDatabase, rootCluster, dbInfo.getDatabaseForDBCmd, opts...)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -316,7 +316,6 @@ func makeDatabaseCommandOptions(ctx context.Context, tc *libclient.TeleportClien
 	var err error
 	opts := append([]dbcmd.ConnectCommandFunc{
 		dbcmd.WithLogger(logger),
-		dbcmd.WithGetDatabaseFunc(dbInfo.getDatabaseForDBCmd),
 	}, extraOpts...)
 
 	if opts, err = maybeAddDBUserPassword(ctx, tc, dbInfo, opts); err != nil {


### PR DESCRIPTION
Backport #61754 to branch/v18

changelog: Fix `tsh db connect` failing to connect to databases using separate ports configuration (non-TLS routing mode).
