### PR TITLE
Add tooltip to Connect tray icon

### DIFF
--- a/web/packages/teleterm/src/tray.ts
+++ b/web/packages/teleterm/src/tray.ts
@@ -48,6 +48,7 @@ export function setTray(
     { label: 'Quit', role: 'quit' },
   ]);
   tray.setContextMenu(contextMenu);
+  tray.setToolTip('Teleport Connect');
 }
 
 function getIcon(runtimeSettings: RuntimeSettings): string | NativeImage {

--- a/web/packages/teleterm/src/tray.ts
+++ b/web/packages/teleterm/src/tray.ts
@@ -41,7 +41,7 @@ export function setTray(
 
   const contextMenu = Menu.buildFromTemplate([
     {
-      label: 'Open Teleport Connect',
+      label: `Open ${app.name}`,
       click: () => window.show(),
     },
     { type: 'separator' },

--- a/web/packages/teleterm/src/tray.ts
+++ b/web/packages/teleterm/src/tray.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Menu, nativeImage, NativeImage, Tray } from 'electron';
+import { app, Menu, nativeImage, NativeImage, Tray } from 'electron';
 
 import { getAssetPath } from 'teleterm/mainProcess/runtimeSettings';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
@@ -48,7 +48,7 @@ export function setTray(
     { label: 'Quit', role: 'quit' },
   ]);
   tray.setContextMenu(contextMenu);
-  tray.setToolTip('Teleport Connect');
+  tray.setToolTip(app.name);
 }
 
 function getIcon(runtimeSettings: RuntimeSettings): string | NativeImage {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/61765

macOS:
<img width="164" height="69" alt="image" src="https://github.com/user-attachments/assets/b6f46585-2b4b-468f-b7cd-d01bd63a6c3e" />

Windows:
<img width="164" height="123" alt="image" src="https://github.com/user-attachments/assets/0fb23363-18e3-436f-98d0-8b9a413234dd" />

The tooltip doesn't show up on Linux.