### PR TITLE
Add `relayAddr` value to the `teleport-kube-agent` chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -41,6 +41,21 @@ Here are a few examples:
 | Teleport Cloud cluster        | `example.teleport.sh:443`           |
 | `teleport-cluster` Helm chart | `teleport.example.com:443`          |
 
+## `relayAddr`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`relayAddr` defines the optional address of the Teleport Relay
+Service tunnel endpoint that this agent should use.
+
+If set, the agent will open reverse tunnels to the specified Relay in addition
+to the tunnels to the control plane, for the protocols supported by the Relay.
+
+relayAddr is available starting from Teleport v18.5.0, taking effect for the
+Kubernetes service.
+
 ## `enterprise`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/.lint/all-v6.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/all-v6.yaml
@@ -1,5 +1,6 @@
 authToken: auth-token
 proxyAddr: proxy.example.com:3080
+relayAddr: relay.example.com:3024
 roles: kube,app,db,jamf
 kubeClusterName: test-kube-cluster-name
 labels:

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -15,6 +15,9 @@ teleport:
   {{- else }}
   auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]
   {{- end }}
+  {{- with .Values.relayAddr }}
+  relay_server: {{ . | quote }}
+  {{- end }}
   {{- if .Values.caPin }}
   ca_pin: {{- toYaml .Values.caPin | nindent 4 }}
   {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -268,6 +268,7 @@ matches snapshot for all-v6.yaml:
             output: stderr
             severity: INFO
           proxy_server: proxy.example.com:3080
+          relay_server: relay.example.com:3024
         version: v3
     kind: ConfigMap
     metadata:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -3,6 +3,7 @@
     "type": "object",
     "required": [
         "proxyAddr",
+        "relayAddr",
         "roles",
         "joinParams",
         "kubeClusterName",
@@ -47,6 +48,11 @@
         },
         "proxyAddr": {
             "$id": "#/properties/proxyAddr",
+            "type": "string",
+            "default": ""
+        },
+        "relayAddr": {
+            "$id": "#/properties/relayAddr",
             "type": "string",
             "default": ""
         },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -32,6 +32,16 @@ roles: "kube"
 # | `teleport-cluster` Helm chart | `teleport.example.com:443`          |
 proxyAddr: ""
 
+# relayAddr(string) -- defines the optional address of the Teleport Relay
+# Service tunnel endpoint that this agent should use.
+#
+# If set, the agent will open reverse tunnels to the specified Relay in addition
+# to the tunnels to the control plane, for the protocols supported by the Relay.
+#
+# relayAddr is available starting from Teleport v18.5.0, taking effect for the
+# Kubernetes service.
+relayAddr: ""
+
 # enterprise(bool) -- controls if the `teleport-kube-agent` chart should deploy
 # the OSS version or the enterprise version of the container image.
 # This must be set to `true` when connecting to Teleport Cloud or self-hosted
@@ -903,7 +913,7 @@ adminClusterRoleBinding:
 # You can override this to use your own Teleport image rather than a
 # Teleport-published image.
 #
-# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater"> 
+# <Admonition type="warning" title="Interaction with Teleport Kube Agent Updater">
 # When using the Teleport Kube Agent Updater, you must ensure the
 # image is available before the updater version target gets updated and
 # Kubernetes tries to pull the image.


### PR DESCRIPTION
This PR adds the ability to specify the `relay_server` in the agent's config file through a new `relayAddr` value (matching `proxyAddr` in nomenclature). The docs assume the feature to be available starting from 18.5.0.