### PR TITLE
[config] expose auth reconnect retry parameters in configuration

### DIFF
--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -116,12 +116,13 @@ teleport:
     connection_limits:
         max_connections: 1000
 
-    # Backoff configuration for instances when reconnecting to Auth before jitter is applied.
-    # These settings can be tweaked to control how aggresively the instance will retry to connect.
-    # reconnect_backoff:
-    #     max_period: "90s"
-    #     min_period: "9s"  # When unset max_period / 10
-    #     step: "18s"       # When unset max_period / 5
+    # Auth Service connection configuration.
+    # These settings can be tweaked to control how aggresively the instance will retry to connect. In addition
+    # each instance will apply jitter.
+    # auth_connection_config:
+    #     upper_limit_between_retries: "90s"  # Cannot be lower than 10s
+    #     initial_connection_delay: "9s"      # When unset upper_limit_between_retries / 10
+    #     backoff_step_duration: "18s"        # When unset upper_limit_between_retries / 5
 
     # Logging configuration. Possible output values to disk via
     # '/var/lib/teleport/teleport.log',

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -117,7 +117,7 @@ teleport:
         max_connections: 1000
 
     # Auth Service connection configuration.
-    # These settings can be tweaked to control how aggresively the instance will retry to connect. In addition
+    # These settings can be tweaked to control how aggresively the Proxy or Agent instances will retry to connect. In addition
     # each instance will apply jitter.
     # auth_connection_config:
     #     upper_limit_between_retries: "90s"  # Cannot be lower than 10s

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -116,6 +116,13 @@ teleport:
     connection_limits:
         max_connections: 1000
 
+    # Backoff configuration for instances when reconnecting to Auth before jitter is applied.
+    # These settings can be tweaked to control how aggresively the instance will retry to connect.
+    # reconnect_backoff:
+    #     max_period: "90s"
+    #     min_period: "9s"  # When unset max_period / 10
+    #     step: "18s"       # When unset max_period / 5
+
     # Logging configuration. Possible output values to disk via
     # '/var/lib/teleport/teleport.log',
     # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -634,7 +634,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
 	tconf.Keygen = testauthority.New()
-	tconf.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(defaults.HighResPollingPeriod)
+	tconf.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(defaults.HighResPollingPeriod)
 	tconf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	tconf.FileDescriptors = append(tconf.FileDescriptors, i.Fds...)
 

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -634,7 +634,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
 	tconf.Keygen = testauthority.New()
-	tconf.MaxRetryPeriod = defaults.HighResPollingPeriod
+	tconf.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(defaults.HighResPollingPeriod)
 	tconf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	tconf.FileDescriptors = append(tconf.FileDescriptors, i.Fds...)
 

--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -212,7 +212,7 @@ func newAuthConfig(t *testing.T, log *slog.Logger, clock clockwork.Clock) *servi
 	config.Proxy.Enabled = false
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(25 * time.Millisecond)
+	config.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 
@@ -255,7 +255,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, log *slog.Logger, cloc
 	config.SetAuthServerAddress(authAddr)
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(25 * time.Millisecond)
+	config.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 

--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -212,7 +212,7 @@ func newAuthConfig(t *testing.T, log *slog.Logger, clock clockwork.Clock) *servi
 	config.Proxy.Enabled = false
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 
@@ -255,7 +255,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, log *slog.Logger, cloc
 	config.SetAuthServerAddress(authAddr)
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5750,7 +5750,7 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *servicecf
 	tconf.PollingPeriod = time.Second
 	tconf.Testing.ClientTimeout = time.Second
 	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
-	tconf.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(time.Second)
+	tconf.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(time.Second)
 	return tconf
 }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5750,7 +5750,7 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *servicecf
 	tconf.PollingPeriod = time.Second
 	tconf.Testing.ClientTimeout = time.Second
 	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
-	tconf.MaxRetryPeriod = time.Second
+	tconf.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(time.Second)
 	return tconf
 }
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -644,11 +644,11 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 	cfg.CachePolicy = *cachePolicy
 
-	reconnectBackoff, err := fc.ReconnectBackoff.Parse()
+	authConnectionConfig, err := fc.AuthConnectionConfig.Parse()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	cfg.ReconnectBackoff = *reconnectBackoff
+	cfg.AuthConnectionConfig = *authConnectionConfig
 
 	cfg.ShutdownDelay = time.Duration(fc.ShutdownDelay)
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -644,6 +644,12 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 	cfg.CachePolicy = *cachePolicy
 
+	reconnectBackoff, err := fc.ReconnectBackoff.Parse()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cfg.ReconnectBackoff = *reconnectBackoff
+
 	cfg.ShutdownDelay = time.Duration(fc.ShutdownDelay)
 
 	// Apply (TLS) cipher suites and (SSH) ciphers, KEX algorithms, and MAC

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -645,9 +645,8 @@ type Global struct {
 	// DiagAddr is the address to expose a diagnostics HTTP endpoint.
 	DiagAddr string `yaml:"diag_addr"`
 
-	// ReconnectBackoff defines the parameters used to control the retry
-	// behavior when attempting to reconnect to auth.
-	ReconnectBackoff ReconnectBackoffConfig `yaml:"reconnect_backoff,omitempty"`
+	// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
+	AuthConnectionConfig AuthConnectionConfig `yaml:"auth_connection_config,omitempty"`
 }
 
 // CachePolicy is used to control  local cache
@@ -683,29 +682,28 @@ func (c *CachePolicy) Parse() (*servicecfg.CachePolicy, error) {
 	return &out, nil
 }
 
-// ReconnectBackoffConfig defines the parameters used to control the retry
-// behavior when attempting to reconnect to auth.
-type ReconnectBackoffConfig struct {
-	// MaxRetryPeriod is the upper limit for how long to wait between retries.
-	MaxRetryPeriod time.Duration `yaml:"max_period,omitempty"`
-	// MinRetryPeriod is the initial delay before the first retry attempt.
+// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
+type AuthConnectionConfig struct {
+	// UpperLimitBetweenRetries is the upper limit for how long to wait between retries.
+	UpperLimitBetweenRetries time.Duration `yaml:"upper_limit_between_retries,omitempty"`
+	// InitialConnectionDelay is the initial delay before the first retry attempt.
 	// The retry logic will apply jitter to this duration.
-	MinRetryPeriod time.Duration `yaml:"min_period,omitempty"`
-	// RetryStep is the amount of time added to the retry delay.
-	RetryStep time.Duration `yaml:"step,omitempty"`
+	InitialConnectionDelay time.Duration `yaml:"initial_connection_delay,omitempty"`
+	// BackoffStepDuration is the amount of time added to the retry delay.
+	BackoffStepDuration time.Duration `yaml:"backoff_step_duration,omitempty"`
 }
 
-// Parse parses reconnect configuration from Teleport config
-func (c *ReconnectBackoffConfig) Parse() (*servicecfg.ReconnectBackoffConfig, error) {
-	out := servicecfg.ReconnectBackoffConfig{
-		MaxRetryPeriod: c.MaxRetryPeriod,
-		MinRetryPeriod: c.MinRetryPeriod,
-		RetryStep:      c.RetryStep,
+// Parse parses [servicecfg.AuthConnectionConfig] from Teleport config
+func (c *AuthConnectionConfig) Parse() (*servicecfg.AuthConnectionConfig, error) {
+	out := &servicecfg.AuthConnectionConfig{
+		UpperLimitBetweenRetries: c.UpperLimitBetweenRetries,
+		InitialConnectionDelay:   c.InitialConnectionDelay,
+		BackoffStepDuration:      c.BackoffStepDuration,
 	}
 	if err := out.CheckAndSetDefaults(); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "failed to parse auth_connection_config")
 	}
-	return &out, nil
+	return out, nil
 }
 
 // Service is a common configuration of a teleport service

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1264,8 +1264,8 @@ func TestBackoffConfig(t *testing.T) {
 			mutate: func(cfg cfgMap) {},
 			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
 				UpperLimitBetweenRetries: 90 * time.Second,
-				BackoffStepDuration:      9 * time.Second,
-				InitialConnectionDelay:   18 * time.Second,
+				InitialConnectionDelay:   9 * time.Second,
+				BackoffStepDuration:      18 * time.Second,
 			},
 			errorFn: require.NoError,
 		},
@@ -1280,8 +1280,8 @@ func TestBackoffConfig(t *testing.T) {
 			},
 			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
 				UpperLimitBetweenRetries: 90 * time.Second,
-				BackoffStepDuration:      9 * time.Second,
-				InitialConnectionDelay:   18 * time.Second,
+				InitialConnectionDelay:   9 * time.Second,
+				BackoffStepDuration:      18 * time.Second,
 			},
 			errorFn: require.NoError,
 		},
@@ -1294,8 +1294,8 @@ func TestBackoffConfig(t *testing.T) {
 			},
 			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
 				UpperLimitBetweenRetries: 3 * time.Minute,
-				BackoffStepDuration:      18 * time.Second,
-				InitialConnectionDelay:   36 * time.Second,
+				InitialConnectionDelay:   18 * time.Second,
+				BackoffStepDuration:      36 * time.Second,
 			},
 			errorFn: require.NoError,
 		},

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -74,9 +74,9 @@ const updateClientsJoinWarning = "This agent joined the cluster during the updat
 // service until succeeds or process gets shut down
 func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*Connector, error) {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:  retryutils.HalfJitter(process.Config.ReconnectBackoff.MinRetryPeriod),
-		Step:   process.Config.ReconnectBackoff.RetryStep,
-		Max:    process.Config.ReconnectBackoff.MaxRetryPeriod,
+		First:  retryutils.HalfJitter(process.Config.AuthConnectionConfig.InitialConnectionDelay),
+		Step:   process.Config.AuthConnectionConfig.BackoffStepDuration,
+		Max:    process.Config.AuthConnectionConfig.UpperLimitBetweenRetries,
 		Clock:  process.Clock,
 		Jitter: retryutils.HalfJitter,
 	})

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -74,9 +74,9 @@ const updateClientsJoinWarning = "This agent joined the cluster during the updat
 // service until succeeds or process gets shut down
 func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*Connector, error) {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:  retryutils.HalfJitter(process.Config.MaxRetryPeriod / 10),
-		Step:   process.Config.MaxRetryPeriod / 5,
-		Max:    process.Config.MaxRetryPeriod,
+		First:  retryutils.HalfJitter(process.Config.ReconnectBackoff.MinRetryPeriod),
+		Step:   process.Config.ReconnectBackoff.RetryStep,
+		Max:    process.Config.ReconnectBackoff.MaxRetryPeriod,
 		Clock:  process.Clock,
 		Jitter: retryutils.HalfJitter,
 	})

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -945,7 +945,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
-	cfg.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(5 * time.Millisecond)
+	cfg.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(5 * time.Millisecond)
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Testing.ConnectFailureC = make(chan time.Duration, 5)
 	cfg.Testing.ClientTimeout = time.Millisecond
@@ -966,7 +966,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	}()
 
 	timeout := time.After(10 * time.Second)
-	step := cfg.ReconnectBackoff.RetryStep
+	step := cfg.AuthConnectionConfig.BackoffStepDuration
 	for i := range 5 {
 		// wait for connection to fail
 		select {
@@ -2313,7 +2313,7 @@ func TestInstanceCertReissue(t *testing.T) {
 	agentCfg.WindowsDesktop.Enabled = true
 	agentCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	agentCfg.Logger = logtest.NewLogger()
-	agentCfg.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(time.Second)
+	agentCfg.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(time.Second)
 	agentCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 
 	agentProc, err := NewTeleport(agentCfg)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -955,15 +955,13 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		// This test must use RoleInstance because all other roles wait for the
 		// Instance connector without a timeout.
 		c, err := process.reconnectToAuthService(types.RoleInstance)
 		require.Equal(t, ErrTeleportExited, err)
 		require.Nil(t, c)
-	}()
+	})
 
 	timeout := time.After(10 * time.Second)
 	step := cfg.AuthConnectionConfig.BackoffStepDuration

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -945,7 +945,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
-	cfg.MaxRetryPeriod = 5 * time.Millisecond
+	cfg.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(5 * time.Millisecond)
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Testing.ConnectFailureC = make(chan time.Duration, 5)
 	cfg.Testing.ClientTimeout = time.Millisecond
@@ -966,7 +966,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	}()
 
 	timeout := time.After(10 * time.Second)
-	step := cfg.MaxRetryPeriod / 5.0
+	step := cfg.ReconnectBackoff.RetryStep
 	for i := range 5 {
 		// wait for connection to fail
 		select {
@@ -2313,7 +2313,7 @@ func TestInstanceCertReissue(t *testing.T) {
 	agentCfg.WindowsDesktop.Enabled = true
 	agentCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	agentCfg.Logger = logtest.NewLogger()
-	agentCfg.MaxRetryPeriod = time.Second
+	agentCfg.ReconnectBackoff = *servicecfg.DefaultRatioReconnectBackoffConfig(time.Second)
 	agentCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 
 	agentProc, err := NewTeleport(agentCfg)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -369,7 +369,7 @@ func (c *AuthConnectionConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.InitialConnectionDelay < 1 {
-		c.InitialConnectionDelay = c.UpperLimitBetweenRetries / 5
+		c.InitialConnectionDelay = c.UpperLimitBetweenRetries / 10
 	} else if c.InitialConnectionDelay > c.UpperLimitBetweenRetries {
 		return trace.BadParameter(
 			"initial_connection_delay (%s) cannot be larger than upper_limit_between_retries (%s)",
@@ -379,7 +379,7 @@ func (c *AuthConnectionConfig) CheckAndSetDefaults() error {
 	}
 
 	if c.BackoffStepDuration < 1 {
-		c.BackoffStepDuration = c.UpperLimitBetweenRetries / 10
+		c.BackoffStepDuration = c.UpperLimitBetweenRetries / 5
 	} else if c.BackoffStepDuration > c.UpperLimitBetweenRetries {
 		return trace.BadParameter(
 			"backoff_step_duration (%s) cannot be larger than upper_limit_between_retries (%s)",
@@ -395,8 +395,8 @@ func (c *AuthConnectionConfig) CheckAndSetDefaults() error {
 func DefaultRatioAuthConnectionConfig(UpperLimitBetweenRetries time.Duration) *AuthConnectionConfig {
 	return &AuthConnectionConfig{
 		UpperLimitBetweenRetries: UpperLimitBetweenRetries,
-		InitialConnectionDelay:   UpperLimitBetweenRetries / 5,
-		BackoffStepDuration:      UpperLimitBetweenRetries / 10,
+		InitialConnectionDelay:   UpperLimitBetweenRetries / 10,
+		BackoffStepDuration:      UpperLimitBetweenRetries / 5,
 	}
 }
 

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -108,9 +108,9 @@ func TestDefaultConfig(t *testing.T) {
 	require.True(t, config.DebugService.Enabled)
 
 	// Reconnect section
-	require.Equal(t, defaults.MaxWatcherBackoff, config.ReconnectBackoff.MaxRetryPeriod)
-	require.Equal(t, 9*time.Second, config.ReconnectBackoff.MinRetryPeriod)
-	require.Equal(t, 18*time.Second, config.ReconnectBackoff.RetryStep)
+	require.Equal(t, defaults.MaxWatcherBackoff, config.AuthConnectionConfig.UpperLimitBetweenRetries)
+	require.Equal(t, 9*time.Second, config.AuthConnectionConfig.BackoffStepDuration)
+	require.Equal(t, 18*time.Second, config.AuthConnectionConfig.InitialConnectionDelay)
 
 }
 

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -109,8 +109,8 @@ func TestDefaultConfig(t *testing.T) {
 
 	// Reconnect section
 	require.Equal(t, defaults.MaxWatcherBackoff, config.AuthConnectionConfig.UpperLimitBetweenRetries)
-	require.Equal(t, 9*time.Second, config.AuthConnectionConfig.BackoffStepDuration)
-	require.Equal(t, 18*time.Second, config.AuthConnectionConfig.InitialConnectionDelay)
+	require.Equal(t, 18*time.Second, config.AuthConnectionConfig.BackoffStepDuration)
+	require.Equal(t, 9*time.Second, config.AuthConnectionConfig.InitialConnectionDelay)
 
 }
 

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -105,6 +106,12 @@ func TestDefaultConfig(t *testing.T) {
 
 	// Debug should always be enabled by default.
 	require.True(t, config.DebugService.Enabled)
+
+	// Reconnect section
+	require.Equal(t, defaults.MaxWatcherBackoff, config.ReconnectBackoff.MaxRetryPeriod)
+	require.Equal(t, 9*time.Second, config.ReconnectBackoff.MinRetryPeriod)
+	require.Equal(t, 18*time.Second, config.ReconnectBackoff.RetryStep)
+
 }
 
 // TestCheckApp validates application configuration.


### PR DESCRIPTION
The new YAML config is as follows:
```
teleport:
    auth_connection_config:
        upper_limit_between_retries: "90s"  # Cannot be lower than 10s
        initial_connection_delay: "9s"      # When unset upper_limit_between_retries / 10
        backoff_step_duration: "18s"        # When unset upper_limit_between_retries / 5
```

Note that currently this only exposes the existing linear backoff, but the naming here is generic enough that we could consider other policies if needed.

Closes: #61741 

Changelog: Added a new global configuration section `auth_connection_config` allowing users to configure the backoff behaviour for Proxy and Agent instances connecting to the Auth Service