### PR TITLE
[refactoring] remove cluster name from jwt signer

### DIFF
--- a/integration/appaccess/jwt.go
+++ b/integration/appaccess/jwt.go
@@ -44,14 +44,13 @@ func verifyJWT(t *testing.T, pack *Pack, token, appURI string) {
 
 	// Verify JWT.
 	key, err := jwt.New(&jwt.Config{
-		PublicKey:   publicKey,
-		ClusterName: pack.jwtAppClusterName,
+		PublicKey: publicKey,
 	})
 	require.NoError(t, err)
-	claims, err := key.Verify(jwt.VerifyParams{
-		Username: pack.username,
-		RawToken: token,
-		URI:      appURI,
+	claims, err := key.Verify(token, jwt.VerifyParams{
+		Issuer:   pack.jwtAppClusterName,
+		Subject:  pack.username,
+		Audience: []string{appURI},
 	})
 	require.NoError(t, err)
 	require.Equal(t, pack.username, claims.Username)

--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -370,7 +370,10 @@ func (a *Server) GenerateSnowflakeJWT(ctx context.Context, req *proto.SnowflakeJ
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	privateKey, err := services.GetJWTSigner(signer, ca.GetClusterName(), a.clock)
+	privateKey, err := jwt.New(&jwt.Config{
+		Clock:      a.clock,
+		PrivateKey: signer,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/integration/integrationv1/awsoidc_test.go
+++ b/lib/auth/integration/integrationv1/awsoidc_test.go
@@ -118,9 +118,8 @@ func TestGenerateAWSOIDCToken(t *testing.T) {
 
 	// Validate JWT against public key
 	key, err := jwt.New(&jwt.Config{
-		ClusterName: clusterName,
-		Clock:       resourceSvc.clock,
-		PublicKey:   publicKey,
+		Clock:     resourceSvc.clock,
+		PublicKey: publicKey,
 	})
 	require.NoError(t, err)
 

--- a/lib/auth/integration/integrationv1/azureoidc_test.go
+++ b/lib/auth/integration/integrationv1/azureoidc_test.go
@@ -100,9 +100,8 @@ func TestGenerateAzureOIDCToken(t *testing.T) {
 		publicKey, err := keys.ParsePublicKey(jwtPubKey)
 		require.NoError(t, err)
 		key, err := jwt.New(&jwt.Config{
-			ClusterName: clusterName,
-			Clock:       resourceSvc.clock,
-			PublicKey:   publicKey,
+			Clock:     resourceSvc.clock,
+			PublicKey: publicKey,
 		})
 		require.NoError(t, err)
 

--- a/lib/auth/keystore/gcp_kms_test.go
+++ b/lib/auth/keystore/gcp_kms_test.go
@@ -599,7 +599,9 @@ func TestGCPKMSKeystore(t *testing.T) {
 				jwtSigner, err := manager.GetJWTSigner(clientContext, ca)
 				require.NoError(t, err, "unexpected error getting JWT signer")
 
-				servicesJWTSigner, err := services.GetJWTSigner(jwtSigner, "test-cluster", nil)
+				servicesJWTSigner, err := jwt.New(&jwt.Config{
+					PrivateKey: jwtSigner,
+				})
 				require.NoError(t, err, "unexpected error from services.GetJWTSigner")
 
 				if tc.doDeleteKey {
@@ -608,9 +610,10 @@ func TestGCPKMSKeystore(t *testing.T) {
 				}
 
 				_, err = servicesJWTSigner.Sign(jwt.SignParams{
+					Issuer:   "test-cluster",
 					Username: "root",
 					Roles:    []string{"access"},
-					URI:      "example.com",
+					Audience: "example.com",
 					Expires:  time.Now().Add(time.Hour),
 				})
 				if tc.expectSignError {

--- a/lib/auth/machineid/machineidv1/workload_identity_service.go
+++ b/lib/auth/machineid/machineidv1/workload_identity_service.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
@@ -509,9 +508,10 @@ func (wis *WorkloadIdentityService) SignJWTSVIDs(
 	if err != nil {
 		return nil, trace.Wrap(err, "getting JWT signer")
 	}
-	jwtKey, err := services.GetJWTSigner(
-		jwtSigner, clusterName.GetClusterName(), wis.clock,
-	)
+	jwtKey, err := jwt.New(&jwt.Config{
+		Clock:      wis.clock,
+		PrivateKey: jwtSigner,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err, "getting JWT key")
 	}

--- a/lib/auth/machineid/workloadidentityv1/issuer_service.go
+++ b/lib/auth/machineid/workloadidentityv1/issuer_service.go
@@ -748,9 +748,10 @@ func (s *IssuanceService) getJWTIssuerKey(
 		return nil, "", trace.Wrap(err, "getting JWT signer")
 	}
 
-	jwtKey, err := services.GetJWTSigner(
-		jwtSigner, s.clusterName, s.clock,
-	)
+	jwtKey, err := jwt.New(&jwt.Config{
+		Clock:      s.clock,
+		PrivateKey: jwtSigner,
+	})
 	if err != nil {
 		return nil, "", trace.Wrap(err, "creating JWT signer")
 	}

--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -711,15 +711,19 @@ func (a *Server) generateAppToken(ctx context.Context, username string, roles []
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
-	privateKey, err := services.GetJWTSigner(signer, ca.GetClusterName(), a.clock)
+	privateKey, err := jwt.New(&jwt.Config{
+		Clock:      a.clock,
+		PrivateKey: signer,
+	})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 	token, err := privateKey.Sign(jwt.SignParams{
+		Issuer:   ca.GetClusterName(),
 		Username: username,
 		Roles:    roles,
 		Traits:   filteredTraits,
-		URI:      uri,
+		Audience: uri,
 		Expires:  expires,
 	})
 	if err != nil {

--- a/lib/integrations/awsoidc/token_generator.go
+++ b/lib/integrations/awsoidc/token_generator.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 )
 
@@ -150,7 +149,10 @@ func GenerateAWSOIDCToken(ctx context.Context, cacheClt Cache, keyStoreManager K
 		return "", trace.Wrap(err)
 	}
 
-	privateKey, err := services.GetJWTSigner(signer, ca.GetClusterName(), req.Clock)
+	privateKey, err := jwt.New(&jwt.Config{
+		Clock:      req.Clock,
+		PrivateKey: signer,
+	})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/integrations/azureoidc/token_generator.go
+++ b/lib/integrations/azureoidc/token_generator.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils/oidc"
 )
 
@@ -80,7 +79,10 @@ func GenerateEntraOIDCToken(ctx context.Context, cache Cache, manager KeyStoreMa
 		return "", trace.Wrap(err)
 	}
 
-	privateKey, err := services.GetJWTSigner(signer, ca.GetClusterName(), clock)
+	privateKey, err := jwt.New(&jwt.Config{
+		Clock:      clock,
+		PrivateKey: signer,
+	})
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -55,9 +55,6 @@ type Config struct {
 
 	// PrivateKey is used to sign and verify tokens.
 	PrivateKey crypto.Signer
-
-	// ClusterName is the name of the cluster that will be signing the JWT tokens.
-	ClusterName string
 }
 
 // CheckAndSetDefaults validates the values of a *Config.
@@ -71,9 +68,6 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.PrivateKey == nil && c.PublicKey == nil {
 		return trace.BadParameter("public or private key is required")
-	}
-	if c.ClusterName == "" {
-		return trace.BadParameter("cluster name is required")
 	}
 
 	return nil
@@ -109,9 +103,6 @@ type SignParams struct {
 	// Expiry is time to live for the token.
 	Expires time.Time
 
-	// URI is the URI of the recipient application.
-	URI string
-
 	// Audience is the Audience for the Token.
 	Audience string
 
@@ -130,7 +121,10 @@ func (p *SignParams) Check() error {
 	if p.Expires.IsZero() {
 		return trace.BadParameter("expires missing")
 	}
-	if p.URI == "" {
+	if p.Issuer == "" {
+		return trace.BadParameter("issuer missing")
+	}
+	if p.Audience == "" {
 		return trace.BadParameter("uri missing")
 	}
 
@@ -221,8 +215,8 @@ func (k *Key) Sign(p SignParams) (string, error) {
 	claims := Claims{
 		Claims: jwt.Claims{
 			Subject:   p.Username,
-			Issuer:    k.config.ClusterName,
-			Audience:  jwt.Audience{p.URI},
+			Issuer:    p.Issuer,
+			Audience:  jwt.Audience{p.Audience},
 			NotBefore: jwt.NewNumericDate(k.config.Clock.Now().Add(-10 * time.Second)),
 			IssuedAt:  jwt.NewNumericDate(k.config.Clock.Now()),
 			Expiry:    jwt.NewNumericDate(p.Expires),
@@ -452,7 +446,7 @@ type PROXYSignParams struct {
 
 const expirationPROXY = time.Second * 60
 
-// SignPROXYJwt will create short lived signed JWT that is used in signed PROXY header
+// SignPROXYJWT will create short-lived signed JWT that is used in signed PROXY header
 func (k *Key) SignPROXYJWT(p PROXYSignParams) (string, error) {
 	claims := Claims{
 		Claims: jwt.Claims{
@@ -469,34 +463,7 @@ func (k *Key) SignPROXYJWT(p PROXYSignParams) (string, error) {
 }
 
 // VerifyParams are the parameters needed to pass the token and data needed to verify.
-type VerifyParams struct {
-	// Username is the Teleport identity.
-	Username string
-
-	// RawToken is the JWT token.
-	RawToken string
-
-	// URI is the URI of the recipient application.
-	URI string
-
-	// Audience is the Audience for the token
-	Audience string
-}
-
-// Check verifies all the values are valid.
-func (p *VerifyParams) Check() error {
-	if p.Username == "" {
-		return trace.BadParameter("username missing")
-	}
-	if p.RawToken == "" {
-		return trace.BadParameter("raw token missing")
-	}
-	if p.URI == "" {
-		return trace.BadParameter("uri missing")
-	}
-
-	return nil
-}
+type VerifyParams = jwt.Expected
 
 type SnowflakeVerifyParams struct {
 	AccountName string
@@ -563,19 +530,11 @@ func (k *Key) verify(rawToken string, expectedClaims jwt.Expected) (*Claims, err
 }
 
 // Verify will validate the passed in JWT token.
-func (k *Key) Verify(p VerifyParams) (*Claims, error) {
-	if err := p.Check(); err != nil {
-		return nil, trace.Wrap(err)
+func (k *Key) Verify(token string, expected VerifyParams) (*Claims, error) {
+	if expected.Time.IsZero() {
+		expected.Time = k.config.Clock.Now()
 	}
-
-	expectedClaims := jwt.Expected{
-		Issuer:   k.config.ClusterName,
-		Subject:  p.Username,
-		Audience: jwt.Audience{p.URI},
-		Time:     k.config.Clock.Now(),
-	}
-
-	return k.verify(p.RawToken, expectedClaims)
+	return k.verify(token, expected)
 }
 
 // AWSOIDCVerifyParams are the params required to verify an AWS OIDC Token.

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -266,7 +266,6 @@ func TestKey_SignAndVerifyAWSOIDC(t *testing.T) {
 			require.NoError(t, err)
 
 			clock := clockwork.NewFakeClockAt(time.Now())
-			const clusterName = "teleport-test"
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
@@ -382,7 +381,6 @@ func TestKey_SignAndVerifyPluginToken(t *testing.T) {
 			require.NoError(t, err)
 
 			clock := clockwork.NewFakeClockAt(time.Now())
-			const clusterName = "teleport-test"
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -46,18 +46,18 @@ func TestSignAndVerify(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				Clock:       clock,
-				PrivateKey:  privateKey,
-				ClusterName: "example.com",
+				Clock:      clock,
+				PrivateKey: privateKey,
 			})
 			require.NoError(t, err)
 
 			// Sign a token with the new key.
 			token, err := key.Sign(SignParams{
+				Issuer:   "example.com",
 				Username: "foo@example.com",
 				Roles:    []string{"foo", "bar"},
 				Expires:  clock.Now().Add(1 * time.Minute),
-				URI:      "http://127.0.0.1:8080",
+				Audience: "http://127.0.0.1:8080",
 			})
 			require.NoError(t, err)
 
@@ -69,10 +69,10 @@ func TestSignAndVerify(t *testing.T) {
 			require.NotEmpty(t, decodedToken.Headers[0].KeyID)
 
 			// Verify that the token can be validated and values match expected values.
-			claims, err := key.Verify(VerifyParams{
-				Username: "foo@example.com",
-				RawToken: token,
-				URI:      "http://127.0.0.1:8080",
+			claims, err := key.Verify(token, VerifyParams{
+				Issuer:   "example.com",
+				Subject:  "foo@example.com",
+				Audience: []string{"http://127.0.0.1:8080"},
 			})
 			require.NoError(t, err)
 			require.Equal(t, "foo@example.com", claims.Username)
@@ -93,8 +93,7 @@ func TestPublicOnlyVerifyAzure(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				PrivateKey:  privateKey,
-				ClusterName: "example.com",
+				PrivateKey: privateKey,
 			})
 			require.NoError(t, err)
 
@@ -108,8 +107,7 @@ func TestPublicOnlyVerifyAzure(t *testing.T) {
 			// Create a new key that can only verify tokens and make sure the token
 			// values match the expected values.
 			key, err = New(&Config{
-				PublicKey:   publicKey,
-				ClusterName: "example.com",
+				PublicKey: publicKey,
 			})
 			require.NoError(t, err)
 			claims, err := key.VerifyAzureToken(token)
@@ -140,34 +138,33 @@ func TestPublicOnlyVerify(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				PrivateKey:  privateKey,
-				ClusterName: "example.com",
+				PrivateKey: privateKey,
 			})
 			require.NoError(t, err)
 
 			// Sign a token with the new key.
 			token, err := key.Sign(SignParams{
+				Issuer:   "example.com",
 				Username: "foo@example.com",
 				Roles:    []string{"foo", "bar"},
 				Traits: wrappers.Traits{
 					"trait1": []string{"value-1", "value-2"},
 				},
-				Expires: clock.Now().Add(1 * time.Minute),
-				URI:     "http://127.0.0.1:8080",
+				Expires:  clock.Now().Add(1 * time.Minute),
+				Audience: "http://127.0.0.1:8080",
 			})
 			require.NoError(t, err)
 
 			// Create a new key that can only verify tokens and make sure the token
 			// values match the expected values.
 			key, err = New(&Config{
-				PublicKey:   publicKey,
-				ClusterName: "example.com",
+				PublicKey: publicKey,
 			})
 			require.NoError(t, err)
-			claims, err := key.Verify(VerifyParams{
-				Username: "foo@example.com",
-				URI:      "http://127.0.0.1:8080",
-				RawToken: token,
+			claims, err := key.Verify(token, VerifyParams{
+				Issuer:   "example.com",
+				Subject:  "foo@example.com",
+				Audience: []string{"http://127.0.0.1:8080"},
 			})
 			require.NoError(t, err)
 			require.Equal(t, "foo@example.com", claims.Username)
@@ -178,7 +175,7 @@ func TestPublicOnlyVerify(t *testing.T) {
 				Username: "foo@example.com",
 				Roles:    []string{"foo", "bar"},
 				Expires:  clock.Now().Add(1 * time.Minute),
-				URI:      "http://127.0.0.1:8080",
+				Audience: "http://127.0.0.1:8080",
 			})
 			require.Error(t, err)
 		})
@@ -197,9 +194,8 @@ func TestKey_SignAndVerifyPROXY(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				PrivateKey:  privateKey,
-				ClusterName: clusterName,
-				Clock:       clock,
+				PrivateKey: privateKey,
+				Clock:      clock,
 			})
 			require.NoError(t, err)
 			source := "1.2.3.4:555"
@@ -274,9 +270,8 @@ func TestKey_SignAndVerifyAWSOIDC(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				PrivateKey:  privateKey,
-				ClusterName: clusterName,
-				Clock:       clock,
+				PrivateKey: privateKey,
+				Clock:      clock,
 			})
 			require.NoError(t, err)
 
@@ -285,7 +280,6 @@ func TestKey_SignAndVerifyAWSOIDC(t *testing.T) {
 			token, err := key.SignAWSOIDC(SignParams{
 				Username: "user",
 				Issuer:   "https://localhost/",
-				URI:      "https://localhost/",
 				Subject:  "system:proxy",
 				Audience: "discover.teleport",
 				Expires:  clock.Now().Add(expiresIn),
@@ -339,29 +333,29 @@ func TestExpiry(t *testing.T) {
 
 			// Create a new key that can be used to sign and verify tokens.
 			key, err := New(&Config{
-				Clock:       clock,
-				PrivateKey:  privateKey,
-				ClusterName: "example.com",
+				Clock:      clock,
+				PrivateKey: privateKey,
 			})
 			require.NoError(t, err)
 
 			// Sign a token with a 1 minute expiration.
 			token, err := key.Sign(SignParams{
+				Issuer:   "example.com",
 				Username: "foo@example.com",
 				Roles:    []string{"foo", "bar"},
 				Traits: wrappers.Traits{
 					"trait1": []string{"value-1", "value-2"},
 				},
-				Expires: clock.Now().Add(1 * time.Minute),
-				URI:     "http://127.0.0.1:8080",
+				Expires:  clock.Now().Add(1 * time.Minute),
+				Audience: "http://127.0.0.1:8080",
 			})
 			require.NoError(t, err)
 
 			// Verify that the token is still valid.
-			claims, err := key.Verify(VerifyParams{
-				Username: "foo@example.com",
-				URI:      "http://127.0.0.1:8080",
-				RawToken: token,
+			claims, err := key.Verify(token, VerifyParams{
+				Issuer:   "example.com",
+				Subject:  "foo@example.com",
+				Audience: []string{"http://127.0.0.1:8080"},
 			})
 			require.NoError(t, err)
 			require.Equal(t, "foo@example.com", claims.Username)
@@ -370,10 +364,10 @@ func TestExpiry(t *testing.T) {
 
 			// Advance time by two minutes and verify the token is no longer valid.
 			clock.Advance(2 * time.Minute)
-			_, err = key.Verify(VerifyParams{
-				Username: "foo@example.com",
-				URI:      "http://127.0.0.1:8080",
-				RawToken: token,
+			_, err = key.Verify(token, VerifyParams{
+				Issuer:   "example.com",
+				Subject:  "foo@example.com",
+				Audience: []string{"http://127.0.0.1:8080"},
 			})
 			require.Error(t, err)
 		})
@@ -392,9 +386,8 @@ func TestKey_SignAndVerifyPluginToken(t *testing.T) {
 
 			// Create a new key that can sign and verify tokens.
 			key, err := New(&Config{
-				PrivateKey:  privateKey,
-				ClusterName: clusterName,
-				Clock:       clock,
+				PrivateKey: privateKey,
+				Clock:      clock,
 			})
 			require.NoError(t, err)
 

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -928,9 +928,8 @@ func (p *PROXYSigner) SignPROXYHeader(source, destination net.Addr) ([]byte, err
 	}
 
 	jwtKey, err := jwt.New(&jwt.Config{
-		Clock:       p.clock,
-		PrivateKey:  signer,
-		ClusterName: p.clusterName,
+		Clock:      p.clock,
+		PrivateKey: signer,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1300,9 +1300,8 @@ func getTestCertCAsGetterAndSigner(t testing.TB, clusterName string) ([]byte, Ce
 	require.NoError(t, err)
 	clock := clockwork.NewFakeClockAt(time.Now())
 	jwtSigner, err := jwt.New(&jwt.Config{
-		Clock:       clock,
-		ClusterName: clusterName,
-		PrivateKey:  proxyPriv,
+		Clock:      clock,
+		PrivateKey: proxyPriv,
 	})
 	require.NoError(t, err)
 

--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -546,9 +546,8 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 
 	// Check JWT using proxy cert's public key
 	jwtVerifier, err := jwt.New(&jwt.Config{
-		Clock:       clock,
-		PublicKey:   signingCert.PublicKey,
-		ClusterName: localClusterName,
+		Clock:     clock,
+		PublicKey: signingCert.PublicKey,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -28,7 +28,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -217,9 +216,8 @@ func checkJWTKeys(cai types.CertAuthority) error {
 			return trace.Wrap(err)
 		}
 		cfg := &jwt.Config{
-			ClusterName: ca.GetClusterName(),
-			PrivateKey:  privateKey,
-			PublicKey:   publicKey,
+			PrivateKey: privateKey,
+			PublicKey:  publicKey,
 		}
 		if _, err = jwt.New(cfg); err != nil {
 			return trace.Wrap(err)
@@ -258,16 +256,6 @@ func checkSAMLIDPCA(cai types.CertAuthority) error {
 		}
 	}
 	return nil
-}
-
-// GetJWTSigner returns the active JWT key used to sign tokens.
-func GetJWTSigner(signer crypto.Signer, clusterName string, clock clockwork.Clock) (*jwt.Key, error) {
-	key, err := jwt.New(&jwt.Config{
-		Clock:       clock,
-		ClusterName: clusterName,
-		PrivateKey:  signer,
-	})
-	return key, trace.Wrap(err)
 }
 
 // GetTLSCerts returns TLS certificates from CA

--- a/lib/srv/alpnproxy/azure_token_middleware.go
+++ b/lib/srv/alpnproxy/azure_token_middleware.go
@@ -207,9 +207,6 @@ func (m *AzureTokenMiddleware) toJWT(claims jwt.AzureTokenClaims) (string, error
 	key, err := jwt.New(&jwt.Config{
 		Clock:      m.Clock,
 		PrivateKey: privateKey,
-		// TODO(gabrielcorado): use the cluster name. This value must match the
-		// one used by the proxy.
-		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {
 		return "", trace.Wrap(err)

--- a/lib/srv/alpnproxy/azure_token_middleware_test.go
+++ b/lib/srv/alpnproxy/azure_token_middleware_test.go
@@ -221,9 +221,8 @@ func testAzureTokenMiddlewareHandleRequest(t *testing.T, alg cryptosuites.Algori
 
 				fromJWT := func(token string, pk crypto.Signer) (*jwt.AzureTokenClaims, error) {
 					key, err := jwt.New(&jwt.Config{
-						Clock:       m.Clock,
-						PrivateKey:  pk,
-						ClusterName: types.TeleportAzureMSIEndpoint,
+						Clock:      m.Clock,
+						PrivateKey: pk,
 					})
 					require.NoError(t, err)
 					return key.VerifyAzureToken(token)

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -259,9 +258,6 @@ func (s *handler) parseAuthHeader(token string, pubKey crypto.PublicKey) (*jwt.A
 	key, err := jwt.New(&jwt.Config{
 		Clock:     s.Clock,
 		PublicKey: pubKey,
-		// TODO(gabrielcorado): use the cluster name. This value must match the
-		// one used by the local proxy middleware.
-		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/snowflake/test.go
+++ b/lib/srv/db/snowflake/test.go
@@ -203,9 +203,8 @@ func (s *TestServer) verifyJWT(ctx context.Context, accName, loginName, token st
 	}
 
 	key, err := jwt.New(&jwt.Config{
-		Clock:       clock,
-		PublicKey:   cert.PublicKey,
-		ClusterName: clusterName,
+		Clock:     clock,
+		PublicKey: cert.PublicKey,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -289,9 +289,6 @@ func (t *transport) resignAzureJWTCookie(r *http.Request) error {
 	clientJWTKey, err := jwt.New(&jwt.Config{
 		Clock:     t.c.clock,
 		PublicKey: r.TLS.PeerCertificates[0].PublicKey,
-		// TODO(gabrielcorado): use the cluster name. This value must match the
-		// one used by the proxy.
-		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -305,9 +302,6 @@ func (t *transport) resignAzureJWTCookie(r *http.Request) error {
 	wsJWTKey, err := jwt.New(&jwt.Config{
 		Clock:      t.c.clock,
 		PrivateKey: wsPrivateKey,
-		// TODO(gabrielcorado): use the cluster name. This value must match the
-		// one used by the proxy.
-		ClusterName: types.TeleportAzureMSIEndpoint,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -389,9 +389,8 @@ func Test_transport_rewriteRequest(t *testing.T) {
 
 				// Sign a azure JWT for the request using the test case key.
 				jwtKey, err := jwt.New(&jwt.Config{
-					Clock:       tr.c.clock,
-					PrivateKey:  tt.jwtPrivateKey,
-					ClusterName: types.TeleportAzureMSIEndpoint,
+					Clock:      tr.c.clock,
+					PrivateKey: tt.jwtPrivateKey,
 				})
 				require.NoError(t, err)
 
@@ -409,9 +408,8 @@ func Test_transport_rewriteRequest(t *testing.T) {
 				require.NoError(t, err)
 
 				wsJWTKey, err := jwt.New(&jwt.Config{
-					Clock:       tr.c.clock,
-					PrivateKey:  wsPrivateKey,
-					ClusterName: types.TeleportAzureMSIEndpoint,
+					Clock:      tr.c.clock,
+					PrivateKey: wsPrivateKey,
 				})
 				require.NoError(t, err)
 


### PR DESCRIPTION
e counterpart:
- https://github.com/gravitational/teleport.e/pull/7661

Changes:
- remove `jwt.Config.ClusterName` as it is not used by most signers. Instead, it will be specified as `SignParams.Issuer` manually when needed.
- remove `services.GetJWTSigner`
- remove `SignParams.URI` and use `SignParams.Audience` instead
- simplify `jwt.Verify`