### PR TITLE
Do not request resources in teleport-cluster config hooks

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -39,10 +39,6 @@ spec:
       - name: "teleport-config-check"
         image: '{{ if $auth.enterprise }}{{ $auth.enterpriseImage }}{{ else }}{{ $auth.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $auth.imagePullPolicy }}
-{{- if $auth.resources }}
-        resources:
-  {{- toYaml $auth.resources | nindent 10 }}
-{{- end }}
 {{- if or $auth.extraEnv $auth.tls.existingCASecretName }}
         env:
   {{- if (gt (len $auth.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -39,10 +39,6 @@ spec:
       - name: "teleport"
         image: '{{ if $proxy.enterprise }}{{ $proxy.enterpriseImage }}{{ else }}{{ $proxy.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $proxy.imagePullPolicy }}
-{{- if $proxy.resources }}
-        resources:
-  {{- toYaml $proxy.resources | nindent 10 }}
-{{- end }}
 {{- if or $proxy.extraEnv $proxy.tls.existingCASecretName }}
         env:
   {{- if (gt (len $proxy.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -56,40 +56,20 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should set resources on auth predeploy job when set in values
+  - it: should not set resources on auth predeploy job when set in values
     template: auth/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 2
-      - equal:
-          path: spec.template.spec.containers[0].resources.limits.memory
-          value: 4Gi
-      - equal:
-          path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 1
-      - equal:
-          path: spec.template.spec.containers[0].resources.requests.memory
-          value: 2Gi
-  - it: should set resources on proxy predeploy job when set in values
+      - isEmpty:
+          path: spec.template.spec.containers[0].resources
+  - it: should not set resources on proxy predeploy job when set in values
     template: proxy/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
-      - equal:
-          path: spec.template.spec.containers[0].resources.limits.cpu
-          value: 2
-      - equal:
-          path: spec.template.spec.containers[0].resources.limits.memory
-          value: 4Gi
-      - equal:
-          path: spec.template.spec.containers[0].resources.requests.cpu
-          value: 1
-      - equal:
-          path: spec.template.spec.containers[0].resources.requests.memory
-          value: 2Gi
+      - isEmpty:
+          path: spec.template.spec.containers[0].resources
 
   - it: should set imagePullSecrets on proxy predeploy job when set in values
     template: proxy/predeploy_job.yaml


### PR DESCRIPTION
Config check hooks don't run a full Teleport, they are only validate that the config file is valid. Applying resoucre requests is not useful and can block the rollout in smaller clusters.

This is a papercut I faced when doing a large Teleport deployment in resource-constrainted AKS clusters.

Changelog: Prevented stuck `teleport-cluster` Helm chart rollouts in small Kubernetes clusters. Removed resource requests from configuration check hooks.