### PR TITLE
[v18] Bump node-forge from 1.3.1 to 1.3.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,8 +442,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       node-forge:
-        specifier: ^1.3.1
-        version: 1.3.1
+        specifier: ^1.3.2
+        version: 1.3.2
       node-pty:
         specifier: 1.1.0-beta34
         version: 1.1.0-beta34
@@ -5521,8 +5521,8 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-forge@1.3.1:
-    resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
+  node-forge@1.3.2:
+    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
     engines: {node: '>= 6.13.0'}
 
   node-int64@0.4.0:
@@ -13022,7 +13022,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  node-forge@1.3.1: {}
+  node-forge@1.3.2: {}
 
   node-int64@0.4.0: {}
 

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@grpc/grpc-js": "1.13.3",
     "@types/which": "^3.0.4",
-    "node-forge": "^1.3.1",
+    "node-forge": "^1.3.2",
     "node-pty": "1.1.0-beta34",
     "ring-buffer-ts": "^1.2.0",
     "split2": "4.2.0",


### PR DESCRIPTION
Backport #61862.