### PR TITLE
[v18] Support templating labels in tbot's `kubernetes/argo-cd` output

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -102,7 +102,7 @@ For example:
 clusterSelectors:
   - name: my-cluster-1
   - labels:
-    environment: production
+      environment: production
 ```
 
 ### `argocd.secretNamespace`
@@ -131,7 +131,15 @@ names will be prefixed with. Defaults to "teleport.argocd-cluster".
 | `object` | `{}` |
 
 `argocd.secretLabels` provides a set of labels that will be applied
-to cluster secrets.
+to cluster secrets. Label values can be Go template strings with the following
+variables:
+
+  - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+    resource that can be indexed using `\{\{index .Labels "key"\}\}`
+
+If the label value is empty, the label will not be added to the secret.
 
 ### `argocd.secretAnnotations`
 
@@ -181,6 +189,8 @@ in Argo CD. It is a Go template string that supports the following variables:
 
   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+    resource that can be indexed using `\{\{index .Labels "key"\}\}`
 
 By default, the following template will be used: "\{\{.ClusterName\}\}-\{\{.KubeName\}\}".
 

--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -131,8 +131,8 @@ names will be prefixed with. Defaults to "teleport.argocd-cluster".
 | `object` | `{}` |
 
 `argocd.secretLabels` provides a set of labels that will be applied
-to cluster secrets. Label values can be Go template strings with the following
-variables:
+to cluster secrets. Label values can be Go template strings (rendered by tbot,
+not Helm) with the following variables:
 
   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
@@ -185,7 +185,8 @@ is non-empty).
 | `string` | `""` |
 
 `argocd.clusterNameTemplate` determines the format of cluster names
-in Argo CD. It is a Go template string that supports the following variables:
+in Argo CD. It is a Go template string (rendered by tbot, not Helm) that
+supports the following variables:
 
   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -398,6 +398,8 @@ disable_exec_plugin: false
 #
 #   - {{.ClusterName}} - Name of the Teleport cluster
 #   - {{.KubeName}} - Name of the Kubernetes cluster resource
+#   - {{.Labels}} - Map of labels applied to the Kubernetes cluster
+# 	   resource that can be indexed using `{{index .Labels "key"}}`
 #
 # By default, the following template will be used: "{{.ClusterName}}-{{.KubeName}}"
 context_name_template: "{{.KubeName}}"
@@ -475,8 +477,19 @@ secret_name_prefix: "argocd-cluster"
 # secret_labels is a set of labels that will be applied to the cluster secrets
 # in addition to the "argocd.argoproj.io/secret-type" label added for Argo CD
 # discovery.
+#
+# Label values can be Go template strings with the following variables:
+#
+#   - {{.ClusterName}} - Name of the Teleport cluster
+#   - {{.KubeName}} - Name of the Kubernetes cluster resource
+#   - {{.Labels}} - Map of labels applied to the Kubernetes cluster
+# 	   resource that can be indexed using `{{index .Labels "key"}}`
+#
+# If the label value is empty, the label will not be added to the secret.
 secret_labels:
   department: engineering
+  cluster-region: |-
+    {{index .Labels "region"}}
 
 # secret_annotations is a set of annotations that will be applied to the cluster
 # secrets in addition to `tbot`'s own annotations:

--- a/examples/chart/tbot/.lint/argocd.yaml
+++ b/examples/chart/tbot/.lint/argocd.yaml
@@ -12,6 +12,8 @@ argocd:
   secretNamespace: my-namespace
   secretLabels:
     baz: qux
+    cluster-region: |-
+      {{index .Labels "region"}}
   secretAnnotations:
     chunky: bacon
   project: my-argo-project
@@ -19,4 +21,5 @@ argocd:
     - dev
     - prod
   clusterResources: true
-  clusterNameTemplate: "{{.KubeName}}"
+  clusterNameTemplate: |-
+    {{.KubeName}}-{{index .Labels "region"}}

--- a/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
@@ -34,7 +34,7 @@ should match the snapshot (argocd):
           join_method: kubernetes
           token: my-token
         outputs:
-        - cluster_name_template: '{{.KubeName}}'
+        - cluster_name_template: '{{.KubeName}}-{{index .Labels "region"}}'
           cluster_resources: true
           namespaces:
           - dev
@@ -44,6 +44,7 @@ should match the snapshot (argocd):
             chunky: bacon
           secret_labels:
             baz: qux
+            cluster-region: '{{index .Labels "region"}}'
           secret_namespace: my-namespace
           selectors:
           - name: foo

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -59,7 +59,7 @@ argocd:
   # clusterSelectors:
   #   - name: my-cluster-1
   #   - labels:
-  #     environment: production
+  #       environment: production
   # ```
   clusterSelectors: []
   # argocd.secretNamespace(string) -- determines to which Kubernetes namespace
@@ -70,7 +70,15 @@ argocd:
   # names will be prefixed with. Defaults to "teleport.argocd-cluster".
   secretNamePrefix: ""
   # argocd.secretLabels(object) -- provides a set of labels that will be applied
-  # to cluster secrets.
+  # to cluster secrets. Label values can be Go template strings with the following
+  # variables:
+  #
+  #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  #   - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+  #     resource that can be indexed using `\{\{index .Labels "key"\}\}`
+  #
+  # If the label value is empty, the label will not be added to the secret.
   secretLabels: {}
   # argocd.secretAnnotations(object) -- provides a set of annotations that will
   # be applied to cluster secrets.
@@ -90,6 +98,8 @@ argocd:
   #
   #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  #   - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+  #     resource that can be indexed using `\{\{index .Labels "key"\}\}`
   #
   # By default, the following template will be used: "\{\{.ClusterName\}\}-\{\{.KubeName\}\}".
   clusterNameTemplate: ""

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -70,8 +70,8 @@ argocd:
   # names will be prefixed with. Defaults to "teleport.argocd-cluster".
   secretNamePrefix: ""
   # argocd.secretLabels(object) -- provides a set of labels that will be applied
-  # to cluster secrets. Label values can be Go template strings with the following
-  # variables:
+  # to cluster secrets. Label values can be Go template strings (rendered by tbot,
+  # not Helm) with the following variables:
   #
   #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
@@ -94,7 +94,8 @@ argocd:
   # is non-empty).
   clusterResources: false
   # argocd.clusterNameTemplate(string) -- determines the format of cluster names
-  # in Argo CD. It is a Go template string that supports the following variables:
+  # in Argo CD. It is a Go template string (rendered by tbot, not Helm) that
+  # supports the following variables:
   #
   #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
   #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -119,7 +119,7 @@ kubeClusterName: ""
 ################################################################
 
 # apps(list) -- is a static list of applications that should be proxied by
-# the agent. See [the Teleport Application access documentation](../../reference/agent-services/application-access.mdx#configuration)
+# the agent. See [the Teleport Application access documentation](../../enroll-resources/application-access/reference.mdx#configuration)
 # for more details.
 #
 # Proxied applications can be defined statically (through this value) or dynamically
@@ -144,7 +144,7 @@ kubeClusterName: ""
 # <Admonition type="tip" title="Supported values">
 #   You can see a list of all the supported values that can be used in a Teleport
 #   Application Service configuration in the [Application Service Configuration
-#   Reference](../../reference/agent-services/application-access.mdx#configuration).
+#   Reference](../../enroll-resources/application-access/reference.mdx#configuration).
 # </Admonition>
 apps: []
 
@@ -189,7 +189,7 @@ clusterDomain: "cluster.local"
 # awsDatabases(list) -- configures AWS database auto-discovery.
 #
 # <Admonition type="note" title="IAM roles">
-#   For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enroll-aws-databases/rds.mdx#step-36-create-iam-policies-for-teleport).
+#   For AWS database auto-discovery to work, your Database Service pods will need to use a role which has appropriate IAM permissions as per the [database documentation](../../enroll-resources/database-access/enroll-aws-databases/rds/mysql-postgres-mariadb.mdx#step-36-create-iam-policies-for-teleport).
 #   After configuring a role, you can use an `eks.amazonaws.com/role-arn` annotation with the `annotations.serviceAccount` value to associate it with the service account and grant permissions:
 #
 #   ```yaml
@@ -330,7 +330,7 @@ azureDatabases: []
 # ```
 #
 # <Admonition type="tip" title="Supported values">
-#   You can see a list of all the supported [values which can be used in a Teleport Database Service configuration here](../../reference/agent-services/database-access-reference/configuration.mdx).
+#   You can see a list of all the supported [values which can be used in a Teleport Database Service configuration here](../../enroll-resources/database-access/reference/configuration.mdx).
 # </Admonition>
 #
 # <Admonition type="tip" title="Trusting Database CA">

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -25,11 +25,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"html/template"
 	"log/slog"
 	"maps"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 
 	"github.com/gravitational/trace"

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -25,6 +25,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"log/slog"
 	"maps"
 	"strconv"
@@ -40,8 +41,6 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/bot/connection"
 	"github.com/gravitational/teleport/lib/tbot/client"
@@ -221,16 +220,16 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 		return nil, trace.Wrap(err)
 	}
 
-	var clusterNames []string
+	// Copy clusters into a map to deduplicate by name.
+	clusters := make(map[string]types.KubeCluster)
 	for _, m := range matches {
-		clusterNames = append(clusterNames, m.cluster.GetName())
+		clusters[m.cluster.GetName()] = m.cluster
 	}
-	clusterNames = utils.Deduplicate(clusterNames)
 
 	s.log.InfoContext(
 		ctx,
 		"Generated identity for Kubernetes access",
-		"matched_cluster_count", len(clusterNames),
+		"matched_cluster_count", len(clusters),
 		"identity", id.Get(),
 	)
 	proxyPong, err := s.proxyPinger.Ping(ctx)
@@ -278,16 +277,17 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 		return nil, trace.BadParameter("TLS trusted CAs missing in provided credentials")
 	}
 
-	credentials := make([]*argoClusterCredentials, len(clusterNames))
-	for idx, clusterName := range clusterNames {
-		credentials[idx] = &argoClusterCredentials{
+	credentials := make([]*argoClusterCredentials, 0, len(clusters))
+	for _, cluster := range clusters {
+		credentials = append(credentials, &argoClusterCredentials{
 			teleportClusterName: proxyPong.ClusterName,
-			kubeClusterName:     clusterName,
+			kubeClusterName:     cluster.GetName(),
+			kubeClusterLabels:   cluster.GetAllLabels(),
 			addr: fmt.Sprintf(
 				"%s/v1/teleport/%s/%s",
 				proxyAddr,
 				encodePathComponent(proxyPong.ClusterName),
-				encodePathComponent(clusterName),
+				encodePathComponent(cluster.GetName()),
 			),
 			tlsClientConfig: argoTLSClientConfig{
 				CAData:     caBytes,
@@ -296,7 +296,7 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 				ServerName: kubeSNI,
 			},
 			botName: id.Get().TLSIdentity.BotName,
-		}
+		})
 	}
 	return credentials, nil
 }
@@ -304,6 +304,7 @@ func (s *ArgoCDOutput) discoverClusters(ctx context.Context) ([]*argoClusterCred
 type argoClusterCredentials struct {
 	teleportClusterName string
 	kubeClusterName     string
+	kubeClusterLabels   map[string]string
 	addr                string
 	tlsClientConfig     argoTLSClientConfig
 	botName             string
@@ -322,7 +323,14 @@ func (s *ArgoCDOutput) renderSecret(cluster *argoClusterCredentials) (*corev1.Se
 	}
 	for k, v := range s.cfg.SecretLabels {
 		// Do not overwrite any of "our" labels.
-		if _, ok := labels[k]; !ok {
+		if _, ok := labels[k]; ok {
+			continue
+		}
+		v, err := renderTemplate(v, cluster)
+		if err != nil {
+			return nil, trace.Wrap(err, "templating secret label %q", k)
+		}
+		if v != "" {
 			labels[k] = v
 		}
 	}
@@ -348,11 +356,7 @@ func (s *ArgoCDOutput) renderSecret(cluster *argoClusterCredentials) (*corev1.Se
 		return nil, trace.Wrap(err, "marshaling cluster credentials")
 	}
 
-	name, err := kubeconfig.ContextNameFromTemplate(
-		s.cfg.ClusterNameTemplate,
-		cluster.teleportClusterName,
-		cluster.kubeClusterName,
-	)
+	name, err := renderTemplate(s.cfg.ClusterNameTemplate, cluster)
 	if err != nil {
 		return nil, trace.Wrap(err, "templating cluster name")
 	}
@@ -426,4 +430,31 @@ func (s *ArgoCDOutput) writeSecret(ctx context.Context, secret *corev1.Secret) e
 		return trace.Wrap(err, "updating secret: %s", fullName)
 	}
 	return nil
+}
+
+func renderTemplate(temp string, cluster *argoClusterCredentials) (string, error) {
+	if temp == "" {
+		return "", nil
+	}
+
+	tmpl, err := template.New("").Parse(temp)
+	if err != nil {
+		return "", trace.BadParameter("failed to parse template, error: %v", err)
+	}
+
+	tmplVars := struct {
+		ClusterName string
+		KubeName    string
+		Labels      map[string]string
+	}{
+		ClusterName: cluster.teleportClusterName,
+		KubeName:    cluster.kubeClusterName,
+		Labels:      cluster.kubeClusterLabels,
+	}
+
+	var b bytes.Buffer
+	if err = tmpl.Execute(&b, tmplVars); err != nil {
+		return "", trace.BadParameter("failed to execute template, error: %v", err)
+	}
+	return b.String(), nil
 }

--- a/lib/tbot/services/k8s/argocd_output_config_test.go
+++ b/lib/tbot/services/k8s/argocd_output_config_test.go
@@ -206,6 +206,23 @@ func TestArgoCDConfig_CheckAndSetDefaults(t *testing.T) {
 			wantErr: "can't evaluate field InvalidVariable",
 		},
 		{
+			name: "invalid secret_labels template",
+			in: func() *ArgoCDOutputConfig {
+				return &ArgoCDOutputConfig{
+					Selectors: []*KubernetesSelector{
+						{Labels: map[string]string{"foo": "bar"}},
+					},
+					SecretNamespace:  "argocd",
+					SecretNamePrefix: "argo-cluster",
+					SecretLabels: map[string]string{
+						"foo": "{{.InvalidVariable}}",
+					},
+					ClusterNameTemplate: "{{.KubeName}}",
+				}
+			},
+			wantErr: "can't evaluate field InvalidVariable",
+		},
+		{
 			name: "defaults",
 			in: func() *ArgoCDOutputConfig {
 				return &ArgoCDOutputConfig{

--- a/lib/tbot/services/k8s/argocd_output_test.go
+++ b/lib/tbot/services/k8s/argocd_output_test.go
@@ -120,7 +120,9 @@ func TestArgoCDOutput_EndToEnd(t *testing.T) {
 			SecretNamePrefix: "my-cluster",
 			SecretNamespace:  "argocd",
 			SecretLabels: map[string]string{
-				"team": "billing",
+				"team":               "billing",
+				"cluster-department": `{{ index .Labels "department" }}`,
+				"non-existent":       `{{ index .Labels "non-existent" }}`,
 			},
 			SecretAnnotations: map[string]string{
 				"managed-by": "ninjas",
@@ -174,6 +176,7 @@ func TestArgoCDOutput_EndToEnd(t *testing.T) {
 		map[string]string{
 			"argocd.argoproj.io/secret-type": "cluster",
 			"team":                           "billing",
+			"cluster-department":             "engineering",
 		},
 		secret.Labels,
 	)


### PR DESCRIPTION
Backport #61804 to branch/v18

changelog: Added support for templating `secret_labels`, and the `{{.Labels}}` template variable, to tbot's `kubernetes/argo-cd` output
