### PR TITLE
Dependabot: Bring back exclude-patterns to ui group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -267,6 +267,14 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+        # Contrary to what the docs say, if a dependency matches more than one rule, it is _not_
+        # included in the first group that it matches. Other groups must be explicitly included,
+        # otherwise Dependabot is going to perform minor Electron updates in the UI group.
+        # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--
+        exclude-patterns:
+          - 'electron*'
+          - node-gyp
+          - node-pty
     open-pull-requests-limit: 20
   - package-ecosystem: github-actions
     directory: '/.github/workflows'


### PR DESCRIPTION
I removed `exclude-patterns` in #58452 because it didn't seem to be necessary, at least according to the docs. It turns out that it is in fact necessary, otherwise Dependabot updates Electron packages in the ui group PR, [as it did in the recent one](https://github.com/gravitational/teleport/pull/61865/commits/6ab7812c070cbdde85d72cf1d32cb10e339195db#diff-8c8592a35383f73ddd9fa44869670328eeab149e498cfe80e06e08f281109909R47-R49).