### PR TITLE
Add `pnpm list-installed-versions`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prettier-check": "prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "prettier-write": "prettier --write --log-level silent '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "process-icons": "pnpm optimize-resource-icons && node web/packages/design/src/Icon/script/script.js && pnpm prettier --log-level silent --write 'web/packages/design/src/Icon/**/*.tsx'",
+    "list-installed-versions": "./web/scripts/list-installed-versions.sh",
     "nop": "exit 0"
   },
   "private": true,

--- a/web/scripts/list-installed-versions.sh
+++ b/web/scripts/list-installed-versions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <package-name>" >&2
+  exit 1
+fi
+
+pnpm why -r "$1" --json | grep "\"$1\"" -A 3 | grep version | tr -s ' ' | cut -d ' ' -f 3 | sort | uniq


### PR DESCRIPTION
When working on the checklist for updating JS packages, I wanted to add a script I've been using to check if a security update indeed updated all necessary versions of a package.

The script was a bit hard to use because the name of the package was repeated twice. To avoid posting it in this form, I created this PR so that it can be invoked through `pnpm list-installed-versions <package-name>`.