### PR TITLE
VNet on Windows: Force refresh policies under group policy key, configure DNS only when necessary

### DIFF
--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -309,14 +309,16 @@ func deleteRegistryKey(key string) error {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-refreshpolicyex
 func forceRefreshComputerPolicies() error {
-	// rp_force is a flag for RefreshPolicyEx which makes it reapply all policies even if no policy
-	// change was detected.
-	const rp_force = 1
+	// refreshComputerPolicies corresponds to the first argument of RefreshPolicyEx which specifies
+	// whether to refresh computer or user policies.
+	const refreshComputerPolicies = 1
+	// rpForce corresponds to the RP_FORCE flag for RefreshPolicyEx which makes it reapply all
+	// policies even if no policy change was detected.
+	const rpForce = 1
 
 	retVal, _, err := procRefreshPolicyEx.Call(
-		// Refresh computer policies.
-		uintptr(1),
-		uintptr(rp_force),
+		uintptr(refreshComputerPolicies),
+		uintptr(rpForce),
 	)
 	if retVal == 0 {
 		return trace.Wrap(err)


### PR DESCRIPTION
Closes #60468.

changelog: Fixed intermittent issues with VNet on Windows when other NRPT rules from GPOs are present under `HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`

The linked issue (and the comment it links to) includes a detailed description of why such force refresh is needed. Arguably, it's a deep rabbit hole and fully understanding the problem requires reading through that lengthy comment in Tailscale's issue tracker. [1]

In short, when adding NRPT rules under `groupPolicyNRPTParentKey` (which we need to do mostly on corporate computers which have other NRPT rules under this key as well), it looks like the rules are not picked up by the DNS client until the policies are refreshed. This happens by itself every ~90 minutes, but we can also call `RefreshPolicyEx` to force those policies to be refreshed.

However, `platformConfigureOS` (and thus `configureDNS`) is currently called on loop every 10 seconds. In order to avoid refreshing the policies every 10 seconds, this PR adds a simple "cache" which makes it so that we call `configureDNS` only when the DNS zones or nameservers have changed. Or if the key under `groupPolicyNRPTParentKey` was found / not found – this is to handle a situation where the key appears in the registry while VNet is running. VNet should add its own rules under the key in that scenario.

#60468 goes into more detail into how I verified with a customer that refreshing the policies fixes their problem.

---

1: Surprisingly, Tailscale has reopened the original issue with the intention of addressing it in a situation where an empty DNS policy prevents Tailscale from working. Maybe there will be lessons for us to learn as well, but in the meantime this PR fixes the issue when there are non-empty NRPT policies in the registry.