### PR TITLE
Update pnpm to 10.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
       "web/.storybook/public"
     ]
   },
-  "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
+  "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
   "engines": {
     "node": "^22"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,3 +43,4 @@ patchedDependencies:
   jest-canvas-mock@2.5.2: web/patches/jest-canvas-mock@2.5.2.patch
 # Do not install packages released less than 2 days (2880 minutes) ago
 minimumReleaseAge: 2880
+trustPolicy: no-downgrade


### PR DESCRIPTION
Also, enable the new `trustPolicy` setting.

> When set to `no-downgrade`, pnpm will fail if a package's trust level has decreased compared to previous releases. For example, if a package was previously published by a trusted publisher but now only has provenance or no trust evidence, installation will fail. This helps prevent installing potentially compromised versions. Trust checks are based solely on publish date, not semver. A package cannot be installed if any earlier-published version had stronger trust evidence. Starting in v10.24.0, prerelease versions are ignored when evaluating trust evidence for a non-prerelease install, so a trusted prerelease cannot block a stable release that lacks trust evidence.

https://pnpm.io/settings#trustpolicy