### PR TITLE
Add computed fields for Azure Discovery Config in tf

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/data-sources/discovery_config.mdx
@@ -210,14 +210,17 @@ Optional:
 
 ### Nested Schema for `spec.azure.install_params`
 
+Required:
+
+- `join_method` (String) JoinMethod is the method to use when joining the cluster
+- `join_token` (String) JoinToken is the token to use when joining the cluster
+
 Optional:
 
 - `azure` (Attributes) Azure is the set of Azure-specific installation parameters. (see [below for nested schema](#nested-schema-for-specazureinstall_paramsazure))
 - `enroll_mode` (Number) EnrollMode indicates the enrollment mode to be used when adding a node. Valid values: 0: uses eice for EC2 matchers which use an integration and script for all the other methods 1: uses script mode 2: uses eice mode (deprecated)
 - `http_proxy_settings` (Attributes) HTTPProxySettings defines HTTP proxy settings for making HTTP requests. When set, this will set the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables before running the installation. (see [below for nested schema](#nested-schema-for-specazureinstall_paramshttp_proxy_settings))
 - `install_teleport` (Boolean) InstallTeleport disables agentless discovery
-- `join_method` (String) JoinMethod is the method to use when joining the cluster
-- `join_token` (String) JoinToken is the token to use when joining the cluster
 - `proxy_addr` (String) PublicProxyAddr is the address of the proxy the discovered node should use to connect to the cluster.
 - `script_name` (String) ScriptName is the name of the teleport installer script resource for the cloud instance to execute
 - `sshd_config` (String) SSHDConfig provides the path to write sshd configuration changes
@@ -226,7 +229,7 @@ Optional:
 
 ### Nested Schema for `spec.azure.install_params.azure`
 
-Optional:
+Required:
 
 - `client_id` (String) ClientID is the client ID of the managed identity discovered nodes should use to join the cluster.
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/discovery_config.mdx
@@ -286,14 +286,17 @@ Optional:
 
 ### Nested Schema for `spec.azure.install_params`
 
+Required:
+
+- `join_method` (String) JoinMethod is the method to use when joining the cluster
+- `join_token` (String) JoinToken is the token to use when joining the cluster
+
 Optional:
 
 - `azure` (Attributes) Azure is the set of Azure-specific installation parameters. (see [below for nested schema](#nested-schema-for-specazureinstall_paramsazure))
 - `enroll_mode` (Number) EnrollMode indicates the enrollment mode to be used when adding a node. Valid values: 0: uses eice for EC2 matchers which use an integration and script for all the other methods 1: uses script mode 2: uses eice mode (deprecated)
 - `http_proxy_settings` (Attributes) HTTPProxySettings defines HTTP proxy settings for making HTTP requests. When set, this will set the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables before running the installation. (see [below for nested schema](#nested-schema-for-specazureinstall_paramshttp_proxy_settings))
 - `install_teleport` (Boolean) InstallTeleport disables agentless discovery
-- `join_method` (String) JoinMethod is the method to use when joining the cluster
-- `join_token` (String) JoinToken is the token to use when joining the cluster
 - `proxy_addr` (String) PublicProxyAddr is the address of the proxy the discovered node should use to connect to the cluster.
 - `script_name` (String) ScriptName is the name of the teleport installer script resource for the cloud instance to execute
 - `sshd_config` (String) SSHDConfig provides the path to write sshd configuration changes
@@ -302,7 +305,7 @@ Optional:
 
 ### Nested Schema for `spec.azure.install_params.azure`
 
-Optional:
+Required:
 
 - `client_id` (String) ClientID is the client ID of the managed identity discovered nodes should use to join the cluster.
 

--- a/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
+++ b/integrations/terraform/protoc-gen-terraform-discoveryconfig.yaml
@@ -44,6 +44,9 @@ computed_fields:
   - 'DiscoveryConfig.header.metadata.revision'
   - 'DiscoveryConfig.header.kind'
   - 'DiscoveryConfig.header.sub_kind'
+  - 'DiscoveryConfig.spec.azure.Params'
+  - 'DiscoveryConfig.spec.azure.Params.ScriptName'
+  - 'DiscoveryConfig.spec.azure.Params.Azure'
 
 # These fields will be marked as Required: true
 required_fields:
@@ -52,6 +55,9 @@ required_fields:
   - 'DiscoveryConfig.header.metadata.name'
   - 'DiscoveryConfig.header.version'
   - 'DiscoveryConfig.spec'
+  - 'DiscoveryConfig.spec.azure.Params.Azure.ClientID'
+  - 'DiscoveryConfig.spec.azure.Params.JoinToken'
+  - 'DiscoveryConfig.spec.azure.Params.JoinMethod'
 
 plan_modifiers:
   # Force to recreate resource if it's name changes

--- a/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
+++ b/integrations/terraform/tfschema/discoveryconfig/v1/discoveryconfig_terraform.go
@@ -383,11 +383,13 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 								"azure": {
 									Attributes: github_com_hashicorp_terraform_plugin_framework_tfsdk.SingleNestedAttributes(map[string]github_com_hashicorp_terraform_plugin_framework_tfsdk.Attribute{"client_id": {
 										Description: "ClientID is the client ID of the managed identity discovered nodes should use to join the cluster.",
-										Optional:    true,
+										Required:    true,
 										Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 									}}),
-									Description: "Azure is the set of Azure-specific installation parameters.",
-									Optional:    true,
+									Computed:      true,
+									Description:   "Azure is the set of Azure-specific installation parameters.",
+									Optional:      true,
+									PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 								},
 								"enroll_mode": {
 									Description: "EnrollMode indicates the enrollment mode to be used when adding a node. Valid values: 0: uses eice for EC2 matchers which use an integration and script for all the other methods 1: uses script mode 2: uses eice mode (deprecated)",
@@ -422,12 +424,12 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 								},
 								"join_method": {
 									Description: "JoinMethod is the method to use when joining the cluster",
-									Optional:    true,
+									Required:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"join_token": {
 									Description: "JoinToken is the token to use when joining the cluster",
-									Optional:    true,
+									Required:    true,
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"proxy_addr": {
@@ -436,9 +438,11 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"script_name": {
-									Description: "ScriptName is the name of the teleport installer script resource for the cloud instance to execute",
-									Optional:    true,
-									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
+									Computed:      true,
+									Description:   "ScriptName is the name of the teleport installer script resource for the cloud instance to execute",
+									Optional:      true,
+									PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
+									Type:          github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 								"sshd_config": {
 									Description: "SSHDConfig provides the path to write sshd configuration changes",
@@ -456,8 +460,10 @@ func GenSchemaDiscoveryConfig(ctx context.Context) (github_com_hashicorp_terrafo
 									Type:        github_com_hashicorp_terraform_plugin_framework_types.StringType,
 								},
 							}),
-							Description: "Params sets the join method when installing on discovered Azure nodes.",
-							Optional:    true,
+							Computed:      true,
+							Description:   "Params sets the join method when installing on discovered Azure nodes.",
+							Optional:      true,
+							PlanModifiers: []github_com_hashicorp_terraform_plugin_framework_tfsdk.AttributePlanModifier{github_com_hashicorp_terraform_plugin_framework_tfsdk.UseStateForUnknown()},
 						},
 						"integration": {
 							Description: "Integration is the integration name used to generate credentials to interact with Azure APIs. Environment credentials will not be used when this value is set.",


### PR DESCRIPTION
In the current branch, terraform will report errors due to returned resource inconsistency due to fields set by CheckAndSetDefaults, so we mark them as computed.

example error
```
module.teleport_azure_discovery.teleport_discovery_config.azure_teleport:
Creating...
╷
│ Error: Provider produced inconsistent result after apply
│
│ When applying changes to
module.teleport_azure_discovery.teleport_discovery_config.azure_teleport,
provider
"provider[\"terraform.releases.teleport.dev/gravitational/teleport\"]"
produced an unexpected new
│ value: .spec.azure[0].install_params.script_name: was null, but now
cty.StringVal("default-installer").
│
│ This is a bug in the provider, which should be reported in the
provider's own issue tracker.
╵
```