### PR TITLE
[v18] Upgrade Prettier to 3.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "msw": "^2.7.6",
     "msw-storybook-addon": "^2.0.5",
     "playwright": "^1.55.1",
-    "prettier": "^3.5.3",
+    "prettier": "^3.7.3",
     "react-select-event": "^5.5.1",
     "storybook": "^9.0.17",
     "svgo": "^4.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,13 +123,13 @@ importers:
         version: link:web/packages/build
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.1
-        version: 4.4.1(prettier@3.5.3)
+        version: 4.4.1(prettier@3.7.3)
       '@storybook/addon-vitest':
         specifier: ^9.0.15
-        version: 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))
+        version: 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))
       '@storybook/react-vite':
         specifier: ^9.0.17
-        version: 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))
+        version: 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -191,14 +191,14 @@ importers:
         specifier: ^1.55.1
         version: 1.56.1
       prettier:
-        specifier: ^3.5.3
-        version: 3.5.3
+        specifier: ^3.7.3
+        version: 3.7.3
       react-select-event:
         specifier: ^5.5.1
         version: 5.5.1
       storybook:
         specifier: ^9.0.17
-        version: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+        version: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
       svgo:
         specifier: ^4.0.0
         version: 4.0.0
@@ -260,7 +260,7 @@ importers:
         version: 5.2.0(eslint@9.26.0)
       eslint-plugin-storybook:
         specifier: ^9.0.17
-        version: 9.0.17(eslint@9.26.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3)
+        version: 9.0.17(eslint@9.26.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3)
       eslint-plugin-testing-library:
         specifier: ^7.1.1
         version: 7.1.1(eslint@9.26.0)(typescript@5.8.3)
@@ -5783,8 +5783,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.7.3:
+    resolution: {integrity: sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8586,13 +8586,13 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.2': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.4.1(prettier@3.5.3)':
+  '@ianvs/prettier-plugin-sort-imports@4.4.1(prettier@3.7.3)':
     dependencies:
       '@babel/generator': 7.27.1
       '@babel/parser': 7.27.1
       '@babel/traverse': 7.27.1
       '@babel/types': 7.27.1
-      prettier: 3.5.3
+      prettier: 3.7.3
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
@@ -9389,27 +9389,27 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.0
 
-  '@storybook/addon-vitest@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))':
+  '@storybook/addon-vitest@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prompts: 2.4.2
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))':
+  '@storybook/builder-vite@9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      '@storybook/csf-plugin': 9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
       ts-dedent: 2.2.0
       vite: 6.3.5(@types/node@22.15.16)(yaml@2.7.1)
 
-  '@storybook/csf-plugin@9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))':
+  '@storybook/csf-plugin@9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))':
     dependencies:
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -9419,25 +9419,25 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/react-dom-shim@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))':
+  '@storybook/react-dom-shim@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))':
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
 
-  '@storybook/react-vite@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))':
+  '@storybook/react-vite@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.40.2)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))
       '@rollup/pluginutils': 5.1.4(rollup@4.40.2)
-      '@storybook/builder-vite': 9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))
-      '@storybook/react': 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3)
+      '@storybook/builder-vite': 9.0.17(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(vite@6.3.5(@types/node@22.15.16)(yaml@2.7.1))
+      '@storybook/react': 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 19.1.0
       react-docgen: 8.0.0
       react-dom: 19.1.0(react@19.1.0)
       resolve: 1.22.10
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
       tsconfig-paths: 4.2.0
       vite: 6.3.5(@types/node@22.15.16)(yaml@2.7.1)
     transitivePeerDependencies:
@@ -9445,13 +9445,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3)':
+  '@storybook/react@9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))
+      '@storybook/react-dom-shim': 9.0.17(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -11434,11 +11434,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-storybook@9.0.17(eslint@9.26.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3))(typescript@5.8.3):
+  eslint-plugin-storybook@9.0.17(eslint@9.26.0)(storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.32.0(eslint@9.26.0)(typescript@5.8.3)
       eslint: 9.26.0
-      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3)
+      storybook: 9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13271,7 +13271,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.5.3: {}
+  prettier@3.7.3: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -13885,7 +13885,7 @@ snapshots:
 
   statuses@2.0.1: {}
 
-  storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.5.3):
+  storybook@9.0.17(@testing-library/dom@10.1.0)(prettier@3.7.3):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.3
@@ -13899,7 +13899,7 @@ snapshots:
       semver: 7.7.2
       ws: 8.18.2
     optionalDependencies:
-      prettier: 3.5.3
+      prettier: 3.7.3
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil

--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -142,10 +142,7 @@ export interface Action {
 }
 
 export interface AlertProps
-  extends Props<AlertKind>,
-    SpaceProps,
-    WidthProps,
-    ColorProps {
+  extends Props<AlertKind>, SpaceProps, WidthProps, ColorProps {
   linkColor?: string;
   /**
    * If specified, the alert's contents will wrap for narrower screens

--- a/web/packages/design/src/Box/Box.tsx
+++ b/web/packages/design/src/Box/Box.tsx
@@ -65,7 +65,8 @@ import {
 } from '../system';
 
 export interface BoxProps
-  extends MaxWidthProps,
+  extends
+    MaxWidthProps,
     MinWidthProps,
     SpaceProps,
     HeightProps,

--- a/web/packages/design/src/Flex/Flex.tsx
+++ b/web/packages/design/src/Flex/Flex.tsx
@@ -43,7 +43,8 @@ import {
 import Box, { BoxProps } from '../Box';
 
 export interface FlexProps
-  extends BoxProps,
+  extends
+    BoxProps,
     AlignItemsProps,
     JustifyContentProps,
     FlexWrapProps,

--- a/web/packages/design/src/Image/Image.tsx
+++ b/web/packages/design/src/Image/Image.tsx
@@ -37,7 +37,8 @@ import {
 } from 'design/system';
 
 interface ImageProps
-  extends SpaceProps,
+  extends
+    SpaceProps,
     ColorProps,
     WidthProps,
     HeightProps,

--- a/web/packages/design/src/LabelState/LabelState.tsx
+++ b/web/packages/design/src/LabelState/LabelState.tsx
@@ -85,11 +85,7 @@ const kinds = ({ theme, kind, shadow }: ThemedKindsProps) => {
 };
 
 interface LabelStateProps
-  extends SpaceProps,
-    KindsProps,
-    WidthProps,
-    ColorProps,
-    FontSizeProps {}
+  extends SpaceProps, KindsProps, WidthProps, ColorProps, FontSizeProps {}
 
 const LabelState = styled.span<LabelStateProps>`
   box-sizing: border-box;

--- a/web/packages/design/src/TextArea/TextArea.tsx
+++ b/web/packages/design/src/TextArea/TextArea.tsx
@@ -38,10 +38,7 @@ import { Theme } from 'design/theme/themes/types';
 export type TextAreaSize = 'large' | 'medium' | 'small';
 
 export interface TextAreaProps
-  extends ColorProps,
-    SpaceProps,
-    WidthProps,
-    HeightProps {
+  extends ColorProps, SpaceProps, WidthProps, HeightProps {
   size?: TextAreaSize;
   hasError?: boolean;
   resizable?: boolean;

--- a/web/packages/shared/components/TextEditor/TextEditor.mock.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.mock.tsx
@@ -34,7 +34,9 @@ jest.mock('./TextEditor', () => {
 function MockTextEditor(props: { data?: [{ content: string }] }) {
   return (
     <div data-testid="mock-text-editor">
-      {props.data?.map(d => <div key={d.content}>{d.content}</div>)}
+      {props.data?.map(d => (
+        <div key={d.content}>{d.content}</div>
+      ))}
     </div>
   );
 }

--- a/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyRecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/tty/TtyRecordingPlayer.tsx
@@ -27,11 +27,10 @@ import { RecordingPlayer, type RecordingPlayerProps } from '../RecordingPlayer';
 import { decodeTtyEvent } from './decoding';
 import { EventType, type TtyEvent } from './types';
 
-interface TtyRecordingPlayerProps
-  extends Omit<
-    RecordingPlayerProps<TtyEvent>,
-    'decodeEvent' | 'endEventType' | 'player' | 'ws'
-  > {
+interface TtyRecordingPlayerProps extends Omit<
+  RecordingPlayerProps<TtyEvent>,
+  'decodeEvent' | 'endEventType' | 'player' | 'ws'
+> {
   clusterId: string;
   sessionId: string;
   initialCols: number;

--- a/web/packages/teleterm/src/services/tshd/cloneableClient.test.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.test.ts
@@ -52,9 +52,9 @@ const tshdRpcErrorObjectMatcher: TshdRpcError = expect.objectContaining({
   cause: undefined,
 });
 
-class MockServiceMethod<T extends (...args: any[]) => any>
-  implements ServiceInfo
-{
+class MockServiceMethod<
+  T extends (...args: any[]) => any,
+> implements ServiceInfo {
   public methods: MethodInfo[];
   public options = {};
   public typeName = '';

--- a/web/packages/teleterm/src/services/tshd/cloneableClient.ts
+++ b/web/packages/teleterm/src/services/tshd/cloneableClient.ts
@@ -393,9 +393,9 @@ function cloneThenRejection<TResult>(
  * Alternatively, we could change cloneableClient to merely return the response property, plus maybe
  * some other fields that we need.
  */
-export class MockedUnaryCall<Response extends object>
-  implements CloneableUnaryCall<any, Response>
-{
+export class MockedUnaryCall<
+  Response extends object,
+> implements CloneableUnaryCall<any, Response> {
   constructor(
     public response: Response,
     private error?: any


### PR DESCRIPTION
It was updated in the monthly update PR #61865. It introduced some changes to how files are formatted, so I'm backporting it to avoid problems with formatting down the line.