### PR TITLE
Create folder if it does not exist when using `tsh workload-identity issue-x509`

### DIFF
--- a/tool/tsh/common/workload_identity.go
+++ b/tool/tsh/common/workload_identity.go
@@ -162,6 +162,11 @@ func (c *issueX509Command) run(cf *CLIConf) error {
 			)
 		}
 
+		// Create directory if it does not exist.
+		if err := os.MkdirAll(c.outputDirectory, teleport.PrivateDirMode); err != nil {
+			return trace.Wrap(err, "creating output directory")
+		}
+
 		// Write private key
 		privBytes, err := x509.MarshalPKCS8PrivateKey(privateKey)
 		if err != nil {

--- a/tool/tsh/common/workload_identity_test.go
+++ b/tool/tsh/common/workload_identity_test.go
@@ -89,14 +89,14 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 	}, time.Second*5, 100*time.Millisecond)
 
 	homeDir, _ := mustLoginLegacy(t, s)
-	temp := t.TempDir()
+	outDir := filepath.Join(t.TempDir(), "out")
 	err = Run(
 		ctx,
 		[]string{
 			"workload-identity",
 			"issue-x509",
 			"--insecure",
-			"--output", temp,
+			"--output", outDir,
 			"--credential-ttl", "10m",
 			"--name-selector", "my-workload-identity",
 		},
@@ -104,7 +104,7 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	certPEM, err := os.ReadFile(filepath.Join(temp, "svid.pem"))
+	certPEM, err := os.ReadFile(filepath.Join(outDir, "svid.pem"))
 	require.NoError(t, err)
 	certs, err := tlsca.ParseCertificatePEMs(certPEM)
 	require.NoError(t, err)
@@ -114,7 +114,7 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 	// Sanity check we generated an ECDSA public key (test suite uses
 	// balanced-v1 algorithm suite).
 	require.IsType(t, (*ecdsa.PublicKey)(nil), certs[0].PublicKey)
-	keyPEM, err := os.ReadFile(filepath.Join(temp, "svid_key.pem"))
+	keyPEM, err := os.ReadFile(filepath.Join(outDir, "svid_key.pem"))
 	require.NoError(t, err)
 	keyBlock, _ := pem.Decode(keyPEM)
 	privateKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
@@ -123,7 +123,7 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 	require.Implements(t, (*crypto.Signer)(nil), privateKey)
 	require.Equal(t, certs[0].PublicKey, privateKey.(crypto.Signer).Public())
 
-	bundlePEM, err := os.ReadFile(filepath.Join(temp, "svid_bundle.pem"))
+	bundlePEM, err := os.ReadFile(filepath.Join(outDir, "svid_bundle.pem"))
 	require.NoError(t, err)
 	bundleBlock, _ := pem.Decode(bundlePEM)
 	_, err = x509.ParseCertificate(bundleBlock.Bytes)


### PR DESCRIPTION
Minor UX improvement - generally in the rest of Teleport, when a folder is specified but does not exist, we create it for the user. However, with this command today, we do not and instead error out.

changelog: Updates `tsh workload-identity issue-x509` to automatically create the specified folder if it does not exist.