### PR TITLE
[v18] AWS EC2 Discovery: discover in all enabled regions

### DIFF
--- a/api/types/matchers_aws_test.go
+++ b/api/types/matchers_aws_test.go
@@ -133,12 +133,12 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 			errCheck: isBadParameterErr,
 		},
 		{
-			name: "wildcard is invalid for regions",
+			name: "wildcard is valid for the ec2 type",
 			in: &AWSMatcher{
-				Types:   []string{"ec2", "rds"},
+				Types:   []string{"ec2"},
 				Regions: []string{"*"},
 			},
-			errCheck: isBadParameterErr,
+			errCheck: require.NoError,
 		},
 		{
 			name: "invalid type",
@@ -174,6 +174,14 @@ func TestAWSMatcherCheckAndSetDefaults(t *testing.T) {
 				Regions: []string{"eu-west-2"},
 			},
 			errCheck: isBadParameterErr,
+		},
+		{
+			name: "wildcard region is valid for ec2 type",
+			in: &AWSMatcher{
+				Types:   []string{"ec2"},
+				Regions: []string{"*"},
+			},
+			errCheck: require.NoError,
 		},
 		{
 			name: "no region",

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.3
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.5.11
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.74
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.4
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0

--- a/go.sum
+++ b/go.sum
@@ -882,6 +882,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 h1:ZNTqv4nIdE/DiBfUUfXcLZ/Spcuz+RjeziUtNJackkM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34/go.mod h1:zf7Vcd1ViW7cPqYWEHLHJkS50X0JS2IKz9Cgaj6ugrs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0 h1:xwcxrq16ND5W+QqsGVpNHcjqyVqX4TX7vp3ifI4aYjg=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0/go.mod h1:Ie/714qgv6ohupWHUxe/6oyAfiCdq9vVJrp+TnJrcqs=
 github.com/aws/aws-sdk-go-v2/service/athena v1.50.4 h1:QWhxjrA0r+FQnDAATdGqLXUvYW0MdUIvCBK89BN3OfU=

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -96,6 +96,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 // indirect

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -225,6 +225,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 h1:ZNTqv4nIdE/DiBfUUfXcLZ/Spcuz+RjeziUtNJackkM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34/go.mod h1:zf7Vcd1ViW7cPqYWEHLHJkS50X0JS2IKz9Cgaj6ugrs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.1 h1:LwY0saNiO7mUY+ijzC6FUX2wWdYkyDOAFSe4xJbbp7k=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.1/go.mod h1:Ie/714qgv6ohupWHUxe/6oyAfiCdq9vVJrp+TnJrcqs=
 github.com/aws/aws-sdk-go-v2/service/athena v1.50.5 h1:jtjq2nXMt8eSB4gTcZwjbKURjrpKJuSQ5LVspf/hiJ4=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.13 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/service/account v1.29.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/athena v1.50.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/bedrockruntime v1.41.0 // indirect

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -276,6 +276,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 h1:ZNTqv4nIdE/DiBfUUfXcLZ/Spcuz+RjeziUtNJackkM=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34/go.mod h1:zf7Vcd1ViW7cPqYWEHLHJkS50X0JS2IKz9Cgaj6ugrs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3 h1:EqpyKDfuTQZFL6Cr1dutmyUx+Z9eDN2oFR1hoMXbmCs=
+github.com/aws/aws-sdk-go-v2/service/account v1.29.3/go.mod h1:3LbGl+sLnaiyCVp2LJXj0gEoeV2Uw0QOsDpP1gDMBVA=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0 h1:xwcxrq16ND5W+QqsGVpNHcjqyVqX4TX7vp3ifI4aYjg=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.36.0/go.mod h1:Ie/714qgv6ohupWHUxe/6oyAfiCdq9vVJrp+TnJrcqs=
 github.com/aws/aws-sdk-go-v2/service/athena v1.50.4 h1:QWhxjrA0r+FQnDAATdGqLXUvYW0MdUIvCBK89BN3OfU=

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service.go
@@ -20,21 +20,26 @@ package discoveryconfigv1
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	conv "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // ServiceConfig holds configuration options for the DiscoveryConfig gRPC service.
@@ -124,7 +129,11 @@ func (s *Service) ListDiscoveryConfigs(ctx context.Context, req *discoveryconfig
 
 	dcs := make([]*discoveryconfigv1.DiscoveryConfig, len(results))
 	for i, r := range results {
-		dcs[i] = conv.ToProto(r)
+		downgraded, err := MaybeDowngradeDiscoveryConfig(ctx, r)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		dcs[i] = conv.ToProto(downgraded)
 	}
 
 	return &discoveryconfigv1.ListDiscoveryConfigsResponse{
@@ -149,7 +158,12 @@ func (s *Service) GetDiscoveryConfig(ctx context.Context, req *discoveryconfigv1
 		return nil, trace.Wrap(err)
 	}
 
-	return conv.ToProto(dc), nil
+	downgraded, err := MaybeDowngradeDiscoveryConfig(ctx, dc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return conv.ToProto(downgraded), nil
 }
 
 // CreateDiscoveryConfig creates a new DiscoveryConfig resource.
@@ -376,4 +390,68 @@ func (s *Service) UpdateDiscoveryConfigStatus(ctx context.Context, req *discover
 
 		return conv.ToProto(resp), nil
 	}
+}
+
+// MaybeDowngradeDiscoveryConfig tests the client version passed through the gRPC metadata,
+// and if necessary downgrades the Discovery Config resource for compatibility with the older client.
+// The following rules are applied:
+//   - if version is lower than 18.5.0, the AWS wildcard region is replaced with "aws-global" sentinel region
+//     this ensures the client can still discover other resources without erroring out.
+func MaybeDowngradeDiscoveryConfig(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) (*discoveryconfig.DiscoveryConfig, error) {
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		// This client is not reporting its version via gRPC metadata, which means it's a client really old or a third-party client.
+		// For those, downgrading the resource will do more harm than good, so the resource is returned as is.
+		return dc, nil
+	}
+
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		return nil, trace.BadParameter("unrecognized client version: %s is not a valid semver", clientVersionString)
+	}
+
+	dc = maybeDowngradeDiscoveryConfigAWSWildcardRegion(dc, clientVersion)
+	return dc, nil
+}
+
+var minSupportedDiscoveryConfigAWSWildcardRegionVersion = semver.Version{Major: 18, Minor: 5, Patch: 0}
+
+// For Auth Server v20.0.0, the expected minimum supported client version is v19.0.0, which supports the AWS wildcard region.
+// This function should be deleted at that time.
+//
+// TODO(@marco): DELETE IN v20.0.0.
+func maybeDowngradeDiscoveryConfigAWSWildcardRegion(dc *discoveryconfig.DiscoveryConfig, clientVersion *semver.Version) *discoveryconfig.DiscoveryConfig {
+	if supported, err := utils.MinVerWithoutPreRelease(
+		clientVersion.String(),
+		minSupportedDiscoveryConfigAWSWildcardRegionVersion.String()); supported || err != nil {
+		return dc
+	}
+
+	var changed bool
+
+	originalDiscoveryConfig := dc
+
+	dc = dc.Clone()
+	awsMatchers := dc.Spec.AWS
+	awsMatchersWithoutRegionWildcard := make([]types.AWSMatcher, 0, len(awsMatchers))
+	for _, awsMatcher := range awsMatchers {
+		if len(awsMatcher.Regions) == 1 && awsMatcher.Regions[0] == types.Wildcard {
+			awsMatcher.Regions = []string{aws.AWSGlobalRegion}
+			changed = true
+		}
+		awsMatchersWithoutRegionWildcard = append(awsMatchersWithoutRegionWildcard, awsMatcher)
+	}
+
+	if !changed {
+		return originalDiscoveryConfig
+	}
+
+	dc.Spec.AWS = awsMatchersWithoutRegionWildcard
+	reason := fmt.Sprintf(`Client version %q does not support discovering all regions. Either update the Discovery Service agent to at least %s or enumerate all the regions in %q discovery config.`,
+		clientVersion, minSupportedDiscoveryConfigAWSWildcardRegionVersion, dc.GetName())
+	if dc.Metadata.Labels == nil {
+		dc.Metadata.Labels = make(map[string]string, 1)
+	}
+	dc.Metadata.Labels[types.TeleportDowngradedLabel] = reason
+	return dc
 }

--- a/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
+++ b/lib/auth/discoveryconfig/discoveryconfigv1/service_test.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	discoveryconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	convert "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
@@ -560,4 +561,95 @@ func initSvc(t *testing.T, clusterName string) (context.Context, localClient, *S
 		IdentityService:        userSvc,
 		DiscoveryConfigService: localResourceService,
 	}, resourceSvc
+}
+
+func TestDowngrade(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		clientVersion string
+		input         *discoveryconfig.DiscoveryConfig
+		expected      *discoveryconfig.DiscoveryConfig
+	}{
+		{
+			name:          "no downgrade for recent client",
+			clientVersion: "18.5.0",
+			input: func() *discoveryconfig.DiscoveryConfig {
+				dc, err := discoveryconfig.NewDiscoveryConfig(
+					header.Metadata{Name: "dc1"},
+					discoveryconfig.Spec{
+						DiscoveryGroup: "group1",
+						AWS: []types.AWSMatcher{
+							{
+								Regions: []string{types.Wildcard},
+								Types:   []string{"ec2"},
+							},
+						},
+					},
+				)
+				require.NoError(t, err)
+				return dc
+			}(),
+			expected: func() *discoveryconfig.DiscoveryConfig {
+				dc, err := discoveryconfig.NewDiscoveryConfig(
+					header.Metadata{Name: "dc1"},
+					discoveryconfig.Spec{
+						DiscoveryGroup: "group1",
+						AWS: []types.AWSMatcher{
+							{
+								Regions: []string{types.Wildcard},
+								Types:   []string{"ec2"},
+							},
+						},
+					},
+				)
+				require.NoError(t, err)
+				return dc
+			}(),
+		},
+		{
+			name:          "downgrade for old client",
+			clientVersion: "18.4.2",
+			input: func() *discoveryconfig.DiscoveryConfig {
+				dc, err := discoveryconfig.NewDiscoveryConfig(
+					header.Metadata{Name: "dc1"},
+					discoveryconfig.Spec{
+						DiscoveryGroup: "group1",
+						AWS: []types.AWSMatcher{
+							{
+								Regions: []string{types.Wildcard},
+								Types:   []string{"ec2"},
+							},
+						},
+					},
+				)
+				require.NoError(t, err)
+				return dc
+			}(),
+			expected: func() *discoveryconfig.DiscoveryConfig {
+				dc, err := discoveryconfig.NewDiscoveryConfig(
+					header.Metadata{Name: "dc1"},
+					discoveryconfig.Spec{
+						DiscoveryGroup: "group1",
+						AWS: []types.AWSMatcher{
+							{
+								Regions: []string{types.Wildcard},
+								Types:   []string{"ec2"},
+							},
+						},
+					},
+				)
+				require.NoError(t, err)
+				return dc
+			}(),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.AddMetadataToContext(t.Context(), map[string]string{
+				metadata.VersionKey: tc.clientVersion,
+			})
+			downgraded, err := MaybeDowngradeDiscoveryConfig(ctx, tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, downgraded)
+		})
+	}
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -90,6 +90,7 @@ import (
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/trail"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -580,6 +581,13 @@ func WatchEvents(watch *authpb.Watch, stream WatchEvent, componentName string, a
 		}
 		if role, ok := event.Resource.(*types.RoleV6); ok {
 			downgraded, err := maybeDowngradeRole(stream.Context(), role)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			event.Resource = downgraded
+		}
+		if dc, ok := event.Resource.(*discoveryconfig.DiscoveryConfig); ok {
+			downgraded, err := discoveryconfigv1.MaybeDowngradeDiscoveryConfig(stream.Context(), dc)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/cloud/awsconfig/awsconfig.go
+++ b/lib/cloud/awsconfig/awsconfig.go
@@ -203,6 +203,17 @@ func (o *options) checkIntegrationCredentials() error {
 // when getting an AWS config.
 type OptionsFn func(*options)
 
+// AssumedRoles extracts the assumed roles from the provided options.
+// Only used in testing.
+func AssumedRoles(opts ...OptionsFn) []AssumeRole {
+	var options options
+	for _, optFn := range opts {
+		optFn(&options)
+	}
+
+	return options.assumeRoles
+}
+
 // WithAssumeRole configures options needed for assuming an AWS role.
 func WithAssumeRole(roleARN, externalID string) OptionsFn {
 	return func(options *options) {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1574,6 +1574,10 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 
 		for _, region := range matcher.Regions {
+			if region == types.Wildcard {
+				continue
+			}
+
 			if !awsregion.IsKnownRegion(region) {
 				const message = "AWS matcher uses unknown region" +
 					"This is either a typo or a new AWS region that is unknown to the AWS SDK used to compile this binary. "

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -4863,6 +4863,23 @@ func TestDiscoveryConfig(t *testing.T) {
 				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
 					{
 						"types":   []string{"ec2"},
+						"regions": []string{"invalid-region"},
+						"tags": cfgMap{
+							"discover_teleport": "yes",
+						},
+					},
+				}
+			},
+		},
+		{
+			desc:          "for EC2 discovery, region can be set to wildcard",
+			expectError:   require.NoError,
+			expectEnabled: require.True,
+			mutate: func(cfg cfgMap) {
+				cfg["discovery_service"].(cfgMap)["enabled"] = "yes"
+				cfg["discovery_service"].(cfgMap)["aws"] = []cfgMap{
+					{
+						"types":   []string{"ec2"},
 						"regions": []string{"*"},
 						"tags": cfgMap{
 							"discover_teleport": "yes",
@@ -4870,6 +4887,22 @@ func TestDiscoveryConfig(t *testing.T) {
 					},
 				}
 			},
+			expectedAWSMatchers: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"*"},
+				Tags: map[string]apiutils.Strings{
+					"discover_teleport": []string{"yes"},
+				},
+				Params: &types.InstallerParams{
+					JoinMethod:      types.JoinMethodIAM,
+					JoinToken:       "aws-discovery-iam-token",
+					SSHDConfig:      "/etc/ssh/sshd_config",
+					ScriptName:      "default-installer",
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				SSM: &types.AWSSSM{DocumentName: "TeleportDiscoveryInstaller"},
+			}},
 		},
 		{
 			desc:          "AWS section is filled with invalid join method",

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -128,6 +129,8 @@ type Config struct {
 
 	// GetEC2Client gets an AWS EC2 client for the given region.
 	GetEC2Client server.EC2ClientGetter
+	// GetAWSRegionsLister gets a client that is capable of listing AWS regions.
+	GetAWSRegionsLister server.RegionsListerGetter
 	// GetSSMClient gets an AWS SSM client for the given region.
 	GetSSMClient func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (server.SSMClient, error)
 	// IntegrationOnlyCredentials discards any Matcher that don't have an Integration.
@@ -280,6 +283,16 @@ kubernetes matchers are present.`)
 				return nil, trace.Wrap(err)
 			}
 			return ec2.NewFromConfig(cfg), nil
+		}
+	}
+	if c.GetAWSRegionsLister == nil {
+		c.GetAWSRegionsLister = func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+			region := "" // Account API is global, no region needed.
+			cfg, err := c.getAWSConfig(ctx, region, opts...)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return account.NewFromConfig(cfg), nil
 		}
 	}
 	if c.AWSFetchersClients == nil {
@@ -598,6 +611,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	s.staticServerAWSFetchers, err = server.MatchersToEC2InstanceFetchers(s.ctx, server.MatcherToEC2FetcherParams{
 		Matchers:              ec2Matchers,
 		EC2ClientGetter:       s.GetEC2Client,
+		RegionsListerGetter:   s.GetAWSRegionsLister,
 		PublicProxyAddrGetter: s.publicProxyAddress,
 	})
 	if err != nil {
@@ -722,6 +736,7 @@ func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []t
 	fetchers, err := server.MatchersToEC2InstanceFetchers(ctx, server.MatcherToEC2FetcherParams{
 		Matchers:              serverMatchers,
 		EC2ClientGetter:       s.GetEC2Client,
+		RegionsListerGetter:   s.GetAWSRegionsLister,
 		DiscoveryConfigName:   discoveryConfigName,
 		PublicProxyAddrGetter: s.publicProxyAddress,
 	})

--- a/lib/srv/discovery/fetchers/eks.go
+++ b/lib/srv/discovery/fetchers/eks.go
@@ -167,6 +167,10 @@ func MakeEKSFetchersFromAWSMatchers(logger *slog.Logger, clients AWSClientGetter
 			for _, region := range matcher.Regions {
 				switch t {
 				case types.AWSMatcherEKS:
+					if region == types.Wildcard {
+						logger.WarnContext(context.Background(), "EKS discovery does not support region discovery, remove the '*' from the regions field", "discovery_config", discoveryConfigName)
+						continue
+					}
 					fetcher, err := NewEKSFetcher(
 						EKSFetcherConfig{
 							ClientGetter:        clients,

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
+	accounttypes "github.com/aws/aws-sdk-go-v2/service/account/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/gravitational/trace"
@@ -198,6 +200,9 @@ func NewEC2Watcher(ctx context.Context, fetchersFn func() []Fetcher, missedRotat
 // EC2ClientGetter gets an AWS EC2 client for the given region.
 type EC2ClientGetter func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
 
+// RegionsListerGetter gets a list of AWS regions.
+type RegionsListerGetter func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error)
+
 // MatcherToEC2FetcherParams contains parameters for converting AWS EC2 Matchers
 // into AWS EC2 Fetchers.
 type MatcherToEC2FetcherParams struct {
@@ -205,6 +210,8 @@ type MatcherToEC2FetcherParams struct {
 	Matchers []types.AWSMatcher
 	// EC2ClientGetter gets an AWS EC2.
 	EC2ClientGetter EC2ClientGetter
+	// RegionsListerGetter gets a client that is capable of listing AWS regions.
+	RegionsListerGetter RegionsListerGetter
 	// DiscoveryConfigName is the name of the DiscoveryConfig that contains the matchers.
 	// Empty if using static matchers (coming from the `teleport.yaml`).
 	DiscoveryConfigName string
@@ -216,67 +223,29 @@ type MatcherToEC2FetcherParams struct {
 
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
 func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToEC2FetcherParams) ([]Fetcher, error) {
-	return matchersToEC2InstanceFetchers(matcherParams, func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
-		if matcher == nil {
-			return matcherParams.EC2ClientGetter(ctx, region, opts...)
-		}
-
-		newOpts := make([]awsconfig.OptionsFn, 0, len(opts)+1)
-		copy(newOpts, opts)
-
-		if matcher.AssumeRole != nil {
-			newOpts = append(newOpts, awsconfig.WithAssumeRole(matcher.AssumeRole.RoleARN, matcher.AssumeRole.ExternalID))
-		}
-
-		newOpts = append(newOpts, awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: matcher.Integration}))
-
-		return matcherParams.EC2ClientGetter(ctx, region, newOpts...)
-	})
-}
-
-// matcherEC2ClientGetter is an EC2 client getter that builds an EC2 client for the given matcher.
-// It includes the source of credentials (integration or ambient) and the assume role if any.
-// Region is not considered part of the identity because each matcher can have multiple regions.
-type matcherEC2ClientGetter func(ctx context.Context, region string, matcher *types.AWSMatcher, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error)
-
-func (g matcherEC2ClientGetter) withMatcher(matcher *types.AWSMatcher) EC2ClientGetter {
-	return func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
-		return g(ctx, region, matcher, opts...)
-	}
-}
-
-func matchersToEC2InstanceFetchers(matcherParams MatcherToEC2FetcherParams, getEC2Client matcherEC2ClientGetter) ([]Fetcher, error) {
 	ret := []Fetcher{}
 	for _, matcher := range matcherParams.Matchers {
-		for _, region := range matcher.Regions {
-			fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
-				ProxyPublicAddrGetter: matcherParams.PublicProxyAddrGetter,
-				Matcher:               matcher,
-				Region:                region,
-				Document:              matcher.SSM.DocumentName,
-				EC2ClientGetter:       getEC2Client.withMatcher(&matcher),
-				Labels:                matcher.Tags,
-				Integration:           matcher.Integration,
-				DiscoveryConfigName:   matcherParams.DiscoveryConfigName,
-			})
-			ret = append(ret, fetcher)
-		}
+		fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
+			Matcher:               matcher,
+			ProxyPublicAddrGetter: matcherParams.PublicProxyAddrGetter,
+			EC2ClientGetter:       matcherParams.EC2ClientGetter,
+			RegionsListerGetter:   matcherParams.RegionsListerGetter,
+			DiscoveryConfigName:   matcherParams.DiscoveryConfigName,
+		})
+		ret = append(ret, fetcher)
 	}
 	return ret, nil
 }
 
 type ec2FetcherConfig struct {
-	Matcher             types.AWSMatcher
-	Region              string
-	Document            string
-	EC2ClientGetter     EC2ClientGetter
-	Labels              types.Labels
-	Integration         string
-	DiscoveryConfigName string
+	Matcher types.AWSMatcher
 	// ProxyPublicAddrGetter returns the public proxy address to use for installation scripts.
 	// This is only used if the matcher does not specify a ProxyAddress.
 	// Example: proxy.example.com:3080 or proxy.example.com
 	ProxyPublicAddrGetter func(ctx context.Context) (string, error)
+	EC2ClientGetter       EC2ClientGetter
+	RegionsListerGetter   RegionsListerGetter
+	DiscoveryConfigName   string
 }
 
 type ec2InstanceFetcher struct {
@@ -349,8 +318,8 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		Values: []string{string(ec2types.InstanceStateNameRunning)},
 	}}
 
-	if _, ok := cfg.Labels["*"]; !ok {
-		for key, val := range cfg.Labels {
+	if _, ok := cfg.Matcher.Tags[types.Wildcard]; !ok {
+		for key, val := range cfg.Matcher.Tags {
 			tagFilters = append(tagFilters, ec2types.Filter{
 				Name:   aws.String("tag:" + key),
 				Values: val,
@@ -396,7 +365,7 @@ func ssmRunCommandParametersForCustomDocuments(cfg ec2FetcherConfig) map[string]
 }
 
 func ssmRunCommandParameters(ctx context.Context, cfg ec2FetcherConfig) (map[string]string, error) {
-	if cfg.Document == types.AWSSSMDocumentRunShellScript {
+	if cfg.Matcher.SSM.DocumentName == types.AWSSSMDocumentRunShellScript {
 		// When using the pre-defined SSM Document AWS-RunShellScript, only the commands parameter is required.
 		// It contains the full installation script that will be executed on the instance.
 		script, err := installerScript(ctx, cfg.Matcher.Params, withProxyAddrGetter(cfg.ProxyPublicAddrGetter))
@@ -420,14 +389,8 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []t
 		return nil, trace.Wrap(err)
 	}
 
-	insts := EC2Instances{
-		Region:              f.Region,
-		DocumentName:        f.Document,
-		Parameters:          ssmRunParams,
-		Rotation:            rotation,
-		Integration:         f.Integration,
-		DiscoveryConfigName: f.DiscoveryConfigName,
-	}
+	instancesByRegion := make(map[string]EC2Instances)
+
 	for _, node := range nodes {
 		// Heartbeating and expiration keeps Teleport Agents up to date, no need to consider those nodes.
 		// Agentless and EICE Nodes don't heartbeat, so they must be manually managed by the DiscoveryService.
@@ -435,7 +398,7 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []t
 			continue
 		}
 		region, ok := node.GetLabel(types.AWSInstanceRegion)
-		if !ok || region != f.Region {
+		if !ok {
 			continue
 		}
 		instID, ok := node.GetLabel(types.AWSInstanceIDLabel)
@@ -450,42 +413,94 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []t
 		if !f.cachedInstances.exists(accountID, instID) {
 			continue
 		}
-		if insts.AccountID == "" {
-			insts.AccountID = accountID
-		}
 
+		if _, ok := instancesByRegion[region]; !ok {
+			instancesByRegion[region] = EC2Instances{
+				Region:              region,
+				DocumentName:        f.Matcher.SSM.DocumentName,
+				Parameters:          ssmRunParams,
+				Rotation:            rotation,
+				Integration:         f.Matcher.Integration,
+				DiscoveryConfigName: f.DiscoveryConfigName,
+				AccountID:           accountID,
+			}
+		}
+		insts := instancesByRegion[region]
 		insts.Instances = append(insts.Instances, EC2Instance{
 			InstanceID: instID,
 		})
+
+		instancesByRegion[region] = insts
 	}
 
-	if len(insts.Instances) == 0 {
+	if len(instancesByRegion) == 0 {
 		return nil, trace.NotFound("no ec2 instances found")
 	}
 
-	return chunkInstances(insts), nil
+	return chunkInstances(instancesByRegion), nil
 }
 
-func chunkInstances(insts EC2Instances) []Instances {
+// chunkInstances splits instances into chunks of 50.
+// This is required because SSM SendCommand API calls only accept up to 50 instance IDs at a time.
+func chunkInstances(instancesByRegion map[string]EC2Instances) []Instances {
 	var instColl []Instances
-	for i := 0; i < len(insts.Instances); i += awsEC2APIChunkSize {
-		end := i + awsEC2APIChunkSize
-		if end > len(insts.Instances) {
-			end = len(insts.Instances)
+	for _, insts := range instancesByRegion {
+		for i := 0; i < len(insts.Instances); i += awsEC2APIChunkSize {
+			end := i + awsEC2APIChunkSize
+			if end > len(insts.Instances) {
+				end = len(insts.Instances)
+			}
+			inst := EC2Instances{
+				AccountID:           insts.AccountID,
+				Region:              insts.Region,
+				DocumentName:        insts.DocumentName,
+				Parameters:          insts.Parameters,
+				Instances:           insts.Instances[i:end],
+				Rotation:            insts.Rotation,
+				Integration:         insts.Integration,
+				DiscoveryConfigName: insts.DiscoveryConfigName,
+			}
+			instColl = append(instColl, Instances{EC2: &inst})
 		}
-		inst := EC2Instances{
-			AccountID:           insts.AccountID,
-			Region:              insts.Region,
-			DocumentName:        insts.DocumentName,
-			Parameters:          insts.Parameters,
-			Instances:           insts.Instances[i:end],
-			Rotation:            insts.Rotation,
-			Integration:         insts.Integration,
-			DiscoveryConfigName: insts.DiscoveryConfigName,
-		}
-		instColl = append(instColl, Instances{EC2: &inst})
 	}
 	return instColl
+}
+
+func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, awsOpts []awsconfig.OptionsFn) ([]string, error) {
+	if !f.Matcher.IsRegionWildcard() {
+		return f.Matcher.Regions, nil
+	}
+
+	regionsListerClient, err := f.RegionsListerGetter(ctx, awsOpts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	paginator := account.NewListRegionsPaginator(regionsListerClient, &account.ListRegionsInput{
+		RegionOptStatusContains: []accounttypes.RegionOptStatus{
+			accounttypes.RegionOptStatusEnabled,
+			accounttypes.RegionOptStatusEnabledByDefault,
+		},
+	})
+
+	var enabledRegions []string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			convertedErr := libcloudaws.ConvertRequestFailureError(err)
+			if trace.IsAccessDenied(convertedErr) {
+				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
+					"Add this permission to the IAM Role, or enumerate all the regions in the AWS matcher.")
+			}
+			return nil, convertedErr
+		}
+
+		for _, region := range page.Regions {
+			enabledRegions = append(enabledRegions, aws.ToString(region.RegionName))
+		}
+	}
+
+	return enabledRegions, nil
 }
 
 // GetInstances fetches all EC2 instances matching configured filters.
@@ -495,13 +510,47 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 		return nil, trace.Wrap(err)
 	}
 
-	ec2Client, err := f.EC2ClientGetter(ctx, f.Region)
+	f.cachedInstances.clear()
+	var allInstances []Instances
+
+	awsOpts := []awsconfig.OptionsFn{
+		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{Name: f.Matcher.Integration}),
+	}
+
+	if f.Matcher.AssumeRole != nil {
+		awsOpts = append(awsOpts, awsconfig.WithAssumeRole(f.Matcher.AssumeRole.RoleARN, f.Matcher.AssumeRole.ExternalID))
+	}
+
+	regions, err := f.matcherRegions(ctx, awsOpts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	for _, region := range regions {
+		regionInstances, err := f.getInstancesInRegion(ctx, rotation, region, awsOpts, ssmRunParams)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		allInstances = append(allInstances, regionInstances...)
+	}
+
+	if len(allInstances) == 0 {
+		return nil, trace.NotFound("no ec2 instances found")
+	}
+
+	return allInstances, nil
+}
+
+// getInstancesInRegion fetches all EC2 instances in a given region.
+func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, rotation bool, region string, awsOpts []awsconfig.OptionsFn, ssmRunParams map[string]string) ([]Instances, error) {
+	ec2Client, err := f.EC2ClientGetter(ctx, region, awsOpts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	var instances []Instances
-	f.cachedInstances.clear()
+
 	paginator := ec2.NewDescribeInstancesPaginator(ec2Client, &ec2.DescribeInstancesInput{
 		Filters: f.Filters,
 	})
@@ -521,12 +570,12 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 				ownerID := aws.ToString(res.OwnerId)
 				inst := EC2Instances{
 					AccountID:           ownerID,
-					Region:              f.Region,
-					DocumentName:        f.Document,
+					Region:              region,
+					DocumentName:        f.Matcher.SSM.DocumentName,
 					Instances:           ToEC2Instances(res.Instances[i:end]),
 					Parameters:          ssmRunParams,
 					Rotation:            rotation,
-					Integration:         f.Integration,
+					Integration:         f.Matcher.Integration,
 					AssumeRoleARN:       f.Matcher.AssumeRole.RoleARN,
 					ExternalID:          f.Matcher.AssumeRole.ExternalID,
 					DiscoveryConfigName: f.DiscoveryConfigName,
@@ -540,10 +589,6 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 		}
 	}
 
-	if len(instances) == 0 {
-		return nil, trace.NotFound("no ec2 instances found")
-	}
-
 	return instances, nil
 }
 
@@ -555,5 +600,5 @@ func (f *ec2InstanceFetcher) GetDiscoveryConfigName() string {
 // IntegrationName identifies the integration name whose credentials were used to fetch the resources.
 // Might be empty when the fetcher is using ambient credentials.
 func (f *ec2InstanceFetcher) IntegrationName() string {
-	return f.Integration
+	return f.Matcher.Integration
 }


### PR DESCRIPTION
Backport #61337 to v18

changelog: Added support for discovering EC2 instances in all regions, without enumerating them. Requires access to `account.ListRegions` in the IAM Role assumed by the Discovery Service.