### PR TITLE
fix User trait label style

### DIFF
--- a/web/packages/teleport/src/Users/UserDetails/UserTraits.tsx
+++ b/web/packages/teleport/src/Users/UserDetails/UserTraits.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import styled from 'styled-components';
+
 import { Button, Flex, Label, Text } from 'design';
 import * as Icons from 'design/Icon';
 
@@ -58,9 +60,9 @@ export function UserTraits({ user, onEdit }: UserDetailsSectionProps) {
         ) : (
           <Flex flexWrap="wrap" gap={2}>
             {traitsWithValues.map(key => (
-              <Label key={key} kind="secondary">
+              <StyledLabel key={key} kind="secondary">
                 {key}: {user.allTraits[key].join(', ')}
-              </Label>
+              </StyledLabel>
             ))}
           </Flex>
         )}
@@ -68,3 +70,9 @@ export function UserTraits({ user, onEdit }: UserDetailsSectionProps) {
     </>
   );
 }
+
+// border-radius matches label height (10px font-size + 2px margin)
+// otherwise, a label with many traits will look like an egg
+const StyledLabel = styled(Label)`
+  border-radius: 12px;
+`;


### PR DESCRIPTION
## Problem

user traits are rendered inside a Label, which ends up looking like a big egg when content spans multiple lines

this PR sets the border-radius from 999px to 12px to match the height of a single line label

### before

<img width="963" height="923" alt="Screenshot 2025-12-02 at 9 14 26 AM" src="https://github.com/user-attachments/assets/f4f4bbe5-8524-4baa-aa72-611ddc39d5d5" />

### after
<img width="963" height="923" alt="Screenshot 2025-12-02 at 9 14 51 AM" src="https://github.com/user-attachments/assets/c65c2b81-c7e3-4cde-85c1-0fb52b9d6415" />

_border radius matches normal label's height_

<img width="963" height="923" alt="Screenshot 2025-12-02 at 9 15 08 AM" src="https://github.com/user-attachments/assets/7609164e-259f-4149-a408-9c2e8bd70237" />

_matches other labels roundness_

### future work

look at alternatives to Labels to present user traits