### PR TITLE
tctl resource: convert CA handler

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -44,7 +44,6 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/devicetrust"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/common"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
@@ -76,43 +75,6 @@ func printMetadataLabels(labels map[string]string) string {
 		pairs = append(pairs, fmt.Sprintf("%v=%v", key, value))
 	}
 	return strings.Join(pairs, ",")
-}
-
-type authorityCollection struct {
-	cas []types.CertAuthority
-}
-
-func (a *authorityCollection) Resources() (r []types.Resource) {
-	for _, resource := range a.cas {
-		r = append(r, resource)
-	}
-	return r
-}
-
-func (a *authorityCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
-	for _, a := range a.cas {
-		for _, key := range a.GetTrustedSSHKeyPairs() {
-			fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
-			if err != nil {
-				fingerprint = fmt.Sprintf("<bad key: %v>", err)
-			}
-			var roles string
-			if a.GetType() == types.HostCA {
-				roles = "N/A"
-			} else {
-				roles = fmt.Sprintf("%v", a.CombinedMapping())
-			}
-			t.AddRow([]string{
-				a.GetClusterName(),
-				string(a.GetType()),
-				fingerprint,
-				roles,
-			})
-		}
-	}
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
 }
 
 type reverseTunnelCollection struct {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"math"
 	"os"
 	"reflect"
@@ -121,7 +120,6 @@ Same as above, but using JSON output:
 func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
 	rc.CreateHandlers = map[string]ResourceCreateHandler{
 		types.KindTrustedCluster:              rc.createTrustedCluster,
-		types.KindCertAuthority:               rc.createCertAuthority,
 		types.KindClusterMaintenanceConfig:    rc.createClusterMaintenanceConfig,
 		types.KindExternalAuditStorage:        rc.createExternalAuditStorage,
 		types.KindNetworkRestrictions:         rc.createNetworkRestrictions,
@@ -441,19 +439,6 @@ func (rc *ResourceCommand) createTrustedCluster(ctx context.Context, client *aut
 		fmt.Printf("WARNING: trusted cluster resource %q has been renamed to match root cluster name %q. this will become an error in future teleport versions, please update your configuration to use the correct name.\n", name, out.GetName())
 	}
 	fmt.Printf("trusted cluster %q has been %v\n", out.GetName(), UpsertVerb(exists, rc.force))
-	return nil
-}
-
-// createCertAuthority creates certificate authority
-func (rc *ResourceCommand) createCertAuthority(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
-	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := client.UpsertCertAuthority(ctx, certAuthority); err != nil {
-		return trace.Wrap(err)
-	}
-	fmt.Printf("certificate authority %q has been updated\n", certAuthority.GetName())
 	return nil
 }
 
@@ -920,21 +905,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("crown_jewel %q has been deleted\n", rc.ref.Name)
-	case types.KindCertAuthority:
-		if rc.ref.SubKind == "" || rc.ref.Name == "" {
-			return trace.BadParameter(
-				"full %s path must be specified (e.g. '%s/%s/clustername')",
-				types.KindCertAuthority, types.KindCertAuthority, types.HostCA,
-			)
-		}
-		err := client.DeleteCertAuthority(ctx, types.CertAuthID{
-			Type:       types.CertAuthType(rc.ref.SubKind),
-			DomainName: rc.ref.Name,
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("%s '%s/%s' has been deleted\n", types.KindCertAuthority, rc.ref.SubKind, rc.ref.Name)
 	case types.KindKubeServer:
 		servers, err := client.GetKubernetesServers(ctx)
 		if err != nil {
@@ -1138,30 +1108,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 
 		return &reverseTunnelCollection{tunnels: tunnels}, nil
-	case types.KindCertAuthority:
-		getAll := rc.ref.SubKind == "" && rc.ref.Name == ""
-		if getAll {
-			var allAuthorities []types.CertAuthority
-			for _, caType := range types.CertAuthTypes {
-				authorities, err := client.GetCertAuthorities(ctx, caType, rc.withSecrets)
-				if err != nil {
-					if trace.IsBadParameter(err) {
-						slog.WarnContext(ctx, "failed to get certificate authority; skipping", "error", err)
-						continue
-					}
-					return nil, trace.Wrap(err)
-				}
-				allAuthorities = append(allAuthorities, authorities...)
-			}
-			return &authorityCollection{cas: allAuthorities}, nil
-		}
-
-		id := types.CertAuthID{Type: types.CertAuthType(rc.ref.SubKind), DomainName: rc.ref.Name}
-		authority, err := client.GetCertAuthority(ctx, id, rc.withSecrets)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		return &authorityCollection{cas: []types.CertAuthority{authority}}, nil
 	case types.KindTrustedCluster:
 		if rc.ref.Name == "" {
 			// TODO(okraport): DELETE IN v21.0.0, replace with regular Collect

--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -1,0 +1,137 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/sshutils"
+)
+
+type certAuthorityCollection struct {
+	cas []types.CertAuthority
+}
+
+func (a *certAuthorityCollection) Resources() (r []types.Resource) {
+	for _, resource := range a.cas {
+		r = append(r, resource)
+	}
+	return r
+}
+
+func (a *certAuthorityCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
+	for _, a := range a.cas {
+		for _, key := range a.GetTrustedSSHKeyPairs() {
+			fingerprint, err := sshutils.AuthorizedKeyFingerprint(key.PublicKey)
+			if err != nil {
+				fingerprint = fmt.Sprintf("<bad key: %v>", err)
+			}
+			var roles string
+			if a.GetType() == types.HostCA {
+				roles = "N/A"
+			} else {
+				roles = fmt.Sprintf("%v", a.CombinedMapping())
+			}
+			t.AddRow([]string{
+				a.GetClusterName(),
+				string(a.GetType()),
+				fingerprint,
+				roles,
+			})
+		}
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func certAuthorityHandler() Handler {
+	return Handler{
+		getHandler:    getCertAuthority,
+		deleteHandler: deleteCertAuthority,
+		createHandler: createCertAuthority,
+		singleton:     false,
+		mfaRequired:   true,
+		description:   "CA used by Teleport to sign certificates or access tokens. Each CA has a specific purpose.",
+	}
+}
+func getCertAuthority(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	getAll := ref.SubKind == "" && ref.Name == ""
+	if getAll {
+		var allAuthorities []types.CertAuthority
+		for _, caType := range types.CertAuthTypes {
+			authorities, err := client.GetCertAuthorities(ctx, caType, opts.WithSecrets)
+			if err != nil {
+				if trace.IsBadParameter(err) {
+					slog.WarnContext(ctx, "failed to get certificate authority; skipping", "error", err)
+					continue
+				}
+				return nil, trace.Wrap(err)
+			}
+			allAuthorities = append(allAuthorities, authorities...)
+		}
+		return &certAuthorityCollection{cas: allAuthorities}, nil
+	}
+
+	id := types.CertAuthID{Type: types.CertAuthType(ref.SubKind), DomainName: ref.Name}
+	authority, err := client.GetCertAuthority(ctx, id, opts.WithSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &certAuthorityCollection{cas: []types.CertAuthority{authority}}, nil
+}
+
+func createCertAuthority(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	certAuthority, err := services.UnmarshalCertAuthority(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := client.UpsertCertAuthority(ctx, certAuthority); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("certificate authority %q has been updated\n", certAuthority.GetName())
+	return nil
+}
+
+func deleteCertAuthority(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if ref.SubKind == "" || ref.Name == "" {
+		return trace.BadParameter(
+			"full %s path must be specified (e.g. '%s/%s/clustername')",
+			types.KindCertAuthority, types.KindCertAuthority, types.HostCA,
+		)
+	}
+	err := client.DeleteCertAuthority(ctx, types.CertAuthID{
+		Type:       types.CertAuthType(ref.SubKind),
+		DomainName: ref.Name,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("%s '%s/%s' has been deleted\n", types.KindCertAuthority, ref.SubKind, ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -47,6 +47,7 @@ func Handlers() map[string]Handler {
 		types.KindAutoUpdateVersion:                  autoUpdateVersionHandler(),
 		types.KindBot:                                botHandler(),
 		types.KindBotInstance:                        botInstanceHandler(),
+		types.KindCertAuthority:                      certAuthorityHandler(),
 		types.KindClusterAuthPreference:              authPreferenceHandler(),
 		types.KindClusterNetworkingConfig:            networkingConfigHandler(),
 		types.KindConnectors:                         connectorsHandler(),


### PR DESCRIPTION
Part of: https://github.com/gravitational/teleport/issues/60370

This PR converts the `cert_authority` resource to the new tctl resource handler format: