### PR TITLE
chore: Bump Go to v1.25.5

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/charlievieth/strcase v0.0.5

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -1,6 +1,6 @@
 module github.com/teleport/assets/backport
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/google/go-github/v41 v41.0.0

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.25.4
+go 1.25.5
 
 require (
 	buf.build/go/bufplugin v0.9.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -2,7 +2,7 @@
 # This file can be included in other Makefiles to avoid duplication.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.25.4
+GOLANG_VERSION ?= go1.25.5
 GOLANGCI_LINT_VERSION ?= v2.4.0
 
 # NOTE: Remember to update engines.node in package.json to match the major version.

--- a/examples/access-plugin-minimal/go.mod
+++ b/examples/access-plugin-minimal/go.mod
@@ -1,6 +1,6 @@
 module teleport-sheets
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20251120161518-a8e2cdc30b24

--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20251120161518-a8e2cdc30b24

--- a/examples/desktop-registration/go.mod
+++ b/examples/desktop-registration/go.mod
@@ -1,6 +1,6 @@
 module teleport-desktop-registration
 
-go 1.25.4
+go 1.25.5
 
 require github.com/gravitational/teleport/api v0.0.0-20251120161518-a8e2cdc30b24
 

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,6 @@
 module go-client
 
-go 1.25.4
+go 1.25.5
 
 require github.com/gravitational/teleport/api v0.0.0-20251120161518-a8e2cdc30b24
 

--- a/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
+++ b/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
@@ -1,6 +1,6 @@
 module verify-teleport-jwt-mcp-go
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0

--- a/examples/service-discovery-api-client/go.mod
+++ b/examples/service-discovery-api-client/go.mod
@@ -1,6 +1,6 @@
 module register-app-service
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport
 
-go 1.25.4
+go 1.25.5
 
 ignore (
 	./build

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/alecthomas/kong v1.13.0

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform-mwi
 
-go 1.25.4
+go 1.25.5
 
 require (
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.25.4
+go 1.25.5
 
 // TF provider dependencies
 require (


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.25.5

Changelog: Updated Go to 1.25.5