### PR TITLE
Reduce usage of go-cmp outside of tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,6 @@ linters:
             - '!**lib/services/compare.go'
             - '!**/lib/services/local/access_list.go'
             - '!**/lib/services/local/users.go'
-            - '!**/lib/services/server.go'
             - '!**/lib/services/user.go'
           deny:
             - pkg: github.com/google/go-cmp/cmp

--- a/api/types/app.go
+++ b/api/types/app.go
@@ -106,6 +106,8 @@ type Application interface {
 	GetIdentityCenter() *AppIdentityCenter
 	// GetMCP fetches MCP specific configuration.
 	GetMCP() *MCP
+	// IsEqual determines if two application resources are equivalent to one another.
+	IsEqual(Application) bool
 }
 
 // NewAppV3 creates a new app resource.

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -154,6 +154,8 @@ type Database interface {
 	// IsAutoUsersEnabled returns true if the database has auto user
 	// provisioning enabled.
 	IsAutoUsersEnabled() bool
+	// IsEqual determines if two database resources are equivalent to one another.
+	IsEqual(Database) bool
 }
 
 // NewDatabaseV3 creates a new database resource.

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -79,6 +79,8 @@ type KubeCluster interface {
 	// GetCloud gets the cloud this kube cluster is running on, or an empty string if it
 	// isn't running on a cloud provider.
 	GetCloud() string
+	// IsEqual determines if two Kubernetes cluster resources are equivalent.
+	IsEqual(KubeCluster) bool
 }
 
 // DiscoveredEKSCluster represents a server discovered by EKS discovery fetchers.
@@ -398,7 +400,7 @@ func (k *KubernetesClusterV3) CheckAndSetDefaults() error {
 	return nil
 }
 
-// IsEqual determines if two user resources are equivalent to one another.
+// IsEqual determines if two Kubernetes cluster resources are equivalent.
 func (k *KubernetesClusterV3) IsEqual(i KubeCluster) bool {
 	if other, ok := i.(*KubernetesClusterV3); ok {
 		return deriveTeleportEqualKubernetesClusterV3(k, other)

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -25,7 +25,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -136,9 +135,21 @@ func compareServers(a, b types.Server) int {
 		return Different
 	}
 
-	if !cmp.Equal(a.GetGitHub(), b.GetGitHub()) {
+	if (a.GetGitHub() == nil && b.GetGitHub() != nil) ||
+		(a.GetGitHub() != nil && b.GetGitHub() == nil) {
 		return Different
 	}
+
+	if a.GetGitHub() != nil && b.GetGitHub() != nil {
+		if a.GetGitHub().Integration != b.GetGitHub().Integration {
+			return Different
+		}
+
+		if a.GetGitHub().Organization != b.GetGitHub().Organization {
+			return Different
+		}
+	}
+
 	if a.GetScope() != b.GetScope() {
 		return Different
 	}
@@ -166,7 +177,7 @@ func compareApplicationServers(a, b types.AppServer) int {
 	if !r.Matches(b.GetRotation()) {
 		return Different
 	}
-	if !cmp.Equal(a.GetApp(), b.GetApp()) {
+	if !a.GetApp().IsEqual(b.GetApp()) {
 		return Different
 	}
 	if !slices.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {
@@ -231,7 +242,7 @@ func compareKubernetesServers(a, b types.KubeServer) int {
 	if !r.Matches(b.GetRotation()) {
 		return Different
 	}
-	if !cmp.Equal(a.GetCluster(), b.GetCluster()) {
+	if !a.GetCluster().IsEqual(b.GetCluster()) {
 		return Different
 	}
 	if !slices.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {
@@ -270,7 +281,7 @@ func compareDatabaseServers(a, b types.DatabaseServer) int {
 	if !r.Matches(b.GetRotation()) {
 		return Different
 	}
-	if !cmp.Equal(a.GetDatabase(), b.GetDatabase()) {
+	if !a.GetDatabase().IsEqual(b.GetDatabase()) {
 		return Different
 	}
 	if !slices.Equal(a.GetProxyIDs(), b.GetProxyIDs()) {

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -71,6 +71,7 @@ func TestHeartbeatKeepAlive(t *testing.T) {
 						Name:      "1",
 					},
 					Spec: types.AppServerSpecV3{
+						App:      &types.AppV3{},
 						Hostname: "2",
 					},
 				}


### PR DESCRIPTION
Replaces direct calls to cmp.Equal with IsEqual or hand rolled comparisons in services.compareServers.

Adding the IsEqual method to the resource interfaces also allows services.CompareResources to prefer it over calls to cmp.Equal.