### PR TITLE
Remove unsafe type assertion in MySQL health check

### DIFF
--- a/lib/srv/db/mysql/connector.go
+++ b/lib/srv/db/mysql/connector.go
@@ -251,10 +251,6 @@ func (rc *recorderConn) Read(p []byte) (int, error) {
 	return io.MultiReader(rc.recordingReader, rc.Conn).Read(p)
 }
 
-func (rc *recorderConn) WriteTo(w io.Writer) (sum int64, err error) {
-	return io.MultiReader(rc.recordingReader, rc.Conn).(io.WriterTo).WriteTo(w)
-}
-
 func (rc *recorderConn) reset() {
 	const bufferSizeLimit = 1 << 20 // 1MB
 	rc.buf.Reset()


### PR DESCRIPTION
io.MultiReader implements io.WriterTo but does not document that. The connection recorder used for MySQL health checks does not need to implement io.WriterTo anyway, so this change removes the implementation and io.WriterTo type assertion.

[This was caught in review](https://github.com/gravitational/teleport/pull/61942#discussion_r2583408619) for the MySQL healthcheck v18 backport, so this PR doesn't need to be backported separately.
- https://github.com/gravitational/teleport/pull/61942