### PR TITLE
EC2 Auto Discover: add new permission `account:ListRegions` which allows region discovery

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -141,6 +141,7 @@ func StatementForEC2SSMAutoDiscover() *Statement {
 	return &Statement{
 		Effect: EffectAllow,
 		Actions: []string{
+			"account:ListRegions",
 			"ec2:DescribeInstances",
 			"ssm:DescribeInstanceInformation",
 			"ssm:GetCommandInvocation",

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -497,6 +497,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 				{
 					Effect: "Allow",
 					Actions: []string{
+						"account:ListRegions",
 						"ec2:DescribeInstances",
 						"ssm:DescribeInstanceInformation",
 						"ssm:GetCommandInvocation",

--- a/lib/integrations/awsoidc/ec2_ssm_iam_config.go
+++ b/lib/integrations/awsoidc/ec2_ssm_iam_config.go
@@ -150,6 +150,9 @@ func NewEC2SSMConfigureClient(ctx context.Context, region string) (EC2SSMConfigu
 // ConfigureEC2SSM creates the required resources in AWS to enable EC2 Auto Discover using script mode..
 // It creates an inline policy with the following permissions:
 //
+// Action: List AWS Regions.
+//   - account:ListRegions
+//
 // Action: List EC2 instances where teleport is going to be installed.
 //   - ec2:DescribeInstances
 //

--- a/lib/integrations/awsoidc/testdata/TestEC2SSMIAMConfigOutput.golden
+++ b/lib/integrations/awsoidc/testdata/TestEC2SSMIAMConfigOutput.golden
@@ -8,6 +8,7 @@ PutRolePolicy: {
             {
                 "Effect": "Allow",
                 "Action": [
+                    "account:ListRegions",
                     "ec2:DescribeInstances",
                     "ssm:DescribeInstanceInformation",
                     "ssm:GetCommandInvocation",

--- a/lib/usertasks/descriptions/ec2-ssm-invocation-failure.md
+++ b/lib/usertasks/descriptions/ec2-ssm-invocation-failure.md
@@ -8,6 +8,7 @@ Usually this happens when:
 
 The IAM Role used by the integration might be missing some required permissions.
 Ensure the following actions are allowed in the IAM Role used by the integration:
+- `account:ListRegions`
 - `ec2:DescribeInstances`
 - `ssm:DescribeInstanceInformation`
 - `ssm:GetCommandInvocation`

--- a/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
+++ b/web/packages/teleport/src/Discover/Server/DiscoveryConfigSsm/DiscoveryConfigSsm.tsx
@@ -420,6 +420,7 @@ const inlinePolicyJson = `{
       {
           "Effect": "Allow",
           "Action": [
+              "account:ListRegions",
               "ec2:DescribeInstances",
               "ssm:DescribeInstanceInformation",
               "ssm:GetCommandInvocation",

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -36,7 +36,7 @@ test('renders ec2 impacts', async () => {
     issueType: 'ec2-ssm-invocation-failure',
     title: 'ec2 ssm invocation failure',
     description:
-      'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+      'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `account:ListRegions`\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
     discoverEks: undefined,
     discoverRds: undefined,
     discoverEc2: {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -138,6 +138,7 @@ Usually this happens when:
 
 The IAM Role used by the integration might be missing some required permissions.
 Ensure the following actions are allowed in the IAM Role used by the integration:
+- \`account:ListRegions\`
 - \`ec2:DescribeInstances\`
 - \`ssm:DescribeInstanceInformation\`
 - \`ssm:GetCommandInvocation\`
@@ -246,7 +247,7 @@ const ec2Detail = {
   issueType: 'ec2-ssm-invocation-failure',
   title: 'EC2 failure',
   description:
-    'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+    'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `account:ListRegions`\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
   discoverEc2: {
     region: 'us-east-2',
     instances: {


### PR DESCRIPTION
This PR adds the new permission to all the set up scripts.
This new permission allows users to discover EC2 instances in all regions without requiring users to enumerate all of them.

Follow up of https://github.com/gravitational/teleport/pull/61337