### PR TITLE
[v18] fix: Bump the "grpcbox" Go version

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.10
+FROM docker.io/golang:1.24.11
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \


### PR DESCRIPTION
Missed in the Go version update earlier today.