### PR TITLE
Reduce allocations in app server watcher

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -59,6 +59,8 @@ type Application interface {
 	SetURI(string)
 	// GetPublicAddr returns the app public address.
 	GetPublicAddr() string
+	// SetPublicAddr sets the app public address.
+	SetPublicAddr(s string)
 	// GetInsecureSkipVerify returns the app insecure setting.
 	GetInsecureSkipVerify() bool
 	// GetRewrite returns the app rewrite configuration.
@@ -249,6 +251,11 @@ func (a *AppV3) SetURI(uri string) {
 // GetPublicAddr returns the app public address.
 func (a *AppV3) GetPublicAddr() string {
 	return a.Spec.PublicAddr
+}
+
+// SetPublicAddr sets the app public address.
+func (a *AppV3) SetPublicAddr(addr string) {
+	a.Spec.PublicAddr = addr
 }
 
 // GetInsecureSkipVerify returns the app insecure setting.


### PR DESCRIPTION
The slice of resources received from the watcher contains a copy of all the items known by the watcher. The app server then cloned each app via types.Application.Copy to get a handle to a types.AppV3 so that the public address could be set if it was empty. The cloned apps are then added to a _new_ slice which is provided to the reconciler.

To reduce memory consumption, types.Application.SetPublicAddr was added to make it possible to set the address without copying an app. The slice from the resource watcher is now reused instead of allocating a new slice for the amended applications.

changelog: Reduced memory consumption of the Application service.