### PR TITLE
docs: Update code block formatting for SELinux installation

### DIFF
--- a/docs/pages/zero-trust-access/management/security/selinux.mdx
+++ b/docs/pages/zero-trust-access/management/security/selinux.mdx
@@ -34,7 +34,7 @@ The SELinux policy module for Teleport SSH Service is officially supported on Re
 
 Before installing the SELinux module ensure that the `selinux-policy-devel` package is installed:
 
-```
+```code
 $ sudo dnf install selinux-policy-devel
 ```
 


### PR DESCRIPTION
Not having the code blocking includes the `$` when you use the copy.