### PR TITLE
Add cluster alert for low audit log disk space

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2413,12 +2413,6 @@ func (a *Server) SetEmitter(emitter apievents.Emitter) {
 	a.emitter = emitter
 }
 
-// SetStreamer sets the current audit event streamer. Note that this is only
-// safe to use before main server start.
-func (a *Server) SetStreamer(streamer events.Streamer) {
-	a.Streamer = streamer
-}
-
 // EmitAuditEvent implements [apievents.Emitter] by delegating to its dedicated
 // emitter rather than falling back to the implementation from [Services] (using
 // the audit log directly, which is almost never what you want).

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2413,6 +2413,12 @@ func (a *Server) SetEmitter(emitter apievents.Emitter) {
 	a.emitter = emitter
 }
 
+// SetStreamer sets the current audit event streamer. Note that this is only
+// safe to use before main server start.
+func (a *Server) SetStreamer(streamer events.Streamer) {
+	a.Streamer = streamer
+}
+
 // EmitAuditEvent implements [apievents.Emitter] by delegating to its dedicated
 // emitter rather than falling back to the implementation from [Services] (using
 // the audit log directly, which is almost never what you want).

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -867,7 +867,11 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 
 func roleSpecForProxyWithRecordAtProxy(clusterName string) types.RoleSpecV6 {
 	base := roleSpecForProxy(clusterName)
-	base.Allow.Rules = append(base.Allow.Rules, types.NewRule(types.KindHostCert, services.RW()))
+	base.Allow.Rules = append(
+		base.Allow.Rules,
+		types.NewRule(types.KindHostCert, services.RW()),
+		types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
+	)
 	return base
 }
 
@@ -1039,6 +1043,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						// access decisions for the given node specifically. this verb grant will need to
 						// be revisited as part of that work.
 						types.NewRule(scopedaccess.KindScopedRole, services.RO()),
+						types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
 					},
 				},
 			})
@@ -1068,6 +1073,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindApp, services.RO()),
 						types.NewRule(types.KindJWT, services.RW()),
 						types.NewRule(types.KindLock, services.RO()),
+						types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
 					},
 				},
 			})
@@ -1102,6 +1108,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindDatabaseObjectImportRule, services.RO()),
 						types.NewRule(types.KindDatabaseObject, services.RW()),
 						types.NewRule(types.KindHealthCheckConfig, services.RO()),
+						types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
 					},
 				},
 			})
@@ -1226,6 +1233,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindKubernetesCluster, services.RO()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindHealthCheckConfig, services.RO()),
+						types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
 					},
 				},
 			})
@@ -1251,6 +1259,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindWindowsDesktopService, services.RW()),
 						types.NewRule(types.KindWindowsDesktop, services.RW()),
 						types.NewRule(types.KindDynamicWindowsDesktop, services.RW()),
+						types.NewRule(types.KindClusterAlert, []string{types.VerbCreate, types.VerbUpdate}),
 					},
 				},
 			})

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"io/fs"
 	"iter"
@@ -40,7 +39,6 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
 	"github.com/gravitational/teleport/api/internalutils/stream"
-	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/recordingmetadata"
 	"github.com/gravitational/teleport/lib/auth/summarizer"
@@ -215,11 +213,6 @@ type AuditLog struct {
 	decrypter DecryptionWrapper
 }
 
-// AlertHandler handles creating cluster alerts.
-type AlertHandler interface {
-	UpsertClusterAlert(ctx context.Context, alert types.ClusterAlert) error
-}
-
 // AuditLogConfig specifies configuration for AuditLog server
 type AuditLogConfig struct {
 	// DataDir is the directory where audit log stores the data
@@ -270,8 +263,6 @@ type AuditLogConfig struct {
 	SessionSummarizerProvider *summarizer.SessionSummarizerProvider
 	// RecordingMetadataProvider provides recording metadata service
 	RecordingMetadataProvider *recordingmetadata.Provider
-	// AlertHandler handles creating cluster alerts.
-	AlertHandler AlertHandler
 }
 
 // CheckAndSetDefaults checks and sets defaults
@@ -811,26 +802,6 @@ func (l *AuditLog) periodicSpaceMonitor() {
 			// If used percentage goes above the alerting level, write to logs as well.
 			if usedPercent > float64(DiskAlertThreshold) {
 				l.log.WarnContext(l.ctx, "Free disk space for audit log is running low", "percentage_used", usedPercent)
-				if l.AlertHandler != nil {
-					alert, err := types.NewClusterAlert(
-						"audit-log-disk-usage",
-						fmt.Sprintf(
-							"Available disk space for audit logs on auth server is running low (%.2f%% remaining). "+
-								"Increase disk space or clean up old logs to avoid service disruption.",
-							100-usedPercent,
-						),
-						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindInstance, types.VerbRead)),
-						types.WithAlertLabel(types.AlertOnLogin, "yes"),
-						types.WithAlertExpires(l.Clock.Now().Add(DiskAlertInterval)),
-					)
-					if err != nil {
-						l.log.WarnContext(l.ctx, "Error creating disk usage alert", "error", err)
-						continue
-					}
-					if err := l.AlertHandler.UpsertClusterAlert(l.ctx, alert); err != nil {
-						l.log.WarnContext(l.ctx, "Error upserting cluster alert", "error", err)
-					}
-				}
 			}
 		case <-l.ctx.Done():
 			return

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -814,7 +814,7 @@ func (l *AuditLog) periodicSpaceMonitor() {
 				if l.AlertHandler != nil {
 					alert, err := types.NewClusterAlert(
 						"audit-log-disk-usage/"+l.ServerID,
-						fmt.Sprintf("Free disk space for audit log is running low on node %q.", l.ServerID),
+						"Free disk space for audit log is running low.",
 						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindNode, types.VerbRead)),
 						types.WithAlertLabel(types.AlertOnLogin, "yes"),
 						types.WithAlertExpires(l.Clock.Now().Add(DiskAlertInterval)),

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -813,7 +813,7 @@ func (l *AuditLog) periodicSpaceMonitor() {
 				l.log.WarnContext(l.ctx, "Free disk space for audit log is running low", "percentage_used", usedPercent)
 				if l.AlertHandler != nil {
 					alert, err := types.NewClusterAlert(
-						"audit-log-disk-usage/"+l.ServerID,
+						"audit-log-disk-usage",
 						"Free disk space for audit log is running low.",
 						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindNode, types.VerbRead)),
 						types.WithAlertLabel(types.AlertOnLogin, "yes"),

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -815,7 +815,7 @@ func (l *AuditLog) periodicSpaceMonitor() {
 					alert, err := types.NewClusterAlert(
 						"audit-log-disk-usage",
 						"Free disk space for audit log is running low.",
-						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindNode, types.VerbRead)),
+						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindInstance, types.VerbRead)),
 						types.WithAlertLabel(types.AlertOnLogin, "yes"),
 						types.WithAlertExpires(l.Clock.Now().Add(DiskAlertInterval)),
 					)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -104,7 +104,7 @@ const (
 	DiskAlertThreshold = 90
 
 	// DiskAlertInterval is disk space check interval.
-	DiskAlertInterval = 5 * time.Minute
+	DiskAlertInterval = 30 * time.Minute
 
 	// InactivityFlushPeriod is a period of inactivity
 	// that triggers upload of the data - flush.
@@ -814,7 +814,11 @@ func (l *AuditLog) periodicSpaceMonitor() {
 				if l.AlertHandler != nil {
 					alert, err := types.NewClusterAlert(
 						"audit-log-disk-usage",
-						"Free disk space for audit log is running low.",
+						fmt.Sprintf(
+							"Available disk space for audit logs on auth server is running low (%.2f%% remaining). "+
+								"Increase disk space or clean up old logs to avoid service disruption.",
+							100-usedPercent,
+						),
 						types.WithAlertLabel(types.AlertVerbPermit, fmt.Sprintf("%s:%s", types.KindInstance, types.VerbRead)),
 						types.WithAlertLabel(types.AlertOnLogin, "yes"),
 						types.WithAlertExpires(l.Clock.Now().Add(DiskAlertInterval)),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2342,6 +2342,7 @@ func (process *TeleportProcess) initAuthService() error {
 			Decrypter:                 encryptedIO,
 			SessionSummarizerProvider: sessionSummarizerProvider,
 			RecordingMetadataProvider: recordingMetadataProvider,
+			AlertHandler:              local.NewStatusService(b),
 		}
 		auditServiceConfig.UID, auditServiceConfig.GID, err = adminCreds()
 		if err != nil {
@@ -2464,9 +2465,6 @@ func (process *TeleportProcess) initAuthService() error {
 		})
 	if err != nil {
 		return trace.Wrap(err)
-	}
-	if localLog, ok := process.auditLog.(*events.AuditLog); ok {
-		localLog.AlertHandler = authServer
 	}
 	authServer.EncryptedIO = encryptedIO
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2465,6 +2465,9 @@ func (process *TeleportProcess) initAuthService() error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	if localLog, ok := process.auditLog.(*events.AuditLog); ok {
+		localLog.AlertHandler = authServer
+	}
 	authServer.EncryptedIO = encryptedIO
 
 	lockWatcher, err := services.NewLockWatcher(process.ExitContext(), services.LockWatcherConfig{

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3759,6 +3759,7 @@ func (process *TeleportProcess) initUploaderService() error {
 		events.Streamer
 		events.AuditLogSessionStreamer
 		services.SessionTrackerService
+		events.AlertHandler
 	}
 
 	// use the local auth server for uploads if auth happens to be
@@ -3832,6 +3833,10 @@ func (process *TeleportProcess) initUploaderService() error {
 
 	uploadsDir := filepath.Join(paths[0]...)
 	corruptedDir := filepath.Join(paths[1]...)
+	hostUUID, err := process.storage.ReadOrGenerateHostID(process.ExitContext(), process.Config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
 		Streamer:                        uploaderClient,
@@ -3841,6 +3846,8 @@ func (process *TeleportProcess) initUploaderService() error {
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,
 		EncryptedRecordingUploadMaxSize: encryptedRecordingMaxUploadSize,
+		ServerID:                        hostUUID,
+		AlertHandler:                    uploaderClient,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This change adds a cluster alert for when the local audit log is running out of disk space.

Resolves #60973.

Changelog: Added alert for when the local audit log is running out of disk space

# Test plan
Create a cluster whose audit log is on a nearly full drive/filesystem.
- [x] Verify that a user with instance read permission sees a disk space alert (checker runs every 5 minutes).
- [x] Verify that a user without instance read permission does not see an alert.