### PR TITLE
[v18] Show application session recordings in `tsh recordings ls` and WebUI

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -757,6 +757,10 @@ func (m *AppSessionChunk) TrimToMaxSize(maxSize int) AuditEvent {
 	return m
 }
 
+func (m *AppSessionChunk) GetSessionChunkID() string {
+	return m.SessionChunkID
+}
+
 func (m *AppSessionRequest) TrimToMaxSize(maxSize int) AuditEvent {
 	size := m.Size()
 	if size <= maxSize {

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -989,6 +989,13 @@ var SessionRecordingEvents = []string{
 	SessionEndEvent,
 	WindowsDesktopSessionEndEvent,
 	DatabaseSessionEndEvent,
+
+	// HTTP/HTTPS application sessions do not emit AppSessionEndEvent.
+	// Their recordings IDs are in AppSessionChunkEvent, so it is included.
+	//
+	// TCP application sessions emit AppSessionEndEvent but produce no
+	// recordings, so it is excluded.
+	AppSessionChunkEvent,
 }
 
 // ServerMetadataGetter represents interface

--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -192,8 +192,8 @@ func TestSearchEvents(t *testing.T) {
 			check: func(t *testing.T, mock *mockAthenaExecutor, paginationKey string) {
 				wantSingleCallToAthena(t, mock)
 				wantQuery(t, mock, selectFromPrefix+whereTimeRange+
-					` AND session_id = ? AND event_type IN (?,?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
-				wantQueryParams(t, mock, append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", "'session.end'", "'windows.desktop.session.end'", "'db.session.end'")...)
+					` AND session_id = ? AND event_type IN (?,?,?,?) ORDER BY event_time ASC, uid ASC LIMIT 100;`)
+				wantQueryParams(t, mock, append(timeRangeParams, "'9762a4fe-ac4b-47b5-ba4f-5f70d065849a'", "'session.end'", "'windows.desktop.session.end'", "'db.session.end'", "'app.session.chunk'")...)
 			},
 		},
 		{

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -86,8 +87,15 @@ func (e *SessionsCollection) WriteText(w io.Writer) error {
 			participants = strings.Join(session.Participants, ", ")
 			target = session.DatabaseName
 			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
+		case *events.AppSessionChunk:
+			id = session.GetSessionChunkID()
+			typ = "app-chunk"
+			participants = session.User
+			target = cmp.Or(session.AppName, session.AppURI)
+			timestamp = session.GetTime().Format(constants.HumanDateFormatSeconds)
+
 		default:
-			slog.WarnContext(context.Background(), "unsupported event type: expected SessionEnd, WindowsDesktopSessionEnd or DatabaseSessionEnd", "event_type", logutils.TypeAttr(event))
+			slog.WarnContext(context.Background(), "unsupported event type: expected SessionEnd, WindowsDesktopSessionEnd, DatabaseSessionEnd or AppSessionChunk", "event_type", logutils.TypeAttr(event))
 			continue
 		}
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -5720,7 +5720,18 @@ func TestShowSessions(t *testing.T) {
 		"session_start": "0001-01-01T00:00:00Z",
 		"session_stop": "0001-01-01T00:00:00Z",
 		"participants": ["someParticipant"]
-    } ]`
+    },
+	{
+		"app_name": "someApp",
+		"ei": 0,
+		"event": "",
+		"server_id": "",
+		"session_chunk_id": "someChunkID",
+		"sid": "",
+		"time": "0001-01-01T00:00:00Z",
+		"uid": "someID5",
+		"user": "someUser"
+	} ]`
 	sessions := []events.AuditEvent{
 		&events.SessionEnd{
 			Metadata: events.Metadata{
@@ -5759,6 +5770,18 @@ func TestShowSessions(t *testing.T) {
 			StartTime:    time.Time{},
 			EndTime:      time.Time{},
 			Participants: []string{"someParticipant"},
+		},
+		&events.AppSessionChunk{
+			Metadata: events.Metadata{
+				ID: "someID5",
+			},
+			UserMetadata: events.UserMetadata{
+				User: "someUser",
+			},
+			AppMetadata: events.AppMetadata{
+				AppName: "someApp",
+			},
+			SessionChunkID: "someChunkID",
 		},
 	}
 	var buf bytes.Buffer

--- a/web/packages/teleport/src/Recordings/RecordingsList.tsx
+++ b/web/packages/teleport/src/Recordings/RecordingsList.tsx
@@ -109,6 +109,8 @@ const renderIconCell = (type: RecordingType) => {
     Icon = Icons.Kubernetes;
   } else if (type === 'database') {
     Icon = Icons.Database;
+  } else if (type === 'app') {
+    Icon = Icons.Application;
   }
 
   return (

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -31,6 +31,7 @@ import styled, { css } from 'styled-components';
 import Box from 'design/Box';
 import Flex from 'design/Flex';
 import {
+  Application,
   ArrowRight,
   Database,
   Desktop,
@@ -363,6 +364,12 @@ export function getRecordingTypeInfo(type: RecordingType): {
       return {
         icon: Desktop,
         label: 'Desktop Session',
+      };
+
+    case 'app':
+      return {
+        icon: Application,
+        label: 'Application Session Chunk',
       };
   }
 }

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.tsx
@@ -104,6 +104,12 @@ export function RecordingItem({
     recording.recordingType
   );
 
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = e => {
+    if (!recording.playable) {
+      e.preventDefault();
+    }
+  };
+
   return (
     <RecordingItemContainer
       data-testid="recording-item"
@@ -112,6 +118,7 @@ export function RecordingItem({
       playable={recording.playable}
       density={density}
       viewMode={viewMode}
+      onClick={handleClick}
     >
       <ThumbnailContainer density={density} viewMode={viewMode}>
         {recording.playable ? (
@@ -196,10 +203,9 @@ const RecordingItemContainer = styled(Link).withConfig({
     overflow: hidden; // Needed to keep the rectangular contents from bleeding out of the round corners.
     display: flex;
     flex-grow: 0;
-    cursor: pointer;
+    cursor: ${p.playable ? 'pointer' : 'default'};
     text-decoration: none;
     color: ${p.theme.colors.text.main};
-    pointer-events: ${p.playable ? 'all' : 'none'};
 
     &:hover {
       background: ${p.theme.colors.levels.surface};

--- a/web/packages/teleport/src/services/recordings/makeRecording.ts
+++ b/web/packages/teleport/src/services/recordings/makeRecording.ts
@@ -29,9 +29,33 @@ export function makeRecording(event: any): Recording {
     return makeDesktopRecording(event);
   } else if (event.code === eventCodes.DATABASE_SESSION_ENDED) {
     return makeDatabaseRecording(event);
+  } else if (event.code === eventCodes.APP_SESSION_CHUNK) {
+    return makeAppRecording(event);
   } else {
     return makeSshOrKubeRecording(event);
   }
+}
+
+function makeAppRecording(event: {
+  time: string;
+  user: string;
+  session_chunk_id: string;
+  app_name: string;
+}): Recording {
+  const { time, user, session_chunk_id, app_name } = event;
+
+  return {
+    duration: 0,
+    durationText: '-',
+    sid: session_chunk_id,
+    createdDate: new Date(time),
+    users: user,
+    hostname: app_name,
+    description: `HTTP access to app ${app_name}`,
+    recordingType: 'app',
+    playable: false,
+    user,
+  } as Recording;
 }
 
 function makeDesktopRecording({

--- a/web/packages/teleport/src/services/recordings/types.ts
+++ b/web/packages/teleport/src/services/recordings/types.ts
@@ -28,7 +28,7 @@ export type RecordingsResponse = {
   startKey: string;
 };
 
-export type RecordingType = 'ssh' | 'desktop' | 'k8s' | 'database';
+export type RecordingType = 'ssh' | 'desktop' | 'k8s' | 'database' | 'app';
 
 export function validateRecordingType(
   value: RecordingType | string
@@ -37,7 +37,8 @@ export function validateRecordingType(
     value === 'ssh' ||
     value === 'database' ||
     value === 'desktop' ||
-    value === 'k8s'
+    value === 'k8s' ||
+    value === 'app'
   );
 }
 


### PR DESCRIPTION
Backport #61840 to branch/v18

changelog: Added support for listing application session recordings in `tsh recording ls` and the Web UI.
changelog: Fixed a Web UI issue where the copy button for the session ID did not work for non-interactive session recordings.
