### PR TITLE
[v18] Reduce allocations in app server watcher

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -59,6 +59,8 @@ type Application interface {
 	SetURI(string)
 	// GetPublicAddr returns the app public address.
 	GetPublicAddr() string
+	// SetPublicAddr sets the app public address.
+	SetPublicAddr(s string)
 	// GetInsecureSkipVerify returns the app insecure setting.
 	GetInsecureSkipVerify() bool
 	// GetRewrite returns the app rewrite configuration.
@@ -247,6 +249,11 @@ func (a *AppV3) SetURI(uri string) {
 // GetPublicAddr returns the app public address.
 func (a *AppV3) GetPublicAddr() string {
 	return a.Spec.PublicAddr
+}
+
+// SetPublicAddr sets the app public address.
+func (a *AppV3) SetPublicAddr(addr string) {
+	a.Spec.PublicAddr = addr
 }
 
 // GetInsecureSkipVerify returns the app insecure setting.


### PR DESCRIPTION
Backport #61985 to branch/v18

changelog: Reduced memory consumption of the Application service.
