### PR TITLE
MWI: `tbot` dynamic services PoC

### DIFF
--- a/lib/tbot/bot/dynamic_service.go
+++ b/lib/tbot/bot/dynamic_service.go
@@ -1,0 +1,61 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bot
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/tbot/bot/connection"
+	"github.com/gravitational/teleport/lib/tbot/client"
+	"github.com/gravitational/teleport/lib/tbot/internal"
+	svcidentity "github.com/gravitational/teleport/lib/tbot/internal/identity"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+)
+
+type dynamicService struct {
+	name        string
+	serviceType string
+	done        <-chan struct{}
+
+	mu  sync.Mutex
+	err error
+}
+
+func (d *dynamicService) error() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return d.err
+}
+
+type dynamicServiceDependencies struct {
+	// context is the context in which dynamic services will spawn. It's usually
+	// considered evil to keep a context around, but it's better to have some
+	// approximately sane lifecycle for spawned services that isn't dependent on
+	// whatever the caller might be.
+	context           context.Context
+	identityService   *svcidentity.Service
+	resolver          reversetunnelclient.Resolver
+	clientBuilder     *client.Builder
+	proxyPinger       connection.ProxyPinger
+	reloadBroadcaster *internal.ChannelBroadcaster
+	statusRegistry    *readyz.Registry
+}

--- a/lib/tbot/cli/start_bot_api.go
+++ b/lib/tbot/cli/start_bot_api.go
@@ -1,0 +1,62 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/services/botapi/botapiconfig"
+	"github.com/gravitational/trace"
+)
+
+// BotAPICommand implements `tbot start bot-api` and
+// `tbot configure bot-api`.
+type BotAPICommand struct {
+	*sharedStartArgs
+	*genericMutatorHandler
+
+	Listen string
+}
+
+func NewBotAPICommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *BotAPICommand {
+	cmd := parentCmd.Command("bot-api", fmt.Sprintf("%s tbot with a bot api listener.", mode))
+
+	c := &BotAPICommand{}
+	c.sharedStartArgs = newSharedStartArgs(cmd)
+	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
+
+	cmd.Flag("listen", "A socket URI to listen on, such as unix:///path/to/socket.sock or tcp://127.0.0.1:1234").Required().StringVar(&c.Listen)
+
+	return c
+}
+
+func (c *BotAPICommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error {
+	if err := c.sharedStartArgs.ApplyConfig(cfg, l); err != nil {
+		return trace.Wrap(err)
+	}
+
+	cfg.Services = append(cfg.Services, &botapiconfig.Config{
+		Listen: c.Listen,
+	})
+
+	return nil
+}

--- a/lib/tbot/cli/start_shared.go
+++ b/lib/tbot/cli/start_shared.go
@@ -339,12 +339,18 @@ const (
 	// CommandModeConfigure indicates a command instance will be used for
 	// `tbot configure ...`
 	CommandModeConfigure
+
+	// CommandModeAPISpawn indicates a command will be used to spawn the service
+	// via a running API listener.
+	CommandModeAPISpawn
 )
 
 func (c CommandMode) String() string {
 	switch c {
 	case CommandModeConfigure:
 		return "Configures"
+	case CommandModeAPISpawn:
+		return "Spawns"
 	default:
 		return "Starts"
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/internal"
 	"github.com/gravitational/teleport/lib/tbot/services/application"
 	"github.com/gravitational/teleport/lib/tbot/services/awsra"
+	"github.com/gravitational/teleport/lib/tbot/services/botapi/botapiconfig"
 	"github.com/gravitational/teleport/lib/tbot/services/database"
 	"github.com/gravitational/teleport/lib/tbot/services/example"
 	"github.com/gravitational/teleport/lib/tbot/services/identity"
@@ -109,6 +110,10 @@ type BotConfig struct {
 	// ReloadCh allows a channel to be injected into the bot to trigger a
 	// renewal.
 	ReloadCh <-chan struct{} `yaml:"-"`
+
+	// DynamicServiceCh is a channel that can be used to spawn services
+	// dynamically.
+	DynamicServiceCh <-chan bot.ServiceBuilder
 
 	// Testing is set in unit tests to attach a faux service which exposes the
 	// bot's underlying identity and client so we can make assertions on it.
@@ -427,6 +432,12 @@ func (o *ServiceConfigs) UnmarshalYAML(node *yaml.Node) error {
 			out = append(out, v)
 		case application.ProxyServiceType:
 			v := &application.ProxyServiceConfig{}
+			if err := node.Decode(v); err != nil {
+				return trace.Wrap(err)
+			}
+			out = append(out, v)
+		case botapiconfig.ServiceType:
+			v := &botapiconfig.Config{}
 			if err := node.Decode(v); err != nil {
 				return trace.Wrap(err)
 			}

--- a/lib/tbot/readyz/reporter.go
+++ b/lib/tbot/readyz/reporter.go
@@ -37,7 +37,7 @@ type reporter struct {
 	mu     *sync.Mutex
 	status *ServiceStatus
 	clock  clockwork.Clock
-	notify func()
+	notify func(status Status, reason string)
 }
 
 func (r *reporter) Report(status Status) {
@@ -54,7 +54,7 @@ func (r *reporter) ReportReason(status Status, reason string) {
 	updatedAt := r.clock.Now()
 	r.status.UpdatedAt = &updatedAt
 
-	r.notify()
+	r.notify(status, reason)
 }
 
 // NoopReporter returns a no-op Reporter that can be used when no real reporter

--- a/lib/tbot/services/botapi/botapi.go
+++ b/lib/tbot/services/botapi/botapi.go
@@ -1,0 +1,23 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package botapi
+
+import "go.opentelemetry.io/otel"
+
+var tracer = otel.Tracer("github.com/gravitational/teleport/lib/tbot/services/botapi")

--- a/lib/tbot/services/botapi/botapiconfig/config.go
+++ b/lib/tbot/services/botapi/botapiconfig/config.go
@@ -1,0 +1,90 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package botapiconfig
+
+import (
+	"net"
+	"net/url"
+
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
+	"github.com/gravitational/trace"
+	"go.yaml.in/yaml/v3"
+)
+
+const ServiceType = "bot-api"
+
+// Config opens an authenticated tunnel for Application
+// Access.
+type Config struct {
+	// Name of the service for logs and the /readyz endpoint.
+	Name string `yaml:"name,omitempty"`
+	// Listen is the address on which database tunnel should listen. Example:
+	// - "tcp://127.0.0.1:3306"
+	// - "tcp://0.0.0.0:3306
+	Listen string `yaml:"listen"`
+
+	// Listener overrides "listen" and directly provides an opened listener to
+	// use.
+	Listener net.Listener `yaml:"-"`
+}
+
+// GetName returns the user-given name of the service, used for validation purposes.
+func (o *Config) GetName() string {
+	return o.Name
+}
+
+// SetName sets the service's name to an automatically generated one.
+func (o *Config) SetName(name string) {
+	o.Name = name
+}
+
+func (s *Config) Type() string {
+	return ServiceType
+}
+
+func (s *Config) MarshalYAML() (any, error) {
+	type raw Config
+	return encoding.WithTypeHeader((*raw)(s), ServiceType)
+}
+
+func (s *Config) UnmarshalYAML(node *yaml.Node) error {
+	// Alias type to remove UnmarshalYAML to avoid recursion
+	type raw Config
+	if err := node.Decode((*raw)(s)); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (s *Config) CheckAndSetDefaults() error {
+	switch {
+	case s.Listen == "" && s.Listener == nil:
+		return trace.BadParameter("listen: should not be empty")
+	}
+	if _, err := url.Parse(s.Listen); err != nil {
+		return trace.Wrap(err, "parsing listen")
+	}
+	return nil
+}
+
+// GetCredentialLifetime returns the credential lifetime configuration.
+func (o *Config) GetCredentialLifetime() bot.CredentialLifetime {
+	return bot.CredentialLifetime{}
+}

--- a/lib/tbot/services/botapi/service.go
+++ b/lib/tbot/services/botapi/service.go
@@ -1,0 +1,180 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package botapi
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+
+	apiclient "github.com/gravitational/teleport/api/client"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tbot/bot"
+	"github.com/gravitational/teleport/lib/tbot/config"
+	"github.com/gravitational/teleport/lib/tbot/identity"
+	"github.com/gravitational/teleport/lib/tbot/internal"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/tbot/services/botapi/botapiconfig"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
+)
+
+type Spawner interface {
+	AddDynamicService(ctx context.Context, cfg config.ServiceConfig) error
+}
+
+func ServiceBuilder(
+	cfg *botapiconfig.Config,
+	spawner Spawner,
+) bot.ServiceBuilder {
+	buildFn := func(deps bot.ServiceDependencies) (bot.Service, error) {
+		if err := cfg.CheckAndSetDefaults(); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		svc := &Service{
+			cfg:                cfg,
+			log:                deps.Logger,
+			botClient:          deps.Client,
+			getBotIdentity:     deps.BotIdentity,
+			botIdentityReadyCh: deps.BotIdentityReadyCh,
+			statusReporter:     deps.GetStatusReporter(),
+			spawner:            spawner,
+		}
+		return svc, nil
+	}
+	return bot.NewServiceBuilder(botapiconfig.ServiceType, cfg.Name, buildFn)
+}
+
+type Service struct {
+	cfg                *botapiconfig.Config
+	log                *slog.Logger
+	botClient          *apiclient.Client
+	getBotIdentity     func() *identity.Identity
+	botIdentityReadyCh <-chan struct{}
+	statusReporter     readyz.Reporter
+
+	spawner Spawner
+}
+
+func (s *Service) String() string {
+	return cmp.Or(
+		s.cfg.Name,
+		"bot-api",
+	)
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	ctx, span := tracer.Start(ctx, "BotAPIService/Run")
+	defer span.End()
+
+	l := s.cfg.Listener
+	if l == nil {
+		s.log.DebugContext(ctx, "Opening listener for bot api.", "listen", s.cfg.Listen)
+		var err error
+		l, err = internal.CreateListener(ctx, s.log, s.cfg.Listen)
+		if err != nil {
+			return trace.Wrap(err, "opening listener")
+		}
+		defer func() {
+			if err := l.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
+				s.log.ErrorContext(ctx, "Failed to close listener", "error", err)
+			}
+		}()
+	}
+
+	if s.botIdentityReadyCh != nil {
+		select {
+		case <-s.botIdentityReadyCh:
+		default:
+			s.log.InfoContext(ctx, "Waiting for internal bot identity to be renewed before running")
+			select {
+			case <-s.botIdentityReadyCh:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+
+	if s.spawner == nil {
+		return trace.BadParameter("a spawner implementation is required")
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/spawn", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var body config.ServiceConfigs
+		if err := yaml.NewDecoder(r.Body).Decode(&body); err != nil {
+			s.log.ErrorContext(r.Context(), "invalid dynamic service config", "error", err)
+			http.Error(w, fmt.Sprintf("invalid service config: %v", err), http.StatusBadRequest)
+			return
+		}
+
+		for i, cfg := range body {
+			s.log.DebugContext(r.Context(), "attempting to spawn new dynamic service", "name", cfg.GetName(), "type", cfg.Type())
+			if err := s.spawner.AddDynamicService(r.Context(), cfg); err != nil {
+				s.log.ErrorContext(r.Context(), "unable to add dynamic service", "error", err)
+				http.Error(w, fmt.Sprintf("unable to add dynamic service [%d]: %v", i, err), http.StatusInternalServerError)
+				return
+			}
+
+			s.log.InfoContext(r.Context(), "spawned new dynamic service", "name", cfg.GetName(), "type", cfg.Type())
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	srv := http.Server{
+		Handler:           mux,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+		BaseContext: func(net.Listener) context.Context {
+			// Use the main context which controls the service being stopped as
+			// the base context for all incoming requests.
+			return ctx
+		},
+	}
+
+	var errCh = make(chan error, 1)
+	go func() {
+		s.log.DebugContext(ctx, "Starting bot api request handler goroutine")
+		errCh <- srv.Serve(l)
+	}()
+	s.log.InfoContext(
+		ctx, "Listening for bot api requests",
+		"address", l.Addr().String(),
+	)
+	s.statusReporter.Report(readyz.Healthy)
+
+	select {
+	case <-ctx.Done():
+		return trace.Wrap(srv.Close(), "closing http server")
+	case err := <-errCh:
+		s.statusReporter.ReportReason(readyz.Unhealthy, err.Error())
+		return trace.Wrap(err, "bot api failed")
+	}
+}


### PR DESCRIPTION
This adds a proof of concept for dynamic service spawning in tbot, which allows for workflows like so:

```
$ tbot start bot-api --listen unix:///path/to/api.sock ... &
$ tbot api spawn identity --address unix:///path/to/api.sock --destination /path/to/dest
$ tbot api spawn application-tunnel --address unix:///path/to/api.sock --app=example --listen tcp://localhost:1234
```

This implementation takes a lot of shortcuts and probably can't be production ready. It's meant to serve more as an exploration of the changes we need to make within tbot to enable dynamic services.

A short summary of changes:
- In addition to the usual set of services launched by tbot in an `errgroup`, we now collect an additional list of dynamic services and cache all the usual service dependencies so they can be reused later.
- A new `SpawnDynamicService` helper was added to allow spawning a `ServiceBuilder` at runtime.
- A new `bot-api` service was added along with CLI helpers, to enable `tbot start bot-api`
- The new bot api service is a trivial HTTP server that accepts YAML service definitions at `/spawn`. These match the syntax used in the `services` block in `tbot.yaml`.
- A new CLI verb, `tbot api spawn`, was added. Existing CLI service definitions can be reused in place, similar to `tbot configure`. An internal helper extracts the generated service config entries, converts them to YAML, and posts them to the API `/spawn` endpoint.
- Tweaks were made to `readyz` to accept status notification callbacks so `SpawnDynamicService` can wait for individual service readiness.