### PR TITLE
Allow nodes to join the cluster based on their AWS Organization

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -301,6 +301,9 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 			if allowRule.AWSARN != "" {
 				return trace.BadParameter(`the %q join method does not support the "aws_arn" parameter`, JoinMethodEC2)
 			}
+			if allowRule.AWSOrganizationID != "" {
+				return trace.BadParameter(`the %q join method does not support the "aws_organization_id" parameter`, JoinMethodEC2)
+			}
 			if allowRule.AWSAccount == "" && allowRule.AWSRole == "" {
 				return trace.BadParameter(`allow rule for %q join method must set "aws_account" or "aws_role"`, JoinMethodEC2)
 			}
@@ -320,8 +323,8 @@ func (p *ProvisionTokenV2) CheckAndSetDefaults() error {
 			if len(allowRule.AWSRegions) != 0 {
 				return trace.BadParameter(`the %q join method does not support the "aws_regions" parameter`, JoinMethodIAM)
 			}
-			if allowRule.AWSAccount == "" && allowRule.AWSARN == "" {
-				return trace.BadParameter(`allow rule for %q join method must set "aws_account" or "aws_arn"`, JoinMethodEC2)
+			if allowRule.AWSAccount == "" && allowRule.AWSARN == "" && allowRule.AWSOrganizationID == "" {
+				return trace.BadParameter(`allow rule for %q join method must set "aws_account", "aws_arn", or "aws_organization"`, JoinMethodIAM)
 			}
 		}
 	case JoinMethodGitHub:

--- a/api/types/provisioning_test.go
+++ b/api/types/provisioning_test.go
@@ -261,6 +261,24 @@ func TestProvisionTokenV2_CheckAndSetDefaults(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			desc: "iam method with aws_organization_id",
+			token: &ProvisionTokenV2{
+				Metadata: Metadata{
+					Name: "test",
+				},
+				Spec: ProvisionTokenSpecV2{
+					Roles:      []SystemRole{RoleNode},
+					JoinMethod: "iam",
+					Allow: []*TokenRule{
+						{
+							AWSOrganizationID: "o-123abcd",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			desc: "github valid",
 			token: &ProvisionTokenV2{
 				Metadata: Metadata{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -929,7 +929,7 @@ func awsOrganizationsClientUsingAmbientCredentials(ctx context.Context, clock cl
 		// Currently, only ambient credentials are supported, which are not available when running within Teleport Cloud.
 		// In that scenario a NotImplemented error is returned.
 		if modules.GetModules().Features().Cloud {
-			return nil, trace.NotImplemented("IAM Joins based on AWS Organization ID are not supported in Teleport Cloud")
+			return nil, trace.NotImplemented("IAM Joins based on AWS Organization ID are not currently supported in Teleport Cloud")
 		}
 
 		// AWS Organizations API has a global API, so no region is required to be passed.

--- a/lib/auth/auth_iamjoin_organizations_test.go
+++ b/lib/auth/auth_iamjoin_organizations_test.go
@@ -1,0 +1,101 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
+	"github.com/aws/aws-sdk-go-v2/service/organizations/types"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/join/iamjoin"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/modules/modulestest"
+)
+
+func TestAWSOrganizationsClientUsingAmbientCredentials(t *testing.T) {
+	t.Run("when running in cloud, the client getter returns an error (ambient credentials can't be used in cloud)", func(t *testing.T) {
+		modulestest.SetTestModules(t, modulestest.Modules{
+			TestFeatures: modules.Features{
+				Cloud: true,
+			},
+		})
+
+		getClientFn, err := awsOrganizationsClientUsingAmbientCredentials(t.Context(), clockwork.NewFakeClock(), nil)
+		require.NoError(t, err)
+
+		_, err = getClientFn(t.Context())
+		require.Error(t, err)
+	})
+
+	t.Run("when running in non-cloud, the getter returns a valid client", func(t *testing.T) {
+		modulestest.SetTestModules(t, modulestest.Modules{
+			TestFeatures: modules.Features{
+				Cloud: false,
+			},
+		})
+
+		fakeClock := clockwork.NewFakeClock()
+
+		numberOfRemoteAPICalls := 0
+		describeAccountRemoteAPIFn := func(c aws.Config) iamjoin.DescribeAccountAPIClient {
+			return func(ctx context.Context, params *organizations.DescribeAccountInput, optFns ...func(*organizations.Options)) (*organizations.DescribeAccountOutput, error) {
+				numberOfRemoteAPICalls++
+				return &organizations.DescribeAccountOutput{
+					Account: &types.Account{Id: aws.String("123456789012")},
+				}, nil
+			}
+		}
+
+		getClientFn, err := awsOrganizationsClientUsingAmbientCredentials(t.Context(), fakeClock, describeAccountRemoteAPIFn)
+		require.NoError(t, err)
+
+		describeAccountAPI, err := getClientFn(t.Context())
+		require.NoError(t, err)
+
+		describeAccountAPIOutput, err := describeAccountAPI(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, numberOfRemoteAPICalls, "expected one remote API call")
+
+		// Call again to verify caching works.
+		describeAccountAPIOutput, err = describeAccountAPI(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, numberOfRemoteAPICalls, "expected no additional remote API calls due to caching")
+
+		// However, after the cache expiration time, a new call should be made.
+		fakeClock.Advance(5 * time.Minute)
+		describeAccountAPIOutput, err = describeAccountAPI(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 2, numberOfRemoteAPICalls, "expected a new remote API call after cache expiration")
+	})
+}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -98,6 +99,9 @@ type AuthServerConfig struct {
 	SessionSummarizerProvider *summarizer.SessionSummarizerProvider
 	// RecordingMetadataProvider allows a test to configure its own recording
 	RecordingMetadataProvider *recordingmetadata.Provider
+	// AWSOrganizationsClientGetter provides an AWS client that can call Organizations APIs.
+	// This is used to allow the IAM join method to validate that an AWS account belongs to a specific AWS Organization.
+	AWSOrganizationsClientGetter iamjoin.OrganizationsAPIGetter
 	// TraceClient allows a test to configure the trace client
 	TraceClient otlptrace.Client
 	// AuthPreferenceSpec is custom initial AuthPreference spec for the test.
@@ -322,26 +326,27 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	}
 
 	srv.AuthServer, err = auth.NewServer(&auth.InitConfig{
-		DataDir:                   cfg.Dir,
-		Backend:                   srv.Backend,
-		VersionStorage:            NewFakeTeleportVersion(),
-		Authority:                 authority.NewWithClock(cfg.Clock),
-		Access:                    access,
-		Identity:                  identity,
-		AuditLog:                  srv.AuditLog,
-		Streamer:                  cfg.Streamer,
-		SkipPeriodicOperations:    true,
-		Emitter:                   emitter,
-		TraceClient:               cfg.TraceClient,
-		Clock:                     cfg.Clock,
-		ClusterName:               clusterName,
-		HostUUID:                  uuid.New().String(),
-		AccessLists:               accessLists,
-		FIPS:                      cfg.FIPS,
-		KeyStoreConfig:            cfg.KeystoreConfig,
-		MultipartHandler:          cfg.UploadHandler,
-		SessionSummarizerProvider: cfg.SessionSummarizerProvider,
-		RecordingMetadataProvider: cfg.RecordingMetadataProvider,
+		DataDir:                      cfg.Dir,
+		Backend:                      srv.Backend,
+		VersionStorage:               NewFakeTeleportVersion(),
+		Authority:                    authority.NewWithClock(cfg.Clock),
+		Access:                       access,
+		Identity:                     identity,
+		AuditLog:                     srv.AuditLog,
+		Streamer:                     cfg.Streamer,
+		SkipPeriodicOperations:       true,
+		Emitter:                      emitter,
+		TraceClient:                  cfg.TraceClient,
+		Clock:                        cfg.Clock,
+		ClusterName:                  clusterName,
+		HostUUID:                     uuid.New().String(),
+		AccessLists:                  accessLists,
+		FIPS:                         cfg.FIPS,
+		KeyStoreConfig:               cfg.KeystoreConfig,
+		MultipartHandler:             cfg.UploadHandler,
+		SessionSummarizerProvider:    cfg.SessionSummarizerProvider,
+		RecordingMetadataProvider:    cfg.RecordingMetadataProvider,
+		AWSOrganizationsClientGetter: cfg.AWSOrganizationsClientGetter,
 	},
 		// Reduce auth.Server bcrypt costs when testing.
 		WithBcryptCost(bcrypt.MinCost),

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6276,6 +6276,7 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		FIPS:               cfg.AuthServer.fips,
 		ScopedTokenService: cfg.AuthServer.Services,
 		OracleHTTPClient:   cfg.OracleHTTPClient,
+		AWSOrganizationsDescribeAccountClientGetter: cfg.AuthServer.GetAWSOrganizationsDescribeAccountClientGetter(),
 	}))
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -6276,7 +6276,6 @@ func NewGRPCServer(cfg GRPCServerConfig) (*GRPCServer, error) {
 		FIPS:               cfg.AuthServer.fips,
 		ScopedTokenService: cfg.AuthServer.Services,
 		OracleHTTPClient:   cfg.OracleHTTPClient,
-		AWSOrganizationsDescribeAccountClientGetter: cfg.AuthServer.GetAWSOrganizationsDescribeAccountClientGetter(),
 	}))
 
 	integrationServiceServer, err := integrationv1.NewService(&integrationv1.ServiceConfig{

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -65,6 +65,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
@@ -312,6 +313,10 @@ type InitConfig struct {
 	// HTTPClientForAWSSTS overwrites the default HTTP client used for making
 	// STS requests. Used in test.
 	HTTPClientForAWSSTS utils.HTTPDoClient
+
+	// AWSOrganizationsDescribeAccountClientGetter provides an AWS client that can call organizations:DescribeAccount.
+	// This is used to allow the IAM join method to validate that an AWS account belongs to a specific AWS Organization.
+	AWSOrganizationsDescribeAccountClientGetter iamjoin.DescribeAccountClientGetter
 
 	// Tracer used to create spans.
 	Tracer oteltrace.Tracer

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -314,9 +314,9 @@ type InitConfig struct {
 	// STS requests. Used in test.
 	HTTPClientForAWSSTS utils.HTTPDoClient
 
-	// AWSOrganizationsDescribeAccountClientGetter provides an AWS client that can call organizations:DescribeAccount.
+	// AWSOrganizationsClientGetter provides an AWS client that can call Organizations APIs.
 	// This is used to allow the IAM join method to validate that an AWS account belongs to a specific AWS Organization.
-	AWSOrganizationsDescribeAccountClientGetter iamjoin.DescribeAccountClientGetter
+	AWSOrganizationsClientGetter iamjoin.OrganizationsAPIGetter
 
 	// Tracer used to create spans.
 	Tracer oteltrace.Tracer

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -44,15 +44,15 @@ func (a *Server) GetHTTPClientForAWSSTS() utils.HTTPDoClient {
 	return a.httpClientForAWSSTS
 }
 
-// SetAWSOrganizationsDescribeAccountClientGetter sets a client getter that will be used for describing accounts in AWS Organizations.
+// SetAWSOrganizationsClientGetter sets a client getter that will be used for describing accounts in AWS Organizations.
 // client-signed sts:GetCallerIdentity requests to AWS, for tests.
-func (a *Server) SetAWSOrganizationsDescribeAccountClientGetter(describeAccountClientGetter iamjoin.DescribeAccountClientGetter) {
-	a.awsOrganizationsDescribeAccountClientGetter = describeAccountClientGetter
+func (a *Server) SetAWSOrganizationsClientGetter(organizationsAPIGetter iamjoin.OrganizationsAPIGetter) {
+	a.awsOrganizationsClientGetter = organizationsAPIGetter
 }
 
-// SetAWSOrganizationsDescribeAccountClientGetter returns client getter which is capable of describing accounts in AWS Organizations.
-func (a *Server) GetAWSOrganizationsDescribeAccountClientGetter() iamjoin.DescribeAccountClientGetter {
-	return a.awsOrganizationsDescribeAccountClientGetter
+// GetAWSOrganizationsClientGetter returns client getter which is capable of describing accounts in AWS Organizations.
+func (a *Server) GetAWSOrganizationsClientGetter() iamjoin.OrganizationsAPIGetter {
+	return a.awsOrganizationsClientGetter
 }
 
 // RegisterUsingIAMMethod registers the caller using the IAM join method and
@@ -106,12 +106,12 @@ func (a *Server) RegisterUsingIAMMethod(
 
 	// check that the GetCallerIdentity request is valid and matches the token
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
-		Challenge:                   challenge,
-		ProvisionToken:              provisionToken,
-		STSIdentityRequest:          req.StsIdentityRequest,
-		HTTPClient:                  a.GetHTTPClientForAWSSTS(),
-		FIPS:                        a.fips,
-		DescribeAccountClientGetter: a.GetAWSOrganizationsDescribeAccountClientGetter(),
+		Challenge:              challenge,
+		ProvisionToken:         provisionToken,
+		STSIdentityRequest:     req.StsIdentityRequest,
+		HTTPClient:             a.GetHTTPClientForAWSSTS(),
+		FIPS:                   a.fips,
+		OrganizationsAPIGetter: a.GetAWSOrganizationsClientGetter(),
 	})
 	if verifiedIdentity != nil {
 		joinFailureMetadata = verifiedIdentity

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -50,8 +50,7 @@ func (a *Server) SetAWSOrganizationsDescribeAccountClientGetter(describeAccountC
 	a.awsOrganizationsDescribeAccountClientGetter = describeAccountClientGetter
 }
 
-// SetAWSOrganizationsDescribeAccountClientGetter returns an HTTP client that should be used for sending
-// client-signed sts:GetCallerIdentity requests to AWS.
+// SetAWSOrganizationsDescribeAccountClientGetter returns client getter which is capable of describing accounts in AWS Organizations.
 func (a *Server) GetAWSOrganizationsDescribeAccountClientGetter() iamjoin.DescribeAccountClientGetter {
 	return a.awsOrganizationsDescribeAccountClientGetter
 }

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -44,12 +44,6 @@ func (a *Server) GetHTTPClientForAWSSTS() utils.HTTPDoClient {
 	return a.httpClientForAWSSTS
 }
 
-// SetAWSOrganizationsClientGetter sets a client getter that will be used for describing accounts in AWS Organizations.
-// client-signed sts:GetCallerIdentity requests to AWS, for tests.
-func (a *Server) SetAWSOrganizationsClientGetter(organizationsAPIGetter iamjoin.OrganizationsAPIGetter) {
-	a.awsOrganizationsClientGetter = organizationsAPIGetter
-}
-
 // GetAWSOrganizationsClientGetter returns client getter which is capable of describing accounts in AWS Organizations.
 func (a *Server) GetAWSOrganizationsClientGetter() iamjoin.OrganizationsAPIGetter {
 	return a.awsOrganizationsClientGetter

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -113,12 +113,11 @@ type AuthService interface {
 
 // ServerConfig holds configuration parameters for [Server].
 type ServerConfig struct {
-	AuthService                                 AuthService
-	Authorizer                                  authz.Authorizer
-	FIPS                                        bool
-	ScopedTokenService                          services.ScopedTokenService
-	OracleHTTPClient                            utils.HTTPDoClient
-	AWSOrganizationsDescribeAccountClientGetter iamjoin.DescribeAccountClientGetter
+	AuthService        AuthService
+	Authorizer         authz.Authorizer
+	FIPS               bool
+	ScopedTokenService services.ScopedTokenService
+	OracleHTTPClient   utils.HTTPDoClient
 }
 
 // Server implements cluster joining for nodes and bots.

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/gcp"
 	"github.com/gravitational/teleport/lib/join/githubactions"
 	"github.com/gravitational/teleport/lib/join/gitlab"
+	"github.com/gravitational/teleport/lib/join/iamjoin"
 	joinauthz "github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -90,6 +91,7 @@ type AuthService interface {
 	CheckLockInForce(constants.LockingMode, []types.LockTarget) error
 	GetClock() clockwork.Clock
 	GetHTTPClientForAWSSTS() utils.HTTPDoClient
+	GetAWSOrganizationsDescribeAccountClientGetter() iamjoin.DescribeAccountClientGetter
 	GetAzureDevopsIDTokenValidator() azuredevops.Validator
 	GetBitbucketIDTokenValidator() bitbucket.Validator
 	GetEC2ClientForEC2JoinMethod() ec2join.EC2Client
@@ -111,11 +113,12 @@ type AuthService interface {
 
 // ServerConfig holds configuration parameters for [Server].
 type ServerConfig struct {
-	AuthService        AuthService
-	Authorizer         authz.Authorizer
-	FIPS               bool
-	ScopedTokenService services.ScopedTokenService
-	OracleHTTPClient   utils.HTTPDoClient
+	AuthService                                 AuthService
+	Authorizer                                  authz.Authorizer
+	FIPS                                        bool
+	ScopedTokenService                          services.ScopedTokenService
+	OracleHTTPClient                            utils.HTTPDoClient
+	AWSOrganizationsDescribeAccountClientGetter iamjoin.DescribeAccountClientGetter
 }
 
 // Server implements cluster joining for nodes and bots.

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -91,7 +91,7 @@ type AuthService interface {
 	CheckLockInForce(constants.LockingMode, []types.LockTarget) error
 	GetClock() clockwork.Clock
 	GetHTTPClientForAWSSTS() utils.HTTPDoClient
-	GetAWSOrganizationsDescribeAccountClientGetter() iamjoin.DescribeAccountClientGetter
+	GetAWSOrganizationsClientGetter() iamjoin.OrganizationsAPIGetter
 	GetAzureDevopsIDTokenValidator() azuredevops.Validator
 	GetBitbucketIDTokenValidator() bitbucket.Validator
 	GetEC2ClientForEC2JoinMethod() ec2join.EC2Client

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -75,11 +75,12 @@ func (s *Server) handleIAMJoin(
 	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
 	// the verified identity matches allow rules in the provision token.
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
-		Challenge:          challenge,
-		ProvisionToken:     token,
-		STSIdentityRequest: solution.STSIdentityRequest,
-		HTTPClient:         s.cfg.AuthService.GetHTTPClientForAWSSTS(),
-		FIPS:               s.cfg.FIPS,
+		Challenge:                   challenge,
+		ProvisionToken:              token,
+		STSIdentityRequest:          solution.STSIdentityRequest,
+		HTTPClient:                  s.cfg.AuthService.GetHTTPClientForAWSSTS(),
+		FIPS:                        s.cfg.FIPS,
+		DescribeAccountClientGetter: s.cfg.AuthService.GetAWSOrganizationsDescribeAccountClientGetter(),
 	})
 	// An identity will be returned even on error if the sts:GetCallerIdentity
 	// request was completed but no allow rules were matched, include it in the

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -75,12 +75,12 @@ func (s *Server) handleIAMJoin(
 	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
 	// the verified identity matches allow rules in the provision token.
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
-		Challenge:                   challenge,
-		ProvisionToken:              token,
-		STSIdentityRequest:          solution.STSIdentityRequest,
-		HTTPClient:                  s.cfg.AuthService.GetHTTPClientForAWSSTS(),
-		FIPS:                        s.cfg.FIPS,
-		DescribeAccountClientGetter: s.cfg.AuthService.GetAWSOrganizationsDescribeAccountClientGetter(),
+		Challenge:              challenge,
+		ProvisionToken:         token,
+		STSIdentityRequest:     solution.STSIdentityRequest,
+		HTTPClient:             s.cfg.AuthService.GetHTTPClientForAWSSTS(),
+		FIPS:                   s.cfg.FIPS,
+		OrganizationsAPIGetter: s.cfg.AuthService.GetAWSOrganizationsClientGetter(),
 	})
 	// An identity will be returned even on error if the sts:GetCallerIdentity
 	// request was completed but no allow rules were matched, include it in the

--- a/lib/utils/aws/organizations/arn.go
+++ b/lib/utils/aws/organizations/arn.go
@@ -25,9 +25,9 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// organizationIDFromAccountARN extracts the organization ID from an account ARN.
+// OrganizationIDFromAccountARN extracts the organization ID from an account ARN.
 // Example ARN: arn:aws:organizations::<org-master-account-id>:account/<org-id>/<account-id>
-func organizationIDFromAccountARN(accountARN string) (string, error) {
+func OrganizationIDFromAccountARN(accountARN string) (string, error) {
 	return organizationIDFromARN(accountARN, "account")
 }
 

--- a/lib/utils/aws/organizations/arn_test.go
+++ b/lib/utils/aws/organizations/arn_test.go
@@ -49,7 +49,7 @@ func TestOrganizationIDFromAccountARN(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			gotOrg, err := organizationIDFromAccountARN(tt.accountARN)
+			gotOrg, err := OrganizationIDFromAccountARN(tt.accountARN)
 			tt.errCheck(t, err)
 			require.Equal(t, tt.expectedOrg, gotOrg)
 		})


### PR DESCRIPTION
This PR allows teleport agents to join based on their AWS Organization.

The flow is pretty similar to what we have today:
- agent tries to join by sending a signed `sts:GetCallerIdentity` request to the Auth Service
- Auth Service performs the request to obtain the Account ID
- (new) then the Auth Service validates that this Account ID is belongs to an allowed AWS Organization.

The Auth Server uses ambient credentials to obtain the Organization ID, by calling `organizations.DescribeAccount` for the account ID it obtained previously.
This will return the account's ARN in the context of organizations, which contains the organization ID.
If the organization ID matches the one allowed by the IAM Join Token, the instance is accepted.

The Auth Server must have access to [`organizations.DescribeAccount`](https://docs.aws.amazon.com/organizations/latest/APIReference/API_DescribeAccount.html).
This API call can only be assigned to IAM Roles which are in the Organizations management account or a delegated management account.

Given that this uses ambient credentials, **it is not possible to use this join method when running in Cloud** because the Auth Server in Teleport Cloud does not have access to the user's AWS account.

In the future we might solve this by adding support for using an AWS OIDC integration as source of credentials for the `organizations.DescribeAccount` API call.

Demo:

<img width="1116" height="1204" alt="image" src="https://github.com/user-attachments/assets/b462be78-6951-49df-a8c5-5538d422ddf3" />


Changelog: Added support for EC2 instances to join the cluster based on their AWS organization (Teleport Cloud not supported).

Related to: https://github.com/gravitational/teleport/issues/22675