### PR TITLE
Clean up the Zero Trust Access docs sidebar

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -982,7 +982,7 @@
     },
     {
       "source": "/admin-guides/infrastructure-as-code/managing-resources/import-existing-resources/",
-      "destination": "/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources/",
+      "destination": "/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources/",
       "permanent": true
     },
     {
@@ -1187,7 +1187,7 @@
     },
     {
       "source": "/admin-guides/access-controls/guides/webauthn/",
-      "destination": "/zero-trust-access/authentication/webauthn/",
+      "destination": "/zero-trust-access/management/security/idp-compromise/",
       "permanent": true
     },
     {
@@ -1267,7 +1267,7 @@
     },
     {
       "source": "/admin-guides/deploy-a-cluster/helm-deployments/argocd-helm/",
-      "destination": "/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm/",
+      "destination": "/enroll-resources/agents/argocd-helm/",
       "permanent": true
     },
     {
@@ -1322,7 +1322,7 @@
     },
     {
       "source": "/admin-guides/deploy-a-cluster/high-availability/",
-      "destination": "/zero-trust-access/deploy-a-cluster/high-availability/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/high-availability/",
       "permanent": true
     },
     {
@@ -1337,12 +1337,12 @@
     },
     {
       "source": "/admin-guides/deploy-a-cluster/multi-region-blueprint/",
-      "destination": "/zero-trust-access/deploy-a-cluster/multi-region-blueprint/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint/",
       "permanent": true
     },
     {
       "source": "/admin-guides/deploy-a-cluster/separate-proxy-service-endpoints/",
-      "destination": "/zero-trust-access/deploy-a-cluster/separate-proxy-service-endpoints/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/separate-proxy-service-endpoints/",
       "permanent": true
     },
     {
@@ -1677,7 +1677,7 @@
     },
     {
       "source": "/zero-trust-access/access-controls/guides/webauthn/",
-      "destination": "/zero-trust-access/authentication/webauthn/",
+      "destination": "/zero-trust-access/management/security/idp-compromise/",
       "permanent": true
     },
     {
@@ -2983,6 +2983,36 @@
     {
       "source": "/identity-governance/idps/saml-microsoft-entra-external-id/",
       "destination": "/identity-governance/idps/usage/saml-microsoft-entra-external-id/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/infrastructure-as-code/managing-resources/import-existing-resources/",
+      "destination": "/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/authentication/webauthn/",
+      "destination": "/zero-trust-access/management/security/idp-compromise/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/deploy-a-cluster/high-availability/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/high-availability/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/deploy-a-cluster/multi-region-blueprint/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/deploy-a-cluster/separate-proxy-service-endpoints/",
+      "destination": "/zero-trust-access/deploy-a-cluster/deployments/separate-proxy-service-endpoints/",
+      "permanent": true
+    },
+    {
+      "source": "/zero-trust-access/deploy-a-cluster/helm-deployments/argocd-helm/",
+      "destination": "/enroll-resources/agents/argocd-helm/",
       "permanent": true
     }
   ]

--- a/docs/pages/enroll-resources/agents/argocd-helm.mdx
+++ b/docs/pages/enroll-resources/agents/argocd-helm.mdx
@@ -1,5 +1,6 @@
 ---
-title: Guides for running Teleport using Helm via ArgoCD
+title: Running Teleport Agents using Helm via ArgoCD
+sidebar_label: Argo CD
 description: How to install and configure Teleport Kubernetes agent using Helm and ArgoCD
 tags:
  - ci-cd
@@ -15,7 +16,7 @@ and ArgoCD.
 
 Argo CD is a declarative, GitOps continuous delivery tool for Kubernetes. This is used to orchestrate large deployments, and avoid the Kubernetes resources to drift from the desired deployment.
 
-Teleport has [an official Helm chart (`teleport-kube-agent`)](../../../reference/helm-reference/teleport-kube-agent.mdx) that deploys a Teleport Agent in a Kubernetes cluster. The agent can be configured to run several services, but by default it runs the `kubernetes_service` to provide access to the Kubernetes API via Teleport.
+Teleport has [an official Helm chart (`teleport-kube-agent`)](../../reference/helm-reference/teleport-kube-agent.mdx) that deploys a Teleport Agent in a Kubernetes cluster. The agent can be configured to run several services, but by default it runs the `kubernetes_service` to provide access to the Kubernetes API via Teleport.
 
 This guide leverages ArgoCD's native Helm support to deploy the Teleport Agent using the `teleport-kube-agent` Helm chart.
 
@@ -26,11 +27,11 @@ This guide leverages ArgoCD's native Helm support to deploy the Teleport Agent u
 - An existing ArgoCD instance (version 2.10 or greater) that can deploy to the
   above Kubernetes cluster.
 - The `tsh` client tool v(=teleport.version=)+ installed on your workstation.
-  You can download this from our [installation page](../../../installation/installation.mdx).
+  You can download this from our [installation page](../../installation/installation.mdx).
   
 ## Step 1/3. Generate a join token
 
-Teleport agents use a join token to obtain certificates and connect to Teleport. See [joining docs](../../../reference/deployment/join-methods.mdx) for more information.
+Teleport agents use a join token to obtain certificates and connect to Teleport. See [joining docs](../../reference/deployment/join-methods.mdx) for more information.
 The token is only used to join initially, the Teleport Kube agent will store its
 certificates in Kubernetes and won't need a token to join again in the future.
 In this section, we will create a token for the agent to join the Teleport cluster.
@@ -43,7 +44,7 @@ You can specify the following token types:
 (!docs/pages/includes/token-types.mdx!)
 
 See the `teleport-kube-agent` [chart
-reference](../../../reference/helm-reference/teleport-kube-agent.mdx#roles) for the
+reference](../../reference/helm-reference/teleport-kube-agent.mdx#roles) for the
 roles and token types that the chart supports.
 
 ## Step 2/3. Configure and deploy the `teleport-kube-agent` Helm chart via ArgoCD
@@ -182,9 +183,9 @@ Kubernetes cluster and view its content as a member of the `viewers` group.
 ## Next steps
 
 - **Further configure the Helm chart values:** For more information on configuring the
-  kube-agent Helm chart see the [kube-agent reference](../../../reference/helm-reference/teleport-kube-agent.mdx).
+  kube-agent Helm chart see the [kube-agent reference](../../reference/helm-reference/teleport-kube-agent.mdx).
 - **Set up RBAC for Kubernetes access:** For more in depth information on configuring
-  access see the [Kubernetes RBAC docs](../../../enroll-resources/kubernetes-access/controls.mdx).
+  access see the [Kubernetes RBAC docs](../kubernetes-access/controls.mdx).
 - **Learn more about working with ArgoCD:** To learn more about managing Helm charts
   via ArgoCD visit the [official docs](https://argo-cd.readthedocs.io/en/stable/).
 

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -176,6 +176,6 @@ and non-human identities.
 | **Deployment options:** ||||
 | Teleport cloud deployment | ✔ | ✖ | ✖ |
 | Self-hosted deployment| ✖ | ✔ | ✔ |
-| Multi-Region High Availability | ✔ (Teleport service) | ✔ (Customer-implemented, via a [supported blueprint](zero-trust-access/deploy-a-cluster/multi-region-blueprint.mdx)) | ✖ |
+| Multi-Region High Availability | ✔ (Teleport service) | ✔ (Customer-implemented, via a [supported blueprint](zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx)) | ✖ |
 | FIPS-compliant binaries available for FedRAMP, including Low, Moderate & High | ✖ | ✔ | ✖ |
 

--- a/docs/pages/reference/access-controls/authentication.mdx
+++ b/docs/pages/reference/access-controls/authentication.mdx
@@ -24,7 +24,7 @@ possible values (types) of MFA:
   multi-factor authenticators and hardware devices.
   You can use [YubiKeys](https://www.yubico.com/), [SoloKeys](https://solokeys.com/) or any other authenticator that
   implements FIDO2 or FIDO U2F standards.
-  See our [Harden your Cluster Against IdP Compromises](../../zero-trust-access/authentication/webauthn.mdx) guide for detailed
+  See our [Harden your Cluster Against IdP Compromises](../../zero-trust-access/management/security/idp-compromise.mdx) guide for detailed
   instructions on setting up WebAuthn for Teleport.
 - `on` enables both TOTP and WebAuthn, and all local users are required to have at least one MFA device registered.
 - `optional` enables both TOTP and WebAuthn but makes it optional for users. Local users that register a MFA device will

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -9,7 +9,7 @@ tags:
 
 The `teleport-cluster` Helm chart deploys a Teleport cluster on Kubernetes.
 This includes deploying proxies, auth servers, and [kubernetes-access](../../enroll-resources/kubernetes-access/introduction.mdx).
-See the [Teleport HA Architecture page](../../zero-trust-access/deploy-a-cluster/high-availability.mdx)
+See the [Teleport HA Architecture page](../../zero-trust-access/deploy-a-cluster/deployments/high-availability.mdx)
 for more details.
 
 You can
@@ -371,7 +371,7 @@ Changing the RP ID will invalidate all already registered webauthn second factor
 
 ### `authentication.webauthn`
 
-See [Harden your Cluster Against IdP Compromises](../../zero-trust-access/authentication/webauthn.mdx) for more details.
+See [Harden your Cluster Against IdP Compromises](../../zero-trust-access/management/security/idp-compromise.mdx) for more details.
 
 #### `authentication.webauthn.attestationAllowedCas`
 

--- a/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
+++ b/docs/pages/zero-trust-access/api/automatically-register-agents.mdx
@@ -1,5 +1,6 @@
 ---
 title: Automatically Register Resources with Teleport
+sidebar_label: Custom Auto-Discovery
 description: Learn how to use the Teleport API to start agents automatically when you add resources to your infrastructure.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/api/getting-started.mdx
+++ b/docs/pages/zero-trust-access/api/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Getting Started Guide
+sidebar_label: Get Started
 description: Get started working with the Teleport API programmatically using Go.
 tags:
  - get-started

--- a/docs/pages/zero-trust-access/api/rbac.mdx
+++ b/docs/pages/zero-trust-access/api/rbac.mdx
@@ -1,5 +1,6 @@
 ---
 title: Generate Teleport Roles from an External RBAC System
+sidebar_label: External RBAC Sync
 description: Use Teleport's API to automatically generate Teleport roles based on third-party RBAC policies
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/authentication/authentication.mdx
+++ b/docs/pages/zero-trust-access/authentication/authentication.mdx
@@ -1,6 +1,7 @@
 ---
 title: Authentication and Session Joining
 description: Provides information on configuring the way users authenticate to your Teleport cluster or join an existing session.
+sidebar_position: 3
 template: "no-toc"
 tags:
  - zero-trust

--- a/docs/pages/zero-trust-access/authentication/headless.mdx
+++ b/docs/pages/zero-trust-access/authentication/headless.mdx
@@ -13,7 +13,7 @@ required mechanisms.
 
 For example:
 
-- Authenticating with [WebAuthn](./webauthn.mdx#set-up-cluster-wide-webauthn) or [SSO MFA](../sso/sso.mdx#allowing-sso-as-an-mfa-method-in-your-cluster) from a remote dev box
+- Authenticating with [WebAuthn](../management/security/idp-compromise.mdx#set-up-cluster-wide-webauthn) or [SSO MFA](../sso/sso.mdx#allowing-sso-as-an-mfa-method-in-your-cluster) from a remote dev box
 - Authenticating with WebAuthn on a machine without a WebAuthn-compatible browser
 - Authenticating with SSO MFA from a browser that is not supported by your SSO provider
 
@@ -45,7 +45,7 @@ to reduce the impact of exfiltration.
 
 ## Prerequisites
 
-- A Teleport cluster with [WebAuthn](./webauthn.mdx#set-up-cluster-wide-webauthn) or [SSO MFA](../sso/sso.mdx#allowing-sso-as-an-mfa-method-in-your-cluster) configured.
+- A Teleport cluster with [WebAuthn](../management/security/idp-compromise.mdx#set-up-cluster-wide-webauthn) or [SSO MFA](../sso/sso.mdx#allowing-sso-as-an-mfa-method-in-your-cluster) configured.
 - Machines for Headless Authentication activities have [Linux](../../installation/installation.mdx), [macOS](../../installation/installation.mdx) or [Windows](../../installation/installation.mdx) `tsh` binary installed.
 - Machines used to approve Headless Authentication requests have a Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary installed.

--- a/docs/pages/zero-trust-access/authentication/impersonation.mdx
+++ b/docs/pages/zero-trust-access/authentication/impersonation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Impersonating Teleport Users
+sidebar_label: Impersonation
 description: How to issue short-lived certs on behalf of Teleport users using impersonation.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/authentication/mfa-for-admin-actions.mdx
+++ b/docs/pages/zero-trust-access/authentication/mfa-for-admin-actions.mdx
@@ -44,7 +44,7 @@ their on-disk Teleport certificates.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-- [WebAuthn configured](webauthn.mdx) on this cluster
+- [WebAuthn configured](../management/security/idp-compromise.mdx) on this cluster
 - Multi-factor authentication hardware device, such as YubiKey or SoloKey
 - A Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) (if using

--- a/docs/pages/zero-trust-access/authentication/passwordless.mdx
+++ b/docs/pages/zero-trust-access/authentication/passwordless.mdx
@@ -34,7 +34,7 @@ your device type, passwordless registrations may also be used for regular MFA.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - Teleport must be configured for WebAuthn. See the [Harden your Cluster Against
-  IdP Compromises](./webauthn.mdx) guide.
+  IdP Compromises](../management/security/idp-compromise.mdx) guide.
 - A hardware device with support for WebAuthn and resident keys.  As an
   alternative, you can use a Mac with biometrics / Touch ID or device that
   supports Windows Hello (Windows 10 19H1 or later).

--- a/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/authentication/per-session-mfa.mdx
@@ -34,7 +34,7 @@ Per-session MFA checks can be satisfied by a webauthn device or by [delegating M
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-- [WebAuthn configured](webauthn.mdx) on this cluster
+- [WebAuthn configured](../management/security/idp-compromise.mdx) on this cluster
 - Hardware device for multi-factor authentication, such as YubiKey or SoloKey
 - A Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) (if using

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -1,5 +1,6 @@
 ---
 title: FedRAMP Compliance for Infrastructure Access
+sidebar_label: FedRAMP
 description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140-2.
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
@@ -1,5 +1,6 @@
 ---
 title: SOC 2 compliance for SSH, Kubernetes, and Databases
+sidebar_label: SOC 2
 description: How to configure SOC 2-compliant access to SSH, Kubernetes, databases, desktops, and web apps
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
@@ -1,5 +1,7 @@
 ---
 title: Self-Hosting Teleport Enterprise
+sidebar_label: Self-Hosting
+sidebar_position: 5
 description: "Guides to running a self-hosted Teleport cluster in production."
 tags:
  - platform-wide
@@ -17,7 +19,7 @@ your approach. Self-hosted Teleport Enterprise deployments typically take place
 in conversation with the team at Teleport.
 
 While designing a deployment, you can consult the [High
-Availability](high-availability.mdx) guide for the components of a production
+Availability](deployments/high-availability.mdx) guide for the components of a production
 Teleport cluster. 
 
 ## Dedicated account dashboard

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-gslb-proxy-peering-ha-deployment.mdx
@@ -1,6 +1,6 @@
 ---
-title: "AWS Multi-Region Proxy Deployment"
-sidebar_label: Multi-Region Proxy Deployment
+title: "AWS Multi-Region Proxy Service Deployment"
+sidebar_label: Multi-Region Proxy Service
 description: "Deploying a high-availability multi-region Teleport cluster using Proxy Peering and Route 53."
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -1,6 +1,6 @@
 ---
-title: Teleport High Availability mode on AWS
-sidebar_label: High Availability
+title: Deploy Teleport in Production with Terraform on AWS
+sidebar_label: Terraform (Production HA)
 description: How to configure Teleport in High Availability mode for AWS deployments.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport Single-Instance Deployment on AWS
-sidebar_label: Single-Instance
+sidebar_label: Terraform (Single-Instance)
 description: How to quickly configure Teleport on a single instance for testing in AWS.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/deployments.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/deployments.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reference Deployment Guides
+title: Deployment Guides
 description: Teleport Installation and Configuration Reference Deployment Guides.
 template: "no-toc"
 tags:

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/gcp.mdx
@@ -1,5 +1,6 @@
 ---
 title: Running Teleport on GCP
+sidebar_label: Google Cloud VMs
 description: How to install and configure Teleport on GCP
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/high-availability.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/high-availability.mdx
@@ -1,5 +1,7 @@
 ---
 title: "Deploying a High Availability Teleport Cluster"
+sidebar_label: High Availability
+sidebar_position: 1
 description: "Deploying a High Availability Teleport Cluster"
 tags:
  - conceptual
@@ -47,7 +49,7 @@ Infrastructure components include:
   credential provisioner will need to manage DNS records to demonstrate control
   over your domain name.
 
-![Architecture of a high availability Teleport deployment](../../../img/ha-diagram.png)
+![Architecture of a high availability Teleport deployment](../../../../img/ha-diagram.png)
 
 ## Layer 4 load balancers
 
@@ -73,7 +75,7 @@ solution) to ensure availability.
 #### TLS Routing
 
 The way you configure the Proxy Service load balancer depends on whether you
-will enable [TLS Routing](../management/operations/tls-routing.mdx) in your
+will enable [TLS Routing](../../management/operations/tls-routing.mdx) in your
 Teleport cluster.
 
 With TLS Routing, the Teleport Proxy Service uses application-layer protocol
@@ -298,7 +300,7 @@ pod or virtual machine in your group.
 
 If you plan to run Teleport on Kubernetes, the `teleport-cluster` Helm chart
 deploys the Auth Service and Proxy Service pools for you. To see how to use this
-Helm chart, read our [Helm Deployments](helm-deployments/helm-deployments.mdx) documentation.
+Helm chart, read our [Helm Deployments](../helm-deployments/helm-deployments.mdx) documentation.
 
 </Admonition>
 
@@ -355,7 +357,7 @@ Create a configuration file and provide it to each of your Proxy Service
 instances at `/etc/teleport.yaml`. We will explain the required configuration
 fields for a high-availability Teleport deployment below. These are the minimum
 requirements, and when planning your high-availability deployment, you will want
-to follow a more specific [deployment guide](deployments/deployments.mdx) for your
+to follow a more specific [deployment guide](deployments.mdx) for your
 environment. 
 
 #### `proxy_service` and `auth_service`
@@ -469,7 +471,7 @@ Create a configuration file and provide it to each of your Auth Service
 instances at `/etc/teleport.yaml`. We will explain the required configuration
 fields for a high-availability Teleport deployment below. These are the minimum
 requirements, and when planning your high-availability deployment, you will want
-to follow a more specific [deployment guide](deployments/deployments.mdx) for your
+to follow a more specific [deployment guide](deployments.mdx) for your
 environment.
 
 #### `storage`
@@ -485,7 +487,7 @@ teleport:
     # ...
 ```
 
-Consult our [Backends Reference](../../reference/deployment/backends.mdx) for the configuration
+Consult our [Backends Reference](../../../reference/deployment/backends.mdx) for the configuration
 fields you should set in the `storage` section.
 
 #### `auth_service` and `proxy_service`
@@ -542,8 +544,8 @@ deployment, read about how to design your own deployment on Kubernetes or a
 cluster of virtual machines in your cloud of choice:
 
 - [High-availability Teleport Deployments on Kubernetes with
-  Helm](helm-deployments/helm-deployments.mdx)
-- [Reference Deployments](deployments/deployments.mdx) for running Teleport on a cluster of
+  Helm](../helm-deployments/helm-deployments.mdx)
+- [Reference Deployments](deployments.mdx) for running Teleport on a cluster of
   virtual machines
 
 ### Ensure high performance
@@ -551,8 +553,8 @@ cluster of virtual machines in your cloud of choice:
 You should also get familiar with how to ensure that your Teleport deployment is
 performing as expected:
 
-- [Scaling a Teleport cluster](../management/operations/scaling.mdx)
-- [Monitoring a Teleport cluster](../management/diagnostics/diagnostics.mdx)
+- [Scaling a Teleport cluster](../../management/operations/scaling.mdx)
+- [Monitoring a Teleport cluster](../../management/diagnostics/diagnostics.mdx)
 
 ### Deploy Teleport services
 
@@ -562,9 +564,9 @@ separate network from your Teleport cluster.
 
 To get started, read about registering:
 
-- [Applications](../../enroll-resources/application-access/getting-started.mdx)
-- [Servers](../../enroll-resources/server-access/getting-started.mdx)
-- [Kubernetes clusters](../../enroll-resources/kubernetes-access/getting-started.mdx)
-- [Databases](../../enroll-resources/database-access/getting-started.mdx)
-- [Windows desktops](../../enroll-resources/desktop-access/introduction.mdx)
-- [Bot users](../../machine-workload-identity/getting-started.mdx)
+- [Applications](../../../enroll-resources/application-access/getting-started.mdx)
+- [Servers](../../../enroll-resources/server-access/getting-started.mdx)
+- [Kubernetes clusters](../../../enroll-resources/kubernetes-access/getting-started.mdx)
+- [Databases](../../../enroll-resources/database-access/getting-started.mdx)
+- [Windows desktops](../../../enroll-resources/desktop-access/introduction.mdx)
+- [Bot users](../../../machine-workload-identity/getting-started.mdx)

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Multi-region Blueprint"
 description: "Blueprint describing how to deploy a multi-region Teleport Enterprise cluster using CockroachDB."
+sidebar_position: 2
 tags:
  - conceptual
  - platform-wide
@@ -37,7 +38,7 @@ Before continuing, you must acknowledge the following warnings:
 For teams with limited bandwidth who need multi-region clusters, Teleport
 offers to host cross-region clusters. You can benefit from the
 setup described in this document without the operational costs and complexity,
-see [the Teleport Enterprise (Cloud) getting started guide](../../get-started/deploy-cloud.mdx)
+see [the Teleport Enterprise (Cloud) getting started guide](../../../get-started/deploy-cloud.mdx)
 for more details.
 
 </Admonition>
@@ -46,14 +47,14 @@ for more details.
 
 A multi-region Teleport deployment is composed of several regional Teleport
 deployments. Teleport stores its state in a multi-region backend and uses
-[Proxy Peering](../management/operations/proxy-peering.mdx) to connect users to resources
+[Proxy Peering](../../management/operations/proxy-peering.mdx) to connect users to resources
 hosted in a different region.
 
 The recommended multi-region backend
-is [the CockroachDB backend](../../reference/deployment/backends.mdx)
+is [the CockroachDB backend](../../../reference/deployment/backends.mdx)
 available in self-hosted Teleport Enterprise.
 
-![Architecture diagram](../../../img/deploy-a-cluster/multi-region-blueprint.svg)
+![Architecture diagram](../../../../img/deploy-a-cluster/multi-region-blueprint.svg)
 
 To run a multi-region Teleport deployment, you must have:
 
@@ -85,7 +86,7 @@ otherwise healthy regions, potentially leading to a full cluster outage.
 - Create 3 peered regional VPCs (e.g., on AWS) or 1 global VPC (e.g., on GKE).
 - Create 1 Kubernetes cluster in each region, **Pod CIDRs must not overlap**.
 - Ensure pod mesh connectivity. Proxy pods must be able to dial each other
-  [on port 3021](../../reference/deployment/networking.mdx). The setup will vary
+  [on port 3021](../../../reference/deployment/networking.mdx). The setup will vary
   based on your network and CNI plugin configuration:
   - If pods are using the native network layer (for example GKE, or AWS' vpc-cni addon)
     you can rely on pure VPC peering, routing, and firewall capabilities to
@@ -269,7 +270,7 @@ The CockroachDB performance depends on the storage type. Make sure to store
 CockroachDB's state on SSDs. When running on Kubernetes, the default storage
 class might not be the one offering the best latency and throughput.
 
-See the [Teleport scaling](../management/operations/scaling.mdx) page for more
+See the [Teleport scaling](../../management/operations/scaling.mdx) page for more
 details on how to size Teleport.
 
 Teleport load varies depending on the usage type (number of connected

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/separate-proxy-service-endpoints.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/separate-proxy-service-endpoints.mdx
@@ -1,5 +1,6 @@
 ---
 title: Separate Internal and External Proxy Service Traffic
+sidebar_label: Dedicated Internal Address
 description: Explains how to set up the Teleport Proxy Service to isolate traffic from the public internet from internal client traffic.
 tags:
 - how-to
@@ -128,7 +129,7 @@ multiplexing enabled.
    address listed, to use the value of the environment variable instead.
 
    The step differs according to whether you installed Teleport on Linux servers
-   using [Manage Updates v2](../../upgrading/agent-managed-updates/agent-managed-updates.mdx) or
+   using [Manage Updates v2](../../../upgrading/agent-managed-updates/agent-managed-updates.mdx) or
    using the `teleport-kube-agent` Helm chart:
 
    <Tabs>
@@ -174,7 +175,7 @@ In this setup, end users would connect to the external address,
 ### Tunnel public address
 
 If your cluster has disabled [TLS
-multiplexing](../../reference/architecture/tls-routing.mdx), you can configure
+multiplexing](../../../reference/architecture/tls-routing.mdx), you can configure
 internal clients, such as Teleport Agents, to connect to the Teleport Proxy
 Service over a port that is separate from the HTTPS port that end users connect
 to. We recommend using the split DNS or multiple public Proxy Service addresses

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx
@@ -1,5 +1,5 @@
 ---
-title: Running an HA Teleport cluster using AWS, EKS, and Helm
+title: Running an HA Teleport Cluster Using AWS, EKS, and Helm
 sidebar_label: EKS
 description: Install and configure an HA Teleport cluster using an AWS EKS cluster
 tags:
@@ -18,7 +18,7 @@ Teleport cluster that runs on AWS EKS.
 The `teleport-cluster` Helm chart deploys the Teleport Auth Service and Teleport
 Proxy Service on your Amazon Elastic Kubernetes Service cluster, implementing
 the architecture described in [Deploying a High Availability Teleport
-Cluster](../high-availability.mdx). The chart requires the following resources,
+Cluster](../deployments/high-availability.mdx). The chart requires the following resources,
 which we show you how to create in this guide:
 
 - **IAM permissions for the Teleport Auth Service**. The Auth Service requires

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/custom.mdx
@@ -1,5 +1,7 @@
 ---
 title: Running Teleport with a Custom Configuration using Helm
+sidebar_label: Custom Configuration
+sidebar_position: 8
 description: Install and configure a Teleport cluster with a custom configuration using Helm
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/disaster-recovery.mdx
@@ -1,5 +1,6 @@
 ---
 title: Managing Disaster Recovery in an Amazon EKS Teleport Cluster
+sidebar_label: Disaster Recovery
 description: Provides guidance for planning a strategy for restoring a self-hosted Teleport cluster on EKS after a regional outage.
 tags:
  - how-to
@@ -36,7 +37,7 @@ for the Teleport Proxy Service.
 
 - Your self-hosted Teleport cluster was launched using the `teleport-cluster`
   Helm chart. We recommend reading [Deploying a High Availability Teleport
-  Cluster](../high-availability.mdx) for a high-level architectural outline of a
+  Cluster](../deployments/high-availability.mdx) for a high-level architectural outline of a
   self-hosted Teleport cluster.
 - You are using Amazon DynamoDB for the cluster state backend and audit event
   backend, and using Amazon S3 for your session recording backend. For
@@ -111,7 +112,7 @@ configure it to connect to an S3 bucket in the new region.
 
 You can use S3 replication rules to create continuous backups from your primary
 region to the backup region. Follow the [Multi-Region
-Blueprint](../multi-region-blueprint.mdx#setting-up-multi-region-aws-s3-replication)
+Blueprint](../deployments/multi-region-blueprint.mdx#setting-up-multi-region-aws-s3-replication)
 guide to plan multi-region S3 bucket replication for your session recording
 backend.
 
@@ -286,7 +287,7 @@ recovery procedure. Possibilities include:
   Teleport cluster deployments across multiple regions, there is no need to lose
   availability while waiting for your cluster to deploy to a new region. Read
   about the architecture of a multi-region Teleport deployment in the
-  [Multi-Region Blueprint](../multi-region-blueprint.mdx) guide.
+  [Multi-Region Blueprint](../deployments/multi-region-blueprint.mdx) guide.
 
 ### Imposing a change freeze
 

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/helm-deployments.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/helm-deployments.mdx
@@ -1,5 +1,7 @@
 ---
-title: Guides for running Teleport using Helm
+title: Guides for Running Teleport Using Helm
+sidebar_label: Helm Deployments
+sidebar_position: 3
 description: How to install and configure Teleport in Kubernetes using Helm
 template: "no-toc"
 tags:

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/ibm.mdx
@@ -1,5 +1,6 @@
 ---
 title: Running Teleport on IBM Cloud
+sidebar_label: IBM Cloud
 description: How to install and configure Teleport on IBM cloud
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -1,5 +1,6 @@
 ---
 title: Deploy Teleport on Kubernetes
+sidebar_label: Get Started
 description: This guide shows you how to deploy Teleport on a Kubernetes cluster using Helm.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/migration-kubernetes-1-25-psp.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/helm-deployments/migration-kubernetes-1-25-psp.mdx
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes 1.25 and PSP removal
+title: Kubernetes 1.25 Migration
 description: How to prepare for the PodSecurityPolicy removal happening in Kubernetes 1.25
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/deploy-a-cluster/license.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/license.mdx
@@ -1,5 +1,6 @@
 ---
 title: Enterprise License File
+sidebar_position: 1
 description: How to manage your Teleport Enterprise license file.
 tags:
  - conceptual

--- a/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/private-keys.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/private-keys/private-keys.mdx
@@ -1,5 +1,6 @@
 ---
 title: Using Teleport with a Key Management Service"
+sidebar_label: External KMS
 description: Provides information on managing Teleport private keys with a third-party service.
 ---
 

--- a/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/export-audit-events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Exporting Teleport Audit Events
+sidebar_label: Audit Event Export
 description: Learn how to export Teleport audit events to your log management solution.
 tags:
  - zero-trust

--- a/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
@@ -1,6 +1,7 @@
 ---
 title: Infrastructure as Code
 description: An introduction to managing Teleport with Infrastructure as Code tools, including Terraform and Kubernetes resources.
+sidebar_position: 4
 tags:
  - infrastructure-as-code
  - conceptual

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
@@ -1,11 +1,12 @@
 ---
 title: "Managing Resources with Infrastructure as Code"
+sidebar_label: Managing Resources
+sidebar_position: 1
 description: Provides instructions on managing specific dynamic resources with tctl and the Teleport Terraform provider and Kubernetes operator.
 template: "no-toc"
 tags:
  - infrastructure-as-code
  - zero-trust
-sidebar_position: 4
 ---
 
 Read the guides in this section for instructions on managing specific dynamic

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/secret-lookup.mdx
@@ -1,5 +1,6 @@
 ---
-title: Looking up values from secrets
+title: Looking up Values from Secrets
+sidebar_label: Secret Lookup
 description: How to store sensitive values in a Kubernetes Secret and have the operator look them up.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-helm.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-helm.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kubernetes Operator in teleport-cluster Helm chart
+sidebar_label: Deploy with a Cluster
 description: Deploy the operator alongside your Helm-deployed Teleport Cluster.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
@@ -1,5 +1,6 @@
 ---
 title: Standalone Kubernetes Operator
+sidebar_label: Deploy without a Cluster
 description: Run a standalone operator against a remote Teleport cluster such as Teleport Cloud.
 tags:
  - infrastructure-as-code

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/import-existing-resources.mdx
@@ -1,6 +1,7 @@
 ---
 title: Importing Teleport Resources into Terraform
 sidebar_label: Importing Resources
+sidebar_position: 2
 description: How to import your existing Teleport resources into Terraform
 tags:
  - infrastructure-as-code
@@ -93,7 +94,7 @@ reference](../../../reference/infrastructure-as-code/terraform-provider/resource
 
 ## Next steps
 
-- Follow [the user and role IaC guide](user-and-role.mdx) to use the Terraform
+- Follow [the user and role IaC guide](../managing-resources/user-and-role.mdx) to use the Terraform
   Provider to create Teleport users and grant them roles.
 - Explore the full list of supported [Terraform provider
   resources](../../../reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx).

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-getting-started.mdx
@@ -671,7 +671,7 @@ do so, you can:
 
 - Import existing `teleport_user` resources and modify them to include the
   `dev_access` and `prod_access` roles (see the
-  [documentation](../managing-resources/import-existing-resources.mdx)).
+  [documentation](import-existing-resources.mdx)).
 - Create a new `teleport_user` resource that includes the roles
   ([documentation](../managing-resources/user-and-role.mdx).
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx
@@ -48,4 +48,4 @@ Some resources have their dedicated Infrastructure-as-Code (IaC) step-by step gu
 - [Creating Access Lists with IaC](../managing-resources/access-list.mdx)
 - [Registering Agentless OpenSSH Servers with IaC](../managing-resources/agentless-ssh-servers.mdx)
 
-Finally, you can [import your existing resources in Terraform](../managing-resources/import-existing-resources.mdx).
+Finally, you can [import your existing resources in Terraform](import-existing-resources.mdx).

--- a/docs/pages/zero-trust-access/infrastructure-as-code/using-tctl.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/using-tctl.mdx
@@ -1,6 +1,8 @@
 ---
 title: "Getting Started with tctl"
+sidebar_label: tctl Admin Tool
 description: Provides a conceptual overview of tctl, the Teleport administrative client tool.
+sidebar_position: 2
 tags:
 - conceptual
 - platform-wide

--- a/docs/pages/zero-trust-access/management/operations/scaling.mdx
+++ b/docs/pages/zero-trust-access/management/operations/scaling.mdx
@@ -13,7 +13,7 @@ self-hosted deployments of Teleport.
 
 ## Hardware recommendations
 
-Set up Teleport with a [High Availability configuration](../../../zero-trust-access/deploy-a-cluster/high-availability.mdx).
+Set up Teleport with a [High Availability configuration](../../deploy-a-cluster/deployments/high-availability.mdx).
 
 | Scenario                                                              | Max Recommended Count | Proxy Service         | Auth Service          | AWS Instance Types |
 |-----------------------------------------------------------------------|-----------------------|-----------------------|-----------------------|--------------------|

--- a/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
+++ b/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
@@ -20,7 +20,7 @@ these alone may not be sufficient to protect against sophisticated attacks targe
 Attackers are constantly evolving their techniques, and traditional security measures may have limitations
 or vulnerabilities that can be exploited.
 
-![IdP threat vector tree](../../../img/access-controls/idp-graph.png)
+![IdP threat vector tree](../../../../img/access-controls/idp-graph.png)
 
 To enhance your defense against IdP compromises, we recommend implementing the following comprehensive security measures.
 
@@ -38,7 +38,7 @@ It's compatible with hardware keys (e.g., YubiKeys, SoloKeys) and biometric auth
 
 - The `tctl` admin tool and `tsh` client tool.
 
-  Visit [Installation](../../installation/installation.mdx) for instructions on downloading `tctl` and `tsh`.
+  Visit [Installation](../../../installation/installation.mdx) for instructions on downloading `tctl` and `tsh`.
 
 - WebAuthn hardware device, such as YubiKey or SoloKey
 
@@ -157,8 +157,8 @@ $ tsh login --proxy=example.teleport.sh
 ```
 
 <Admonition type="note">
-  WebAuthn for logging in to Teleport is only required for [local users](
-  ../../reference/access-controls/authentication.mdx#local-no-authentication-connector).
+  WebAuthn for logging in to Teleport is only required for [local
+  users](../../../reference/access-controls/authentication.mdx#local-no-authentication-connector).
   SSO users should configure multi-factor authentication in their SSO provider.
 </Admonition>
 
@@ -179,7 +179,7 @@ when starting new:
 <Admonition type="note">
   In addition to per-session MFA, enable login MFA in your SSO provider and/or
   for all [local Teleport
-  users](../../reference/access-controls/authentication.mdx)
+  users](../../../reference/access-controls/authentication.mdx)
   to improve security.
 </Admonition>
 
@@ -365,7 +365,7 @@ enrolls the user's device in their next Teleport (`tsh`) login.
 
 For auto-enrollment to work, the following conditions must be met:
 - A device must be registered. Registration may be [manual](#implement-cluster-wide-device-trust) or
-  performed using [an MDM integration](../../identity-governance/device-trust/device-trust.mdx#mdm-integrations).
+  performed using [an MDM integration](../../../identity-governance/device-trust/device-trust.mdx#mdm-integrations).
 - Auto-enrollment must be enabled in the cluster setting.
 
 ### Step 1/2. Enable auto-enrollment in your cluster settings
@@ -493,8 +493,8 @@ Update the `cluster_auth_preference` definition to include the following content
 ## Next steps
 For additional cluster hardening measures, see:
 
-- [Passwordless Authentication](./passwordless.mdx): Provides passwordless and usernameless authentication.
-- [Locking](../../identity-governance/locking.mdx): Lock access to active user sessions or hosts.
-- [Moderated Sessions](./joining-sessions.mdx): Require session auditors and allow fine-grained live session access.
-- [Hardware Key Support](./hardware-key-support.mdx): Enforce the use of hardware-based private keys.
-- [Configuring SSO for MFA checks](../sso/sso.mdx#configuring-sso-for-mfa-checks): Delegate per-session MFA to your IdP. 
+- [Passwordless Authentication](../../authentication/passwordless.mdx): Provides passwordless and usernameless authentication.
+- [Locking](../../../identity-governance/locking.mdx): Lock access to active user sessions or hosts.
+- [Moderated Sessions](../../authentication/joining-sessions.mdx): Require session auditors and allow fine-grained live session access.
+- [Hardware Key Support](../../authentication/hardware-key-support.mdx): Enforce the use of hardware-based private keys.
+- [Configuring SSO for MFA checks](../../sso/sso.mdx#configuring-sso-for-mfa-checks): Delegate per-session MFA to your IdP. 

--- a/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/labels.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add Labels to Resources
+sidebar_label: Labels
 description: How to assign static and command-based dynamic labels to Teleport resources.
 tags:
  - how-to

--- a/docs/pages/zero-trust-access/rbac-get-started/rbac-get-started.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/rbac-get-started.mdx
@@ -1,5 +1,7 @@
 ---
 title: Get Started with Role-Based Access Control
+sidebar_label: Role-Based Access Control
+sidebar_position: 1
 description: Provides an introduction to the Teleport role-based access control system.
 tags:
  - privileged-access

--- a/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-demo.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started With Teleport Access Controls
+sidebar_label: Get Started
 description: Teleport Role-Based Access Control.
 tags:
  - privileged-access

--- a/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
+++ b/docs/pages/zero-trust-access/rbac-get-started/role-templates.mdx
@@ -1,5 +1,6 @@
 ---
 title: Teleport Role Templates
+sidebar_label: Role Templates
 description: This guide explains templating in Teleport roles. Templates allow you to enable access to resources depending on the traits of a local or single sign-on user.
 tags:
  - sso

--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -1,5 +1,7 @@
 ---
 title: Configure Single Sign-On
+sidebar_label: Single Sign-On
+sidebar_position: 2
 description: How to set up single sign-on (SSO) using Teleport
 tags:
  - sso


### PR DESCRIPTION
Make the Zero Trust Access sidebar easier to navigate by reducing noise. Shorten sidebar labels and add a more logical order based on how broadly applicable a given guide is.

To limit the scope, this change does not address the  Management subsection, which will be reserved for a future change (see #57908). This change does not modify the SSO or Login Rules sections, since
 #61492 will complete that work instead.

Details:
- `/zero-trust-access/infrastructure-as-code/`: Put Managing Resources first, since it includes beginner-level how-to instructions for all three IaC tools we support.
- Move the Terraform resource import guide to the Terraform subsection. It's only applicable to Terraform, and out of place in the Managing Resources section, in which each page has to do with a single resource type.
- Move the IdP Compromise guide. It belongs in the Security section. Also rename the file to more accurately reflect the guide's content.
- Move the general HA guide into Deployment Guides, since that section contains other architectural plans for deploying Teleport. The same goes for the Multi-Region Blueprint guide and Proxy Service traffic separation guide.
- Move the Argo CD guide to the Agents section, since it's a guide to joining an agent, not deploying a Teleport cluster.