### PR TITLE
Limit tshd notifications to one per kind per root cluster

### DIFF
--- a/web/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
+++ b/web/packages/teleterm/src/ui/components/Notifcations/NotificationsHost.tsx
@@ -16,18 +16,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useCallback } from 'react';
+
 import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useStoreSelector } from 'teleterm/ui/hooks/useStoreSelector';
 
 import { Notifications } from './Notifications';
 
 export function NotificationsHost() {
   const { notificationsService } = useAppContext();
-
-  notificationsService.useState();
+  const notifications = useStoreSelector(
+    'notificationsService',
+    useCallback(state => state, [])
+  );
 
   return (
     <Notifications
-      items={notificationsService.getNotifications()}
+      items={[...notifications.values()]}
       onRemoveItem={item => notificationsService.removeNotification(item)}
     />
   );

--- a/web/packages/teleterm/src/ui/services/notifications/notificationsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/notifications/notificationsService.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  NotificationContent,
+  NotificationsService,
+} from './notificationsService';
+
+describe('using a key', () => {
+  it('replaces previous notification with same key', () => {
+    const service = new NotificationsService();
+    const firstNotification: NotificationContent = {
+      description: 'bar',
+      key: 'foo-1',
+    };
+    service.notifyInfo(firstNotification);
+    expect(service.getNotifications()).toEqual([
+      expect.objectContaining({
+        content: expect.objectContaining({ description: 'bar' }),
+      }),
+    ]);
+
+    const secondNotification: NotificationContent = {
+      description: 'baz',
+      key: ['foo', 1],
+    };
+    service.notifyWarning(secondNotification);
+    expect(service.getNotifications()).toEqual([
+      expect.objectContaining({
+        content: expect.objectContaining({ description: 'baz' }),
+      }),
+    ]);
+  });
+});

--- a/web/packages/teleterm/src/ui/services/notifications/notificationsService.ts
+++ b/web/packages/teleterm/src/ui/services/notifications/notificationsService.ts
@@ -20,26 +20,66 @@ import type {
   ToastNotificationItem,
   ToastNotificationItemContent,
 } from 'shared/components/ToastNotification';
-import { useStore } from 'shared/libs/stores';
 
 import { ImmutableStore } from 'teleterm/ui/services/immutableStore';
 import { unique } from 'teleterm/ui/utils/uid';
 
-export class NotificationsService extends ImmutableStore<
-  ToastNotificationItem[]
-> {
-  state: ToastNotificationItem[] = [];
+export type NotificationContent = ToastNotificationItemContent & {
+  key?: NotificationKey;
+};
+export type NotificationKey = string | (string | number)[];
 
-  notifyError(content: ToastNotificationItemContent): string {
-    return this.notify({ severity: 'error', content });
+type State = Map<string, ToastNotificationItem>;
+
+export class NotificationsService extends ImmutableStore<State> {
+  state: State = new Map();
+
+  /**
+   * Adds a notification with error severity.
+   *
+   * If key is passed, replaces any previous notification with equal key. If an array is passed as
+   * a key, the array is joined with '-'.
+   */
+  notifyError(rawContent: NotificationContent): string {
+    const severity = 'error';
+    if (typeof rawContent === 'string') {
+      return this.notify({ severity, content: rawContent });
+    }
+
+    const { key, ...content } = rawContent;
+    return this.notify({ severity, content, key });
   }
 
-  notifyWarning(content: ToastNotificationItemContent): string {
-    return this.notify({ severity: 'warn', content });
+  /**
+   * Adds a notification with warn severity.
+   *
+   * If key is passed, replaces any previous notification with equal key. If an array is passed as
+   * a key, the array is joined with '-'.
+   */
+  notifyWarning(rawContent: NotificationContent): string {
+    const severity = 'warn';
+    if (typeof rawContent === 'string') {
+      return this.notify({ severity, content: rawContent });
+    }
+
+    const { key, ...content } = rawContent;
+    return this.notify({ severity, content, key });
   }
 
-  notifyInfo(content: ToastNotificationItemContent): string {
-    return this.notify({ severity: 'info', content });
+  /**
+   * Adds a notification with info severity.
+   *
+   * If key is passed, replaces any previous notification with equal key. If an array is passed as
+   * a key, the array is joined with '-'.
+   */
+  notifyInfo(rawContent: NotificationContent): string {
+    const severity = 'info';
+    if (typeof rawContent === 'string') {
+      return this.notify({ severity, content: rawContent });
+    }
+
+    const { key, ...content } = rawContent;
+    return this.notify({ severity, content, key });
   }
 
   removeNotification(id: string): void {
@@ -47,32 +87,34 @@ export class NotificationsService extends ImmutableStore<
       return;
     }
 
-    if (!this.state.length) {
+    if (this.state.size === 0) {
       return;
     }
 
-    this.setState(draftState =>
-      draftState.filter(stateItem => stateItem.id !== id)
-    );
+    this.setState(draftState => {
+      draftState.delete(id);
+    });
   }
 
   getNotifications(): ToastNotificationItem[] {
-    return this.state;
+    return [...this.state.values()];
   }
 
   hasNotification(id: string): boolean {
-    return !!this.state.find(n => n.id === id);
+    return this.state.has(id);
   }
 
-  useState(): ToastNotificationItem[] {
-    return useStore(this).state;
-  }
-
-  private notify(options: Omit<ToastNotificationItem, 'id'>): string {
-    const id = unique();
+  private notify(
+    options: Omit<ToastNotificationItem, 'id'> & { key?: NotificationKey }
+  ): string {
+    const id = options.key
+      ? typeof options.key === 'string'
+        ? options.key
+        : options.key.join('-')
+      : unique();
 
     this.setState(draftState => {
-      draftState.push({
+      draftState.set(id, {
         severity: options.severity,
         content: options.content,
         id,


### PR DESCRIPTION
Closes #51336.

changelog: Fixed an issue where Teleport Connect could generate a flurry of notifications about not being able to connect to a resource

You can see in [Bartosz's report](https://gravitational.slack.com/archives/C03FJA391M3/p1764936455036299) that Connect can generate a bunch of notifications. In this case it's about an app proxy not being able to connect to the app because the user did not relogin within 1 minute. This can happen when a program repeatedly tries to connect to a proxied resource over the course of a night. When you open Connect the next day, you're greeted by a flurry of notifications that's impossible to close manually because there's so many of them.

My solution to this is to add a `key` property to a notification. Notifications with the same key overwrite each other. This enables us to limit tshd notifications to one per kind per root cluster. This way if there are multiple clients hammering multiple local proxies all belonging to the same cluster, the user is only ever going to see a single notification in Connect.

Sure, we lose some information, but the notifications are not supposed to be detailed diagnostic reports, merely a sign that something went wrong. If the user sees a single notification about not being able to relogin, they should still know what to do.

There are already callsites where we manually apply the one notification limit (e.g., [in `AppContext`](https://github.com/gravitational/teleport/blob/e15cc40a77bb187597446ad27da73a542bb87d5a/web/packages/teleterm/src/ui/appContext.ts#L257-L274)). The new `key` property will remove the need to store the notification ID manually and instead the callsite will be able to just pass constant key to the notifications service.

---

I tested this by logging in as a user with short TTL, then starting a Postgres gateway, waiting for the cert to expire and then attempting to connect to the proxy through multiple psql invocations in separate shell sessions.