### PR TITLE
Add a distinguished name string parser

### DIFF
--- a/api/utils/pkixname/parser.go
+++ b/api/utils/pkixname/parser.go
@@ -1,0 +1,583 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkixname
+
+import (
+	"bytes"
+	"container/list"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	oidRegexp      = regexp.MustCompile(`^\d+(\.\d+)*$`)
+	attrTypeRegexp = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9-])*$`)
+)
+
+// ParseDistinguishedName parses an RFD 2253-like distinguished name parser.
+//
+// For example: "C=US,O=Teleport,CN=Teleport CA".
+//
+// Deviations in relation to the RFD:
+//   - Common OIDs are not supported: use "C" instead of 2.5.4.6, "O" instead of
+//     2.5.4.10, etc.
+//   - Hexstrings are not supported (ie, "#1234ABCD"). Custom OIDs values must
+//     be strings.
+//   - Attribute types may not be prefixed with "oid." or "OID.".
+//   - Escaped characters are limited to specials and the space character (' ').
+//     No other escapes are allowed, including hex escaping.
+//   - Multi-valued RDNs are only allowed if all values refer to the same
+//     attributeType.
+//   - The only character interpreted as whitespace is the space character
+//     (' ').
+//
+// Reference: https://www.rfc-editor.org/rfc/rfc2253.
+func ParseDistinguishedName(dn string) (*pkix.Name, error) {
+	const maxDNLength = 4096 // arbitrary-ish upper value
+	switch {
+	case dn == "": // Early exit.
+		return &pkix.Name{}, nil
+	case len(dn) > maxDNLength:
+		return nil, errors.New("distinguished name too large, refusing to parse")
+	}
+
+	tokens, err := tokenize(dn)
+	if err != nil {
+		return nil, err
+	}
+
+	dst := &pkix.Name{}
+	if tokens.Len() == 0 {
+		return dst, nil
+	}
+	if err := parseRDNSequence(dst, *tokens); err != nil {
+		return nil, fmt.Errorf("malformed RDNs: %w", err)
+	}
+	return dst, nil
+}
+
+// parseRDNSequence parses a RelativeDistinguishedName sequence, ie, a sequence
+// of AttributeTypeAndValue separated by commas or pluses.
+func parseRDNSequence(dst *pkix.Name, tokens tokenList) error {
+	seenAttrs := make(map[string]struct{})
+	markAttr := func(attr string) error {
+		if _, ok := seenAttrs[attr]; ok {
+			return fmt.Errorf("repeated attributeType %q, remaining tokens: %s", attr, tokens)
+		}
+		seenAttrs[attr] = struct{}{}
+		return nil
+	}
+
+	prevAttr, err := parseATV(dst, tokens)
+	if err != nil {
+		return err
+	}
+	_ = markAttr(prevAttr)
+
+	for {
+		tok, ok := tokens.Peek()
+		if !ok {
+			return nil // end
+		}
+
+		switch tok.kind {
+		case tokenPlus:
+			tokens.PopSilently()
+
+			// Validate that prevAttr == current attr.
+			// If `!ok` just keep going and parseATV() will fail.
+			if nextTok, ok := tokens.Peek(); ok &&
+				nextTok.kind == tokenAttrType &&
+				nextTok.value != prevAttr {
+				return fmt.Errorf(
+					"multi-valued RDN must refer to the same attribute, but found %q instead of %q, remaining tokens: %s",
+					prevAttr,
+					nextTok.value,
+					tokens,
+				)
+			}
+
+			prevAttr, err = parseATV(dst, tokens)
+			if err != nil {
+				return err
+			}
+
+		case tokenComma:
+			tokens.PopSilently()
+			prevAttr, err = parseATV(dst, tokens)
+			if err != nil {
+				return err
+			}
+			if err := markAttr(prevAttr); err != nil {
+				return err
+			}
+
+		default:
+			// Force an error.
+			return requireTokenKind(tokenComma, tok, tokens)
+		}
+	}
+}
+
+// parseATV parses an AttributeTypeAndValue.
+//
+// Eg: "CN" EQUAL "Llama CA".
+func parseATV(dst *pkix.Name, tokens tokenList) (attr string, _ error) {
+	t1, t2, t3, ok := tokens.Peek3()
+	if !ok {
+		return "", fmt.Errorf(
+			"not enough tokens to parse AttributeTypeValue, remaining tokens: %s",
+			tokens,
+		)
+	}
+	if err := requireTokenKind(tokenAttrType, t1, tokens); err != nil {
+		return "", err
+	}
+	if err := requireTokenKind(tokenEqual, t2, tokens); err != nil {
+		return "", err
+	}
+	if err := requireTokenKind(tokenString, t3, tokens); err != nil {
+		return "", err
+	}
+
+	// Pop tokens before returning. We retain the tokens up until the end so
+	// eventual errors include them in the message.
+	defer func() {
+		tokens.PopSilently()
+		tokens.PopSilently()
+		tokens.PopSilently()
+	}()
+
+	attr = t1.value
+	value := t3.value
+
+	// Parse as OID?
+	if oidRegexp.MatchString(attr) {
+		return attr, parseOIDExtraName(dst, attr, value)
+	}
+	// Verify attributeType character set.
+	if !attrTypeRegexp.MatchString(attr) {
+		return "", fmt.Errorf("invalid attributeType (bad character set): %q", attr)
+	}
+
+	switch attr {
+	case "SERIALNUMBER":
+		dst.SerialNumber = value
+	case "CN":
+		dst.CommonName = value
+	case "OU":
+		dst.OrganizationalUnit = append(dst.OrganizationalUnit, value)
+	case "O":
+		dst.Organization = append(dst.Organization, value)
+	case "POSTALCODE":
+		dst.PostalCode = append(dst.PostalCode, value)
+	case "STREET":
+		dst.StreetAddress = append(dst.StreetAddress, value)
+	case "L":
+		dst.Locality = append(dst.Locality, value)
+	case "ST":
+		dst.Province = append(dst.Province, value)
+	case "C":
+		dst.Country = append(dst.Country, value)
+	default:
+		return "", fmt.Errorf("unknown attributeType %q, remaining tokens: %s", attr, tokens)
+	}
+	return attr, nil
+}
+
+func parseOIDExtraName(dst *pkix.Name, attr, value string) error {
+	parts := strings.Split(attr, ".")
+	oid := make(asn1.ObjectIdentifier, 0, len(parts))
+	for _, val := range parts {
+		num, err := strconv.Atoi(val)
+		if err != nil {
+			return fmt.Errorf(
+				"cannot parse OID component %q as int, OID=%q: %w", val, attr, err)
+		}
+		oid = append(oid, num)
+	}
+
+	dst.ExtraNames = append(dst.ExtraNames, pkix.AttributeTypeAndValue{
+		Type:  oid,
+		Value: value,
+	})
+	return nil
+}
+
+func requireTokenKind(wantKind tokenKind, tok *token, tokens tokenList) error {
+	if tok.kind == wantKind {
+		return nil
+	}
+	return fmt.Errorf(
+		"found %s instead of %s, remaining tokens: %s",
+		tok.kind,
+		wantKind,
+		tokens,
+	)
+}
+
+type tokenKind int
+
+const (
+	tokenAttrType = iota + 1
+	tokenString
+	tokenEqual
+	tokenPlus
+	tokenComma
+)
+
+func (k tokenKind) String() string {
+	switch k {
+	case tokenAttrType:
+		return "ATTR"
+	case tokenString:
+		return "STRING"
+	case tokenEqual:
+		return "EQUAL"
+	case tokenPlus:
+		return "PLUS"
+	case tokenComma:
+		return "COMMA"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+type token struct {
+	kind  tokenKind
+	value string
+}
+
+func (t token) String() string {
+	switch t.kind {
+	case tokenAttrType:
+		return t.value
+	case tokenString:
+		return fmt.Sprintf("%q", t.value)
+	default:
+		return t.kind.String()
+	}
+}
+
+type tokenizeState int
+
+const (
+	// initial state, ignores whitespaces.
+	// Transitions to attrType.
+	// Is a valid final state.
+	tokenizeStateInit = iota
+	// Wants an attributeType, ignores whitespaces.
+	// Transitions to attrType.
+	tokenizeStateNameComponent
+	// attributeType parsing started.
+	// Transitions to stringStart.
+	tokenizeStateAttrType
+	// Wants string, ignores whitespaces.
+	// Transitions to string (without consuming the rune) or stringQuote.
+	tokenizeStateStringStart
+	// string parsing started.
+	// Transitions to stringEnd, stringEscape or nameComponent.
+	// Is a valid final state.
+	tokenizeStateString
+	// string parsing found a whitespace. Buffers whitespaces.
+	// Transitions to string (without consuming the rune) or nameComponent.
+	// Is a valid final state.
+	tokenizeStateStringEnd
+	// string escape parsing stated (found '\\'), wants the escaped rune.
+	// Transitions back to string or stringQuote.
+	tokenizeStateStringEscape
+	// Quoted string parsing started.
+	// Transitions to stringEscape or stringQuoteEnd.
+	tokenizeStateStringQuote
+	// Quoted string parsing ended. Ignores whitespace.
+	// Transitions to nameComponent.
+	// Is a valid final state.
+	tokenizeStateStringQuoteEnd
+)
+
+type tokenList struct {
+	list *list.List
+}
+
+func (l tokenList) Len() int {
+	return l.list.Len()
+}
+
+func (l tokenList) Peek() (*token, bool) {
+	if l.list.Len() == 0 {
+		return nil, false
+	}
+
+	e := l.list.Front()
+	return e.Value.(*token), true
+}
+
+func (l tokenList) Peek3() (_, _, _ *token, _ bool) {
+	if l.list.Len() < 3 {
+		return nil, nil, nil, false
+	}
+
+	e1 := l.list.Front()
+	e2 := e1.Next()
+	e3 := e2.Next()
+	return e1.Value.(*token), e2.Value.(*token), e3.Value.(*token), true
+}
+
+func (l tokenList) PopSilently() {
+	l.list.Remove(l.list.Front())
+}
+
+func (l tokenList) PushValue(k tokenKind, v string) {
+	l.list.PushBack(&token{kind: k, value: v})
+}
+
+func (l tokenList) Push(k tokenKind) {
+	l.PushValue(k, "")
+}
+
+func (l tokenList) String() string {
+	if l.list.Len() == 0 {
+		return ""
+	}
+
+	buf := &bytes.Buffer{}
+	root := l.list.Front()
+	for e := root; e != nil; e = e.Next() {
+		if e != root {
+			buf.WriteRune(' ')
+		}
+		buf.WriteString(e.Value.(*token).String())
+	}
+
+	return buf.String()
+}
+
+// tokenize parses a DN string into a sequence of tokens.
+// It handles whitespaces, quotes, escapes and guarantees a correct sequence of
+// tokens: ATTR EQUAL STRING, optionally followed by a PLUS/COMMA and another
+// sequence.
+//
+// An empty string, or a string composed only of whitespace, results in an empty
+// list of tokens.
+//
+// attributeType values are not validated. They are guaranteed to be formed by
+// attributeType or OID characters, but may be invalid according to either type.
+// It's up to callers to narrow down and validate them.
+//
+// https://www.rfc-editor.org/rfc/rfc2253#section-3.
+func tokenize(dn string) (*tokenList, error) {
+	tokens := &tokenList{
+		list: list.New(),
+	}
+	emit := func(k tokenKind) {
+		tokens.Push(k)
+	}
+
+	buf := &bytes.Buffer{}
+	trailingSpaceBuf := &bytes.Buffer{}
+	emitBuffer := func(k tokenKind) {
+		val := buf.String()
+		buf.Reset()
+		tokens.PushValue(k, val)
+	}
+
+	errTrace := func(pos int) string {
+		end := min(pos+10, len(dn)) // arbitrary "forward" point into dn.
+		return fmt.Sprintf("pos=%d, substring %q", pos, dn[pos:end])
+	}
+
+	var state, prevState tokenizeState
+	escapeStart := func() {
+		prevState = state
+		state = tokenizeStateStringEscape
+	}
+	escapeEnd := func() {
+		state = prevState
+	}
+
+	// Used only with '+', ',' and ';' runes.
+	transitionToNameComponent := func(r rune) {
+		switch r {
+		case '+':
+			emit(tokenPlus)
+		case ',', ';':
+			emit(tokenComma)
+		default:
+			panic(fmt.Sprintf("cannot transition to name-component from rune %q, state %v", r, state))
+		}
+		state = tokenizeStateNameComponent
+	}
+
+	for pos, r := range dn {
+		// Skip whitespace in these states.
+		if r == ' ' &&
+			(state == tokenizeStateInit ||
+				state == tokenizeStateNameComponent ||
+				state == tokenizeStateStringStart ||
+				state == tokenizeStateStringQuoteEnd) {
+			continue
+		}
+
+		// string start/end handling.
+		// This happens early because we sometimes transition to "string" without
+		// consuming the rune.
+		switch state {
+		case tokenizeStateStringStart:
+			switch r {
+			case '+', ',', ';':
+				return nil, fmt.Errorf("want attributeValue, found %q: %s", r, errTrace(pos))
+			case '#':
+				return nil, fmt.Errorf("hexstring not supported: %s", errTrace(pos))
+			case '"':
+				state = tokenizeStateStringQuote
+				// Note that a quoted string may be empty.
+				continue
+			default:
+				state = tokenizeStateString
+				// Rune not consumed.
+			}
+
+		case tokenizeStateStringEnd:
+			switch r {
+			case ' ':
+				trailingSpaceBuf.WriteRune(r)
+				continue
+			case '+', ',', ';':
+				trailingSpaceBuf.Reset() // whitespace discarded.
+				emitBuffer(tokenString)
+				transitionToNameComponent(r)
+				continue
+			default:
+				trailingSpaceBuf.WriteTo(buf) // whitespace copied back.
+				trailingSpaceBuf.Reset()
+				state = tokenizeStateString
+				// Rune not consumed.
+			}
+		}
+
+		switch state {
+		case tokenizeStateInit, tokenizeStateNameComponent:
+			switch {
+			case isAttrType(r):
+				state = tokenizeStateAttrType
+				buf.WriteRune(r)
+			default:
+				return nil, fmt.Errorf("want attributeType, found %q: %s", r, errTrace(pos))
+			}
+
+		case tokenizeStateAttrType:
+			switch {
+			case isAttrType(r):
+				buf.WriteRune(r)
+			case r == '=':
+				emitBuffer(tokenAttrType)
+				emit(tokenEqual)
+				state = tokenizeStateStringStart
+			default:
+				return nil, fmt.Errorf("want attributeType or '=', found %q: %s", r, errTrace(pos))
+			}
+
+		case tokenizeStateString:
+			switch r {
+			case '+', ',', ';':
+				emitBuffer(tokenString)
+				transitionToNameComponent(r)
+			case '\\':
+				escapeStart()
+			case '<', '>', '"':
+				// We could '<' and '>', but let's be strict.
+				return nil, fmt.Errorf("special character %q not quoted: %s", r, errTrace(pos))
+			case ' ':
+				trailingSpaceBuf.WriteRune(r)
+				state = tokenizeStateStringEnd
+			case '=', '#': // Go does this.
+				// NOT OK per RFD, should be escaped.
+				fallthrough
+			default:
+				buf.WriteRune(r)
+			}
+
+		case tokenizeStateStringEscape:
+			switch r {
+			case ' ': // Go does this.
+				// OK per RFD and allows the "\\ " trick.
+				fallthrough
+			case ',', '=', '+', '<', '>', '#', ';', '\\', '"':
+				buf.WriteRune(r)
+				escapeEnd()
+			default:
+				return nil, fmt.Errorf("unexpected escaped character %q: %s", r, errTrace(pos))
+			}
+
+		case tokenizeStateStringQuote:
+			switch r {
+			case '\\':
+				escapeStart()
+			case '"':
+				emitBuffer(tokenString)
+				state = tokenizeStateStringQuoteEnd
+			default:
+				buf.WriteRune(r)
+			}
+
+		case tokenizeStateStringQuoteEnd:
+			switch r {
+			case '+', ',', ';':
+				transitionToNameComponent(r)
+			default:
+				return nil, fmt.Errorf("want '+' or ',', found %q: %s", r, errTrace(pos))
+			}
+		}
+	}
+
+	// Input ended, check the final state.
+	switch state {
+	case tokenizeStateInit:
+		// OK.
+	case tokenizeStateNameComponent:
+		return nil, fmt.Errorf("want attributeType, found EOF")
+	case tokenizeStateAttrType:
+		return nil, fmt.Errorf("want attributeType or '=', found EOF")
+	case tokenizeStateStringStart:
+		return nil, fmt.Errorf("want attributeValue, found EOF")
+	case tokenizeStateString, tokenizeStateStringEnd:
+		// OK.
+		emitBuffer(tokenString)
+	case tokenizeStateStringEscape:
+		return nil, fmt.Errorf("want escaped character, found EOF")
+	case tokenizeStateStringQuote:
+		return nil, fmt.Errorf("want closing quote, found EOF")
+	case tokenizeStateStringQuoteEnd:
+		// OK.
+	default:
+		// This should not be reached. All states are handled above.
+		return nil, fmt.Errorf("found EOF (state=%d)", state)
+	}
+
+	return tokens, nil
+}
+
+func isAttrType(r rune) bool {
+	return r >= 'A' && r <= 'Z' ||
+		r >= 'a' && r <= 'z' ||
+		r >= '0' && r <= '9' ||
+		r == '-' ||
+		r == '.'
+}

--- a/api/utils/pkixname/parser.go
+++ b/api/utils/pkixname/parser.go
@@ -31,11 +31,11 @@ var (
 	attrTypeRegexp = regexp.MustCompile(`^[A-Za-z]([A-Za-z0-9-])*$`)
 )
 
-// ParseDistinguishedName parses an RFD 2253-like distinguished name parser.
+// ParseDistinguishedName parses an RFC 2253-like distinguished name parser.
 //
 // For example: "C=US,O=Teleport,CN=Teleport CA".
 //
-// Deviations in relation to the RFD:
+// Deviations in relation to the RFC:
 //   - Common OIDs are not supported: use "C" instead of 2.5.4.6, "O" instead of
 //     2.5.4.10, etc.
 //   - Hexstrings are not supported (ie, "#1234ABCD"). Custom OIDs values must
@@ -508,7 +508,7 @@ func tokenize(dn string) (*tokenList, error) {
 				trailingSpaceBuf.WriteRune(r)
 				state = tokenizeStateStringEnd
 			case '=', '#': // Go does this.
-				// NOT OK per RFD, should be escaped.
+				// NOT OK per RFC, should be escaped.
 				fallthrough
 			default:
 				buf.WriteRune(r)
@@ -517,7 +517,7 @@ func tokenize(dn string) (*tokenList, error) {
 		case tokenizeStateStringEscape:
 			switch r {
 			case ' ': // Go does this.
-				// OK per RFD and allows the "\\ " trick.
+				// OK per RFC and allows the "\\ " trick.
 				fallthrough
 			case ',', '=', '+', '<', '>', '#', ';', '\\', '"':
 				buf.WriteRune(r)

--- a/api/utils/pkixname/parser_test.go
+++ b/api/utils/pkixname/parser_test.go
@@ -148,7 +148,7 @@ func TestParseDistinguishedName(t *testing.T) {
 		},
 		{
 			name: "empty value",
-			in:   "CN=, C= ,O=Llama,OU=",
+			in:   "CN=, C = ,O=Llama,OU=",
 			want: &pkix.Name{
 				Country:            []string{""},
 				Organization:       []string{"Llama"},
@@ -157,11 +157,19 @@ func TestParseDistinguishedName(t *testing.T) {
 		},
 		{
 			name: "empty quoted value",
-			in:   `CN="" , C= "" ,O="Llama",OU=""`,
+			in:   `CN="" , C = "" ,O="Llama",OU=""`,
 			want: &pkix.Name{
 				Country:            []string{""},
 				Organization:       []string{"Llama"},
 				OrganizationalUnit: []string{""},
+			},
+		},
+		{
+			name: "whitespaces",
+			in:   `  CN  =  Llama CA  ,  O  =  "Llama"  +  O  =  Teleport  `,
+			want: &pkix.Name{
+				Organization: []string{"Llama", "Teleport"},
+				CommonName:   "Llama CA",
 			},
 		},
 
@@ -169,6 +177,21 @@ func TestParseDistinguishedName(t *testing.T) {
 			name:    "malformed DN: incomplete ATV",
 			in:      `C`,
 			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: incomplete ATV 2",
+			in:      `C  `,
+			wantErr: "want '=' attributeValue",
+		},
+		{
+			name:    "malformed DN: incomplete ATV 3",
+			in:      `C,`,
+			wantErr: "want attributeType or '='",
+		},
+		{
+			name:    "malformed DN: incomplete ATV 4",
+			in:      `C  ,`,
+			wantErr: "want '=' attributeValue",
 		},
 		{
 			name:    "malformed DN: invalid start",

--- a/api/utils/pkixname/parser_test.go
+++ b/api/utils/pkixname/parser_test.go
@@ -148,19 +148,27 @@ func TestParseDistinguishedName(t *testing.T) {
 		},
 		{
 			name: "empty value",
-			in:   `CN=""`, // strange but valid
-			want: &pkix.Name{},
+			in:   "CN=, C= ,O=Llama,OU=",
+			want: &pkix.Name{
+				Country:            []string{""},
+				Organization:       []string{"Llama"},
+				OrganizationalUnit: []string{""},
+			},
+		},
+		{
+			name: "empty quoted value",
+			in:   `CN="" , C= "" ,O="Llama",OU=""`,
+			want: &pkix.Name{
+				Country:            []string{""},
+				Organization:       []string{"Llama"},
+				OrganizationalUnit: []string{""},
+			},
 		},
 
 		{
 			name:    "malformed DN: incomplete ATV",
 			in:      `C`,
 			wantErr: "want attributeType",
-		},
-		{
-			name:    "malformed DN: incomplete ATV2",
-			in:      `C=`,
-			wantErr: "want attributeValue",
 		},
 		{
 			name:    "malformed DN: invalid start",
@@ -183,17 +191,7 @@ func TestParseDistinguishedName(t *testing.T) {
 			wantErr: "special character",
 		},
 		{
-			name:    "malformed DN: invalid attributeValue 2",
-			in:      `C=+`,
-			wantErr: "want attributeValue",
-		},
-		{
-			name:    "malformed DN: invalid attributeValue 3",
-			in:      `C=,`,
-			wantErr: "want attributeValue",
-		},
-		{
-			name:    "malformed DN: ",
+			name:    "malformed DN: missing =",
 			in:      `C+1`,
 			wantErr: "want attributeType or '='",
 		},
@@ -201,6 +199,21 @@ func TestParseDistinguishedName(t *testing.T) {
 			name:    "malformed second DN: trailing ,",
 			in:      `C=1,`,
 			wantErr: "want attributeType, found EOF",
+		},
+		{
+			name:    "malformed second DN: empty string and trailing +",
+			in:      `C=+`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed second DN: empty string and trailing ,",
+			in:      `C=,`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed second DN: empty string and trailing ;",
+			in:      `C=;`,
+			wantErr: "want attributeType",
 		},
 		{
 			name:    "malformed DN: string extravaganza",

--- a/api/utils/pkixname/parser_test.go
+++ b/api/utils/pkixname/parser_test.go
@@ -1,0 +1,330 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkixname_test
+
+import (
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/utils/pkixname"
+)
+
+func TestParseDistinguishedName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		in       string
+		want     *pkix.Name
+		wantErr  string // error substring
+		skipGoDN bool
+	}{
+		{
+			name: "common attributes",
+			in:   "SERIALNUMBER=12345,CN=Teleport CA,OU=Core,O=Teleport,POSTALCODE=94612,STREET=2100 Franklin St,L=Oakland,ST=California,C=US",
+			want: &pkix.Name{
+				Country:            []string{"US"},
+				Organization:       []string{"Teleport"},
+				OrganizationalUnit: []string{"Core"},
+				Locality:           []string{"Oakland"},
+				Province:           []string{"California"},
+				StreetAddress:      []string{"2100 Franklin St"},
+				PostalCode:         []string{"94612"},
+				SerialNumber:       "12345",
+				CommonName:         "Teleport CA",
+			},
+		},
+		{
+			name: "escaped characters",
+			in:   `CN=\,\=\+\<\>\#\;\\\"`,
+			want: &pkix.Name{
+				CommonName: `,=+<>#;\"`,
+			},
+		},
+		{
+			name: "escaped spaces",
+			in:   `CN=\   Llama CA  \ `,
+			want: &pkix.Name{
+				CommonName: "   Llama CA   ",
+			},
+		},
+		{
+			name:    "invalid <",
+			in:      "CN=<",
+			wantErr: "not quoted",
+		},
+		{
+			name:    "invalid >",
+			in:      "CN=>",
+			wantErr: "not quoted",
+		},
+		{
+			name: "quoted string",
+			in:   `CN=   "  Llama  CA  ,=+<>#;\\'\"  "  `,
+			want: &pkix.Name{
+				CommonName: `  Llama  CA  ,=+<>#;\'"  `,
+			},
+		},
+		{
+			name: "quoted string transitions",
+			in:   `C="US"+C="CA",CN="Bar"`,
+			want: &pkix.Name{
+				Country:    []string{"US", "CA"},
+				CommonName: "Bar",
+			},
+		},
+		{
+			name: "string with trailing spaces transitions",
+			in:   `C=US + C=CA , CN=Bar  `,
+			want: &pkix.Name{
+				Country:    []string{"US", "CA"},
+				CommonName: "Bar",
+			},
+		},
+		{
+			name: "semicolon",
+			in:   "O=Llama;OU=Core Team;CN=Llama Core Team CA",
+			want: &pkix.Name{
+				Organization:       []string{"Llama"},
+				OrganizationalUnit: []string{"Core Team"},
+				CommonName:         "Llama Core Team CA",
+			},
+		},
+		{
+			name: "multi-valued RDN",
+			in:   "O=Teleport+O=Llama+O=Llama with spaces,CN=Teleport Llama CA",
+			want: &pkix.Name{
+				Organization: []string{"Teleport", "Llama", "Llama with spaces"},
+				CommonName:   "Teleport Llama CA",
+			},
+		},
+		{
+			name: "custom OIDs",
+			in:   "1=Foo,1.2=Bar,1.2.3.4.5.6.7=Baz",
+			want: &pkix.Name{
+				ExtraNames: []pkix.AttributeTypeAndValue{
+					{
+						Type:  asn1.ObjectIdentifier{1},
+						Value: "Foo",
+					},
+					{
+						Type:  asn1.ObjectIdentifier{1, 2},
+						Value: "Bar",
+					},
+					{
+						Type:  asn1.ObjectIdentifier{1, 2, 3, 4, 5, 6, 7},
+						Value: "Baz",
+					},
+				},
+			},
+			skipGoDN: true, // outputs custom OIDs as hexstring
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: &pkix.Name{},
+		},
+		{
+			name: "whitespaces string",
+			in:   "   ",
+			want: &pkix.Name{},
+		},
+		{
+			name: "empty value",
+			in:   `CN=""`, // strange but valid
+			want: &pkix.Name{},
+		},
+
+		{
+			name:    "malformed DN: incomplete ATV",
+			in:      `C`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: incomplete ATV2",
+			in:      `C=`,
+			wantErr: "want attributeValue",
+		},
+		{
+			name:    "malformed DN: invalid start",
+			in:      `+C=1`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: invalid start 2",
+			in:      `,C=1`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: invalid start 3",
+			in:      `=C=1`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: invalid attributeValue",
+			in:      `C=<`,
+			wantErr: "special character",
+		},
+		{
+			name:    "malformed DN: invalid attributeValue 2",
+			in:      `C=+`,
+			wantErr: "want attributeValue",
+		},
+		{
+			name:    "malformed DN: invalid attributeValue 3",
+			in:      `C=,`,
+			wantErr: "want attributeValue",
+		},
+		{
+			name:    "malformed DN: ",
+			in:      `C+1`,
+			wantErr: "want attributeType or '='",
+		},
+		{
+			name:    "malformed second DN: trailing ,",
+			in:      `C=1,`,
+			wantErr: "want attributeType, found EOF",
+		},
+		{
+			name:    "malformed DN: string extravaganza",
+			in:      `C=Foo " Bar " Baz`,
+			wantErr: "special character",
+		},
+		{
+			name:    "malformed DN: string extravaganza 2",
+			in:      `C="Foo " Bar "Baz"`,
+			wantErr: "want '+' or ','",
+		},
+		{
+			name:    "malformed DN: incomplete escape",
+			in:      `CN=\`,
+			wantErr: "want escaped character",
+		},
+		{
+			name:    "malformed DN: incomplete quote",
+			in:      `CN="`,
+			wantErr: "want closing quote",
+		},
+		{
+			name:    "malformed DN: quoted attribute",
+			in:      `"CN"=Foo`,
+			wantErr: "want attributeType",
+		},
+		{
+			name:    "malformed DN: invalid attributeType charset",
+			in:      "L.LAMA=Bar", // letter start means no dots allowed
+			wantErr: "invalid attributeType",
+		},
+		{
+			name:    "malformed DN: invalid attributeType charset 2",
+			in:      "1LLAMA=Bar", // number start not allowed
+			wantErr: "invalid attributeType",
+		},
+		{
+			name:    "malformed DN: invalid oid",
+			in:      "1.9999999999999999999.3=Bar", // too large for int
+			wantErr: "cannot parse OID",
+		},
+		{
+			name:    "invalid: repeated attributeType",
+			in:      "C=US,C=CA",
+			wantErr: "repeated attributeType",
+		},
+		{
+			name:    "invalid: unknown attributeType",
+			in:      "LLAMA=Yes",
+			wantErr: "unknown attributeType",
+		},
+
+		{
+			name: "rfc2253 example1",
+			in:   `CN=Steve Kille,O=Isode Limited,C=GB`,
+			want: &pkix.Name{
+				Country:      []string{"GB"},
+				Organization: []string{"Isode Limited"},
+				CommonName:   "Steve Kille",
+			},
+		},
+		{
+			name: "rfc2253 example2",
+			// We don't allow OU+CN, it has to be the same attr.
+			in:      `OU=Sales+CN=J. Smith,O=Widget Inc.,C=US`,
+			wantErr: "multi-valued RDN",
+		},
+		{
+			name: "rfc2253 example3",
+			in:   `CN=L. Eagle,O=Sue\, Grabbit and Runn,C=GB`,
+			want: &pkix.Name{
+				Country:      []string{"GB"},
+				Organization: []string{"Sue, Grabbit and Runn"},
+				CommonName:   "L. Eagle",
+			},
+		},
+		{
+			name:    "rfc2253 example4",
+			in:      `CN=Before\0DAfter,O=Test,C=GB`, // We don't allow hex escapes.
+			wantErr: "unexpected escaped character",
+		},
+		{
+			name:    "rfc2253 example5",
+			in:      `1.3.6.1.4.1.1466.0=#04024869,O=Test,C=GB`,
+			wantErr: "hexstring not supported",
+		},
+		{
+			name:    "rfc2253 example6",
+			in:      `SN=Lu\C4\8Di\C4\87`, // We don't allow hex escapes.
+			wantErr: "unexpected escaped character",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := pkixname.ParseDistinguishedName(test.in)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "ParseDistinguishedName() error mismatch")
+				return
+			}
+			require.NoError(t, err, "ParseDistinguishedName() errored")
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("pkix.Name mismatch (-want +got)\n%s", diff)
+			}
+
+			if test.skipGoDN {
+				return
+			}
+
+			// If Go generates a different string, parse it too.
+			// The end result is equivalent.
+			goDN := test.want.String()
+			if goDN != test.in {
+				t.Run("Go's DN", func(t *testing.T) {
+					t.Logf("DN: [%s]", goDN)
+
+					got, err := pkixname.ParseDistinguishedName(goDN)
+					require.NoError(t, err, "ParseDistinguishedName() errored")
+					if diff := cmp.Diff(test.want, got); diff != "" {
+						t.Errorf("pkix.Name mismatch (-want +got)\n%s", diff)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds an RFC 2253-like distinguished name parser.

See the godoc in ParseDistinguishedName for details.

https://github.com/gravitational/teleport.e/issues/7675