### PR TITLE
Web: Add empty states for single resources

### DIFF
--- a/web/packages/teleport/src/components/Empty/Empty.story.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.story.tsx
@@ -1,0 +1,105 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router';
+
+import Empty from '.';
+import { EmptyResourceKind } from './type';
+
+type StoryProps = {
+  resourceKind: EmptyResourceKind;
+  canCreate: boolean;
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Teleport/EmptyResource',
+  argTypes: {
+    resourceKind: {
+      control: { type: 'select' },
+      options: [
+        'node',
+        'kube_cluster',
+        'app',
+        'db',
+        'windows_desktop',
+        'git_server',
+        'awsIcApp',
+      ],
+    },
+    canCreate: {
+      control: { type: 'boolean' },
+    },
+  },
+  // default
+  args: {
+    resourceKind: 'app',
+    canCreate: true,
+  },
+};
+export default meta;
+
+export function SingleResource(props: StoryProps) {
+  return (
+    <MemoryRouter>
+      <Empty
+        canCreate={props.canCreate}
+        clusterId="some-cluster-id"
+        kind={props.resourceKind}
+      />
+    </MemoryRouter>
+  );
+}
+
+export const CustomCanCreate = () => {
+  return (
+    <MemoryRouter>
+      <Empty
+        canCreate={true}
+        clusterId="some-cluster-id"
+        emptyStateInfo={{
+          byline: 'custom byline',
+          title: 'custom title',
+          readOnly: {
+            title: 'custom read only title',
+            resource: 'custom read only resource',
+          },
+        }}
+      />
+    </MemoryRouter>
+  );
+};
+
+export const CustomCannotCreate = () => {
+  return (
+    <MemoryRouter>
+      <Empty
+        canCreate={false}
+        clusterId="some-cluster-id"
+        emptyStateInfo={{
+          byline: 'custom byline',
+          title: 'custom title',
+          readOnly: {
+            title: 'custom read only title',
+            resource: 'custom read only resource',
+          },
+        }}
+      />
+    </MemoryRouter>
+  );
+};

--- a/web/packages/teleport/src/components/Empty/Empty.test.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.test.tsx
@@ -20,9 +20,10 @@ import { MemoryRouter } from 'react-router';
 
 import { render, screen } from 'design/utils/testing';
 
-import Empty, { Props } from './Empty';
+import Empty from './Empty';
+import { Custom } from './type';
 
-test('empty state for enterprise or oss, with create perms', async () => {
+test('empty state with create perms', async () => {
   render(
     <MemoryRouter>
       <Empty {...props} />
@@ -34,7 +35,7 @@ test('empty state for enterprise or oss, with create perms', async () => {
   ).resolves.toBeVisible();
 });
 
-test('empty state for cant create or leaf cluster', async () => {
+test('empty state without create perms', async () => {
   render(
     <MemoryRouter>
       <Empty {...props} canCreate={false} />
@@ -46,7 +47,7 @@ test('empty state for cant create or leaf cluster', async () => {
   ).resolves.toBeVisible();
 });
 
-const props: Props = {
+const props: Custom = {
   clusterId: 'im-a-cluster',
   canCreate: true,
   emptyStateInfo: {

--- a/web/packages/teleport/src/components/Empty/type.ts
+++ b/web/packages/teleport/src/components/Empty/type.ts
@@ -1,0 +1,57 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ResourceAccessKind } from 'teleport/Roles/RoleEditor/StandardEditor/standardmodel';
+
+/**
+ * awsIcApp describes a sub_kind of application and some features
+ * require an empty state for it e.g. access list.
+ */
+export type EmptyResourceKind = ResourceAccessKind | 'awsIcApp';
+
+type Base = {
+  canCreate: boolean;
+  clusterId: string;
+};
+
+/**
+ * Custom allows you to customize the empty state info.
+ */
+export type Custom = Base & {
+  emptyStateInfo: EmptyStateInfo;
+  kind?: never;
+};
+
+/**
+ * SingleResource uses default empty state info specific
+ * to the resource kind specified.
+ */
+export type SingleResource = Base & {
+  kind: EmptyResourceKind;
+  emptyStateInfo?: never;
+};
+
+export type EmptyStateInfo = {
+  byline: string;
+  docsURL?: string;
+  readOnly: {
+    title: string;
+    resource: string;
+  };
+  title: string;
+};


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Added default empty states specific to resource kind.
Kept the original `custom` empty state behavior with icon defaulting to `server`
Added story: https://localhost:9003/?path=/story/teleport-emptyresource--single-resource

<details>
<summary>screenshots with different kinds</summary>

<img width="376" height="265" alt="image" src="https://github.com/user-attachments/assets/72f08f63-7101-4fb0-b18d-859f283d24b4" />
<img width="451" height="258" alt="image" src="https://github.com/user-attachments/assets/443affec-2936-4923-9c79-87ffd85bdd44" />
<img width="372" height="237" alt="image" src="https://github.com/user-attachments/assets/ea0360d4-142b-4ea2-b209-2a600362610c" />
<img width="337" height="245" alt="image" src="https://github.com/user-attachments/assets/d4594bd8-2a12-4f8c-84dd-598e3210f35c" />
<img width="423" height="251" alt="image" src="https://github.com/user-attachments/assets/e2c7803b-11fe-4cb2-b25e-69be6ab567e8" />
<img width="354" height="246" alt="image" src="https://github.com/user-attachments/assets/9227a3ba-77f1-45df-9080-8dc41374d602" />
<img width="382" height="261" alt="image" src="https://github.com/user-attachments/assets/6d37c349-eded-41b5-b198-624efb6009dd" />


</details>
