### PR TITLE
Implement terraform/stringify webapi endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1032,6 +1032,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/yaml/parse/:kind", h.WithAuth(h.yamlParse))
 	h.POST("/webapi/yaml/stringify/:kind", h.WithAuth(h.yamlStringify))
 
+	h.POST("/webapi/terraform/stringify/:kind", h.WithAuth(h.terraformStringify))
+
 	// Desktop access endpoints.
 	h.GET("/webapi/sites/:site/desktops", h.WithClusterAuth(h.clusterDesktopsGet))
 	h.GET("/webapi/sites/:site/desktopservices", h.WithClusterAuth(h.clusterDesktopServicesGet))

--- a/lib/web/tfgen.go
+++ b/lib/web/tfgen.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/tfgen"
+)
+
+type terraformStringifyResponse struct {
+	Terraform string `json:"terraform"`
+}
+
+func (h *Handler) terraformStringify(
+	w http.ResponseWriter,
+	r *http.Request,
+	params httprouter.Params,
+	ctx *SessionContext,
+) (any, error) {
+	kind := params.ByName("kind")
+	if len(kind) == 0 {
+		return nil, trace.BadParameter("query param %q is required", "kind")
+	}
+
+	var tfResult []byte
+
+	switch kind {
+	case types.KindAccessMonitoringRule:
+		var req struct {
+			Resource *accessmonitoringrulesv1.AccessMonitoringRule `json:"resource"`
+		}
+
+		err := httplib.ReadResourceJSON(r, &req)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		tfResult, err = tfgen.Generate(req.Resource)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+	default:
+		return nil, trace.NotImplemented("Generate Terraform for kind %q is not supported", kind)
+	}
+
+	return terraformStringifyResponse{Terraform: string(tfResult)}, nil
+}

--- a/lib/web/tfgen_test.go
+++ b/lib/web/tfgen_test.go
@@ -1,0 +1,105 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+const validAccessMonitoringRuleTerraform = `resource "teleport_access_monitoring_rule" "foo" {
+  version = "v1"
+
+  metadata = {
+    name = "foo"
+  }
+
+  spec = {
+    subjects  = ["access_request"]
+    condition = "some-condition"
+    notification = {
+      name       = "mattermost"
+      recipients = ["apple"]
+    }
+  }
+}
+`
+
+func TestTerraformStringify_Valid(t *testing.T) {
+	t.Parallel()
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "test@example.com", nil)
+
+	req := struct {
+		Resource *accessmonitoringrulesv1.AccessMonitoringRule `json:"resource"`
+	}{
+		Resource: getAccessMonitoringRuleResource(),
+	}
+
+	endpoint := pack.clt.Endpoint("webapi", "terraform", "stringify", types.KindAccessMonitoringRule)
+	re, err := pack.clt.PostJSON(context.Background(), endpoint, req)
+	require.NoError(t, err)
+
+	var resp terraformStringifyResponse
+	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+	require.Equal(t, validAccessMonitoringRuleTerraform, resp.Terraform)
+}
+
+func TestTerraformStringify_Errors(t *testing.T) {
+	t.Parallel()
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "test@example.com", nil)
+
+	testCases := []struct {
+		desc string
+		kind string
+	}{
+		{
+			desc: "unsupported kind",
+			kind: "something-random",
+		},
+		{
+			desc: "missing kind",
+			kind: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			endpoint := pack.clt.Endpoint("webapi", "terraform", "stringify", tc.kind)
+			_, err := pack.clt.PostJSON(context.Background(), endpoint, struct {
+				Resource *accessmonitoringrulesv1.AccessMonitoringRule `json:"resource"`
+			}{
+				Resource: getAccessMonitoringRuleResource(),
+			})
+
+			require.Error(t, err)
+		})
+	}
+}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -48,6 +48,7 @@ import generateResourcePath from './generateResourcePath';
 import { IntegrationTag } from './Integrations/Enroll/Shared';
 import type { MfaChallengeResponse } from './services/mfa';
 import { KindAuthConnectors } from './services/resources';
+import { TerraformSupportedResourceKind } from './services/tfgen/types';
 
 export type Cfg = typeof cfg;
 const cfg = {
@@ -537,6 +538,10 @@ const cfg = {
     yaml: {
       parse: '/v1/webapi/yaml/parse/:kind',
       stringify: '/v1/webapi/yaml/stringify/:kind',
+    },
+
+    tfgen: {
+      stringify: '/v1/webapi/terraform/stringify/:kind',
     },
 
     sessionRecording: {
@@ -1176,6 +1181,10 @@ const cfg = {
 
   getYamlStringifyUrl(kind: YamlSupportedResourceKind) {
     return generatePath(cfg.api.yaml.stringify, { kind });
+  },
+
+  getTerraformStringifyUrl(kind: TerraformSupportedResourceKind) {
+    return generatePath(cfg.api.tfgen.stringify, { kind });
   },
 
   getLocksRoute() {

--- a/web/packages/teleport/src/services/tfgen/index.ts
+++ b/web/packages/teleport/src/services/tfgen/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { tfgenService } from './tfgen';

--- a/web/packages/teleport/src/services/tfgen/tfgen.ts
+++ b/web/packages/teleport/src/services/tfgen/tfgen.ts
@@ -1,0 +1,36 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cfg from 'teleport/config';
+import api from 'teleport/services/api';
+
+import {
+  TerraformStringifyRequest,
+  TerraformSupportedResourceKind,
+} from './types';
+
+export const tfgenService = {
+  stringify<T>(
+    kind: TerraformSupportedResourceKind,
+    req: TerraformStringifyRequest<T>
+  ): Promise<string> {
+    return api
+      .post(cfg.getTerraformStringifyUrl(kind), req)
+      .then(resp => resp.terraform);
+  },
+};

--- a/web/packages/teleport/src/services/tfgen/types.ts
+++ b/web/packages/teleport/src/services/tfgen/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export type TerraformStringifyRequest<T> = {
+  resource: T;
+};
+
+export enum TerraformSupportedResourceKind {
+  AccessMonitoringRule = 'access_monitoring_rule',
+}

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -36,6 +36,7 @@ import RecordingsService from './services/recordings';
 import ResourceService from './services/resources';
 import sessionService from './services/session';
 import { storageService } from './services/storageService';
+import { tfgenService } from './services/tfgen/tfgen';
 import userService from './services/user';
 import userGroupService from './services/userGroups';
 import { yamlService } from './services/yaml/yaml';
@@ -64,6 +65,7 @@ class TeleportContext implements types.Context {
   mfaService = new MfaService();
   notificationService = new NotificationService();
   yamlService = yamlService;
+  tfgenService = tfgenService;
 
   notificationContentFactory = notificationContentFactory;
 


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport.e/issues/7690
Requires: https://github.com/gravitational/teleport/pull/61660

This PR extends the webapi to support a new endpoint `/webapi/terraform/stringify/:kind` that converts a provided resource into Terraform config. The endpoint follows the same format as the `webapi/yaml/stringify/:kind` endpoint.

Currently, the only supported kind for this endpoint is `access_monitoring_rules`. `TerraformSupportedResourceKind` and `terraformStringify` implementation must be updated to support additional resource kinds.