### PR TITLE
[v17] VNet on Windows: Force refresh policies under group policy key, configure DNS only when necessary

### DIFF
--- a/lib/vnet/osconfig_windows.go
+++ b/lib/vnet/osconfig_windows.go
@@ -309,14 +309,16 @@ func deleteRegistryKey(key string) error {
 
 // https://learn.microsoft.com/en-us/windows/win32/api/userenv/nf-userenv-refreshpolicyex
 func forceRefreshComputerPolicies() error {
-	// rp_force is a flag for RefreshPolicyEx which makes it reapply all policies even if no policy
-	// change was detected.
-	const rp_force = 1
+	// refreshComputerPolicies corresponds to the first argument of RefreshPolicyEx which specifies
+	// whether to refresh computer or user policies.
+	const refreshComputerPolicies = 1
+	// rpForce corresponds to the RP_FORCE flag for RefreshPolicyEx which makes it reapply all
+	// policies even if no policy change was detected.
+	const rpForce = 1
 
 	retVal, _, err := procRefreshPolicyEx.Call(
-		// Refresh computer policies.
-		uintptr(1),
-		uintptr(rp_force),
+		uintptr(refreshComputerPolicies),
+		uintptr(rpForce),
 	)
 	if retVal == 0 {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #61881 to branch/v17

changelog: Fixed intermittent issues with VNet on Windows when other NRPT rules from GPOs are present under `HKLM:\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\DnsPolicyConfig`
