### PR TITLE
Add path filter to Unit Tests (Helm)

### DIFF
--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -28,6 +28,7 @@ jobs:
               - 'examples/chart/**'
               - 'Makefile'
               - 'docs/pages/reference/helm-reference/*'
+              - 'docs/pages/includes/helm-reference/*'
 
   test:
     name: Unit Tests (Helm)


### PR DESCRIPTION
Add the `docs/pages/includes/helm-reference/*` path as a path filter to Unit Tests (Helm) so that, if we accidentally change a generated Helm reference page (e.g., with a script), the check exits with an error.