### PR TITLE
Simplify networking process error logs

### DIFF
--- a/lib/sshutils/networking/networking.go
+++ b/lib/sshutils/networking/networking.go
@@ -47,7 +47,6 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
-	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/uds"
 )
 
@@ -142,25 +141,6 @@ func (p *Process) start(ctx context.Context) error {
 		p.conn.Close()
 		return trace.Wrap(err)
 	}
-
-	// The child process writes errors to the parent connection for logging purposes.
-	go func() {
-		for {
-			buf := make([]byte, RequestBufferSize)
-			n, err := p.conn.Read(buf)
-			if err != nil {
-				if utils.IsOKNetworkError(err) {
-					return
-				}
-				slog.WarnContext(ctx, "Failed to read error from networking process.", "error", err)
-				return
-			}
-
-			if n > 0 {
-				slog.WarnContext(ctx, "Received unexpected error from networking process.", "error", string(buf[:n]))
-			}
-		}
-	}()
 
 	go func() {
 		defer close(p.done)


### PR DESCRIPTION
Make the networking process log errors directly through the new logger file descriptor rather than through the per-request uds connection.

Manual Tests:
- [x] Start an agent/x11/port forwarding session. Confirm that the forwarding still works and the process closes on completion.
Note: the errors logged here are not expected or easy to reproduce, so the logging itself is not manually tested outside of the testing done for #61297

Depends on #61297