### PR TITLE
Changes to support login loadtest agent

### DIFF
--- a/lib/auth/authtest/helpers_mfa.go
+++ b/lib/auth/authtest/helpers_mfa.go
@@ -20,6 +20,7 @@ package authtest
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -47,8 +48,54 @@ type Device struct {
 	passwordless bool
 }
 
+var _ json.Marshaler = (*Device)(nil)
+
+func (d *Device) MarshalJSON() ([]byte, error) {
+	alias := struct {
+		MFA          *types.MFADevice `json:"mfa"`
+		TOTPSecret   string           `json:"totp_secret"`
+		Key          *mocku2f.Key     `json:"key"`
+		Origin       string           `json:"origin"`
+		Passwordless bool             `json:"passwordless"`
+	}{
+		MFA:          d.MFA,
+		TOTPSecret:   d.TOTPSecret,
+		Key:          d.Key,
+		Origin:       d.origin,
+		Passwordless: d.passwordless,
+	}
+
+	return json.Marshal(&alias)
+}
+
+func (d *Device) UnmarshalJSON(data []byte) error {
+	var alias struct {
+		MFA          *types.MFADevice `json:"mfa"`
+		TOTPSecret   string           `json:"totp_secret"`
+		Key          *mocku2f.Key     `json:"key"`
+		Origin       string           `json:"origin"`
+		Passwordless bool             `json:"passwordless"`
+	}
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return trace.Wrap(err)
+	}
+	d.MFA = alias.MFA
+	d.TOTPSecret = alias.TOTPSecret
+	d.Key = alias.Key
+	d.origin = alias.Origin
+	d.passwordless = alias.Passwordless
+	d.clock = clockwork.NewRealClock()
+	return nil
+}
+
 // TestDeviceOpt is a creation option for TestDevice.
 type TestDeviceOpt func(d *Device)
+
+func WithOrigin(origin string) TestDeviceOpt {
+	return func(d *Device) {
+		d.origin = origin
+	}
+}
 
 func WithTestDeviceClock(clock clockwork.Clock) TestDeviceOpt {
 	return func(d *Device) {

--- a/lib/auth/mocku2f/mocku2f.go
+++ b/lib/auth/mocku2f/mocku2f.go
@@ -85,10 +85,13 @@ type Key struct {
 	counter uint32
 }
 
-var _ json.Marshaler = (*Key)(nil)
+var (
+	_ json.Marshaler   = (*Key)(nil)
+	_ json.Unmarshaler = (*Key)(nil)
+)
 
 func (k *Key) MarshalJSON() ([]byte, error) {
-	type Alias Key
+	type alias Key
 
 	privateKey, err := x509.MarshalECPrivateKey(k.PrivateKey)
 	if err != nil {
@@ -97,21 +100,21 @@ func (k *Key) MarshalJSON() ([]byte, error) {
 	s := struct {
 		PrivateKey []byte `json:"PrivateKey"`
 		Counter    uint32 `json:"Counter"`
-		*Alias
+		*alias
 	}{
 		PrivateKey: privateKey,
 		Counter:    k.counter,
-		Alias:      (*Alias)(k),
+		alias:      (*alias)(k),
 	}
 	return json.Marshal(s)
 }
 
 func (k *Key) UnmarshalJSON(data []byte) error {
-	type Alias Key
+	type alias Key
 	var s struct {
 		PrivateKey []byte `json:"PrivateKey"`
 		Counter    uint32 `json:"Counter"`
-		*Alias
+		*alias
 	}
 	if err := json.Unmarshal(data, &s); err != nil {
 		return trace.Wrap(err)
@@ -122,7 +125,7 @@ func (k *Key) UnmarshalJSON(data []byte) error {
 		return trace.Wrap(err, "parsing private key")
 	}
 
-	*k = Key(*s.Alias)
+	*k = Key(*s.alias)
 	k.PrivateKey = privateKey
 	k.counter = s.Counter
 	return nil


### PR DESCRIPTION
This PR does 2 minor changes to the `authtest` and `mocku2f` libraries to support json marshalling and unmarshalling test devices. This should not affect production code in any way.

Required by: https://github.com/gravitational/teleport.e/pull/7711