### PR TITLE
[v18][mcp] defer sending session start event to capture more session metadata

### DIFF
--- a/lib/srv/mcp/audit.go
+++ b/lib/srv/mcp/audit.go
@@ -20,11 +20,15 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -69,6 +73,11 @@ func (c *sessionAuditorConfig) checkAndSetDefaults() error {
 // sessionAuditor handles audit events for a session.
 type sessionAuditor struct {
 	sessionAuditorConfig
+
+	// pendingSessionStartEvent is used to delay sending the session start event
+	// until more metadata is received.
+	pendingSessionStartEvent *apievents.MCPSessionStart
+	mu                       sync.Mutex
 }
 
 func newSessionAuditor(cfg sessionAuditorConfig) (*sessionAuditor, error) {
@@ -126,10 +135,11 @@ func (a *sessionAuditor) shouldEmitEvent(method string) bool {
 	}
 }
 
-func (a *sessionAuditor) emitStartEvent(ctx context.Context, options ...eventOptionFunc) {
+func (a *sessionAuditor) appendStartEvent(ctx context.Context, options ...eventOptionFunc) {
 	opts := newEventOptions(options...)
 
-	a.emitEvent(ctx, &apievents.MCPSessionStart{
+	// Prepare it to have the correct index.
+	preparedEvent, err := a.preparer.PrepareSessionEvent(&apievents.MCPSessionStart{
 		Metadata: a.makeEventMetadata(
 			events.MCPSessionStartEvent,
 			events.MCPSessionStartCode,
@@ -139,9 +149,20 @@ func (a *sessionAuditor) emitStartEvent(ctx context.Context, options ...eventOpt
 		UserMetadata:       a.makeUserMetadata(),
 		ConnectionMetadata: a.makeConnectionMetadata(),
 		AppMetadata:        a.makeAppMetadata(),
-		McpSessionId:       a.sessionCtx.mcpSessionID.String(),
 		EgressAuthType:     guessEgressAuthType(opts.header, a.sessionCtx.App.GetRewrite()),
 	})
+	if err != nil {
+		a.logger.ErrorContext(ctx, "failed to prepare session start event", "error", err)
+		return
+	}
+	event, ok := preparedEvent.GetAuditEvent().(*apievents.MCPSessionStart)
+	if !ok {
+		a.logger.ErrorContext(ctx, "failed to get session start event from prepared event")
+		return
+	}
+	a.mu.Lock()
+	a.pendingSessionStartEvent = event
+	a.mu.Unlock()
 }
 
 func (a *sessionAuditor) emitEndEvent(ctx context.Context, options ...eventOptionFunc) {
@@ -168,7 +189,7 @@ func (a *sessionAuditor) emitEndEvent(ctx context.Context, options ...eventOptio
 		event.Status.Success = false
 		event.Status.Error = opts.err.Error()
 	}
-	a.emitEvent(ctx, event)
+	a.flushAndEmitEvent(ctx, event)
 }
 
 func (a *sessionAuditor) emitNotificationEvent(ctx context.Context, msg *mcputils.JSONRPCNotification, options ...eventOptionFunc) {
@@ -199,7 +220,7 @@ func (a *sessionAuditor) emitNotificationEvent(ctx context.Context, msg *mcputil
 		event.Status.Success = false
 		event.Status.Error = opts.err.Error()
 	}
-	a.emitEvent(ctx, event)
+	a.flushAndEmitEvent(ctx, event)
 }
 
 func (a *sessionAuditor) emitRequestEvent(ctx context.Context, msg *mcputils.JSONRPCRequest, options ...eventOptionFunc) {
@@ -232,7 +253,16 @@ func (a *sessionAuditor) emitRequestEvent(ctx context.Context, msg *mcputils.JSO
 		event.Status.Success = false
 		event.Status.Error = opts.err.Error()
 	}
-	a.emitEvent(ctx, event)
+
+	// Initialize should be the first request. Let's not flush session start
+	// event yet but wait for the initialize result. Flush if request is
+	// anything else to avoid delaying.
+	if msg.Method == mcputils.MethodInitialize {
+		a.updatePendingSessionStartEventWithInitializeRequest(msg)
+		a.emitEvent(ctx, event)
+	} else {
+		a.flushAndEmitEvent(ctx, event)
+	}
 }
 
 func (a *sessionAuditor) emitListenSSEStreamEvent(ctx context.Context, options ...eventOptionFunc) {
@@ -255,7 +285,7 @@ func (a *sessionAuditor) emitListenSSEStreamEvent(ctx context.Context, options .
 		event.Status.Success = false
 		event.Status.Error = opts.err.Error()
 	}
-	a.emitEvent(ctx, event)
+	a.flushAndEmitEvent(ctx, event)
 }
 
 func (a *sessionAuditor) emitInvalidHTTPRequest(ctx context.Context, r *http.Request) {
@@ -274,6 +304,22 @@ func (a *sessionAuditor) emitInvalidHTTPRequest(ctx context.Context, r *http.Req
 		RawQuery:        r.URL.RawQuery,
 		Headers:         wrappers.Traits(r.Header),
 	}
+	a.flushAndEmitEvent(ctx, event)
+}
+
+func (a *sessionAuditor) flush(ctx context.Context) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pendingSessionStartEvent != nil {
+		if err := a.emitter.EmitAuditEvent(ctx, a.pendingSessionStartEvent); err != nil {
+			a.logger.ErrorContext(ctx, "failed to emit session start event", "error", err)
+		}
+		a.pendingSessionStartEvent = nil
+	}
+}
+
+func (a *sessionAuditor) flushAndEmitEvent(ctx context.Context, event apievents.AuditEvent) {
+	a.flush(ctx)
 	a.emitEvent(ctx, event)
 }
 
@@ -335,6 +381,47 @@ func (a *sessionAuditor) makeSessionMetadata() apievents.SessionMetadata {
 
 func (a *sessionAuditor) makeUserMetadata() apievents.UserMetadata {
 	return a.sessionCtx.Identity.GetUserMetadata()
+}
+
+func (a *sessionAuditor) updatePendingSessionStartEvent(fn func(*apievents.MCPSessionStart)) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.pendingSessionStartEvent != nil {
+		fn(a.pendingSessionStartEvent)
+	}
+}
+
+func (a *sessionAuditor) updatePendingSessionStartEventWithInitializeRequest(msg *mcputils.JSONRPCRequest) {
+	// TODO(greedy52) avoid the Marshal when migrating to official SDK.
+	paramsData, err := json.Marshal(msg.Params)
+	if err != nil {
+		return
+	}
+	var params mcp.InitializeParams
+	if err := json.Unmarshal(paramsData, &params); err != nil {
+		return
+	}
+	a.updatePendingSessionStartEvent(func(sessionStartEvent *apievents.MCPSessionStart) {
+		sessionStartEvent.ProtocolVersion = params.ProtocolVersion
+		sessionStartEvent.ClientInfo = fmt.Sprintf("%s/%s", params.ClientInfo.Name, params.ClientInfo.Version)
+	})
+}
+
+func (a *sessionAuditor) updatePendingSessionStartEventWithInitializeResult(ctx context.Context, resp *mcputils.JSONRPCResponse) {
+	if initResult, err := resp.GetInitializeResult(); err == nil && initResult != nil {
+		a.updatePendingSessionStartEvent(func(sessionStartEvent *apievents.MCPSessionStart) {
+			sessionStartEvent.ServerInfo = fmt.Sprintf("%s/%s", initResult.ServerInfo.Name, initResult.ServerInfo.Version)
+		})
+	}
+
+	// We can flush now as we receive the result.
+	a.flush(ctx)
+}
+
+func (a *sessionAuditor) updatePendingSessionStartEventWithExternalSessionID(sessionID string) {
+	a.updatePendingSessionStartEvent(func(event *apievents.MCPSessionStart) {
+		event.McpSessionId = sessionID
+	})
 }
 
 var headersWithSecret = []string{

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -19,6 +19,7 @@
 package mcp
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"net"
@@ -32,6 +33,7 @@ import (
 	docker "github.com/docker/docker/client"
 	"github.com/gravitational/trace"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -199,6 +201,7 @@ func makeTestAuthContext(t *testing.T, roleSet services.RoleSet, app types.Appli
 			Username:   user.GetName(),
 			Groups:     user.GetRoles(),
 			Principals: user.GetLogins(),
+			Expires:    time.Now().Add(time.Hour),
 		},
 	}
 	if app != nil {
@@ -350,4 +353,43 @@ type mockAuthClient struct {
 
 func (m mockAuthClient) GenerateAppToken(_ context.Context, req types.GenerateAppTokenRequest) (string, error) {
 	return "app-token-for-" + req.Username, nil
+}
+
+func checkSessionStartAndInitializeEvents(t *testing.T, events []apievents.AuditEvent, extraChecks ...func(*testing.T, *apievents.MCPSessionStart)) {
+	t.Helper()
+	// "notifications/initialized" may or may not slip in so just check the
+	// first two.
+	slices.SortFunc(events, func(a, b apievents.AuditEvent) int {
+		return cmp.Compare(a.GetIndex(), b.GetIndex())
+	})
+	require.GreaterOrEqual(t, len(events), 2)
+	sessionStart, ok := events[0].(*apievents.MCPSessionStart)
+	require.True(t, ok)
+	assert.Equal(t, "test-client/1.0.0", sessionStart.ClientInfo)
+	request, ok := events[1].(*apievents.MCPSessionRequest)
+	require.True(t, ok)
+	assert.Equal(t, string(mcp.MethodInitialize), request.Message.Method)
+
+	for _, check := range extraChecks {
+		check(t, sessionStart)
+	}
+}
+
+func checkSessionStartWithServerInfo(wantName, wantVersion string) func(*testing.T, *apievents.MCPSessionStart) {
+	return func(t *testing.T, sessionStart *apievents.MCPSessionStart) {
+		t.Helper()
+		require.Equal(t, wantName+"/"+wantVersion, sessionStart.ServerInfo)
+	}
+}
+func checkSessionStartWithEgressAuthType(wantEgress string) func(*testing.T, *apievents.MCPSessionStart) {
+	return func(t *testing.T, sessionStart *apievents.MCPSessionStart) {
+		t.Helper()
+		require.Equal(t, wantEgress, sessionStart.EgressAuthType)
+	}
+}
+func checkSessionStartHasExternalSessionID() func(*testing.T, *apievents.MCPSessionStart) {
+	return func(t *testing.T, sessionStart *apievents.MCPSessionStart) {
+		t.Helper()
+		require.NotEmpty(t, sessionStart.SessionID)
+	}
 }

--- a/lib/srv/mcp/http.go
+++ b/lib/srv/mcp/http.go
@@ -79,6 +79,7 @@ func (s *Server) handleStreamableHTTP(ctx context.Context, sessionCtx *SessionCt
 	if err != nil {
 		return trace.Wrap(err, "setting up session handler")
 	}
+	defer session.sessionAuditor.flush(s.cfg.ParentContext)
 
 	transport, err := s.makeStreamableHTTPTransport(session)
 	if err != nil {
@@ -170,7 +171,7 @@ func (t *streamableHTTPTransport) RoundTrip(r *http.Request) (*http.Response, er
 
 func (t *streamableHTTPTransport) setExternalSessionID(header http.Header) {
 	if id := header.Get(mcpSessionIDHeader); id != "" {
-		t.mcpSessionID.Store(&id)
+		t.updatePendingSessionStartEventWithExternalSessionID(id)
 	}
 }
 
@@ -221,11 +222,11 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 	switch {
 	case baseMessage.IsRequest():
 		mcpRequest := baseMessage.MakeRequest()
-		if errResp, authErr := t.sessionHandler.processClientRequestNoAudit(r.Context(), mcpRequest); authErr != nil {
+		if errResp, authErr := t.sessionHandler.processClientRequest(r.Context(), mcpRequest); authErr != nil {
 			return t.handleRequestAuthError(r, mcpRequest, errResp, authErr)
 		}
 	case baseMessage.IsNotification():
-		// nothing to do, yet.
+		t.sessionHandler.processClientNotification(r.Context(), baseMessage.MakeNotification())
 	default:
 		// Not sending it to the server if we don't understand it.
 		t.emitInvalidHTTPRequest(t.parentCtx, r)
@@ -247,11 +248,11 @@ func (t *streamableHTTPTransport) handleMCPMessage(r *http.Request) (*http.Respo
 		mcpRequest := baseMessage.MakeRequest()
 		// Only emit session start if "initialize" succeeded.
 		if mcpRequest.Method == mcputils.MethodInitialize && respErrForAudit == nil {
-			t.emitStartEvent(t.parentCtx, eventWithHeader(r.Header))
+			t.appendStartEvent(r.Context(), eventWithHeader(r.Header))
 		}
-		t.emitRequestEvent(t.parentCtx, mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitRequestEvent(r.Context(), mcpRequest, eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	case baseMessage.IsNotification():
-		t.emitNotificationEvent(t.parentCtx, baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
+		t.emitNotificationEvent(r.Context(), baseMessage.MakeNotification(), eventWithError(respErrForAudit), eventWithHeader(r.Header))
 	}
 	return resp, trace.Wrap(err)
 }
@@ -305,7 +306,11 @@ func newHTTPResponseReplacer(sessionHandler *sessionHandler) *streamableHTTPResp
 }
 
 func (p *streamableHTTPResponseReplacer) ProcessResponse(ctx context.Context, resp *mcputils.JSONRPCResponse) mcp.JSONRPCMessage {
-	return p.processServerResponse(ctx, resp)
+	method, response := p.processServerResponse(ctx, resp)
+	if method == mcputils.MethodInitialize {
+		p.sessionAuditor.updatePendingSessionStartEventWithInitializeResult(ctx, resp)
+	}
+	return response
 }
 func (p *streamableHTTPResponseReplacer) ProcessNotification(ctx context.Context, notification *mcputils.JSONRPCNotification) mcp.JSONRPCMessage {
 	p.processServerNotification(ctx, notification)

--- a/lib/srv/mcp/http_test.go
+++ b/lib/srv/mcp/http_test.go
@@ -107,6 +107,7 @@ func Test_handleStreamableHTTP(t *testing.T) {
 				defer wg.Done()
 				defer conn.Close()
 				testCtx := setupTestContext(t, withAdminRole(t), withApp(app), withClientConn(conn))
+				testCtx.sessionID = "test-session-id" // use same session id
 				assert.NoError(t, s.HandleSession(t.Context(), testCtx.SessionCtx))
 			}()
 		}
@@ -141,11 +142,11 @@ func Test_handleStreamableHTTP(t *testing.T) {
 				libevents.MCPSessionRequestCode, // "tools/call"
 			}, sliceutils.Map(emitter.Events(), getEventCode))
 		}, 2*time.Second, time.Millisecond*100, "waiting for events")
-
-		// First event must be the start event.
-		startEvent, ok := emitter.Events()[0].(*apievents.MCPSessionStart)
-		require.True(t, ok)
-		require.Equal(t, "app-jwt", startEvent.EgressAuthType)
+		checkSessionStartAndInitializeEvents(t, emitter.Events(),
+			checkSessionStartWithServerInfo("test-server", "1.0.0"),
+			checkSessionStartHasExternalSessionID(),
+			checkSessionStartWithEgressAuthType("app-jwt"),
+		)
 
 		// Close client and wait for end event.
 		require.NoError(t, client.Close())

--- a/lib/srv/mcp/session_test.go
+++ b/lib/srv/mcp/session_test.go
@@ -19,6 +19,9 @@
 package mcp
 
 import (
+	"context"
+	"slices"
+	"sync"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -29,6 +32,24 @@ import (
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/utils/mcputils"
 )
+
+type captureMessageWriter struct {
+	mu   sync.Mutex
+	msgs []mcp.JSONRPCMessage
+}
+
+func (c *captureMessageWriter) WriteMessage(_ context.Context, msg mcp.JSONRPCMessage) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.msgs = append(c.msgs, msg)
+	return nil
+}
+
+func (c *captureMessageWriter) messages() []mcp.JSONRPCMessage {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.msgs)
+}
 
 func Test_sessionHandler(t *testing.T) {
 	tests := []struct {
@@ -82,23 +103,26 @@ func Test_sessionHandler(t *testing.T) {
 			require.NoError(t, err)
 
 			t.Run("notification", func(t *testing.T) {
-				handler.processClientNotification(ctx, &mcputils.JSONRPCNotification{
+				msg := &mcputils.JSONRPCNotification{
 					JSONRPC: mcp.JSONRPC_VERSION,
 					Method:  "notifications/initialized",
-				})
+				}
+				capture := &captureMessageWriter{}
+				require.NoError(t, handler.onClientNotification(capture)(ctx, msg))
 				event := mockEmitter.LastEvent()
 				require.NotNil(t, event)
 				requestEvent, ok := event.(*apievents.MCPSessionNotification)
 				require.True(t, ok)
 				require.Equal(t, "notifications/initialized", requestEvent.Message.Method)
+				require.Equal(t, []mcp.JSONRPCMessage{msg}, capture.messages())
 			})
 
 			for _, allowedTool := range tt.allowedTools {
 				t.Run("allow tools call "+allowedTool, func(t *testing.T) {
 					clientReq := requestBuilder.makeToolsCallRequest(allowedTool)
-					msg, dir := handler.processClientRequest(ctx, clientReq)
-					require.Equal(t, replyToServer, dir)
-					require.Equal(t, clientReq, msg)
+					clientCapture := &captureMessageWriter{}
+					serverCapture := &captureMessageWriter{}
+					require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
 
 					event := mockEmitter.LastEvent()
 					require.NotNil(t, event)
@@ -107,17 +131,19 @@ func Test_sessionHandler(t *testing.T) {
 					require.True(t, requestEvent.Success)
 					require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
 					checkParamsHaveNameField(t, requestEvent.Message.Params, allowedTool)
+
+					// Server receives the client's request.
+					require.Equal(t, []mcp.JSONRPCMessage{clientReq}, serverCapture.messages())
+					require.Empty(t, clientCapture.messages())
 				})
 			}
 
 			for _, deniedTool := range tt.deniedTools {
 				t.Run("deny tools call "+deniedTool, func(t *testing.T) {
 					clientReq := requestBuilder.makeToolsCallRequest(deniedTool)
-					msg, dir := handler.processClientRequest(ctx, clientReq)
-					require.Equal(t, replyToClient, dir)
-					errMsg, ok := msg.(mcp.JSONRPCError)
-					require.True(t, ok)
-					require.Equal(t, clientReq.ID, errMsg.ID)
+					clientCapture := &captureMessageWriter{}
+					serverCapture := &captureMessageWriter{}
+					require.NoError(t, handler.onClientRequest(clientCapture, serverCapture)(ctx, clientReq))
 
 					event := mockEmitter.LastEvent()
 					require.NotNil(t, event)
@@ -126,6 +152,13 @@ func Test_sessionHandler(t *testing.T) {
 					require.False(t, requestEvent.Success)
 					require.Equal(t, mcputils.MethodToolsCall, requestEvent.Message.Method)
 					checkParamsHaveNameField(t, requestEvent.Message.Params, deniedTool)
+
+					// Server does not receive the client's request. An error is
+					// sent to client.
+					require.Empty(t, serverCapture.messages())
+					clientMessages := clientCapture.messages()
+					require.Len(t, clientMessages, 1)
+					require.IsType(t, mcp.JSONRPCError{}, clientMessages[0])
 				})
 			}
 
@@ -134,8 +167,8 @@ func Test_sessionHandler(t *testing.T) {
 
 				// First make a request so the handler can track the method by ID.
 				clientReq := requestBuilder.makeToolsListRequest()
-				_, dir := handler.processClientRequest(ctx, clientReq)
-				require.Equal(t, replyToServer, dir)
+				_, authErr := handler.processClientRequest(ctx, clientReq)
+				require.NoError(t, authErr)
 
 				// tools/list does not trigger audit event.
 				require.Nil(t, mockEmitter.LastEvent())
@@ -145,8 +178,11 @@ func Test_sessionHandler(t *testing.T) {
 				// filtering.
 				allTools := append(tt.allowedTools, tt.deniedTools...)
 				serverResponse := makeToolsCallResponse(t, clientReq.ID, allTools...)
-				processedResponse := handler.processServerResponse(ctx, serverResponse)
-				checkToolsListResponse(t, processedResponse, clientReq.ID, tt.allowedTools)
+				capture := &captureMessageWriter{}
+				require.NoError(t, handler.onServerResponse(capture)(ctx, serverResponse))
+				clientMessages := capture.messages()
+				require.Len(t, clientMessages, 1)
+				checkToolsListResponse(t, clientMessages[0], clientReq.ID, tt.allowedTools)
 			})
 		})
 	}

--- a/lib/srv/mcp/stdio.go
+++ b/lib/srv/mcp/stdio.go
@@ -84,6 +84,7 @@ func (s *Server) handleStdio(ctx context.Context, sessionCtx *SessionCtx, makeSe
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer session.close()
 
 	session.logger.InfoContext(ctx, "Started handling stdio session")
 	defer session.logger.InfoContext(ctx, "Completed handling stdio session")
@@ -131,11 +132,6 @@ func (s *Server) handleStdio(ctx context.Context, sessionCtx *SessionCtx, makeSe
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
-	// TODO(greedy52) capture client info then emit start event with client
-	// information.
-	session.emitStartEvent(s.cfg.ParentContext)
-	defer session.emitEndEvent(s.cfg.ParentContext)
 
 	go clientRequestReader.Run(ctx)
 	go serverResponseReader.Run(ctx)

--- a/lib/srv/mcp/stdio_test.go
+++ b/lib/srv/mcp/stdio_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -96,18 +97,14 @@ func Test_handleStdio(t *testing.T) {
 		require.NoError(t, handlerErr)
 	}()
 
-	// Use a real client. Verify session start and end events.
+	// Use a real client.
 	stdioClient := mcptest.NewStdioClientFromConn(t, testCtx.clientSourceConn)
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		event := emitter.LastEvent()
-		_, ok := event.(*apievents.MCPSessionStart)
-		assert.True(collect, ok)
-	}, time.Second*5, time.Millisecond*100, "expect session start")
 
 	// Some basic tests on the demo server.
 	resp, err := mcptest.InitializeClient(ctx, stdioClient)
 	require.NoError(t, err)
 	require.Equal(t, "teleport-demo", resp.ServerInfo.Name)
+	checkSessionStartAndInitializeEvents(t, emitter.Events(), checkSessionStartWithServerInfo("teleport-demo", teleport.Version))
 
 	listToolsResult, err := stdioClient.ListTools(ctx, mcp.ListToolsRequest{})
 	require.NoError(t, err)


### PR DESCRIPTION
backport of #61253 to branch/v18

minor conflict in test files.