### PR TITLE
Add `annotations` support for Event Handler helm chart

### DIFF
--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "event-handler.fullname" . }}
+  {{- with .Values.annotations.config }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}
 data:

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "event-handler.fullname" . }}
+  {{- with .Values.annotations.deployment }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}
 spec:
@@ -15,12 +19,12 @@ spec:
       {{- include "event-handler.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
+      {{- with coalesce .Values.annotations.pod .Values.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "event-handler.selectorLabels" . | nindent 8 }}
+        {{- include "event-handler.labels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -20,7 +20,10 @@ should match the snapshot:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
+            app.kubernetes.io/version: 19.0.0-dev
+            helm.sh/chart: teleport-plugin-event-handler-19.0.0-dev
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/tests/configmap_test.yaml
+++ b/examples/chart/event-handler/tests/configmap_test.yaml
@@ -16,3 +16,21 @@ tests:
           keyPath: myclient.key
     asserts:
       - matchSnapshot: {}
+
+  - it: should not contain annotations when not defined
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
+  - it: should contain annotations when defined
+    set:
+      annotations:
+        config:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -18,6 +18,7 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
+
   - it: should mount tls.existingCASecretName and set environment when set in values
     template: deployment.yaml
     values:
@@ -42,3 +43,61 @@ tests:
             value: /etc/teleport-tls-ca/ca.pem
       - matchSnapshot:
           path: spec.template.spec
+
+  - it: should not contain deployment or pod annotations when not defined
+    asserts:
+      - isNull:
+          path: metadata.annotations
+      - isNull:
+          path: spec.template.metadata.annotations
+
+  - it: should contain deployment annotations when defined
+    set:
+      annotations:
+        deployment:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - isNull:
+          path: spec.template.metadata.annotations
+
+  - it: should contain pod annotations when defined
+    set:
+      annotations:
+        pod:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - isNull:
+          path: metadata.annotations
+
+  - it: should contain both annotations when defined
+    set:
+      annotations:
+        deployment:
+          keyA: valA
+          keyB: valB
+        pod:
+          keyA: valA'
+          keyC: valC
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            keyA: valA
+            keyB: valB
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            keyA: valA'
+            keyC: valC

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -11,6 +11,7 @@
         "podSecurityContext",
         "securityContext",
         "nodeSelector",
+        "annotations",
         "tolerations",
         "affinity",
         "teleport",
@@ -224,6 +225,32 @@
             "type": "object",
             "default": {},
             "additionalProperties": true
+        },
+        "annotations": {
+            "$id": "#/properties/annotations",
+            "type": "object",
+            "required": [
+                "config",
+                "deployment",
+                "pod"
+            ],
+            "properties": {
+                "config": {
+                    "$id": "#/properties/annotations/properties/config",
+                    "type": "object",
+                    "default": {}
+                },
+                "deployment": {
+                    "$id": "#/properties/annotations/properties/deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "pod": {
+                    "$id": "#/properties/annotations/properties/pod",
+                    "type": "object",
+                    "default": {}
+                }
+            }
         },
         "tls": {
             "$id": "#/properties/tls",

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -128,6 +128,18 @@ persistentVolumeClaim:
   existingClaim: ""
   volumeName: "storage"
 
+# annotations -- contains annotations to apply to the different Kubernetes
+# objects created by the chart. See [the Kubernetes annotation
+# documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+# for more details.
+annotations:
+  # annotations.config(object) -- are annotations to set on the ConfigMap.
+  config: {}
+  # annotations.deployment(object) -- are annotations to set on the Deployment.
+  deployment: {}
+  # annotations.pod(object) -- are annotations to set on the Pods.
+  pod: {}
+
 #
 # Deployment
 #

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -153,6 +153,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Deprecated way to set pod annotations. `annotations.pod` should be preferred.
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Fixes #49406

This PR adds `annotations` support for the Event Handler helm chart for ConfigMap, Pod, and Deployment. A minor fix was added to set Pod's labels properly.

changelog: Added `annotations` support for `teleport-plugin-event-handler` helm chart