### PR TITLE
Add TF IaC EntraID SSO + SAML connector setup

### DIFF
--- a/examples/terraform/entra-id-sso/azure.tf
+++ b/examples/terraform/entra-id-sso/azure.tf
@@ -1,0 +1,94 @@
+# Azure EntraID SAML application resources
+
+# Normalize proxy URL to always include https://
+locals {
+  proxy_url = startswith(var.proxy_public_addr, "https://") ? var.proxy_public_addr : "https://${var.proxy_public_addr}"
+}
+
+# Get current Azure AD configuration
+data "azuread_client_config" "current" {}
+
+# Create the Application Registration
+resource "azuread_application" "teleport_saml" {
+  display_name = "Teleport ${local.proxy_url}"
+
+  api {
+    mapped_claims_enabled          = true
+    requested_access_token_version = 2
+  }
+  web {
+    redirect_uris = [
+      "${local.proxy_url}/v1/webapi/saml/acs/${var.auth_connector_name}"
+    ]
+  }
+  group_membership_claims = ["SecurityGroup"]
+  optional_claims {
+    saml2_token {
+      name = "groups"
+    }
+  }
+  sign_in_audience = "AzureADMyOrg"
+}
+
+# Set the Identifier URI (Entity ID) for SAML
+resource "azuread_application_identifier_uri" "teleport_saml" {
+  application_id = azuread_application.teleport_saml.id
+  identifier_uri = "${local.proxy_url}/v1/webapi/saml/acs/${var.auth_connector_name}"
+}
+
+# Create the Enterprise Application (Service Principal)
+resource "azuread_service_principal" "teleport_saml" {
+  client_id = azuread_application.teleport_saml.client_id
+
+  preferred_single_sign_on_mode = "saml"
+  app_role_assignment_required = false
+
+  feature_tags {
+    enterprise            = true
+    custom_single_sign_on = true
+  }
+}
+
+# Create a SAML signing certificate
+resource "azuread_service_principal_token_signing_certificate" "teleport_saml" {
+  service_principal_id = azuread_service_principal.teleport_saml.id
+  display_name         = "CN=azure-sso"
+  end_date             = timeadd(timestamp(), "8760h") # 1 year
+}
+
+# Set the preferred signing certificate
+resource "azuread_service_principal_certificate" "teleport_saml" {
+  service_principal_id = azuread_service_principal.teleport_saml.id
+  type                 = "AsymmetricX509Cert"
+  value                = azuread_service_principal_token_signing_certificate.teleport_saml.value
+  end_date             = azuread_service_principal_token_signing_certificate.teleport_saml.end_date
+}
+
+# Create Claims Mapping Policy to set NameID to email (optional)
+resource "azuread_claims_mapping_policy" "teleport_email_nameid" {
+  display_name = "Teleport NameID Email Policy"
+  definition = [
+    jsonencode({
+      ClaimsMappingPolicy = {
+        Version              = 1
+        IncludeBasicClaimSet = "true"
+        ClaimsSchema = [
+          {
+            Source           = "user"
+            ID               = "mail"
+            SamlClaimType    = "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"
+            SamlNameIdFormat = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+          }
+        ]
+      }
+    })
+  ]
+}
+
+# Assign the claims mapping policy to the service principal
+resource "azuread_service_principal_claims_mapping_policy_assignment" "teleport_saml" {
+  claims_mapping_policy_id = azuread_claims_mapping_policy.teleport_email_nameid.id
+  service_principal_id     = azuread_service_principal.teleport_saml.id
+}
+
+

--- a/examples/terraform/entra-id-sso/outputs.tf
+++ b/examples/terraform/entra-id-sso/outputs.tf
@@ -1,0 +1,19 @@
+output "application_id" {
+  description = "Application (Client) ID"
+  value       = azuread_application.teleport_saml.client_id
+}
+
+output "tenant_id" {
+  description = "Azure AD Tenant ID"
+  value       = data.azuread_client_config.current.tenant_id
+}
+
+output "federation_metadata_url" {
+  description = "SAML Federation Metadata URL"
+  value       = "https://login.microsoftonline.com/${data.azuread_client_config.current.tenant_id}/federationmetadata/2007-06/federationmetadata.xml?appid=${azuread_application.teleport_saml.client_id}"
+}
+
+output "teleport_connector_name" {
+  description = "Name of the created SAML connector in Teleport"
+  value       = teleport_saml_connector.entra_id.metadata.name
+}

--- a/examples/terraform/entra-id-sso/teleport.tf
+++ b/examples/terraform/entra-id-sso/teleport.tf
@@ -1,0 +1,33 @@
+# Teleport SAML connector creation
+
+# Create the SAML connector in Teleport
+resource "teleport_saml_connector" "entra_id" {
+  version = "v2"
+  metadata = {
+    name = var.auth_connector_name
+  }
+
+  spec = {
+    # ACS URL where SAML responses  sent
+    acs = "${local.proxy_url}/v1/webapi/saml/acs/${var.auth_connector_name}"
+
+    # Entity descriptor URL from Azure AD
+    entity_descriptor_url = "https://login.microsoftonline.com/${data.azuread_client_config.current.tenant_id}/federationmetadata/2007-06/federationmetadata.xml?appid=${azuread_application.teleport_saml.client_id}"
+
+    # Map Azure AD groups to Teleport roles
+    attributes_to_roles = var.attributes_to_roles
+
+    # Display name in Teleport UI
+    display = var.display
+
+    # Allow IdP-initiated login
+    allow_idp_initiated = var.allow_idp_initiated
+  }
+
+  # Wait for Azure resources to be fully provisioned
+  depends_on = [
+    azuread_application.teleport_saml,
+    azuread_service_principal.teleport_saml,
+    azuread_service_principal_token_signing_certificate.teleport_saml
+  ]
+}

--- a/examples/terraform/entra-id-sso/terraform.tfvars.example
+++ b/examples/terraform/entra-id-sso/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# EntraID SAML Connector Configuration
+
+# Teleport Proxy public address (with or without https:// prefix)
+# Examples: "teleport.example.com:443" or "https://teleport.example.com:443"
+proxy_public_addr = "teleport.example.com:443"
+
+# SAML connector name in Teleport
+auth_connector_name = "entra-id"

--- a/examples/terraform/entra-id-sso/variables.tf
+++ b/examples/terraform/entra-id-sso/variables.tf
@@ -1,0 +1,38 @@
+variable "proxy_public_addr" {
+  description = "Teleport Proxy public address (with or without https:// prefix, e.g., 'teleport.example.com' or 'https://teleport.example.com')"
+  type        = string
+}
+
+variable "auth_connector_name" {
+  description = "Name of the SAML connector in Teleport"
+  type        = string
+  default     = "entra-id"
+}
+
+variable "attributes_to_roles" {
+  description = "List of attribute mappings from Azure AD groups to Teleport roles"
+  type = list(object({
+    name  = string
+    value = string
+    roles = list(string)
+  }))
+  default = [
+    {
+      name  = "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"
+      value = "*"
+      roles = ["requester"]
+    }
+  ]
+}
+
+variable "display" {
+  description = "Display name for the SAML connector in Teleport UI"
+  type        = string
+  default     = "Entra ID"
+}
+
+variable "allow_idp_initiated" {
+  description = "Allow IdP-initiated SAML login"
+  type        = bool
+  default     = false
+}

--- a/examples/terraform/entra-id-sso/versions.tf
+++ b/examples/terraform/entra-id-sso/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 2.47"
+    }
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = "~> 18.0"
+    }
+  }
+}


### PR DESCRIPTION
#### WIP

### What

Add EntraID SAML app setup + Teleport SAML entraID connector setup as a teleport module
allowing customers to just do: 

```tf

terraform {
  required_version = ">= 1.0"

  required_providers {
    azuread = {
      source  = "hashicorp/azuread"
      version = "~> 2.47"
    }
    teleport = {
      source  = "terraform.releases.teleport.dev/gravitational/teleport"
      version = "~> 18.0"
    }
  }
}


locals {
  proxy_public_addr = "teleport.exampe.com:443"
}


provider "azuread" {}

provider "teleport" {
  addr = local.proxy_public_addr
}

module "entra-teleport-sso" {
  source            = "github.com/gravitational/teleport//examples/terraform/entra-id-sso"
  proxy_public_addr = local.proxy_public_addr
}

```

So Setup full entraID + telepot SSO integration  on Teleport and Azure sides 
