### PR TITLE
Access Lists: Add status fixing functions

### DIFF
--- a/lib/backend/backendtest/randomly_erroring_backend.go
+++ b/lib/backend/backendtest/randomly_erroring_backend.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtest
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"math/rand/v2"
+
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+var ErrRandomBackend = errors.New("RandomlyErroringBackend error")
+
+// RandomlyErroringBackend wraps Backend reading methods making them fail 50% of the time with
+// [ErrRandomBackend].
+type RandomlyErroringBackend struct {
+	backend.Backend
+}
+
+// NewRandomlyErroringBackend creates new instance of RandomlyErroringBackend for a given backend.
+func NewRandomlyErroringBackend(b backend.Backend) *RandomlyErroringBackend {
+	return &RandomlyErroringBackend{
+		Backend: b,
+	}
+}
+
+func (b *RandomlyErroringBackend) Get(ctx context.Context, key backend.Key) (*backend.Item, error) {
+	if rand.IntN(2) == 0 {
+		return nil, ErrRandomBackend
+	}
+	return b.Backend.Get(ctx, key)
+}
+
+func (b *RandomlyErroringBackend) Items(ctx context.Context, params backend.ItemsParams) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		for item, err := range b.Backend.Items(ctx, params) {
+			var ok bool
+			if rand.IntN(2) == 0 {
+				ok = yield(backend.Item{}, ErrRandomBackend)
+			} else {
+				ok = yield(item, err)
+			}
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func (b *RandomlyErroringBackend) GetRange(ctx context.Context, startKey, endKey backend.Key, limit int) (*backend.GetResult, error) {
+	if rand.IntN(2) == 0 {
+		return nil, ErrRandomBackend
+	}
+	return b.Backend.GetRange(ctx, startKey, endKey, limit)
+}

--- a/lib/backend/backendtest/randomly_erroring_backend_test.go
+++ b/lib/backend/backendtest/randomly_erroring_backend_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backendtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+func TestRandomlyErroringBackend(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	mem, err := memory.New(memory.Config{Context: ctx})
+	require.NoError(t, err)
+
+	var key, value = backend.NewKey("test_key_1"), []byte("test_value_1")
+
+	randomlyErroringBackend := NewRandomlyErroringBackend(mem)
+	_, err = randomlyErroringBackend.Put(ctx, backend.Item{Key: key, Value: value})
+	require.NoError(t, err)
+
+	const iterations, minBoundary, maxBoundary = 200, 50, 150
+
+	// Get
+	randomErrCnt := 0
+	for range iterations {
+		item, err := randomlyErroringBackend.Get(ctx, key)
+		if err != nil {
+			require.ErrorIs(t, err, ErrRandomBackend)
+			randomErrCnt++
+		} else {
+			require.Equal(t, key, item.Key)
+			require.Equal(t, value, item.Value)
+		}
+	}
+	require.GreaterOrEqual(t, randomErrCnt, minBoundary)
+	require.LessOrEqual(t, randomErrCnt, maxBoundary)
+
+	// GetRange
+	randomErrCnt = 0
+	for range iterations {
+		res, err := randomlyErroringBackend.GetRange(ctx, key, key, 100)
+		if err != nil {
+			require.ErrorIs(t, err, ErrRandomBackend)
+			randomErrCnt++
+		} else {
+			require.Len(t, res.Items, 1)
+			item := res.Items[0]
+			require.Equal(t, key, item.Key)
+			require.Equal(t, value, item.Value)
+		}
+	}
+	require.GreaterOrEqual(t, randomErrCnt, minBoundary)
+	require.LessOrEqual(t, randomErrCnt, maxBoundary)
+
+	// Items
+	randomErrCnt = 0
+	for range iterations {
+		for item, err := range randomlyErroringBackend.Items(ctx, backend.ItemsParams{StartKey: key, EndKey: key, Limit: 100}) {
+			if err != nil {
+				require.ErrorIs(t, err, ErrRandomBackend)
+				randomErrCnt++
+			} else {
+				require.Equal(t, key, item.Key)
+				require.Equal(t, value, item.Value)
+			}
+		}
+	}
+	require.GreaterOrEqual(t, randomErrCnt, minBoundary)
+	require.LessOrEqual(t, randomErrCnt, maxBoundary)
+}

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -95,6 +95,13 @@ type AccessListsInternal interface {
 	// overwriting the list's members if successful.
 	UpdateAccessListAndOverwriteMembers(context.Context, *accesslist.AccessList, []*accesslist.AccessListMember) (*accesslist.AccessList, []*accesslist.AccessListMember, error)
 
+	// CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
+	CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error)
+
+	// EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
+	// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
+	EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error
+
 	// InsertAccessListCollection inserts a complete collection of access lists and their members from a single
 	// upstream source (e.g. EntraID) using a batch operation for improved performance.
 	//

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -1181,6 +1181,85 @@ func (a *AccessListService) updatedMembersNestedRelationships(ctx context.Contex
 	return nil
 }
 
+// CleanupAccessListStatus removes invalid Status.OwnerOf and Status.MemberOf references.
+func (a *AccessListService) CleanupAccessListStatus(ctx context.Context, accessListName string) (*accesslist.AccessList, error) {
+	return a.runWithGlobalLockAccessList(ctx, accessListName, func() (*accesslist.AccessList, error) {
+		accessList, err := a.service.GetResource(ctx, accessListName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		var ownerRefreshErr error
+		accessList.Status.OwnerOf = slices.DeleteFunc(accessList.Status.OwnerOf, func(ownerOf string) bool {
+			ownedList, err := a.service.GetResource(ctx, ownerOf)
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				ownerRefreshErr = err
+				return false
+			}
+			isActualOwner := slices.ContainsFunc(ownedList.Spec.Owners, func(ownedListOwner accesslist.Owner) bool {
+				return ownedListOwner.MembershipKind == accesslist.MembershipKindList && ownedListOwner.Name == accessList.GetName()
+			})
+			return !isActualOwner
+		})
+		if ownerRefreshErr != nil {
+			return nil, trace.Wrap(ownerRefreshErr)
+		}
+
+		var memberRefreshErr error
+		accessList.Status.MemberOf = slices.DeleteFunc(accessList.Status.MemberOf, func(memberOf string) bool {
+			if _, err := a.memberService.WithPrefix(memberOf).GetResource(ctx, accessList.GetName()); err != nil {
+				if trace.IsNotFound(err) {
+					return true
+				}
+				memberRefreshErr = err
+			}
+			return false
+		})
+		if memberRefreshErr != nil {
+			return nil, trace.Wrap(memberRefreshErr)
+		}
+
+		accessList, err = a.service.UpdateResource(ctx, accessList)
+		return accessList, trace.Wrap(err)
+	})
+}
+
+// EnsureNestedAccessListStatuses goes over all nested owners and nested members of the named
+// access list and ensures nested lists' statuses owner_of/member_of contain the access list name.
+func (a *AccessListService) EnsureNestedAccessListStatuses(ctx context.Context, accessListName string) error {
+	return a.runWithGlobalLock(ctx, accessListName, func() error {
+		accessList, err := a.service.GetResource(ctx, accessListName)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		for _, owner := range accessList.Spec.Owners {
+			if owner.MembershipKind == accesslist.MembershipKindList {
+				if err := a.updateAccessListOwnerOf(ctx, accessListName, owner.Name, true); err != nil {
+					return trace.Wrap(err)
+				}
+			}
+		}
+
+		members, err := a.memberService.WithPrefix(accessListName).GetResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		for _, member := range members {
+			if member.Spec.MembershipKind == accesslist.MembershipKindList {
+				if err := a.updateAccessListMemberOf(ctx, accessListName, member.GetName(), true); err != nil {
+					return trace.Wrap(err)
+				}
+			}
+		}
+
+		return nil
+	})
+}
+
 // InsertAccessListCollection inserts a complete collection of access lists and their members from a single
 // upstream source (e.g. EntraID) using a batch operation for improved performance.
 //
@@ -1248,4 +1327,22 @@ func (a *AccessListService) collectionToBackendItemsIter(collection *accesslists
 			}
 		}
 	}
+}
+
+func (a *AccessListService) runWithGlobalLock(ctx context.Context, accessListName string, fn func() error) error {
+	return a.service.RunWhileLocked(ctx, []string{accessListResourceLockName}, 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return a.service.RunWhileLocked(ctx, lockName(accessListName), 2*accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+			return trace.Wrap(fn())
+		})
+	})
+}
+
+func (a *AccessListService) runWithGlobalLockAccessList(ctx context.Context, accessListName string, fn func() (*accesslist.AccessList, error)) (*accesslist.AccessList, error) {
+	var res *accesslist.AccessList
+	err := a.runWithGlobalLock(ctx, accessListName, func() error {
+		var err error
+		res, err = fn()
+		return trace.Wrap(err)
+	})
+	return res, err
 }


### PR DESCRIPTION
This adds 2 new status reconciliation functions to `AccessListService`.

- `CleanupStatus` - this one takes access list `AL` and **removes** all `status.member_of/owner_of` entries which invalid. It operates on the `AL` itself.
- `EnsureNestedListsStatuses` - takes access list `AL`, but unlike `CleanupStatus` it operates on `AL`'s owners and children and does not change the `AL` itself. It **adds** (if missing) `AL.GetName()` to: 
  - `status.member_of` to all `AL`'s children
  - `status.owner_of` to all `AL`'s owners

Backports:

- [x] https://github.com/gravitational/teleport/pull/62159
- [x] No v17 backport as we don't rely on status to calculate hierarchy in v17