### PR TITLE
Add fix for AltGr key

### DIFF
--- a/web/packages/shared/components/DesktopSession/InputHandler.tsx
+++ b/web/packages/shared/components/DesktopSession/InputHandler.tsx
@@ -191,7 +191,18 @@ export class InputHandler {
       return;
     }
 
+    // Check if AltGraph is being pressed
+    const isAltGraphActive = e.getModifierState('AltGraph');
+
     this.remoteModifierState.forEach((state, modifier) => {
+      // When AltGr is pressed, browsers synthesize ControlLeft+AltRight, but
+      // getModifierState('Control') and getModifierState('Alt') return false
+      // because the physical keys aren't pressed. Skip sync to avoid sending
+      // incorrect UP events while AltGr is active.
+      if (isAltGraphActive && (modifier === 'Control' || modifier === 'Alt')) {
+        return;
+      }
+
       const localState = e.getModifierState(modifier)
         ? ButtonState.DOWN
         : ButtonState.UP;
@@ -200,6 +211,7 @@ export class InputHandler {
         // If the local state is different from the remote state, send the updates.
         cli.sendKeyboardInput(modifier + 'Left', localState);
         cli.sendKeyboardInput(modifier + 'Right', localState);
+
         // Update the remote state to match the local state.
         this.remoteModifierState.set(modifier, localState);
       }


### PR DESCRIPTION
We had a few customer reports that the `AltGr + Q` combination to print `@` wasn't working.
The issue stems from browsers logically pressing `LeftControl` and `RightAlt`, when a user physically presses `AltGr`, and those keys not being picked up by `getModifierState()` because they're not physically being pressed. The fix is to skip synchronising `Control` and `Alt` if `AltGr` is pressed.

Closes #59883

changelog: Fixed issue where AltGr key combinations did not work correctly in remote desktop sessions.