### PR TITLE
fix: Set the security-key hint when using cross-platform mode on Windows

### DIFF
--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -304,4 +305,9 @@ func Diag(ctx context.Context) (*DiagResult, error) {
 	res.LoginSuccessful = true
 
 	return res, nil
+}
+
+// getPackageLogger returns a logger with component="WebAuthnWin".
+func getPackageLogger() *slog.Logger {
+	return slog.With(teleport.ComponentKey, "WebAuthnWin")
 }

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -33,9 +33,9 @@ import (
 
 	"github.com/go-webauthn/webauthn/protocol"
 	"github.com/go-webauthn/webauthn/protocol/webauthncose"
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
 )

--- a/lib/auth/webauthnwin/api_test.go
+++ b/lib/auth/webauthnwin/api_test.go
@@ -178,6 +178,8 @@ func TestLogin(t *testing.T) {
 		},
 	}
 
+	const wantOptsVersion uint32 = 9
+
 	tests := []struct {
 		name        string
 		origin      string
@@ -191,10 +193,8 @@ func TestLogin(t *testing.T) {
 			origin:      origin,
 			assertionIn: func() *wantypes.CredentialAssertion { return okAssertion },
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(5), req.opts.dwVersion)
-
+				assert.Equal(t, wantOptsVersion, req.opts.dwVersion)
 				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
-
 				assert.Equal(t, webauthnAttachmentAny, req.opts.dwAuthenticatorAttachment)
 			},
 		},
@@ -208,10 +208,8 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(5), req.opts.dwVersion)
-
+				assert.Equal(t, wantOptsVersion, req.opts.dwVersion)
 				assert.Equal(t, webauthnUserVerificationRequired, req.opts.dwUserVerificationRequirement)
-
 				assert.Equal(t, webauthnAttachmentPlatform, req.opts.dwAuthenticatorAttachment)
 			},
 		},
@@ -225,10 +223,8 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(5), req.opts.dwVersion)
-
+				assert.Equal(t, wantOptsVersion, req.opts.dwVersion)
 				assert.Equal(t, webauthnUserVerificationPreferred, req.opts.dwUserVerificationRequirement)
-
 				assert.Equal(t, webauthnAttachmentCrossPlatform, req.opts.dwAuthenticatorAttachment)
 			},
 		},
@@ -242,8 +238,7 @@ func TestLogin(t *testing.T) {
 			},
 			opts: LoginOpts{AuthenticatorAttachment: AttachmentCrossPlatform},
 			assertFn: func(t *testing.T, car *wanpb.CredentialAssertionResponse, req *getAssertionRequest) {
-				assert.Equal(t, uint32(5), req.opts.dwVersion)
-
+				assert.Equal(t, wantOptsVersion, req.opts.dwVersion)
 				assert.Equal(t, webauthnUserVerificationDiscouraged, req.opts.dwUserVerificationRequirement)
 			},
 		},

--- a/lib/auth/webauthnwin/ctypes.go
+++ b/lib/auth/webauthnwin/ctypes.go
@@ -29,6 +29,10 @@ const (
 	webauthnUserVerificationRequired    = uint32(1)
 	webauthnUserVerificationPreferred   = uint32(2)
 	webauthnUserVerificationDiscouraged = uint32(3)
+
+	webauthnCredentialHintSecurityKey  = "security-key"
+	webauthnCredentialHintClientDevice = "client-device"
+	webauthnCredentialHintHybrid       = "hybrid"
 )
 
 type webauthnRPEntityInformation struct {
@@ -329,6 +333,8 @@ type webauthnAuthenticatorGetAssertionOptions struct {
 
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_9
+	//
+	// https://github.com/microsoft/webauthn/blob/c3ed95fd7603441a0253c55c14e79239cb556a9f/webauthn.h#L958.
 	//
 
 	// Web Origin. For Remote Web App scenario.

--- a/lib/auth/webauthnwin/ctypes.go
+++ b/lib/auth/webauthnwin/ctypes.go
@@ -289,13 +289,58 @@ type webauthnAuthenticatorGetAssertionOptions struct {
 	//
 	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_5
 	//
-	// This field is kept just to keep size of struct valid.
-	_ uint32
-	// Size of pbCredLargeBlob
-	// This field is kept just to keep size of struct valid.
-	_ uint32
-	// This field is kept just to keep size of struct valid.
-	_ *byte
+
+	_               uint32 // dwCredLargeBlobOperation
+	cbCredLargeBlob uint32
+	pbCredLargeBlob *byte
+
+	//
+	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_6
+	//
+
+	// PRF values which will be converted into HMAC-SECRET values according to WebAuthn Spec.
+	_ uint32 // pHmacSecretSaltValues
+
+	// Optional. BrowserInPrivate Mode. Defaulting to FALSE.
+	bBrowserInPrivateMode bool
+
+	//
+	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_7
+	//
+
+	// Deprecated
+	// Optional. Linked Device Connection Info.
+	_ uint32 // pLinkedDevice
+
+	// Optional. Allowlist MUST contain 1 credential applicable for Hybrid transport.
+	bAutoFill bool
+
+	// Size of pbJsonExt
+	cbJsonExt uint32
+	pbJsonExt *byte
+
+	//
+	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_8
+	//
+
+	// PublicKeyCredentialHints (https://w3c.github.io/webauthn/#enum-hints)
+	cCredentialHints     uint32
+	ppwszCredentialHints *uint16
+
+	//
+	// The following fields have been added in WEBAUTHN_AUTHENTICATOR_GET_ASSERTION_OPTIONS_VERSION_9
+	//
+
+	// Web Origin. For Remote Web App scenario.
+	pwszRemoteWebOrigin *uint16
+
+	// UTF-8 encoded JSON serialization of the PublicKeyCredentialRequestOptions.
+	cbPublicKeyCredentialRequestOptionsJSON uint32
+	pbPublicKeyCredentialRequestOptionsJSON *byte
+
+	// Authenticator ID got from WebAuthNGetAuthenticatorList API.
+	cbAuthenticatorID uint32
+	pbAuthenticatorID *byte
 }
 
 //nolint:unused // TODO: remove when linter runs on windows build tag

--- a/lib/auth/webauthnwin/ctypes.go
+++ b/lib/auth/webauthnwin/ctypes.go
@@ -244,6 +244,7 @@ type webauthnClientData struct {
 	pwszHashAlgID *uint16
 }
 
+//nolint:unused // This type maps a C struct. We need to keep the layout consistent.
 type webauthnAuthenticatorGetAssertionOptions struct {
 	dwVersion uint32
 	// Time that the operation is expected to complete within.


### PR DESCRIPTION
The WebAuthn "cross-platform" authenticator attachment has evolved over time to include both physical security keys and phones. tsh uses WebAuthn.dll on Windows, which over time has adopted the new interpretation and now prompts for both security keys and phones on "cross-platform" mode (see screenshot on #62060). This is a regression of sorts for tsh, which has always equated cross-platform to security keys (and doesn't even support phones on various platforms).

This fixes the issue by updating the corresponding WebAuthn.dll structs to v9 and setting the credential hint "security-key" when using cross-platform mode.

Note that all of this is specific to users running `tsh --mfa-mode=cross-platform <command>` (or equivalent). Other flows are unfiltered, meaning all options are there by default.

#62060

Changelog: Changed "tsh --mfa-mode=cross-platform" to favor security keys on current Windows versions