### PR TITLE
Move scoped token secret out of name

### DIFF
--- a/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
+++ b/api/gen/proto/go/teleport/join/v1/joinservice.pb.go
@@ -468,7 +468,9 @@ func (*ClientParams_BotParams) isClientParams_Payload() {}
 type TokenInit struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// ClientParams holds parameters for the specific type of client trying to join.
-	ClientParams  *ClientParams `protobuf:"bytes,1,opt,name=client_params,json=clientParams,proto3" json:"client_params,omitempty"`
+	ClientParams *ClientParams `protobuf:"bytes,1,opt,name=client_params,json=clientParams,proto3" json:"client_params,omitempty"`
+	// The secret value that must be provided when using the token join method.
+	Secret        string `protobuf:"bytes,2,opt,name=secret,proto3" json:"secret,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -508,6 +510,13 @@ func (x *TokenInit) GetClientParams() *ClientParams {
 		return x.ClientParams
 	}
 	return nil
+}
+
+func (x *TokenInit) GetSecret() string {
+	if x != nil {
+		return x.Secret
+	}
+	return ""
 }
 
 // OIDCInit holds the OIDC identity token used for all OIDC-based join methods.
@@ -2856,9 +2865,10 @@ const file_teleport_join_v1_joinservice_proto_rawDesc = "" +
 	"hostParams\x12<\n" +
 	"\n" +
 	"bot_params\x18\x02 \x01(\v2\x1b.teleport.join.v1.BotParamsH\x00R\tbotParamsB\t\n" +
-	"\apayload\"P\n" +
+	"\apayload\"h\n" +
 	"\tTokenInit\x12C\n" +
-	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\"j\n" +
+	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\x12\x16\n" +
+	"\x06secret\x18\x02 \x01(\tR\x06secret\"j\n" +
 	"\bOIDCInit\x12C\n" +
 	"\rclient_params\x18\x01 \x01(\v2\x1e.teleport.join.v1.ClientParamsR\fclientParams\x12\x19\n" +
 	"\bid_token\x18\x02 \x01(\fR\aidToken\"\xb7\x01\n" +

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -53,7 +53,9 @@ type ScopedToken struct {
 	// Scope is the scope of the token resource.
 	Scope string `protobuf:"bytes,5,opt,name=scope,proto3" json:"scope,omitempty"`
 	// Spec is the token specification.
-	Spec          *ScopedTokenSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	Spec *ScopedTokenSpec `protobuf:"bytes,6,opt,name=spec,proto3" json:"spec,omitempty"`
+	// The status of a scoped token.
+	Status        *ScopedTokenStatus `protobuf:"bytes,7,opt,name=status,proto3" json:"status,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -130,6 +132,13 @@ func (x *ScopedToken) GetSpec() *ScopedTokenSpec {
 	return nil
 }
 
+func (x *ScopedToken) GetStatus() *ScopedTokenStatus {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
 // ScopedTokenSpec is the specification of a scoped token.
 type ScopedTokenSpec struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -197,23 +206,73 @@ func (x *ScopedTokenSpec) GetJoinMethod() string {
 	return ""
 }
 
+// The status of a scoped token.
+type ScopedTokenStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The secret that must be provided as part of the challenge when joining using
+	// the token join method.
+	Secret        string `protobuf:"bytes,1,opt,name=secret,proto3" json:"secret,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ScopedTokenStatus) Reset() {
+	*x = ScopedTokenStatus{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ScopedTokenStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ScopedTokenStatus) ProtoMessage() {}
+
+func (x *ScopedTokenStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ScopedTokenStatus.ProtoReflect.Descriptor instead.
+func (*ScopedTokenStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ScopedTokenStatus) GetSecret() string {
+	if x != nil {
+		return x.Secret
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a!teleport/header/v1/metadata.proto\"\xe7\x01\n" +
+	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\vScopedToken\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
-	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\"o\n" +
+	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"o\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
 	"\vjoin_method\x18\x03 \x01(\tR\n" +
-	"joinMethodBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"joinMethod\"+\n" +
+	"\x11ScopedTokenStatus\x12\x16\n" +
+	"\x06secret\x18\x01 \x01(\tR\x06secretBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -227,20 +286,22 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
-	(*ScopedToken)(nil),     // 0: teleport.scopes.joining.v1.ScopedToken
-	(*ScopedTokenSpec)(nil), // 1: teleport.scopes.joining.v1.ScopedTokenSpec
-	(*v1.Metadata)(nil),     // 2: teleport.header.v1.Metadata
+	(*ScopedToken)(nil),       // 0: teleport.scopes.joining.v1.ScopedToken
+	(*ScopedTokenSpec)(nil),   // 1: teleport.scopes.joining.v1.ScopedTokenSpec
+	(*ScopedTokenStatus)(nil), // 2: teleport.scopes.joining.v1.ScopedTokenStatus
+	(*v1.Metadata)(nil),       // 3: teleport.header.v1.Metadata
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	2, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	3, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	2, // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -254,7 +315,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/join/v1/joinservice.proto
+++ b/api/proto/teleport/join/v1/joinservice.proto
@@ -105,6 +105,8 @@ message ClientParams {
 message TokenInit {
   // ClientParams holds parameters for the specific type of client trying to join.
   ClientParams client_params = 1;
+  // The secret value that must be provided when using the token join method.
+  string secret = 2;
 }
 
 // OIDCInit holds the OIDC identity token used for all OIDC-based join methods.

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -42,6 +42,9 @@ message ScopedToken {
 
   // Spec is the token specification.
   ScopedTokenSpec spec = 6;
+
+  // The status of a scoped token.
+  ScopedTokenStatus status = 7;
 }
 
 // ScopedTokenSpec is the specification of a scoped token.
@@ -57,4 +60,11 @@ message ScopedTokenSpec {
   // The joining method required in order to use this token.
   // Supported joining methods for scoped tokens only include 'token'.
   string join_method = 3;
+}
+
+// The status of a scoped token.
+message ScopedTokenStatus {
+  // The secret that must be provided as part of the challenge when joining using
+  // the token join method.
+  string secret = 1;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -183,6 +183,10 @@ type ProvisionToken interface {
 	// unscoped
 	GetAssignedScope() string
 
+	// GetSecret returns the token's secret value and a bool representing whether
+	// or not the token had a secret..
+	GetSecret() (string, bool)
+
 	// Clone creates a copy of the token.
 	Clone() ProvisionToken
 }
@@ -661,6 +665,12 @@ func (p *ProvisionTokenV2) GetSafeName() string {
 // unscoped
 func (p *ProvisionTokenV2) GetAssignedScope() string {
 	return ""
+}
+
+// GetSecret always returns an empty string and false because a [ProvisionTokenV2] does not have a
+// dedicated secret value. The name itself is the secret for the "token" join method.
+func (p *ProvisionTokenV2) GetSecret() (string, bool) {
+	return "", false
 }
 
 // String returns the human readable representation of a provisioning token.

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -133,8 +133,10 @@ type BoundKeypairParams struct {
 // RegisterParams specifies parameters
 // for first time register operation with auth server
 type RegisterParams struct {
-	// Token is a secure token to join the cluster
+	// Token is the name of a secure token to join the cluster
 	Token string
+	// TokenSecret is the secret value required when using the token join method with a scoped token.
+	TokenSecret string
 	// ID is identity ID
 	ID state.IdentityID
 	// AuthServers is a list of auth servers to dial

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -87,16 +87,17 @@ func TestScopedJoiningService(t *testing.T) {
 		token, err := createToken(ctx, service, baseToken)
 		require.NoError(t, err)
 
-		withoutNameOpts := []gocmp.Option{
+		createOpts := []gocmp.Option{
 			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 			protocmp.IgnoreFields(&headerv1.Metadata{}, "name"),
+			protocmp.IgnoreFields(&joiningv1.ScopedToken{}, "status"),
 			protocmp.Transform(),
 		}
 		cmpOpts := []gocmp.Option{
 			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 			protocmp.Transform(),
 		}
-		assert.Empty(t, gocmp.Diff(baseToken, token, withoutNameOpts...))
+		assert.Empty(t, gocmp.Diff(baseToken, token, createOpts...))
 
 		// make sure update is no-op
 		_, err = service.UpdateScopedToken(ctx, &joiningv1.UpdateScopedTokenRequest{})
@@ -233,6 +234,7 @@ func TestScopedJoiningService(t *testing.T) {
 		cmpOpts := []gocmp.Option{
 			protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
 			protocmp.IgnoreFields(&headerv1.Metadata{}, "name"),
+			protocmp.IgnoreFields(&joiningv1.ScopedToken{}, "status"),
 			protocmp.Transform(),
 		}
 		assert.Empty(t, gocmp.Diff(baseToken, stageTokenAA, cmpOpts...))

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -84,6 +84,8 @@ type CommandLineFlags struct {
 	AuthServerAddr []string
 	// --token flag
 	AuthToken string
+	// --token-secret flag
+	TokenSecret string
 	// --join-method flag
 	JoinMethod string
 	// CAPins are the SKPI hashes of the CAs used to verify the Auth Server.
@@ -2795,6 +2797,11 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		cfg.SetToken(clf.AuthToken)
 	}
 
+	if clf.TokenSecret != "" {
+		// store the value of the --token-secret flag:
+		cfg.SetTokenSecret(clf.TokenSecret)
+	}
+
 	// Apply flags used for the node to validate the Auth Server.
 	if err = cfg.ApplyCAPins(clf.CAPins); err != nil {
 		return trace.Wrap(err)
@@ -2893,6 +2900,11 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 	if clf.AuthToken != "" {
 		// store the value of the --token flag:
 		cfg.SetToken(clf.AuthToken)
+	}
+
+	if clf.TokenSecret != "" {
+		// store the value of the --token-secret flag:
+		cfg.SetTokenSecret(clf.TokenSecret)
 	}
 
 	slog.DebugContext(context.Background(), "Disabling all services, only the Teleport OpenSSH service can run during the `teleport join openssh` command")
@@ -3087,6 +3099,7 @@ func applyTokenConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 
 	if fc.JoinParams != (JoinParams{}) {
 		cfg.SetToken(fc.JoinParams.TokenName)
+		cfg.SetTokenSecret(fc.JoinParams.TokenSecret)
 
 		if err := types.ValidateJoinMethod(fc.JoinParams.Method); err != nil {
 			return trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -503,9 +503,10 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 
 // JoinParams configures the parameters for Simplified Node Joining.
 type JoinParams struct {
-	TokenName string           `yaml:"token_name"`
-	Method    types.JoinMethod `yaml:"method"`
-	Azure     AzureJoinParams  `yaml:"azure,omitempty"`
+	TokenName   string           `yaml:"token_name"`
+	TokenSecret string           `yaml:"token_secret,omitempty"`
+	Method      types.JoinMethod `yaml:"method"`
+	Azure       AzureJoinParams  `yaml:"azure,omitempty"`
 }
 
 // AzureJoinParams configures the parameters specific to the Azure join method.

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -100,6 +100,9 @@ type TokenInit struct {
 
 	// ClientParams holds parameters for the specific type of client trying to join.
 	ClientParams ClientParams
+	// Secret holds the token secret required when using the token join method with
+	// a scoped token.
+	Secret string
 }
 
 func (i *TokenInit) Check() error {

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -374,7 +374,7 @@ func joinWithMethod(
 		}
 		return oidcJoin(stream, joinParams, clientParams)
 	case types.JoinMethodToken:
-		return tokenJoin(stream, clientParams)
+		return tokenJoin(stream, clientParams, joinParams.TokenSecret)
 	case types.JoinMethodTPM:
 		return tpmJoin(ctx, stream, joinParams, clientParams)
 	case types.JoinMethodTerraformCloud:
@@ -400,6 +400,7 @@ func joinWithMethod(
 func tokenJoin(
 	stream messages.ClientStream,
 	clientParams messages.ClientParams,
+	secret string,
 ) (messages.Response, error) {
 	// The token join method is relatively simple, the flow is
 	//
@@ -412,6 +413,7 @@ func tokenJoin(
 	// that's left is to send the TokenInit message and receive the final result.
 	tokenInitMsg := &messages.TokenInit{
 		ClientParams: clientParams,
+		Secret:       secret,
 	}
 	if err := stream.Send(tokenInitMsg); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -212,6 +212,7 @@ func tokenInitToMessage(req *joinv1.TokenInit) (*messages.TokenInit, error) {
 	}
 	return &messages.TokenInit{
 		ClientParams: clientParams,
+		Secret:       req.GetSecret(),
 	}, nil
 }
 
@@ -222,6 +223,7 @@ func tokenInitFromMessage(msg *messages.TokenInit) (*joinv1.TokenInit, error) {
 	}
 	return &joinv1.TokenInit{
 		ClientParams: clientParams,
+		Secret:       msg.Secret,
 	}, nil
 }
 

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -30,6 +30,11 @@ type Token interface {
 	// join methods where the name is secret. This should be used when logging
 	// the token name.
 	GetSafeName() string
+	// GetSecret returns either the token's secret or an empty string depending on whether
+	// or not the token has an explicit secret value. It also returns an explicit boolean
+	// to disambiguate between cases where the token has no secret or the token secret is
+	// not populated.
+	GetSecret() (string, bool)
 	// GetJoinMethod returns joining method that must be used with this token.
 	GetJoinMethod() types.JoinMethod
 	// GetRoles returns a list of teleport roles that will be granted to the

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -48,6 +48,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: fmt.Sprintf("expected kind %v, got %q", types.KindScopedToken, ""),
 		},
@@ -63,6 +66,9 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: fmt.Sprintf("expected version %v, got %q", types.V1, ""),
@@ -82,6 +88,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: fmt.Sprintf("expected sub_kind %v, got %q", "", "subkind"),
 		},
@@ -96,6 +105,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "missing name",
 		},
@@ -107,6 +119,9 @@ func TestValidateScopedToken(t *testing.T) {
 				Scope:   "/aa",
 				Metadata: &headerv1.Metadata{
 					Name: "testtoken",
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: "spec must not be nil",
@@ -124,6 +139,9 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: "scoped token must have a scope assigned",
@@ -143,6 +161,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "validating scoped token resource scope",
 		},
@@ -160,6 +181,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "validating scoped token resource scope",
 			expectedWeakErr:   "validating scoped token resource scope",
@@ -176,6 +200,9 @@ func TestValidateScopedToken(t *testing.T) {
 				Spec: &joiningv1.ScopedTokenSpec{
 					Roles:      []string{types.RoleNode.String()},
 					JoinMethod: string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
@@ -195,6 +222,9 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
 		},
@@ -211,6 +241,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "aa/bb}",
 					JoinMethod:    string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
@@ -230,6 +263,9 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/bb/aa",
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "scoped token assigned scope must be descendant of its resource scope",
 		},
@@ -247,6 +283,9 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodUnspecified),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
 			expectedWeakErr:   fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
@@ -263,6 +302,9 @@ func TestValidateScopedToken(t *testing.T) {
 				Spec: &joiningv1.ScopedTokenSpec{
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 			expectedStrongErr: "scoped token must have at least one role",
@@ -282,6 +324,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{"random_role"},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: "validating scoped token roles",
 		},
@@ -299,9 +344,31 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
 			},
 			expectedStrongErr: fmt.Sprintf("role %q does not support scoping", types.RoleInstance),
 		},
+		{
+			name: "no secret with token join method",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+				},
+			},
+			expectedStrongErr: "secret value must be defined for a scoped token",
+		},
+		// TODO (eriktate): add a test case for a missing secret with non-token join method once scoped
+		// tokens support other join methods
 		{
 			name: "valid scoped token",
 			token: &joiningv1.ScopedToken{
@@ -315,6 +382,9 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
 				},
 			},
 		},

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -714,9 +714,15 @@ func (process *TeleportProcess) makeJoinParams(
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	tokenSecret, err := process.Config.TokenSecret()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	dataDir := cmp.Or(process.Config.DataDir, defaults.DataDir)
 	joinParams := &joinclient.JoinParams{
 		Token:                token,
+		TokenSecret:          tokenSecret,
 		ID:                   id,
 		AuthServers:          process.Config.AuthServerAddresses(),
 		ProxyServer:          process.Config.ProxyServer,

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -281,6 +281,11 @@ type Config struct {
 	// using Token()
 	token string
 
+	// tokenSecret is either the secret needed to join with the token defined for the config, or
+	// a path that contains the secret. This is private to avoid external packages reading the
+	// value - the value should be obtained using TokenSecret()
+	tokenSecret string
+
 	// v1, v2 -
 	// AuthServers is a list of auth servers, proxies and peer auth servers to
 	// connect to. Yes, this is not just auth servers, the field name is
@@ -534,11 +539,34 @@ func (cfg *Config) Token() (string, error) {
 	return token, nil
 }
 
+// TokenSecret returns token secret needed to join the auth server with the configured token
+//
+// If the value stored points to a file, it will attempt to read the token secret from the file
+// and return an error if it wasn't successful.
+// If the value stored doesn't point to a file, it'll return the value stored.
+// If the secret hasn't been set, an empty string will be returned
+func (cfg *Config) TokenSecret() (string, error) {
+	secret, err := utils.TryReadValueAsFile(cfg.tokenSecret)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return secret, nil
+}
+
 // SetToken stores the value for --token or auth_token in the config
 //
 // This can be either the token or an absolute path to a file containing the token.
 func (cfg *Config) SetToken(token string) {
 	cfg.token = token
+}
+
+// SetTokenSecret stores the value for --token-secret or join_params.token_secret in the
+// config.
+//
+// This can be either the secret or an absolute path to a file containing the secret.
+func (cfg *Config) SetTokenSecret(secret string) {
+	cfg.tokenSecret = secret
 }
 
 // HasToken gives the ability to check if there has been a token value stored

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -65,6 +65,9 @@ func TestScopedTokenService(t *testing.T) {
 			JoinMethod:    "token",
 			Roles:         []string{types.RoleNode.String()},
 		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret",
+		},
 	}
 
 	created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
@@ -153,6 +156,9 @@ func TestScopedTokenList(t *testing.T) {
 			Roles: []string{
 				types.RoleNode.String(),
 			},
+		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret",
 		},
 	}
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -134,7 +134,8 @@ Run this on the new node to join the cluster:
 
 > teleport start \
    --roles={{.roles}} \
-   --token={{.token}} \{{range .ca_pins}}
+   --token={{.token}} \{{with .secret}}
+   --token-secret={{.}} \{{end}}{{range .ca_pins}}
    --ca-pin={{.}} \{{end}}
    --auth-server={{.auth_server}}
 

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -42,7 +42,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/itertools/stream"
-	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
@@ -60,10 +59,10 @@ type ScopedTokensCommand struct {
 	// tokenType is the type of token. For example, "node".
 	tokenType string
 
-	// Value is the value of the token. Can be used to either act on a
+	// name of the token. Can be used to either act on a
 	// token (for example, delete a token) or used to create a token with a
-	// specific value.
-	value string
+	// specific name.
+	name string
 
 	// assignedScope allows for filtering tokens by the scope they assign
 	assignedScope string
@@ -98,7 +97,7 @@ func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *s
 	// tctl scoped tokens add ..."
 	c.tokenAdd = tokens.Command("add", "Create a scoped invitation token.")
 	c.tokenAdd.Flag("type", "Type(s) of token to add, e.g. --type=node").Required().StringVar(&c.tokenType)
-	c.tokenAdd.Flag("value", "Override the default random generated token with a specified value").StringVar(&c.value)
+	c.tokenAdd.Flag("name", "Override the default, randomly generated token name with a specified name").StringVar(&c.name)
 	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v minutes",
 		int(defaults.ProvisioningTokenTTL/time.Minute))).
 		Default(fmt.Sprintf("%v", defaults.ProvisioningTokenTTL)).
@@ -109,7 +108,7 @@ func (c *ScopedTokensCommand) Initialize(scopedCmd *kingpin.CmdClause, config *s
 
 	// "tctl scoped tokens rm ..."
 	c.tokenDel = tokens.Command("rm", "Delete/revoke a scoped invitation token.").Alias("del")
-	c.tokenDel.Arg("token", "Token to delete").StringVar(&c.value)
+	c.tokenDel.Arg("token", "Token to delete").StringVar(&c.name)
 
 	// "tctl scoped tokens ls"
 	c.tokenList = tokens.Command("ls", "List invitation tokens.")
@@ -158,7 +157,7 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 		roles = append(roles, types.RoleApp, types.RoleDiscovery)
 	}
 
-	tokenName := c.value
+	tokenName := c.name
 
 	expires := time.Now().UTC().Add(c.ttl)
 	tok := &joiningv1.ScopedToken{
@@ -187,12 +186,14 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 	}
 
 	tokenName = tok.GetMetadata().GetName()
+	tokenSecret := tok.GetStatus().GetSecret()
 	// Print token information formatted with JSON, YAML, or just print the raw token.
 	switch c.format {
 	case teleport.JSON, teleport.YAML:
 		expires := time.Now().Add(c.ttl)
 		tokenInfo := map[string]any{
 			"token":        tokenName,
+			"token_secret": tokenSecret,
 			"roles":        roles,
 			"scope":        tok.GetScope(),
 			"assign_scope": tok.GetSpec().GetAssignedScope(),
@@ -220,23 +221,24 @@ func (c *ScopedTokensCommand) Add(ctx context.Context, client *authclient.Client
 	}
 
 	return trace.Wrap(showJoinInstructions(ctx, joinInstructionsInput{
-		out:       c.Stdout,
-		ttl:       c.ttl,
-		roles:     roles,
-		tokenName: tokenName,
-		client:    client,
+		out:         c.Stdout,
+		ttl:         c.ttl,
+		roles:       roles,
+		tokenName:   tokenName,
+		tokenSecret: tokenSecret,
+		client:      client,
 	}))
 }
 
 // Del is called to execute "scoped tokens del ..." command.
 func (c *ScopedTokensCommand) Del(ctx context.Context, client *authclient.Client) error {
-	if c.value == "" {
+	if c.name == "" {
 		return trace.BadParameter("Need an argument: token")
 	}
-	if err := client.DeleteScopedToken(ctx, c.value); err != nil {
+	if err := client.DeleteScopedToken(ctx, c.name); err != nil {
 		return trace.Wrap(err)
 	}
-	fmt.Fprintf(c.Stdout, "Token %s has been deleted\n", c.value)
+	fmt.Fprintf(c.Stdout, "Token %s has been deleted\n", c.name)
 	return nil
 }
 
@@ -267,11 +269,11 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 		return left.GetMetadata().GetExpires().AsTime().Compare(right.GetMetadata().GetExpires().AsTime())
 	})
 
-	nameFunc := func(tok *joiningv1.ScopedToken) string {
+	secretFunc := func(tok *joiningv1.ScopedToken) string {
 		if c.withSecrets {
-			return tok.GetMetadata().GetName()
+			return tok.GetStatus().GetSecret()
 		}
-		return joining.GetSafeScopedTokenName(tok)
+		return "******"
 	}
 	switch c.format {
 	case teleport.JSON:
@@ -286,11 +288,11 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 		}
 	case teleport.Text:
 		for _, token := range tokens {
-			fmt.Fprintln(c.Stdout, nameFunc(token))
+			fmt.Fprintln(c.Stdout, token.GetMetadata().GetName())
 		}
 	default:
 		tokensView := func() string {
-			table := asciitable.MakeTable([]string{"Token", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
+			table := asciitable.MakeTable([]string{"Token", "Secret", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
 			now := time.Now()
 			for _, t := range tokens {
 				expiry := "never"
@@ -300,7 +302,7 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 					expdur := expiresAt.Sub(now).Round(time.Second)
 					expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
 				}
-				table.AddRow([]string{nameFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), printMetadataLabels(t.GetMetadata().Labels), expiry})
+				table.AddRow([]string{t.GetMetadata().GetName(), secretFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), printMetadataLabels(t.GetMetadata().Labels), expiry})
 			}
 			return table.AsBuffer().String()
 		}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -903,17 +903,18 @@ func generateAgentValues(params valueGeneratorParams) ([]byte, error) {
 }
 
 type joinInstructionsInput struct {
-	client     *authclient.Client
-	roles      types.SystemRoles
-	out        io.Writer
-	tokenName  string
-	ttl        time.Duration
-	appName    string
-	appURI     string
-	dbName     string
-	dbURI      string
-	dbProtocol string
-	caPins     []string
+	client      *authclient.Client
+	roles       types.SystemRoles
+	out         io.Writer
+	tokenName   string
+	tokenSecret string
+	ttl         time.Duration
+	appName     string
+	appURI      string
+	dbName      string
+	dbURI       string
+	dbProtocol  string
+	caPins      []string
 }
 
 func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
@@ -1016,6 +1017,7 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 	default:
 		return nodeMessageTemplate.Execute(in.out, map[string]any{
 			"token":       in.tokenName,
+			"secret":      in.tokenSecret,
 			"roles":       strings.ToLower(in.roles.String()),
 			"minutes":     int(in.ttl.Minutes()),
 			"ca_pins":     in.caPins,

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -143,6 +143,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start.Flag("token",
 		"Invitation token or path to file with token value. Used to register with an auth server [none]").
 		StringVar(&ccf.AuthToken)
+	start.Flag("token-secret", "Invitation token secret or path to file with secret value. Used to register with an auth server [none]").
+		StringVar(&ccf.TokenSecret)
 	start.Flag("ca-pin",
 		"CA pin to validate the Auth Server (can be repeated for multiple pins)").
 		StringsVar(&ccf.CAPins)


### PR DESCRIPTION
This PR removes the need for scoped token names to be considered secret by moving the secret value into the `Status`.