### PR TITLE
[v18] lib/teleterm: Do not reissue user certs before issuing gateway cert

### DIFF
--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -81,15 +81,6 @@ func GetApp(ctx context.Context, authClient authclient.ClientI, appName string) 
 
 // ReissueAppCert issue new certificates for the app and saves them to disk.
 func (c *Cluster) ReissueAppCert(ctx context.Context, clusterClient *client.ClusterClient, routeToApp proto.RouteToApp) (tls.Certificate, error) {
-	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
-	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
-		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests,
-	})
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-
 	result, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 		RouteToCluster: c.clusterClient.SiteName,
 		RouteToApp:     routeToApp,

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -95,15 +95,6 @@ func (c *Cluster) reissueDBCerts(ctx context.Context, clusterClient *client.Clus
 		return tls.Certificate{}, trace.BadParameter("the username must be present")
 	}
 
-	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
-	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
-		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests,
-	})
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-
 	result, err := clusterClient.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 		RouteToCluster:  c.clusterClient.SiteName,
 		RouteToDatabase: client.RouteToDatabaseToProto(routeToDatabase),

--- a/lib/teleterm/clusters/cluster_kubes.go
+++ b/lib/teleterm/clusters/cluster_kubes.go
@@ -58,15 +58,6 @@ type KubeServer struct {
 
 // reissueKubeCert issue new certificates for kube cluster and saves them to disk.
 func (c *Cluster) reissueKubeCert(ctx context.Context, clusterClient *client.ClusterClient, kubeCluster string) (tls.Certificate, error) {
-	// Refresh the certs to account for clusterClient.SiteName pointing at a leaf cluster.
-	err := clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, client.ReissueParams{
-		RouteToCluster: c.clusterClient.SiteName,
-		AccessRequests: c.status.ActiveRequests,
-	})
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-
 	result, err := clusterClient.IssueUserCertsWithMFA(
 		ctx, client.ReissueParams{
 			RouteToCluster:    c.clusterClient.SiteName,

--- a/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
+++ b/web/packages/teleterm/src/mainProcess/clusterLifecycleManager/clusterLifecycleManager.ts
@@ -248,6 +248,9 @@ export class ClusterLifecycleManager {
     // The watcher 'changed' event may be emitted right after the user logs in
     // or assumes a role via Connect (which already closes all clients
     // for the profile), so we avoid closing them again if they're already up to date.
+    //
+    // This needs to be done before the check for changed access. It handles a scenario where the
+    // user logged in again via tsh and the auth server has disconnect_expired_cert enabled.
     await client.clearStaleClusterClients({ rootClusterUri: next.uri });
     await this.syncOrUpdateCluster(next);
 


### PR DESCRIPTION
Backport #62096 to branch/v18

changelog: Fixed "the client connection is closing" error happening under certain conditions in Teleport Connect when connecting to resources with per-session MFA enabled