### PR TITLE
implement app server watcher

### DIFF
--- a/lib/reversetunnel/leaf_cluster.go
+++ b/lib/reversetunnel/leaf_cluster.go
@@ -89,6 +89,9 @@ type leafCluster struct {
 	// nodeWatcher provides access the node set for the leaf cluster.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
+	// appServerWatcher is a app server watcher.
+	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// remoteCA is the last remote certificate authority recorded by the client.
 	// It is used to detect CA rotation status changes. If the rotation
 	// state has been changed, the tunnel will reconnect to re-create the client
@@ -168,6 +171,10 @@ func (s *leafCluster) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, e
 // NodeWatcher returns the services.NodeWatcher for the leaf cluster.
 func (s *leafCluster) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return s.nodeWatcher, nil
+}
+
+func (s *leafCluster) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return s.appServerWatcher, nil
 }
 
 // GitServerWatcher returns the Git server watcher for the leaf cluster.

--- a/lib/reversetunnel/local_cluster.go
+++ b/lib/reversetunnel/local_cluster.go
@@ -183,6 +183,11 @@ func (s *localCluster) NodeWatcher() (*services.GenericWatcher[types.Server, rea
 	return s.srv.NodeWatcher, nil
 }
 
+// AppServerWatcher returns the watcher that maintains the app server set for the cluster
+func (s *localCluster) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return s.srv.AppServerWatcher, nil
+}
+
 // GitServerWatcher returns a Git server watcher for this cluster.
 func (s *localCluster) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return s.srv.GitServerWatcher, nil

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -98,6 +98,14 @@ func (p *expectedLeafClusters) NodeWatcher() (*services.GenericWatcher[types.Ser
 	return cluster.NodeWatcher()
 }
 
+func (p *expectedLeafClusters) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	cluster, err := p.pickCluster()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return cluster.AppServerWatcher()
+}
+
 func (p *expectedLeafClusters) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	cluster, err := p.pickCluster()
 	if err != nil {
@@ -209,6 +217,10 @@ func (s *expectedLeafCluster) CachingAccessPoint() (authclient.RemoteProxyAccess
 
 func (s *expectedLeafCluster) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return nil, s.discoveryError("unable to fetch node watcher for leaf cluster")
+}
+
+func (s *expectedLeafCluster) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return nil, s.discoveryError("unable to fetch app server watcher for leaf cluster")
 }
 
 func (s *expectedLeafCluster) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -131,6 +131,8 @@ type Cluster interface {
 	NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error)
 	// GitServerWatcher returns the Git server watcher for the cluster
 	GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error)
+	// AppServerWatcher returns the watcher that maintains the app server set for the cluster
+	AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error)
 	// GetTunnelsCount returns the amount of active inbound tunnels
 	// from the remote cluster
 	GetTunnelsCount() int

--- a/lib/service/acme.go
+++ b/lib/service/acme.go
@@ -34,8 +34,6 @@ import (
 type hostPolicyCheckerConfig struct {
 	// publicAddrs is a list of pubic addresses to support acme for
 	publicAddrs []utils.NetAddr
-	// clt is used to get the list of registered applications
-	clt app.Getter
 	// clusterGetter is used to retrieve connected Teleport clusters.
 	clusterGetter reversetunnelclient.ClusterGetter
 	// clusterName is a name of this cluster
@@ -60,7 +58,7 @@ func (h *hostPolicyChecker) checkHost(ctx context.Context, host string) error {
 		return nil
 	}
 
-	_, _, err := app.ResolveFQDN(ctx, h.cfg.clt, h.cfg.clusterGetter, h.dnsNames, host)
+	_, _, err := app.ResolveFQDN(ctx, h.cfg.clusterGetter, h.cfg.clusterName, h.dnsNames, host)
 	if err == nil {
 		return nil
 	}
@@ -87,10 +85,6 @@ func newHostPolicyChecker(cfg hostPolicyCheckerConfig) (*hostPolicyChecker, erro
 }
 
 func (h *hostPolicyCheckerConfig) CheckAndSetDefaults() ([]string, error) {
-	if h.clt == nil {
-		return nil, trace.BadParameter("missing parameter clt")
-	}
-
 	if h.clusterGetter == nil {
 		return nil, trace.BadParameter("missing parameter clusterGetter")
 	}

--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -248,6 +248,50 @@ type Application interface {
 
 var _ Application = types.Application(nil)
 
+// ProxiedService is a read only variant of [types.ProxiedService].
+type ProxiedService interface {
+	// GetProxyIDs returns a list of proxy ids this service is connected to.
+	GetProxyIDs() []string
+}
+
+var _ ProxiedService = types.ProxiedService(nil)
+
+// AppServer is a read only variant of [types.AppServer].
+type AppServer interface {
+	// ResourceWithLabels provides common resource methods.
+	ResourceWithLabels
+	// GetNamespace returns server namespace.
+	GetNamespace() string
+	// GetTeleportVersion returns the teleport version the server is running on.
+	GetTeleportVersion() string
+	// GetHostname returns the server hostname.
+	GetHostname() string
+	// GetHostID returns ID of the host the server is running on.
+	GetHostID() string
+	// GetRotation gets the state of certificate authority rotation.
+	GetRotation() types.Rotation
+	// String returns string representation of the server.
+	String() string
+	// Copy returns a copy of this app server object.
+	Copy() types.AppServer
+	// GetApp returns the app this app server proxies.
+	GetApp() types.Application
+	// GetTunnelType returns the tunnel type associated with the app server.
+	GetTunnelType() types.TunnelType
+	// ProxiedService provides common methods for a proxied service.
+	ProxiedService
+	// GetRelayGroup returns the name of the Relay group that the app server is
+	// connected to.
+	GetRelayGroup() string
+	// GetRelayIDs returns the list of Relay host IDs that the app server is
+	// connected to.
+	GetRelayIDs() []string
+	// GetScope returns the scope this server belongs to.
+	GetScope() string
+}
+
+var _ AppServer = types.AppServer(nil)
+
 // KubeServer is a read only variant of [types.KubeServer].
 type KubeServer interface {
 	// ResourceWithLabels provides common resource methods.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1802,6 +1802,7 @@ func TestProxyRoundRobin(t *testing.T) {
 		LockWatcher:           lockWatcher,
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
@@ -1945,6 +1946,7 @@ func TestProxyDirectAccess(t *testing.T) {
 		LockWatcher:           lockWatcher,
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
@@ -2621,6 +2623,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 			LockWatcher:           lockWatcher,
 			NodeWatcher:           nodeWatcher,
 			GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
+			AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 			CertAuthorityWatcher:  caWatcher,
 			EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
 				return nil, errors.New("eice disabled in tests")
@@ -2881,6 +2884,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 		LockWatcher:           lockWatcher,
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {
 			return nil, errors.New("eice disabled in tests")
@@ -3242,6 +3246,21 @@ func newCertAuthorityWatcher(ctx context.Context, t *testing.T, client types.Eve
 	return caWatcher
 }
 
+func newAppServerWatcher(ctx context.Context, t *testing.T, client *authclient.Client) *services.GenericWatcher[types.AppServer, readonly.AppServer] {
+	t.Helper()
+
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client:    client,
+		},
+	})
+
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+	return appServerWatcher
+}
+
 // newSigner creates a new SSH signer that can be used by the Server.
 func newSigner(t testing.TB, ctx context.Context, testServer *authtest.Server) ssh.Signer {
 	t.Helper()
@@ -3311,6 +3330,7 @@ func TestHostUserCreationProxy(t *testing.T) {
 		LockWatcher:           lockWatcher,
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -175,6 +175,9 @@ type Handler struct {
 	// the proxy's cache and get nodes in real time.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
+	// appServerWatcher ia a app server watcher to speed up app look up.
+	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// tracer is used to create spans.
 	tracer oteltrace.Tracer
 
@@ -306,6 +309,9 @@ type Config struct {
 	// the proxy's cache and get nodes in real time.
 	NodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
+	// AppServerWatcher ia a app server watcher to speed up app look up.
+	AppServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// PresenceChecker periodically runs the mfa ceremony for moderated
 	// sessions.
 	PresenceChecker PresenceChecker
@@ -368,7 +374,7 @@ func (h *APIHandler) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	}
 	publicAddr := raddr.Host()
 
-	servers, err := app.MatchUnshuffled(r.Context(), h.handler.cfg.AccessPoint, app.MatchPublicAddr(publicAddr))
+	servers, err := h.handler.appServerWatcher.CurrentResourcesWithFilter(r.Context(), app.MatchPublicAddr(publicAddr))
 	if err != nil {
 		h.handler.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
 		return
@@ -627,6 +633,10 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 	if cfg.NodeWatcher != nil {
 		h.nodeWatcher = cfg.NodeWatcher
+	}
+
+	if cfg.AppServerWatcher != nil {
+		h.appServerWatcher = cfg.AppServerWatcher
 	}
 
 	const v1Prefix = "/v1"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -235,6 +235,7 @@ type webSuiteConfig struct {
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
+	t.Helper()
 	mockU2F, err := mocku2f.Create()
 	require.NoError(t, err)
 	require.NotNil(t, mockU2F)
@@ -440,6 +441,15 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 	t.Cleanup(proxyGitServerWatcher.Close)
 
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    s.proxyClient,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ID:       node.ID(),
 		Listener: revTunListener,
@@ -456,6 +466,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		LockWatcher:           proxyLockWatcher,
 		NodeWatcher:           proxyNodeWatcher,
 		GitServerWatcher:      proxyGitServerWatcher,
+		AppServerWatcher:      appServerWatcher,
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		LocalAuthAddresses:    []string{s.server.TLS.Listener.Addr().String()},
@@ -8457,6 +8468,7 @@ func withKubeProxy() proxyOption {
 func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regular.Server, authServer *authtest.TLSServer,
 	hostSigners []ssh.Signer, clock *clockwork.FakeClock, opts ...proxyOption,
 ) *testProxy {
+	t.Helper()
 	cfg := proxyConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -8526,6 +8538,15 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	require.NoError(t, err)
 	t.Cleanup(proxyGitServerWatcher.Close)
 
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    client,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ID:       node.ID(),
 		Listener: revTunListener,
@@ -8543,6 +8564,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		NodeWatcher:           proxyNodeWatcher,
 		GitServerWatcher:      proxyGitServerWatcher,
 		CertAuthorityWatcher:  proxyCAWatcher,
+		AppServerWatcher:      appServerWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		LocalAuthAddresses:    []string{authServer.Listener.Addr().String()},
 		EICESigner: func(ctx context.Context, target types.Server, integration types.Integration, login, token string, ap cryptosuites.AuthPreferenceGetter) (ssh.Signer, error) {

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -26,117 +26,40 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
 )
-
-// Getter returns a list of registered apps and the local cluster name.
-type Getter interface {
-	// GetApplicationServers returns registered application servers.
-	GetApplicationServers(context.Context, string) ([]types.AppServer, error)
-
-	// GetClusterName returns cluster name
-	GetClusterName(ctx context.Context) (types.ClusterName, error)
-}
 
 // MatchUnshuffled will match a list of applications with the passed in matcher
 // function. Matcher functions that can match on public address and name are
 // available.
-func MatchUnshuffled(ctx context.Context, authClient Getter, fn Matcher) ([]types.AppServer, error) {
-	servers, err := authClient.GetApplicationServers(ctx, defaults.Namespace)
+func MatchUnshuffled(ctx context.Context, cluster reversetunnelclient.Cluster, fn Matcher) ([]types.AppServer, error) {
+	watcher, err := cluster.AppServerWatcher()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var as []types.AppServer
-	for _, server := range servers {
-		if fn(ctx, server) {
-			as = append(as, server)
-		}
-	}
-
-	return as, nil
+	servers, err := watcher.CurrentResourcesWithFilter(ctx, fn)
+	return servers, trace.Wrap(err)
 }
 
-// MatchOne will match a single AppServer with the provided matcher function.
-// If no AppServer are matched, it will return an error.
-func MatchOne(ctx context.Context, authClient Getter, fn Matcher) (types.AppServer, error) {
-	servers, err := authClient.GetApplicationServers(ctx, defaults.Namespace)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	for _, server := range servers {
-		if fn(ctx, server) {
-			return server, nil
-		}
-	}
-
-	return nil, trace.NotFound("couldn't match any types.AppServer")
-}
-
-// Matcher allows matching on different properties of an application.
-type Matcher func(context.Context, types.AppServer) bool
+// Matcher allows matching on different properties of an app server.
+type Matcher func(readonly.AppServer) bool
 
 // MatchPublicAddr matches on the public address of an application.
 func MatchPublicAddr(publicAddr string) Matcher {
-	return func(_ context.Context, appServer types.AppServer) bool {
+	return func(appServer readonly.AppServer) bool {
 		return appServer.GetApp().GetPublicAddr() == publicAddr
 	}
 }
 
 // MatchName matches on the name of an application.
 func MatchName(name string) Matcher {
-	return func(_ context.Context, appServer types.AppServer) bool {
+	return func(appServer readonly.AppServer) bool {
 		return appServer.GetApp().GetName() == name
 	}
-}
-
-// MatchHealthy tries to establish a connection with the server using the
-// `dialAppServer` function. The app server is matched if the function call
-// doesn't return any error.
-func MatchHealthy(clusterGetter reversetunnelclient.ClusterGetter, clusterName string) Matcher {
-	return func(ctx context.Context, appServer types.AppServer) bool {
-		// Redirected apps don't need to be dialed, as the proxy will redirect to them.
-		if redirectInsteadOfForward(appServer) {
-			return true
-		}
-
-		// Apps that use the Integration should use its credentials which are obtained in Proxy.
-		// There's no need for an ApplicationService in this scenario.
-		if appServer.GetApp().GetIntegration() != "" {
-			return true
-		}
-
-		conn, err := dialAppServer(ctx, clusterGetter, clusterName, appServer)
-		if err != nil {
-			return false
-		}
-
-		conn.Close()
-		return true
-	}
-}
-
-// MatchAll matches if all the Matcher functions return true.
-func MatchAll(matchers ...Matcher) Matcher {
-	return func(ctx context.Context, appServer types.AppServer) bool {
-		for _, fn := range matchers {
-			if !fn(ctx, appServer) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
-// ClusterGetter provides a means to retrieve all connected
-// Teleport clusters - either local or remote.
-type ClusterGetter interface {
-	Clusters(context.Context) ([]reversetunnelclient.Cluster, error)
 }
 
 // ResolveFQDN makes a best effort attempt to resolve FQDN to an application
@@ -147,15 +70,16 @@ type ClusterGetter interface {
 // cluster, this method will always return "acme" running within the root
 // cluster. Always supply public address and cluster name to deterministically
 // resolve an application.
-func ResolveFQDN(ctx context.Context, clt Getter, clusterGetter ClusterGetter, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, localClusterName string, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+	clusterClient, err := clusterGetter.Cluster(ctx, localClusterName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
 	// Try and match FQDN to public address of application within cluster.
-	servers, err := MatchUnshuffled(ctx, clt, MatchPublicAddr(fqdn))
+	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
-		clusterName, err := clt.GetClusterName(ctx)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		return servers[rand.N(len(servers))], clusterName.GetClusterName(), nil
+		return servers[rand.N(len(servers))], localClusterName, nil
 	}
 
 	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)
@@ -171,12 +95,7 @@ func ResolveFQDN(ctx context.Context, clt Getter, clusterGetter ClusterGetter, p
 		return nil, "", trace.Wrap(err)
 	}
 	for _, clusterClient := range clusterClients {
-		authClient, err := clusterClient.CachingAccessPoint()
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-
-		servers, err = MatchUnshuffled(ctx, authClient, MatchName(appName))
+		servers, err = MatchUnshuffled(ctx, clusterClient, MatchName(appName))
 		if err == nil && len(servers) > 0 {
 			return servers[rand.N(len(servers))], clusterClient.GetName(), nil
 		}

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -522,3 +522,59 @@ func Test_transport_with_integration(t *testing.T) {
 
 	require.Equal(t, message, string(bs))
 }
+
+func Test_isAppServerDialable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string // description of this test case
+		dialErr error
+		match   bool
+		app     func() types.AppServer
+	}{
+		{
+			name:  "WithHealthyApp",
+			match: true,
+			app:   mustNewAppServer(t, types.OriginDynamic),
+		},
+		{
+			name:    "WithUnhealthyApp",
+			dialErr: errors.New("failed to connect"),
+			match:   false,
+			app:     mustNewAppServer(t, types.OriginDynamic),
+		},
+		{
+			name:    "WithUnhealthyOktaApp",
+			dialErr: errors.New("failed to connect"),
+			match:   true,
+			app:     mustNewAppServer(t, types.OriginOkta),
+		},
+		{
+			name:    "WithIntegrationApp",
+			dialErr: errors.New("failed to connect"),
+			match:   true,
+			app: func() types.AppServer {
+				appServer := mustNewAppServer(t, types.OriginDynamic)()
+				app := appServer.GetApp().Copy()
+				app.Spec.Integration = "my-integration"
+				appServer.SetApp(app)
+
+				return appServer
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			clusterGetter := &mockClusterGetter{
+				cluster: &mockCluster{
+					dialErr: tt.dialErr,
+				},
+			}
+
+			clusterClient, _ := clusterGetter.Cluster(ctx, "")
+			got := isAppServerDialable(ctx, clusterClient, tt.app())
+			require.Equal(t, tt.match, got, tt.app())
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a new watcher for app server. This follows the
same pattern as the node watcher. This speeds up app resolve
time significantly and reduces the amount of cloning done for AppServer.

By default the max staleness time for app servers is 1 min, matching
that of node watcher.

This commit also changes the app matcher to take a readonly variant
to make it compliant with generic watcher. This also means the
checks that require context have been refactored to a seperate callsite.

Note: While this improves memory footprint significantly, it is not ideal to fetch the entire app server collection for look up purposes. For a more long term solution this work should be moved to the backend/cache if possible for the cache to return filtered results based on the required attributes. 

Changelog: Improved application server resolution times for large number of applications.