### PR TITLE
[v18][config] expose auth reconnect retry parameters in configuration

### DIFF
--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -116,6 +116,14 @@ teleport:
     connection_limits:
         max_connections: 1000
 
+    # Auth Service connection configuration.
+    # These settings can be tweaked to control how aggresively the Proxy or Agent instances will retry to connect. In addition
+    # each instance will apply jitter.
+    # auth_connection_config:
+    #     upper_limit_between_retries: "90s"  # Cannot be lower than 10s
+    #     initial_connection_delay: "9s"      # When unset upper_limit_between_retries / 10
+    #     backoff_step_duration: "18s"        # When unset upper_limit_between_retries / 5
+
     # Logging configuration. Possible output values to disk via
     # '/var/lib/teleport/teleport.log',
     # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -622,7 +622,7 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
 	tconf.Keygen = testauthority.New()
-	tconf.MaxRetryPeriod = defaults.HighResPollingPeriod
+	tconf.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(defaults.HighResPollingPeriod)
 	tconf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	tconf.FileDescriptors = append(tconf.FileDescriptors, i.Fds...)
 

--- a/integration/hsm/helpers.go
+++ b/integration/hsm/helpers.go
@@ -212,7 +212,7 @@ func newAuthConfig(t *testing.T, log *slog.Logger, clock clockwork.Clock) *servi
 	config.Proxy.Enabled = false
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 
@@ -255,7 +255,7 @@ func newProxyConfig(t *testing.T, authAddr utils.NetAddr, log *slog.Logger, cloc
 	config.SetAuthServerAddress(authAddr)
 	config.Logger = log
 	config.InstanceMetadataClient = imds.NewDisabledIMDSClient()
-	config.MaxRetryPeriod = 25 * time.Millisecond
+	config.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(25 * time.Millisecond)
 	config.PollingPeriod = 2 * time.Second
 	config.Clock = clock
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5793,7 +5793,7 @@ func (s *integrationTestSuite) rotationConfig(disableWebService bool) *servicecf
 	tconf.PollingPeriod = time.Second
 	tconf.Testing.ClientTimeout = time.Second
 	tconf.Testing.ShutdownTimeout = 2 * tconf.Testing.ClientTimeout
-	tconf.MaxRetryPeriod = time.Second
+	tconf.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(time.Second)
 	return tconf
 }
 

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -643,6 +643,12 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 	cfg.CachePolicy = *cachePolicy
 
+	authConnectionConfig, err := fc.AuthConnectionConfig.Parse()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cfg.AuthConnectionConfig = *authConnectionConfig
+
 	cfg.ShutdownDelay = time.Duration(fc.ShutdownDelay)
 
 	// Apply (TLS) cipher suites and (SSH) ciphers, KEX algorithms, and MAC

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -644,6 +644,9 @@ type Global struct {
 
 	// DiagAddr is the address to expose a diagnostics HTTP endpoint.
 	DiagAddr string `yaml:"diag_addr"`
+
+	// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
+	AuthConnectionConfig AuthConnectionConfig `yaml:"auth_connection_config,omitempty"`
 }
 
 // CachePolicy is used to control  local cache
@@ -677,6 +680,30 @@ func (c *CachePolicy) Parse() (*servicecfg.CachePolicy, error) {
 		return nil, trace.Wrap(err)
 	}
 	return &out, nil
+}
+
+// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
+type AuthConnectionConfig struct {
+	// UpperLimitBetweenRetries is the upper limit for how long to wait between retries.
+	UpperLimitBetweenRetries time.Duration `yaml:"upper_limit_between_retries,omitempty"`
+	// InitialConnectionDelay is the initial delay before the first retry attempt.
+	// The retry logic will apply jitter to this duration.
+	InitialConnectionDelay time.Duration `yaml:"initial_connection_delay,omitempty"`
+	// BackoffStepDuration is the amount of time added to the retry delay.
+	BackoffStepDuration time.Duration `yaml:"backoff_step_duration,omitempty"`
+}
+
+// Parse parses [servicecfg.AuthConnectionConfig] from Teleport config
+func (c *AuthConnectionConfig) Parse() (*servicecfg.AuthConnectionConfig, error) {
+	out := &servicecfg.AuthConnectionConfig{
+		UpperLimitBetweenRetries: c.UpperLimitBetweenRetries,
+		InitialConnectionDelay:   c.InitialConnectionDelay,
+		BackoffStepDuration:      c.BackoffStepDuration,
+	}
+	if err := out.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err, "failed to parse auth_connection_config")
+	}
+	return out, nil
 }
 
 // Service is a common configuration of a teleport service

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/sshutils/x11"
 )
 
@@ -1242,6 +1243,125 @@ func TestX11Config(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tc.expectX11Config, serverCfg)
+		})
+	}
+}
+
+func TestBackoffConfig(t *testing.T) {
+	testCases := []struct {
+		desc                   string
+		mutate                 func(cfgMap)
+		expectSvcBackoffConfig *servicecfg.AuthConnectionConfig
+		errorFn                func(t require.TestingT, err error, msgAndArgs ...interface{})
+	}{
+		{
+			desc:   "default",
+			mutate: func(cfg cfgMap) {},
+			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
+				UpperLimitBetweenRetries: 90 * time.Second,
+				InitialConnectionDelay:   9 * time.Second,
+				BackoffStepDuration:      18 * time.Second,
+			},
+			errorFn: require.NoError,
+		},
+		{
+			desc: "negative values use defaults",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"initial_connection_delay":    "-1m",
+					"upper_limit_between_retries": "-5m",
+					"backoff_step_duration":       "-3s",
+				}
+			},
+			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
+				UpperLimitBetweenRetries: 90 * time.Second,
+				InitialConnectionDelay:   9 * time.Second,
+				BackoffStepDuration:      18 * time.Second,
+			},
+			errorFn: require.NoError,
+		},
+		{
+			desc: "use default ratio when only max is given",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"upper_limit_between_retries": "3m",
+				}
+			},
+			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
+				UpperLimitBetweenRetries: 3 * time.Minute,
+				InitialConnectionDelay:   18 * time.Second,
+				BackoffStepDuration:      36 * time.Second,
+			},
+			errorFn: require.NoError,
+		},
+		{
+			desc: "user specified",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"initial_connection_delay":    "1m",
+					"upper_limit_between_retries": "5m",
+					"backoff_step_duration":       "3s",
+				}
+			},
+			expectSvcBackoffConfig: &servicecfg.AuthConnectionConfig{
+				UpperLimitBetweenRetries: 5 * time.Minute,
+				InitialConnectionDelay:   time.Minute,
+				BackoffStepDuration:      3 * time.Second,
+			},
+			errorFn: require.NoError,
+		},
+		{
+			desc: "minimum upper range enforced",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"upper_limit_between_retries": "2ms",
+				}
+			},
+			expectSvcBackoffConfig: nil,
+			errorFn: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.ErrorContains(t, err, "cannot be set below")
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+		{
+			desc: "cannot set initial delay above upper limit",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"initial_connection_delay": "2h",
+				}
+			},
+			expectSvcBackoffConfig: nil,
+			errorFn: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.ErrorContains(t, err, "cannot be larger than upper_limit_between_retries")
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+		{
+			desc: "cannot set step above upper limit",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["auth_connection_config"] = cfgMap{
+					"backoff_step_duration": "2h",
+				}
+			},
+			expectSvcBackoffConfig: nil,
+			errorFn: func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+				require.ErrorContains(t, err, "cannot be larger than upper_limit_between_retries")
+				require.True(t, trace.IsBadParameter(err))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			text := bytes.NewBuffer(editConfig(t, tc.mutate))
+
+			cfg, err := ReadConfig(text)
+			require.NoError(t, err)
+
+			svccfg, err := cfg.AuthConnectionConfig.Parse()
+			tc.errorFn(t, err)
+
+			require.Equal(t, tc.expectSvcBackoffConfig, svccfg)
 		})
 	}
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -73,9 +73,9 @@ const updateClientsJoinWarning = "This agent joined the cluster during the updat
 // service until succeeds or process gets shut down
 func (process *TeleportProcess) reconnectToAuthService(role types.SystemRole) (*Connector, error) {
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
-		First:  retryutils.HalfJitter(process.Config.MaxRetryPeriod / 10),
-		Step:   process.Config.MaxRetryPeriod / 5,
-		Max:    process.Config.MaxRetryPeriod,
+		First:  retryutils.HalfJitter(process.Config.AuthConnectionConfig.InitialConnectionDelay),
+		Step:   process.Config.AuthConnectionConfig.BackoffStepDuration,
+		Max:    process.Config.AuthConnectionConfig.UpperLimitBetweenRetries,
 		Clock:  process.Clock,
 		Jitter: retryutils.HalfJitter,
 	})

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -949,7 +949,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
-	cfg.MaxRetryPeriod = 5 * time.Millisecond
+	cfg.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(5 * time.Millisecond)
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Testing.ConnectFailureC = make(chan time.Duration, 5)
 	cfg.Testing.ClientTimeout = time.Millisecond
@@ -970,7 +970,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	}()
 
 	timeout := time.After(10 * time.Second)
-	step := cfg.MaxRetryPeriod / 5.0
+	step := cfg.AuthConnectionConfig.BackoffStepDuration
 	for i := 0; i < 5; i++ {
 		// wait for connection to fail
 		select {
@@ -2315,7 +2315,7 @@ func TestInstanceCertReissue(t *testing.T) {
 	agentCfg.WindowsDesktop.Enabled = true
 	agentCfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	agentCfg.Logger = logtest.NewLogger()
-	agentCfg.MaxRetryPeriod = time.Second
+	agentCfg.AuthConnectionConfig = *servicecfg.DefaultRatioAuthConnectionConfig(time.Second)
 	agentCfg.InstanceMetadataClient = imds.NewDisabledIMDSClient()
 
 	agentProc, err := NewTeleport(agentCfg)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -235,8 +235,8 @@ type Config struct {
 	// attempts as used by the rotation state service
 	RotationConnectionInterval time.Duration
 
-	// MaxRetryPeriod is the maximum period between reconnection attempts to auth
-	MaxRetryPeriod time.Duration
+	// AuthConnectionConfig defines the Auth Service connection configuration.
+	AuthConnectionConfig AuthConnectionConfig
 
 	// TeleportHome is the path to tsh configuration and data, used
 	// for loading profiles when TELEPORT_HOME is set
@@ -337,6 +337,59 @@ type AuditLogConfig struct {
 	Enabled bool
 	// StartDate is the start date for exporting audit logs. It defaults to 90 days ago on the first export.
 	StartDate time.Time
+}
+
+// AuthConnectionConfig defines the parameters used to connect to the Auth Service.
+type AuthConnectionConfig struct {
+	// UpperLimitBetweenRetries is the upper limit for how long to wait between retries.
+	UpperLimitBetweenRetries time.Duration
+	// InitialConnectionDelay is the initial delay before the first retry attempt.
+	// The retry logic will apply jitter to this duration.
+	InitialConnectionDelay time.Duration
+	// BackoffStepDuration is the amount of time added to the retry delay.
+	BackoffStepDuration time.Duration
+}
+
+// CheckAndSetDefaults checks and sets default values
+func (c *AuthConnectionConfig) CheckAndSetDefaults() error {
+	const minWatcherBackoff = 10 * time.Second
+
+	if c.UpperLimitBetweenRetries < 1 {
+		c.UpperLimitBetweenRetries = defaults.MaxWatcherBackoff
+	} else if c.UpperLimitBetweenRetries < minWatcherBackoff {
+		return trace.BadParameter("upper_limit_between_retries (%s) cannot be set below %s", c.UpperLimitBetweenRetries, minWatcherBackoff)
+	}
+
+	if c.InitialConnectionDelay < 1 {
+		c.InitialConnectionDelay = c.UpperLimitBetweenRetries / 10
+	} else if c.InitialConnectionDelay > c.UpperLimitBetweenRetries {
+		return trace.BadParameter(
+			"initial_connection_delay (%s) cannot be larger than upper_limit_between_retries (%s)",
+			c.InitialConnectionDelay,
+			c.UpperLimitBetweenRetries,
+		)
+	}
+
+	if c.BackoffStepDuration < 1 {
+		c.BackoffStepDuration = c.UpperLimitBetweenRetries / 5
+	} else if c.BackoffStepDuration > c.UpperLimitBetweenRetries {
+		return trace.BadParameter(
+			"backoff_step_duration (%s) cannot be larger than upper_limit_between_retries (%s)",
+			c.BackoffStepDuration,
+			c.UpperLimitBetweenRetries,
+		)
+	}
+
+	return nil
+}
+
+// DefaultRatioAuthConnectionConfig returns AuthConnectionConfig with parameters based on UpperLimitBetweenRetries
+func DefaultRatioAuthConnectionConfig(UpperLimitBetweenRetries time.Duration) *AuthConnectionConfig {
+	return &AuthConnectionConfig{
+		UpperLimitBetweenRetries: UpperLimitBetweenRetries,
+		InitialConnectionDelay:   UpperLimitBetweenRetries / 10,
+		BackoffStepDuration:      UpperLimitBetweenRetries / 5,
+	}
 }
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.
@@ -632,7 +685,7 @@ func ApplyDefaults(cfg *Config) {
 	defaults.ConfigureLimiter(&cfg.WindowsDesktop.ConnLimiter)
 
 	cfg.RotationConnectionInterval = defaults.HighResPollingPeriod
-	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.AuthConnectionConfig = *DefaultRatioAuthConnectionConfig(defaults.MaxWatcherBackoff)
 	cfg.Testing.ConnectFailureC = make(chan time.Duration, 1)
 	cfg.CircuitBreakerConfig = breaker.DefaultBreakerConfig(cfg.Clock)
 

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -105,6 +106,12 @@ func TestDefaultConfig(t *testing.T) {
 
 	// Debug should always be enabled by default.
 	require.True(t, config.DebugService.Enabled)
+
+	// Reconnect section
+	require.Equal(t, defaults.MaxWatcherBackoff, config.AuthConnectionConfig.UpperLimitBetweenRetries)
+	require.Equal(t, 18*time.Second, config.AuthConnectionConfig.BackoffStepDuration)
+	require.Equal(t, 9*time.Second, config.AuthConnectionConfig.InitialConnectionDelay)
+
 }
 
 // TestCheckApp validates application configuration.


### PR DESCRIPTION
Backport #61835 to branch/v18

Changelog: Added a new global configuration section auth_connection_config allowing users to configure the backoff behaviour for Proxy and Agent instances connecting to the Auth Service