### PR TITLE
[v17] Fix event handler to gracefully drop malformed sessions

### DIFF
--- a/integrations/event-handler/session_events_job.go
+++ b/integrations/event-handler/session_events_job.go
@@ -238,8 +238,9 @@ func (j *SessionEventsJob) processSession(ctx context.Context, s session, proces
 // from session recordings that were previously not found.
 func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 	const (
-		initialProcessingDelay = time.Minute
-		processingInterval     = 3 * time.Minute
+		initialProcessingDelay      = time.Minute
+		processingInterval          = 3 * time.Minute
+		maxNumberOfInflightSessions = 10
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -260,7 +261,7 @@ func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 		}
 
 		err := j.app.State.IterateMissingRecordings(func(sess session, attempts int) error {
-			semaphore := make(chan struct{}, j.app.Config.Concurrency*2)
+			semaphore := make(chan struct{}, maxNumberOfInflightSessions)
 
 			return j.ingestSession(ctx, sess, attempts, semaphore)
 		})

--- a/integrations/event-handler/session_events_job.go
+++ b/integrations/event-handler/session_events_job.go
@@ -115,7 +115,7 @@ func (j *SessionEventsJob) run(ctx context.Context) error {
 	for {
 		select {
 		case s := <-j.sessions:
-			if err := j.ingestSession(ctx, s, 0); err != nil {
+			if err := j.ingestSession(ctx, s, 0, nil); err != nil {
 				j.app.log.WarnContext(ctx, "Unable to ingest session event", "error", err)
 			}
 		case <-ctx.Done():
@@ -127,7 +127,7 @@ func (j *SessionEventsJob) run(ctx context.Context) error {
 	}
 }
 
-func (j *SessionEventsJob) ingestSession(ctx context.Context, s session, attempt int) error {
+func (j *SessionEventsJob) ingestSession(ctx context.Context, s session, attempt int, semaphore chan struct{}) error {
 	log := j.app.log.With(
 		"id", s.ID,
 		"index", s.Index,
@@ -136,14 +136,17 @@ func (j *SessionEventsJob) ingestSession(ctx context.Context, s session, attempt
 		log.DebugContext(ctx, "Starting session ingest")
 	}
 
+	if semaphore == nil {
+		semaphore = j.semaphore
+	}
 	select {
-	case j.semaphore <- struct{}{}:
+	case semaphore <- struct{}{}:
 	case <-ctx.Done():
 		return trace.Wrap(ctx.Err())
 	}
 
 	go func() {
-		defer func() { <-j.semaphore }()
+		defer func() { <-semaphore }()
 
 		if err := j.processSessionFunc(ctx, s, attempt); err != nil {
 			log.ErrorContext(ctx, "Failed processing session recording", "error", err)
@@ -257,7 +260,9 @@ func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 		}
 
 		err := j.app.State.IterateMissingRecordings(func(sess session, attempts int) error {
-			return j.ingestSession(ctx, sess, attempts)
+			semaphore := make(chan struct{}, j.app.Config.Concurrency*2)
+
+			return j.ingestSession(ctx, sess, attempts, semaphore)
 		})
 		if err != nil && !lib.IsCanceled(err) {
 			j.app.log.WarnContext(ctx, "Unable to load previously failed sessions for processing", "error", err)

--- a/integrations/event-handler/session_events_job.go
+++ b/integrations/event-handler/session_events_job.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -47,6 +46,10 @@ type session struct {
 	UploadTime time.Time
 }
 
+// processSessionFunc mimics the signature of
+// [SessionEventsJob.processSession].
+type processSessionFunc func(ctx context.Context, s session, processingAttempt int) error
+
 // SessionEventsJob incapsulates session events consumption logic
 type SessionEventsJob struct {
 	lib.ServiceJob
@@ -56,6 +59,7 @@ type SessionEventsJob struct {
 	logLimiter             *rate.Limiter
 	backpressureLogLimiter *rate.Limiter
 	sessionsProcessed      atomic.Uint64
+	processSessionFunc     processSessionFunc
 }
 
 // NewSessionEventsJob creates new EventsJob structure
@@ -68,6 +72,7 @@ func NewSessionEventsJob(app *App) *SessionEventsJob {
 		backpressureLogLimiter: rate.NewLimiter(rate.Every(time.Minute), 1),
 	}
 
+	j.processSessionFunc = j.processSession
 	j.ServiceJob = lib.NewServiceJob(j.run)
 
 	return j
@@ -110,33 +115,9 @@ func (j *SessionEventsJob) run(ctx context.Context) error {
 	for {
 		select {
 		case s := <-j.sessions:
-			log := j.app.log.With(
-				"id", s.ID,
-				"index", s.Index,
-			)
-
-			if j.logLimiter.Allow() {
-				log.DebugContext(ctx, "Starting session ingest")
+			if err := j.ingestSession(ctx, s, 0); err != nil {
+				j.app.log.WarnContext(ctx, "Unable to ingest session event", "error", err)
 			}
-
-			select {
-			case j.semaphore <- struct{}{}:
-			case <-ctx.Done():
-				log.ErrorContext(ctx, "Failed to acquire semaphore", "error", ctx.Err())
-				return nil
-			}
-
-			func(s session, log *slog.Logger) {
-				j.app.SpawnCritical(func(ctx context.Context) error {
-					defer func() { <-j.semaphore }()
-
-					if err := j.processSession(ctx, s, 0); err != nil {
-						return trace.Wrap(err)
-					}
-
-					return nil
-				})
-			}(s, log)
 		case <-ctx.Done():
 			if lib.IsCanceled(ctx.Err()) {
 				return nil
@@ -144,6 +125,32 @@ func (j *SessionEventsJob) run(ctx context.Context) error {
 			return ctx.Err()
 		}
 	}
+}
+
+func (j *SessionEventsJob) ingestSession(ctx context.Context, s session, attempt int) error {
+	log := j.app.log.With(
+		"id", s.ID,
+		"index", s.Index,
+	)
+	if j.logLimiter.Allow() {
+		log.DebugContext(ctx, "Starting session ingest")
+	}
+
+	select {
+	case j.semaphore <- struct{}{}:
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
+	}
+
+	go func() {
+		defer func() { <-j.semaphore }()
+
+		if err := j.processSessionFunc(ctx, s, attempt); err != nil {
+			log.ErrorContext(ctx, "Failed processing session recording", "error", err)
+		}
+	}()
+
+	return nil
 }
 
 func (j *SessionEventsJob) processSession(ctx context.Context, s session, processingAttempt int) error {
@@ -228,9 +235,8 @@ func (j *SessionEventsJob) processSession(ctx context.Context, s session, proces
 // from session recordings that were previously not found.
 func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 	const (
-		initialProcessingDelay      = time.Minute
-		processingInterval          = 3 * time.Minute
-		maxNumberOfInflightSessions = 10
+		initialProcessingDelay = time.Minute
+		processingInterval     = 3 * time.Minute
 	)
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -243,7 +249,6 @@ func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 	timer := time.NewTimer(jitter(initialProcessingDelay))
 	defer timer.Stop()
 
-	semaphore := make(chan struct{}, maxNumberOfInflightSessions)
 	for {
 		select {
 		case <-timer.C:
@@ -252,21 +257,7 @@ func (j *SessionEventsJob) processMissingRecordings(ctx context.Context) error {
 		}
 
 		err := j.app.State.IterateMissingRecordings(func(sess session, attempts int) error {
-			select {
-			case semaphore <- struct{}{}:
-			case <-ctx.Done():
-				return trace.Wrap(ctx.Err())
-			}
-
-			go func() {
-				defer func() { <-semaphore }()
-
-				if err := j.processSession(ctx, sess, attempts); err != nil {
-					j.app.log.DebugContext(ctx, "Failed processing session recording", "error", err)
-				}
-			}()
-
-			return nil
+			return j.ingestSession(ctx, sess, attempts)
 		})
 		if err != nil && !lib.IsCanceled(err) {
 			j.app.log.WarnContext(ctx, "Unable to load previously failed sessions for processing", "error", err)

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -22,12 +22,12 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/peterbourgon/diskv/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
-	"github.com/gravitational/trace"
 )
 
 // TestConsumeSessionNoEventsFound tests that the consumeSession method returns without error

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -15,15 +15,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"log/slog"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/peterbourgon/diskv/v3"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	"github.com/gravitational/trace"
 )
 
 // TestConsumeSessionNoEventsFound tests that the consumeSession method returns without error
@@ -40,8 +44,52 @@ func TestConsumeSessionNoEventsFound(t *testing.T) {
 		client: &mockClient{},
 		log:    slog.Default(),
 	})
-	_, err := j.consumeSession(context.Background(), session{ID: sessionID})
+	_, err := j.consumeSession(t.Context(), session{ID: sessionID})
 	require.NoError(t, err)
+}
+
+// TestIngestSession tests that the ingestSession method returns without error if a malformed
+// session event is processed.
+func TestIngestSession(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		startTime := time.Now().Add(-time.Minute)
+		out := &bytes.Buffer{}
+		log := slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{Level: slog.LevelError}))
+
+		j := NewSessionEventsJob(&App{
+			Config: &StartCmdConfig{
+				IngestConfig: IngestConfig{
+					StorageDir:       t.TempDir(),
+					Timeout:          time.Second,
+					BatchSize:        100,
+					Concurrency:      5,
+					StartTime:        &startTime,
+					SkipSessionTypes: map[string]struct{}{"print": {}, "desktop.recording": {}},
+					WindowSize:       time.Hour * 24,
+					DryRun:           true,
+				},
+			},
+			State: &State{
+				dv: diskv.New(diskv.Options{
+					BasePath: t.TempDir(),
+				}),
+			},
+			client: &mockClient{},
+			log:    log,
+		})
+
+		j.processSessionFunc = func(ctx context.Context, s session, processingAttempt int) error {
+			return trace.LimitExceeded("Session ingestion exceeded attempt limit")
+		}
+
+		err := j.ingestSession(t.Context(), session{ID: "test"}, 0)
+		require.NoError(t, err)
+
+		synctest.Wait()
+
+		require.Contains(t, out.String(), "Failed processing session recording")
+		require.Contains(t, out.String(), "Session ingestion exceeded attempt limit")
+	})
 }
 
 type mockClient struct {

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -82,7 +82,7 @@ func TestIngestSession(t *testing.T) {
 			return trace.LimitExceeded("Session ingestion exceeded attempt limit")
 		}
 
-		err := j.ingestSession(t.Context(), session{ID: "test"}, 0)
+		err := j.ingestSession(t.Context(), session{ID: "test"}, 0, nil)
 		require.NoError(t, err)
 
 		synctest.Wait()

--- a/integrations/event-handler/session_events_job_test.go
+++ b/integrations/event-handler/session_events_job_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"log/slog"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client"
 	auditlogpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/auditlog/v1"
+	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 // TestConsumeSessionNoEventsFound tests that the consumeSession method returns without error


### PR DESCRIPTION
Backport #62073 to branch/v17

changelog: Fixed bug where event handler dies on malformed session events