### PR TITLE
Implement access_monitoring_rule terraform webapi endpoint

### DIFF
--- a/lib/web/access_monitoring_rule.go
+++ b/lib/web/access_monitoring_rule.go
@@ -1,0 +1,57 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+
+	accessmonitoringrulesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessmonitoringrules/v1"
+	"github.com/gravitational/teleport/lib/tfgen"
+)
+
+func (h *Handler) accessMonitoringRuleGenerateTerraform(
+	_ http.ResponseWriter,
+	r *http.Request,
+	_ httprouter.Params,
+	_ *SessionContext,
+) (any, error) {
+	var req accessMonitoringRuleGenerateTerraformRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	tfResult, err := tfgen.Generate(req.Resource)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return accessMonitoringRuleGenerateTerraformResponse{Terraform: string(tfResult)}, nil
+}
+
+type accessMonitoringRuleGenerateTerraformRequest struct {
+	Resource *accessmonitoringrulesv1.AccessMonitoringRule `json:"resource"`
+}
+
+type accessMonitoringRuleGenerateTerraformResponse struct {
+	Terraform string `json:"terraform"`
+}

--- a/lib/web/access_monitoring_rule_test.go
+++ b/lib/web/access_monitoring_rule_test.go
@@ -1,0 +1,65 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const validAccessMonitoringRuleTerraform = `resource "teleport_access_monitoring_rule" "foo" {
+  version = "v1"
+
+  metadata = {
+    name = "foo"
+  }
+
+  spec = {
+    subjects  = ["access_request"]
+    condition = "some-condition"
+    notification = {
+      name       = "mattermost"
+      recipients = ["apple"]
+    }
+  }
+}
+`
+
+func TestAccessMonitoringRuleGenerateTerraform_Valid(t *testing.T) {
+	t.Parallel()
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+	pack := proxy.authPack(t, "test@example.com", nil)
+
+	req := accessMonitoringRuleGenerateTerraformRequest{
+		Resource: getAccessMonitoringRuleResource(),
+	}
+
+	endpoint := pack.clt.Endpoint("webapi", "access-monitoring-rule", "terraform")
+	re, err := pack.clt.PostJSON(context.Background(), endpoint, req)
+	require.NoError(t, err)
+
+	var resp accessMonitoringRuleGenerateTerraformResponse
+	require.NoError(t, json.Unmarshal(re.Bytes(), &resp))
+	require.Equal(t, validAccessMonitoringRuleTerraform, resp.Terraform)
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1032,6 +1032,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/yaml/parse/:kind", h.WithAuth(h.yamlParse))
 	h.POST("/webapi/yaml/stringify/:kind", h.WithAuth(h.yamlStringify))
 
+	// Access Monitoring Rule Terraform
+	h.POST("/webapi/access-monitoring-rule/terraform", h.WithAuth(h.accessMonitoringRuleGenerateTerraform))
+
 	// Desktop access endpoints.
 	h.GET("/webapi/sites/:site/desktops", h.WithClusterAuth(h.clusterDesktopsGet))
 	h.GET("/webapi/sites/:site/desktopservices", h.WithClusterAuth(h.clusterDesktopServicesGet))

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -546,6 +546,10 @@ const cfg = {
         '/v1/webapi/sites/:clusterId/sessionrecording/:sessionId/playback/ws',
       thumbnail: '/v1/webapi/sites/:clusterId/sessionthumbnail/:sessionId',
     },
+
+    accessMonitoringRule: {
+      terraform: '/v1/webapi/access-monitoring-rule/terraform'
+    },
   },
 
   playable_db_protocols: [],
@@ -1176,6 +1180,10 @@ const cfg = {
 
   getYamlStringifyUrl(kind: YamlSupportedResourceKind) {
     return generatePath(cfg.api.yaml.stringify, { kind });
+  },
+
+  getAccessMonitoringRuleTerraformUrl() {
+    return generatePath(cfg.api.accessMonitoringRule.terraform)
   },
 
   getLocksRoute() {

--- a/web/packages/teleport/src/services/accessmonitoringrule/accesmonitoringrule.ts
+++ b/web/packages/teleport/src/services/accessmonitoringrule/accesmonitoringrule.ts
@@ -1,0 +1,30 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cfg from 'teleport/config';
+import api from 'teleport/services/api';
+
+import { GenerateTerraformRequest } from './types';
+
+export const accessMonitoringRuleService = {
+  terraform(req: GenerateTerraformRequest): Promise<string> {
+    return api
+      .post(cfg.getAccessMonitoringRuleTerraformUrl(), req)
+      .then(resp => resp.terraform);
+  },
+};

--- a/web/packages/teleport/src/services/accessmonitoringrule/index.ts
+++ b/web/packages/teleport/src/services/accessmonitoringrule/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { accessMonitoringRuleService } from './accesmonitoringrule';

--- a/web/packages/teleport/src/services/accessmonitoringrule/types.ts
+++ b/web/packages/teleport/src/services/accessmonitoringrule/types.ts
@@ -1,0 +1,23 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AccessMonitoringRule } from 'e-teleport/services/accessmonitoringrule/types';
+
+export type GenerateTerraformRequest = {
+  resource: AccessMonitoringRule;
+};

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -41,6 +41,7 @@ import userGroupService from './services/userGroups';
 import { yamlService } from './services/yaml/yaml';
 import { StoreNav, StoreUserContext } from './stores';
 import * as types from './types';
+import { accessMonitoringRuleService } from './services/accessmonitoringrule';
 
 class TeleportContext implements types.Context {
   // stores
@@ -64,6 +65,7 @@ class TeleportContext implements types.Context {
   mfaService = new MfaService();
   notificationService = new NotificationService();
   yamlService = yamlService;
+  accessAutomationService = accessMonitoringRuleService;
 
   notificationContentFactory = notificationContentFactory;
 


### PR DESCRIPTION
Supports: https://github.com/gravitational/teleport.e/issues/7690
Requires: https://github.com/gravitational/teleport/pull/61660
Supersedes: https://github.com/gravitational/teleport/pull/62048

This PR extends the webapi to support a new endpoint /webapi/access-monitoring-rule/terraform that converts a provided access_monitoring_rule into Terraform config.

This is required to support a terraform generation view for the Access Automations page https://github.com/gravitational/teleport.e/pull/7695