### PR TITLE
[buddy] CLI reference: add env var config and frontmatter

### DIFF
--- a/lib/utils/docenvdefaults/tsh.yaml
+++ b/lib/utils/docenvdefaults/tsh.yaml
@@ -1,0 +1,74 @@
+TELEPORT_AUTH:
+  description: "Any defined authentication connector, including `passwordless` and `local` (i.e., no authentication connector)"
+  default: "none"
+  type: "string"
+
+TELEPORT_CLUSTER:
+  description: "Name of a Teleport root or leaf cluster"
+  default: "none"
+  type: "string"
+
+TELEPORT_LOGIN:
+  description: "Login name to be used by default on the remote host"
+  default: "none"
+  type: "string"
+
+TELEPORT_LOGIN_BIND_ADDR:
+  description: "Address in the form of host:port to bind to for login command webhook"
+  default: "none"
+  type: "string"
+
+TELEPORT_LOGIN_BROWSER:
+  description: "Set to `none` to stop the system default browser from opening for SSO logins. If the value is not `none`, `tsh` will open the system default browser."
+  default: "none"
+  type: "string"
+
+TELEPORT_PROXY:
+  description: "Address of the Teleport proxy server"
+  default: "none"
+  type: "string"
+
+TELEPORT_RELAY:
+  description: "Address of the Teleport relay server to use, \"none\" to disable the use of a relay, or \"default\" to use the default address specified by the control plane at login time. Defaults to port 443."
+  default: "none"
+  type: "string"
+
+TELEPORT_HEADLESS:
+  description: "Use headless authentication"
+  default: false
+  type: "bool"
+
+TELEPORT_HOME:
+  description: "Home location for tsh configuration and data"
+  default: "none"
+  type: "string"
+
+TELEPORT_USER:
+  description: "A Teleport user name"
+  default: "none"
+  type: "string"
+
+TELEPORT_ADD_KEYS_TO_AGENT:
+  description: "Specifies if the user certificate should be stored on the running SSH agent"
+  default: "auto"
+  type: "string"
+
+TELEPORT_USE_LOCAL_SSH_AGENT:
+  description: "Disable or enable local SSH agent integration"
+  default: "none"
+  type: "string"
+
+TELEPORT_GLOBAL_TSH_CONFIG:
+  description: "Override location of global `tsh` config file from default `/etc/tsh.yaml`"
+  default: "none"
+  type: "string"
+
+TELEPORT_MFA_MODE:
+  description: "Preferred mode for MFA and Passwordless assertions"
+  default: "auto"
+  type: "string"
+
+TELEPORT_IDENTITY_FILE:
+  description: "File path to identity file"
+  default: "none"
+  type: "string"

--- a/lib/utils/docs-usage.md.tmpl
+++ b/lib/utils/docs-usage.md.tmpl
@@ -54,6 +54,10 @@ $ {{.Name}}{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]
 ---
 title: {{.App.Name}} Reference
 description: Provides a comprehensive list of commands, arguments, and flags for {{.App.Name}}.
+sidebar_label: {{.App.Name}}
+tags:
+  - reference
+  - {{if eq .App.Name "tbot"}}mwi{{else}}platform-wide{{end}}
 ---
 
 This guide provides a comprehensive list of commands, arguments, and flags for
@@ -62,7 +66,7 @@ This guide provides a comprehensive list of commands, arguments, and flags for
 {{ end -}}
 
 {{template "FormatUsage" .App -}}
-{{if .Context.Flags -}}
+{{if .Context.Flags|AnyVisibleFlags -}}
 Global flags:
 
 |Flag|Default|Description|

--- a/lib/utils/usage_docs.go
+++ b/lib/utils/usage_docs.go
@@ -87,9 +87,9 @@ func anyVisibleFlags(f []*kingpin.FlagModel) bool {
 // provided exposes an environment variable for configuration.
 func anyEnvVarsForCmd(args []*kingpin.ArgModel, flags []*kingpin.FlagModel) bool {
 	return slices.ContainsFunc(args, func(arg *kingpin.ArgModel) bool {
-		return arg.Envar != ""
+		return arg.Envar != "" && !arg.Hidden
 	}) || slices.ContainsFunc(flags, func(flag *kingpin.FlagModel) bool {
-		return flag.Envar != ""
+		return flag.Envar != "" && !flag.Hidden
 	})
 }
 


### PR DESCRIPTION
This change edits the CLI reference generator to fill in environment variables that are currently present only in the manually maintained CLI reference documentation, beginning with `tsh`. If the generator finds a YAML file named after the CLI tool it is generating a page for, it loads that file and adds the environment variables listed there to the complete list of environment variables for the CLI tool. This way, if a CLI reads environment variables directly from the OS, rather than from the `kingpin` library, we can still include these variables in the docs.

This change also adds the `sidebar_label` and `tags `frontmatter fields to each reference page.