### PR TITLE
[v18] Run make gen-resource-docs

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -384,7 +384,7 @@ http_proxy_settings: # [...]
 |Field Name|Description|Type|
 |---|---|---|
 |azure|The set of Azure-specific installation parameters.|[Azure Installer Params](#azure-installer-params)|
-|enroll_mode|Indicates the enrollment mode to be used when adding a node. Valid values: 0: uses eice for EC2 matchers which use an integration and script for all the other methods 1: uses script mode 2: uses eice mode (deprecated)|[Install Param Enroll Mode](#install-param-enroll-mode)|
+|enroll_mode|Indicates the enrollment mode to be used when adding a node. Valid values: 0: uses eice for EC2 matchers which use an integration and script for all the other methods 1: uses script mode 2: uses eice mode|[Install Param Enroll Mode](#install-param-enroll-mode)|
 |http_proxy_settings|Defines HTTP proxy settings for making HTTP requests. When set, this will set the HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables before running the installation.|[HTTP Proxy Settings](#http-proxy-settings)|
 |install_teleport|Disables agentless discovery|Boolean|
 |join_method|The method to use when joining the cluster|[Join Method](#join-method)|


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/62130 backported `discovery-config.mdx` but that didn't trigger the proto lint workflow. This runs `make gen-resource-docs` to make the file in sync with the protos on `branch/v18` so any proto change backports will pass