### PR TITLE
Generate an App Server V3 reference page

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -8,10 +8,22 @@ resources:
     package: github.com/gravitational/teleport/api/types
     yaml_kind: app
     yaml_version: v3
+    introduction: |
+      The `app` resource represents a single application protected by Teleport.
+      To learn more about using the `app` resource, see [Dynamic App
+      Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
   - type: AppServerV3
     package: types
     yaml_kind: app_server
     yaml_version: v3
+    introduction: |
+      The `app_server` resource represents an instance of the Teleport
+      Application Service, which allows you to [protect
+      applications](../../../enroll-resources/application-access/application-access.mdx)
+      with Teleport.
+
+      To manage applications proxied by Teleport instead, you can use the [`app`
+      resource](app-v3.mdx).
   - type: DatabaseServerV3
     package: github.com/gravitational/teleport/api/types
     yaml_kind: db_server

--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -8,6 +8,10 @@ resources:
     package: github.com/gravitational/teleport/api/types
     yaml_kind: app
     yaml_version: v3
+  - type: AppServerV3
+    package: types
+    yaml_kind: app_server
+    yaml_version: v3
   - type: DatabaseServerV3
     package: github.com/gravitational/teleport/api/types
     yaml_kind: db_server

--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -9,21 +9,41 @@ resources:
     yaml_kind: app
     yaml_version: v3
     introduction: |
-      The `app` resource represents a single application protected by Teleport.
+      The `app` resource represents an application that is dynamically
+      registered with Teleport. 
+
+      If you configure the Teleport Application Service with **dynamic resource
+      watchers**, the service queries the Teleport backend for `app` resources
+      that match their configured filters. For each matching `app`, the
+      Application Service creates an `app_server` resource configured to proxy
+      the target application.
+
       To learn more about using the `app` resource, see [Dynamic App
       Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
+
+      To learn more about the `app_server` resource, see the [reference
+      guide](app-server-v3.mdx).
   - type: AppServerV3
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: app_server
     yaml_version: v3
     introduction: |
-      The `app_server` resource represents an instance of the Teleport
-      Application Service, which allows you to [protect
-      applications](../../../enroll-resources/application-access/application-access.mdx)
-      with Teleport.
+      The `app_server` resource represents an application that has been
+      registered with Teleport. 
 
-      To manage applications proxied by Teleport instead, you can use the [`app`
-      resource](app-v3.mdx).
+      The Teleport Application Service creates an `app_server` in two situations:
+
+        1. It reads information about the target application in its
+           configuration file when it first starts.
+        1. It fetches a dynamically registered `app` resource from the Teleport
+           backend that matches its dynamic resource watchers.
+
+        There can be multiple instances of an `app_server` for a single
+        application, each corresponding to a different Teleport Application
+        Service instance that proxies the application. Read more about [High
+        Availability](../../../enroll-resources/application-access/configuration/ha.mdx)
+        for the Teleport Application Service. Read the [reference
+        guide](./app-v3.mdx) for the `app` resource.
   - type: DatabaseServerV3
     package: github.com/gravitational/teleport/api/types
     yaml_kind: db_server

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
@@ -30,8 +30,15 @@ import (
 // pageContent represents a reference page for a single resource and its related
 // fields. Fields must be exported so we can use them in templates.
 type pageContent struct {
+	// Introduction is optional text to override the default introduction, taken
+	// from Resource.
+	Introduction string
+	// Resource represents the dynamic Teleport resource that is the subject
+	// of the page.
 	Resource resourceSection
-	Fields   map[resource.PackageInfo]resource.ReferenceEntry
+	// Fields are the top-level fields of the dynamic resource for this
+	// page.
+	Fields map[resource.PackageInfo]resource.ReferenceEntry
 }
 
 // resourceSection represents a top-level section of the resource reference
@@ -67,6 +74,9 @@ type ResourceConfig struct {
 	// The value of the "version" field within a YAML manifest for this
 	// resource, e.g., "v6".
 	VersionValue string `yaml:"yaml_version"`
+	// Introduction paragraph(s) to add to the template in place of the
+	// default, which is the GoDoc for the resource type.
+	Introduction string `yaml:"introduction"`
 }
 
 // GeneratorConfig is the user-facing configuration for the resource reference
@@ -119,6 +129,7 @@ func Generate(prefix string, conf GeneratorConfig, tmpl *template.Template) erro
 		}
 
 		pc := pageContent{}
+		pc.Introduction = r.Introduction
 
 		// decl is a dynamic resource type, so get data for the type and
 		// its dependencies.

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
@@ -11,7 +11,7 @@ sidebar_label: {{ .Resource.SectionName }}
 **Kind**: `{{ .Resource.Kind }}`<br/>
 **Version**: `{{ .Resource.Version }}`
 
-{{ .Resource.Description }}
+{{ or .Introduction .Resource.Description }}
 
 {{- if gt (len .Resource.ResourceExample) 0 }}
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -1,0 +1,443 @@
+---
+title: App Server V3 Reference
+description: Provides a reference of fields within the App Server V3 resource, which you can manage with tctl.
+sidebar_label: App Server V3
+---
+{/* vale 3rd-party-products.former-names = NO */}
+{/* vale messaging.capitalization = NO */}
+{/* Automatically generated from: types/types.pb.go */}
+{/* DO NOT EDIT */}
+
+**Kind**: `app_server`<br/>
+**Version**: `v3`
+
+Represents a single proxied web app.
+
+## Top-level fields
+
+Example:
+
+```yaml
+kind: "string"
+sub_kind: "string"
+version: "string"
+metadata: # [...]
+spec: # [...]
+scope: "string"
+```
+|Field Name|Description|Type|
+|---|---|---|
+|kind|The app server resource kind. Always "app_server".|string|
+|metadata|The app server metadata.|[Metadata](#metadata)|
+|scope|The advertized scope of the server which can not change once assigned.|string|
+|spec|The app server spec.|[App Server Spec V3](#app-server-spec-v3)|
+|sub_kind|An optional resource subkind.|string|
+|version|The resource version.|string|
+
+## App AWS
+
+Contains additional options for AWS applications.
+
+
+Example:
+
+```yaml
+external_id: "string"
+roles_anywhere_profile: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|external_id|The AWS External ID used when assuming roles in this app.|string|
+|roles_anywhere_profile|Contains the IAM Roles Anywhere fields associated with this Application. These fields are set when performing the synchronization of AWS IAM Roles Anywhere Profiles into Teleport Apps.|[App AWS Roles Anywhere Profile](#app-aws-roles-anywhere-profile)|
+
+## App AWS Roles Anywhere Profile
+
+Contains the fields that represent an AWS IAM Roles Anywhere Profile.
+
+
+Example:
+
+```yaml
+profile_arn: "string"
+accept_role_session_name: true
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|accept_role_session_name|Whether this Roles Anywhere Profile accepts a custom role session name. When not supported, the AWS Session Name will be the X.509 certificate's serial number. When supported, the AWS Session Name will be the identity's username. This value comes from: https://docs.aws.amazon.com/rolesanywhere/latest/APIReference/API_ProfileDetail.html / acceptRoleSessionName|Boolean|
+|profile_arn|The AWS IAM Roles Anywhere Profile ARN that originated this Teleport App.|string|
+
+## App Identity Center
+
+Encapsulates information about an AWS Identity Center account application.
+
+
+Example:
+
+```yaml
+account_id: "string"
+permission_sets: 
+  - # [...]
+  - # [...]
+  - # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|account_id|Account ID is the AWS-assigned ID of the account|string|
+|permission_sets|Lists the available permission sets on the given account|[][Identity Center Permission Set](#identity-center-permission-set)|
+
+## App Server Spec V3
+
+The app access server spec.
+
+
+Example:
+
+```yaml
+version: "string"
+hostname: "string"
+host_id: "string"
+rotation: # [...]
+app: # [...]
+proxy_ids: 
+  - "string"
+  - "string"
+  - "string"
+relay_group: "string"
+relay_ids: 
+  - "string"
+  - "string"
+  - "string"
+component_features: # See description
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|app|The app proxied by this app server.|[App V3](#app-v3)|
+|component_features|Component_features contains features supported by this app server.||
+|host_id|The app server host uuid.|string|
+|hostname|The app server hostname.|string|
+|proxy_ids|A list of proxy IDs this server is expected to be connected to.|[]string|
+|relay_group|The name of the Relay group that the server is connected to|string|
+|relay_ids|The list of Relay host IDs that the server is connected to|[]string|
+|rotation|Contains the app server CA rotation information.|[Rotation](#rotation)|
+|version|The Teleport version that the server is running.|string|
+
+## App Spec V3
+
+The AppV3 resource spec.
+
+
+Example:
+
+```yaml
+uri: "string"
+public_addr: "string"
+dynamic_labels: 
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
+insecure_skip_verify: true
+rewrite: # [...]
+aws: # [...]
+cloud: "string"
+UserGroups: 
+  - "string"
+  - "string"
+  - "string"
+integration: "string"
+required_app_names: 
+  - "string"
+  - "string"
+  - "string"
+cors: # [...]
+identity_center: # [...]
+tcp_ports: 
+  - # [...]
+  - # [...]
+  - # [...]
+use_any_proxy_public_addr: true
+mcp: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|UserGroups|A list of user group IDs that this app is associated with.|[]string|
+|aws|Contains additional options for AWS applications.|[App AWS](#app-aws)|
+|cloud|Identifies the cloud instance the app represents.|string|
+|cors|Policy defines the Cross-Origin Resource Sharing settings for the app.|[CORS Policy](#cors-policy)|
+|dynamic_labels|The app's command labels.|map[string][Command Label V2](#command-label-v2)|
+|identity_center|Encapsulates information specific to AWS IAM Identity Center. Only valid for Identity Center account apps.|[App Identity Center](#app-identity-center)|
+|insecure_skip_verify|Disables app's TLS certificate verification.|Boolean|
+|integration|The integration name that must be used to access this Application. Only applicable to AWS App Access. If present, the Application must use the Integration's credentials instead of ambient credentials to access Cloud APIs.|string|
+|mcp|Contains MCP server related configurations.|[MCP](#mcp)|
+|public_addr|The public address the application is accessible at.|string|
+|required_app_names|A list of app names that are required for this app to function. Any app listed here will be part of the authentication redirect flow and authenticate alongside this app.|[]string|
+|rewrite|A list of rewriting rules to apply to requests and responses.|[Rewrite](#rewrite)|
+|tcp_ports|A list of ports and port ranges that an app agent can forward connections to. Only applicable to TCP App Access. If this field is not empty, URI is expected to contain no port number and start with the tcp protocol.|[][Port Range](#port-range)|
+|uri|The web app endpoint.|string|
+|use_any_proxy_public_addr|Will rebuild this app's fqdn based on the proxy public addr that the request originated from. This should be true if your proxy has multiple proxy public addrs and you want the app to be accessible from any of them. If `public_addr` is explicitly set in the app spec, setting this value to true will overwrite that public address in the web UI.|Boolean|
+
+## App V3
+
+Represents an app resource.
+
+
+Example:
+
+```yaml
+kind: "string"
+sub_kind: "string"
+version: "string"
+metadata: # [...]
+spec: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|kind|The app resource kind. Always "app".|string|
+|metadata|The app resource metadata.|[Metadata](#metadata)|
+|spec|The app resource spec.|[App Spec V3](#app-spec-v3)|
+|sub_kind|An optional resource subkind.|string|
+|version|The resource version. It must be specified. Supported values are:`v3`.|string|
+
+## CORS Policy
+
+Defines the CORS policy for AppSpecV3
+
+
+Example:
+
+```yaml
+allowed_origins: 
+  - "string"
+  - "string"
+  - "string"
+allowed_methods: 
+  - "string"
+  - "string"
+  - "string"
+allowed_headers: 
+  - "string"
+  - "string"
+  - "string"
+allow_credentials: true
+max_age: 1
+exposed_headers: 
+  - "string"
+  - "string"
+  - "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|allow_credentials|Allow_credentials indicates whether credentials are allowed.|Boolean|
+|allowed_headers|Allowed_headers specifies which headers can be used when accessing the app.|[]string|
+|allowed_methods|Allowed_methods specifies which methods are allowed when accessing the app.|[]string|
+|allowed_origins|Allowed_origins specifies which origins are allowed to access the app.|[]string|
+|exposed_headers|Exposed_headers indicates which headers are made available to scripts via the browser.|[]string|
+|max_age|Max_age indicates how long (in seconds) the results of a preflight request can be cached.|number|
+
+## Command Label V2
+
+A label that has a value as a result of the output generated by running command, e.g. hostname
+
+
+Example:
+
+```yaml
+period: # [...]
+command: 
+  - "string"
+  - "string"
+  - "string"
+result: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|command|A command to run|[]string|
+|period|A time between command runs|[Duration](#duration)|
+|result|Captures standard output|string|
+
+## Duration
+
+A wrapper around duration to set up custom marshal/unmarshal
+
+
+## Header
+
+Represents a single HTTP header passed over to the proxied application.
+
+
+Example:
+
+```yaml
+name: "string"
+value: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|name|The http header name.|string|
+|value|The http header value.|string|
+
+## Identity Center Permission Set
+
+Defines a permission set that is available on an IdentityCenter account app
+
+
+Example:
+
+```yaml
+arn: "string"
+name: "string"
+assignment_name: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|arn|The fully-formed ARN of the Permission Set.|string|
+|assignment_name|The ID of the Teleport Account Assignment resource that represents this permission being assigned on the enclosing Account.|string|
+|name|The human-readable name of the Permission Set.|string|
+
+## MCP
+
+Contains MCP server-related configurations.
+
+
+Example:
+
+```yaml
+command: "string"
+args: 
+  - "string"
+  - "string"
+  - "string"
+run_as_host_user: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|args|To execute with the command.|[]string|
+|command|To launch stdio-based MCP servers.|string|
+|run_as_host_user|The host user account under which the command will be executed. Required for stdio-based MCP servers.|string|
+
+## Metadata
+
+Resource metadata
+
+
+Example:
+
+```yaml
+name: "string"
+description: "string"
+labels: 
+  "string": "string"
+  "string": "string"
+  "string": "string"
+expires: # See description
+revision: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|description|Object description|string|
+|expires|A global expiry time header can be set on any resource in the system.||
+|labels|A set of labels|map[string]string|
+|name|An object name|string|
+|revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
+
+## Port Range
+
+Describes a port range for TCP apps. The range starts with Port and ends with EndPort. PortRange can be used to describe a single port in which case the Port field is the port and the EndPort field is 0.
+
+
+Example:
+
+```yaml
+port: 1
+end_port: 1
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|end_port|Describes the end of the range, inclusive. If set, it must be between 2 and 65535 and be greater than Port when describing a port range. When omitted or set to zero, it signifies that the port range defines a single port.|number|
+|port|Describes the start of the range. It must be between 1 and 65535.|number|
+
+## Rewrite
+
+A list of rewriting rules to apply to requests and responses.
+
+
+Example:
+
+```yaml
+redirect: 
+  - "string"
+  - "string"
+  - "string"
+headers: 
+  - # [...]
+  - # [...]
+  - # [...]
+jwt_claims: "string"
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|headers|A list of headers to inject when passing the request over to the application.|[][Header](#header)|
+|jwt_claims|Configures whether roles/traits are included in the JWT token.|string|
+|redirect|Defines a list of hosts which will be rewritten to the public address of the application if they occur in the "Location" header.|[]string|
+
+## Rotation
+
+A status of the rotation of the certificate authority
+
+
+Example:
+
+```yaml
+state: "string"
+phase: "string"
+mode: "string"
+current_id: "string"
+started: # See description
+grace_period: # [...]
+last_rotated: # See description
+schedule: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|current_id|The ID of the rotation operation to differentiate between rotation attempts.|string|
+|grace_period|A period during which old and new CA are valid for checking purposes, but only new CA is issuing certificates.|[Duration](#duration)|
+|last_rotated|Specifies the last time of the completed rotation.||
+|mode|Sets manual or automatic rotation mode.|string|
+|phase|The current rotation phase.|string|
+|schedule|A rotation schedule - used in automatic mode to switch between phases.|[Rotation Schedule](#rotation-schedule)|
+|started|Set to the time when rotation has been started in case if the state of the rotation is "in_progress".||
+|state|Could be one of "init" or "in_progress".|string|
+
+## Rotation Schedule
+
+A rotation schedule setting time switches for different phases.
+
+
+Example:
+
+```yaml
+update_clients: # See description
+update_servers: # See description
+standby: # See description
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|standby|Specifies time to switch to the "Standby" phase.||
+|update_clients|Specifies time to switch to the "Update clients" phase||
+|update_servers|Specifies time to switch to the "Update servers" phase.||
+

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -11,7 +11,14 @@ sidebar_label: App Server V3
 **Kind**: `app_server`<br/>
 **Version**: `v3`
 
-Represents a single proxied web app.
+The `app_server` resource represents an instance of the Teleport
+Application Service, which allows you to [protect
+applications](../../../enroll-resources/application-access/application-access.mdx)
+with Teleport.
+
+To manage applications proxied by Teleport instead, you can use the [`app`
+resource](app-v3.mdx).
+
 
 ## Top-level fields
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -11,13 +11,22 @@ sidebar_label: App Server V3
 **Kind**: `app_server`<br/>
 **Version**: `v3`
 
-The `app_server` resource represents an instance of the Teleport
-Application Service, which allows you to [protect
-applications](../../../enroll-resources/application-access/application-access.mdx)
-with Teleport.
+The `app_server` resource represents an application that has been
+registered with Teleport. 
 
-To manage applications proxied by Teleport instead, you can use the [`app`
-resource](app-v3.mdx).
+The Teleport Application Service creates an `app_server` in two situations:
+
+  1. It reads information about the target application in its
+     configuration file when it first starts.
+  1. It fetches a dynamically registered `app` resource from the Teleport
+     backend that matches its dynamic resource watchers.
+
+  There can be multiple instances of an `app_server` for a single
+  application, each corresponding to a different Teleport Application
+  Service instance that proxies the application. Read more about [High
+  Availability](../../../enroll-resources/application-access/configuration/ha.mdx)
+  for the Teleport Application Service. Read the [reference
+  guide](./app-v3.mdx) for the `app` resource.
 
 
 ## Top-level fields
@@ -117,13 +126,13 @@ relay_ids:
   - "string"
   - "string"
   - "string"
-component_features: # See description
+component_features: # [...]
 ```
 
 |Field Name|Description|Type|
 |---|---|---|
 |app|The app proxied by this app server.|[App V3](#app-v3)|
-|component_features|Component_features contains features supported by this app server.||
+|component_features|Component_features contains features supported by this app server.|[Component Features](#component-features)|
 |host_id|The app server host uuid.|string|
 |hostname|The app server hostname.|string|
 |proxy_ids|A list of proxy IDs this server is expected to be connected to.|[]string|
@@ -268,6 +277,29 @@ result: "string"
 |command|A command to run|[]string|
 |period|A time between command runs|[Duration](#duration)|
 |result|Captures standard output|string|
+
+## Component Feature ID
+
+An identifier for a specific feature supported by a Teleport component.
+
+
+## Component Features
+
+Represents a set of features supported by a given Teleport component.
+
+
+Example:
+
+```yaml
+features: 
+  - # [...]
+  - # [...]
+  - # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|features|Features is a list of supported feature identifiers.|[][Component Feature ID](#component-feature-id)|
 
 ## Duration
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -11,7 +11,10 @@ sidebar_label: App V3
 **Kind**: `app`<br/>
 **Version**: `v3`
 
-Represents an app resource.
+The `app` resource represents a single application protected by Teleport.
+To learn more about using the `app` resource, see [Dynamic App
+Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
+
 
 ## Top-level fields
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -11,9 +11,20 @@ sidebar_label: App V3
 **Kind**: `app`<br/>
 **Version**: `v3`
 
-The `app` resource represents a single application protected by Teleport.
+The `app` resource represents an application that is dynamically
+registered with Teleport. 
+
+If you configure the Teleport Application Service with **dynamic resource
+watchers**, the service queries the Teleport backend for `app` resources
+that match their configured filters. For each matching `app`, the
+Application Service creates an `app_server` resource configured to proxy
+the target application.
+
 To learn more about using the `app` resource, see [Dynamic App
 Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
+
+To learn more about the `app_server` resource, see the [reference
+guide](app-server-v3.mdx).
 
 
 ## Top-level fields


### PR DESCRIPTION
This change alters the configuration of the resource reference generator to generate a page for the App Server V3 resource, and includes the new page.

This change also modifies the resource reference configuration to support custom introduction paragraphs. If the configuration for a dynamic resource in the resource reference generator includes the `introduction` field, use the value of that field for the introductory paragraphs of the reference page rather than the GoDoc-based description of the resource.

Begin by adding introductions to the `app` and `app_server` resources.