### PR TITLE
scoped ssh routing

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1801,13 +1801,21 @@ func (a *ServerWithRoles) GetSSHTargets(ctx context.Context, req *proto.GetSSHTa
 	lreq := &proto.ListUnifiedResourcesRequest{
 		Kinds:            []string{types.KindNode},
 		SortBy:           types.SortBy{Field: types.ResourceMetadataName},
-		UseSearchAsRoles: true,
+		UseSearchAsRoles: a.scopedContext == nil, // TODO(fspmarshall/scopes): switch this to always be true once we support search_as_roles with scoped identities
 	}
+
+	// note that we're using a ServerWithRoles level method here rather than some internal method. We are
+	// delegating all RBAC filtering to the lister and then performing additional filtering on top of that.
+	// Until we unify scoped/unscoped resource listing this bifurcation is necessary to ensure that search_as_roles
+	// results are available for unscoped identities.
+	lister := a.ListUnifiedResources
+	if a.scopedContext != nil {
+		lister = a.scopedListUnifiedResources
+	}
+
 	var servers []*types.ServerV2
 	for {
-		// note that we're calling ServerWithRoles.ListUnifiedResources here rather than some internal method. This method
-		// delegates all RBAC filtering to ListResources, and then performs additional filtering on top of that.
-		lrsp, err := a.ListUnifiedResources(ctx, lreq)
+		lrsp, err := lister(ctx, lreq)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -4746,16 +4746,23 @@ func (g *GRPCServer) CreateAuthenticateChallenge(ctx context.Context, req *authp
 	actx, err := g.authenticate(ctx)
 	if err != nil {
 		if errors.Is(err, services.ErrScopedIdentity) && isScopePinnedLocalUserCredential(ctx) && req.MFARequiredCheck != nil {
-			if _, ok := req.MFARequiredCheck.Target.(*authpb.IsMFARequiredRequest_AdminAction); ok {
-				// NOTE: scopes don't currently have a concept of admin action MFA. a lot of client logic wants to do a preemtive
-				// check to see if MFA is required. ordinarily we just return an access denied when a scoped identity is used to
-				// call an API that doesn't support scoping yet, but doing so here would complicate client logic a lot. it is
-				// therefore preferable to instead consider a scoped invocation a valid call that just happens to result in a
-				// no mfa required result.
-				return &authpb.MFAAuthenticateChallenge{
-					MFARequired: authpb.MFARequired_MFA_REQUIRED_NO,
-				}, nil
+			switch req.MFARequiredCheck.Target.(type) {
+			case *authpb.IsMFARequiredRequest_AdminAction:
+			case *authpb.IsMFARequiredRequest_Node:
+			default:
+				// we are only suppressing the subset of MFA required checks that need to be suppressed for currently
+				// supported scoped workflows.
+				return nil, trace.Wrap(err)
 			}
+
+			// NOTE: scopes don't currently have a concept of MFA. a lot of client logic wants to do a preemtive
+			// check to see if MFA is required. ordinarily we just return an access denied when a scoped identity is used to
+			// call an API that doesn't support scoping yet, but doing so here in all cases would complicate client logic a lot. it is
+			// therefore preferable to instead consider a scoped invocation a valid call that just happens to result in a
+			// no mfa required result.
+			return &authpb.MFAAuthenticateChallenge{
+				MFARequired: authpb.MFARequired_MFA_REQUIRED_NO,
+			}, nil
 		}
 
 		return nil, trace.Wrap(err)
@@ -4813,6 +4820,8 @@ func (g *GRPCServer) ListUnifiedResources(ctx context.Context, req *authpb.ListU
 	auth, err := g.authenticate(ctx)
 	if err != nil {
 		if errors.Is(err, services.ErrScopedIdentity) {
+			// TODO(fspmarshall/scopes): Do away with this bifurcated implementation in favor of making ListUnifiedResources
+			// able to support scoped callers directly.
 			return g.scopedListUnifiedResources(ctx, req)
 		}
 		return nil, trace.Wrap(err)
@@ -4862,10 +4871,31 @@ func (g *GRPCServer) ListResources(ctx context.Context, req *authpb.ListResource
 func (g *GRPCServer) GetSSHTargets(ctx context.Context, req *authpb.GetSSHTargetsRequest) (*authpb.GetSSHTargetsResponse, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
+		if errors.Is(err, services.ErrScopedIdentity) {
+			// NOTE: this pattern of having separate code paths for scoped identities is temporary. GetSSHTargets
+			// relies upon ListUnifiedResources internally, which hasn't yet been fully ported to support scopes.
+			// until that work is done, we need to have this separate code path to ensure that search_as_roles
+			// functions as expected for unscoped callers.
+			return g.scopedGetSSHTargets(ctx, req)
+		}
 		return nil, trace.Wrap(err)
 	}
 
 	rsp, err := auth.ServerWithRoles.GetSSHTargets(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return rsp, nil
+}
+
+func (g *GRPCServer) scopedGetSSHTargets(ctx context.Context, req *authpb.GetSSHTargetsRequest) (*authpb.GetSSHTargetsResponse, error) {
+	auth, err := g.scopedAuthenticate(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	rsp, err := auth.GetSSHTargets(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -34,6 +34,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -43,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/desktop"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -101,7 +103,7 @@ func (c *ProxiedMetricConn) Close() error {
 	return trace.Wrap(c.Conn.Close())
 }
 
-type serverResolverFn = func(ctx context.Context, host, port string, cluster cluster) (types.Server, error)
+type serverResolverFn = func(ctx context.Context, scopePin *scopesv1.Pin, host, port string, cluster cluster) (types.Server, error)
 type windowsDesktopServiceConnectorFn = func(ctx context.Context, config *desktop.ConnectionConfig) (conn net.Conn, version string, err error)
 
 // ClusterGetter provides access to connected local or remote clusters.
@@ -211,7 +213,7 @@ func NewRouter(cfg RouterConfig) (*Router, error) {
 // DialHost dials the node that matches the provided host, port and cluster. If no matching node
 // is found an error is returned. If more than one matching node is found and the cluster networking
 // configuration is not set to route to the most recent an error is returned.
-func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, clusterName string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, signer agentless.SignerCreator) (_ net.Conn, err error) {
+func (r *Router) DialHost(ctx context.Context, scopePin *scopesv1.Pin, clientSrcAddr, clientDstAddr net.Addr, host, port, clusterName string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, signer agentless.SignerCreator) (_ net.Conn, err error) {
 	ctx, span := r.tracer.Start(
 		ctx,
 		"router/DialHost",
@@ -231,6 +233,9 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 
 	cluster := r.localCluster
 	if clusterName != r.clusterName {
+		if scopePin != nil {
+			return nil, trace.AccessDenied("identity pinned to scope %q cannot dial remote cluster %q (scoping does not support cross-cluster operations)", scopePin.GetScope(), clusterName)
+		}
 		remoteCluster, err := r.getRemoteCluster(ctx, clusterName, clusterAccessChecker)
 		if err != nil {
 			return nil, trace.Wrap(err, "looking up remote cluster %q", clusterName)
@@ -239,7 +244,7 @@ func (r *Router) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.
 	}
 
 	span.AddEvent("looking up server")
-	target, err := r.serverResolver(ctx, host, port, fakeCluster{cluster})
+	target, err := r.serverResolver(ctx, scopePin, host, port, fakeCluster{cluster})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -474,11 +479,14 @@ func (r fakeCluster) GetClusterNetworkingConfig(ctx context.Context) (types.Clus
 
 // getServer attempts to locate a node matching the provided host and port in
 // the provided cluster.
-func getServer(ctx context.Context, host, port string, cluster cluster) (types.Server, error) {
+func getServer(ctx context.Context, scopePin *scopesv1.Pin, host, port string, cluster cluster) (types.Server, error) {
 	if org, ok := types.GetGitHubOrgFromNodeAddr(host); ok {
+		if scopePin != nil {
+			return nil, trace.AccessDenied("identity pinned to scope %q cannot dial github server for %q (scoped identities not supported)", scopePin.GetScope(), org)
+		}
 		return getGitHubServer(ctx, org, cluster)
 	}
-	return getServerWithResolver(ctx, host, port, cluster, nil /* use default resolver */)
+	return getServerWithResolver(ctx, scopePin, host, port, cluster, nil /* use default resolver */)
 }
 
 var disableUnqualifiedLookups = os.Getenv("TELEPORT_UNSTABLE_DISABLE_UNQUALIFIED_LOOKUPS") == "yes"
@@ -486,7 +494,7 @@ var disableUnqualifiedLookups = os.Getenv("TELEPORT_UNSTABLE_DISABLE_UNQUALIFIED
 // getServerWithResolver attempts to locate a node matching the provided host and port in
 // the provided cluster. The resolver argument is used in certain tests to mock DNS resolution
 // and can generally be left nil.
-func getServerWithResolver(ctx context.Context, host, port string, cluster cluster, resolver apiutils.HostResolver) (types.Server, error) {
+func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, port string, cluster cluster, resolver apiutils.HostResolver) (types.Server, error) {
 	if cluster == nil {
 		return nil, trace.BadParameter("invalid remote cluster provided")
 	}
@@ -512,6 +520,21 @@ func getServerWithResolver(ctx context.Context, host, port string, cluster clust
 	var maxScore int
 	scores := make(map[string]int)
 	matches, err := cluster.GetNodes(ctx, func(server readonly.Server) bool {
+		if scopePin != nil {
+			// TODO(fspmarshall/scopes): implement scope-aware node storage. filtering agents based on scope is sub-optimal. scoping
+			// provides a natural machanism for efficiently storing resources in trees s.t. we only need query the subset of resources
+			// that are subject to the target scope. in very large clusters, reworking our node route table storage such that it is
+			// scope-partitioned could provide significant routing performance improvements.
+			agentScope := scopes.Root
+			if server.GetScope() != "" {
+				agentScope = server.GetScope()
+			}
+
+			if !scopes.ResourceScope(agentScope).IsSubjectToPolicyScope(scopePin.GetScope()) {
+				return false
+			}
+		}
+
 		score := routeMatcher.RouteToServerScore(server)
 		if score < 1 {
 			return false
@@ -536,6 +559,17 @@ func getServerWithResolver(ctx context.Context, host, port string, cluster clust
 			}
 		}
 	}
+
+	// NOTE: there is an open question here about wether or not we should be doing scope-aware
+	// disambiguation when multiple matches are found. In some cases, this seems like the obviously
+	// right thing to do.  For example, when there is a match in `/foo` and a match in `/foo/bar`,
+	// it would seem obvious that the match in `/foo` should be preferred per scope hierarchy rules.
+	// However, not all cases are so clear (e.g. `/foo/bar` and `/foo/bax`), and there may be an
+	// argument that disambiguation within the set of scope-subject nodes may inadvertently hide
+	// the nature of scope-based routing and lead to a false sense of security, causing undesirable
+	// outcomes should the node in the parent scope ever go offline. For now, we are opting to leave
+	// scope-aware disambiguation as a future enhancement, in favor of only using scope to exclude those
+	// nodes that would *never* be routable per the provided scope pin.
 
 	if len(matches) > 1 {
 		// in the event of multiple matches, some matches may be of higher quality than others

--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -465,6 +465,9 @@ type Server interface {
 
 	// GetGitHub returns the GitHub server spec.
 	GetGitHub() *types.GitHubServerMetadata
+
+	// GetScope returns the scope this server belongs to.
+	GetScope() string
 }
 
 var _ Server = types.Server(nil)

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -79,6 +79,11 @@ func NewScopedAccessCheckerContext(ctx context.Context, info *AccessInfo, localC
 	}, nil
 }
 
+// ScopePin returns the scope pin that this context was created from.
+func (c *ScopedAccessCheckerContext) ScopePin() *scopesv1.Pin {
+	return c.builder.info.ScopePin
+}
+
 // CheckersForResourceScope returns a stream of scoped access checkers, descending from root to the specified resource
 // scope. This is the mechanism that *must* be used for getting checkers when checking access to a resource. This
 // method both evaluates immediate compliance of the resource scope with the scope pin, and yields correctly ordered

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -218,6 +218,14 @@ func (c *SplitAccessCheckerContext) Scoped() *ScopedAccessCheckerContext {
 	return c.scopedContext
 }
 
+// ScopePin returns the scope pin associated with the context, if any.
+func (c *SplitAccessCheckerContext) ScopePin() (*scopesv1.Pin, bool) {
+	if c.scopedContext == nil {
+		return nil, false
+	}
+	return c.scopedContext.ScopePin(), true
+}
+
 // CheckMaybeHasAccessToRules returns an error if the context definitely does not have access to the provided rules. in practice
 // this currently just serves to exit early in the event that we are dealing with an unscoped identity without appropriate
 // permissions, but it could be extended in future to perform more complex checks if needed.

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -255,7 +255,7 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 	aGetter := func() (sshagent.Client, error) {
 		return t.ctx.StartAgentChannel()
 	}
-	conn, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.UnstableClusterAccessChecker, aGetter, signer)
+	conn, err := t.router.DialHost(ctx, identity.UnmappedIdentity.ScopePin, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.UnstableClusterAccessChecker, aGetter, signer)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	transportv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
@@ -120,7 +121,7 @@ func (f fakeDialer) DialSite(ctx context.Context, clusterName string, clientSrcA
 	return conn, nil
 }
 
-func (f fakeDialer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
+func (f fakeDialer) DialHost(ctx context.Context, scopePin *scopesv1.Pin, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
 	key := fmt.Sprintf("%s.%s.%s", host, port, cluster)
 	conn, ok := f.hostConns[key]
 	if !ok {
@@ -954,7 +955,7 @@ func (s *sshServer) DialSite(ctx context.Context, clusterName string, clientSrcA
 // nil and is of type testAgent, then the server will serve its keyring
 // over the underlying [streamutils.ReadWriter] so that tests can exercise
 // ssh agent multiplexing.
-func (s *sshServer) DialHost(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
+func (s *sshServer) DialHost(ctx context.Context, scopePin *scopesv1.Pin, clientSrcAddr, clientDstAddr net.Addr, host, port, cluster string, clusterAccessChecker func(types.RemoteCluster) error, agentGetter sshagent.ClientGetter, singer agentless.SignerCreator) (_ net.Conn, err error) {
 	conn, err := s.dial()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -171,6 +171,7 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	conn, err := h.cfg.Router.DialHost(
 		ctx,
+		ident.ScopePin,
 		&utils.NetAddr{Addr: r.RemoteAddr},
 		&h.cfg.ProxyWebAddr,
 		req.serverID,

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	authproto "github.com/gravitational/teleport/api/client/proto"
+	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/mfa"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
@@ -668,7 +669,7 @@ func newMFACeremony(stream *terminal.WSStream, createAuthenticateChallenge mfa.C
 	}
 }
 
-type connectWithMFAFn = func(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
+type connectWithMFAFn = func(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error)
 
 // connectToHost establishes a connection to the target host. To reduce connection
 // latency if per session mfa is required, connections are tried with the existing
@@ -711,7 +712,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	mfaCtx, mfaCancel := context.WithCancel(ctx)
 	go func() {
 		// try connecting to the node with the certs we already have
-		clt, err := t.connectToNode(directCtx, ws, tc, accessChecker, getAgent, signer)
+		clt, err := t.connectToNode(directCtx, ident.ScopePin, ws, tc, accessChecker, getAgent, signer)
 		directResultC <- clientRes{clt: clt, err: err}
 	}()
 
@@ -719,7 +720,7 @@ func (t *sshBaseHandler) connectToHost(ctx context.Context, ws terminal.WSConn, 
 	// function returns early
 	go func() {
 		// try performing mfa and then connecting with the single use certs
-		clt, err := connectToNodeWithMFA(mfaCtx, ws, tc, accessChecker, getAgent, signer)
+		clt, err := connectToNodeWithMFA(mfaCtx, ident.ScopePin, ws, tc, accessChecker, getAgent, signer)
 		mfaResultC <- clientRes{clt: clt, err: err}
 	}()
 
@@ -913,8 +914,8 @@ func (t *TerminalHandler) streamTerminal(ctx context.Context, tc *client.Telepor
 
 // connectToNode attempts to connect to the host with the already
 // provisioned certs for the user.
-func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
-	conn, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
+func (t *sshBaseHandler) connectToNode(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+	conn, err := t.router.DialHost(ctx, scopePin, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
 	if err != nil {
 		t.logger.WarnContext(ctx, "Unable to stream terminal - failed to dial host", "error", err)
 
@@ -966,19 +967,19 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, ws terminal.WSConn, 
 
 // connectToNodeWithMFA attempts to perform the mfa ceremony and then dial the
 // host with the retrieved single use certs.
-func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
+func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator) (*client.NodeClient, error) {
 	// perform mfa ceremony and retrieve new certs
 	authMethods, err := t.issueSessionMFACerts(ctx, tc, t.stream.WSStream)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return t.connectToNodeWithMFABase(ctx, ws, tc, accessChecker, getAgent, signer, authMethods)
+	return t.connectToNodeWithMFABase(ctx, scopePin, ws, tc, accessChecker, getAgent, signer, authMethods)
 }
 
 // connectToNodeWithMFABase attempts to dial the host with the provided auth
 // methods.
-func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator, authMethods []ssh.AuthMethod) (*client.NodeClient, error) {
+func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, scopePin *scopesv1.Pin, ws terminal.WSConn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent sshagent.ClientGetter, signer agentless.SignerCreator, authMethods []ssh.AuthMethod) (*client.NodeClient, error) {
 	sshConfig := &ssh.ClientConfig{
 		User:            tc.HostLogin,
 		Auth:            authMethods,
@@ -987,7 +988,7 @@ func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, ws termin
 	}
 
 	// connect to the node again with the new certs
-	conn, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
+	conn, err := t.router.DialHost(ctx, scopePin, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker.CheckAccessToRemoteCluster, getAgent, signer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3029,14 +3029,31 @@ func listNodesAllClusters(cf *CLIConf) error {
 
 func printNodesWithClusters(nodes []nodeListing, verbose bool, output io.Writer) error {
 	var rows [][]string
+	var withScope bool
 	for _, n := range nodes {
-		rows = append(rows, getNodeRow(n.Proxy, n.Cluster, n.Node, verbose))
+		if n.Node.GetScope() != "" {
+			withScope = true
+			break
+		}
 	}
+
+	for _, n := range nodes {
+		rows = append(rows, getNodeRow(n.Proxy, n.Cluster, n.Node, withScope, verbose))
+	}
+
 	var t asciitable.Table
 	if verbose {
-		t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		if withScope {
+			t = asciitable.MakeTable([]string{"Scope", "Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		} else {
+			t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		}
 	} else {
-		t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
+		if withScope {
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
+		} else {
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Proxy", "Cluster", "Node Name", "Address", "Labels"}, rows, "Labels")
+		}
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
 		return trace.Wrap(err)
@@ -3243,7 +3260,7 @@ func serializeNodes(nodes []types.Server, format string) (string, error) {
 	return string(out), trace.Wrap(err)
 }
 
-func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string {
+func getNodeRow(proxy, cluster string, node types.Server, withScope bool, verbose bool) []string {
 	// Reusable function to get addr or tunnel for each node
 	getAddr := func(n types.Server) string {
 		switch {
@@ -3257,6 +3274,11 @@ func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string
 	}
 
 	row := make([]string, 0)
+
+	if withScope {
+		row = append(row, node.GetScope())
+	}
+
 	if proxy != "" && cluster != "" {
 		row = append(row, proxy, cluster)
 	}
@@ -3272,19 +3294,30 @@ func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string
 
 func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool) error {
 	var rows [][]string
+	var withScope bool
 	for _, n := range nodes {
-		rows = append(rows, getNodeRow("", "", n, verbose))
+		if n.GetScope() != "" {
+			withScope = true
+			break
+		}
+	}
+	for _, n := range nodes {
+		rows = append(rows, getNodeRow("", "", n, withScope, verbose))
 	}
 	var t asciitable.Table
 	switch verbose {
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
-		t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
+		t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
 	// In normal mode chunk the labels and print two per line and allow multiple
 	// lines per node.
 	case false:
-		t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
+		if withScope {
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Scope", "Node Name", "Address", "Labels"}, rows, "Labels")
+		} else {
+			t = asciitable.MakeTableWithTruncatedColumn([]string{"Node Name", "Address", "Labels"}, rows, "Labels")
+		}
 	}
 	if _, err := fmt.Fprintln(output, t.AsBuffer().String()); err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR adds scope-pin awareness to SSH routing.  Prior to this change, a client identity pinned to a given scope would still be routed based on the entire node set.  While this wasn't a problem from a node access-control perspective (access control checks already enforce scoping), it was a problem from a usability/isolation prospective as agents in different scopes with the same hostnames would produce ambiguous host errors, even when there was only one valid target in the callers current scope.

With this change, routing always considers only the subset of nodes that are subject to the pin of the callers scope.  For example, if the caller has logged into `/staging` then routing will consider nodes in `/staging`, `/staging/west`, etc.  But conflicting nodes in `/prod` will be ignored.

This PR also updates the fallback behavior in the event of ambiguity to work correctly with scoped identities, improving the UX in the case where ambiguity remains even after pinning (e.g. if two child scopes both separately host a node with the same hostname).

Part of ongoing work related to Scopes (https://github.com/gravitational/teleport/issues/54601).