### PR TITLE
Run the readiness logic synchronously

### DIFF
--- a/lib/service/diagnostic.go
+++ b/lib/service/diagnostic.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 
 	"github.com/gravitational/roundtrip"
-	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/gravitational/teleport"
@@ -36,10 +35,6 @@ type diagnosticHandlerConfig struct {
 }
 
 func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerConfig, logger *slog.Logger) (http.Handler, error) {
-	if process.state == nil {
-		return nil, trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
-	}
-
 	mux := http.NewServeMux()
 
 	if config.enableMetrics {
@@ -54,7 +49,7 @@ func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerCon
 		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 		})
-		mux.HandleFunc("/readyz", process.state.readinessHandler())
+		mux.HandleFunc("/readyz", process.HandleReadiness)
 	}
 
 	if config.enableLogLeveler {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -733,9 +733,6 @@ type TeleportProcess struct {
 	// need to add and remove metrics seevral times (e.g. hosted plugin metrics).
 	*metrics.SyncGatherers
 
-	// state is the process state machine tracking if the process is healthy or not.
-	state *processState
-
 	tsrv reversetunnelclient.Server
 }
 
@@ -1174,14 +1171,14 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		}
 	}
 
-	supervisor := NewSupervisor(processID, cfg.Logger)
+	if cfg.Clock == nil {
+		cfg.Clock = clockwork.NewRealClock()
+	}
+
+	supervisor := NewSupervisor(processID, cfg.Logger, cfg.Clock)
 	store, err := storage.NewProcessStorage(supervisor.ExitContext(), filepath.Join(cfg.DataDir, teleport.ComponentProcess))
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	if cfg.Clock == nil {
-		cfg.Clock = clockwork.NewRealClock()
 	}
 
 	// full heartbeat announces are on average every 2/3 * 6/7 of the default
@@ -1459,12 +1456,6 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 	}
 
 	serviceStarted := false
-
-	ps, err := process.newProcessStateMachine()
-	if err != nil {
-		return nil, trace.Wrap(err, "failed to initialize process state machine")
-	}
-	process.state = ps
 
 	if !cfg.DiagnosticAddr.IsEmpty() {
 		if err := process.initDiagnosticService(); err != nil {
@@ -4006,42 +3997,6 @@ func (process *TeleportProcess) initMetricsService() error {
 	return nil
 }
 
-// newProcessStateMachine creates a state machine tracking the Teleport process
-// state. The state machine is then used by the diagnostics or the debug service
-// to evaluate the process health.
-func (process *TeleportProcess) newProcessStateMachine() (*processState, error) {
-	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDiagnosticHealth, process.id))
-	// Create a state machine that will process and update the internal state of
-	// Teleport based off Events. Use this state machine to return the
-	// status from the /readyz endpoint.
-	ps, err := newProcessState(process)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	process.RegisterFunc("readyz.monitor", func() error {
-		// Start loop to monitor for events that are used to update Teleport state.
-		ctx, cancel := context.WithCancel(process.GracefulExitContext())
-		defer cancel()
-
-		eventCh := make(chan Event, 1024)
-		process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
-		process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
-		process.ListenForEvents(ctx, TeleportStartingEvent, eventCh)
-
-		for {
-			select {
-			case e := <-eventCh:
-				ps.update(e)
-			case <-ctx.Done():
-				logger.DebugContext(process.ExitContext(), "Teleport is exiting, returning.")
-				return nil
-			}
-		}
-	})
-	return ps, nil
-}
-
 // initDiagnosticService starts diagnostic service currently serving healthz
 // and prometheus endpoints
 func (process *TeleportProcess) initDiagnosticService() error {
@@ -4123,10 +4078,6 @@ func (process *TeleportProcess) initDiagnosticService() error {
 // disable its sensitive pprof and log-setting endpoints, but the liveness
 // and readiness ones are always active.
 func (process *TeleportProcess) initDebugService(exposeDebugRoutes bool) error {
-	if process.state == nil {
-		return trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
-	}
-
 	logger := process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentDebug, process.id))
 
 	// Unix socket creation can fail on paths too long. Depending on the UNIX implementation,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1175,7 +1175,10 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		cfg.Clock = clockwork.NewRealClock()
 	}
 
-	supervisor := NewSupervisor(processID, cfg.Logger, cfg.Clock)
+	supervisor, err := NewSupervisor(processID, cfg.Logger, cfg.Clock)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	store, err := storage.NewProcessStorage(supervisor.ExitContext(), filepath.Join(cfg.DataDir, teleport.ComponentProcess))
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/state.go
+++ b/lib/service/state.go
@@ -19,20 +19,20 @@
 package service
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"sync"
 	"time"
 
 	"github.com/gravitational/roundtrip"
-	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/client/debug"
 	"github.com/gravitational/teleport/lib/defaults"
-	"github.com/gravitational/teleport/lib/observability/metrics"
 )
 
 type componentStateEnum byte
@@ -64,9 +64,8 @@ func init() {
 
 // processState tracks the state of the Teleport process.
 type processState struct {
-	process *TeleportProcess
-	mu      sync.Mutex
-	states  map[string]*componentState
+	mu     sync.Mutex
+	states map[string]*componentState
 }
 
 type componentState struct {
@@ -74,44 +73,29 @@ type componentState struct {
 	state        componentStateEnum
 }
 
-// newProcessState returns a new FSM that tracks the state of the Teleport process.
-func newProcessState(process *TeleportProcess) (*processState, error) {
-	err := metrics.RegisterPrometheusCollectors(stateGauge)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &processState{
-		process: process,
-		states:  make(map[string]*componentState),
-	}, nil
-}
-
 // update the state of a Teleport component.
-func (f *processState) update(event Event) {
+func (f *processState) update(ctx context.Context, log *slog.Logger, now time.Time, event, component string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	defer f.updateGauge()
 
-	component, ok := event.Payload.(string)
-	if !ok {
-		f.process.logger.ErrorContext(f.process.ExitContext(), "Received event broadcast without component name, this is a bug!", "event", event.Name)
-		return
-	}
 	s, ok := f.states[component]
 	if !ok {
+		if f.states == nil {
+			f.states = make(map[string]*componentState)
+		}
 		// Register a new component.
-		s = &componentState{recoveryTime: f.process.Clock.Now(), state: stateStarting}
+		s = &componentState{recoveryTime: now, state: stateStarting}
 		f.states[component] = s
 	}
 
-	switch event.Name {
+	switch event {
 	case TeleportStartingEvent:
-		f.process.logger.DebugContext(f.process.ExitContext(), "Teleport component is starting", "component", component)
+		log.DebugContext(ctx, "Teleport component is starting", "component", component)
 	// If a degraded event was received, always change the state to degraded.
 	case TeleportDegradedEvent:
 		s.state = stateDegraded
-		f.process.logger.InfoContext(f.process.ExitContext(), "Detected Teleport component is running in a degraded state.", "component", component)
+		log.InfoContext(ctx, "Detected Teleport component is running in a degraded state.", "component", component)
 	// If the current state is degraded, and a OK event has been
 	// received, change the state to recovering. If the current state is
 	// recovering and a OK events is received, if it's been longer
@@ -121,15 +105,15 @@ func (f *processState) update(event Event) {
 		switch s.state {
 		case stateStarting:
 			s.state = stateOK
-			f.process.logger.DebugContext(f.process.ExitContext(), "Teleport component has started.", "component", component)
+			log.DebugContext(ctx, "Teleport component has started.", "component", component)
 		case stateDegraded:
 			s.state = stateRecovering
-			s.recoveryTime = f.process.Clock.Now()
-			f.process.logger.InfoContext(f.process.ExitContext(), "Teleport component is recovering from a degraded state.", "component", component)
+			s.recoveryTime = now
+			log.InfoContext(ctx, "Teleport component is recovering from a degraded state.", "component", component)
 		case stateRecovering:
-			if f.process.Clock.Since(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
+			if now.Sub(s.recoveryTime) > defaults.HeartbeatCheckPeriod*2 {
 				s.state = stateOK
-				f.process.logger.InfoContext(f.process.ExitContext(), "Teleport component has recovered from a degraded state.", "component", component)
+				log.InfoContext(ctx, "Teleport component has recovered from a degraded state.", "component", component)
 			}
 		}
 	}
@@ -178,32 +162,30 @@ func (f *processState) getState() componentStateEnum {
 	return f.getStateLocked()
 }
 
-func (f *processState) readinessHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		switch f.getState() {
-		// 503
-		case stateDegraded:
-			roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, debug.Readiness{
-				Status: "teleport is in a degraded state, check logs for details",
-				PID:    os.Getpid(),
-			})
-		// 400
-		case stateRecovering:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
-				Status: "teleport is recovering from a degraded state, check logs for details",
-				PID:    os.Getpid(),
-			})
-		case stateStarting:
-			roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
-				Status: "teleport is starting and hasn't joined the cluster yet",
-				PID:    os.Getpid(),
-			})
-		// 200
-		case stateOK:
-			roundtrip.ReplyJSON(w, http.StatusOK, debug.Readiness{
-				Status: "ok",
-				PID:    os.Getpid(),
-			})
-		}
+func (f *processState) handleReadiness(w http.ResponseWriter, r *http.Request) {
+	switch f.getState() {
+	// 503
+	case stateDegraded:
+		roundtrip.ReplyJSON(w, http.StatusServiceUnavailable, debug.Readiness{
+			Status: "teleport is in a degraded state, check logs for details",
+			PID:    os.Getpid(),
+		})
+	// 400
+	case stateRecovering:
+		roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
+			Status: "teleport is recovering from a degraded state, check logs for details",
+			PID:    os.Getpid(),
+		})
+	case stateStarting:
+		roundtrip.ReplyJSON(w, http.StatusBadRequest, debug.Readiness{
+			Status: "teleport is starting and hasn't joined the cluster yet",
+			PID:    os.Getpid(),
+		})
+	// 200
+	case stateOK:
+		roundtrip.ReplyJSON(w, http.StatusOK, debug.Readiness{
+			Status: "ok",
+			PID:    os.Getpid(),
+		})
 	}
 }

--- a/lib/service/state_test.go
+++ b/lib/service/state_test.go
@@ -103,8 +103,10 @@ func TestProcessStateStarting(t *testing.T) {
 	log := logtest.NewLogger()
 
 	fakeClock := clockwork.NewFakeClock()
+	supervisor, err := NewSupervisor("test-process-state", log, fakeClock)
+	require.NoError(t, err)
 	process := &TeleportProcess{
-		Supervisor: NewSupervisor("test-process-state", log, fakeClock),
+		Supervisor: supervisor,
 		Clock:      fakeClock,
 		logger:     log,
 	}

--- a/lib/service/state_test.go
+++ b/lib/service/state_test.go
@@ -19,7 +19,6 @@
 package service
 
 import (
-	"context"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -103,56 +102,24 @@ func TestProcessStateStarting(t *testing.T) {
 	slowComponent := teleport.Component("slow-component")
 	log := logtest.NewLogger()
 
-	supervisor := NewSupervisor("test-process-state", log)
+	fakeClock := clockwork.NewFakeClock()
 	process := &TeleportProcess{
-		Supervisor: supervisor,
-		Clock:      clockwork.NewFakeClock(),
+		Supervisor: NewSupervisor("test-process-state", log, fakeClock),
+		Clock:      fakeClock,
 		logger:     log,
 	}
-	ps, err := newProcessState(process)
-	require.NoError(t, err)
-	process.state = ps
-
-	eventProcessor := newFakeEventProcessor(t.Context(), process)
+	ps := &process.Supervisor.(*LocalSupervisor).processState
 
 	require.Equal(t, stateStarting, ps.getState(), "no services are running, we are starting")
 	process.OnHeartbeat(component)(nil)
-	eventProcessor.processEvent()
 	require.Equal(t, stateOK, ps.getState(), "a single service is running, we are healthy")
 
 	process.ExpectService(slowComponent)
-	eventProcessor.processEvent()
 	require.Equal(t, stateStarting, ps.getState(), "we know about a second service starting, we should be in starting state")
 
 	process.OnHeartbeat(component)(nil)
-	eventProcessor.processEvent()
 	require.Equal(t, stateStarting, ps.getState(), "we know about a second service starting, we should still be in starting state")
 
 	process.OnHeartbeat(slowComponent)(nil)
-	eventProcessor.processEvent()
 	require.Equal(t, stateOK, ps.getState(), "two services are running, we are healthy")
-}
-
-// fakeEventProcessor synchronously processes events in tests. The real TeleportProcess
-// has a dedicated routine for that, but testing with asynchronous event processing
-// would be troublesome and flaky.
-type fakeEventProcessor struct {
-	eventCh chan Event
-	ps      *processState
-}
-
-func newFakeEventProcessor(ctx context.Context, process *TeleportProcess) *fakeEventProcessor {
-	eventCh := make(chan Event, 1024)
-	process.ListenForEvents(ctx, TeleportDegradedEvent, eventCh)
-	process.ListenForEvents(ctx, TeleportOKEvent, eventCh)
-	process.ListenForEvents(ctx, TeleportStartingEvent, eventCh)
-	return &fakeEventProcessor{
-		eventCh: eventCh,
-		ps:      process.state,
-	}
-}
-
-func (f *fakeEventProcessor) processEvent() {
-	evt := <-f.eventCh
-	f.ps.update(evt)
 }

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -465,7 +465,19 @@ func (s *LocalSupervisor) BroadcastEvent(event Event) {
 			s.log.ErrorContext(s.closeContext, "Received event broadcast without component name, this is a bug!", "event", event.Name)
 			break
 		}
-		s.processState.update(s.closeContext, s.log, s.clock.Now(), event.Name, componentName)
+		updateResult := s.processState.update(s.clock.Now(), event.Name, componentName)
+		switch updateResult {
+		case updateStarting:
+			s.log.DebugContext(s.closeContext, "Teleport component is starting", "component", componentName)
+		case updateStarted:
+			s.log.DebugContext(s.closeContext, "Teleport component has started.", "component", componentName)
+		case updateDegraded:
+			s.log.InfoContext(s.closeContext, "Detected Teleport component is running in a degraded state.", "component", componentName)
+		case updateRecovering:
+			s.log.InfoContext(s.closeContext, "Teleport component is recovering from a degraded state.", "component", componentName)
+		case updateRecovered:
+			s.log.InfoContext(s.closeContext, "Teleport component has recovered from a degraded state.", "component", componentName)
+		}
 	}
 
 	s.events[event.Name] = event

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -436,6 +436,10 @@ func (s *LocalSupervisor) BroadcastEvent(event Event) {
 	s.Lock()
 	defer s.Unlock()
 
+	// some events have additional handling here because they affect the
+	// behavior or status of the process as a whole: Exit begins the shutdown by
+	// causing contexts to be closed, and Degraded/OK/Starting update the
+	// process' health.
 	switch event.Name {
 	case TeleportExitEvent:
 		// if exit event includes a context payload, it is a "graceful" exit, and


### PR DESCRIPTION
This PR moves the `lib/service.processState` machinery at the `LocalSupervisor` level, so that `(*LocalSupervisor).BroadcastEvent` can update the process state synchronously instead of relying on a monitoring goroutine. This avoids problems with readiness caused by events being broadcast before the monitoring goroutine is in place, either because of sequencing or because of a goroutine race.

changelog: fixed Teleport instances running the Auth Service sometimes not becoming ready during initialization