### PR TITLE
Use conn address as destination address for moderated SFTP

### DIFF
--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -169,11 +170,15 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	signer := agentless.SignerFromSSHIdentity(ident, h.auth.accessPoint, tc.SiteName, tc.Username)
 
+	clientDstAddr := h.cfg.ProxyWebAddr
+	if srvConn, err := authz.ConnFromContext(r.Context()); err == nil {
+		clientDstAddr = utils.FromAddr(srvConn.LocalAddr())
+	}
 	conn, err := h.cfg.Router.DialHost(
 		ctx,
 		ident.ScopePin,
 		&utils.NetAddr{Addr: r.RemoteAddr},
-		&h.cfg.ProxyWebAddr,
+		&clientDstAddr,
 		req.serverID,
 		"0",
 		tc.SiteName,


### PR DESCRIPTION
This change updates moderated SFTP to use the proxy server's actual IP address as determined from the connection, as opposed to the listener address which may be unspecified (i.e. `0.0.0.0` or `[::]`). This fixes a bug where an unspecified listener address might be a different IP version to the version on the connection, causing SignPROXYHeader to fail.

Changelog: Fixed unspecified proxy address breaking moderated SFTP when mixing IPv4 and IPv6

# Test Plan
- [x] Create a cluster with an unspecified proxy address (likely `[::]:3080` to force IPv6). Ensure that file transfers work in a moderated SFTP session.