### PR TITLE
MWI: Add `/wait` endpoint and `tbot wait` CLI helper

### DIFF
--- a/lib/tbot/cli/wait.go
+++ b/lib/tbot/cli/wait.go
@@ -19,9 +19,8 @@
 package cli
 
 import (
+	"net/http"
 	"time"
-
-	"github.com/jonboulle/clockwork"
 )
 
 // WaitCommand supports `tbot wait`
@@ -32,9 +31,9 @@ type WaitCommand struct {
 	Service  string
 	Timeout  time.Duration
 
-	// Clock is an optional clock which may be overridden in tests. It cannot be
-	// specified via the CLI.
-	Clock clockwork.Clock
+	// Client is an optional alternative HTTP client implementation for use in
+	// tests. If unspecified, a standard client is used.
+	Client *http.Client
 }
 
 // NewWaitCommand initializes the subcommand for `tbot wait`

--- a/lib/tbot/cli/wait.go
+++ b/lib/tbot/cli/wait.go
@@ -1,0 +1,60 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+// WaitCommand supports `tbot wait`
+type WaitCommand struct {
+	*genericExecutorHandler[WaitCommand]
+
+	DiagAddr string
+	Service  string
+	Timeout  time.Duration
+
+	// Clock is an optional clock which may be overridden in tests. It cannot be
+	// specified via the CLI.
+	Clock clockwork.Clock
+}
+
+// NewWaitCommand initializes the subcommand for `tbot wait`
+func NewWaitCommand(app KingpinClause, action func(*WaitCommand) error) *WaitCommand {
+	cmd := app.Command("wait", "Waits for a running tbot to become ready.")
+
+	c := &WaitCommand{}
+	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
+
+	cmd.Flag("diag-addr", "The configured --diag-addr of a running bot, in host:port form.").Required().StringVar(&c.DiagAddr)
+	cmd.Flag(
+		"service",
+		"An optional name. If set, waits for only the named service to "+
+			"become healthy. If unset, waits for all services.",
+	).StringVar(&c.Service)
+	cmd.Flag(
+		"timeout",
+		"An optional timeout. If set, returns an error if all specified "+
+			"services have reported healthy by the timeout.",
+	).DurationVar(&c.Timeout)
+
+	return c
+}

--- a/lib/tbot/internal/diagnostics/service.go
+++ b/lib/tbot/internal/diagnostics/service.go
@@ -122,6 +122,8 @@ func (s *Service) Run(ctx context.Context) error {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("OK"))
 	}))
+	mux.Handle("/wait", readyz.HTTPWaitHandler(s.statusRegistry))
+	mux.Handle("/wait/", readyz.HTTPWaitHandler(s.statusRegistry))
 	mux.Handle("/readyz", readyz.HTTPHandler(s.statusRegistry))
 	mux.Handle("/readyz/", readyz.HTTPHandler(s.statusRegistry))
 	srv := http.Server{

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -36,7 +37,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
 )
 
 func TestReadyz(t *testing.T) {

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -216,9 +216,9 @@ func (c *inMemoryTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	rr := httptest.NewRecorder()
 
 	// We can't just naively return the result of ServeHTTP since it doesn't
-	// return errors when the context is cancelled. To fix that, wrap it in
+	// return errors when the context is canceled. To fix that, wrap it in
 	// another goroutine and manually return an error if the context is
-	// cancelled.
+	// canceled.
 	go func() {
 		c.handler.ServeHTTP(rr, r)
 		close(done)
@@ -307,7 +307,7 @@ func TestWaitAPI(t *testing.T) {
 
 				code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
 				require.NoError(t, err)
-				require.Equal(t, code, 200)
+				require.Equal(t, 200, code)
 			},
 		},
 		{

--- a/lib/tbot/readyz/readyz_test.go
+++ b/lib/tbot/readyz/readyz_test.go
@@ -20,8 +20,11 @@ package readyz_test
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -29,7 +32,11 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
 )
 
 func TestReadyz(t *testing.T) {
@@ -183,5 +190,238 @@ func TestAllServicesReported(t *testing.T) {
 	case <-reg.AllServicesReported():
 	default:
 		t.Fatal("AllServicesReported should not be blocked")
+	}
+}
+
+// testDefaultClient returns a usable http.Client with a relatively short
+// timeout
+func testDefaultClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	client, err := defaults.HTTPClient()
+	require.NoError(t, err)
+
+	client.Timeout = time.Second
+
+	return client
+}
+
+// errorTransport is a mock roundtripper that just returns an error
+type errorTransport struct{}
+
+func (c *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("error")
+}
+
+func testDummyClient() *http.Client {
+	return &http.Client{
+		Transport: &errorTransport{},
+		Timeout:   time.Second * 1,
+	}
+}
+
+func testWaitFetch(t *testing.T, client *http.Client, service string, endpoint *url.URL) (int, error) {
+	t.Helper()
+
+	if service != "" {
+		endpoint = endpoint.JoinPath(service)
+	}
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, endpoint.String(), nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		// Let the test examine errors here
+		return 0, trace.Wrap(err)
+	}
+	defer resp.Body.Close()
+
+	bytes, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	require.NoError(t, err)
+
+	// Note: trace.ReadError does not categorize 5xx errors, so we'll just add
+	// some details to the status.
+	return resp.StatusCode, trace.Wrap(trace.ReadError(resp.StatusCode, bytes), resp.Status)
+}
+
+func TestWaitAPI(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	clock := clockwork.NewFakeClockAt(now)
+
+	tests := []struct {
+		name string
+		exec func(t *testing.T, reg *readyz.Registry, endpoint *url.URL)
+	}{
+		{
+			name: "simple - not ready",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				reg.AddService("svc", "a")
+
+				_, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.ErrorContains(t, err, "Client.Timeout exceeded")
+			},
+		},
+		{
+			name: "simple - ready",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+				a.Report(readyz.Healthy)
+
+				code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.NoError(t, err)
+				require.Equal(t, code, 200)
+			},
+		},
+		{
+			name: "simple - error",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+				a.ReportReason(readyz.Unhealthy, "testing error")
+
+				code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.Error(t, err)
+				require.Equal(t, 503, code)
+			},
+		},
+		{
+			name: "simple - no server",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				_, err := testWaitFetch(t, testDummyClient(), "", endpoint)
+				require.ErrorContains(t, err, "error")
+			},
+		},
+		{
+			name: "eventually becomes healthy",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+
+				// First try times out (waiting for initial status)
+				_, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.ErrorContains(t, err, "Client.Timeout exceeded")
+
+				a.Report(readyz.Unhealthy)
+
+				// Second try returns, but reports unhealthy
+				code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.Error(t, err) // error has no details to examine
+				require.Equal(t, 503, code)
+
+				// Third try reports healthy
+				a.Report(readyz.Healthy)
+
+				code, err = testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.NoError(t, err)
+				require.Equal(t, 200, code)
+			},
+		},
+		{
+			name: "specific service - not found",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				_ = reg.AddService("svc", "a")
+
+				_, err := testWaitFetch(t, testDefaultClient(t), "invalid", endpoint)
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name: "specific service - error",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+				a.ReportReason(readyz.Unhealthy, "testing error")
+
+				code, err := testWaitFetch(t,
+					testDefaultClient(t),
+					"a",
+					endpoint,
+				)
+				require.Error(t, err) // no message to examine
+				require.Equal(t, 503, code)
+			},
+		},
+		{
+			name: "multiple services",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+				b := reg.AddService("svc", "b")
+				a.Report(readyz.Healthy)
+
+				_, err := testWaitFetch(t, testDefaultClient(t), "a", endpoint)
+				require.NoError(t, err)
+
+				// "b" should still be waiting
+				_, err = testWaitFetch(t, testDefaultClient(t), "b", endpoint)
+				require.ErrorContains(t, err, "Client.Timeout")
+
+				// Overall should also still wait
+				_, err = testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.ErrorContains(t, err, "Client.Timeout")
+
+				b.ReportReason(readyz.Unhealthy, "invalid")
+
+				// It should now show an error
+				code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.Error(t, err) // error has no message
+				require.Equal(t, 503, code)
+
+				// Once "b" is heathy, both specific and overall status should report healthy.
+				b.Report(readyz.Healthy)
+
+				code, err = testWaitFetch(t, testDefaultClient(t), "b", endpoint)
+				require.NoError(t, err)
+				require.Equal(t, 200, code)
+
+				code, err = testWaitFetch(t, testDefaultClient(t), "", endpoint)
+				require.NoError(t, err)
+				require.Equal(t, 200, code)
+			},
+		},
+		{
+			name: "ongoing waiter receives status",
+			exec: func(t *testing.T, reg *readyz.Registry, endpoint *url.URL) {
+				a := reg.AddService("svc", "a")
+
+				// Start waiting
+				ch := make(chan error)
+				go func() {
+					code, err := testWaitFetch(t, testDefaultClient(t), "", endpoint)
+					if err != nil && code != 200 {
+						err = fmt.Errorf("error: %d", code)
+					}
+
+					ch <- err
+				}()
+
+				// Sleep a bit so we actually wait
+				time.Sleep(time.Millisecond * 100)
+				a.Report(readyz.Healthy)
+
+				select {
+				case res := <-ch:
+					require.NoError(t, res, "overall status should report healthy")
+				case <-time.After(100 * time.Millisecond):
+					require.Fail(t, "timed out waiting for waiter to receive ready status")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			reg := readyz.NewRegistry(readyz.WithClock(clock))
+
+			srv := httptest.NewServer(readyz.HTTPWaitHandler(reg))
+			srv.URL = srv.URL + "/wait"
+			t.Cleanup(srv.Close)
+
+			u, err := url.Parse(srv.URL)
+			require.NoError(t, err)
+
+			tt.exec(t, reg, u)
+		})
 	}
 }

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -53,7 +53,7 @@ func main() {
 	}
 }
 
-const appHelp = `Teleport Machine & Workload Identity 
+const appHelp = `Teleport Machine & Workload Identity
 
 Machine & Workload Identity issues and renews short-lived certificates so your
 machines can access Teleport protected resources in the same way your engineers do!
@@ -125,6 +125,10 @@ func Run(args []string, stdout io.Writer) error {
 
 		cli.NewCopyBinariesCommand(app, func(cbc *cli.CopyBinariesCommand) error {
 			return onCopyBinariesCommand(ctx, cbc)
+		}),
+
+		cli.NewWaitCommand(app, func(wc *cli.WaitCommand) error {
+			return onWaitCommand(ctx, wc)
 		}),
 
 		// `start` and `configure` commands

--- a/tool/tbot/wait.go
+++ b/tool/tbot/wait.go
@@ -1,0 +1,151 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tbot/cli"
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+)
+
+func waitFetch(ctx context.Context, client *http.Client, endpoint *url.URL) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return trace.Wrap(err, "could not build wait request")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return trace.Wrap(err, "making http request")
+	}
+	defer resp.Body.Close()
+
+	bytes, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = trace.ReadError(resp.StatusCode, bytes)
+	if err != nil {
+		return trace.Wrap(err, "wait api response")
+	}
+
+	// TODO: parse the status and ensure it is actually healthy
+
+	return nil
+}
+
+func onWaitCommand(ctx context.Context, cmd *cli.WaitCommand) error {
+	l := log.With("diag_addr", cmd.DiagAddr, "service", cmd.Service)
+
+	if cmd.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cmd.Timeout)
+		defer cancel()
+	}
+
+	var clock clockwork.Clock
+	if cmd.Clock != nil {
+		clock = cmd.Clock
+	} else {
+		clock = clockwork.NewRealClock()
+	}
+
+	diagAddr := cmd.DiagAddr
+	if diagAddr == "" {
+		return trace.BadParameter("--diag-addr is required")
+	}
+
+	// Allow plain host:port syntax; url.Parse will fail without a scheme, so if
+	// none is specified, prepend http
+	if !strings.Contains(diagAddr, "://") {
+		diagAddr = "http://" + diagAddr
+	}
+
+	baseURL, err := url.Parse(diagAddr)
+	if err != nil {
+		return trace.Wrap(err, "parsing --diag-addr")
+	}
+
+	var endpoint *url.URL
+	if cmd.Service == "" {
+		endpoint = baseURL.JoinPath("wait")
+	} else {
+		endpoint = baseURL.JoinPath("wait", cmd.Service)
+	}
+
+	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+		Driver: retryutils.NewExponentialDriver(20 * time.Millisecond),
+		Jitter: retryutils.HalfJitter,
+		Max:    2 * time.Second,
+		Clock:  clock,
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating retry helper")
+	}
+
+	client, err := defaults.HTTPClient()
+	if err != nil {
+		return trace.Wrap(err, "creating http client")
+	}
+
+	// Set a reasonably strict timeout. It could theoretically take a long time
+	// for a service to become ready even if the endpoint is functioning and
+	// exceed this timeout, but retrying again is mostly harmless and avoids our
+	// retry loop getting stuck for any other reason.
+	client.Timeout = 5 * time.Second
+
+	l.InfoContext(ctx, "waiting for bot to become available")
+
+	now := clock.Now()
+
+LOOP:
+	for {
+		err = waitFetch(ctx, client, endpoint)
+		if err == nil {
+			break LOOP
+		} else {
+			l.DebugContext(ctx, "wait failed, retrying", "error", err)
+		}
+
+		retry.Inc()
+		select {
+		case <-ctx.Done():
+			l.WarnContext(ctx, "bot did not become ready in time", "timeout", cmd.Timeout)
+			return ctx.Err()
+		case <-retry.After():
+		}
+	}
+
+	if err == nil {
+		l.InfoContext(ctx, "bot reported healthy", "after", clock.Since(now))
+	}
+
+	return trace.Wrap(err, "waiting for bot to become ready")
+}

--- a/tool/tbot/wait.go
+++ b/tool/tbot/wait.go
@@ -21,12 +21,14 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -34,11 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/cli"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 	"github.com/gravitational/teleport/lib/utils"
-	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 )
-
-var errServiceNotHealthy = errors.New("service is not yet healthy")
 
 // waitFetch fetches a status report from the given endpoint using the provided
 // client. It only returns without an error if the endpoint returns a valid

--- a/tool/tbot/wait.go
+++ b/tool/tbot/wait.go
@@ -43,7 +43,7 @@ import (
 func waitFetch(ctx context.Context, l *slog.Logger, client *http.Client, service string, endpoint *url.URL) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
-		return trace.Wrap(err, "could not build wait request")
+		return trace.Wrap(err, "building wait request")
 	}
 
 	resp, err := client.Do(req)

--- a/tool/tbot/wait_test.go
+++ b/tool/tbot/wait_test.go
@@ -40,9 +40,9 @@ func (c *inMemoryTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	rr := httptest.NewRecorder()
 
 	// We can't just naively return the result of ServeHTTP since it doesn't
-	// return errors when the context is cancelled. To fix that, wrap it in
+	// return errors when the context is canceled. To fix that, wrap it in
 	// another goroutine and manually return an error if the context is
-	// cancelled.
+	// canceled.
 	go func() {
 		c.handler.ServeHTTP(rr, r)
 		close(done)

--- a/tool/tbot/wait_test.go
+++ b/tool/tbot/wait_test.go
@@ -1,0 +1,169 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/tbot/cli"
+	"github.com/gravitational/teleport/lib/tbot/readyz"
+)
+
+func testDefaultClient(t *testing.T) *http.Client {
+	t.Helper()
+
+	client, err := defaults.HTTPClient()
+	require.NoError(t, err)
+
+	client.Timeout = time.Second
+
+	return client
+}
+
+// errorTransport is a mock roundtripper that just returns an error
+type errorTransport struct{}
+
+func (c *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("error")
+}
+
+func testDummyClient() *http.Client {
+	return &http.Client{
+		Transport: &errorTransport{},
+		Timeout:   time.Second * 1,
+	}
+}
+
+func testWaitFetch(t *testing.T, client *http.Client, service string, endpoint *url.URL) error {
+	t.Helper()
+
+	if service != "" {
+		endpoint = endpoint.JoinPath(service)
+	}
+
+	return waitFetch(t.Context(), slog.Default(), client, service, endpoint)
+}
+
+func TestWaitTimeoutExceeded(t *testing.T) {
+	t.Parallel()
+
+	reg := readyz.NewRegistry()
+	_ = reg.AddService("svc", "a")
+
+	srv := httptest.NewServer(readyz.HTTPWaitHandler(reg))
+	baseURL := srv.URL
+	srv.URL = baseURL + "/wait"
+	t.Cleanup(srv.Close)
+
+	ch := make(chan error)
+	go func() {
+		ch <- onWaitCommand(t.Context(), &cli.WaitCommand{
+			DiagAddr: baseURL,
+			Service:  "a",
+			Timeout:  time.Millisecond * 250,
+		})
+	}()
+
+	// Wait with a decent buffer.
+	time.Sleep(time.Millisecond * 500)
+
+	select {
+	case res := <-ch:
+		require.ErrorContains(t, res, "context deadline exceeded")
+	case <-time.After(250 * time.Millisecond):
+		require.Fail(t, "wait failed to honor timeout")
+	}
+}
+
+func TestWaitSuccess(t *testing.T) {
+	t.Parallel()
+
+	reg := readyz.NewRegistry()
+	a := reg.AddService("svc", "a")
+
+	srv := httptest.NewServer(readyz.HTTPWaitHandler(reg))
+	baseURL := srv.URL
+	srv.URL = baseURL + "/wait"
+	t.Cleanup(srv.Close)
+
+	ch := make(chan error)
+	go func() {
+		ch <- onWaitCommand(t.Context(), &cli.WaitCommand{
+			DiagAddr: baseURL,
+			Service:  "a",
+			Timeout:  time.Second * 2,
+		})
+	}()
+
+	a.Report(readyz.Healthy)
+
+	select {
+	case res := <-ch:
+		require.NoError(t, res, "must report ready")
+	case <-time.After(3 * time.Second):
+		require.Fail(t, "test timed out and failed to honor configured timeout")
+	}
+}
+
+func TestWaitEventualSuccess(t *testing.T) {
+	t.Parallel()
+
+	reg := readyz.NewRegistry()
+	a := reg.AddService("svc", "a")
+
+	srv := httptest.NewServer(readyz.HTTPWaitHandler(reg))
+	baseURL := srv.URL
+	srv.URL = baseURL + "/wait"
+	t.Cleanup(srv.Close)
+
+	ch := make(chan error)
+	go func() {
+		ch <- onWaitCommand(t.Context(), &cli.WaitCommand{
+			DiagAddr: baseURL,
+			Service:  "a",
+
+			// More generous timeout since this will depend on exponential
+			// backoff (with configured worst case of 2 seconds)
+			Timeout:  time.Second * 5,
+		})
+	}()
+
+	// Initially report unhealthy. This internally triggers a response and the
+	// HTTP endpoint will return the unhealthy status instead of waiting. The
+	// CLI should retry until the endpoint reports healthy.
+	a.ReportReason(readyz.Unhealthy, "oops")
+	time.Sleep(time.Millisecond * 200)
+	a.Report(readyz.Healthy)
+
+	select {
+	case res := <-ch:
+		require.NoError(t, res, "must report ready")
+	case <-time.After(6 * time.Second):
+		require.Fail(t, "test timed out and failed to honor configured timeout")
+	}
+}

--- a/tool/tbot/wait_test.go
+++ b/tool/tbot/wait_test.go
@@ -149,7 +149,7 @@ func TestWaitEventualSuccess(t *testing.T) {
 
 			// More generous timeout since this will depend on exponential
 			// backoff (with configured worst case of 2 seconds)
-			Timeout:  time.Second * 5,
+			Timeout: time.Second * 5,
 		})
 	}()
 

--- a/tool/tbot/wait_test.go
+++ b/tool/tbot/wait_test.go
@@ -19,55 +19,15 @@
 package main
 
 import (
-	"errors"
-	"log/slog"
-	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/cli"
 	"github.com/gravitational/teleport/lib/tbot/readyz"
 )
-
-func testDefaultClient(t *testing.T) *http.Client {
-	t.Helper()
-
-	client, err := defaults.HTTPClient()
-	require.NoError(t, err)
-
-	client.Timeout = time.Second
-
-	return client
-}
-
-// errorTransport is a mock roundtripper that just returns an error
-type errorTransport struct{}
-
-func (c *errorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return nil, errors.New("error")
-}
-
-func testDummyClient() *http.Client {
-	return &http.Client{
-		Transport: &errorTransport{},
-		Timeout:   time.Second * 1,
-	}
-}
-
-func testWaitFetch(t *testing.T, client *http.Client, service string, endpoint *url.URL) error {
-	t.Helper()
-
-	if service != "" {
-		endpoint = endpoint.JoinPath(service)
-	}
-
-	return waitFetch(t.Context(), slog.Default(), client, service, endpoint)
-}
 
 func TestWaitTimeoutExceeded(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
This adds two new features meant to improve use of `tbot` as a background service:
- A new `/wait(/service)` endpoint that functions similarly to `/readyz`, but waits to respond until the specified service (or all services) are initialized
- A new CLI helper, `tbot wait`, that requests this endpoint with a few robustness protections to make it safe and useful in bash scripts, like allowing it to start running before the diagnostics endpoint itself is ready and still return success appropriately.

Some small internal changes to tbot's readyz service were also made to track per-service initialization.

Note that as with `/readyz` the diagnostics service needs to be enabled via `--diag-addr` or similar for this functionality to be useful.

The HTTP API and the CLI helper have slightly different semantics for what "ready" means, as we want to minimize parsing and error handling for shell users:
- The HTTP API waits for the first readiness report from the service, after which it returns the latest status without delay. This means it may return when the service is unhealthy.
- The CLI helper waits for the service to actually report healthy. This means it may continue checking even once the wait endpoint returns a value.

Fixes #62117
changelog: Add `tbot wait` API and helper to let scripts wait for bots to become ready

---

### Usage examples

```code
# start a bot in the background
$ tbot start identity ... --diag-addr 127.0.0.1:4444

# wait for all services to become healthy
$ tbot wait --diag-addr 127.0.0.1:4444

# wait for a specific service to become healthy
$ tbot wait --diag-addr 127.0.0.1:4444 --service identity-1

# wait for a specific service to become healthy, with a timeout
$ tbot wait --diag-addr 127.0.0.1:4444 --service identity-1 --timeout 30s
```