### PR TITLE
[v18] Run the readiness logic synchronously

### DIFF
--- a/lib/service/diagnostic.go
+++ b/lib/service/diagnostic.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 
 	"github.com/gravitational/roundtrip"
-	"github.com/gravitational/trace"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/gravitational/teleport"
@@ -36,10 +35,6 @@ type diagnosticHandlerConfig struct {
 }
 
 func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerConfig, logger *slog.Logger) (http.Handler, error) {
-	if process.state == nil {
-		return nil, trace.BadParameter("teleport process state machine has not yet been initialized (this is a bug)")
-	}
-
 	mux := http.NewServeMux()
 
 	if config.enableMetrics {
@@ -54,7 +49,7 @@ func (process *TeleportProcess) newDiagnosticHandler(config diagnosticHandlerCon
 		mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 			roundtrip.ReplyJSON(w, http.StatusOK, map[string]any{"status": "ok"})
 		})
-		mux.HandleFunc("/readyz", process.state.readinessHandler())
+		mux.HandleFunc("/readyz", process.HandleReadiness)
 	}
 
 	if config.enableLogLeveler {

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -293,8 +293,11 @@ func TestMonitor(t *testing.T) {
 	require.NoError(t, err)
 
 	// this simulates events that happened to be broadcast before the
-	// readyz.monitor started listening for events
+	// process was started
+	process.ExpectService("dummy")
+	process.ExpectService(teleport.ComponentAuth)
 	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: teleport.ComponentAuth})
+	process.BroadcastEvent(Event{Name: TeleportOKEvent, Payload: "dummy"})
 
 	require.NoError(t, process.Start())
 	t.Cleanup(func() {
@@ -922,10 +925,12 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 			cfg.Proxy.ACME.Enabled = tc.acmeEnabled
 			cfg.DataDir = makeTempDir(t)
 			cfg.Proxy.PublicAddrs = utils.MustParseAddrList("localhost")
+			supervisor, err := NewSupervisor("process-id", cfg.Logger, cfg.Clock)
+			require.NoError(t, err)
 			process := TeleportProcess{
 				Config: cfg,
 				// Setting Supervisor so that `ExitContext` can be called.
-				Supervisor: NewSupervisor("process-id", cfg.Logger),
+				Supervisor: supervisor,
 			}
 			tls, err := process.setupProxyTLSConfig(
 				&Connector{},
@@ -1291,8 +1296,10 @@ func TestProxyGRPCServers(t *testing.T) {
 
 	// Create a new Teleport process to initialize the gRPC servers with KubeProxy
 	// enabled.
+	supervisor, err := NewSupervisor(hostID, logtest.NewLogger(), nil)
+	require.NoError(t, err)
 	process := &TeleportProcess{
-		Supervisor: NewSupervisor(hostID, logtest.NewLogger()),
+		Supervisor: supervisor,
 		Config: &servicecfg.Config{
 			Proxy: servicecfg.ProxyConfig{
 				Kube: servicecfg.KubeProxyConfig{
@@ -1633,19 +1640,18 @@ func TestDebugService(t *testing.T) {
 	// In this test we don't want to spin a whole process and have to wait for
 	// every service to report ready (there's an integration test for this).
 	// So we craft a minimal process with only the debug service in it.
+	supervisor, err := NewSupervisor("supervisor-test", log, fakeClock)
+	require.NoError(t, err)
 	process := &TeleportProcess{
 		Config:          cfg,
 		Clock:           fakeClock,
 		logger:          log,
 		metricsRegistry: localRegistry,
 		SyncGatherers:   metrics.NewSyncGatherers(localRegistry, prometheus.DefaultGatherer),
-		Supervisor:      NewSupervisor("supervisor-test", log),
+		Supervisor:      supervisor,
 	}
 
-	fakeState, err := newProcessState(process)
-	require.NoError(t, err)
-	fakeState.update(Event{TeleportOKEvent, "dummy"})
-	process.state = fakeState
+	process.BroadcastEvent(Event{TeleportOKEvent, "dummy"})
 
 	httpClient := &http.Client{
 		Timeout: 10 * time.Second,
@@ -2129,19 +2135,18 @@ func TestDiagnosticsService(t *testing.T) {
 	// In this test we don't want to spin a whole process and have to wait for
 	// every service to report ready (there's an integration test for this).
 	// So we craft a minimal process with only the debug service in it.
+	supervisor, err := NewSupervisor("supervisor-test", log, fakeClock)
+	require.NoError(t, err)
 	process := &TeleportProcess{
 		Config:          cfg,
 		Clock:           fakeClock,
 		logger:          log,
 		metricsRegistry: localRegistry,
 		SyncGatherers:   metrics.NewSyncGatherers(localRegistry, prometheus.DefaultGatherer),
-		Supervisor:      NewSupervisor("supervisor-test", log),
+		Supervisor:      supervisor,
 	}
 
-	fakeState, err := newProcessState(process)
-	require.NoError(t, err)
-	fakeState.update(Event{TeleportOKEvent, "dummy"})
-	process.state = fakeState
+	process.BroadcastEvent(Event{TeleportOKEvent, "dummy"})
 
 	require.NoError(t, process.initDiagnosticService())
 	require.NoError(t, process.Start())

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -23,10 +23,12 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/gravitational/teleport"
@@ -104,6 +106,9 @@ type Supervisor interface {
 	// GracefulExitContext returns context that will be closed when
 	// a graceful or hard TeleportExitEvent is broadcast.
 	GracefulExitContext() context.Context
+
+	// HandleReadiness is the HTTP handler for "/readyz".
+	HandleReadiness(http.ResponseWriter, *http.Request)
 }
 
 // EventMapping maps a sequence of incoming
@@ -167,10 +172,22 @@ type LocalSupervisor struct {
 
 	// log specifies the logger
 	log *slog.Logger
+
+	// clock is used as a source of time, to support fake clocks in tests.
+	clock clockwork.Clock
+
+	// processState is the process state machine tracking if the process is
+	// healthy or not.
+	processState processState
 }
 
 // NewSupervisor returns new instance of initialized supervisor
-func NewSupervisor(id string, parentLog *slog.Logger) Supervisor {
+func NewSupervisor(id string, parentLog *slog.Logger, clock clockwork.Clock) (*LocalSupervisor, error) {
+	// used by processState
+	if err := metrics.RegisterPrometheusCollectors(stateGauge); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	ctx := context.TODO()
 
 	closeContext, cancel := context.WithCancel(ctx)
@@ -180,6 +197,10 @@ func NewSupervisor(id string, parentLog *slog.Logger) Supervisor {
 	// graceful exit context is a subcontext of exit context since any work that terminates
 	// in the event of graceful exit must also terminate in the event of an immediate exit.
 	gracefulExitContext, signalGracefulExit := context.WithCancel(exitContext)
+
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
 
 	srv := &LocalSupervisor{
 		state:        stateCreated,
@@ -198,9 +219,12 @@ func NewSupervisor(id string, parentLog *slog.Logger) Supervisor {
 		signalGracefulExit:  signalGracefulExit,
 
 		log: parentLog.With(teleport.ComponentKey, teleport.Component(teleport.ComponentProcess, id)),
+
+		clock: clock,
 	}
+
 	go srv.fanOut()
-	return srv
+	return srv, nil
 }
 
 // Event is a special service event that can be generated
@@ -404,13 +428,23 @@ func (s *LocalSupervisor) GracefulExitContext() context.Context {
 	return s.gracefulExitContext
 }
 
+// HandleReadiness implements [Supervisor].
+func (s *LocalSupervisor) HandleReadiness(w http.ResponseWriter, r *http.Request) {
+	s.processState.handleReadiness(w, r)
+}
+
 // BroadcastEvent generates event and broadcasts it to all
 // subscribed parties.
 func (s *LocalSupervisor) BroadcastEvent(event Event) {
 	s.Lock()
 	defer s.Unlock()
 
-	if event.Name == TeleportExitEvent {
+	// some events have additional handling here because they affect the
+	// behavior or status of the process as a whole: Exit begins the shutdown by
+	// causing contexts to be closed, and Degraded/OK/Starting update the
+	// process' health.
+	switch event.Name {
+	case TeleportExitEvent:
 		// if exit event includes a context payload, it is a "graceful" exit, and
 		// we need to hold off closing the supervisor's exit context until after
 		// the graceful context has closed.  If not, it is an immediate exit.
@@ -425,6 +459,25 @@ func (s *LocalSupervisor) BroadcastEvent(event Event) {
 			}()
 		} else {
 			s.signalExit()
+		}
+	case TeleportDegradedEvent, TeleportOKEvent, TeleportStartingEvent:
+		componentName, ok := event.Payload.(string)
+		if !ok {
+			s.log.ErrorContext(s.closeContext, "Received event broadcast without component name, this is a bug!", "event", event.Name)
+			break
+		}
+		updateResult := s.processState.update(s.clock.Now(), event.Name, componentName)
+		switch updateResult {
+		case updateStarting:
+			s.log.DebugContext(s.closeContext, "Teleport component is starting", "component", componentName)
+		case updateStarted:
+			s.log.DebugContext(s.closeContext, "Teleport component has started.", "component", componentName)
+		case updateDegraded:
+			s.log.InfoContext(s.closeContext, "Detected Teleport component is running in a degraded state.", "component", componentName)
+		case updateRecovering:
+			s.log.InfoContext(s.closeContext, "Teleport component is recovering from a degraded state.", "component", componentName)
+		case updateRecovered:
+			s.log.InfoContext(s.closeContext, "Teleport component has recovered from a degraded state.", "component", componentName)
 		}
 	}
 


### PR DESCRIPTION
Backport of #62178 to branch/v18

changelog: fixed Teleport instances running the Auth Service sometimes not becoming ready during initialization