### PR TITLE
[v18] Extend user_login_state with SAML connector info and grants 

### DIFF
--- a/api/proto/teleport/userloginstate/v1/userloginstate.proto
+++ b/api/proto/teleport/userloginstate/v1/userloginstate.proto
@@ -32,32 +32,73 @@ message UserLoginState {
 
 // Spec is the specification for a user login state.
 message Spec {
-  // roles are the user roles attached to the user.
+  // roles are the user roles attached to the user. Basically, [roles] = [original_roles] +
+  // [access_list_roles].
   repeated string roles = 1;
 
-  // traits are the traits attached to the user.
+  // traits are the traits attached to the user. Basically, [roles] = [original_traits] +
+  // [access_list_traits].
   repeated teleport.trait.v1.Trait traits = 2;
 
   // user_type is the type of user this state represents.
   string user_type = 3;
 
-  // original_roles are the user roles that are part of the user's static definition. These roles are
-  // not affected by access granted by access lists and are obtained prior to granting access list access.
+  // original_roles are the user roles that are part of the user's static definition. These roles
+  // are not affected by access granted by access lists and are obtained prior to granting access
+  // list access. Basically, [original_roles] = [roles] - [access_list_roles].
   repeated string original_roles = 4;
 
-  // original_traits are the user traits that are part of the user's static definition. These traits are
-  // not affected by access granted by access lists and are obtained prior to granting access list access.
+  // original_traits are the user traits that are part of the user's static definition. These
+  // traits are not affected by access granted by access lists and are obtained prior to granting
+  // access list access. Basically, [original_traits] = [traits] - [access_list_traits].
   repeated teleport.trait.v1.Trait original_traits = 5;
 
   // GitHubIdentity is the external identity attached to this user state.
   ExternalIdentity git_hub_identity = 6;
+
+  // saml_identities are the identities created from the SAML connectors used to log in by this
+  // user name. They are useful for RBAC calculation when there is a user with same username form
+  // multiple SSO connectors, i.e. having multiple SSO indentities.
+  //
+  // NOTE: There is no mechanism to clean those identities. If the the user is deleted, the
+  // user_login_state and it's saml_identities will not be deleted. Or even if the user still
+  // exists, but it's SAML identity expires it isn't cleared from the user_login_state. This means
+  // the information stored here can be used only as long as there is a background sync running and
+  // making sure the user's info is up-to-date. E.g. Okta assignment creator is using this
+  // information, but it is running only when Okta user sync is active and periodically updates the
+  // user which in turn updates the user_login_state.
+  //
+  // NOTE2: This field isn't currently used. It's introduced so we can resolve the
+  // https://github.com/gravitational/teleport.e/issues/6723 issue in stages.
+  // The STAGE 1 is to introduce this field and give enough time to get existing Teleport
+  // installations to get updated and populate this field.
+  // The STAGE 2 is in the v19 release (or maybe even v20) to deploy the actual fix PR
+  // (https://github.com/gravitational/teleport.e/pull/7168) reading this field and calculating
+  // access to Okta resources. See more details in the description of the fix PR.
+  //
+  // TODO(kopiczko) v19: consider proceeding with the STAGE 2 described above.
+  repeated ExternalIdentity saml_identities = 7;
+
+  // access_list_roles are roles granted to this user by the Access Lists
+  // membership/ownership.  Basically, [access_list_roles] = [roles] - [original_roles].
+  repeated string access_list_roles = 8;
+
+  // access_list_traits are traits granted to this user by the Access Lists membership/ownership.
+  // Basically, [access_list_traits] = [traits] - [original_traits].
+  repeated teleport.trait.v1.Trait access_list_traits = 9;
 }
 
 // ExternalIdentity defines an external identity attached to this user state.
 message ExternalIdentity {
-  // UserId is the unique identifier of the external identity such as GitHub user
+  // UserID is the unique identifier of the external identity such as GitHub user
   // ID.
   string user_id = 1;
   // Username is the username of the external identity.
   string username = 2;
+  // ConnectorID is the connector this identity was created with. It's empty for the local user.
+  string connector_id = 3;
+  // GrantedRoles specific for this identity. E.g.: from connector attributes mapping.
+  repeated string granted_roles = 4;
+  // GrantedTraits specific for this identity. E.g.: from connector roles attributes mapping.
+  repeated teleport.trait.v1.Trait granted_traits = 5;
 }

--- a/api/types/trait/trait.go
+++ b/api/types/trait/trait.go
@@ -34,3 +34,15 @@ func (t Traits) Clone() Traits {
 	}
 	return out
 }
+
+// Merge src traits into dst. If you don't want the dst to be mutated do a Clone() first.
+// Duplicated values are removed, but the order of values for a given trait is not guaranteed.
+func Merge(dst, src Traits) {
+	for key, values := range src {
+		dst[key] = append(dst[key], values...)
+	}
+	for key, values := range dst {
+		slices.Sort(values)
+		dst[key] = slices.Compact(values)
+	}
+}

--- a/api/types/trait/trait_test.go
+++ b/api/types/trait/trait_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trait
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	testCases := []struct {
+		name        string
+		dst         Traits
+		src         Traits
+		expectedDst Traits
+	}{
+		{
+			name: "typical",
+			dst: Traits{
+				"only_dst": []string{"dst1"},
+				"logins":   []string{"root", "ec2-user"},
+			},
+			src: Traits{
+				"only_src": []string{"src1"},
+				"logins":   []string{"ubuntu", "ec2-user"},
+			},
+			expectedDst: Traits{
+				"only_src": []string{"src1"},
+				"only_dst": []string{"dst1"},
+				"logins":   []string{"ec2-user", "root", "ubuntu"},
+			},
+		},
+		{
+			name: "empty_dst",
+			dst:  Traits{},
+			src: Traits{
+				"only_src": []string{"src1"},
+			},
+			expectedDst: Traits{
+				"only_src": []string{"src1"},
+			},
+		},
+	}
+	for _, tt := range testCases {
+		Merge(tt.dst, tt.src)
+		require.Empty(t, cmp.Diff(tt.expectedDst, tt.dst))
+	}
+}

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -63,6 +63,8 @@ type User interface {
 	GetOIDCIdentities() []ExternalIdentity
 	// GetSAMLIdentities returns a list of connected SAML identities
 	GetSAMLIdentities() []ExternalIdentity
+	// SetSAMLIdentities sets a list of connected SAML identities
+	SetSAMLIdentities([]ExternalIdentity)
 	// GetGithubIdentities returns a list of connected Github identities
 	GetGithubIdentities() []ExternalIdentity
 	// SetGithubIdentities sets the list of connected GitHub identities
@@ -455,6 +457,11 @@ func (u *UserV2) GetOIDCIdentities() []ExternalIdentity {
 // GetSAMLIdentities returns a list of connected SAML identities
 func (u *UserV2) GetSAMLIdentities() []ExternalIdentity {
 	return u.Spec.SAMLIdentities
+}
+
+// SetSAMLIdentities sets a list of connected SAML identities
+func (u *UserV2) SetSAMLIdentities(identities []ExternalIdentity) {
+	u.Spec.SAMLIdentities = identities
 }
 
 // GetGithubIdentities returns a list of connected Github identities

--- a/api/types/userloginstate/convert/v1/user_login_state.go
+++ b/api/types/userloginstate/convert/v1/user_login_state.go
@@ -33,12 +33,15 @@ func FromProto(msg *userloginstatev1.UserLoginState) (*userloginstate.UserLoginS
 	}
 
 	uls, err := userloginstate.New(headerv1.FromMetadataProto(msg.GetHeader().GetMetadata()), userloginstate.Spec{
-		OriginalRoles:  msg.GetSpec().GetOriginalRoles(),
-		OriginalTraits: traitv1.FromProto(msg.GetSpec().GetOriginalTraits()),
-		Roles:          msg.GetSpec().GetRoles(),
-		Traits:         traitv1.FromProto(msg.GetSpec().GetTraits()),
-		UserType:       types.UserType(msg.GetSpec().GetUserType()),
-		GitHubIdentity: externalIdentityFromProto(msg.GetSpec().GetGitHubIdentity()),
+		OriginalRoles:    msg.GetSpec().GetOriginalRoles(),
+		OriginalTraits:   traitv1.FromProto(msg.GetSpec().GetOriginalTraits()),
+		AccessListRoles:  msg.GetSpec().GetAccessListRoles(),
+		AccessListTraits: traitv1.FromProto(msg.GetSpec().GetAccessListTraits()),
+		Roles:            msg.GetSpec().GetRoles(),
+		Traits:           traitv1.FromProto(msg.GetSpec().GetTraits()),
+		UserType:         types.UserType(msg.GetSpec().GetUserType()),
+		GitHubIdentity:   externalIdentityFromProto(msg.GetSpec().GetGitHubIdentity()),
+		SAMLIdentities:   externalIdentitiesFromProto(msg.GetSpec().GetSamlIdentities()),
 	})
 
 	return uls, trace.Wrap(err)
@@ -49,12 +52,15 @@ func ToProto(uls *userloginstate.UserLoginState) *userloginstatev1.UserLoginStat
 	return &userloginstatev1.UserLoginState{
 		Header: headerv1.ToResourceHeaderProto(uls.ResourceHeader),
 		Spec: &userloginstatev1.Spec{
-			OriginalRoles:  uls.GetOriginalRoles(),
-			OriginalTraits: traitv1.ToProto(uls.GetOriginalTraits()),
-			Roles:          uls.GetRoles(),
-			Traits:         traitv1.ToProto(uls.GetTraits()),
-			UserType:       string(uls.Spec.UserType),
-			GitHubIdentity: externalIdentityToProto(uls.Spec.GitHubIdentity),
+			OriginalRoles:    uls.GetOriginalRoles(),
+			OriginalTraits:   traitv1.ToProto(uls.GetOriginalTraits()),
+			AccessListRoles:  uls.GetAccessListRoles(),
+			AccessListTraits: traitv1.ToProto(uls.GetAccessListTraits()),
+			Roles:            uls.GetRoles(),
+			Traits:           traitv1.ToProto(uls.GetTraits()),
+			UserType:         string(uls.Spec.UserType),
+			GitHubIdentity:   externalIdentityToProto(uls.Spec.GitHubIdentity),
+			SamlIdentities:   externalIdentitiesToProto(uls.Spec.SAMLIdentities),
 		},
 	}
 }
@@ -62,19 +68,41 @@ func ToProto(uls *userloginstate.UserLoginState) *userloginstatev1.UserLoginStat
 func externalIdentityFromProto(identity *userloginstatev1.ExternalIdentity) *userloginstate.ExternalIdentity {
 	if identity != nil {
 		return &userloginstate.ExternalIdentity{
-			UserID:   identity.UserId,
-			Username: identity.Username,
+			ConnectorID:   identity.ConnectorId,
+			UserID:        identity.UserId,
+			Username:      identity.Username,
+			GrantedRoles:  identity.GrantedRoles,
+			GrantedTraits: traitv1.FromProto(identity.GrantedTraits),
 		}
 	}
 	return nil
 }
 
+func externalIdentitiesFromProto(identities []*userloginstatev1.ExternalIdentity) []userloginstate.ExternalIdentity {
+	var res []userloginstate.ExternalIdentity
+	for _, identity := range identities {
+		res = append(res, *externalIdentityFromProto(identity))
+	}
+	return res
+}
+
 func externalIdentityToProto(identity *userloginstate.ExternalIdentity) *userloginstatev1.ExternalIdentity {
 	if identity != nil {
 		return &userloginstatev1.ExternalIdentity{
-			UserId:   identity.UserID,
-			Username: identity.Username,
+			ConnectorId:   identity.ConnectorID,
+			UserId:        identity.UserID,
+			Username:      identity.Username,
+			GrantedRoles:  identity.GrantedRoles,
+			GrantedTraits: traitv1.ToProto(identity.GrantedTraits),
 		}
 	}
 	return nil
+}
+
+func externalIdentitiesToProto(identities []userloginstate.ExternalIdentity) []*userloginstatev1.ExternalIdentity {
+	var res []*userloginstatev1.ExternalIdentity
+	for _, identity := range identities {
+		res = append(res, externalIdentityToProto(&identity))
+	}
+	return res
 }

--- a/api/types/userloginstate/derived.gen.go
+++ b/api/types/userloginstate/derived.gen.go
@@ -47,8 +47,11 @@ func deriveTeleportEqual_(this, that *Spec) bool {
 			deriveTeleportEqual_3(this.OriginalTraits, that.OriginalTraits) &&
 			deriveTeleportEqual_2(this.Roles, that.Roles) &&
 			deriveTeleportEqual_3(this.Traits, that.Traits) &&
+			deriveTeleportEqual_2(this.AccessListRoles, that.AccessListRoles) &&
+			deriveTeleportEqual_3(this.AccessListTraits, that.AccessListTraits) &&
 			this.UserType == that.UserType &&
-			deriveTeleportEqual_4(this.GitHubIdentity, that.GitHubIdentity)
+			deriveTeleportEqual_4(this.GitHubIdentity, that.GitHubIdentity) &&
+			deriveTeleportEqual_5(this.SAMLIdentities, that.SAMLIdentities)
 }
 
 // deriveDeepCopy recursively copies the contents of src into dst.
@@ -113,12 +116,54 @@ func deriveDeepCopy_(dst, src *Spec) {
 	} else {
 		dst.Traits = nil
 	}
+	if src.AccessListRoles == nil {
+		dst.AccessListRoles = nil
+	} else {
+		if dst.AccessListRoles != nil {
+			if len(src.AccessListRoles) > len(dst.AccessListRoles) {
+				if cap(dst.AccessListRoles) >= len(src.AccessListRoles) {
+					dst.AccessListRoles = (dst.AccessListRoles)[:len(src.AccessListRoles)]
+				} else {
+					dst.AccessListRoles = make([]string, len(src.AccessListRoles))
+				}
+			} else if len(src.AccessListRoles) < len(dst.AccessListRoles) {
+				dst.AccessListRoles = (dst.AccessListRoles)[:len(src.AccessListRoles)]
+			}
+		} else {
+			dst.AccessListRoles = make([]string, len(src.AccessListRoles))
+		}
+		copy(dst.AccessListRoles, src.AccessListRoles)
+	}
+	if src.AccessListTraits != nil {
+		dst.AccessListTraits = make(map[string][]string, len(src.AccessListTraits))
+		deriveDeepCopy_2(dst.AccessListTraits, src.AccessListTraits)
+	} else {
+		dst.AccessListTraits = nil
+	}
 	dst.UserType = src.UserType
 	if src.GitHubIdentity == nil {
 		dst.GitHubIdentity = nil
 	} else {
 		dst.GitHubIdentity = new(ExternalIdentity)
-		*dst.GitHubIdentity = *src.GitHubIdentity
+		deriveDeepCopy_3(dst.GitHubIdentity, src.GitHubIdentity)
+	}
+	if src.SAMLIdentities == nil {
+		dst.SAMLIdentities = nil
+	} else {
+		if dst.SAMLIdentities != nil {
+			if len(src.SAMLIdentities) > len(dst.SAMLIdentities) {
+				if cap(dst.SAMLIdentities) >= len(src.SAMLIdentities) {
+					dst.SAMLIdentities = (dst.SAMLIdentities)[:len(src.SAMLIdentities)]
+				} else {
+					dst.SAMLIdentities = make([]ExternalIdentity, len(src.SAMLIdentities))
+				}
+			} else if len(src.SAMLIdentities) < len(dst.SAMLIdentities) {
+				dst.SAMLIdentities = (dst.SAMLIdentities)[:len(src.SAMLIdentities)]
+			}
+		} else {
+			dst.SAMLIdentities = make([]ExternalIdentity, len(src.SAMLIdentities))
+		}
+		deriveDeepCopy_4(dst.SAMLIdentities, src.SAMLIdentities)
 	}
 }
 
@@ -128,7 +173,7 @@ func deriveTeleportEqual_1(this, that *header.Metadata) bool {
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Description == that.Description &&
-			deriveTeleportEqual_5(this.Labels, that.Labels) &&
+			deriveTeleportEqual_6(this.Labels, that.Labels) &&
 			this.Expires.Equal(that.Expires)
 }
 
@@ -172,8 +217,27 @@ func deriveTeleportEqual_3(this, that map[string][]string) bool {
 func deriveTeleportEqual_4(this, that *ExternalIdentity) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
+			this.ConnectorID == that.ConnectorID &&
 			this.UserID == that.UserID &&
-			this.Username == that.Username
+			this.Username == that.Username &&
+			deriveTeleportEqual_2(this.GrantedRoles, that.GrantedRoles) &&
+			deriveTeleportEqual_3(this.GrantedTraits, that.GrantedTraits)
+}
+
+// deriveTeleportEqual_5 returns whether this and that are equal.
+func deriveTeleportEqual_5(this, that []ExternalIdentity) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_4(&this[i], &that[i])) {
+			return false
+		}
+	}
+	return true
 }
 
 // deriveDeepCopy_1 recursively copies the contents of src into dst.
@@ -182,13 +246,13 @@ func deriveDeepCopy_1(dst, src *header.Metadata) {
 	dst.Description = src.Description
 	if src.Labels != nil {
 		dst.Labels = make(map[string]string, len(src.Labels))
-		deriveDeepCopy_3(dst.Labels, src.Labels)
+		deriveDeepCopy_5(dst.Labels, src.Labels)
 	} else {
 		dst.Labels = nil
 	}
 	func() {
 		field := new(time.Time)
-		deriveDeepCopy_4(field, &src.Expires)
+		deriveDeepCopy_6(field, &src.Expires)
 		dst.Expires = *field
 	}()
 	dst.Revision = src.Revision
@@ -221,8 +285,50 @@ func deriveDeepCopy_2(dst, src map[string][]string) {
 	}
 }
 
-// deriveTeleportEqual_5 returns whether this and that are equal.
-func deriveTeleportEqual_5(this, that map[string]string) bool {
+// deriveDeepCopy_3 recursively copies the contents of src into dst.
+func deriveDeepCopy_3(dst, src *ExternalIdentity) {
+	dst.ConnectorID = src.ConnectorID
+	dst.UserID = src.UserID
+	dst.Username = src.Username
+	if src.GrantedRoles == nil {
+		dst.GrantedRoles = nil
+	} else {
+		if dst.GrantedRoles != nil {
+			if len(src.GrantedRoles) > len(dst.GrantedRoles) {
+				if cap(dst.GrantedRoles) >= len(src.GrantedRoles) {
+					dst.GrantedRoles = (dst.GrantedRoles)[:len(src.GrantedRoles)]
+				} else {
+					dst.GrantedRoles = make([]string, len(src.GrantedRoles))
+				}
+			} else if len(src.GrantedRoles) < len(dst.GrantedRoles) {
+				dst.GrantedRoles = (dst.GrantedRoles)[:len(src.GrantedRoles)]
+			}
+		} else {
+			dst.GrantedRoles = make([]string, len(src.GrantedRoles))
+		}
+		copy(dst.GrantedRoles, src.GrantedRoles)
+	}
+	if src.GrantedTraits != nil {
+		dst.GrantedTraits = make(map[string][]string, len(src.GrantedTraits))
+		deriveDeepCopy_2(dst.GrantedTraits, src.GrantedTraits)
+	} else {
+		dst.GrantedTraits = nil
+	}
+}
+
+// deriveDeepCopy_4 recursively copies the contents of src into dst.
+func deriveDeepCopy_4(dst, src []ExternalIdentity) {
+	for src_i, src_value := range src {
+		func() {
+			field := new(ExternalIdentity)
+			deriveDeepCopy_3(field, &src_value)
+			dst[src_i] = *field
+		}()
+	}
+}
+
+// deriveTeleportEqual_6 returns whether this and that are equal.
+func deriveTeleportEqual_6(this, that map[string]string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -241,14 +347,14 @@ func deriveTeleportEqual_5(this, that map[string]string) bool {
 	return true
 }
 
-// deriveDeepCopy_3 recursively copies the contents of src into dst.
-func deriveDeepCopy_3(dst, src map[string]string) {
+// deriveDeepCopy_5 recursively copies the contents of src into dst.
+func deriveDeepCopy_5(dst, src map[string]string) {
 	for src_key, src_value := range src {
 		dst[src_key] = src_value
 	}
 }
 
-// deriveDeepCopy_4 recursively copies the contents of src into dst.
-func deriveDeepCopy_4(dst, src *time.Time) {
+// deriveDeepCopy_6 recursively copies the contents of src into dst.
+func deriveDeepCopy_6(dst, src *time.Time) {
 	*dst = *src
 }

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2730,7 +2730,7 @@ func certRequestDeviceExtensions(ext tlsca.DeviceExtensions) certRequestOption {
 	}
 }
 
-// GetUserOrLoginState will return the given user or the login state associated with the user.
+// GetUserOrLoginState will return the given user login state or if not found, the user itself.
 func (a *Server) GetUserOrLoginState(ctx context.Context, username string) (services.UserState, error) {
 	// use Services (real backend instead of cache) to make sure that the GetUserOrLoginState function
 	// return always the up-to-date user state.

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -59,7 +59,6 @@ import (
 	"github.com/gravitational/teleport/lib/auth/join/oracle"
 	"github.com/gravitational/teleport/lib/auth/moderation"
 	"github.com/gravitational/teleport/lib/auth/okta"
-	"github.com/gravitational/teleport/lib/auth/userloginstate"
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -3431,8 +3430,15 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// preserved in user login state, where local users may get updated roles
 	// from ConnectMyComputer setup. So here we retrieve additional fields from
 	// user login state. Ideally we should solve this some other way.
-	if err := userloginstate.UpdatePreservedAttributes(ctx, user, a.authServer.Services); err != nil {
-		return nil, trace.Wrap(err, "updating preserved attributes")
+	if githubIdentities := user.GetGithubIdentities(); len(githubIdentities) == 0 {
+		uls, err := a.authServer.Services.GetUserLoginState(ctx, user.GetName())
+		if trace.IsNotFound(err) {
+			// Nothing to do.
+		} else if err != nil {
+			return nil, trace.Wrap(err, "updating GitHub identities")
+		} else if githubIdentities := uls.GetGithubIdentities(); len(githubIdentities) > 0 {
+			user.SetGithubIdentities(githubIdentities)
+		}
 	}
 
 	// Do not allow SSO users to be impersonated.

--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -22,11 +22,15 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -132,18 +136,13 @@ func NewGenerator(config GeneratorConfig) (*Generator, error) {
 	}, nil
 }
 
-// Generate will generate the user login state for the given user.
-func (g *Generator) Generate(ctx context.Context, user types.User, ulsService services.UserLoginStates) (*userloginstate.UserLoginState, error) {
-	return g.generate(ctx, user, ulsService, false)
-}
-
 // GeneratePureULS is a variant of user login state generation that emits no usage events and ignores any existing user login state
 // in the backend. Used for auditing/introspection purposes.
 func (g *Generator) GeneratePureULS(ctx context.Context, user types.User) (*userloginstate.UserLoginState, error) {
 	return g.generate(ctx, user, nil, true)
 }
 
-// generate is the underlying implementation for Generate and GeneratePure.
+// Generate will generate the user login state for the given user.
 func (g *Generator) generate(ctx context.Context, user types.User, ulsService services.UserLoginStates, pure bool) (*userloginstate.UserLoginState, error) {
 	var originalTraits map[string][]string
 	var traits map[string][]string
@@ -165,6 +164,22 @@ func (g *Generator) generate(ctx context.Context, user types.User, ulsService se
 		}
 	}
 
+	var samlIdentities []userloginstate.ExternalIdentity
+	if !pure {
+		connector := user.GetCreatedBy().Connector
+		if connector != nil && connector.Type == constants.SAML {
+			samlIdentities = []userloginstate.ExternalIdentity{
+				{
+					ConnectorID:   connector.ID,
+					UserID:        connector.Identity,
+					Username:      connector.Identity,
+					GrantedRoles:  slices.Clone(user.GetRoles()),
+					GrantedTraits: maps.Clone(traits),
+				},
+			}
+		}
+	}
+
 	// Create a new empty user login state.
 	uls, err := userloginstate.New(
 		header.Metadata{
@@ -177,6 +192,7 @@ func (g *Generator) generate(ctx context.Context, user types.User, ulsService se
 			Traits:         traits,
 			UserType:       user.GetUserType(),
 			GitHubIdentity: githubIdentity,
+			SAMLIdentities: samlIdentities,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -189,8 +205,7 @@ func (g *Generator) generate(ctx context.Context, user types.User, ulsService se
 	}
 
 	if !pure {
-		// Preserve states like GitHub identities across logins.
-		if err := UpdatePreservedAttributes(ctx, uls, ulsService); err != nil {
+		if err := updatePreservedAttributes(ctx, uls, ulsService); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -321,13 +336,20 @@ func selectGrants(acl *accesslist.AccessList, owner bool) accesslist.Grants {
 // returning inherited roles and traits if AccessListUserAssignmentType is inherited.
 func (g *Generator) grantRolesAndTraits(grants accesslist.Grants, state *userloginstate.UserLoginState) {
 	state.Spec.Roles = append(state.Spec.Roles, grants.Roles...)
+	state.Spec.AccessListRoles = append(state.Spec.AccessListRoles, grants.Roles...)
 
-	if state.Spec.Traits == nil && len(grants.Traits) > 0 {
-		state.Spec.Traits = map[string][]string{}
+	if len(grants.Traits) > 0 {
+		if state.Spec.Traits == nil {
+			state.Spec.Traits = map[string][]string{}
+		}
+		if state.Spec.AccessListTraits == nil {
+			state.Spec.AccessListTraits = map[string][]string{}
+		}
 	}
 
 	for k, values := range grants.Traits {
 		state.Spec.Traits[k] = append(state.Spec.Traits[k], values...)
+		state.Spec.AccessListTraits[k] = append(state.Spec.AccessListTraits[k], values...)
 	}
 }
 
@@ -337,6 +359,10 @@ func (g *Generator) postProcess(ctx context.Context, state *userloginstate.UserL
 	state.Spec.Roles = utils.Deduplicate(state.Spec.Roles)
 	for k, v := range state.Spec.Traits {
 		state.Spec.Traits[k] = utils.Deduplicate(v)
+	}
+	state.Spec.AccessListRoles = utils.Deduplicate(state.Spec.AccessListRoles)
+	for k, v := range state.Spec.AccessListTraits {
+		state.Spec.AccessListTraits[k] = utils.Deduplicate(v)
 	}
 
 	// If there are no roles, don't bother filtering out non-existent roles
@@ -412,34 +438,48 @@ func (g *Generator) emitUsageEvent(ctx context.Context, user types.User, state *
 	return nil
 }
 
-// UpdatePreservedAttributes retrieves attributes that can be preserved in user
-// login state cross logins.
-func UpdatePreservedAttributes(ctx context.Context, user services.UserState, ulsService services.UserLoginStates) error {
-	// Use the new/existing GitHubIdentities.
-	// TODO(greedy52) implement a way to remove the identity or find a way to
-	// avoid keeping the identity forever in user login state.
-	if len(user.GetGithubIdentities()) > 0 {
+// updatePreservedAttributes that should be preserved in user login state across logins.
+func updatePreservedAttributes(ctx context.Context, uls *userloginstate.UserLoginState, ulsService services.UserLoginStates) error {
+	existingULS, err := ulsService.GetUserLoginState(ctx, uls.GetName())
+	if trace.IsNotFound(err) {
 		return nil
-	}
-
-	// Find the old state if exists.
-	old, err := ulsService.GetUserLoginState(ctx, user.GetName())
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return nil
-		}
+	} else if err != nil {
 		return trace.Wrap(err)
 	}
-
-	if githubIdentities := old.GetGithubIdentities(); len(githubIdentities) > 0 {
-		user.SetGithubIdentities(githubIdentities)
+	if len(uls.GetGithubIdentities()) == 0 {
+		uls.SetGithubIdentities(existingULS.GetGithubIdentities())
 	}
+	// We need to preserve SAML identity as user may log in using another auth connector and
+	// overwrite roles and traits mapped from the previous connector. The information about
+	// other connectors may be needed to calculate access to provider-specific resources like
+	// Okta. See https://github.com/gravitational/teleport.e/pull/7168.
+	preserveSAMLIdentities(uls, existingULS)
 	return nil
+}
+
+// preserveSAMLIdentities merges SAML identities from u2 to u1.
+func preserveSAMLIdentities(dst, src *userloginstate.UserLoginState) {
+	ids1 := dst.Spec.SAMLIdentities
+	ids2 := src.Spec.SAMLIdentities
+
+	for _, id2 := range ids2 {
+		ok := slices.ContainsFunc(ids1, func(id1 userloginstate.ExternalIdentity) bool {
+			return id1.ConnectorID == id2.ConnectorID
+		})
+		if !ok {
+			ids1 = append(ids1, id2)
+		}
+	}
+	slices.SortFunc(ids1, func(x, y userloginstate.ExternalIdentity) int {
+		return strings.Compare(x.ConnectorID, y.ConnectorID)
+	})
+
+	dst.Spec.SAMLIdentities = ids1
 }
 
 // Refresh will take the user and update the user login state in the backend.
 func (g *Generator) Refresh(ctx context.Context, user types.User, ulsService services.UserLoginStates) (*userloginstate.UserLoginState, error) {
-	uls, err := g.Generate(ctx, user, ulsService)
+	uls, err := g.generate(ctx, user, ulsService, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/userloginstate/generator_bench_test.go
+++ b/lib/auth/userloginstate/generator_bench_test.go
@@ -66,7 +66,7 @@ func BenchmarkGenerate(b *testing.B) {
 			b.ResetTimer()
 
 			for b.Loop() {
-				_, err := svc.Generate(b.Context(), user, backendSvc)
+				_, err := svc.generate(b.Context(), user, backendSvc, false /* pure */)
 				if err != nil {
 					b.Fatalf("Generate: %v", err)
 				}

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -1469,8 +1469,8 @@ func AccessInfoFromRemoteTLSIdentity(identity tlsca.Identity, roleMap types.Role
 	}, nil
 }
 
-// UserState is a representation of a user's current state.
-type UserState interface {
+// UserAccessState is a representation of a user's current state required for calculating access.
+type UserAccessState interface {
 	// GetName returns the username associated with the user state.
 	GetName() string
 
@@ -1479,6 +1479,11 @@ type UserState interface {
 
 	// GetTraits returns the traits associated with the user's current sate.
 	GetTraits() map[string][]string
+}
+
+// UserState is a representation of a user's current state.
+type UserState interface {
+	UserAccessState
 
 	// GetUserType returns the user type for the user login state.
 	GetUserType() types.UserType
@@ -1499,18 +1504,18 @@ type UserState interface {
 // traits held be the given user state. This should only be used in cases where the
 // user does not have any active access requests (initial web login, initial
 // tbot certs, tests).
-func AccessInfoFromUserState(user UserState) *AccessInfo {
+func AccessInfoFromUserState(user UserAccessState) *AccessInfo {
 	return accessInfoFromUserState(user, user.GetRoles(), nil)
 }
 
 // ScopePinnedAccessInfoFromUserState returns a new AccessInfo populated from the
 // traits held by the user and the provided scope pin. Population/verification of the
 // scope pin must be performed prior to calling this function.
-func ScopePinnedAccessInfoFromUserState(user UserState, pin *scopesv1.Pin) *AccessInfo {
+func ScopePinnedAccessInfoFromUserState(user UserAccessState, pin *scopesv1.Pin) *AccessInfo {
 	return accessInfoFromUserState(user, nil, pin)
 }
 
-func accessInfoFromUserState(user UserState, roles []string, pin *scopesv1.Pin) *AccessInfo {
+func accessInfoFromUserState(user UserAccessState, roles []string, pin *scopesv1.Pin) *AccessInfo {
 	return &AccessInfo{
 		Username: user.GetName(),
 		Roles:    roles,

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -102,7 +102,7 @@ type UserOrLoginStateGetter interface {
 	UserGetter
 }
 
-// GetUserOrLoginState will return the given user or the login state associated with the user.
+// GetUserOrLoginState will return the given user login state or if not found, the user itself.
 func GetUserOrLoginState(ctx context.Context, getter UserOrLoginStateGetter, username string) (UserState, error) {
 	uls, err := getter.GetUserLoginState(ctx, username)
 	if err != nil && !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {


### PR DESCRIPTION
Backport #58581 to branch/v18

### Manual tests

> [!TIP]
>
>  The `saml_identities` in the `user_login_state` can be checked with:
>
> ```
> teleport backend get /user_login_state/user@domain --format json | jq '.[].Value' -r | jq '.spec.saml_identities'
> ```

1. Setup 2 Okta orgs and Entra ID org with the same user; create local user with the same name
2. Login as the local user
3. Login as okta_1 user - this should fail with log: local user with name user@domain already exists. Either change NameID in assertion or remove local user and try again
4. Remove local user and login with okta_1
5. Verify `saml_identities` (see the tip above), if it has proper `GrantedRoles` and `GrantedTraits` and if the `ConnectorID` matches
6. Login with another connector okta_2
7. Verify `saml_identities` (see the tip above), if it has proper `GrantedRoles` and `GrantedTraits` and if the `ConnectorID` matches for
    - okta_1
    - okta_2
8. Login with another connector entraid
9. Verify `saml_identities` (see the tip above), if it has proper `GrantedRoles` and `GrantedTraits` and if the `ConnectorID` matches for
    - okta_1
    - okta_2
    - entraid
