### PR TITLE
[v18] Managed Updates: Kube Canaries

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -809,7 +809,7 @@ It is also used as a failover when fetching the version using the webapi protoco
 | `string` | `""` |
 
 `updater.group` is the update group used when fetching the version using the webapi protocol.
-When unset, the group defaults to `update.releaseChannel`.
+When unset, the group defaults to `default`.
 
 ### `updater.image`
 

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -198,6 +198,10 @@ spec:
           - name: KUBERNETES_TOKEN_PATH
             value: /var/run/secrets/tokens/join-sa-token
           {{- end }}
+          {{- if .Values.updater.enabled }}
+           - name: "TELEPORT_UPDATE_CONFIG_FILE"
+             value: "/etc/updater-config/update.yaml"
+          {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"
         {{- if .Values.insecureSkipProxyTLSVerify }}
@@ -262,6 +266,11 @@ spec:
           name: "jamf-api-credentials"
           readOnly: true
 {{- end }}
+{{- if .Values.updater.enabled }}
+        - mountPath: /etc/updater-config
+          name: "updater-config"
+          readOnly: true
+{{- end }}
 {{- if .Values.extraVolumeMounts }}
   {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
 {{- end }}
@@ -301,6 +310,11 @@ spec:
       - name: "jamf-api-credentials"
         secret:
           secretName: {{ .Values.jamfCredentialsSecret.name }}
+{{- end }}
+{{- if .Values.updater.enabled }}
+      - name: "updater-config"
+        configMap:
+          name: {{ .Release.Name }}-updater
 {{- end }}
 {{- if .Values.extraVolumes }}
   {{- toYaml .Values.extraVolumes | nindent 6 }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -199,8 +199,8 @@ spec:
             value: /var/run/secrets/tokens/join-sa-token
           {{- end }}
           {{- if .Values.updater.enabled }}
-           - name: "TELEPORT_UPDATE_CONFIG_FILE"
-             value: "/etc/updater-config/update.yaml"
+          - name: "TELEPORT_UPDATE_CONFIG_FILE"
+            value: "/etc/updater-config/update.yaml"
           {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -71,7 +71,7 @@ spec:
     would be a breaking change when the teleport proxy starts override the explicitly set RFD-109 version server */ -}}
   {{- if and $updater.proxyAddr (not $versionServerOverride)}}
           - "--proxy-address={{ $updater.proxyAddr }}"
-          - "--update-group={{ default $updater.releaseChannel $updater.group }}"
+          - "--update-group={{ default "default" $updater.group }}"
   {{- end }}
 {{- if $updater.pullCredentials }}
           - "--pull-credentials={{ $updater.pullCredentials }}"

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -53,12 +53,13 @@ rules:
   verbs:
     - create
     - patch
-# the updater needs to get and update the configmap containing updater state
+# the updater needs to create, get, and update the configmap containing updater state
 - apiGroups:
     - ""
   resources:
     - configmaps
   verbs:
+    - create
     - watch
     - list
 - apiGroups:
@@ -67,7 +68,6 @@ rules:
     - configmaps
   verbs:
     - get
-    - create
     - update
   resourceNames:
     - {{ .Release.Name }}-updater

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -53,6 +53,16 @@ rules:
   verbs:
     - create
     - patch
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - get
+    - create
+    - update
+  resourceNames:
+    - {{ .Release.Name }}-updater
 # the controller in the updater must be able to watch deployments and
 # statefulsets and get the one it should reconcile
 - apiGroups:

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -53,6 +53,14 @@ rules:
   verbs:
     - create
     - patch
+# the updater needs to get and update the configmap containing updater state
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - watch
+    - list
 - apiGroups:
     - ""
   resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
@@ -44,6 +44,7 @@ sets the correct role rules:
       resources:
       - configmaps
       verbs:
+      - create
       - watch
       - list
     - apiGroups:
@@ -54,7 +55,6 @@ sets the correct role rules:
       - configmaps
       verbs:
       - get
-      - create
       - update
     - apiGroups:
       - apps

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
@@ -40,6 +40,23 @@ sets the correct role rules:
       - create
       - patch
     - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-updater
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - create
+      - update
+    - apiGroups:
       - apps
       resources:
       - deployments

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -855,6 +855,25 @@ tests:
             name: TELEPORT_EXT_UPGRADER_VERSION
             value: 13.4.5
 
+  - it: should mount the update.yaml configmap when updater is enabled
+    template: statefulset.yaml
+    values:
+      - ../.lint/updater.yaml
+    set:
+      teleportVersionOverride: 13.4.5
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEPORT_UPDATE_CONFIG_FILE
+            value: /etc/updater-config/update.yaml
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: updater-config
+            configMap:
+              name: RELEASE-NAME-updater
+
   - it: should set the installation method environment variable
     template: statefulset.yaml
     values:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -868,6 +868,12 @@ tests:
             name: TELEPORT_UPDATE_CONFIG_FILE
             value: /etc/updater-config/update.yaml
       - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/updater-config
+            name: updater-config
+            readOnly: true
+      - contains:
           path: spec.template.spec.volumes
           content:
             name: updater-config

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -878,6 +878,29 @@ tests:
             configMap:
               name: RELEASE-NAME-updater
 
+  - it: should not mount the update.yaml configmap when updater is disabled
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEPORT_UPDATE_CONFIG_FILE
+            value: /etc/updater-config/update.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/updater-config
+            name: updater-config
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: updater-config
+            configMap:
+              name: RELEASE-NAME-updater
+
   - it: should set the installation method environment variable
     template: statefulset.yaml
     values:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -859,8 +859,6 @@ tests:
     template: statefulset.yaml
     values:
       - ../.lint/updater.yaml
-    set:
-      teleportVersionOverride: 13.4.5
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -103,7 +103,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--update-group=stable/cloud"
+          content: "--update-group=default"
   - it: uses the update group when set
     set:
       proxyAddr: proxy.teleport.example.com:443

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -671,7 +671,7 @@ updater:
   releaseChannel: "stable/cloud"
 
   # updater.group(string) -- is the update group used when fetching the version using the webapi protocol.
-  # When unset, the group defaults to `update.releaseChannel`.
+  # When unset, the group defaults to `default`.
   group: ""
 
   # updater.image(string) -- sets the container image used for Teleport updater

--- a/integrations/kube-agent-updater/Dockerfile
+++ b/integrations/kube-agent-updater/Dockerfile
@@ -17,6 +17,7 @@ RUN go mod download
 
 # Copy in code
 COPY lib/ lib/
+COPY entitlements/ entitlements/
 COPY *.go ./
 COPY integrations/kube-agent-updater/ integrations/kube-agent-updater/
 

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -391,7 +391,7 @@ func getUpdateID(ctx context.Context, mgr manager.Manager, ref kclient.ObjectKey
 		if err != nil {
 			ctrl.Log.Error(err, "updater configmap is malformed, canary deployment may fail", "configmap", updateYAML)
 		}
-		return uuid.Nil, nil // proceed with empty UUID instead of crashing or deleting user data
+		return updateID, nil // proceed with empty UUID instead of crashing or deleting user data
 	}
 	return uuid.Nil, trace.Errorf("failing due to multiple conflicts")
 }

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -177,7 +177,7 @@ func main() {
 	var updateYAML v1.ConfigMap
 	err = mgr.GetClient().Get(ctx, kclient.ObjectKey{
 		Namespace: agentNamespace,
-		Name:      agentName + "-update",
+		Name:      agentName + "-updater",
 	}, &updateYAML)
 	switch {
 	case apierrors.IsNotFound(err):

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -184,6 +184,7 @@ func main() {
 		ctrl.Log.Error(err, "failed to get updater ID, exiting")
 		os.Exit(1)
 	}
+	ctrl.Log.Info("update ID and group are set", "update_id", updateID, "update_group", updateGroup)
 
 	// Craft the version getter and update triggers based on the configuration (use RFD-109 APIs, RFD-184, or both).
 	var criticalUpdateTriggers []maintenance.Trigger

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -34,6 +35,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -41,6 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/gravitational/teleport/api/client/webclient"
@@ -173,28 +176,13 @@ func main() {
 	// Pre-fetch the ID if it already exists, so that we can use it to lookup versions.
 	// This logic could be moved into the reconciler, but it would require refactoring
 	// all version getter implementations to accept an ID dynamically in GetVersion.
-	var updateID uuid.UUID
-	var updateYAML v1.ConfigMap
-	err = mgr.GetAPIReader().Get(ctx, kclient.ObjectKey{
+	updateID, err := getUpdateID(ctx, mgr, kclient.ObjectKey{
 		Namespace: agentNamespace,
 		Name:      agentName + "-updater",
-	}, &updateYAML)
-	switch {
-	case apierrors.IsNotFound(err):
-		updateID, err = uuid.NewRandom()
-		if err != nil {
-			ctrl.Log.Error(err, "failed to generate updater ID, exiting")
-			os.Exit(1)
-		}
-		ctrl.Log.Info("generated new updater ID", "id", updateID)
-	case err != nil:
-		ctrl.Log.Error(err, "failed to generate updater ID, exiting")
+	})
+	if err != nil {
+		ctrl.Log.Error(err, "failed to get updater ID, exiting")
 		os.Exit(1)
-	default:
-		updateID, err = uuid.Parse(updateYAML.Data[agent.BinaryName+".id"])
-		if err != nil {
-			ctrl.Log.Error(err, "updater configmap is malformed, canary deployment may fail", "configmap", updateYAML)
-		}
 	}
 
 	// Craft the version getter and update triggers based on the configuration (use RFD-109 APIs, RFD-184, or both).
@@ -362,4 +350,48 @@ func main() {
 		ctrl.Log.Error(err, "failed to start manager, exiting")
 		os.Exit(1)
 	}
+}
+
+// getUpdateID returns the update ID from the updater configmap, creating it if it does not exist.
+func getUpdateID(ctx context.Context, mgr manager.Manager, ref kclient.ObjectKey) (uuid.UUID, error) {
+	// This should always succeed after two tries, as a conflict between read/create
+	// will always be resolved on the final read.
+	for range 2 {
+		var updateID uuid.UUID
+		var updateYAML v1.ConfigMap
+		err := mgr.GetAPIReader().Get(ctx, ref, &updateYAML)
+		if apierrors.IsNotFound(err) {
+			updateID, err = uuid.NewRandom()
+			if err != nil {
+				return uuid.Nil, trace.Wrap(err, "failed to generate updater ID")
+			}
+			updateYAML = v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: ref.Namespace,
+					Name:      ref.Name,
+				},
+				Data: map[string]string{
+					agent.BinaryName + ".id": updateID.String(),
+				},
+			}
+			if err = mgr.GetClient().Create(ctx, &updateYAML); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					ctrl.Log.Info("retrying updater configmap read due to conflict")
+					continue
+				}
+				return uuid.Nil, trace.Wrap(err, "failed to persist updater configmap")
+			}
+			ctrl.Log.Info("generated new updater ID", "id", updateID)
+			return updateID, nil
+		}
+		if err != nil {
+			return uuid.Nil, trace.Wrap(err, "failed to retrieve updater configmap")
+		}
+		updateID, err = uuid.Parse(updateYAML.Data[agent.BinaryName+".id"])
+		if err != nil {
+			ctrl.Log.Error(err, "updater configmap is malformed, canary deployment may fail", "configmap", updateYAML)
+		}
+		return uuid.Nil, nil // proceed with empty UUID instead of crashing or deleting user data
+	}
+	return uuid.Nil, trace.Errorf("failing due to multiple conflicts")
 }

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -175,7 +175,7 @@ func main() {
 	// all version getter implementations to accept an ID dynamically in GetVersion.
 	var updateID uuid.UUID
 	var updateYAML v1.ConfigMap
-	err = mgr.GetClient().Get(ctx, kclient.ObjectKey{
+	err = mgr.GetAPIReader().Get(ctx, kclient.ObjectKey{
 		Namespace: agentNamespace,
 		Name:      agentName + "-updater",
 	}, &updateYAML)

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -313,9 +313,19 @@ func main() {
 		baseImage,
 	)
 
+	statusWriter := controller.StatusWriter{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		UpdateID:         updateID,
+		UpdateGroup:      updateGroup,
+		UpdateConfigName: updateConfigName,
+		ProxyAddress:     proxyAddress,
+	}
+
 	// Controller registration
 	deploymentController := controller.DeploymentVersionUpdater{
 		VersionUpdater: versionUpdater,
+		StatusWriter:   statusWriter,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 	}
@@ -326,13 +336,10 @@ func main() {
 	}
 
 	statefulsetController := controller.StatefulSetVersionUpdater{
-		VersionUpdater:   versionUpdater,
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		UpdateID:         updateID,
-		UpdateGroup:      updateGroup,
-		UpdateConfigName: updateConfigName,
-		ProxyAddress:     proxyAddress,
+		VersionUpdater: versionUpdater,
+		StatusWriter:   statusWriter,
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
 	}
 
 	if err := statefulsetController.SetupWithManager(mgr); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/status_writer.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package controller
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gravitational/teleport/lib/autoupdate/agent"
+)
+
+const updaterIDFile = agent.BinaryName + ".id"
+
+type StatusWriter struct {
+	kclient.Client
+	// Scheme for Kubernetes objects.
+	Scheme *runtime.Scheme
+	// UpdateID is the unique ID of the updater.
+	UpdateID uuid.UUID
+	// UpdateGroup is the group of the updater.
+	UpdateGroup string
+	// UpdateConfigName is the name of the configmap containing the updater status.
+	UpdateConfigName string
+	// ProxyAddress is the address of the proxy.
+	ProxyAddress string
+}
+
+// writeStatus updates the configmap with the latest status of the updater.
+func (c *StatusWriter) writeStatus(ctx context.Context, owner metav1.Object, version string, failed bool) error {
+	log := ctrllog.FromContext(ctx)
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      c.UpdateConfigName,
+			Namespace: owner.GetNamespace(),
+		},
+	}
+	op, err := controllerutil.CreateOrUpdate(ctx, c.Client, cm, func() error {
+		if err := c.generateData(ctx, cm, version, failed, time.Now()); err != nil {
+			return trace.Wrap(err)
+		}
+		// Setting the owner ref ensures that the configmap is reset if the statefulset is deleted.
+		return controllerutil.SetOwnerReference(owner, cm, c.Scheme)
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	log.V(1).Info("updater configmap reconciled",
+		"name", cm.Name,
+		"namespace", owner.GetNamespace(),
+		"op", string(op),
+		"failed", failed,
+		"version", version,
+	)
+	return nil
+}
+
+// generateData generates the data for the configmap based on the provided version and failed flag.
+func (c *StatusWriter) generateData(ctx context.Context, cm *corev1.ConfigMap, version string, failed bool, updateTime time.Time) error {
+	log := ctrllog.FromContext(ctx)
+	var config agent.UpdateConfig
+
+	switch s := cm.Data[agent.UpdateConfigName]; {
+	case len(s) > 0:
+		err := yaml.Unmarshal([]byte(s), &config)
+		if err == nil {
+			break
+		}
+		log.Error(err, "overwriting corrupted configmap data")
+		fallthrough
+	default:
+		config = agent.UpdateConfig{
+			Version: agent.UpdateConfigV1,
+			Kind:    agent.UpdateConfigKind,
+			Spec: agent.UpdateSpec{
+				Enabled: true,
+				Proxy:   c.ProxyAddress,
+				Group:   c.UpdateGroup,
+			},
+			Status: agent.UpdateStatus{
+				IDFile: filepath.Join("/etc/updater-config", updaterIDFile),
+				Active: agent.Revision{
+					Version: version,
+					// TODO: add enterprise and FIPS flags
+				},
+			},
+		}
+	}
+	// Update the status if the update failed or if the version is present and different from the active one.
+	if failed ||
+		(version != "" && config.Status.Active.Version != version) {
+		config.Status.Active.Version = version
+		config.Status.LastUpdate = &agent.LastUpdate{
+			Success: !failed,
+			Time:    updateTime.UTC().Truncate(time.Millisecond),
+			// TODO: set target version for update, requires GetVersion refactor
+		}
+	}
+	out, err := yaml.Marshal(config)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	cm.Data = map[string]string{
+		updaterIDFile:          c.UpdateID.String(),
+		agent.UpdateConfigName: string(out),
+	}
+	return nil
+}

--- a/integrations/kube-agent-updater/pkg/controller/status_writer.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer.go
@@ -55,7 +55,7 @@ func (c *StatusWriter) writeStatus(ctx context.Context, owner metav1.Object, ver
 	log := ctrllog.FromContext(ctx)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      owner.GetName() + "-update",
+			Name:      owner.GetName() + "-updater",
 			Namespace: owner.GetNamespace(),
 		},
 	}

--- a/integrations/kube-agent-updater/pkg/controller/status_writer.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer.go
@@ -46,8 +46,6 @@ type StatusWriter struct {
 	UpdateID uuid.UUID
 	// UpdateGroup is the group of the updater.
 	UpdateGroup string
-	// UpdateConfigName is the name of the configmap containing the updater status.
-	UpdateConfigName string
 	// ProxyAddress is the address of the proxy.
 	ProxyAddress string
 }
@@ -57,7 +55,7 @@ func (c *StatusWriter) writeStatus(ctx context.Context, owner metav1.Object, ver
 	log := ctrllog.FromContext(ctx)
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.UpdateConfigName,
+			Name:      owner.GetName() + "-update",
 			Namespace: owner.GetNamespace(),
 		},
 	}

--- a/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
@@ -1,0 +1,184 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gravitational/teleport/lib/autoupdate/agent"
+)
+
+func TestGenerateData(t *testing.T) {
+	tests := []struct {
+		name           string
+		data           map[string]string
+		version        string
+		failed         bool
+		updateGroup    string
+		proxyAddress   string
+		expectedConfig string
+	}{
+		{
+			name:         "new configmap",
+			version:      "1.0.0",
+			updateGroup:  "test-group",
+			proxyAddress: "proxy.example.com",
+			expectedConfig: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    active:
+        version: 1.0.0
+`,
+		},
+		{
+			name: "success",
+			data: map[string]string{
+				updaterIDFile: "old",
+				agent.UpdateConfigName: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    active:
+       version: 0.9.0
+`,
+			},
+			version:      "1.0.0",
+			updateGroup:  "test-group",
+			proxyAddress: "proxy.example.com",
+			expectedConfig: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    last_update:
+        success: true
+        time: 1970-01-01T00:00:01Z
+        target:
+            version: ""
+    active:
+        version: 1.0.0
+`,
+		},
+		{
+			name: "failure",
+			data: map[string]string{
+				updaterIDFile: "old",
+				agent.UpdateConfigName: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    active:
+       version: 1.0.0
+`,
+			},
+			version:      "1.0.0",
+			failed:       true,
+			updateGroup:  "test-group",
+			proxyAddress: "proxy.example.com",
+			expectedConfig: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    last_update:
+        success: false
+        time: 1970-01-01T00:00:01Z
+        target:
+            version: ""
+    active:
+        version: 1.0.0
+`,
+		},
+		{
+			name: "invalid defaults",
+			data: map[string]string{
+				agent.UpdateConfigName: `bad`,
+			},
+			version:      "1.0.0",
+			updateGroup:  "test-group",
+			proxyAddress: "proxy.example.com",
+			expectedConfig: `version: v1
+kind: update_config
+spec:
+    proxy: proxy.example.com
+    path: ""
+    group: test-group
+    enabled: true
+    pinned: false
+status:
+    id_file: /etc/updater-config/teleport-update.id
+    active:
+        version: 1.0.0
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sw := &StatusWriter{
+				UpdateID:     uuid.New(),
+				UpdateGroup:  tc.updateGroup,
+				ProxyAddress: tc.proxyAddress,
+			}
+			cm := &corev1.ConfigMap{
+				Data: tc.data,
+			}
+			updateTime := time.Unix(1, 0)
+			err := sw.generateData(t.Context(), cm, tc.version, tc.failed, updateTime)
+			require.NoError(t, err)
+			require.Len(t, cm.Data, 2)
+			require.Equal(t, cm.Data[agent.UpdateConfigName], tc.expectedConfig)
+			require.Equal(t, cm.Data[updaterIDFile], sw.UpdateID.String())
+		})
+	}
+}

--- a/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
@@ -177,8 +177,8 @@ status:
 			err := sw.generateData(t.Context(), cm, tc.version, tc.failed, updateTime)
 			require.NoError(t, err)
 			require.Len(t, cm.Data, 2)
-			require.Equal(t, cm.Data[agent.UpdateConfigName], tc.expectedConfig)
-			require.Equal(t, cm.Data[updaterIDFile], sw.UpdateID.String())
+			require.Equal(t, tc.expectedConfig, cm.Data[agent.UpdateConfigName])
+			require.Equal(t, sw.UpdateID.String(), cm.Data[updaterIDFile])
 		})
 	}
 }

--- a/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/status_writer_test.go
@@ -65,9 +65,9 @@ status:
 				agent.UpdateConfigName: `version: v1
 kind: update_config
 spec:
-    proxy: proxy.example.com
+    proxy: old-proxy.example.com
     path: ""
-    group: test-group
+    group: test-group-old
     enabled: true
     pinned: false
 status:

--- a/lib/autoupdate/agent/config.go
+++ b/lib/autoupdate/agent/config.go
@@ -40,12 +40,12 @@ const (
 )
 
 const (
-	// updateConfigName specifies the name of the file inside versionsDirName containing configuration for the teleport update.
-	updateConfigName = "update.yaml"
-
-	// UpdateConfig metadata
-	updateConfigVersion = "v1"
-	updateConfigKind    = "update_config"
+	// UpdateConfigName specifies the name of the file inside versionsDirName containing configuration for the teleport update.
+	UpdateConfigName = "update.yaml"
+	// UpdateConfigV1 specifies the version of the update.yaml file.
+	UpdateConfigV1 = "v1"
+	// UpdateConfigKind specifies the kind of the update.yaml file.
+	UpdateConfigKind = "update_config"
 )
 
 // UpdateConfig describes the update.yaml file schema.
@@ -196,8 +196,8 @@ func readConfig(path string) (*UpdateConfig, error) {
 	f, err := os.Open(path)
 	if errors.Is(err, fs.ErrNotExist) {
 		return &UpdateConfig{
-			Version: updateConfigVersion,
-			Kind:    updateConfigKind,
+			Version: UpdateConfigV1,
+			Kind:    UpdateConfigKind,
 		}, nil
 	}
 	if err != nil {
@@ -208,10 +208,10 @@ func readConfig(path string) (*UpdateConfig, error) {
 	if err := yaml.NewDecoder(f).Decode(&cfg); err != nil {
 		return nil, trace.Wrap(err, "failed to parse")
 	}
-	if k := cfg.Kind; k != updateConfigKind {
+	if k := cfg.Kind; k != UpdateConfigKind {
 		return nil, trace.Errorf("invalid kind %s", k)
 	}
-	if v := cfg.Version; v != updateConfigVersion {
+	if v := cfg.Version; v != UpdateConfigV1 {
 		return nil, trace.Errorf("invalid version %s", v)
 	}
 	return &cfg, nil

--- a/lib/autoupdate/agent/integrations.go
+++ b/lib/autoupdate/agent/integrations.go
@@ -56,7 +56,7 @@ func IsManagedByUpdater() (bool, error) {
 	if p == "" {
 		return false, nil
 	}
-	_, err = os.Stat(filepath.Join(p, updateConfigName))
+	_, err = os.Stat(filepath.Join(p, UpdateConfigName))
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
@@ -102,7 +102,7 @@ func stablePathForBinary(origPath, defaultPath string) (string, error) {
 	// This is determined by looking for ../../../update.yaml, if we are in ../../../versions.
 	// update.yaml will always have the target path if Managed Updates are enabled.
 	if p := findParentMatching(origPath, versionsDirName, 4); p != "" {
-		cfgPath := filepath.Join(p, updateConfigName)
+		cfgPath := filepath.Join(p, UpdateConfigName)
 		cfg, err := readConfig(cfgPath)
 		if err == nil && cfg.Spec.Path != "" {
 			// If the path exists and resolves, it is always the best candidate path,
@@ -152,7 +152,7 @@ func findConfigFile() (string, error) {
 	if p == "" {
 		return "", trace.Errorf("installation not managed by updater")
 	}
-	return filepath.Join(p, updateConfigName), nil
+	return filepath.Join(p, UpdateConfigName), nil
 }
 
 // ReadHelloUpdaterInfo reads the updater config and generates a proto.UpdaterV2Info

--- a/lib/autoupdate/agent/integrations_test.go
+++ b/lib/autoupdate/agent/integrations_test.go
@@ -182,10 +182,10 @@ func TestStablePath(t *testing.T) {
 			if tt.path != "" && !filepath.IsAbs(tt.path) {
 				tt.path = filepath.Join(nsDir, tt.path)
 				createPath = filepath.Join(nsDir, "bin")
-				cfgPath := filepath.Join(nsDir, updateConfigName)
+				cfgPath := filepath.Join(nsDir, UpdateConfigName)
 				err := writeConfig(cfgPath, &UpdateConfig{
-					Version: updateConfigVersion,
-					Kind:    updateConfigKind,
+					Version: UpdateConfigV1,
+					Kind:    UpdateConfigKind,
 					Spec: UpdateSpec{
 						Path: createPath,
 					},

--- a/lib/autoupdate/agent/setup.go
+++ b/lib/autoupdate/agent/setup.go
@@ -577,7 +577,7 @@ func (ns *Namespace) writeConfigFiles(ctx context.Context, path string, rev Revi
 		InstallSuffix:     ns.name,
 		InstallDir:        ns.installDir,
 		Path:              path,
-		UpdaterConfigFile: filepath.Join(ns.Dir(), updateConfigName),
+		UpdaterConfigFile: filepath.Join(ns.Dir(), UpdateConfigName),
 	}
 
 	for _, v := range []struct {

--- a/lib/autoupdate/agent/updater.go
+++ b/lib/autoupdate/agent/updater.go
@@ -138,7 +138,7 @@ func NewLocalUpdater(cfg LocalUpdaterConfig, ns *Namespace) (*Updater, error) {
 		Log:                cfg.Log,
 		Pool:               certPool,
 		InsecureSkipVerify: cfg.InsecureSkipVerify,
-		UpdateConfigFile:   filepath.Join(ns.Dir(), updateConfigName),
+		UpdateConfigFile:   filepath.Join(ns.Dir(), UpdateConfigName),
 		UpdateIDFile:       ns.updaterIDFile,
 		MachineIDFile:      systemdMachineIDFile,
 		TeleportIDFile:     filepath.Join(ns.dataDir, teleportHostIDFileName),
@@ -418,7 +418,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 	// Read configuration from update.yaml and override any new values passed as flags.
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	origCfg := cfg.Copy()
 	// Set the desired state.
@@ -470,7 +470,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 	// The written file does not contain updated versions, only the desired configuration.
 	// It is reverted if the installation fails to start, so that configuration is not persisted.
 	if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
-		return trace.Wrap(err, "failed to write %s", updateConfigName)
+		return trace.Wrap(err, "failed to write %s", UpdateConfigName)
 	}
 	defer func() {
 		if err != nil {
@@ -496,7 +496,7 @@ func (u *Updater) Install(ctx context.Context, override OverrideConfig) (err err
 	// Note: skip_version is never set on failed enable, only failed update.
 
 	if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
-		return trace.Wrap(err, "failed to write %s", updateConfigName)
+		return trace.Wrap(err, "failed to write %s", UpdateConfigName)
 	}
 	u.Log.InfoContext(ctx, "Configuration updated.")
 	u.LogConfigWarnings(ctx, cfg.Spec.Path)
@@ -530,7 +530,7 @@ func sameProxies(a, b string) bool {
 func (u *Updater) Remove(ctx context.Context, force bool) error {
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if err := updateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return trace.Wrap(err)
@@ -785,7 +785,7 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 	// Read configuration from update.yaml.
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return out, trace.Wrap(err, "failed to read %s", updateConfigName)
+		return out, trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if err := updateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return out, trace.Wrap(err)
@@ -812,7 +812,7 @@ func (u *Updater) Status(ctx context.Context) (Status, error) {
 func (u *Updater) Disable(ctx context.Context) error {
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if !cfg.Spec.Enabled {
 		u.Log.InfoContext(ctx, "Automatic updates already disabled.")
@@ -820,7 +820,7 @@ func (u *Updater) Disable(ctx context.Context) error {
 	}
 	cfg.Spec.Enabled = false
 	if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
-		return trace.Wrap(err, "failed to write %s", updateConfigName)
+		return trace.Wrap(err, "failed to write %s", UpdateConfigName)
 	}
 	return nil
 }
@@ -830,7 +830,7 @@ func (u *Updater) Disable(ctx context.Context) error {
 func (u *Updater) Unpin(ctx context.Context) error {
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if !cfg.Spec.Pinned {
 		u.Log.InfoContext(ctx, "Current version not pinned.", activeKey, cfg.Status.Active)
@@ -838,7 +838,7 @@ func (u *Updater) Unpin(ctx context.Context) error {
 	}
 	cfg.Spec.Pinned = false
 	if err := writeConfig(u.UpdateConfigFile, cfg); err != nil {
-		return trace.Wrap(err, "failed to write %s", updateConfigName)
+		return trace.Wrap(err, "failed to write %s", UpdateConfigName)
 	}
 	return nil
 }
@@ -852,7 +852,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	// Read configuration from update.yaml and override any new values passed as flags.
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if err := updateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return trace.Wrap(err)
@@ -872,7 +872,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	}
 
 	if cfg.Spec.Path == "" {
-		return trace.Errorf("failed to read destination path for binary links from %s", updateConfigName)
+		return trace.Errorf("failed to read destination path for binary links from %s", UpdateConfigName)
 	}
 	cfg.Status.IDFile = u.UpdateIDFile
 
@@ -945,7 +945,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 	}
 	writeErr := writeConfig(u.UpdateConfigFile, cfg)
 	if writeErr != nil {
-		writeErr = trace.Wrap(writeErr, "failed to write %s", updateConfigName)
+		writeErr = trace.Wrap(writeErr, "failed to write %s", UpdateConfigName)
 	} else {
 		u.Log.InfoContext(ctx, "Configuration updated.")
 	}
@@ -959,7 +959,7 @@ func (u *Updater) Update(ctx context.Context, now bool) error {
 
 func (u *Updater) find(ctx context.Context, cfg *UpdateConfig, id string) (FindResp, error) {
 	if cfg.Spec.Proxy == "" {
-		return FindResp{}, trace.Errorf("Teleport proxy URL must be specified with --proxy or present in %s", updateConfigName)
+		return FindResp{}, trace.Errorf("Teleport proxy URL must be specified with --proxy or present in %s", UpdateConfigName)
 	}
 	addr, err := libutils.ParseAddr(cfg.Spec.Proxy)
 	if err != nil {
@@ -1381,7 +1381,7 @@ func (u *Updater) cleanup(ctx context.Context, cfg *UpdateConfig, keep []Revisio
 func (u *Updater) LinkPackage(ctx context.Context) error {
 	cfg, err := readConfig(u.UpdateConfigFile)
 	if err != nil {
-		return trace.Wrap(err, "failed to read %s", updateConfigName)
+		return trace.Wrap(err, "failed to read %s", UpdateConfigName)
 	}
 	if err := updateConfigSpec(&cfg.Spec, OverrideConfig{}); err != nil {
 		return trace.Wrap(err)

--- a/lib/autoupdate/agent/updater_test.go
+++ b/lib/autoupdate/agent/updater_test.go
@@ -95,8 +95,8 @@ func TestUpdater_Disable(t *testing.T) {
 		{
 			name: "enabled",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: true,
 				},
@@ -105,8 +105,8 @@ func TestUpdater_Disable(t *testing.T) {
 		{
 			name: "already disabled",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -132,7 +132,7 @@ func TestUpdater_Disable(t *testing.T) {
 			ns := &Namespace{installDir: dir}
 			_, err := ns.Init()
 			require.NoError(t, err)
-			cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+			cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{
 				InsecureSkipVerify: true,
 			}, ns)
@@ -182,8 +182,8 @@ func TestUpdater_Unpin(t *testing.T) {
 		{
 			name: "pinned",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Pinned: true,
 				},
@@ -192,8 +192,8 @@ func TestUpdater_Unpin(t *testing.T) {
 		{
 			name: "not pinned",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Pinned: false,
 				},
@@ -219,7 +219,7 @@ func TestUpdater_Unpin(t *testing.T) {
 			ns := &Namespace{installDir: dir}
 			_, err := ns.Init()
 			require.NoError(t, err)
-			cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+			cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{
 				InsecureSkipVerify: true,
@@ -290,8 +290,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates enabled during window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -315,8 +315,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates enabled now",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -340,8 +340,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates enabled now, not started or enabled",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -367,8 +367,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates disabled during window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -384,8 +384,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "missing path during window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Group:   "group",
 					BaseURL: "https://example.com",
@@ -401,8 +401,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates enabled outside of window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -418,8 +418,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "updates disabled outside of window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Group:   "group",
@@ -434,8 +434,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "insecure URL",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "http://example.com",
@@ -449,8 +449,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "install error",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Enabled: true,
@@ -467,8 +467,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "version already installed in window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -484,8 +484,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "version already installed outside of window",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -500,8 +500,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "version detects as linked",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -527,8 +527,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "backup version removed on install",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -555,8 +555,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "backup version is linked",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -583,8 +583,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "backup version kept when no change",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -604,8 +604,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "FIPS and Enterprise flags",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -638,8 +638,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "setup fails",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -669,8 +669,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "agpl requires base URL",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					Enabled: true,
@@ -692,8 +692,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "skip version",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -711,8 +711,8 @@ func TestUpdater_Update(t *testing.T) {
 		{
 			name: "pinned version",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path:    defaultPathDir,
 					BaseURL: "https://example.com",
@@ -762,7 +762,7 @@ func TestUpdater_Update(t *testing.T) {
 				}
 				_, err := ns.Init()
 				require.NoError(t, err)
-				cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+				cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 				updater, err := NewLocalUpdater(LocalUpdaterConfig{
 					InsecureSkipVerify: true,
@@ -933,8 +933,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "updates enabled",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: true,
 				},
@@ -946,8 +946,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "pinned",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Pinned: true,
 				},
@@ -959,8 +959,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "updates disabled",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -972,8 +972,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "already linked",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -986,8 +986,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "link error",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -1012,8 +1012,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "systemd is not installed, already linked",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -1025,8 +1025,8 @@ func TestUpdater_LinkPackage(t *testing.T) {
 		{
 			name: "SELinux blocks service from being read",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: false,
 				},
@@ -1044,7 +1044,7 @@ func TestUpdater_LinkPackage(t *testing.T) {
 			ns := &Namespace{installDir: dir}
 			_, err := ns.Init()
 			require.NoError(t, err)
-			cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+			cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{
 				InsecureSkipVerify: true,
@@ -1125,16 +1125,16 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no active version",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 			},
 			teardownCalls: 1,
 		},
 		{
 			name: "no conflicting system links, process disabled, force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision(version, 0),
 				},
@@ -1146,8 +1146,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process active, force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1164,8 +1164,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1182,8 +1182,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, no force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1198,8 +1198,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, no systemd, force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1217,8 +1217,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, custom path, force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: "custom",
 				},
@@ -1233,8 +1233,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, custom path, no force",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: "custom",
 				},
@@ -1247,8 +1247,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "no system links, process disabled, custom path, no force, custom service",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: "custom",
 				},
@@ -1264,8 +1264,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1281,8 +1281,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version with tbot",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1298,8 +1298,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version, no systemd",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1317,8 +1317,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version, no reload",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1334,8 +1334,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version, sync error",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1352,8 +1352,8 @@ func TestUpdater_Remove(t *testing.T) {
 		{
 			name: "active version, reload error",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Path: defaultPathDir,
 				},
@@ -1377,7 +1377,7 @@ func TestUpdater_Remove(t *testing.T) {
 				ns := &Namespace{installDir: dir}
 				_, err := ns.Init()
 				require.NoError(t, err)
-				cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+				cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 				updater, err := NewLocalUpdater(LocalUpdaterConfig{
 					InsecureSkipVerify: true,
@@ -1514,8 +1514,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "config from file",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Enabled: true,
 					Group:   "group",
@@ -1537,8 +1537,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "config from user",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					Group:   "old-group",
 					BaseURL: "https://example.com/old",
@@ -1567,8 +1567,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "defaults",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("old-version", 0),
 				},
@@ -1584,8 +1584,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "override skip",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("old-version", 0),
 					Skip:   toPtr(NewRevision("16.3.0", 0)),
@@ -1602,8 +1602,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "insecure URL",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					BaseURL: "http://example.com",
 				},
@@ -1614,8 +1614,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "install error",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 			},
 			installErr: errors.New("install error"),
 
@@ -1627,8 +1627,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "agpl requires base URL",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 			},
 			agpl:         true,
 			requestGroup: "default",
@@ -1637,8 +1637,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "version already installed",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("16.3.0", 0),
 				},
@@ -1654,8 +1654,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "backup version removed on install",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("old-version", 0),
 					Backup: toPtr(NewRevision("backup-version", 0)),
@@ -1673,8 +1673,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "backup version kept for validation",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("16.3.0", 0),
 					Backup: toPtr(NewRevision("backup-version", 0)),
@@ -1730,8 +1730,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "setup fails already installed",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Status: UpdateStatus{
 					Active: NewRevision("16.3.0", 0),
 				},
@@ -1771,8 +1771,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "install selinux from file",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					SELinuxSSH: true,
 				},
@@ -1793,8 +1793,8 @@ func TestUpdater_Install(t *testing.T) {
 		{
 			name: "install selinux from user",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					SELinuxSSH: false,
 				},
@@ -1835,7 +1835,7 @@ func TestUpdater_Install(t *testing.T) {
 				}
 				_, err := ns.Init()
 				require.NoError(t, err)
-				cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+				cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 				updater, err := NewLocalUpdater(LocalUpdaterConfig{
 					InsecureSkipVerify: true,
@@ -2148,8 +2148,8 @@ func TestUpdater_Setup(t *testing.T) {
 		{
 			name: "install selinux false in file",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					SELinuxSSH: false,
 				},
@@ -2161,8 +2161,8 @@ func TestUpdater_Setup(t *testing.T) {
 		{
 			name: "remove selinux",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					SELinuxSSH: true,
 				},
@@ -2175,8 +2175,8 @@ func TestUpdater_Setup(t *testing.T) {
 		{
 			name: "selinux no-op",
 			cfg: &UpdateConfig{
-				Version: updateConfigVersion,
-				Kind:    updateConfigKind,
+				Version: UpdateConfigV1,
+				Kind:    UpdateConfigKind,
 				Spec: UpdateSpec{
 					SELinuxSSH: false,
 				},
@@ -2196,7 +2196,7 @@ func TestUpdater_Setup(t *testing.T) {
 			}
 			_, err := ns.Init()
 			require.NoError(t, err)
-			cfgPath := filepath.Join(ns.Dir(), updateConfigName)
+			cfgPath := filepath.Join(ns.Dir(), UpdateConfigName)
 
 			updater, err := NewLocalUpdater(LocalUpdaterConfig{}, ns)
 			require.NoError(t, err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1373,7 +1373,8 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 			hello.ExternalUpgraderVersion = "v" + upgraderVersion.String()
 		}
 
-		if upgraderKind == types.UpgraderKindTeleportUpdate {
+		if upgraderKind == types.UpgraderKindTeleportUpdate ||
+			upgraderKind == types.UpgraderKindKubeController {
 			info, err := autoupdate.ReadHelloUpdaterInfo(supervisor.ExitContext(), cfg.Logger, hostID)
 			if err != nil {
 				// Failing to detect teleport-update info is not fatal, we continue.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1376,6 +1376,12 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 		if upgraderKind == types.UpgraderKindTeleportUpdate ||
 			upgraderKind == types.UpgraderKindKubeController {
 			info, err := autoupdate.ReadHelloUpdaterInfo(supervisor.ExitContext(), cfg.Logger, hostID)
+			// If the config file is not present for Kubernetes upgraders, do not set the updater info.
+			// This ensures that older chart versions maintain the same behavior when used with newer Teleport.
+			if errors.Is(err, autoupdate.ErrConfigNotFound) &&
+				upgraderKind == types.UpgraderKindKubeController {
+				return hello, nil
+			}
 			if err != nil {
 				// Failing to detect updater info is not fatal, we continue.
 				cfg.Logger.WarnContext(supervisor.ExitContext(), "Error recovering updater status, this might affect automatic update tracking and progress.", "error", err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1377,8 +1377,8 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 			upgraderKind == types.UpgraderKindKubeController {
 			info, err := autoupdate.ReadHelloUpdaterInfo(supervisor.ExitContext(), cfg.Logger, hostID)
 			if err != nil {
-				// Failing to detect teleport-update info is not fatal, we continue.
-				cfg.Logger.WarnContext(supervisor.ExitContext(), "Error recovering teleport-update status, this might affect automatic update tracking and progress.", "error", err)
+				// Failing to detect updater info is not fatal, we continue.
+				cfg.Logger.WarnContext(supervisor.ExitContext(), "Error recovering updater status, this might affect automatic update tracking and progress.", "error", err)
 				info = &types.UpdaterV2Info{UpdaterStatus: types.UpdaterStatus_UPDATER_STATUS_UNREADABLE}
 			}
 			hello.UpdaterInfo = info


### PR DESCRIPTION
Backport #61360 to branch/v18

changelog: Add support for selecting Kube agents as Managed Updates v2 canaries. Important: the default update group is corrected to "default" from "stable/cloud"
