### PR TITLE
Fix backwards compatibility with Proxy Recording mode fixes

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1200,7 +1200,7 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 		reply, payload, err := s.remoteClient.SendRequest(ctx, teleport.SessionIDQueryRequestV2, true, nil)
 		if err != nil {
 			s.logger.WarnContext(ctx, "Failed to send session ID query request", "error", err)
-		} else if !reply && payload != nil {
+		} else if !reply && len(payload) != 0 {
 			// If the target node replies with a payload, this means that the connection itself has been rejected,
 			// presumably due to an authz error, and the server is trying to communicate the error with the first
 			// req/chan received.


### PR DESCRIPTION
Fix a backwards compatibility issues in https://github.com/gravitational/teleport/pull/59850 where an old node would fail to respond to the new `session-id-query-v2@goteleport.com` query and the up to date proxy would treat it as a fatal error for the session:

```
> tsh ssh root@cvasquez-desktop-discovery-sh                                   
ERROR: ssh: rejected: administratively prohibited (remote session open failed: )
```

<details>
<summary>Manual Tests</summary>

Last run: 1aa58e9b0969b5d2526c0aa53938959115c2a7e7

Backwards compatibility:
| Proxy | Node  |  ✅  |
|------|-------|------|
| new | new | ✅ |
| new | old  | ✅ |
| old  | new | ✅ |
| old  | old   | ✅ |

</details>