### PR TITLE
[v17] Remove 'wasm-pack' Build Dependency

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -66,7 +66,7 @@ jobs:
         run: |
           rustup override set ${{ env.RUST_VERSION }}
 
-      - name: Install wasm-pack
+      - name: Install wasm-deps
         run: make ensure-wasm-deps
 
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ default.etcd
 out
 build
 !/web/packages/build
+/web/packages/shared/libs/ironrdp/pkg/**
 *.o
 *.a
 *.so

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ CARGO_TARGET_linux_386 := i686-unknown-linux-gnu
 CARGO_TARGET_linux_amd64 := x86_64-unknown-linux-gnu
 
 CARGO_TARGET := --target=$(RUST_TARGET_ARCH)
+CARGO_WASM_TARGET := wasm32-unknown-unknown
 
 # If set to 1, Windows RDP client is not built.
 RDPCLIENT_SKIP_BUILD ?= 0
@@ -488,6 +489,26 @@ ifeq ("$(with_rdpclient)", "yes")
 		cargo build -p rdp-client $(if $(FIPS),--features=fips) --release --locked $(CARGO_TARGET)
 endif
 
+define ironrdp_package_json
+{
+  "name": "ironrdp",
+  "version": "0.1.0",
+  "module": "ironrdp.js",
+  "types": "ironrdp.d.ts",
+  "files": ["ironrdp_bg.wasm","ironrdp.js","ironrdp.d.ts"],
+  "sideEffects": ["./snippets/*"]
+}
+endef
+export ironrdp_package_json
+
+.PHONY: build-ironrdp-wasm
+build-ironrdp-wasm: ironrdp = web/packages/shared/libs/ironrdp
+build-ironrdp-wasm: ensure-wasm-deps
+	cargo build --package ironrdp --lib --target $(CARGO_WASM_TARGET) --release
+	wasm-opt target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm -o target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm -O
+	wasm-bindgen target/$(CARGO_WASM_TARGET)/release/ironrdp.wasm --out-dir $(ironrdp)/pkg --typescript --target web
+	printenv ironrdp_package_json > $(ironrdp)/pkg/package.json
+
 # Build libfido2 and dependencies for MacOS. Uses exported C_ARCH variable defined earlier.
 .PHONY: build-fido2
 build-fido2:
@@ -539,7 +560,7 @@ endif
 	rm -f *.zip
 	rm -f gitref.go
 	rm -rf build.assets/tooling/bin
-	# Clean up wasm-pack build artifacts
+	# Clean up wasm build artifacts
 	rm -rf web/packages/shared/libs/ironrdp/pkg/
 
 .PHONY: clean-ui
@@ -1820,29 +1841,18 @@ ensure-js-deps:
 ifeq ($(WEBASSETS_SKIP_BUILD),1)
 ensure-wasm-deps:
 else
-ensure-wasm-deps: ensure-wasm-pack ensure-wasm-bindgen
+ensure-wasm-deps: ensure-wasm-bindgen ensure-wasm-opt rustup-install-wasm-toolchain
 
-# Get the version of wasm-bindgen from cargo, as that is what wasm-pack is
-# going to do when it checks for the right version. The buildboxes do not
-# have jq installed (yet), so have a hacky awk version on standby.
-CARGO_GET_VERSION_JQ = cargo metadata --locked --format-version=1 | jq -r 'first(.packages[] | select(.name? == "$(1)") | .version)'
-CARGO_GET_VERSION_AWK = awk -F '[ ="]+' '/^name = "$(1)"$$/ {inpkg = 1} inpkg && $$1 == "version" {print $$2; exit}' Cargo.lock
+WASM_BINDGEN_VERSION = $(shell awk ' \
+  $$1 == "name" && $$3 == "\"wasm-bindgen\"" { in_pkg=1; next } \
+  in_pkg && $$1 == "version" { gsub(/"/, "", $$3); print $$3; exit } \
+' Cargo.lock)
 
-BIN_JQ = $(shell which jq 2>/dev/null)
-CARGO_GET_VERSION = $(if $(BIN_JQ),$(CARGO_GET_VERSION_JQ),$(CARGO_GET_VERSION_AWK))
+.PHONY: print-wasm-bindgen-version
+print-wasm-bindgen-version:
+	@echo $(WASM_BINDGEN_VERSION)
 
-ensure-wasm-pack: NEED_VERSION = $(shell $(MAKE) --no-print-directory -s -C build.assets print-wasm-pack-version)
-ensure-wasm-pack: INSTALLED_VERSION = $(word 2,$(shell wasm-pack --version 2>/dev/null))
-ensure-wasm-pack:
-	$(if $(filter-out $(INSTALLED_VERSION),$(NEED_VERSION)),\
-		cargo install wasm-pack --force --locked --version "$(NEED_VERSION)", \
-		@echo wasm-pack up-to-date: $(INSTALLED_VERSION) \
-	)
-
-# TODO: Use CARGO_GET_VERSION_AWK instead of hardcoded version
-#       On 386 Arch, calling the variable produces a malformed command that fails the build.
-#ensure-wasm-bindgen: NEED_VERSION = $(shell $(call CARGO_GET_VERSION,wasm-bindgen))
-ensure-wasm-bindgen: NEED_VERSION = 0.2.95
+ensure-wasm-bindgen: NEED_VERSION = $(WASM_BINDGEN_VERSION)
 ensure-wasm-bindgen: INSTALLED_VERSION = $(word 2,$(shell wasm-bindgen --version 2>/dev/null))
 ensure-wasm-bindgen:
 ifneq ($(CI)$(FORCE),)
@@ -1858,6 +1868,11 @@ else
 	)
 endif
 endif
+
+.PHONY: ensure-wasm-opt
+ensure-wasm-opt: WASM_OPT_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-wasm-opt-version)
+ensure-wasm-opt:
+	cargo install --locked wasm-opt@$(WASM_OPT_VERSION)
 
 .PHONY: build-ui
 build-ui: ensure-js-deps ensure-wasm-deps
@@ -1883,6 +1898,10 @@ rustup-set-version:
 .PHONY: rustup-install-target-toolchain
 rustup-install-target-toolchain: rustup-set-version
 	rustup target add $(RUST_TARGET_ARCH)
+
+.PHONY: rustup-install-wasm-toolchain
+rustup-install-wasm-toolchain: rustup-set-version
+	rustup target add $(CARGO_WASM_TARGET)
 
 # changelog generates PR changelog between the provided base tag and the tip of
 # the specified branch.

--- a/README.md
+++ b/README.md
@@ -150,9 +150,6 @@ Ensure you have installed correct versions of necessary dependencies:
   * [`pnpm`](https://pnpm.io/installation#using-corepack). If you have Node.js installed, run `corepack enable pnpm` to make `pnpm` available.
   * If you prefer not to install/use pnpm, but have docker available, you can run `make docker-ui` instead.
   * The `Rust` and `Cargo` version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11) (search for `RUST_VERSION`) are required.
-  * The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required.
-  * [`binaryen`](https://github.com/WebAssembly/binaryen) (which contains `wasm-opt`) is required to be installed manually
-    on linux aarch64 (64-bit ARM). You can check if it's already installed on your system by running `which wasm-opt`. If not you can install it like `apt-get install binaryen` (for Debian-based Linux). `wasm-pack` will install this automatically on other platforms.
 
 For an example of Dev Environment setup on a Mac, see [these instructions](BUILD_macos.md).
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -182,8 +182,6 @@ RUN apt-get -y update && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
     tee /etc/apt/sources.list.d/hashicorp.list > /dev/null && \
     apt-get update && apt-get install terraform -y --no-install-recommends && \
-    # Manually install the wasm-opt binary from the binaryen package on ARM64.
-    if [ "$BUILDARCH" = "arm64" ]; then apt-get install -y binaryen; fi && \
     pip3 --no-cache-dir install yamllint && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \
@@ -229,9 +227,10 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustup target add wasm32-unknown-unknown && \
     if [ "$BUILDARCH" = "amd64" ]; then rustup target add aarch64-unknown-linux-gnu i686-unknown-linux-gnu; fi
 
-ARG WASM_PACK_VERSION
-# Install wasm-pack for targeting WebAssembly from Rust.
-RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
+ARG WASM_OPT_VERSION
+ARG WASM_BINDGEN_VERSION
+# Install wasm-bindgen-ci and wasm-opt for bulding rust webassembly module.
+RUN cargo install --locked wasm-opt@${WASM_OPT_VERSION} wasm-bindgen-cli@${WASM_BINDGEN_VERSION}
 
 # Switch back to root for the remaining instructions and keep it as the default
 # user.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -279,11 +279,6 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustc --version && \
     rustup target add wasm32-unknown-unknown
 
-# Install wasm-pack for targeting WebAssembly from Rust.
-ARG WASM_PACK_VERSION
-# scl enable is required to use the newer C compiler installed above. Without it, the build fails.
-RUN scl enable ${DEVTOOLSET} "cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}"
-
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.
 USER root

--- a/build.assets/Dockerfile-node
+++ b/build.assets/Dockerfile-node
@@ -49,8 +49,6 @@ RUN apt-get -y update && \
     # Used during tag builds to build the RPM package of Connect.
     rpm \
     && \
-    # Manually install the wasm-opt binary from the binaryen package on ARM64.
-    if [ "$BUILDARCH" = "arm64" ]; then apt-get install -y binaryen; fi && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/*
@@ -83,6 +81,7 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustup target add wasm32-unknown-unknown && \
     if [ "$BUILDARCH" = "amd64" ]; then rustup target add aarch64-unknown-linux-gnu; fi
 
-# Install wasm-pack for targeting WebAssembly from Rust.
-ARG WASM_PACK_VERSION
-RUN cargo install wasm-pack --locked --version ${WASM_PACK_VERSION}
+ARG WASM_OPT_VERSION
+ARG WASM_BINDGEN_VERSION
+# Install wasm-bindgen-ci and wasm-opt for bulding rust webassembly module.
+RUN cargo install --locked wasm-opt@${WASM_OPT_VERSION} wasm-bindgen-cli@${WASM_BINDGEN_VERSION}

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -56,6 +56,10 @@ endif
 # $(ARCH) is the target architecture we want to build for.
 REQUIRE_HOST_ARCH = $(if $(filter-out $(ARCH),$(RUNTIME_ARCH)),$(error Cannot cross-compile $@ $(ARCH) on $(RUNTIME_ARCH)))
 
+# Determine which version of wasm-bindgen should be installed on build containers
+# responsible for building webassets.
+WASM_BINDGEN_VERSION ?= $(shell $(MAKE) -C .. --no-print-directory  print-wasm-bindgen-version)
+
 # This determines which make target we call in this repo's top level Makefile when
 # make release in this Makefile is called. Currently this supports its default value
 # (release) and release-unix-preserving-webassets. See the release-arm target for
@@ -176,7 +180,8 @@ buildbox:
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg GOLANGCI_LINT_VERSION=$(GOLANGCI_LINT_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
+		--build-arg WASM_OPT_VERSION=$(WASM_OPT_VERSION) \
+		--build-arg WASM_BINDGEN_VERSION=$(WASM_BINDGEN_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg BUF_VERSION=$(BUF_VERSION) \
@@ -219,7 +224,6 @@ buildbox-centos7:
 		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
@@ -248,7 +252,6 @@ buildbox-centos7-fips:
 		--build-arg TARGETARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
@@ -297,7 +300,8 @@ buildbox-node:
 		--build-arg GID=$(GID) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
+		--build-arg WASM_OPT_VERSION=$(WASM_OPT_VERSION) \
+		--build-arg WASM_BINDGEN_VERSION=$(WASM_BINDGEN_VERSION) \
 		--cache-to type=inline \
 		--cache-from $(BUILDBOX_NODE) \
 		$(if $(PUSH),--push,--load) \
@@ -738,11 +742,18 @@ print-rust-version:
 	@echo $(RUST_VERSION)
 
 #
-# Print the wasm-pack version used to build Teleport.
+# Print the wasm-opt version used to build Teleport.
 #
-.PHONY:print-wasm-pack-version
-print-wasm-pack-version:
-	@echo $(WASM_PACK_VERSION)
+.PHONY:print-wasm-opt-version
+print-wasm-opt-version:
+	@echo $(WASM_OPT_VERSION)
+
+#
+# Print the wasm-bindgen version used to build Teleport.
+#
+.PHONY:print-wasm-bindgen-version
+print-wasm-bindgen-version:
+	@echo $(WASM_BINDGEN_VERSION)
 
 #
 # Print the Node version used to build Teleport Connect.

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -11,7 +11,7 @@ NODE_VERSION ?= 22.21.0
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.81.0
-WASM_PACK_VERSION ?= 0.12.1
+WASM_OPT_VERSION ?= 0.116.1
 LIBBPF_VERSION ?= 1.2.2
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -164,23 +164,15 @@ function Enable-Node {
     }
 }
 
-function Install-WasmPack {
+function Install-WasmDeps {
     <#
     .SYNOPSIS
-        Builds and installs wasm-pack and dependent tooling.
+        Builds and installs wasm-bindgen-cli, wasm-opt, and wasm32-unknown-unknown toolchain.
     #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory)]
-        [string] $WasmPackVersion
-    )
-    begin {
-        Write-Host "::group::Installing wasm-pack $WasmPackVersion"
-        # TODO(camscale): Don't hard-code wasm-binden-cli version
-        cargo install wasm-bindgen-cli --locked --version 0.2.95
-        cargo install wasm-pack --locked --version "$WasmPackVersion"
-        Write-Host "::endgroup::"
-    }
+    
+    Write-Host "::group::Installing wasm-bindgen-cli, wasm-opt, and wasm32-unknown-unknown toolchain"
+    make -C "$TeleportSourceDirectory" ensure-wasm-deps
+    Write-Host "::endgroup::"
 }
 
 function Install-Wintun {
@@ -314,8 +306,7 @@ function Install-BuildRequirements {
         $GoVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-go-version).TrimStart("go")
         Install-Go -GoVersion "$GoVersion" -ToolchainDir "$InstallDirectory"
 
-        $WasmPackVersion = $(make --no-print-directory -C "$TeleportSourceDirectory/build.assets" print-wasm-pack-version).Trim()
-        Install-WasmPack -WasmPackVersion "$WasmPackVersion"
+        Install-WasmDeps
     }
     Write-Host $("All build requirements installed in {0:g}" -f $CommandDuration)
 }

--- a/devbox.json
+++ b/devbox.json
@@ -14,7 +14,6 @@
     "yamllint@latest",
     "zlib@latest",
     "rustup@latest",
-    "wasm-pack@latest",
     "wasm-bindgen-cli@latest",
     "pkg-config@latest",
 

--- a/devbox.lock
+++ b/devbox.lock
@@ -344,26 +344,6 @@
         }
       }
     },
-    "wasm-pack@latest": {
-      "last_modified": "2023-12-13T22:54:10Z",
-      "resolved": "github:NixOS/nixpkgs/fd04bea4cbf76f86f244b9e2549fca066db8ddff#wasm-pack",
-      "source": "devbox-search",
-      "version": "0.12.1",
-      "systems": {
-        "aarch64-darwin": {
-          "store_path": "/nix/store/nc5066l6dy3h98fq9nphha44wgibzg10-wasm-pack-0.12.1"
-        },
-        "aarch64-linux": {
-          "store_path": "/nix/store/x4hg3a0fc9bgzlsgp0i63xs7maal3d01-wasm-pack-0.12.1"
-        },
-        "x86_64-darwin": {
-          "store_path": "/nix/store/0qy7hbczxfawq3f1fvf31yynqfycvfyk-wasm-pack-0.12.1"
-        },
-        "x86_64-linux": {
-          "store_path": "/nix/store/b1f3w3sk72m1fpgz5mn5dwnn6bnd19jz-wasm-pack-0.12.1"
-        }
-      }
-    },
     "yamllint@latest": {
       "last_modified": "2023-06-30T04:44:22Z",
       "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#yamllint",

--- a/web/README.md
+++ b/web/README.md
@@ -28,10 +28,6 @@ pnpm install
 
 You will also need the following tools installed:
 * The `Rust` and `Cargo` version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11) (search for `RUST_VERSION`) are required.
-* The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required:
-  `curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh`
-* [`binaryen`](https://github.com/WebAssembly/binaryen) (which contains `wasm-opt`) is required to be installed manually
-    on linux aarch64 (64-bit ARM). You can check if it's already installed on your system by running `which wasm-opt`. If not you can install it like `apt-get install binaryen` (for Debian-based Linux). `wasm-pack` will install this automatically on other platforms.
 
 To build the Teleport open source version
 

--- a/web/packages/shared/README.md
+++ b/web/packages/shared/README.md
@@ -15,7 +15,6 @@ Add `@gravitational/shared` to your package.json file.
 ### WASM
 
 This package includes a WASM module built from a Rust codebase located in `packages/shared/libs/ironrdp`.
-It is built with the help of [wasm-pack](https://github.com/rustwasm/wasm-pack).
 
 Running `pnpm build-wasm` builds the WASM binary as well as the appropriate Javascript/Typescript
 bindings and types in `web/packages/shared/libs/ironrdp/pkg`.

--- a/web/packages/shared/package.json
+++ b/web/packages/shared/package.json
@@ -10,7 +10,7 @@
     "directory": "packages/shared"
   },
   "scripts": {
-    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && RUST_MIN_STACK=16777216 wasm-pack build ./libs/ironrdp --target web"
+    "build-wasm": "node ../../scripts/clean-up-ironrdp-artifacts.mjs && make -C ../../../ build-ironrdp-wasm"
   },
   "dependencies": {
     "@gravitational/design": "workspace:*",

--- a/web/packages/teleport/README.md
+++ b/web/packages/teleport/README.md
@@ -5,11 +5,3 @@ This package contains the source code of Teleport Web UI.
 ## Development
 
 Follow the instructions from `web/README.md`.
-
-#### wasm-pack
-
-The [`wasm-pack`](https://github.com/rustwasm/wasm-pack) version in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12) (search for `WASM_PACK_VERSION`) is required to build the WebAssembly module.
-
-When calling `wasm-pack`, we set the environment variable `RUST_MIN_STACK=16777216`. This is necessary to avoid a `SIGSEGV` error when building the module on some systems.
-
-`16777216` was chosen based on [the suggestion in the rust compiler error message](https://github.com/rust-lang/rust/blob/10a7aa14fed9b528b74b0f098c4899c37c09a9c7/compiler/rustc_driver_impl/src/signal_handler.rs#L104-L106) to double the [`DEFAULT_STACK_SIZE`](https://github.com/rust-lang/rust/blob/10a7aa14fed9b528b74b0f098c4899c37c09a9c7/compiler/rustc_interface/src/util.rs#L52) value.

--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -53,11 +53,8 @@ pnpm install && make build/tsh
 
 The app depends on Rust WASM code. To compile it, the following tools have to be installed:
 * `Rust` and `Cargo`. The required version is specified by `RUST_VERSION` in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L11).
-* [`wasm-pack`](https://github.com/rustwasm/wasm-pack). The required version is specified by `WASM_PACK_VERSION` in [build.assets/Makefile](https://github.com/gravitational/teleport/blob/master/build.assets/versions.mk#L12).
-* [`binaryen`](https://github.com/WebAssembly/binaryen) which contains `wasm-opt`. This is required on on linux aarch64 (64-bit ARM).
-  You can check if it's already installed on your system by running `which wasm-opt`. If not you can install it like `apt-get install binaryen` (for Debian-based Linux). `wasm-pack` will install this automatically on other platforms.
 
-To automatically install `wasm-pack`, run the following command:
+To automatically install `wasm-bindgen-cli` and `wasm-opt`, run the following command:
 ```shell
 make ensure-wasm-deps
 ```


### PR DESCRIPTION
Backport #58618 to branchv/17

Test build: https://github.com/gravitational/teleport.e/actions/runs/20175894451