### PR TITLE
Fix flaky TestKube/Join by using io.Pipe instead of os.Pipe

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -596,7 +596,6 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 			},
 		)
 	}
-
 }
 
 // testKubePortForwardPodDisconnect tests Kubernetes port forwarding
@@ -760,7 +759,6 @@ func testKubePortForwardPodDisconnect(t *testing.T, suite *KubeSuite) {
 			},
 		)
 	}
-
 }
 
 // TestKubeTrustedClustersClientCert tests scenario with trusted clusters
@@ -2003,7 +2001,6 @@ func testKubeExecWeb(t *testing.T, suite *KubeSuite) {
 		err = ws.Close()
 		require.NoError(t, err)
 	})
-
 }
 
 type ReaderWithDeadline interface {
@@ -2444,8 +2441,7 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 		session = sessions[0]
 	}, 10*time.Second, time.Second)
 
-	participantStdinR, participantStdinW, err := os.Pipe()
-	require.NoError(t, err)
+	participantStdinR, participantStdinW := io.Pipe()
 	participantStdoutR, participantStdoutW, err := os.Pipe()
 	require.NoError(t, err)
 
@@ -2530,13 +2526,14 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 	// send a test message from the participant
 	participantStdinW.Write([]byte("\ahi from peer\n\r"))
 
+	// validate that the output from both messages above is
+	// written to the participant stdout in the expected order.
+	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from peer"))
+
 	// type "hi from term" followed by "enter" to broadcast data
 	// to all participants.
 	term.Type("\ahi from term\n\r")
 
-	// validate that the output from both messages above is
-	// written to the participant stdout in the expected order.
-	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from peer"))
 	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from term"))
 
 	// send exit command to close the session


### PR DESCRIPTION
In TestKube/Join, we previously used os.Pipe[1] to create stdin for the test which uses os.File. However, os.File instances are implicitly closed when garbage collected via a runtime finalizer inserted in newFile[2].

Under CPU-constrained conditions, the garbage collector can run mid-test and detect that participantStdinW is no longer referenced. This triggers the finalizer, which closes the writer file descriptor, causing the reader to receive io.EOF.

Since Kubernetes terminates exec sessions when stdin closes, the EOF can arrive before the client receives the server payload, causing the test to fail intermittently.

Replacing os.Pipe with io.Pipe resolves this issue, as io.Pipe does not use file descriptors and is not subject to finalizer cleanup.

[1] https://github.com/golang/go/blob/1b291b70dff51732415da5b68debe323704d8e8d/src/os/pipe_unix.go#L27
[2] https://github.com/golang/go/blob/1b291b70dff51732415da5b68debe323704d8e8d/src/os/file_unix.go#L224

Fixes https://github.com/gravitational/teleport/issues/55044