### PR TITLE
[v17] Fix flaky TestKube/Join by using io.Pipe instead of os.Pipe

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -594,7 +594,6 @@ func testKubePortForward(t *testing.T, suite *KubeSuite) {
 			},
 		)
 	}
-
 }
 
 // testKubePortForwardPodDisconnect tests Kubernetes port forwarding
@@ -1997,7 +1996,6 @@ func testKubeExecWeb(t *testing.T, suite *KubeSuite) {
 		err = ws.Close()
 		require.NoError(t, err)
 	})
-
 }
 
 type ReaderWithDeadline interface {
@@ -2440,8 +2438,7 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 		session = sessions[0]
 	}, 10*time.Second, time.Second)
 
-	participantStdinR, participantStdinW, err := os.Pipe()
-	require.NoError(t, err)
+	participantStdinR, participantStdinW := io.Pipe()
 	participantStdoutR, participantStdoutW, err := os.Pipe()
 	require.NoError(t, err)
 
@@ -2526,13 +2523,14 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 	// send a test message from the participant
 	participantStdinW.Write([]byte("\ahi from peer\n\r"))
 
+	// validate that the output from both messages above is
+	// written to the participant stdout in the expected order.
+	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from peer"))
+
 	// type "hi from term" followed by "enter" to broadcast data
 	// to all participants.
 	term.Type("\ahi from term\n\r")
 
-	// validate that the output from both messages above is
-	// written to the participant stdout in the expected order.
-	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from peer"))
 	require.NoError(t, waitForOutput(t.Context(), participantStdoutR, "hi from term"))
 
 	// send exit command to close the session


### PR DESCRIPTION
Backport #62229 to branch/v17