### PR TITLE
Helm proxy service skip ports option

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2048,6 +2048,23 @@ Allows to specify the service type.
     type: LoadBalancer
   ```
 
+## `service.skipPorts`
+
+| Type      | Default value  | Required? |
+|-----------|----------------|-----------|
+| `boolean` | `false`        | No        |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/services-networking/service/)
+
+Boolean value that specifies whether to generate default Teleport proxy ports.
+
+`values.yaml` example:
+
+  ```yaml
+  service:
+    skipPorts: true
+  ```
+
 ## `service.spec.loadBalancerIP`
 
 | Type     | Default value | Required? |

--- a/examples/chart/teleport-cluster/templates/proxy/service.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/service.yaml
@@ -36,12 +36,13 @@ spec:
 {{- with $proxy.service.spec }}
   {{- toYaml . | nindent 2 }}
 {{- end }}
+{{- if and (not .Values.service.skipPorts) (empty .Values.service.spec.ports) }}
   ports:
   - name: tls
     port: 443
     targetPort: 3080
     protocol: TCP
-{{- if ne $proxy.proxyListenerMode "multiplex" }}
+  {{- if ne $proxy.proxyListenerMode "multiplex" }}
   - name: sshproxy
     port: 3023
     targetPort: 3023
@@ -58,17 +59,18 @@ spec:
     port: 3036
     targetPort: 3036
     protocol: TCP
-  {{- if $proxy.separatePostgresListener }}
+    {{- if $proxy.separatePostgresListener }}
   - name: postgres
     port: 5432
     targetPort: 5432
     protocol: TCP
-  {{- end }}
-  {{- if $proxy.separateMongoListener }}
+    {{- end }}
+    {{- if $proxy.separateMongoListener }}
   - name: mongo
     port: 27017
     targetPort: 27017
     protocol: TCP
+    {{- end }}
   {{- end }}
 {{- end }}
   selector: {{- include "teleport-cluster.proxy.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
I added an option to the helm chart under service to skip deploying the default tls port on our proxy service. 
This allows the ports: section under spec to be manually defined. 

Example:
```yaml
service:
  type: NodePort
  skipPorts: true
  spec:
    ports:
    - name: tls 
      nodePort: 30552
      port: 443 
      protocol: TCP 
      targetPort: 3080
    - name: debug
      nodePort: 30052
      port: 3000
      protocol: TCP
      targetPort: 3000
```

Before the change, you could not add a nodePort or additional ports to the deployed proxy service. Using this optional non-default variable can help in environments where networking is more difficult, such as a self-hosted cluster.

I tested by deploying with and without `skipPorts: true` and with `make -C build.assets lint-helm test-helm`