### PR TITLE
[v18] Skip app_server heartbeats with no changes

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -6860,6 +6860,24 @@ func (a *Server) UpsertApplicationServer(ctx context.Context, server types.AppSe
 	return lease, nil
 }
 
+// UnconditionalUpdateApplicationServer implements [services.PresenceInternal]
+// by delegating to [Server.Services] and then potentially emitting a
+// [usagereporter] event.
+func (a *Server) UnconditionalUpdateApplicationServer(ctx context.Context, server types.AppServer) (types.AppServer, error) {
+	server, err := a.Services.UnconditionalUpdateApplicationServer(ctx, server)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	a.AnonymizeAndSubmit(&usagereporter.ResourceHeartbeatEvent{
+		Name:   server.GetName(),
+		Kind:   usagereporter.ResourceKindAppServer,
+		Static: server.Expiry().IsZero(),
+	})
+
+	return server, nil
+}
+
 // UpsertDatabaseServer implements [services.Presence] by delegating to
 // [Server.Services] and then potentially emitting a [usagereporter] event.
 func (a *Server) UpsertDatabaseServer(ctx context.Context, server types.DatabaseServer) (*types.KeepAlive, error) {

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -945,7 +945,7 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 		handle.sshServer = &heartBeatInfo[*types.ServerV2]{
 			resource: sshServer,
 		}
-	} else if handle.sshServer.keepAliveErrs == 0 && services.CompareServers(handle.sshServer.resource, sshServer) < services.Different {
+	} else if handle.sshServer.keepAliveErrs == 0 && services.CompareServers(handle.sshServer.resource, sshServer) != services.Different {
 		// if we have successfully upserted this exact server the last time
 		// (except for the expiry), we don't need to upsert it again right now
 		return nil
@@ -1084,7 +1084,7 @@ func (c *Controller) handleAppServerHB(handle *upstreamHandle, appServer *types.
 			resource: appServer,
 		}
 		handle.appServers[appKey] = srv
-	} else if srv.keepAliveErrs == 0 && services.CompareServers(srv.resource, appServer) < services.Different {
+	} else if srv.keepAliveErrs == 0 && services.CompareServers(srv.resource, appServer) != services.Different {
 		// if we have successfully upserted this exact server the last time
 		// (except for the expiry), we don't need to upsert it again right now
 		return nil

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -57,6 +57,7 @@ type Auth interface {
 	UpsertNode(context.Context, types.Server) (*types.KeepAlive, error)
 
 	UpsertApplicationServer(context.Context, types.AppServer) (*types.KeepAlive, error)
+	UnconditionalUpdateApplicationServer(context.Context, types.AppServer) (types.AppServer, error)
 	DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error
 
 	UpsertDatabaseServer(context.Context, types.DatabaseServer) (*types.KeepAlive, error)
@@ -1072,40 +1073,52 @@ func (c *Controller) handleAppServerHB(handle *upstreamHandle, appServer *types.
 
 	appKey := resourceKey{hostID: appServer.GetHostID(), name: appServer.GetApp().GetName()}
 
-	if _, ok := handle.appServers[appKey]; !ok {
+	srv := handle.appServers[appKey]
+	if srv == nil {
 		c.onConnectFunc(constants.KeepAliveApp)
 		if c.appHBVariableDuration != nil {
 			c.appHBVariableDuration.Inc()
 		}
-		handle.appServers[appKey] = &heartBeatInfo[*types.AppServerV3]{}
 		handle.appKeepAliveDelay.Add(appKey)
+		srv = &heartBeatInfo[*types.AppServerV3]{
+			resource: appServer,
+		}
+		handle.appServers[appKey] = srv
+	} else if srv.keepAliveErrs == 0 && services.CompareServers(srv.resource, appServer) < services.Different {
+		// if we have successfully upserted this exact server the last time
+		// (except for the expiry), we don't need to upsert it again right now
+		return nil
+	} else {
+		srv.resource = appServer
 	}
 
-	now := c.clock.Now()
+	srv.resource.SetExpiry(c.clock.Now().Add(c.serverTTL).UTC())
 
-	appServer.SetExpiry(now.Add(c.serverTTL).UTC())
-
-	lease, err := c.auth.UpsertApplicationServer(c.closeContext, appServer)
-	if err == nil {
+	if _, err := c.auth.UpsertApplicationServer(c.closeContext, srv.resource); err == nil {
 		c.testEvent(appUpsertOk)
 		// store the new lease and reset retry state
-		srv := handle.appServers[appKey]
-		srv.lease = lease
+		srv.keepAliveErrs = 0
 		srv.retryUpsert = false
-		srv.resource = appServer
+
+		handle.appKeepAliveDelay.Reset(appKey)
 	} else {
 		c.testEvent(appUpsertErr)
-		slog.WarnContext(c.closeContext, "Failed to upsert app server on heartbeat",
+		slog.WarnContext(c.closeContext, "Failed to announce app server",
 			"server_id", handle.Hello().ServerID,
 			"error", err,
 		)
 
-		// blank old lease if any and set retry state. next time handleKeepAlive is called
-		// we will attempt to upsert the server again.
-		srv := handle.appServers[appKey]
-		srv.lease = nil
+		// we use keepAliveErrs as a general upsert error count, retryUpsert as
+		// a flag to signify that we MUST succeed the very next upsert: if we're
+		// here it means that we have a new resource to upsert and we have
+		// failed to do so once, so if we fail again we are going to fall too
+		// far behind and we should let the instance go and connect to a
+		// healthier auth server
+		srv.keepAliveErrs++
+		if srv.retryUpsert || srv.keepAliveErrs > c.maxKeepAliveErrs {
+			return trace.Wrap(err, "failed to announce app server")
+		}
 		srv.retryUpsert = true
-		srv.resource = appServer
 	}
 	return nil
 }
@@ -1270,59 +1283,53 @@ func (c *Controller) handleAgentMetadata(handle *upstreamHandle, m *proto.Upstre
 }
 
 func (c *Controller) keepAliveAppServer(handle *upstreamHandle, now time.Time, name resourceKey) error {
-	srv, ok := handle.appServers[name]
-	if !ok {
+	srv := handle.appServers[name]
+	if srv == nil {
 		handle.appKeepAliveDelay.Remove(name)
 		return trace.Errorf("desync between app server hb registry and keepalive delay (this is a bug)")
 	}
 
-	if srv.lease != nil {
-		lease := *srv.lease
-		lease.Expires = now.Add(c.serverTTL).UTC()
-		if err := c.auth.KeepAliveServer(c.closeContext, lease); err != nil {
-			c.testEvent(appKeepAliveErr)
-
-			srv.keepAliveErrs++
-			handle.appServers[name] = srv
-			shouldRemove := srv.keepAliveErrs > c.maxKeepAliveErrs
-			slog.WarnContext(c.closeContext, "Failed to keep alive app server",
-				"server_id", handle.Hello().ServerID,
-				"error", err,
-				"error_count", srv.keepAliveErrs,
-				"should_remove", shouldRemove,
-			)
-
-			if shouldRemove {
-				c.testEvent(appKeepAliveDel)
-				c.onDisconnectFunc(constants.KeepAliveApp, 1)
-				if c.appHBVariableDuration != nil {
-					c.appHBVariableDuration.Dec()
-				}
-				delete(handle.appServers, name)
-				handle.appKeepAliveDelay.Remove(name)
-			}
+	srv.resource.SetExpiry(now.Add(c.serverTTL).UTC())
+	if _, err := c.auth.UnconditionalUpdateApplicationServer(c.closeContext, srv.resource); err == nil {
+		if srv.retryUpsert {
+			c.testEvent(appUpsertRetryOk)
 		} else {
-			srv.keepAliveErrs = 0
 			c.testEvent(appKeepAliveOk)
 		}
-	} else if srv.retryUpsert {
-		srv.resource.SetExpiry(c.clock.Now().Add(c.serverTTL).UTC())
-		lease, err := c.auth.UpsertApplicationServer(c.closeContext, srv.resource)
-		if err != nil {
+		srv.keepAliveErrs = 0
+		srv.retryUpsert = false
+	} else {
+		if srv.retryUpsert {
 			c.testEvent(appUpsertRetryErr)
-			slog.WarnContext(c.closeContext, "Failed to upsert app server on retry",
+			slog.WarnContext(c.closeContext, "Failed to update app server on retry",
 				"server_id", handle.Hello().ServerID,
 				"error", err,
 			)
-			// since this is retry-specific logic, an error here means that upsert failed twice in
-			// a row. Missing upserts is more problematic than missing keepalives so we don't bother
-			// attempting a third time.
-			return trace.Errorf("failed to upsert app server on retry: %v", err)
+			// retryUpsert is set when we get a new resource and we fail to
+			// upsert it; if we're here it means that we have failed to upsert
+			// it _again_, so we have fallen quite far behind
+			return trace.Wrap(err, "failed to update app server on retry")
 		}
-		c.testEvent(appUpsertRetryOk)
 
-		srv.lease = lease
-		srv.retryUpsert = false
+		c.testEvent(appKeepAliveErr)
+		srv.keepAliveErrs++
+		shouldRemove := srv.keepAliveErrs > c.maxKeepAliveErrs
+		slog.WarnContext(c.closeContext, "Failed to update app server on keepalive",
+			"server_id", handle.Hello().ServerID,
+			"error", err,
+			"error_count", srv.keepAliveErrs,
+			"should_remove", shouldRemove,
+		)
+
+		if shouldRemove {
+			c.testEvent(appKeepAliveDel)
+			c.onDisconnectFunc(constants.KeepAliveApp, 1)
+			if c.appHBVariableDuration != nil {
+				c.appHBVariableDuration.Dec()
+			}
+			delete(handle.appServers, name)
+			handle.appKeepAliveDelay.Remove(name)
+		}
 	}
 
 	return nil

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -110,6 +111,19 @@ func (a *fakeAuth) UpsertApplicationServer(_ context.Context, server types.AppSe
 	}
 	a.lastServerExpiry = server.Expiry()
 	return &types.KeepAlive{}, a.err
+}
+
+func (a *fakeAuth) UnconditionalUpdateApplicationServer(_ context.Context, server types.AppServer) (types.AppServer, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.keepalives++
+
+	if a.failKeepAlives > 0 {
+		a.failKeepAlives--
+		return nil, trace.Errorf("unconditional update failed as test condition")
+	}
+	a.lastServerExpiry = server.Expiry()
+	return server, a.err
 }
 
 func (a *fakeAuth) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
@@ -728,7 +742,7 @@ func testAppServerBasics(t *testing.T) {
 		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
 			AppServer: &types.AppServerV3{
 				Metadata: types.Metadata{
-					Name: serverID,
+					Name: fmt.Sprintf("app-%d", i),
 				},
 				Spec: types.AppServerSpecV3{
 					HostID: serverID,
@@ -783,7 +797,7 @@ func testAppServerBasics(t *testing.T) {
 		err := downstream.Send(ctx, &proto.InventoryHeartbeat{
 			AppServer: &types.AppServerV3{
 				Metadata: types.Metadata{
-					Name: serverID,
+					Name: fmt.Sprintf("app-%d", i),
 				},
 				Spec: types.AppServerSpecV3{
 					HostID: serverID,
@@ -792,6 +806,9 @@ func testAppServerBasics(t *testing.T) {
 						Version: types.V3,
 						Metadata: types.Metadata{
 							Name: fmt.Sprintf("app-%d", i),
+							Labels: map[string]string{
+								"foo": uuid.NewString(),
+							},
 						},
 						Spec: types.AppSpecV3{},
 					},
@@ -844,20 +861,26 @@ func testAppServerBasics(t *testing.T) {
 	// set up to induce enough consecutive errors to cause stream closure
 	auth.mu.Lock()
 	auth.failUpserts = 5
+	auth.failKeepAlives = 5
 	auth.mu.Unlock()
 
 	err = downstream.Send(ctx, &proto.InventoryHeartbeat{
 		AppServer: &types.AppServerV3{
 			Metadata: types.Metadata{
-				Name: serverID,
+				Name: "app-0",
 			},
 			Spec: types.AppServerSpecV3{
 				HostID: serverID,
 				App: &types.AppV3{
-					Kind:     types.KindApp,
-					Version:  types.V3,
-					Metadata: types.Metadata{},
-					Spec:     types.AppSpecV3{},
+					Kind:    types.KindApp,
+					Version: types.V3,
+					Metadata: types.Metadata{
+						Name: "app-0",
+						Labels: map[string]string{
+							"foo": uuid.NewString(),
+						},
+					},
+					Spec: types.AppSpecV3{},
 				},
 			},
 		},
@@ -2209,7 +2232,7 @@ func awaitEvents(t *testing.T, ch <-chan testEvent, opts ...eventOption) {
 		opt(&options)
 	}
 
-	timeout := time.After(time.Second * 30)
+	timeout := time.After(time.Second * 300)
 	for {
 		if len(options.expect) == 0 {
 			return

--- a/lib/inventory/internal/delay/multi_test.go
+++ b/lib/inventory/internal/delay/multi_test.go
@@ -19,6 +19,7 @@ package delay
 import (
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -28,8 +29,11 @@ import (
 )
 
 func TestMultiBasics(t *testing.T) {
-	const interval = time.Millisecond * 20
 	t.Parallel()
+	synctest.Test(t, testMultiBasics)
+}
+func testMultiBasics(t *testing.T) {
+	const interval = time.Millisecond * 20
 
 	multi := NewMulti[int](MultiParams{
 		FixedInterval: interval,
@@ -41,6 +45,7 @@ func TestMultiBasics(t *testing.T) {
 	for i := 1; i <= 10; i++ {
 		// add a subinterval
 		multi.Add(i)
+		time.Sleep(time.Nanosecond)
 	}
 
 	for i := 0; i < 30; i++ {
@@ -82,11 +87,33 @@ func TestMultiBasics(t *testing.T) {
 	case <-time.After(interval * 3):
 		t.Fatal("timeout waiting for re-added delay to fire")
 	}
+
+	time.Sleep(interval / 2)
+	multi.Add(42)
+	added42 := time.Now()
+
+	elapsed := <-multi.Elapsed()
+	require.Equal(t, added42.Add(interval/2), elapsed)
+	require.Equal(t, 777, multi.Tick(elapsed))
+
+	time.Sleep(interval / 2)
+	multi.Reset(42)
+	reset42 := time.Now()
+
+	elapsed = <-multi.Elapsed()
+	require.Equal(t, reset42.Add(interval/2), elapsed)
+	require.Equal(t, 777, multi.Tick(elapsed))
+
+	elapsed = <-multi.Elapsed()
+	require.Equal(t, reset42.Add(interval), elapsed)
+	require.Equal(t, 42, multi.Tick(elapsed))
 }
 
 func TestMultiJitter(t *testing.T) {
 	t.Parallel()
-
+	synctest.Test(t, testMultiJitter)
+}
+func testMultiJitter(t *testing.T) {
 	var jitterCalled atomic.Bool
 	fakeJitter := func(d time.Duration) time.Duration {
 		jitterCalled.Store(true)

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -1293,6 +1293,42 @@ func (s *PresenceService) UpsertApplicationServer(ctx context.Context, server ty
 	}, nil
 }
 
+// UnconditionalUpdateApplicationServer implements [services.PresenceInternal].
+func (s *PresenceService) UnconditionalUpdateApplicationServer(ctx context.Context, server types.AppServer) (types.AppServer, error) {
+	if err := services.CheckAndSetDefaults(server); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if err := types.ValidateNamespaceDefault(server.GetNamespace()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	value, err := services.MarshalAppServer(server)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Since an app server represents a single proxied application, there may
+	// be multiple database servers on a single host, so they are stored under
+	// the following path in the backend:
+	//   /appServers/<namespace>/<host-uuid>/<name>
+	lease, err := s.Update(ctx, backend.Item{
+		Key: backend.NewKey(appServersPrefix,
+			server.GetNamespace(),
+			server.GetHostID(),
+			server.GetName(),
+		),
+		Value:    value,
+		Expires:  server.Expiry(),
+		Revision: server.GetRevision(),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	server.SetRevision(lease.Revision)
+	return server, nil
+}
+
 // DeleteApplicationServer removes specified application server.
 func (s *PresenceService) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
 	key := backend.NewKey(appServersPrefix, namespace, hostID, name)

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -215,11 +215,10 @@ type PresenceInternal interface {
 	// UpsertRelayServer creates or updates a relay server heartbeat, unconditionally.
 	UpsertRelayServer(ctx context.Context, relayServer *presencev1.RelayServer) (*presencev1.RelayServer, error)
 
-	// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
-	RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error]
-
-	// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
-	RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error]
+	// UnconditionalUpdateApplicationServer writes an app_server if one with the
+	// same host ID and name exists in storage, no matter its contents (i.e., it
+	// doesn't check the revision of the app_server in storage).
+	UnconditionalUpdateApplicationServer(ctx context.Context, server types.AppServer) (types.AppServer, error)
 
 	// RangeApplicationServersWithName returns an iterator over application servers for a given app name.
 	RangeApplicationServersWithName(ctx context.Context, appName string) iter.Seq2[types.AppServer, error]
@@ -240,4 +239,10 @@ type PresenceInternal interface {
 		name string,
 		condition backend.Condition,
 	) ([]backend.ConditionalAction, error)
+
+	// RangeDatabaseServersWithName returns an iterator over database proxy servers for a given database name.
+	RangeDatabaseServersWithName(ctx context.Context, databaseName string) iter.Seq2[types.DatabaseServer, error]
+
+	// RangeKubernetesServersWithName returns an iterator over kubernetes servers for a given cluster name.
+	RangeKubernetesServersWithName(ctx context.Context, clusterName string) iter.Seq2[types.KubeServer, error]
 }


### PR DESCRIPTION
Backport #61960 to branch/v18

changelog: reduced write load for the cluster state storage in clusters with large amounts of app resources

### Manual tests

- [x] Keepalive by means of UnconditionalUpdateAppServer works as expected
  - [x] The TTL is set as expected
- [x] Unchanged heartbeats are skipped
- [x] Changed heartbeats are not skipped
  - [x] The TTL is set as expected
