### PR TITLE
docs: list out mcp acronym for intro page in description

### DIFF
--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Servers
-description: Protect MCP servers with Teleport's access controls and auditing capabilities 
+description: Protect Model Context Protocol (MCP)  servers with Teleport's access controls and auditing capabilities 
 template: doc-page
 tags:
  - mcp

--- a/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
+++ b/docs/pages/enroll-resources/mcp-access/mcp-access.mdx
@@ -1,6 +1,6 @@
 ---
 title: MCP Servers
-description: Protect Model Context Protocol (MCP)  servers with Teleport's access controls and auditing capabilities 
+description: Protect Model Context Protocol (MCP) servers with Teleport's access controls and auditing capabilities 
 template: doc-page
 tags:
  - mcp


### PR DESCRIPTION
The acronym MCP was not spelled out in the page.