### PR TITLE
docs: add checkpoints to docs Getting Started guide

### DIFF
--- a/docs/pages/get-started/connect.mdx
+++ b/docs/pages/get-started/connect.mdx
@@ -76,6 +76,16 @@ Follow these steps to enroll your Ubuntu Linux server:
 
 Now you'll see your Ubuntu server listed under Resources in your Teleport Web UI. Click on the Connect button to SSH into the server.
 
+<Checkpoint
+  title="Verify server enrollment"
+  description="Confirm that your Ubuntu server appears in the Teleport Web UI and that you can connect to it via SSH."
+>
+  Here are some troubleshooting tips:
+  - If the server doesn't appear, verify the Teleport Agent is running on the server with `systemctl status teleport`.
+  - Ensure the server can reach your Teleport cluster over the network (check firewalls and security groups).
+  - Check the agent logs for errors: `journalctl -u teleport`.
+</Checkpoint>
+
 <details>
   <summary>How does passwordless SSH work?</summary>
 

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -258,6 +258,16 @@ internet, a local container, or a private network:
 
    ![Teleport Welcome Screen](../../img/quickstart/welcome.png)
 
+<Checkpoint
+  title="Verify Teleport is running"
+  description="Confirm that you can access the Teleport Web UI and see the welcome screen."
+>
+  Here are some troubleshooting tips:
+  - Ensure that Teleport is running on your host (`systemctl status teleport` on a VM, or check that the `teleport start` command is still running in your container).
+  - Verify that port 443 (or 3080 for Docker) is accessible and not blocked by a firewall.
+  - Check the Teleport logs for errors: `sudo journalctl -u teleport` on a VM, or review the terminal output in your container.
+</Checkpoint>
+
 ## Step 3/4. Create a Teleport user and set up multi-factor authentication
 
 In this step, we'll create a new Teleport user, `teleport-admin`, which is
@@ -354,6 +364,16 @@ Click on `Connect` to access it via the web-based terminal, or use Teleport's [`
 ```code
 $ tsh ssh root@<server-name>
 ```
+
+<Checkpoint
+  title="Verify server access"
+  description="Confirm that you can authenticate and connect to your Linux server through the Teleport Web UI or via tsh ssh."
+>
+  Here are some troubleshooting tips:
+  - Ensure the user you created has the correct logins assigned (e.g., `root`, `ubuntu`, `ec2-user`) that match existing OS users on the host.
+  - If you receive a permission denied error, verify that the login user exists on the Linux host or create it with `adduser <login>`.
+  - Check that your MFA device is properly enrolled and that you're completing the authentication challenge.
+</Checkpoint>
 
 ## Next step: deploy Teleport Agents
 


### PR DESCRIPTION
This PR adds interactive checkpoints for deploy-community and connect pages in the docs Get Started guide.

These checkpoints enable the user to provide feedback through events and comments, as well as receive troubleshooting tips to follow if needed.