### PR TITLE
Resource reference generator: Load custom intros

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -8,10 +8,22 @@ resources:
     package: types
     yaml_kind: app
     yaml_version: v3
+    introduction: |
+      The `app` resource represents a single application protected by Teleport.
+      To learn more about using the `app` resource, see [Dynamic App
+      Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
   - type: AppServerV3
     package: types
     yaml_kind: app_server
     yaml_version: v3
+    introduction: |
+      The `app_server` resource represents an instance of the Teleport
+      Application Service, which allows you to [protect
+      applications](../../../enroll-resources/application-access/application-access.mdx)
+      with Teleport.
+
+      To manage applications proxied by Teleport instead, you can use the [`app`
+      resource](app-v3.mdx).
   - type: DatabaseServerV3
     package: types
     yaml_kind: db_server

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.go
@@ -30,8 +30,15 @@ import (
 // pageContent represents a reference page for a single resource and its related
 // fields. Fields must be exported so we can use them in templates.
 type pageContent struct {
+	// Introduction is optional text to override the default introduction, taken
+	// from Resource.
+	Introduction string
+	// Resource represents the dynamic Teleport resource that is the subject
+	// of the page.
 	Resource resourceSection
-	Fields   map[resource.PackageInfo]resource.ReferenceEntry
+	// Fields are the top-level fields of the dynamic resource for this
+	// page.
+	Fields map[resource.PackageInfo]resource.ReferenceEntry
 }
 
 // resourceSection represents a top-level section of the resource reference
@@ -67,6 +74,9 @@ type ResourceConfig struct {
 	// The value of the "version" field within a YAML manifest for this
 	// resource, e.g., "v6".
 	VersionValue string `yaml:"yaml_version"`
+	// Introduction paragraph(s) to add to the template in place of the
+	// default, which is the GoDoc for the resource type.
+	Introduction string `yaml:"introduction"`
 }
 
 // GeneratorConfig is the user-facing configuration for the resource reference
@@ -118,6 +128,7 @@ func Generate(conf GeneratorConfig, tmpl *template.Template) error {
 		}
 
 		pc := pageContent{}
+		pc.Introduction = r.Introduction
 
 		// decl is a dynamic resource type, so get data for the type and
 		// its dependencies.

--- a/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
+++ b/build.assets/tooling/cmd/resource-ref-generator/reference/reference.tmpl
@@ -11,7 +11,7 @@ sidebar_label: {{ .Resource.SectionName }}
 **Kind**: `{{ .Resource.Kind }}`<br/>
 **Version**: `{{ .Resource.Version }}`
 
-{{ .Resource.Description }}
+{{ or .Introduction .Resource.Description }}
 
 {{- if gt (len .Resource.ResourceExample) 0 }}
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-server-v3.mdx
@@ -11,7 +11,14 @@ sidebar_label: App Server V3
 **Kind**: `app_server`<br/>
 **Version**: `v3`
 
-Represents a single proxied web app.
+The `app_server` resource represents an instance of the Teleport
+Application Service, which allows you to [protect
+applications](../../../enroll-resources/application-access/application-access.mdx)
+with Teleport.
+
+To manage applications proxied by Teleport instead, you can use the [`app`
+resource](app-v3.mdx).
+
 
 ## Top-level fields
 

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/app-v3.mdx
@@ -11,7 +11,10 @@ sidebar_label: App V3
 **Kind**: `app`<br/>
 **Version**: `v3`
 
-Represents an app resource.
+The `app` resource represents a single application protected by Teleport.
+To learn more about using the `app` resource, see [Dynamic App
+Registration](../../../enroll-resources/application-access/configuration/dynamic-registration.mdx).
+
 
 ## Top-level fields
 


### PR DESCRIPTION
If the configuration for a dynamic resource in the resource reference generator includes the `introduction` field, use the value of that field for the introductory paragraphs of the reference page rather than the GoDoc-based description of the resource.

Begin by adding introductions to the `app` and `app_server` resources.