### PR TITLE
[v18] Update Event Handler helm chart with `extra` field patterns

### DIFF
--- a/examples/chart/event-handler/templates/configmap.yaml
+++ b/examples/chart/event-handler/templates/configmap.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels.config }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 data:
   teleport-event-handler.toml: |
     storage = {{ .Values.eventHandler.storagePath | toJson }}

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -8,6 +8,9 @@ metadata:
   {{- end }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels.deployment }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: 1
   {{- if or .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.existingClaim }}
@@ -25,6 +28,9 @@ spec:
       {{- end }}
       labels:
         {{- include "event-handler.labels" . | nindent 8 }}
+        {{- with .Values.extraLabels.pod }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -40,16 +46,23 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /usr/local/bin/teleport-plugin
+          args:
             - start
             - "--config"
             - "/etc/teleport-event-handler.toml"
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
             - name: "TELEPORT_PLUGIN_FAIL_FAST"
               value: "true"
-          {{- if .Values.tls.existingCASecretName }}
+            {{- if .Values.tls.existingCASecretName }}
             - name: SSL_CERT_FILE
               value: /etc/teleport-tls-ca/ca.pem
-          {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 80
@@ -71,11 +84,11 @@ spec:
             - name: certificate
               mountPath: /var/lib/teleport/plugins/event-handler/client.key
               subPath: {{ .Values.fluentd.certificate.keyPath }}
-          {{- if .Values.tls.existingCASecretName }}
+            {{- if .Values.tls.existingCASecretName }}
             - mountPath: /etc/teleport-tls-ca
               name: "teleport-tls-ca"
               readOnly: true
-          {{- end }}
+            {{- end }}
             {{- if or .Values.persistentVolumeClaim.enabled .Values.persistentVolumeClaim.existingClaim }}
             - name: "{{ .Values.persistentVolumeClaim.volumeName }}"
               mountPath: "{{ .Values.eventHandler.storagePath }}"

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -26,11 +26,12 @@ should match the snapshot:
             helm.sh/chart: teleport-plugin-event-handler-18.5.1
         spec:
           containers:
-          - command:
-            - /usr/local/bin/teleport-plugin
+          - args:
             - start
             - --config
             - /etc/teleport-event-handler.toml
+            command:
+            - /usr/local/bin/teleport-plugin
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
@@ -75,11 +76,12 @@ should match the snapshot:
 should mount tls.existingCASecretName and set environment when set in values:
   1: |
     containers:
-    - command:
-      - /usr/local/bin/teleport-plugin
+    - args:
       - start
       - --config
       - /etc/teleport-event-handler.toml
+      command:
+      - /usr/local/bin/teleport-plugin
       env:
       - name: TELEPORT_PLUGIN_FAIL_FAST
         value: "true"

--- a/examples/chart/event-handler/tests/configmap_test.yaml
+++ b/examples/chart/event-handler/tests/configmap_test.yaml
@@ -16,12 +16,10 @@ tests:
           keyPath: myclient.key
     asserts:
       - matchSnapshot: {}
-
   - it: should not contain annotations when not defined
     asserts:
       - isNull:
           path: metadata.annotations
-
   - it: should contain annotations when defined
     set:
       annotations:
@@ -34,3 +32,13 @@ tests:
           value:
             keyA: valA
             keyB: valB
+  - it: sets extraLabels when set in values
+    set:
+      extraLabels:
+        config:
+          test-key: test-label-config
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            test-key: test-label-config

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -9,7 +9,6 @@ tests:
         tag: v98.76.54
     asserts:
       - matchSnapshot: {}
-
   - it: uses the recreate strategy if a PV is mounted
     set:
       persistentVolumeClaim:
@@ -18,7 +17,6 @@ tests:
       - equal:
           path: spec.strategy.type
           value: Recreate
-
   - it: should mount tls.existingCASecretName and set environment when set in values
     template: deployment.yaml
     values:
@@ -43,14 +41,12 @@ tests:
             value: /etc/teleport-tls-ca/ca.pem
       - matchSnapshot:
           path: spec.template.spec
-
   - it: should not contain deployment or pod annotations when not defined
     asserts:
       - isNull:
           path: metadata.annotations
       - isNull:
           path: spec.template.metadata.annotations
-
   - it: should contain deployment annotations when defined
     set:
       annotations:
@@ -65,7 +61,6 @@ tests:
             keyB: valB
       - isNull:
           path: spec.template.metadata.annotations
-
   - it: should contain pod annotations when defined
     set:
       annotations:
@@ -80,7 +75,6 @@ tests:
             keyB: valB
       - isNull:
           path: metadata.annotations
-
   - it: should contain both annotations when defined
     set:
       annotations:
@@ -101,3 +95,38 @@ tests:
           value:
             keyA: valA'
             keyC: valC
+  - it: sets extraLabels when set in values
+    set:
+      extraLabels:
+        deployment:
+          test-key: test-label-deployment
+        pod:
+          test-key: test-label-pod
+    asserts:
+      - isSubset:
+          path: metadata.labels
+          content:
+            test-key: test-label-deployment
+      - isSubset:
+          path: spec.template.metadata.labels
+          content:
+            test-key: test-label-pod
+  - it: sets extraArgs when set in values
+    set:
+      extraArgs:
+        - --extra-arg
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --extra-arg
+  - it: sets extraEnv when set in values
+    set:
+      extraEnv:
+        - name: TEST_ENV
+          value: test-value
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TEST_ENV
+            value: test-value

--- a/examples/chart/event-handler/values.schema.json
+++ b/examples/chart/event-handler/values.schema.json
@@ -14,6 +14,8 @@
         "annotations",
         "tolerations",
         "affinity",
+        "extraArgs",
+        "extraEnv",
         "teleport",
         "fluentd"
     ],
@@ -132,6 +134,16 @@
             },
             "additionalProperties": true
         },
+        "extraArgs": {
+            "$id": "#/properties/extraArgs",
+            "type": "array",
+            "default": []
+        },
+        "extraEnv": {
+            "$id": "#/properties/extraEnv",
+            "type": "array",
+            "default": []
+        },
         "resources": {
             "$id": "#/properties/resources",
             "type": "object",
@@ -247,6 +259,27 @@
                 },
                 "pod": {
                     "$id": "#/properties/annotations/properties/pod",
+                    "type": "object",
+                    "default": {}
+                }
+            }
+        },
+        "extraLabels": {
+            "$id": "#/properties/extraLabels",
+            "type": "object",
+            "properties": {
+                "config": {
+                    "$id": "#/properties/extraLabels/properties/config",
+                    "type": "object",
+                    "default": {}
+                },
+                "deployment": {
+                    "$id": "#/properties/extraLabels/properties/deployment",
+                    "type": "object",
+                    "default": {}
+                },
+                "pod": {
+                    "$id": "#/properties/extraLabels/properties/pod",
                     "type": "object",
                     "default": {}
                 }

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -139,29 +139,84 @@ annotations:
   deployment: {}
   # annotations.pod(object) -- are annotations to set on the Pods.
   pod: {}
+  
+# extraLabels -- contains additional Kubernetes labels to apply on the resources
+# created by the chart. See [the Kubernetes label documentation
+# ](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+# for more information.
+extraLabels:
+  # extraLabels.config(object) -- are labels to set on the ConfigMap.
+  config: {}
+  # extraLabels.deployment(object) -- are labels to set on the Deployment.
+  deployment: {}
+  # extraLabels.pod(object) -- are labels to set on the Pods.
+  pod: {}
 
 #
 # Deployment
 #
+# image -- sets the container image used for plugin pods created by the chart.
+#
+# You can override this to use your own plugin image rather than a Teleport-published image.
 image:
+  # image.repository(string) -- is the image repository.
   repository: public.ecr.aws/gravitational/teleport-plugin-event-handler
+  # image.pullPolicy(string) -- is the [Kubernetes image pull policy](https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy).
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # image.tag(string) -- Overrides the image tag whose default is the chart appVersion.
+  #
+  # Normally, the version of the Teleport plugin matches the
+  # version of the chart. If you install chart version 15.0.0, you'll use
+  # the plugin version 15.0.0. Upgrading the plugin is done by upgrading the chart.
+  #
+  # <Admonition type="warning">
+  # `image.tag` is intended for development and custom tags. This MUST NOT be
+  # used to control the plugin version in a typical deployment. This
+  # chart is designed to run a specific plugin version. You will face
+  # compatibility issues trying to run a different version with it.
+  #
+  # If you want to run the Teleport plugin version `X.Y.Z`, you should use
+  # `helm install --version X.Y.Z` instead.
+  # </Admonition>
   tag: ""
 
+# imagePullSecrets(list) -- is a list of secrets containing authorization tokens
+# which can be optionally used to access a private Docker registry.
+#
+# See the [Kubernetes reference](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod) for more details.
 imagePullSecrets: []
+
+# nameOverride(string) -- optionally overrides the name of the chart, used
+# together with the release name when giving a name to resources.
 nameOverride: ""
+# fullnameOverride(string) -- optionally overrides the full name of resources.
 fullnameOverride: ""
 
 # Deprecated way to set pod annotations. `annotations.pod` should be preferred.
 podAnnotations: {}
 
+# podSecurityContext(object) -- sets the pod security context for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+# for more details.
+#
+# To unset the security context, set it to `null` or `~`.
 podSecurityContext: {}
 
+# securityContext(object) -- sets the container security context for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+# for more details.
+#
+# To unset the security context, set it to `null` or `~`.
 securityContext: {}
 
+# resources(object) -- sets the resource requests/limits for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+# for more details.
 resources: {}
 
+# nodeSelector(object) -- sets the node selector for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+# for more details.
 nodeSelector: {}
 
 # tls -- contains settings for mounting your own TLS material in the event-handler pod.
@@ -179,15 +234,52 @@ tls:
   #   The key containing the root CA in the secret must be `ca.pem`.
   existingCASecretName: ""
 
+# tolerations(list) -- sets the tolerations for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+# for more details.
 tolerations: []
 
+# affinity(object) -- sets the affinities for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+# for more details.
 affinity: {}
 
+# volumes(list) -- sets the volumes mounted into the main event-handler pod.
+# See [the Kubernetes volume
+# documentation](https://kubernetes.io/docs/concepts/storage/volumes/) for more
+# details.
+#
+# For example:
+# ```yaml
+# - name: storage
+#   persistentVolumeClaim:
+#     claimName: teleport-plugin-event-handler
+# ```
 volumes: []
-  # - name: storage
-  #   persistentVolumeClaim:
-  #     claimName: teleport-plugin-event-handler
 
+# volumeMounts(list) -- sets the volume mounts for the main event-handler container.
+# See [the Kubernetes volume
+# documentation](https://kubernetes.io/docs/concepts/storage/volumes/) for more
+# details.
+#
+# For example:
+# ```yaml
+# - name: storage
+#   mountPath: "/var/lib/teleport/plugins/event-handler/storage"
+# ```
 volumeMounts: []
-  # - name: storage
-  #   mountPath: "/var/lib/teleport/plugins/event-handler/storage"
+
+# extraArgs(list) -- contains extra arguments to pass to `teleport-plugin start` for
+# the main event-handler container.
+extraArgs: []
+
+# extraEnv(list) -- contains extra environment variables to set in the main
+# event-handler container.
+#
+# For example:
+# ```yaml
+# extraEnv:
+#   - name: HTTPS_PROXY
+#     value: "http://username:password@my.proxy.host:3128"
+# ```
+extraEnv: []


### PR DESCRIPTION
Backport #62183 to branch/v18

changelog: Added support for extraArgs/extraEnv/extraLabels patterns for `teleport-plugin-event-handler` helm chart