### PR TITLE
[v17] docs: Remove Outdated Limitation Regarding Desktop Access SSO MFA Support

### DIFF
--- a/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
@@ -237,6 +237,7 @@ Current limitations for this feature are:
 - For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
   (The OpenSSH `ssh` client does not work with per-session MFA).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
+- For desktop access, MFA checks using an SSO provider are supported on v17.5.3 or higher.
 - When accessing a
   [multi-port](../../../enroll-resources/application-access/guides/tcp.mdx#configuring-access-to-multiple-ports)
   TCP application through [VNet](../../../connect-your-client/vnet.mdx), the first connection over

--- a/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/zero-trust-access/access-controls/guides/per-session-mfa.mdx
@@ -237,7 +237,6 @@ Current limitations for this feature are:
 - For SSH connections besides the Web UI, the `tsh` or Teleport Connect client must be used for per-session MFA.
   (The OpenSSH `ssh` client does not work with per-session MFA).
 - Only `kubectl` supports per-session WebAuthn authentication for Kubernetes.
-- For desktop access, only WebAuthn devices are supported.
 - When accessing a
   [multi-port](../../../enroll-resources/application-access/guides/tcp.mdx#configuring-access-to-multiple-ports)
   TCP application through [VNet](../../../connect-your-client/vnet.mdx), the first connection over


### PR DESCRIPTION
Backport #62262 to branch/v17

Note: For the v17 backport, instead of removing this line from the docs, I've modified it to explain which release adds support for SSO MFA.