### PR TITLE
Single use scoped join tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -150,7 +151,11 @@ type ScopedTokenSpec struct {
 	Roles []string `protobuf:"bytes,2,rep,name=roles,proto3" json:"roles,omitempty"`
 	// The joining method required in order to use this token.
 	// Supported joining methods for scoped tokens only include 'token'.
-	JoinMethod    string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
+	JoinMethod string `protobuf:"bytes,3,opt,name=join_method,json=joinMethod,proto3" json:"join_method,omitempty"`
+	// The usage mode of the token. Can be "single_use" or "unlimited". Single use
+	// tokens can only be used to provision a single resource. Unlimited tokens
+	// can be be used to provision any number of resources until it expires.
+	UsageMode     string `protobuf:"bytes,4,opt,name=usage_mode,json=usageMode,proto3" json:"usage_mode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -206,19 +211,256 @@ func (x *ScopedTokenSpec) GetJoinMethod() string {
 	return ""
 }
 
+func (x *ScopedTokenSpec) GetUsageMode() string {
+	if x != nil {
+		return x.UsageMode
+	}
+	return ""
+}
+
+// The host certificate parameters that should be cached and leveraged for
+// token reuse
+type HostCertParams struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The host ID generated for the host.
+	HostId string `protobuf:"bytes,1,opt,name=host_id,json=hostId,proto3" json:"host_id,omitempty"`
+	// The host's name.
+	NodeName string `protobuf:"bytes,2,opt,name=node_name,json=nodeName,proto3" json:"node_name,omitempty"`
+	// The system role of the host
+	Role string `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
+	// The additional principals to include
+	AdditionalPrincipals []string `protobuf:"bytes,4,rep,name=additional_principals,json=additionalPrincipals,proto3" json:"additional_principals,omitempty"`
+	// The scope to assign the host to.
+	AssignedScope string `protobuf:"bytes,5,opt,name=assigned_scope,json=assignedScope,proto3" json:"assigned_scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HostCertParams) Reset() {
+	*x = HostCertParams{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HostCertParams) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HostCertParams) ProtoMessage() {}
+
+func (x *HostCertParams) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HostCertParams.ProtoReflect.Descriptor instead.
+func (*HostCertParams) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *HostCertParams) GetHostId() string {
+	if x != nil {
+		return x.HostId
+	}
+	return ""
+}
+
+func (x *HostCertParams) GetNodeName() string {
+	if x != nil {
+		return x.NodeName
+	}
+	return ""
+}
+
+func (x *HostCertParams) GetRole() string {
+	if x != nil {
+		return x.Role
+	}
+	return ""
+}
+
+func (x *HostCertParams) GetAdditionalPrincipals() []string {
+	if x != nil {
+		return x.AdditionalPrincipals
+	}
+	return nil
+}
+
+func (x *HostCertParams) GetAssignedScope() string {
+	if x != nil {
+		return x.AssignedScope
+	}
+	return ""
+}
+
+// The usage status of a single use scoped token.
+type SingleUseStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The timestamp representing when a single use token was successfully used for
+	// provisioning.
+	UsedAt *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=used_at,json=usedAt,proto3" json:"used_at,omitempty"`
+	// The timestamp representing when a single use token should no longer be avaialable
+	// for idempotent retries.
+	ReusableUntil *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=reusable_until,json=reusableUntil,proto3" json:"reusable_until,omitempty"`
+	// The fingerprint of the public key provided by the host that used the token.
+	UsedByFingerprint []byte `protobuf:"bytes,3,opt,name=used_by_fingerprint,json=usedByFingerprint,proto3" json:"used_by_fingerprint,omitempty"`
+	// The relevant host parameters provided while initially using a single use token.
+	HostCertParams *HostCertParams `protobuf:"bytes,4,opt,name=host_cert_params,json=hostCertParams,proto3" json:"host_cert_params,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *SingleUseStatus) Reset() {
+	*x = SingleUseStatus{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SingleUseStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SingleUseStatus) ProtoMessage() {}
+
+func (x *SingleUseStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SingleUseStatus.ProtoReflect.Descriptor instead.
+func (*SingleUseStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *SingleUseStatus) GetUsedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.UsedAt
+	}
+	return nil
+}
+
+func (x *SingleUseStatus) GetReusableUntil() *timestamppb.Timestamp {
+	if x != nil {
+		return x.ReusableUntil
+	}
+	return nil
+}
+
+func (x *SingleUseStatus) GetUsedByFingerprint() []byte {
+	if x != nil {
+		return x.UsedByFingerprint
+	}
+	return nil
+}
+
+func (x *SingleUseStatus) GetHostCertParams() *HostCertParams {
+	if x != nil {
+		return x.HostCertParams
+	}
+	return nil
+}
+
+// The usage status of a scoped token.
+type UsageStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The usage status of a scoped token.
+	//
+	// Types that are valid to be assigned to Status:
+	//
+	//	*UsageStatus_SingleUse
+	Status        isUsageStatus_Status `protobuf_oneof:"status"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UsageStatus) Reset() {
+	*x = UsageStatus{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UsageStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UsageStatus) ProtoMessage() {}
+
+func (x *UsageStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UsageStatus.ProtoReflect.Descriptor instead.
+func (*UsageStatus) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *UsageStatus) GetStatus() isUsageStatus_Status {
+	if x != nil {
+		return x.Status
+	}
+	return nil
+}
+
+func (x *UsageStatus) GetSingleUse() *SingleUseStatus {
+	if x != nil {
+		if x, ok := x.Status.(*UsageStatus_SingleUse); ok {
+			return x.SingleUse
+		}
+	}
+	return nil
+}
+
+type isUsageStatus_Status interface {
+	isUsageStatus_Status()
+}
+
+type UsageStatus_SingleUse struct {
+	// The usage status of a single use scoped token.
+	SingleUse *SingleUseStatus `protobuf:"bytes,1,opt,name=single_use,json=singleUse,proto3,oneof"`
+}
+
+func (*UsageStatus_SingleUse) isUsageStatus_Status() {}
+
 // The status of a scoped token.
 type ScopedTokenStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The secret that must be provided as part of the challenge when joining using
 	// the token join method.
-	Secret        string `protobuf:"bytes,1,opt,name=secret,proto3" json:"secret,omitempty"`
+	Secret string `protobuf:"bytes,1,opt,name=secret,proto3" json:"secret,omitempty"`
+	// The usage status of the scoped token.
+	Usage         *UsageStatus `protobuf:"bytes,2,opt,name=usage,proto3" json:"usage,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedTokenStatus) Reset() {
 	*x = ScopedTokenStatus{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -230,7 +472,7 @@ func (x *ScopedTokenStatus) String() string {
 func (*ScopedTokenStatus) ProtoMessage() {}
 
 func (x *ScopedTokenStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[2]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -243,7 +485,7 @@ func (x *ScopedTokenStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScopedTokenStatus.ProtoReflect.Descriptor instead.
 func (*ScopedTokenStatus) Descriptor() ([]byte, []int) {
-	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{2}
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ScopedTokenStatus) GetSecret() string {
@@ -253,11 +495,18 @@ func (x *ScopedTokenStatus) GetSecret() string {
 	return ""
 }
 
+func (x *ScopedTokenStatus) GetUsage() *UsageStatus {
+	if x != nil {
+		return x.Usage
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
-	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
+	"&teleport/scopes/joining/v1/token.proto\x12\x1ateleport.scopes.joining.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a!teleport/header/v1/metadata.proto\"\xae\x02\n" +
 	"\vScopedToken\x12\x12\n" +
 	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x19\n" +
 	"\bsub_kind\x18\x02 \x01(\tR\asubKind\x12\x18\n" +
@@ -265,14 +514,32 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"o\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x8e\x01\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
 	"\vjoin_method\x18\x03 \x01(\tR\n" +
-	"joinMethod\"+\n" +
+	"joinMethod\x12\x1d\n" +
+	"\n" +
+	"usage_mode\x18\x04 \x01(\tR\tusageMode\"\xb6\x01\n" +
+	"\x0eHostCertParams\x12\x17\n" +
+	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
+	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
+	"\x04role\x18\x03 \x01(\tR\x04role\x123\n" +
+	"\x15additional_principals\x18\x04 \x03(\tR\x14additionalPrincipals\x12%\n" +
+	"\x0eassigned_scope\x18\x05 \x01(\tR\rassignedScope\"\x8f\x02\n" +
+	"\x0fSingleUseStatus\x123\n" +
+	"\aused_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x06usedAt\x12A\n" +
+	"\x0ereusable_until\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\rreusableUntil\x12.\n" +
+	"\x13used_by_fingerprint\x18\x03 \x01(\fR\x11usedByFingerprint\x12T\n" +
+	"\x10host_cert_params\x18\x04 \x01(\v2*.teleport.scopes.joining.v1.HostCertParamsR\x0ehostCertParams\"e\n" +
+	"\vUsageStatus\x12L\n" +
+	"\n" +
+	"single_use\x18\x01 \x01(\v2+.teleport.scopes.joining.v1.SingleUseStatusH\x00R\tsingleUseB\b\n" +
+	"\x06status\"j\n" +
 	"\x11ScopedTokenStatus\x12\x16\n" +
-	"\x06secret\x18\x01 \x01(\tR\x06secretBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x06secret\x18\x01 \x01(\tR\x06secret\x12=\n" +
+	"\x05usage\x18\x02 \x01(\v2'.teleport.scopes.joining.v1.UsageStatusR\x05usageBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -286,22 +553,31 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
-	(*ScopedToken)(nil),       // 0: teleport.scopes.joining.v1.ScopedToken
-	(*ScopedTokenSpec)(nil),   // 1: teleport.scopes.joining.v1.ScopedTokenSpec
-	(*ScopedTokenStatus)(nil), // 2: teleport.scopes.joining.v1.ScopedTokenStatus
-	(*v1.Metadata)(nil),       // 3: teleport.header.v1.Metadata
+	(*ScopedToken)(nil),           // 0: teleport.scopes.joining.v1.ScopedToken
+	(*ScopedTokenSpec)(nil),       // 1: teleport.scopes.joining.v1.ScopedTokenSpec
+	(*HostCertParams)(nil),        // 2: teleport.scopes.joining.v1.HostCertParams
+	(*SingleUseStatus)(nil),       // 3: teleport.scopes.joining.v1.SingleUseStatus
+	(*UsageStatus)(nil),           // 4: teleport.scopes.joining.v1.UsageStatus
+	(*ScopedTokenStatus)(nil),     // 5: teleport.scopes.joining.v1.ScopedTokenStatus
+	(*v1.Metadata)(nil),           // 6: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil), // 7: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	3, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	6, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1, // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
-	2, // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	5, // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
+	7, // 3: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	7, // 4: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2, // 5: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3, // 6: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4, // 7: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	8, // [8:8] is the sub-list for method output_type
+	8, // [8:8] is the sub-list for method input_type
+	8, // [8:8] is the sub-list for extension type_name
+	8, // [8:8] is the sub-list for extension extendee
+	0, // [0:8] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -309,13 +585,16 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 	if File_teleport_scopes_joining_v1_token_proto != nil {
 		return
 	}
+	file_teleport_scopes_joining_v1_token_proto_msgTypes[4].OneofWrappers = []any{
+		(*UsageStatus_SingleUse)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -16,6 +16,7 @@ syntax = "proto3";
 
 package teleport.scopes.joining.v1;
 
+import "google/protobuf/timestamp.proto";
 import "teleport/header/v1/metadata.proto";
 
 option go_package = "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1";
@@ -60,6 +61,49 @@ message ScopedTokenSpec {
   // The joining method required in order to use this token.
   // Supported joining methods for scoped tokens only include 'token'.
   string join_method = 3;
+
+  // The usage mode of the token. Can be "single_use" or "unlimited". Single use
+  // tokens can only be used to provision a single resource. Unlimited tokens
+  // can be be used to provision any number of resources until it expires.
+  string usage_mode = 4;
+}
+
+// The host certificate parameters that should be cached and leveraged for
+// token reuse
+message HostCertParams {
+  // The host ID generated for the host.
+  string host_id = 1;
+  // The host's name.
+  string node_name = 2;
+  // The system role of the host
+  string role = 3;
+  // The additional principals to include
+  repeated string additional_principals = 4;
+  // The scope to assign the host to.
+  string assigned_scope = 5;
+}
+
+// The usage status of a single use scoped token.
+message SingleUseStatus {
+  // The timestamp representing when a single use token was successfully used for
+  // provisioning.
+  google.protobuf.Timestamp used_at = 1;
+  // The timestamp representing when a single use token should no longer be avaialable
+  // for idempotent retries.
+  google.protobuf.Timestamp reusable_until = 2;
+  // The fingerprint of the public key provided by the host that used the token.
+  bytes used_by_fingerprint = 3;
+  // The relevant host parameters provided while initially using a single use token.
+  HostCertParams host_cert_params = 4;
+}
+
+// The usage status of a scoped token.
+message UsageStatus {
+  // The usage status of a scoped token.
+  oneof status {
+    // The usage status of a single use scoped token.
+    SingleUseStatus single_use = 1;
+  }
 }
 
 // The status of a scoped token.
@@ -67,4 +111,6 @@ message ScopedTokenStatus {
   // The secret that must be provided as part of the challenge when joining using
   // the token join method.
   string secret = 1;
+  // The usage status of the scoped token.
+  UsageStatus usage = 2;
 }

--- a/lib/auth/scopes/joining/service_test.go
+++ b/lib/auth/scopes/joining/service_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	jointoken "github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -80,6 +81,7 @@ func TestScopedJoiningService(t *testing.T) {
 				AssignedScope: "/staging/aa",
 				JoinMethod:    "token",
 				Roles:         []string{"Node"},
+				UsageMode:     string(jointoken.TokenUsageModeUnlimited),
 			},
 		}
 
@@ -224,6 +226,7 @@ func TestScopedJoiningService(t *testing.T) {
 				AssignedScope: "/staging/aa",
 				JoinMethod:    "token",
 				Roles:         []string{"Node"},
+				UsageMode:     string(jointoken.TokenUsageModeUnlimited),
 			},
 		}
 
@@ -237,7 +240,9 @@ func TestScopedJoiningService(t *testing.T) {
 			protocmp.IgnoreFields(&joiningv1.ScopedToken{}, "status"),
 			protocmp.Transform(),
 		}
-		assert.Empty(t, gocmp.Diff(baseToken, stageTokenAA, cmpOpts...))
+		expectedToken := proto.CloneOf(baseToken)
+		expectedToken.Status = &joiningv1.ScopedTokenStatus{}
+		assert.Empty(t, gocmp.Diff(expectedToken, stageTokenAA, cmpOpts...))
 
 		// ensure writer can't create a token at an orthogonal scope
 		stageTokenBB := proto.CloneOf(baseToken)
@@ -262,7 +267,7 @@ func TestScopedJoiningService(t *testing.T) {
 			Name: stageTokenAA.Metadata.Name,
 		})
 		require.NoError(t, err)
-		require.Empty(t, gocmp.Diff(baseToken, getRes.GetToken(), cmpOpts...))
+		require.Empty(t, gocmp.Diff(expectedToken, getRes.GetToken(), cmpOpts...))
 
 		// ensure reader can't get token at orthogonal scope
 		_, err = reader.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -148,13 +149,19 @@ func (s *Server) getProvisionToken(ctx context.Context, name string) (provision.
 
 	wg := &sync.WaitGroup{}
 	wg.Go(func() {
-		tok, err := s.cfg.ScopedTokenService.UseScopedToken(ctx, name)
+		res, err := s.cfg.ScopedTokenService.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name: name,
+		})
 		if err != nil {
 			scopedErr = err
 			return
 		}
+		if err := joining.ValidateTokenForUse(res.GetToken()); err != nil {
+			scopedErr = err
+			return
+		}
 
-		scoped, scopedErr = joining.NewToken(tok)
+		scoped, scopedErr = joining.NewToken(res.GetToken())
 	})
 	wg.Go(func() {
 		// Fetch the provision token and validate that it is not expired.
@@ -483,7 +490,7 @@ func (s *Server) makeHostResult(
 	token provision.Token,
 	rawClaims any,
 ) (*messages.HostResult, error) {
-	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(token), token.GetAssignedScope(), rawClaims)
+	certsParams, err := makeHostCertsParams(ctx, diag, authCtx, hostParams, configuredJoinMethod(token), rawClaims)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -509,7 +516,6 @@ func makeHostCertsParams(
 	authCtx *joinauthz.Context,
 	hostParams *messages.HostParams,
 	joinMethod types.JoinMethod,
-	scope string,
 	rawClaims any,
 ) (*HostCertsParams, error) {
 	// GenerateHostCertsForJoin requires the TLS key to be PEM-encoded.

--- a/lib/join/server_token.go
+++ b/lib/join/server_token.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 // handleTokenJoin handles join attempts for the token join method.
@@ -58,5 +59,19 @@ func (s *Server) handleTokenJoin(
 		nil, /*rawClaims*/
 		nil, /*attrs*/
 	)
-	return result, trace.Wrap(err)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Scoped tokens have usage limits, so once we've verified that host certs could
+	// be generated we need to attempt to consume the token. Any error should be
+	// considered a join failure.
+	if scopedToken, ok := joining.GetScopedToken(token); ok {
+		publicKey := tokenInit.ClientParams.HostParams.PublicKeys.PublicTLSKey
+		if _, err := s.cfg.ScopedTokenService.UseScopedToken(stream.Context(), scopedToken, publicKey); err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
+	return result, nil
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -23,6 +23,7 @@ import (
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/scopes"
 )
 
@@ -33,6 +34,16 @@ var rolesSupportingScopes = types.SystemRoles{
 var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodToken): {},
 }
+
+// TokenUsageMode represents the possible usage modes of a scoped token.
+type TokenUsageMode string
+
+const (
+	// TokenUsageModeSingle denotes a token that can only provision a single resource.
+	TokenUsageModeSingle TokenUsageMode = "single_use"
+	// TokenUsageModeUnlimited denotes a token that can provision any number of resources.
+	TokenUsageModeUnlimited = "unlimited"
+)
 
 // StrongValidateToken checks if the scoped token is well-formed according to
 // all scoped token rules. This function *must* be used to validate any scoped
@@ -80,6 +91,12 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 
 	if token.GetStatus().GetSecret() == "" && types.JoinMethod(spec.JoinMethod) == types.JoinMethodToken {
 		return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
+	}
+
+	switch TokenUsageMode(spec.GetUsageMode()) {
+	case TokenUsageModeSingle, TokenUsageModeUnlimited:
+	default:
+		return trace.BadParameter("scoped token mode is not supported")
 	}
 
 	if len(spec.Roles) == 0 {
@@ -130,21 +147,30 @@ func WeakValidateToken(token *joiningv1.ScopedToken) error {
 	return nil
 }
 
+var ErrTokenExpired = &trace.LimitExceededError{Message: "scoped token is expired"}
+
+var ErrTokenExhausted = &trace.LimitExceededError{Message: "scoped token usage exhausted"}
+
 // ValidateTokenForUse checks if a given scoped token can be used for
-// provisioning.
+// provisioning. Returns a [*trace.LimitExceededError] if the token is expired
 func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
 	if err := WeakValidateToken(token); err != nil {
 		return trace.Wrap(err)
 	}
 
+	now := time.Now().UTC()
 	ttl := token.GetMetadata().GetExpires()
-	if ttl == nil || ttl.AsTime().IsZero() {
-		return nil
+	if ttl != nil && !ttl.AsTime().IsZero() {
+		if ttl.AsTime().Before(now) {
+			return trace.Wrap(ErrTokenExpired)
+		}
 	}
 
-	now := time.Now().UTC()
-	if ttl.AsTime().Before(now) {
-		return trace.LimitExceeded("scoped token is expired")
+	reusableUntil := token.GetStatus().GetUsage().GetSingleUse().GetReusableUntil()
+	if reusableUntil != nil && !reusableUntil.AsTime().IsZero() {
+		if reusableUntil.AsTime().Before(now) {
+			return trace.Wrap(ErrTokenExhausted)
+		}
 	}
 
 	return nil
@@ -253,4 +279,15 @@ func (t *Token) GetIntegration() string {
 // GetSecret returns the token's secret value.
 func (t *Token) GetSecret() (string, bool) {
 	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken
+}
+
+// GetScopedToken attempts to return the underlying [*joiningv1.ScopedToken] backing a
+// [provision.Token]. Returns a boolean indicating whether the token is scoped or not.
+func GetScopedToken(token provision.Token) (*joiningv1.ScopedToken, bool) {
+	wrapper, ok := token.(*Token)
+	if !ok {
+		return nil, false
+	}
+
+	return wrapper.scoped, true
 }

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -47,6 +47,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -66,6 +67,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -87,6 +89,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -104,6 +107,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -139,6 +143,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -160,6 +165,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -180,6 +186,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -200,6 +207,7 @@ func TestValidateScopedToken(t *testing.T) {
 				Spec: &joiningv1.ScopedTokenSpec{
 					Roles:      []string{types.RoleNode.String()},
 					JoinMethod: string(types.JoinMethodToken),
+					UsageMode:  string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -221,6 +229,7 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -241,6 +250,7 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "aa/bb}",
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -262,6 +272,7 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "/bb/aa",
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -282,6 +293,7 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodUnspecified),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -302,6 +314,7 @@ func TestValidateScopedToken(t *testing.T) {
 				Spec: &joiningv1.ScopedTokenSpec{
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -323,6 +336,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{"random_role"},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -343,6 +357,7 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -363,9 +378,31 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 			},
 			expectedStrongErr: "secret value must be defined for a scoped token",
+		},
+		{
+			name: "invalid usage mode",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     "invalid",
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
+			},
+			expectedStrongErr: "scoped token mode is not supported",
 		},
 		// TODO (eriktate): add a test case for a missing secret with non-token join method once scoped
 		// tokens support other join methods
@@ -382,6 +419,7 @@ func TestValidateScopedToken(t *testing.T) {
 					Roles:         []string{types.RoleNode.String()},
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -668,6 +668,7 @@ func (process *TeleportProcess) instanceJoin() (*state.Identity, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	identity, err := state.ReadIdentityFromKeyPair(privateKeyPEM, joinResult.Certs)
 	return identity, trace.Wrap(err)
 }

--- a/lib/services/local/provisioning_test.go
+++ b/lib/services/local/provisioning_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -348,6 +349,7 @@ func TestProvisioningServiceTokenNameConflict(t *testing.T) {
 			AssignedScope: "/test/one",
 			JoinMethod:    "token",
 			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
 		},
 		Status: &joiningv1.ScopedTokenStatus{
 			Secret: "secret",

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -17,12 +17,16 @@
 package local
 
 import (
+	"cmp"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
@@ -139,21 +143,57 @@ func (s *ScopedTokenService) GetScopedToken(ctx context.Context, req *joiningv1.
 	return &joiningv1.GetScopedTokenResponse{Token: token}, nil
 }
 
-// UseScopedToken fetches a scoped join token by unique name and checks if it
-// can be used for provisioning. Expired tokens will be deleted.
-func (s *ScopedTokenService) UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error) {
-	token, err := s.svc.GetResource(ctx, name)
+// tokenReuseDuration is how long a scoped token can be reused by the host that consumed it
+const tokenReuseDuration = time.Minute * 30
+
+// UseScopedToken attempts to use a scoped token to provision a resource. A
+// [trace.LimitExceededError] error is returned if the token is expired or has
+// been exhausted, which should be treated as a failure to provision. The
+// given public key is an idempotency key to allow the same host to temporarily
+// retry a failed join due to spurious errors even after the token has been
+// consumed.
+func (s *ScopedTokenService) UseScopedToken(ctx context.Context, token *joiningv1.ScopedToken, publicKey []byte) (*joiningv1.ScopedToken, error) {
+	if err := joining.ValidateTokenForUse(token); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if joining.TokenUsageMode(token.Spec.UsageMode) != joining.TokenUsageModeSingle {
+		return token, nil
+	}
+
+	// make sure the correct, non-nil usage status is set
+	token.Status = cmp.Or(token.Status, &joiningv1.ScopedTokenStatus{})
+	token.Status.Usage = cmp.Or(token.Status.Usage, &joiningv1.UsageStatus{})
+	if token.Status.Usage.Status == nil {
+		token.Status.Usage.Status = &joiningv1.UsageStatus_SingleUse{
+			SingleUse: &joiningv1.SingleUseStatus{},
+		}
+	}
+	usage := token.Status.Usage.GetSingleUse()
+	if usage == nil {
+		return nil, trace.Errorf("single use token does not have a single use status")
+	}
+
+	fp := sha256.Sum256(publicKey)
+	if len(usage.GetUsedByFingerprint()) > 0 {
+		// no need to update the token if we're retrying for the same public key
+		if slices.Equal(usage.GetUsedByFingerprint(), fp[:]) {
+			return token, nil
+		}
+
+		return nil, trace.Wrap(joining.ErrTokenExhausted)
+	}
+
+	// set the public key if this is the first time this token has been used
+	usage.UsedByFingerprint = fp[:]
+	usage.UsedAt = timestamppb.New(time.Now())
+	usage.ReusableUntil = timestamppb.New(time.Now().Add(tokenReuseDuration))
+
+	token, err := s.svc.ConditionalUpdateResource(ctx, token)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if err := joining.ValidateTokenForUse(token); err != nil {
-		if trace.IsLimitExceeded(err) {
-			if err := s.svc.DeleteResource(ctx, name); err != nil {
-				return nil, trace.LimitExceeded("cleaning up expired token: %v", err)
-			}
-		}
-		return nil, trace.Wrap(err)
-	}
+
 	return token, nil
 }
 

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -18,10 +18,12 @@ package local_test
 
 import (
 	"cmp"
+	"crypto/sha256"
 	"fmt"
 	"slices"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -36,7 +38,9 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services/local"
 )
 
@@ -59,6 +63,7 @@ func TestScopedTokenService(t *testing.T) {
 			AssignedScope: "/test/one",
 			JoinMethod:    "token",
 			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
 		},
 		Status: &joiningv1.ScopedTokenStatus{
 			Secret: "secret",
@@ -109,7 +114,7 @@ func TestScopedTokenService(t *testing.T) {
 	require.NoError(t, err)
 
 	// expired tokens should error and delete the token
-	expiredToken, err = service.UseScopedToken(ctx, expiredRes.Token.Metadata.Name)
+	expiredToken, err = service.UseScopedToken(ctx, expiredRes.Token, nil)
 	// If for some reason the expired token is not automatically deleted by the backend, a
 	// LimitExceededError will be returned. Otherwise, we should expect the token not to be found.
 	require.True(t, trace.IsLimitExceeded(err) || trace.IsNotFound(err))
@@ -119,11 +124,6 @@ func TestScopedTokenService(t *testing.T) {
 		Name: expiredRes.Token.Metadata.Name,
 	})
 	require.True(t, trace.IsNotFound(err))
-
-	// active tokens should function like a get
-	activeToken, err = service.UseScopedToken(ctx, activeToken.Metadata.Name)
-	require.NoError(t, err)
-	assert.Empty(t, gocmp.Diff(activeToken, activeRes.Token, cmpOpts...))
 
 	fetchedActive, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
 		Name: activeRes.Token.Metadata.Name,
@@ -153,6 +153,7 @@ func TestScopedTokenList(t *testing.T) {
 			Roles: []string{
 				types.RoleNode.String(),
 			},
+			UsageMode: string(joining.TokenUsageModeUnlimited),
 		},
 		Status: &joiningv1.ScopedTokenStatus{
 			Secret: "secret",
@@ -373,6 +374,7 @@ func TestScopedTokenNameCollisions(t *testing.T) {
 			AssignedScope: "/test/one",
 			JoinMethod:    "token",
 			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
 		},
 		Status: &joiningv1.ScopedTokenStatus{
 			Secret: "secret",
@@ -454,5 +456,72 @@ func TestScopedTokenNameCollisions(t *testing.T) {
 				require.Fail(t, "unexpected failure to create either a scoped or classic token", name)
 			}
 		}
+	})
+}
+
+func TestScopedTokenUse(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		bk, err := memory.New(memory.Config{})
+		require.NoError(t, err)
+		service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+		require.NoError(t, err)
+
+		ctx := t.Context()
+
+		token := &joiningv1.ScopedToken{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name:    "testtoken",
+				Expires: timestamppb.New(time.Now().Add(24 * time.Hour)),
+			},
+			Scope: "/test",
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/test/one",
+				JoinMethod:    "token",
+				Roles:         []string{types.RoleNode.String()},
+				UsageMode:     string(joining.TokenUsageModeSingle),
+			},
+			Status: &joiningv1.ScopedTokenStatus{
+				Secret: "secret",
+			},
+		}
+
+		created, err := service.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+			Token: token,
+		})
+		require.NoError(t, err)
+
+		testKey := []byte("test")
+		otherKey := []byte("other")
+		fp := sha256.Sum256(testKey)
+		reuseDuration := 30 * time.Minute
+
+		now := time.Now().UTC()
+		// first usage should always succeed
+		tok, err := service.UseScopedToken(ctx, created.GetToken(), testKey)
+		require.NoError(t, err)
+		usage := tok.GetStatus().GetUsage().GetSingleUse()
+		require.NotNil(t, now.Add(reuseDuration), usage.GetReusableUntil().AsTime())
+		require.Equal(t, now, usage.GetUsedAt().AsTime())
+		require.Equal(t, fp[:], usage.GetUsedByFingerprint())
+
+		// reusing the same token should succeed with the same public key when
+		// reusuable_until is still in the future
+		tok, err = service.UseScopedToken(ctx, tok, testKey)
+		require.NoError(t, err)
+		usage = tok.GetStatus().GetUsage().GetSingleUse()
+		require.Equal(t, now.Add(reuseDuration), usage.GetReusableUntil().AsTime())
+		require.Equal(t, now, usage.GetUsedAt().AsTime())
+		require.Equal(t, fp[:], usage.GetUsedByFingerprint())
+
+		// reusing with a different key should fail
+		_, err = service.UseScopedToken(ctx, tok, otherKey)
+		require.ErrorIs(t, err, joining.ErrTokenExhausted)
+
+		// reusing with the same key after reusuble_until has elapsed should fail
+		<-time.After(reuseDuration + time.Minute)
+		_, err = service.UseScopedToken(ctx, tok, testKey)
+		require.ErrorIs(t, err, joining.ErrTokenExhausted)
 	})
 }

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -30,10 +30,11 @@ type ScopedTokenService interface {
 	// GetScopedToken fetches a scoped join token by unique name
 	GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.GetScopedTokenResponse, error)
 
-	// UseScopedToken fetches a scoped join token by unique name and checks if it can
-	// be used for provisioning. If the token is expired, [UseScopedToken] should also
-	// delete it from the backend.
-	UseScopedToken(ctx context.Context, name string) (*joiningv1.ScopedToken, error)
+	// UseScopedToken attempts to use a scoped token to provision a resource. The given public
+	// key should be used as an idempotency key in cases where the usage limits apply and retries
+	// should not the token.
+	UseScopedToken(ctx context.Context, token *joiningv1.ScopedToken, publicKey []byte) (*joiningv1.ScopedToken, error)
+
 	// ListScopedTokens retrieves a paginated list of scoped join tokens
 	ListScopedTokens(ctx context.Context, req *joiningv1.ListScopedTokensRequest) (*joiningv1.ListScopedTokensResponse, error)
 

--- a/tool/tctl/common/scoped_token_command_test.go
+++ b/tool/tctl/common/scoped_token_command_test.go
@@ -101,25 +101,30 @@ func TestScopedTokens(t *testing.T) {
 	require.Len(t, out.Roles, 1)
 	require.Equal(t, types.KindNode, strings.ToLower(out.Roles[0]))
 
+	// with --mode
+	buf, err = runScopedCommand(t, clt, append([]string{"tokens", "add", "--type=node", "--format", teleport.JSON, "--mode", "single_use"}, scopeFlags...))
+	require.NoError(t, err)
+	out = mustDecodeJSON[addedToken](t, buf)
+
 	// Test all output formats of "tokens ls".
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls"})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(buf.String(), "Token "))
-	require.Equal(t, 6, strings.Count(buf.String(), "\n")) // account for header lines
+	require.Equal(t, 7, strings.Count(buf.String(), "\n")) // account for header lines
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.Text})
 	require.NoError(t, err)
-	require.Equal(t, 4, strings.Count(buf.String(), "\n"))
+	require.Equal(t, 5, strings.Count(buf.String(), "\n"))
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.JSON})
 	require.NoError(t, err)
 	jsonOut := mustDecodeJSON[[]listedScopedToken](t, buf)
-	require.Len(t, jsonOut, 4)
+	require.Len(t, jsonOut, 5)
 
 	buf, err = runScopedCommand(t, clt, []string{"tokens", "ls", "--format", teleport.YAML})
 	require.NoError(t, err)
 	yamlOut := []listedScopedToken{}
 	mustDecodeYAMLDocuments(t, buf, &yamlOut)
-	require.Len(t, yamlOut, 4)
+	require.Len(t, yamlOut, 5)
 	require.Equal(t, jsonOut, yamlOut)
 }


### PR DESCRIPTION
This PR adds the `single_use` usage mode for scoped tokens as defined in #59784. It differs from standard, unlimited use tokens in that it may only be used to provision one resource. Once the token has been used, any future attempts should result in a join failure.

# Manual testing
- [x] Create a single use token `tctl scoped tokens add --type node --scope /local --assign-scope /local --mode single_use`
- [x] Provision an SSH node using the single use token, confirm success
- [x] Attempt to provision a new resource using the same token, confirm failure