### PR TITLE
docs: Fix typos in helm charts and Kubernetes Operator

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-datadog.mdx
@@ -251,7 +251,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
@@ -216,7 +216,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-email.mdx
@@ -336,7 +336,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-jira.mdx
@@ -284,7 +284,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-mattermost.mdx
@@ -212,7 +212,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-msteams.mdx
@@ -248,7 +248,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-pagerduty.mdx
@@ -204,7 +204,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-slack.mdx
@@ -216,7 +216,7 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 | `string` | `"kubernetes"` |
 
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
 ## `annotations`
 

--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -242,7 +242,7 @@ Ignored if `tbotConfig` is set.
 | `string` | `"kubernetes"` |
 
 `joinMethod` describes how tbot joins the Teleport cluster.
-See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 Ignored if `tbotConfig` is set.
 
 ## `token`

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-kube-agent.mdx
@@ -1203,7 +1203,7 @@ Teleport-published image.
 By default, the image contains only the Teleport application and its runtime
 dependencies, and does not contain a shell.
 This setting only takes effect when [`enterprise`](#enterprise) is `true`.
-When running an enterprise version, you must use [`image`](#image) instead.
+When running an OSS version, you must use [`image`](#image) instead.
 
 ## `imagePullSecrets`
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-operator.mdx
@@ -151,7 +151,7 @@ put on the `Pod` resources created by the chart.
 `annotations.serviceAccount` contains the Kubernetes annotations
 put on the `Deployment` resource created by the chart.
 
-## `annotations`
+## `labels`
 
 ### `labels.deployment`
 

--- a/docs/pages/includes/helm-reference/zz_generated.teleport-relay.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.teleport-relay.mdx
@@ -557,7 +557,7 @@ By default, the image contains only the Teleport application and its runtime
 dependencies, and does not contain a shell.
 
 This setting only takes effect when [`enterprise`](#enterprise) is `true`.
-When running an enterprise version, you must use [`image`](#image) instead.
+When running an OSS version, you must use [`image`](#image) instead.
 
 ## `imagePullSecrets`
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
@@ -176,7 +176,7 @@ References](../../reference/infrastructure-as-code/terraform-provider/terraform-
 ### Kubernetes operator resources 
 
 For comprehensive reference guides for resources you can manage with the
-Teleport Terraform provider, see [Teleport Terraform Provider
+Kubernetes operator, see [Teleport Kubernetes Operator Resource
 References](../../reference/infrastructure-as-code/operator-resources/operator-resources.mdx).
 
 ## Other ways to use the dynamic resource API

--- a/examples/chart/access/datadog/values.yaml
+++ b/examples/chart/access/datadog/values.yaml
@@ -134,7 +134,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/discord/values.yaml
+++ b/examples/chart/access/discord/values.yaml
@@ -130,7 +130,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/email/values.yaml
+++ b/examples/chart/access/email/values.yaml
@@ -176,7 +176,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/jira/values.yaml
+++ b/examples/chart/access/jira/values.yaml
@@ -153,7 +153,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/mattermost/values.yaml
+++ b/examples/chart/access/mattermost/values.yaml
@@ -120,7 +120,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/msteams/values.yaml
+++ b/examples/chart/access/msteams/values.yaml
@@ -144,7 +144,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/pagerduty/values.yaml
+++ b/examples/chart/access/pagerduty/values.yaml
@@ -117,7 +117,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/access/slack/values.yaml
+++ b/examples/chart/access/slack/values.yaml
@@ -130,7 +130,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -149,7 +149,7 @@ tbot:
   teleportAuthAddress: ""
 
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
-  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
   token: ""
 

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -130,7 +130,7 @@ outputs: []
 services: []
 
 # joinMethod(string) -- describes how tbot joins the Teleport cluster.
-# See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+# See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 # Ignored if `tbotConfig` is set.
 joinMethod: "kubernetes"
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -89,7 +89,7 @@ annotations:
   # put on the `Deployment` resource created by the chart.
   serviceAccount: {}
 
-# annotations --
+# labels --
 labels:
   # labels.deployment(object) -- contains the Kubernetes labels
   # put on the `Deployment` resource created by the chart.

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -947,7 +947,7 @@ image: public.ecr.aws/gravitational/teleport-distroless
 # By default, the image contains only the Teleport application and its runtime
 # dependencies, and does not contain a shell.
 # This setting only takes effect when [`enterprise`](#enterprise) is `true`.
-# When running an enterprise version, you must use [`image`](#image) instead.
+# When running an OSS version, you must use [`image`](#image) instead.
 enterpriseImage: public.ecr.aws/gravitational/teleport-ent-distroless
 
 # imagePullSecrets(list) -- is a list of secrets containing authorization tokens

--- a/examples/chart/teleport-relay/values.yaml
+++ b/examples/chart/teleport-relay/values.yaml
@@ -317,7 +317,7 @@ image: public.ecr.aws/gravitational/teleport-distroless
 # dependencies, and does not contain a shell.
 #
 # This setting only takes effect when [`enterprise`](#enterprise) is `true`.
-# When running an enterprise version, you must use [`image`](#image) instead.
+# When running an OSS version, you must use [`image`](#image) instead.
 enterpriseImage: public.ecr.aws/gravitational/teleport-ent-distroless
 
 # imagePullSecrets(list) -- is a list of secrets containing authorization tokens


### PR DESCRIPTION
This PR fixes various typos in helm charts: `values.yaml` which auto-generates the references.
Kubernetes Operator description in IaC section now has proper description.