### PR TITLE
fix: Bot instance service unhealthy reason layout

### DIFF
--- a/web/packages/teleport/src/BotInstances/Details/HealthTab.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/HealthTab.test.tsx
@@ -54,8 +54,7 @@ describe('HealthTab', () => {
       type: 'database-tunnel',
       updatedAt: 'Reported 14 minutes ago',
       status: 'Unhealthy',
-      reason:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+      reason: 'permission denied',
     });
 
     expectItem({
@@ -101,7 +100,9 @@ function expectItem(match: {
   expect(within(item).getByText(match.updatedAt)).toBeInTheDocument();
   expect(within(item).getByText(match.status)).toBeInTheDocument();
   if (match.reason) {
-    expect(within(item).getByText(match.reason)).toBeInTheDocument();
+    expect(
+      within(item).getByText(match.reason, { exact: false })
+    ).toBeInTheDocument();
   }
 }
 

--- a/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/HealthTab.tsx
@@ -93,7 +93,9 @@ export function HealthTab(props: { data: GetBotInstanceResponse }) {
 
                 {h.reason ? (
                   <ReasonContainer $status={h.status}>
-                    {h.reason}
+                    <ReasonInnerContainer>
+                      <ReasonText>{h.reason}</ReasonText>
+                    </ReasonInnerContainer>
                   </ReasonContainer>
                 ) : undefined}
               </ItemContainer>
@@ -145,6 +147,7 @@ export const HealthStatusDot = styled.div<{
 const ReasonContainer = styled.div<{
   $status: BotInstanceServiceHealthStatus | undefined;
 }>`
+  background-color: ${p => p.theme.colors.levels.sunken};
   border-width: 0;
   border-left-width: ${({ theme }) => theme.space[1]}px;
   border-style: solid;
@@ -160,6 +163,17 @@ const ReasonContainer = styled.div<{
           ? theme.colors.interactive.tonal.neutral[1]
           : theme.colors.interactive.solid.alert.default};
   padding: 0 ${({ theme }) => theme.space[2]}px;
+  overflow: auto;
+`;
+
+const ReasonInnerContainer = styled.div`
+  width: max-content;
+`;
+
+const ReasonText = styled.code`
+  font-size: ${({ theme }) => theme.fontSizes[1]}px;
+  white-space: pre-wrap;
+  tab-size: ${({ theme }) => theme.space[3]}px;
 `;
 
 const TitleText = styled(Text).attrs({

--- a/web/packages/teleport/src/test/helpers/botInstances.ts
+++ b/web/packages/teleport/src/test/helpers/botInstances.ts
@@ -138,7 +138,7 @@ export const mockGetBotInstanceResponse = {
             seconds: new Date('2025-10-10T10:46:00Z').getTime() / 1_000,
           },
           reason:
-            'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+            'rendering OpenSSH config\n\twriting known_hosts to destination\n\t\treading "/opt/teleport/identity/known_hosts"\n\t\t\topen /opt/teleport/identity/known_hosts: permission denied',
         },
         {
           service: {


### PR DESCRIPTION
## Summary
This change fixes the formatting of service health reason values (which are often stacktrace-like). Previously, values were displayed as simple text where line breaks and tabs were ignored. Now the text formatting is honoured and the readability is better. The element will also scroll horizontally for long lines and/or narrow windows.

Changelog: Fixed service health reason formatting for bot instances

## Changes
- Handle line breaks and tabs in string value

## Demo
_Before_
<img width="1060" height="854" alt="Screenshot 2025-12-16 at 13 11 03" src="https://github.com/user-attachments/assets/24aa42c1-e0c3-44b6-8a29-25d1bef7cbe7" />

_After_
<img width="1060" height="854" alt="Screenshot 2025-12-16 at 13 10 15" src="https://github.com/user-attachments/assets/cfeb3894-106d-4285-aa63-cba63040e302" />
