### PR TITLE
[v18] Use conn address as destination address for moderated SFTP

### DIFF
--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -169,10 +170,14 @@ func (h *Handler) transferFile(w http.ResponseWriter, r *http.Request, p httprou
 
 	signer := agentless.SignerFromSSHIdentity(ident, h.auth.accessPoint, tc.SiteName, tc.Username)
 
+	clientDstAddr := h.cfg.ProxyWebAddr
+	if srvConn, err := authz.ConnFromContext(r.Context()); err == nil {
+		clientDstAddr = utils.FromAddr(srvConn.LocalAddr())
+	}
 	conn, err := h.cfg.Router.DialHost(
 		ctx,
 		&utils.NetAddr{Addr: r.RemoteAddr},
-		&h.cfg.ProxyWebAddr,
+		&clientDstAddr,
 		req.serverID,
 		"0",
 		tc.SiteName,


### PR DESCRIPTION
Backport #62184 to branch/v18

changelog: Fixed unspecified proxy address breaking moderated SFTP when mixing IPv4 and IPv6
