### PR TITLE
[v18] helm: disable SA token automount and mount token via STS pod spec in kube-agent chart

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -83,6 +83,7 @@ spec:
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
     spec:
+      automountServiceAccountToken: true
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
   {{- toYaml .Values.imagePullSecrets | nindent 6 }}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -11,5 +11,6 @@ metadata:
 {{- if .Values.annotations.serviceAccount }}
   annotations:
 {{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
-{{- end -}}
+{{- end }}
+automountServiceAccountToken: false
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
   {{- toYaml .Values.extraLabels.pod | nindent 8 }}
 {{- end }}
     spec:
+      automountServiceAccountToken: true
       {{- if .Values.dnsConfig }}
       dnsConfig: {{- toYaml .Values.dnsConfig | nindent 8 }}
       {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -12,6 +12,7 @@ should create ServiceAccount for post-delete hook by default:
 ? should inherit ServiceAccount name from values and not create serviceAccount if
   serviceAccount.create is false and serviceAccount.name is set
 : 1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - kube-state
@@ -95,6 +96,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
             app: RELEASE-NAME
           name: RELEASE-NAME-delete-hook
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - kube-state
@@ -125,6 +127,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
           serviceAccountName: lint-serviceaccount
 should not create ServiceAccount, Role or RoleBinding for post-delete hook if serviceAccount.create and rbac.create are false:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - kube-state
@@ -155,6 +158,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
     serviceAccountName: lint-serviceaccount
 should set nodeSelector in post-delete hook:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - kube-state
@@ -187,6 +191,7 @@ should set nodeSelector in post-delete hook:
     serviceAccountName: RELEASE-NAME-delete-hook
 should set resources in the Job's pod spec if resources is set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - kube-state

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -1,6 +1,7 @@
 sets ServiceAccount annotations when specified:
   1: |
     apiVersion: v1
+    automountServiceAccountToken: false
     kind: ServiceAccount
     metadata:
       annotations:
@@ -11,6 +12,7 @@ sets ServiceAccount annotations when specified:
 sets ServiceAccount labels when specified:
   1: |
     apiVersion: v1
+    automountServiceAccountToken: false
     kind: ServiceAccount
     metadata:
       labels:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -1,5 +1,6 @@
 sets Pod annotations when specified:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -86,6 +87,7 @@ sets Pod annotations when specified:
         secretName: teleport-kube-agent-join-token
 sets Pod labels when specified:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -196,6 +198,7 @@ sets StatefulSet labels when specified:
             app.kubernetes.io/name: teleport-kube-agent
             resource: pod
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
@@ -313,6 +316,7 @@ sets by default a container security context:
       type: RuntimeDefault
 should add insecureSkipProxyTLSVerify to args when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -400,6 +404,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         secretName: teleport-kube-agent-join-token
 should add volumeClaimTemplate for data volume when using StatefulSet and action is an Upgrade:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -506,6 +511,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
           labels:
             app: RELEASE-NAME
         spec:
+          automountServiceAccountToken: true
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
@@ -602,6 +608,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
           storageClassName: aws-gp2
 should add volumeMount for data volume when using StatefulSet:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -688,6 +695,7 @@ should add volumeMount for data volume when using StatefulSet:
         secretName: teleport-kube-agent-join-token
 should expose diag port:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -774,6 +782,7 @@ should expose diag port:
         secretName: teleport-kube-agent-join-token
 should generate Statefulset when storage is disabled and mode is a Upgrade:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -874,6 +883,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
                 - RELEASE-NAME
             topologyKey: kubernetes.io/hostname
           weight: 50
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -972,6 +982,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
                 - RELEASE-NAME
             topologyKey: kubernetes.io/hostname
           weight: 50
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1058,6 +1069,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         secretName: teleport-kube-agent-join-token
 should have one replica when replicaCount is not set:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1144,6 +1156,7 @@ should have one replica when replicaCount is not set:
         secretName: teleport-kube-agent-join-token
 should install Statefulset when storage is disabled and mode is a Fresh Install:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1232,6 +1245,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
       name: data
 should mount extraVolumes and extraVolumeMounts:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1323,6 +1337,7 @@ should mount extraVolumes and extraVolumeMounts:
         secretName: mySecret
 should mount jamfCredentialsSecret if it already exists and when role is jamf:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1417,6 +1432,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         secretName: existing-teleport-jamf-secret
 should mount jamfCredentialsSecret.name when role is jamf:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1511,6 +1527,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         secretName: teleport-jamf-api-credentials
 should mount tls.existingCASecretName and set environment when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1607,6 +1624,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         secretName: helm-lint-existing-tls-secret-ca
 should mount tls.existingCASecretName and set extra environment when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1705,6 +1723,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         secretName: helm-lint-existing-tls-secret-ca
 should not add emptyDir for data when using StatefulSet:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1791,6 +1810,7 @@ should not add emptyDir for data when using StatefulSet:
         secretName: teleport-kube-agent-join-token
 should provision initContainer correctly when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -1937,6 +1957,7 @@ should set affinity when set in values:
                 - teleport
             topologyKey: kubernetes.io/hostname
           weight: 1
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2023,6 +2044,7 @@ should set affinity when set in values:
         secretName: teleport-kube-agent-join-token
 should set default serviceAccountName when not set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2120,6 +2142,7 @@ should set dnsConfig when set in values:
     - my.dns.search.suffix
 should set environment when extraEnv set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2208,6 +2231,7 @@ should set environment when extraEnv set in values:
         secretName: teleport-kube-agent-join-token
 should set image and tag correctly:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2294,6 +2318,7 @@ should set image and tag correctly:
         secretName: teleport-kube-agent-join-token
 should set imagePullPolicy when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2380,6 +2405,7 @@ should set imagePullPolicy when set in values:
         secretName: teleport-kube-agent-join-token
 should set nodeSelector if set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2480,6 +2506,7 @@ should set preferred affinity when more than one replica is used:
                 - RELEASE-NAME
             topologyKey: kubernetes.io/hostname
           weight: 50
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2566,6 +2593,7 @@ should set preferred affinity when more than one replica is used:
         secretName: teleport-kube-agent-join-token
 should set probeTimeoutSeconds when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2662,6 +2690,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
               values:
               - RELEASE-NAME
           topologyKey: kubernetes.io/hostname
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2748,6 +2777,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         secretName: teleport-kube-agent-join-token
 should set resources when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2843,6 +2873,7 @@ should set resources when set in values:
         secretName: teleport-kube-agent-join-token
 should set serviceAccountName when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -2929,6 +2960,7 @@ should set serviceAccountName when set in values:
         secretName: teleport-kube-agent-join-token
 should set storage.requests when set in values and action is an Upgrade:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -3015,6 +3047,7 @@ should set storage.requests when set in values and action is an Upgrade:
         secretName: teleport-kube-agent-join-token
 should set storage.storageClassName when set in values and action is an Upgrade:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
@@ -3101,6 +3134,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         secretName: teleport-kube-agent-join-token
 should set tolerations when set in values:
   1: |
+    automountServiceAccountToken: true
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000


### PR DESCRIPTION
Backport #61612 to branch/v18

changelog: Added `automountServiceAccountToken: false` to the `teleport-kube-agent` Helm chart to pass security linters.
