### PR TITLE
Add links to the MWI Feature Matrix section

### DIFF
--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -114,10 +114,10 @@ certificates, access control, and auditability.
 |**Ephemeral Authorization:** With granular ABAC/RBAC for workload interactions | ✔ | ✔ | ✔ |
 |**Auditability:** Audit data, exportable to SIEMs, for compliance reporting & reviews | ✔ | ✔ | ✔ |
 |**Integration:** Supports open-source policy agents, dev tool APIs, and Cloud IAM. Others include Jenkins, Github actions, Terraform Cloud, AWS Roles anywhere and more. | ✔ | ✔ | ✔ |
-|**HSM and TPM support** for bootstrapping, joining, and encryption | ✔ | ✔ | ✖ |
+|**HSM and [TPM support](machine-workload-identity/deployment/linux-tpm.mdx)** for bootstrapping, joining, and encryption | ✔ | ✔ | ✖ |
 |**Open Standards** \- JWT, SPIFFE, x509 and others to avoid vendor lock-in | ✔ | ✔ | ✔ |
-|**External PKI integration:** Configure an external PKI hierarchy to use for issuing SPIFFE SVIDs | ✔ | ✔ | ✖ |
-|**Sigstore attestation:** Enforce validation of container supply-chain security when issuing SPIFFE SVIDs  | ✔ | ✔ | ✖ |
+|**[External PKI integration](reference/machine-workload-identity/workload-identity/issuer-override.mdx):** Configure an external PKI hierarchy to use for issuing SPIFFE SVIDs | ✔ | ✔ | ✖ |
+|[**Sigstore attestation:**](reference/machine-workload-identity/workload-identity/sigstore-attestation.mdx) Enforce validation of container supply-chain security when issuing SPIFFE SVIDs  | ✔ | ✔ | ✖ |
 
 ## Teleport Identity Governance
 


### PR DESCRIPTION
Link to relevant documentation pages to help users understand the features that are gated behind an Enterprise license in MWI.