### PR TITLE
Provide better error message for ambiguous host user creation denial

### DIFF
--- a/api/gen/proto/go/teleport/decision/v1alpha1/ssh_access.pb.go
+++ b/api/gen/proto/go/teleport/decision/v1alpha1/ssh_access.pb.go
@@ -418,8 +418,10 @@ type SSHAccessPermit struct {
 	// Preconditions is a list of conditions that must be satisfied before access is granted.
 	// If any precondition is not satisfied, access must be denied.
 	Preconditions []*Precondition `protobuf:"bytes,26,rep,name=preconditions,proto3" json:"preconditions,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// DecisionContext provides additional context for select access permit decisions.
+	DecisionContext *SSHAccessPermitContext `protobuf:"bytes,27,opt,name=decision_context,json=decisionContext,proto3" json:"decision_context,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *SSHAccessPermit) Reset() {
@@ -578,6 +580,123 @@ func (x *SSHAccessPermit) GetPreconditions() []*Precondition {
 	return nil
 }
 
+func (x *SSHAccessPermit) GetDecisionContext() *SSHAccessPermitContext {
+	if x != nil {
+		return x.DecisionContext
+	}
+	return nil
+}
+
+// SSHAccessPermitContext provides additional context for select access permit decisions.
+type SSHAccessPermitContext struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// HostUserCreationAllowedBy is a list of determinants that allow host user creation.
+	HostUserCreationAllowedBy []*Determinant `protobuf:"bytes,1,rep,name=host_user_creation_allowed_by,json=hostUserCreationAllowedBy,proto3" json:"host_user_creation_allowed_by,omitempty"`
+	// HostUserCreationDeniedBy is a list of determinants that deny host user creation.
+	HostUserCreationDeniedBy []*Determinant `protobuf:"bytes,2,rep,name=host_user_creation_denied_by,json=hostUserCreationDeniedBy,proto3" json:"host_user_creation_denied_by,omitempty"`
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *SSHAccessPermitContext) Reset() {
+	*x = SSHAccessPermitContext{}
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *SSHAccessPermitContext) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*SSHAccessPermitContext) ProtoMessage() {}
+
+func (x *SSHAccessPermitContext) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use SSHAccessPermitContext.ProtoReflect.Descriptor instead.
+func (*SSHAccessPermitContext) Descriptor() ([]byte, []int) {
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *SSHAccessPermitContext) GetHostUserCreationAllowedBy() []*Determinant {
+	if x != nil {
+		return x.HostUserCreationAllowedBy
+	}
+	return nil
+}
+
+func (x *SSHAccessPermitContext) GetHostUserCreationDeniedBy() []*Determinant {
+	if x != nil {
+		return x.HostUserCreationDeniedBy
+	}
+	return nil
+}
+
+// Determinant is a resource that provided a determining factor for a decision. For example, a role or scoped_role.
+type Determinant struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Kind is the determinant kind.
+	Kind string `protobuf:"bytes,1,opt,name=kind,proto3" json:"kind,omitempty"`
+	// Name is the determinant name.
+	Name          string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Determinant) Reset() {
+	*x = Determinant{}
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Determinant) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Determinant) ProtoMessage() {}
+
+func (x *Determinant) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Determinant.ProtoReflect.Descriptor instead.
+func (*Determinant) Descriptor() ([]byte, []int) {
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *Determinant) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *Determinant) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 // SSHAccessDenial describes an SSH access denial.
 type SSHAccessDenial struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -588,7 +707,7 @@ type SSHAccessDenial struct {
 
 func (x *SSHAccessDenial) Reset() {
 	*x = SSHAccessDenial{}
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[3]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -600,7 +719,7 @@ func (x *SSHAccessDenial) String() string {
 func (*SSHAccessDenial) ProtoMessage() {}
 
 func (x *SSHAccessDenial) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[3]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -613,7 +732,7 @@ func (x *SSHAccessDenial) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SSHAccessDenial.ProtoReflect.Descriptor instead.
 func (*SSHAccessDenial) Descriptor() ([]byte, []int) {
-	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{3}
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *SSHAccessDenial) GetMetadata() *DenialMetadata {
@@ -657,7 +776,7 @@ type LockTarget struct {
 
 func (x *LockTarget) Reset() {
 	*x = LockTarget{}
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[4]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -669,7 +788,7 @@ func (x *LockTarget) String() string {
 func (*LockTarget) ProtoMessage() {}
 
 func (x *LockTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[4]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -682,7 +801,7 @@ func (x *LockTarget) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LockTarget.ProtoReflect.Descriptor instead.
 func (*LockTarget) Descriptor() ([]byte, []int) {
-	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{4}
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *LockTarget) GetUser() string {
@@ -775,7 +894,7 @@ type HostUsersInfo struct {
 
 func (x *HostUsersInfo) Reset() {
 	*x = HostUsersInfo{}
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[5]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -787,7 +906,7 @@ func (x *HostUsersInfo) String() string {
 func (*HostUsersInfo) ProtoMessage() {}
 
 func (x *HostUsersInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[5]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -800,7 +919,7 @@ func (x *HostUsersInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HostUsersInfo.ProtoReflect.Descriptor instead.
 func (*HostUsersInfo) Descriptor() ([]byte, []int) {
-	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{5}
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *HostUsersInfo) GetGroups() []string {
@@ -849,7 +968,7 @@ type Precondition struct {
 
 func (x *Precondition) Reset() {
 	*x = Precondition{}
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -861,7 +980,7 @@ func (x *Precondition) String() string {
 func (*Precondition) ProtoMessage() {}
 
 func (x *Precondition) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[6]
+	mi := &file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -874,7 +993,7 @@ func (x *Precondition) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Precondition.ProtoReflect.Descriptor instead.
 func (*Precondition) Descriptor() ([]byte, []int) {
-	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{6}
+	return file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Precondition) GetKind() PreconditionKind {
@@ -899,7 +1018,7 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\x06permit\x18\x01 \x01(\v2+.teleport.decision.v1alpha1.SSHAccessPermitH\x00R\x06permit\x12E\n" +
 	"\x06denial\x18\x02 \x01(\v2+.teleport.decision.v1alpha1.SSHAccessDenialH\x00R\x06denialB\n" +
 	"\n" +
-	"\bdecision\"\x9a\b\n" +
+	"\bdecision\"\xf9\b\n" +
 	"\x0fSSHAccessPermit\x12F\n" +
 	"\bmetadata\x18\x01 \x01(\v2*.teleport.decision.v1alpha1.PermitMetadataR\bmetadata\x12#\n" +
 	"\rforward_agent\x18\x03 \x01(\bR\fforwardAgent\x12Z\n" +
@@ -920,7 +1039,14 @@ const file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc = "" +
 	"\flock_targets\x18\x16 \x03(\v2&.teleport.decision.v1alpha1.LockTargetR\vlockTargets\x12!\n" +
 	"\fmapped_roles\x18\x17 \x03(\tR\vmappedRoles\x12Q\n" +
 	"\x0fhost_users_info\x18\x18 \x01(\v2).teleport.decision.v1alpha1.HostUsersInfoR\rhostUsersInfo\x12N\n" +
-	"\rpreconditions\x18\x1a \x03(\v2(.teleport.decision.v1alpha1.PreconditionR\rpreconditionsJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\r\x10\x0eJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\b\x11\x10\x12\"Y\n" +
+	"\rpreconditions\x18\x1a \x03(\v2(.teleport.decision.v1alpha1.PreconditionR\rpreconditions\x12]\n" +
+	"\x10decision_context\x18\x1b \x01(\v22.teleport.decision.v1alpha1.SSHAccessPermitContextR\x0fdecisionContextJ\x04\b\x02\x10\x03J\x04\b\x04\x10\x05J\x04\b\a\x10\bJ\x04\b\f\x10\rJ\x04\b\r\x10\x0eJ\x04\b\x0f\x10\x10J\x04\b\x10\x10\x11J\x04\b\x11\x10\x12\"\xec\x01\n" +
+	"\x16SSHAccessPermitContext\x12i\n" +
+	"\x1dhost_user_creation_allowed_by\x18\x01 \x03(\v2'.teleport.decision.v1alpha1.DeterminantR\x19hostUserCreationAllowedBy\x12g\n" +
+	"\x1chost_user_creation_denied_by\x18\x02 \x03(\v2'.teleport.decision.v1alpha1.DeterminantR\x18hostUserCreationDeniedBy\"5\n" +
+	"\vDeterminant\x12\x12\n" +
+	"\x04kind\x18\x01 \x01(\tR\x04kind\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"Y\n" +
 	"\x0fSSHAccessDenial\x12F\n" +
 	"\bmetadata\x18\x01 \x01(\v2*.teleport.decision.v1alpha1.DenialMetadataR\bmetadata\"\xb5\x02\n" +
 	"\n" +
@@ -974,7 +1100,7 @@ func file_teleport_decision_v1alpha1_ssh_access_proto_rawDescGZIP() []byte {
 }
 
 var file_teleport_decision_v1alpha1_ssh_access_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_teleport_decision_v1alpha1_ssh_access_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_decision_v1alpha1_ssh_access_proto_goTypes = []any{
 	(SSHPortForwardMode)(0),           // 0: teleport.decision.v1alpha1.SSHPortForwardMode
 	(HostUserMode)(0),                 // 1: teleport.decision.v1alpha1.HostUserMode
@@ -982,41 +1108,46 @@ var file_teleport_decision_v1alpha1_ssh_access_proto_goTypes = []any{
 	(*EvaluateSSHAccessRequest)(nil),  // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest
 	(*EvaluateSSHAccessResponse)(nil), // 4: teleport.decision.v1alpha1.EvaluateSSHAccessResponse
 	(*SSHAccessPermit)(nil),           // 5: teleport.decision.v1alpha1.SSHAccessPermit
-	(*SSHAccessDenial)(nil),           // 6: teleport.decision.v1alpha1.SSHAccessDenial
-	(*LockTarget)(nil),                // 7: teleport.decision.v1alpha1.LockTarget
-	(*HostUsersInfo)(nil),             // 8: teleport.decision.v1alpha1.HostUsersInfo
-	(*Precondition)(nil),              // 9: teleport.decision.v1alpha1.Precondition
-	(*RequestMetadata)(nil),           // 10: teleport.decision.v1alpha1.RequestMetadata
-	(*SSHAuthority)(nil),              // 11: teleport.decision.v1alpha1.SSHAuthority
-	(*SSHIdentity)(nil),               // 12: teleport.decision.v1alpha1.SSHIdentity
-	(*Resource)(nil),                  // 13: teleport.decision.v1alpha1.Resource
-	(*PermitMetadata)(nil),            // 14: teleport.decision.v1alpha1.PermitMetadata
-	(*durationpb.Duration)(nil),       // 15: google.protobuf.Duration
-	(*timestamppb.Timestamp)(nil),     // 16: google.protobuf.Timestamp
-	(*DenialMetadata)(nil),            // 17: teleport.decision.v1alpha1.DenialMetadata
+	(*SSHAccessPermitContext)(nil),    // 6: teleport.decision.v1alpha1.SSHAccessPermitContext
+	(*Determinant)(nil),               // 7: teleport.decision.v1alpha1.Determinant
+	(*SSHAccessDenial)(nil),           // 8: teleport.decision.v1alpha1.SSHAccessDenial
+	(*LockTarget)(nil),                // 9: teleport.decision.v1alpha1.LockTarget
+	(*HostUsersInfo)(nil),             // 10: teleport.decision.v1alpha1.HostUsersInfo
+	(*Precondition)(nil),              // 11: teleport.decision.v1alpha1.Precondition
+	(*RequestMetadata)(nil),           // 12: teleport.decision.v1alpha1.RequestMetadata
+	(*SSHAuthority)(nil),              // 13: teleport.decision.v1alpha1.SSHAuthority
+	(*SSHIdentity)(nil),               // 14: teleport.decision.v1alpha1.SSHIdentity
+	(*Resource)(nil),                  // 15: teleport.decision.v1alpha1.Resource
+	(*PermitMetadata)(nil),            // 16: teleport.decision.v1alpha1.PermitMetadata
+	(*durationpb.Duration)(nil),       // 17: google.protobuf.Duration
+	(*timestamppb.Timestamp)(nil),     // 18: google.protobuf.Timestamp
+	(*DenialMetadata)(nil),            // 19: teleport.decision.v1alpha1.DenialMetadata
 }
 var file_teleport_decision_v1alpha1_ssh_access_proto_depIdxs = []int32{
-	10, // 0: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.metadata:type_name -> teleport.decision.v1alpha1.RequestMetadata
-	11, // 1: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_authority:type_name -> teleport.decision.v1alpha1.SSHAuthority
-	12, // 2: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_identity:type_name -> teleport.decision.v1alpha1.SSHIdentity
-	13, // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.node:type_name -> teleport.decision.v1alpha1.Resource
+	12, // 0: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.metadata:type_name -> teleport.decision.v1alpha1.RequestMetadata
+	13, // 1: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_authority:type_name -> teleport.decision.v1alpha1.SSHAuthority
+	14, // 2: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.ssh_identity:type_name -> teleport.decision.v1alpha1.SSHIdentity
+	15, // 3: teleport.decision.v1alpha1.EvaluateSSHAccessRequest.node:type_name -> teleport.decision.v1alpha1.Resource
 	5,  // 4: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.permit:type_name -> teleport.decision.v1alpha1.SSHAccessPermit
-	6,  // 5: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.denial:type_name -> teleport.decision.v1alpha1.SSHAccessDenial
-	14, // 6: teleport.decision.v1alpha1.SSHAccessPermit.metadata:type_name -> teleport.decision.v1alpha1.PermitMetadata
+	8,  // 5: teleport.decision.v1alpha1.EvaluateSSHAccessResponse.denial:type_name -> teleport.decision.v1alpha1.SSHAccessDenial
+	16, // 6: teleport.decision.v1alpha1.SSHAccessPermit.metadata:type_name -> teleport.decision.v1alpha1.PermitMetadata
 	0,  // 7: teleport.decision.v1alpha1.SSHAccessPermit.port_forward_mode:type_name -> teleport.decision.v1alpha1.SSHPortForwardMode
-	15, // 8: teleport.decision.v1alpha1.SSHAccessPermit.client_idle_timeout:type_name -> google.protobuf.Duration
-	16, // 9: teleport.decision.v1alpha1.SSHAccessPermit.disconnect_expired_cert:type_name -> google.protobuf.Timestamp
-	7,  // 10: teleport.decision.v1alpha1.SSHAccessPermit.lock_targets:type_name -> teleport.decision.v1alpha1.LockTarget
-	8,  // 11: teleport.decision.v1alpha1.SSHAccessPermit.host_users_info:type_name -> teleport.decision.v1alpha1.HostUsersInfo
-	9,  // 12: teleport.decision.v1alpha1.SSHAccessPermit.preconditions:type_name -> teleport.decision.v1alpha1.Precondition
-	17, // 13: teleport.decision.v1alpha1.SSHAccessDenial.metadata:type_name -> teleport.decision.v1alpha1.DenialMetadata
-	1,  // 14: teleport.decision.v1alpha1.HostUsersInfo.mode:type_name -> teleport.decision.v1alpha1.HostUserMode
-	2,  // 15: teleport.decision.v1alpha1.Precondition.kind:type_name -> teleport.decision.v1alpha1.PreconditionKind
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	17, // 8: teleport.decision.v1alpha1.SSHAccessPermit.client_idle_timeout:type_name -> google.protobuf.Duration
+	18, // 9: teleport.decision.v1alpha1.SSHAccessPermit.disconnect_expired_cert:type_name -> google.protobuf.Timestamp
+	9,  // 10: teleport.decision.v1alpha1.SSHAccessPermit.lock_targets:type_name -> teleport.decision.v1alpha1.LockTarget
+	10, // 11: teleport.decision.v1alpha1.SSHAccessPermit.host_users_info:type_name -> teleport.decision.v1alpha1.HostUsersInfo
+	11, // 12: teleport.decision.v1alpha1.SSHAccessPermit.preconditions:type_name -> teleport.decision.v1alpha1.Precondition
+	6,  // 13: teleport.decision.v1alpha1.SSHAccessPermit.decision_context:type_name -> teleport.decision.v1alpha1.SSHAccessPermitContext
+	7,  // 14: teleport.decision.v1alpha1.SSHAccessPermitContext.host_user_creation_allowed_by:type_name -> teleport.decision.v1alpha1.Determinant
+	7,  // 15: teleport.decision.v1alpha1.SSHAccessPermitContext.host_user_creation_denied_by:type_name -> teleport.decision.v1alpha1.Determinant
+	19, // 16: teleport.decision.v1alpha1.SSHAccessDenial.metadata:type_name -> teleport.decision.v1alpha1.DenialMetadata
+	1,  // 17: teleport.decision.v1alpha1.HostUsersInfo.mode:type_name -> teleport.decision.v1alpha1.HostUserMode
+	2,  // 18: teleport.decision.v1alpha1.Precondition.kind:type_name -> teleport.decision.v1alpha1.PreconditionKind
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_teleport_decision_v1alpha1_ssh_access_proto_init() }
@@ -1039,7 +1170,7 @@ func file_teleport_decision_v1alpha1_ssh_access_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc), len(file_teleport_decision_v1alpha1_ssh_access_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   7,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/decision/v1alpha1/ssh_access.proto
+++ b/api/proto/teleport/decision/v1alpha1/ssh_access.proto
@@ -119,6 +119,25 @@ message SSHAccessPermit {
   // Preconditions is a list of conditions that must be satisfied before access is granted.
   // If any precondition is not satisfied, access must be denied.
   repeated Precondition preconditions = 26;
+
+  // DecisionContext provides additional context for select access permit decisions.
+  SSHAccessPermitContext decision_context = 27;
+}
+
+// SSHAccessPermitContext provides additional context for select access permit decisions.
+message SSHAccessPermitContext {
+  // HostUserCreationAllowedBy is a list of determinants that allow host user creation.
+  repeated Determinant host_user_creation_allowed_by = 1;
+  // HostUserCreationDeniedBy is a list of determinants that deny host user creation.
+  repeated Determinant host_user_creation_denied_by = 2;
+}
+
+// Determinant is a resource that provided a determining factor for a decision. For example, a role or scoped_role.
+message Determinant {
+  // Kind is the determinant kind.
+  string kind = 1;
+  // Name is the determinant name.
+  string name = 2;
 }
 
 // SSHAccessDenial describes an SSH access denial.

--- a/lib/decision/service.go
+++ b/lib/decision/service.go
@@ -216,15 +216,9 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		bpfEvents = append(bpfEvents, event)
 	}
 
-	hostUsersInfo, err := accessChecker.HostUsers(target)
+	hostUsersDecision, err := accessChecker.HostUsers(target)
 	if err != nil {
-		if !trace.IsAccessDenied(err) {
-			return nil, trace.Wrap(err)
-		}
-		// the way host user creation permissions currently work, an "access denied" just indicates
-		// that host user creation is disabled, and does not indicate that access should be disallowed.
-		// for the purposes of the decision service, we represent this disabled state as nil.
-		hostUsersInfo = nil
+		return nil, trace.Wrap(err)
 	}
 
 	permit := &decisionpb.SSHAccessPermit{
@@ -246,7 +240,11 @@ func (s *Service) EvaluateSSHAccess(ctx context.Context, req *decisionpb.Evaluat
 		MappedRoles:           accessInfo.Roles,
 		HostSudoers:           hostSudoers,
 		BpfEvents:             bpfEvents,
-		HostUsersInfo:         hostUsersInfo,
+		HostUsersInfo:         hostUsersDecision.Info,
+		DecisionContext: &decisionpb.SSHAccessPermitContext{
+			HostUserCreationAllowedBy: hostUsersDecision.AllowedBy,
+			HostUserCreationDeniedBy:  hostUsersDecision.DeniedBy,
+		},
 	}
 
 	return &decisionpb.EvaluateSSHAccessResponse{

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -240,7 +240,7 @@ type AccessChecker interface {
 
 	// HostUsers returns host user information matching a server or nil if
 	// a role disallows host user creation
-	HostUsers(types.Server) (*decisionpb.HostUsersInfo, error)
+	HostUsers(types.Server) (*HostUsersDecision, error)
 
 	// HostSudoers returns host sudoers entries matching a server
 	HostSudoers(types.Server) ([]string, error)
@@ -1231,20 +1231,31 @@ func convertHostUserMode(mode types.CreateHostUserMode) decisionpb.HostUserMode 
 	}
 }
 
-// HostUsers returns host user information matching a server or nil if
-// a role disallows host user creation
-func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, error) {
+// HostUsersDecision is a decision to allow or disallow host user creation.
+type HostUsersDecision struct {
+	// Info is host users information. If host users creation is disallowed, this will be nil.
+	Info *decisionpb.HostUsersInfo
+	// AllowedBy is a list of determinants that allow host user creation.
+	AllowedBy []*decisionpb.Determinant
+	// DeniedBy is a list of determinants that disallow host user creation.
+	DeniedBy []*decisionpb.Determinant
+}
+
+// HostUsers returns host user decision matching a server.
+func (a *accessChecker) HostUsers(s types.Server) (*HostUsersDecision, error) {
 	groups := set.New[string]()
 	shellToRoles := make(map[string][]string)
 	var shell string
 	var mode types.CreateHostUserMode
+
+	decision := new(HostUsersDecision)
 
 	for _, role := range a.RoleSet {
 		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		// skip nodes that dont have matching labels
+		// skip roles that don't have matching labels
 		if !result {
 			continue
 		}
@@ -1259,11 +1270,18 @@ func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, er
 			}
 		}
 
-		// if any of the matching roles do not enable create host
-		// user, the user should not be allowed on
 		if createHostUserMode == types.CreateHostUserMode_HOST_USER_MODE_OFF {
-			return nil, trace.AccessDenied("role %q prevents creating host users", role.GetName())
+			decision.DeniedBy = append(decision.DeniedBy, &decisionpb.Determinant{
+				Kind: role.GetKind(),
+				Name: role.GetName(),
+			})
+			continue
 		}
+
+		decision.AllowedBy = append(decision.AllowedBy, &decisionpb.Determinant{
+			Kind: role.GetKind(),
+			Name: role.GetName(),
+		})
 
 		if mode == types.CreateHostUserMode_HOST_USER_MODE_UNSPECIFIED {
 			mode = createHostUserMode
@@ -1283,6 +1301,13 @@ func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, er
 		for _, group := range role.GetHostGroups(types.Allow) {
 			groups.Add(group)
 		}
+	}
+
+	// if any of the matching roles do not enable create host user, the user should not be allowed on
+	// Represent denial by returning the decision with a nil info field.
+	if len(decision.DeniedBy) > 0 {
+		decision.Info = nil
+		return decision, nil
 	}
 
 	if len(shellToRoles) > 1 {
@@ -1322,13 +1347,15 @@ func (a *accessChecker) HostUsers(s types.Server) (*decisionpb.HostUsersInfo, er
 		uid = uidL[0]
 	}
 
-	return &decisionpb.HostUsersInfo{
+	decision.Info = &decisionpb.HostUsersInfo{
 		Groups: groups.Elements(),
 		Mode:   convertHostUserMode(mode),
 		Uid:    uid,
 		Gid:    gid,
 		Shell:  shell,
-	}, nil
+	}
+
+	return decision, nil
 }
 
 // HostSudoers returns host sudoers entries matching a server

--- a/lib/services/access_checker_test.go
+++ b/lib/services/access_checker_test.go
@@ -600,7 +600,7 @@ func TestAccessCheckerHostUsersShell(t *testing.T) {
 
 	// the first value for shell encountered while checking roles should be used, which means
 	// secondaryShell should never be the result here
-	require.Equal(t, expectedShell, hui.Shell)
+	require.Equal(t, expectedShell, hui.Info.Shell)
 }
 
 func TestAccessCheckerDesktopGroups(t *testing.T) {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -8349,9 +8349,9 @@ func TestHostUsers_getGroups(t *testing.T) {
 	} {
 		t.Run(tc.test, func(t *testing.T) {
 			accessChecker := makeAccessCheckerWithRoleSet(tc.roles)
-			info, err := accessChecker.HostUsers(tc.server)
+			hu, err := accessChecker.HostUsers(tc.server)
 			require.NoError(t, err)
-			require.ElementsMatch(t, tc.groups, info.Groups)
+			require.ElementsMatch(t, tc.groups, hu.Info.Groups)
 		})
 	}
 }
@@ -8779,6 +8779,7 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -8830,10 +8831,15 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 	} {
 		t.Run(tc.test, func(t *testing.T) {
 			accessChecker := makeAccessCheckerWithRoleSet(tc.roles)
-			info, err := accessChecker.HostUsers(tc.server)
-			require.Equal(t, tc.canCreate, err == nil && info != nil)
+			hu, err := accessChecker.HostUsers(tc.server)
+			require.NoError(t, err)
 			if tc.canCreate {
-				require.Equal(t, convertHostUserMode(tc.expectedMode), info.Mode)
+				require.NotEmpty(t, hu.AllowedBy)
+				require.Empty(t, hu.DeniedBy)
+				require.Equal(t, convertHostUserMode(tc.expectedMode), hu.Info.Mode)
+			} else {
+				require.NotEmpty(t, hu.DeniedBy)
+				require.Nil(t, hu.Info)
 			}
 		})
 	}

--- a/lib/services/scoped_access_checker.go
+++ b/lib/services/scoped_access_checker.go
@@ -493,7 +493,7 @@ func (c *ScopedAccessChecker) EnhancedRecordingSet() map[string]bool {
 
 // HostUsers returns host user information matching a server or nil if
 // a role disallows host user creation
-func (c *ScopedAccessChecker) HostUsers(srv types.Server) (*decisionpb.HostUsersInfo, error) {
+func (c *ScopedAccessChecker) HostUsers(srv types.Server) (*HostUsersDecision, error) {
 	// scoped roles do not currently support host users, but we don't currently foresee
 	// issues with mirroring the classic role interface here since host users are not
 	// certificate-bound and are not calculated pre-access-check. depeding on wether or not

--- a/lib/services/split_access_checker.go
+++ b/lib/services/split_access_checker.go
@@ -54,7 +54,7 @@ type CommonAccessChecker interface {
 	CheckAccessToRules(ctx RuleContext, resource string, verbs ...string) error
 	HostSudoers(types.Server) ([]string, error)
 	EnhancedRecordingSet() map[string]bool
-	HostUsers(types.Server) (*decisionpb.HostUsersInfo, error)
+	HostUsers(types.Server) (*HostUsersDecision, error)
 	CheckAgentForward(login string) error
 	MaxConnections() int64
 	MaxSessions() int64

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -1035,15 +1035,9 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		bpfEvents = append(bpfEvents, event)
 	}
 
-	hostUsersInfo, err := checker.Common().HostUsers(target)
+	hostUsersDecision, err := checker.Common().HostUsers(target)
 	if err != nil {
-		if !trace.IsAccessDenied(err) {
-			return nil, trace.Wrap(err)
-		}
-		// the way host user creation permissions currently work, an "access denied" just indicates
-		// that host user creation is disabled, and does not indicate that access should be disallowed.
-		// for the purposes of the decision service, we represent this disabled state as nil.
-		hostUsersInfo = nil
+		return nil, trace.Wrap(err)
 	}
 
 	return &decisionpb.SSHAccessPermit{
@@ -1062,7 +1056,11 @@ func (a *ahLoginChecker) evaluateScopedSSHAccess(ident *sshca.Identity, ca types
 		MappedRoles:           accessInfo.Roles,
 		HostSudoers:           hostSudoers,
 		BpfEvents:             bpfEvents,
-		HostUsersInfo:         hostUsersInfo,
+		HostUsersInfo:         hostUsersDecision.Info,
+		DecisionContext: &decisionpb.SSHAccessPermitContext{
+			HostUserCreationAllowedBy: hostUsersDecision.AllowedBy,
+			HostUserCreationDeniedBy:  hostUsersDecision.DeniedBy,
+		},
 	}, nil
 }
 
@@ -1150,15 +1148,9 @@ func (a *ahLoginChecker) evaluateSSHAccess(ident *sshca.Identity, ca types.CertA
 		bpfEvents = append(bpfEvents, event)
 	}
 
-	hostUsersInfo, err := accessChecker.HostUsers(target)
+	hostUsersDecision, err := accessChecker.HostUsers(target)
 	if err != nil {
-		if !trace.IsAccessDenied(err) {
-			return nil, trace.Wrap(err)
-		}
-		// the way host user creation permissions currently work, an "access denied" just indicates
-		// that host user creation is disabled, and does not indicate that access should be disallowed.
-		// for the purposes of the decision service, we represent this disabled state as nil.
-		hostUsersInfo = nil
+		return nil, trace.Wrap(err)
 	}
 
 	return &decisionpb.SSHAccessPermit{
@@ -1177,8 +1169,12 @@ func (a *ahLoginChecker) evaluateSSHAccess(ident *sshca.Identity, ca types.CertA
 		MappedRoles:           accessInfo.Roles,
 		HostSudoers:           hostSudoers,
 		BpfEvents:             bpfEvents,
-		HostUsersInfo:         hostUsersInfo,
+		HostUsersInfo:         hostUsersDecision.Info,
 		Preconditions:         preconds,
+		DecisionContext: &decisionpb.SSHAccessPermitContext{
+			HostUserCreationAllowedBy: hostUsersDecision.AllowedBy,
+			HostUserCreationDeniedBy:  hostUsersDecision.DeniedBy,
+		},
 	}, nil
 }
 

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -203,7 +203,10 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	e.waitForOutputStreams.Go(func() {
 		defer stderrR.Close()
 
-		childErr, err := reexec.ReadChildError(stderrR)
+		childErr, err := reexec.ReadChildError(stderrR, &reexec.ErrorContext{
+			DecisionContext: e.Ctx.Identity.AccessPermit.DecisionContext,
+			Login:           e.Ctx.Identity.Login,
+		})
 		if err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
 			return

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -418,7 +418,8 @@ func RunCommand() (exitErr error, err error) {
 		// Open the PAM context.
 		pamContext, err := pam.Open(cfg)
 		if err != nil {
-			return nil, trace.Wrap(err, "failed to open PAM context")
+			// Format the PAM error to be user friendly.
+			return nil, trace.Errorf("failed to open PAM context: %v", err.Error())
 		}
 		defer pamContext.Close()
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -226,7 +226,10 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	t.waitForOutputStreams.Go(func() {
 		defer stderrR.Close()
 
-		childErr, err := reexec.ReadChildError(stderrR)
+		childErr, err := reexec.ReadChildError(stderrR, &reexec.ErrorContext{
+			DecisionContext: t.serverContext.Identity.AccessPermit.DecisionContext,
+			Login:           t.serverContext.Identity.Login,
+		})
 		if err != nil {
 			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
 			return

--- a/lib/sshutils/reexec/reexec.go
+++ b/lib/sshutils/reexec/reexec.go
@@ -76,7 +76,7 @@ func ReadChildError(stderr io.Reader, context *ErrorContext) (string, error) {
 
 	unknownUserError := user.UnknownUserError(context.Login)
 	switch {
-	case strings.Contains(errMsg.String(), "Authentication failure."): // opaque PAM auth error.
+	case strings.Contains(errMsg.String(), "failed to open PAM context"): // PAM errors are often cause by an unknown user.
 		if _, err := user.Lookup(context.Login); errors.Is(err, unknownUserError) {
 			if ambiguousHostUserDenial {
 				return ambiguousHostUserError(), nil

--- a/lib/sshutils/reexec/reexec.go
+++ b/lib/sshutils/reexec/reexec.go
@@ -20,26 +20,73 @@
 package reexec
 
 import (
+	"errors"
+	"fmt"
 	"io"
+	"os/user"
 	"strings"
 
 	"github.com/gravitational/trace"
+
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 )
 
 const maxRead = 4096
 
-// ReadChildError reads the child process's stderr pipe and returns it as a string.
+// ErrorContext contains context used to enrich child process launch errors.
+type ErrorContext struct {
+	// DecisionContext contains RBAC decision details used to clarify
+	// access related launch failures.
+	DecisionContext *decisionpb.SSHAccessPermitContext
+	// Login is the target OS login used by the child process.
+	Login string
+}
+
+// ReadChildError reads the child process's stderr pipe and returns it as a string,
+// potentially with additional error context gathered from the given ErrorContext.
 // If the stderr pipe is empty, an empty string and nil error is returned.
-func ReadChildError(stderr io.Reader) (string, error) {
+func ReadChildError(stderr io.Reader, context *ErrorContext) (string, error) {
 	// Read the error msg from stderr.
 	errMsg := new(strings.Builder)
 	if _, err := io.Copy(errMsg, io.LimitReader(stderr, maxRead)); err != nil {
 		return "", trace.Wrap(err, "failed to read error message from child process")
 	}
 
-	// TODO(Joerger): Process the err msg from stderr to provide deeper insights into
-	// the cause of the session failure to add to the error message.
-	// e.g. user unknown because host user creation denied.
+	if errMsg.Len() == 0 {
+		return "", nil
+	}
+
+	// If we don't have a decision context, we don't have any context to
+	// add to the error message. Return stderr as is.
+	if context == nil || context.DecisionContext == nil {
+		return errMsg.String(), nil
+	}
+
+	// If some roles allow host user creation while others deny it, this can be
+	// ambiguous to the end user and warrants clarification if it results in an
+	// unknown user error.
+	ambiguousHostUserDenial := len(context.DecisionContext.HostUserCreationDeniedBy) > 0 && len(context.DecisionContext.HostUserCreationAllowedBy) > 0
+	ambiguousHostUserError := func() string {
+		var deniedBy []string
+		for _, d := range context.DecisionContext.HostUserCreationDeniedBy {
+			deniedBy = append(deniedBy, fmt.Sprintf("%v: %q", d.Kind, d.Name))
+		}
+		return fmt.Sprintf("%s: host user creation denied by the following resources: [%s]\r\n", strings.TrimRight(errMsg.String(), ".\r\n"), strings.Join(deniedBy, ", "))
+	}
+
+	unknownUserError := user.UnknownUserError(context.Login)
+	switch {
+	case strings.Contains(errMsg.String(), "Authentication failure."): // opaque PAM auth error.
+		if _, err := user.Lookup(context.Login); errors.Is(err, unknownUserError) {
+			if ambiguousHostUserDenial {
+				return ambiguousHostUserError(), nil
+			}
+		}
+	case strings.Contains(errMsg.String(), unknownUserError.Error()):
+		if ambiguousHostUserDenial {
+			return ambiguousHostUserError(), nil
+		}
+	}
 
 	return errMsg.String(), nil
 }

--- a/lib/sshutils/reexec/reexec_test.go
+++ b/lib/sshutils/reexec/reexec_test.go
@@ -25,40 +25,75 @@ import (
 	"testing/iotest"
 
 	"github.com/stretchr/testify/require"
+
+	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
 )
 
 func TestReadChildError(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		readErr    error
-		stderrIn   string
-		wantStderr string
+		name         string
+		readErr      error
+		childErrIn   string
+		wantChildErr string
+		context      *ErrorContext
 	}{
 		{
-			name:       "empty stderr",
-			stderrIn:   "",
-			wantStderr: "",
+			name:         "empty stderr",
+			childErrIn:   "",
+			wantChildErr: "",
 		},
 		{
-			name:       "has stderr",
-			stderrIn:   "Failed to launch: test error.\r\n",
-			wantStderr: "Failed to launch: test error.\r\n",
+			name:         "has stderr",
+			childErrIn:   "Failed to launch: test error.\r\n",
+			wantChildErr: "Failed to launch: test error.\r\n",
 		},
 		{
-			name:       "stderr at max read limit",
-			stderrIn:   strings.Repeat("a", maxRead),
-			wantStderr: strings.Repeat("a", maxRead),
+			name:         "stderr at max read limit",
+			childErrIn:   strings.Repeat("a", maxRead),
+			wantChildErr: strings.Repeat("a", maxRead),
 		},
 		{
-			name:       "stderr over max read limit is truncated",
-			stderrIn:   strings.Repeat("a", maxRead) + "b",
-			wantStderr: strings.Repeat("a", maxRead),
+			name:         "stderr over max read limit is truncated",
+			childErrIn:   strings.Repeat("a", maxRead) + "b",
+			wantChildErr: strings.Repeat("a", maxRead),
 		},
 		{
 			name:    "read error",
 			readErr: errors.New("read failure"),
+		},
+		{
+			name:       "unknown user error with mixed host user creation decisions gets contextualized",
+			childErrIn: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec.\r\n",
+			context: &ErrorContext{
+				Login: "teleport-test-user-does-not-exist-reexec",
+				DecisionContext: &decisionpb.SSHAccessPermitContext{
+					HostUserCreationAllowedBy: []*decisionpb.Determinant{
+						{Kind: "role", Name: "allow-role"},
+					},
+					HostUserCreationDeniedBy: []*decisionpb.Determinant{
+						{Kind: "role", Name: "deny-role"},
+					},
+				},
+			},
+			wantChildErr: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec: host user creation denied by the following resources: [role: \"deny-role\"]\r\n",
+		},
+		{
+			name:       "pam context error for unknown user gets contextualized",
+			childErrIn: "Failed to launch: failed to open PAM context: pam_start failed.\r\n",
+			context: &ErrorContext{
+				Login: "teleport-test-user-does-not-exist-pam",
+				DecisionContext: &decisionpb.SSHAccessPermitContext{
+					HostUserCreationAllowedBy: []*decisionpb.Determinant{
+						{Kind: "role", Name: "allow-role"},
+					},
+					HostUserCreationDeniedBy: []*decisionpb.Determinant{
+						{Kind: "role", Name: "deny-role"},
+					},
+				},
+			},
+			wantChildErr: "Failed to launch: failed to open PAM context: pam_start failed: host user creation denied by the following resources: [role: \"deny-role\"]\r\n",
 		},
 	}
 
@@ -67,14 +102,14 @@ func TestReadChildError(t *testing.T) {
 			t.Parallel()
 
 			if tt.readErr != nil {
-				_, err := ReadChildError(iotest.ErrReader(tt.readErr))
+				_, err := ReadChildError(iotest.ErrReader(tt.readErr), tt.context)
 				require.ErrorIs(t, err, tt.readErr)
 				return
 			}
 
-			got, err := ReadChildError(strings.NewReader(tt.stderrIn))
+			got, err := ReadChildError(strings.NewReader(tt.childErrIn), tt.context)
 			require.NoError(t, err)
-			require.Equal(t, tt.wantStderr, got)
+			require.Equal(t, tt.wantChildErr, got)
 		})
 	}
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8324,7 +8324,11 @@ func TestReexecErrorPropagation(t *testing.T) {
 
 	// Use a non-existent OS user to force reexec failures in the node.
 	missingLogin := "does-not-exist"
-	nodeAccessMissingLogin, err := types.NewRole("node-access-missing-login", types.RoleSpecV6{
+	roleNodeAccessMissingLogin, err := types.NewRole("node-access-missing-login", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			ForwardAgent:        types.NewBool(true),
+			PermitX11Forwarding: types.NewBool(true),
+		},
 		Allow: types.RoleConditions{
 			Logins:     []string{missingLogin},
 			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
@@ -8334,14 +8338,35 @@ func TestReexecErrorPropagation(t *testing.T) {
 
 	userMissingLogin, err := types.NewUser("user-missing-login")
 	require.NoError(t, err)
-	userMissingLogin.SetRoles([]string{nodeAccessMissingLogin.GetName()})
+	userMissingLogin.SetRoles([]string{roleNodeAccessMissingLogin.GetName()})
+
+	// When the user has mixed host user creation modes the error should be given additional context.
+	roleHostUserAllow, err := types.NewRole("node-access-allow-host-user", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			CreateHostUserMode: types.CreateHostUserMode_HOST_USER_MODE_KEEP,
+		},
+		Allow: types.RoleConditions{
+			Logins:     []string{missingLogin},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+
+	userHostUserCreationContext, err := types.NewUser("user-host-user-creation-context")
+	require.NoError(t, err)
+	userHostUserCreationContext.SetRoles([]string{roleNodeAccessMissingLogin.GetName(), roleHostUserAllow.GetName()})
 
 	sshHostname := "test-ssh-server"
 	rootServerOpts := []testserver.TestServerOptFunc{
-		testserver.WithBootstrap(connector, nodeAccessMissingLogin, userMissingLogin),
+		testserver.WithBootstrap(connector, roleNodeAccessMissingLogin, roleHostUserAllow, userMissingLogin, userHostUserCreationContext),
 		testserver.WithHostname(sshHostname),
 		testserver.WithConfig(func(cfg *servicecfg.Config) {
 			cfg.SSH.Enabled = true
+			cfg.SSH.X11 = &x11.ServerConfig{
+				Enabled:       true,
+				DisplayOffset: x11.DefaultDisplayOffset,
+				MaxDisplay:    x11.DefaultMaxDisplays,
+			}
 		}),
 	}
 	rootServer, err := testserver.NewTeleportProcess(t.TempDir(), rootServerOpts...)
@@ -8361,59 +8386,116 @@ func TestReexecErrorPropagation(t *testing.T) {
 		require.Len(t, rootNodes, 1)
 	}, 10*time.Second, 100*time.Millisecond)
 
-	homePath := t.TempDir()
+	login := func(t *testing.T, loginUser types.User) string {
+		t.Helper()
+		homePath := t.TempDir()
+		err := Run(ctx, []string{
+			"login",
+			"--insecure",
+			"--proxy", proxyAddr.String(),
+		}, setHomePath(homePath), setMockSSOLogin(authServer, loginUser, connector.GetName()))
+		require.NoError(t, err)
+		return homePath
+	}
 
-	sshCases := []struct {
+	userMissingLoginHomePath := login(t, userMissingLogin)
+	userHostUserCreationContextHomePath := login(t, userHostUserCreationContext)
+
+	type testCase struct {
 		name          string
 		tty           bool
 		remoteCommand []string
-	}{
-		{
-			name: "ssh shell",
-		},
-		{
-			name:          "ssh command",
-			remoteCommand: []string{"echo", "hello"},
-		},
-		{
-			name:          "ssh command w/ tty",
-			remoteCommand: []string{"echo", "hello"},
-			tty:           true,
-		},
 	}
 
-	err = Run(ctx, []string{
-		"login",
-		"--insecure",
-		"--proxy", proxyAddr.String(),
-	}, setHomePath(homePath), setMockSSOLogin(authServer, userMissingLogin, connector.GetName()))
-	require.NoError(t, err)
-
-	for _, sc := range sshCases {
-		t.Run(sc.name, func(t *testing.T) {
-			t.Parallel()
-			stdout := &output{buf: bytes.Buffer{}}
-
-			args := []string{"ssh", "--insecure"}
-			if sc.tty {
-				args = append(args, "--tty")
-			}
-			args = append(args, fmt.Sprintf("%s@%s", missingLogin, sshHostname))
-			args = append(args, sc.remoteCommand...)
-
-			err := Run(ctx, args,
-				setHomePath(homePath),
-				func(conf *CLIConf) error {
-					conf.OverrideStdout = stdout
-					return nil
-				},
-			)
-			require.Error(t, err)
-
-			expectErr := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
-
-			// Check for exact match to catch regressions with new lines.
-			require.Equal(t, expectErr, stdout.String())
-		})
+	sshShell := testCase{name: "ssh shell"}
+	sshCommand := testCase{
+		name:          "ssh command",
+		remoteCommand: []string{"echo", "hello"},
 	}
+	sshCommandTTY := testCase{
+		name:          "ssh command w/ tty",
+		remoteCommand: []string{"echo", "hello"},
+		tty:           true,
+	}
+
+	runSSH := func(t *testing.T, tc testCase, homePath string, login string) (string, error) {
+		stdout := &output{buf: bytes.Buffer{}}
+
+		// If the shell succeeds, ensure it exits immediately.
+		stdin := &bytes.Buffer{}
+		if len(tc.remoteCommand) == 0 {
+			_, err := stdin.WriteString("exit\n")
+			require.NoError(t, err)
+		}
+
+		args := []string{"ssh", "--insecure"}
+		if tc.tty {
+			args = append(args, "--tty")
+		}
+		args = append(args, fmt.Sprintf("%s@%s", login, sshHostname))
+		args = append(args, tc.remoteCommand...)
+
+		// The shell should succeed even though agent/x11 forwarding will be denied.
+		err := Run(ctx, args,
+			setHomePath(homePath),
+			func(conf *CLIConf) error {
+				conf.OverrideStdout = stdout
+				conf.overrideStdin = stdin
+				return nil
+			},
+		)
+		return stdout.String(), err
+	}
+
+	t.Run("unknown user error", func(t *testing.T) {
+		t.Parallel()
+		homePath := userMissingLoginHomePath
+
+		for _, tc := range []testCase{sshShell, sshCommand, sshCommandTTY} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				stdout, err := runSSH(t, tc, homePath, missingLogin)
+
+				var exitCodeErr *common.ExitCodeError
+				require.ErrorAs(t, err, &exitCodeErr)
+				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
+
+				// The top level ssh error comes after the forwarding errors and after terminal setup.
+				// If there is a tty allocated, we expect CRLF instead of just LF.
+				expectStdout := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
+
+				// Check for exact match to catch regressions with new lines.
+				require.Equal(t, expectStdout, stdout)
+			})
+		}
+	})
+
+	t.Run("error with host user creation context", func(t *testing.T) {
+		t.Parallel()
+		homePath := userHostUserCreationContextHomePath
+
+		for _, tc := range []testCase{sshCommand} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				stdout, err := runSSH(t, tc, homePath, missingLogin)
+
+				var exitCodeErr *common.ExitCodeError
+				require.ErrorAs(t, err, &exitCodeErr)
+				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
+
+				// The top level ssh error comes after the forwarding errors and after terminal setup.
+				// If there is a tty allocated, we expect CRLF instead of just LF.
+				expectStdout := fmt.Sprintf("Failed to launch: %s: host user creation denied by the following resources: [%s: %q]\r\n",
+					user.UnknownUserError(missingLogin),
+					types.KindRole,
+					roleNodeAccessMissingLogin.GetName(),
+				)
+
+				// Check for exact match to catch regressions with new lines.
+				require.Equal(t, expectStdout, stdout)
+			})
+		}
+	})
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8421,13 +8421,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 	runSSH := func(t *testing.T, tc testCase, homePath string, login string) (string, error) {
 		stdout := &output{buf: bytes.Buffer{}}
 
-		// If the shell succeeds, ensure it exits immediately.
-		stdin := &bytes.Buffer{}
-		if len(tc.remoteCommand) == 0 {
-			_, err := stdin.WriteString("exit\n")
-			require.NoError(t, err)
-		}
-
 		args := []string{"ssh", "--insecure"}
 		if tc.tty {
 			args = append(args, "--tty")
@@ -8440,7 +8433,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 			setHomePath(homePath),
 			func(conf *CLIConf) error {
 				conf.OverrideStdout = stdout
-				conf.overrideStdin = stdin
 				return nil
 			},
 		)
@@ -8461,8 +8453,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 				require.ErrorAs(t, err, &exitCodeErr)
 				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
 
-				// The top level ssh error comes after the forwarding errors and after terminal setup.
-				// If there is a tty allocated, we expect CRLF instead of just LF.
 				expectStdout := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
 
 				// Check for exact match to catch regressions with new lines.
@@ -8485,8 +8475,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 				require.ErrorAs(t, err, &exitCodeErr)
 				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
 
-				// The top level ssh error comes after the forwarding errors and after terminal setup.
-				// If there is a tty allocated, we expect CRLF instead of just LF.
 				expectStdout := fmt.Sprintf("Failed to launch: %s: host user creation denied by the following resources: [%s: %q]\r\n",
 					user.UnknownUserError(missingLogin),
 					types.KindRole,


### PR DESCRIPTION
Add a user friendly error message when a session fails to start due to an unknown user, and the Teleport user has roles with conflicting host user creation permissions.

<details>
<summary>Example output</summary>

Before:
```
> tsh ssh dne@server01
Failed to launch: user: unknown user dne.
```

After:
```
> tsh ssh dne@server01               
Failed to launch: user: unknown user dne: host user creation denied by the following resources: [role: "dev2", role: "dev3"]
```

</details>

<details>
<summary>Manual Tests</summary>

Last Run: 086b8e07337497434318b475e7535b2381eb51a2
- [x] Host user creation denied by 2 roles
- [x] Host user creation allowed by 1 role, denied by 1 role
- [x] Host user creation allowed by 2 roles

</details>

Depends on https://github.com/gravitational/teleport/pull/63910
Closes https://github.com/gravitational/teleport/issues/40370