### PR TITLE
security(web): bump react to v19.2.3 (CVE-2025-55182)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-day-picker": "^9.11.2",
     "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.0",
-    "react-is": "^19.2.0",
+    "react-is": "^19.2.3",
     "react-router": "5.3.4",
     "react-router-dom": "5.3.4",
     "react-select": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
   "devDependencies": {
     "@gravitational/build": "workspace:*",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
-    "@storybook/react-vite": "^9.1.16",
     "@storybook/addon-vitest": "^9.1.16",
+    "@storybook/react-vite": "^9.1.16",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -82,9 +82,9 @@
     "history": "^4.9.0",
     "immer": "^11.0.1",
     "prop-types": "^15.8.1",
-    "react": "^19.2.0",
+    "react": "^19.2.3",
     "react-day-picker": "^9.11.2",
-    "react-dom": "^19.2.0",
+    "react-dom": "^19.2.3",
     "react-error-boundary": "^6.0.0",
     "react-is": "^19.2.0",
     "react-router": "5.3.4",
@@ -93,8 +93,8 @@
     "react-transition-group": "^4.4.5",
     "styled-components": "^6.1.19",
     "tslib": "^2.8.1",
-    "usehooks-ts": "^3.1.1",
     "use-immer": "^0.11.0",
+    "usehooks-ts": "^3.1.1",
     "whatwg-fetch": "^3.6.20"
   },
   "msw": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 6.38.8
       '@floating-ui/react':
         specifier: ^0.27.16
-        version: 0.27.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 0.27.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@grpc/grpc-js':
         specifier: 1.14.1
         version: 1.14.1
@@ -38,7 +38,7 @@ importers:
         version: 1.2.3
       '@nivo/bar':
         specifier: ^0.99.0
-        version: 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@protobuf-ts/runtime':
         specifier: ^2.11.1
         version: 2.11.1
@@ -47,13 +47,13 @@ importers:
         version: 2.11.1
       '@tanstack/react-query':
         specifier: ^5.90.11
-        version: 5.90.11(react@19.2.0)
+        version: 5.90.11(react@19.2.3)
       '@uiw/codemirror-themes':
         specifier: ^4.25.3
         version: 4.25.3(@codemirror/view@6.38.8)
       '@uiw/react-codemirror':
         specifier: ^4.25.3
-        version: 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/view@6.38.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/view@6.38.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
@@ -76,44 +76,44 @@ importers:
         specifier: ^15.8.1
         version: 15.8.1
       react:
-        specifier: ^19.2.0
-        version: 19.2.0
+        specifier: ^19.2.3
+        version: 19.2.3
       react-day-picker:
         specifier: ^9.11.2
-        version: 9.11.2(react@19.2.0)
+        version: 9.11.2(react@19.2.3)
       react-dom:
-        specifier: ^19.2.0
-        version: 19.2.0(react@19.2.0)
+        specifier: ^19.2.3
+        version: 19.2.3(react@19.2.3)
       react-error-boundary:
         specifier: ^6.0.0
-        version: 6.0.0(react@19.2.0)
+        version: 6.0.0(react@19.2.3)
       react-is:
         specifier: ^19.2.0
         version: 19.2.0
       react-router:
         specifier: 5.3.4
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.3)
       react-router-dom:
         specifier: 5.3.4
-        version: 5.3.4(react@19.2.0)
+        version: 5.3.4(react@19.2.3)
       react-select:
         specifier: ^5.10.2
-        version: 5.10.2(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 5.10.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-transition-group:
         specifier: ^4.4.5
-        version: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       styled-components:
         specifier: ^6.1.19
-        version: 6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
       use-immer:
         specifier: ^0.11.0
-        version: 0.11.0(immer@11.0.1)(react@19.2.0)
+        version: 0.11.0(immer@11.0.1)(react@19.2.3)
       usehooks-ts:
         specifier: ^3.1.1
-        version: 3.1.1(react@19.2.0)
+        version: 3.1.1(react@19.2.3)
       whatwg-fetch:
         specifier: ^3.6.20
         version: 3.6.20
@@ -126,16 +126,16 @@ importers:
         version: 4.7.0(prettier@3.7.3)
       '@storybook/addon-vitest':
         specifier: ^9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))
       '@storybook/react-vite':
         specifier: ^9.1.16
-        version: 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
+        version: 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.1.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.1.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.1.0)
@@ -242,7 +242,7 @@ importers:
         version: 4.2.2(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
       babel-plugin-styled-components:
         specifier: ^2.1.4
-        version: 2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       eslint:
         specifier: ^9.39.1
         version: 9.39.1
@@ -315,7 +315,7 @@ importers:
         version: 5.1.25
       jest-styled-components:
         specifier: ^7.2.0
-        version: 7.2.0(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+        version: 7.2.0(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
 
   web/packages/shared:
     dependencies:
@@ -416,6 +416,12 @@ importers:
       events:
         specifier: 3.3.0
         version: 3.3.0
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@gravitational/build':
         specifier: workspace:*
@@ -510,7 +516,7 @@ importers:
         version: 3.3.0
       react-dnd:
         specifier: ^14.0.4
-        version: 14.0.5(@types/node@22.19.1)(@types/react@19.2.7)(react@19.2.0)
+        version: 14.0.5(@types/node@22.19.1)(@types/react@19.2.7)(react@19.2.3)
       react-dnd-html5-backend:
         specifier: ^14.0.2
         version: 14.1.0
@@ -5725,10 +5731,10 @@ packages:
     resolution: {integrity: sha512-kmob/FOTwep7DUWf9KjuenKX0vyvChr3oTdvvPt09V60Iz75FJp+T/0ZeHMbAfJj2WaVWqAPP5Hmm3PYzSPPKg==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-dom@19.2.0:
-    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+  react-dom@19.2.3:
+    resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
     peerDependencies:
-      react: ^19.2.0
+      react: ^19.2.3
 
   react-error-boundary@6.0.0:
     resolution: {integrity: sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==}
@@ -5778,8 +5784,8 @@ packages:
       react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react@19.2.0:
-    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
+  react@19.2.3:
+    resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
   read-binary-file-arch@1.0.6:
@@ -8066,17 +8072,17 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0)':
+  '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.3)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
-      react: 19.2.0
+      react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
     transitivePeerDependencies:
@@ -8096,9 +8102,9 @@ snapshots:
 
   '@emotion/unitless@0.8.1': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.0)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.3)':
     dependencies:
-      react: 19.2.0
+      react: 19.2.3
 
   '@emotion/utils@1.4.2': {}
 
@@ -8237,18 +8243,18 @@ snapshots:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@floating-ui/dom': 1.7.4
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  '@floating-ui/react@0.27.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@floating-ui/react@0.27.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@floating-ui/utils': 0.2.10
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
       tabbable: 6.2.0
 
   '@floating-ui/utils@0.2.10': {}
@@ -8607,60 +8613,60 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nivo/annotations@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/annotations@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/colors': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lodash: 4.17.21
-      react: 19.2.0
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
-  '@nivo/axes@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/axes@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@nivo/scales': 0.99.0
-      '@nivo/text': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/text': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/d3-format': 1.4.5
       '@types/d3-time-format': 2.3.4
       d3-format: 1.4.5
       d3-time-format: 3.0.0
-      react: 19.2.0
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
-  '@nivo/bar@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/bar@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/annotations': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/axes': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/annotations': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/axes': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@nivo/canvas': 0.99.0
-      '@nivo/colors': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/legends': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/legends': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@nivo/scales': 0.99.0
-      '@nivo/text': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/text': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/d3-scale': 4.0.9
       '@types/d3-shape': 3.1.7
       d3-scale: 4.0.2
       d3-shape: 3.2.0
       lodash: 4.17.21
-      react: 19.2.0
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
   '@nivo/canvas@0.99.0': {}
 
-  '@nivo/colors@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/colors@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
       '@types/d3-color': 3.1.3
       '@types/d3-scale': 4.0.9
       '@types/d3-scale-chromatic': 3.1.0
@@ -8668,15 +8674,15 @@ snapshots:
       d3-scale: 4.0.2
       d3-scale-chromatic: 3.1.0
       lodash: 4.17.21
-      react: 19.2.0
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
-  '@nivo/core@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/core@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@nivo/tooltip': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@nivo/tooltip': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/d3-shape': 3.1.7
       d3-color: 3.1.0
       d3-format: 1.4.5
@@ -8686,21 +8692,21 @@ snapshots:
       d3-shape: 3.2.0
       d3-time-format: 3.0.0
       lodash: 4.17.21
-      react: 19.2.0
-      react-virtualized-auto-sizer: 1.0.26(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      use-debounce: 10.0.4(react@19.2.0)
+      react: 19.2.3
+      react-virtualized-auto-sizer: 1.0.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      use-debounce: 10.0.4(react@19.2.3)
     transitivePeerDependencies:
       - react-dom
 
-  '@nivo/legends@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/legends@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/colors': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/text': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
+      '@nivo/colors': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/text': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
       '@types/d3-scale': 4.0.9
       d3-scale: 4.0.2
-      react: 19.2.0
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
@@ -8716,26 +8722,26 @@ snapshots:
       d3-time-format: 3.0.0
       lodash: 4.17.21
 
-  '@nivo/text@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/text@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
-  '@nivo/theming@0.99.0(react@19.2.0)':
+  '@nivo/theming@0.99.0(react@19.2.3)':
     dependencies:
       lodash: 4.17.21
-      react: 19.2.0
+      react: 19.2.3
 
-  '@nivo/tooltip@0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@nivo/tooltip@0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@nivo/core': 0.99.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@nivo/theming': 0.99.0(react@19.2.0)
-      '@react-spring/web': 10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
+      '@nivo/core': 0.99.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@nivo/theming': 0.99.0(react@19.2.3)
+      '@react-spring/web': 10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
     transitivePeerDependencies:
       - react-dom
 
@@ -8986,37 +8992,37 @@ snapshots:
 
   '@react-dnd/shallowequal@2.0.0': {}
 
-  '@react-spring/animated@10.0.1(react@19.2.0)':
+  '@react-spring/animated@10.0.1(react@19.2.3)':
     dependencies:
-      '@react-spring/shared': 10.0.1(react@19.2.0)
+      '@react-spring/shared': 10.0.1(react@19.2.3)
       '@react-spring/types': 10.0.1
-      react: 19.2.0
+      react: 19.2.3
 
-  '@react-spring/core@10.0.1(react@19.2.0)':
+  '@react-spring/core@10.0.1(react@19.2.3)':
     dependencies:
-      '@react-spring/animated': 10.0.1(react@19.2.0)
-      '@react-spring/shared': 10.0.1(react@19.2.0)
+      '@react-spring/animated': 10.0.1(react@19.2.3)
+      '@react-spring/shared': 10.0.1(react@19.2.3)
       '@react-spring/types': 10.0.1
-      react: 19.2.0
+      react: 19.2.3
 
   '@react-spring/rafz@10.0.1': {}
 
-  '@react-spring/shared@10.0.1(react@19.2.0)':
+  '@react-spring/shared@10.0.1(react@19.2.3)':
     dependencies:
       '@react-spring/rafz': 10.0.1
       '@react-spring/types': 10.0.1
-      react: 19.2.0
+      react: 19.2.3
 
   '@react-spring/types@10.0.1': {}
 
-  '@react-spring/web@10.0.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@react-spring/web@10.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@react-spring/animated': 10.0.1(react@19.2.0)
-      '@react-spring/core': 10.0.1(react@19.2.0)
-      '@react-spring/shared': 10.0.1(react@19.2.0)
+      '@react-spring/animated': 10.0.1(react@19.2.3)
+      '@react-spring/core': 10.0.1(react@19.2.3)
+      '@react-spring/shared': 10.0.1(react@19.2.3)
       '@react-spring/types': 10.0.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
@@ -9113,10 +9119,10 @@ snapshots:
       color: 5.0.2
       text-hex: 1.0.0
 
-  '@storybook/addon-vitest@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))':
+  '@storybook/addon-vitest@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/icons': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@storybook/icons': 1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       prompts: 2.4.2
       storybook: 9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
@@ -9138,28 +9144,28 @@ snapshots:
 
   '@storybook/global@5.0.0': {}
 
-  '@storybook/icons@1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@storybook/icons@1.4.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))':
+  '@storybook/react-dom-shim@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))':
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
 
-  '@storybook/react-vite@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.53.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))':
+  '@storybook/react-vite@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.53.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.53.3)
       '@storybook/builder-vite': 9.1.16(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
-      '@storybook/react': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)
+      '@storybook/react': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)
       find-up: 7.0.0
       magic-string: 0.30.19
-      react: 19.2.0
+      react: 19.2.3
       react-docgen: 8.0.0
-      react-dom: 19.2.0(react@19.2.0)
+      react-dom: 19.2.3(react@19.2.3)
       resolve: 1.22.10
       storybook: 9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
       tsconfig-paths: 4.2.0
@@ -9169,12 +9175,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)':
+  '@storybook/react@9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))(typescript@5.9.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      '@storybook/react-dom-shim': 9.1.16(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1)))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
       storybook: 9.1.16(@testing-library/dom@10.1.0)(msw@2.12.3(@types/node@22.19.1)(typescript@5.9.3))(prettier@3.7.3)(vite@7.1.12(@types/node@22.19.1)(yaml@2.8.1))
     optionalDependencies:
       typescript: 5.9.3
@@ -9292,10 +9298,10 @@ snapshots:
 
   '@tanstack/query-core@5.90.11': {}
 
-  '@tanstack/react-query@5.90.11(react@19.2.0)':
+  '@tanstack/react-query@5.90.11(react@19.2.3)':
     dependencies:
       '@tanstack/query-core': 5.90.11
-      react: 19.2.0
+      react: 19.2.3
 
   '@testing-library/dom@10.1.0':
     dependencies:
@@ -9317,12 +9323,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.1.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.1.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.1.0
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -9661,7 +9667,7 @@ snapshots:
       '@codemirror/state': 6.5.2
       '@codemirror/view': 6.38.8
 
-  '@uiw/react-codemirror@4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/view@6.38.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@uiw/react-codemirror@4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/view@6.38.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@codemirror/commands': 6.10.0
@@ -9670,8 +9676,8 @@ snapshots:
       '@codemirror/view': 6.38.8
       '@uiw/codemirror-extensions-basic-setup': 4.25.3(@codemirror/autocomplete@6.20.0)(@codemirror/view@6.38.8)
       codemirror: 6.0.2
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
 
@@ -10062,14 +10068,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-styled-components@2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+  babel-plugin-styled-components@2.1.4(@babel/core@7.28.5)(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -12163,10 +12169,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-styled-components@7.2.0(styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)):
+  jest-styled-components@7.2.0(styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)):
     dependencies:
       '@adobe/css-tools': 4.4.3
-      styled-components: 6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      styled-components: 6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   jest-util@30.2.0:
     dependencies:
@@ -12909,25 +12915,25 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  react-day-picker@9.11.2(react@19.2.0):
+  react-day-picker@9.11.2(react@19.2.3):
     dependencies:
       '@date-fns/tz': 1.4.1
       date-fns: 4.1.0
       date-fns-jalali: 4.1.0-0
-      react: 19.2.0
+      react: 19.2.3
 
   react-dnd-html5-backend@14.1.0:
     dependencies:
       dnd-core: 14.0.1
 
-  react-dnd@14.0.5(@types/node@22.19.1)(@types/react@19.2.7)(react@19.2.0):
+  react-dnd@14.0.5(@types/node@22.19.1)(@types/react@19.2.7)(react@19.2.3):
     dependencies:
       '@react-dnd/invariant': 2.0.0
       '@react-dnd/shallowequal': 2.0.0
       dnd-core: 14.0.1
       fast-deep-equal: 3.1.3
       hoist-non-react-statics: 3.3.2
-      react: 19.2.0
+      react: 19.2.3
     optionalDependencies:
       '@types/node': 22.19.1
       '@types/react': 19.2.7
@@ -12951,15 +12957,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@19.2.0(react@19.2.0):
+  react-dom@19.2.3(react@19.2.3):
     dependencies:
-      react: 19.2.0
+      react: 19.2.3
       scheduler: 0.27.0
 
-  react-error-boundary@6.0.0(react@19.2.0):
+  react-error-boundary@6.0.0(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
-      react: 19.2.0
+      react: 19.2.3
 
   react-is@16.13.1: {}
 
@@ -12969,18 +12975,18 @@ snapshots:
 
   react-is@19.2.0: {}
 
-  react-router-dom@5.3.4(react@19.2.0):
+  react-router-dom@5.3.4(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-router: 5.3.4(react@19.2.0)
+      react: 19.2.3
+      react-router: 5.3.4(react@19.2.3)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@5.3.4(react@19.2.0):
+  react-router@5.3.4(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
       history: 4.10.1
@@ -12988,7 +12994,7 @@ snapshots:
       loose-envify: 1.4.0
       path-to-regexp: 1.9.0
       prop-types: 15.8.1
-      react: 19.2.0
+      react: 19.2.3
       react-is: 16.13.1
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
@@ -12997,38 +13003,38 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.1.0
 
-  react-select@5.10.2(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-select@5.10.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
       '@emotion/cache': 11.14.0
-      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.0)
+      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.3)
       '@floating-ui/dom': 1.7.4
       '@types/react-transition-group': 4.4.12(@types/react@19.2.7)
       memoize-one: 6.0.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-transition-group: 4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.7)(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-transition-group: 4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.7)(react@19.2.3)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
 
-  react-transition-group@4.4.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-transition-group@4.4.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.4
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  react-virtualized-auto-sizer@1.0.26(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-virtualized-auto-sizer@1.0.26(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
-  react@19.2.0: {}
+  react@19.2.3: {}
 
   read-binary-file-arch@1.0.6:
     dependencies:
@@ -13522,7 +13528,7 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  styled-components@6.1.19(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  styled-components@6.1.19(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@emotion/is-prop-valid': 1.2.2
       '@emotion/unitless': 0.8.1
@@ -13530,8 +13536,8 @@ snapshots:
       css-to-react-native: 3.2.0
       csstype: 3.2.3
       postcss: 8.4.49
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
       shallowequal: 1.1.0
       stylis: 4.3.2
       tslib: 2.6.2
@@ -13855,25 +13861,25 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-debounce@10.0.4(react@19.2.0):
+  use-debounce@10.0.4(react@19.2.3):
     dependencies:
-      react: 19.2.0
+      react: 19.2.3
 
-  use-immer@0.11.0(immer@11.0.1)(react@19.2.0):
+  use-immer@0.11.0(immer@11.0.1)(react@19.2.3):
     dependencies:
       immer: 11.0.1
-      react: 19.2.0
+      react: 19.2.3
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.7)(react@19.2.0):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.7)(react@19.2.3):
     dependencies:
-      react: 19.2.0
+      react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
 
-  usehooks-ts@3.1.1(react@19.2.0):
+  usehooks-ts@3.1.1(react@19.2.3):
     dependencies:
       lodash.debounce: 4.0.8
-      react: 19.2.0
+      react: 19.2.3
 
   utf8-byte-length@1.0.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0(react@19.2.3)
       react-is:
-        specifier: ^19.2.0
-        version: 19.2.0
+        specifier: ^19.2.3
+        version: 19.2.3
       react-router:
         specifier: 5.3.4
         version: 5.3.4(react@19.2.3)
@@ -416,12 +416,6 @@ importers:
       events:
         specifier: 3.3.0
         version: 3.3.0
-      react:
-        specifier: 19.2.3
-        version: 19.2.3
-      react-dom:
-        specifier: 19.2.3
-        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@gravitational/build':
         specifier: workspace:*
@@ -5750,8 +5744,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-is@19.2.0:
-    resolution: {integrity: sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==}
+  react-is@19.2.3:
+    resolution: {integrity: sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==}
 
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
@@ -12973,7 +12967,7 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-is@19.2.0: {}
+  react-is@19.2.3: {}
 
   react-router-dom@5.3.4(react@19.2.3):
     dependencies:


### PR DESCRIPTION
Bumps `react`, `react-dom`, and `react-is` to 19.2.3 to mitigate a RCE vulnerability in React Server Components as per CVE-2025-55182 among two other, less severe vulnerabilities.

As far as I can `teleport` is not affected by the vulnerabilities, but I think it would be best to address this anyway.

References:
- https://nvd.nist.gov/vuln/detail/CVE-2025-55182
- https://react.dev/blog/2025/12/03/critical-security-vulnerability-in-react-server-components
- https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components
 