### PR TITLE
Add reload on error to SID cache

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -379,9 +379,10 @@ func NewWindowsService(cfg WindowsServiceConfig) (*WindowsService, error) {
 	if cfg.LDAPConfig.Enabled() {
 		var err error
 		sidCache, err = utils.NewFnCache(utils.FnCacheConfig{
-			TTL:     4 * time.Hour,
-			Clock:   cfg.Clock,
-			Context: ctx,
+			TTL:         4 * time.Hour,
+			Clock:       cfg.Clock,
+			Context:     ctx,
+			ReloadOnErr: true,
 		})
 		if err != nil {
 			close()


### PR DESCRIPTION
To avoid caching errors when getting user SIDs, add `ReloadOnErr` to the `sidCache`.

changelog: Fixed desktop access issue where failed Active Directory SID lookups would be cached