### PR TITLE
[18.5.1] bump cloud docs version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "18.4.1",
+      "version": "18.5.1",
       "major_version": "18",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
relates to: https://github.com/gravitational/cloud/issues/15668

