### PR TITLE
Add missing Admonition types

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/teleport-connect.mdx
@@ -574,7 +574,7 @@ If you prefer a different directory, you can configure it via the `tshHome` prop
 Teleport Connect actively monitors the tsh directory, so updates made with tsh (such as logging in, logging out,
 or adding new clusters) will automatically appear in the app.
 
-<Admonition title="Note">
+<Admonition type="note" title="Note">
 Older versions of Teleport Connect used a separate set of profiles stored in an internal tsh directory.
 On the first launch, the app will automatically migrate your profiles to the new location.
 </Admonition>

--- a/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
+++ b/docs/pages/enroll-resources/database-access/enrollment/google-cloud/alloydb.mdx
@@ -247,7 +247,7 @@ $ sudo teleport db configure create \
 This command will generate a Teleport Database Service configuration file and
 save it to `/etc/teleport.yaml`.
 
-<Admonition title="Choose how Teleport connects to AlloyDB">
+<Admonition type="tip" title="Choose how Teleport connects to AlloyDB">
 By default, Teleport uses [_private_](https://cloud.google.com/alloydb/docs/about-private-services-access) AlloyDB endpoint. To change this to either [public](https://cloud.google.com/alloydb/docs/connect-public-ip) or [PSC](https://cloud.google.com/alloydb/docs/about-private-service-connect) endpoints, update the `endpoint_type` field:
 
 ```yaml

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/maintenance.mdx
@@ -28,7 +28,7 @@ flow, as AWS will not display it again.
 
 ## Rotating the token
 
-<Admonition>
+<Admonition type="warning">
 This functionality is only available in `tctl` and cannot yet be done in the Teleport UI.
 </Admonition>
 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
@@ -89,7 +89,7 @@ which tells the AWS tools to use SSO authentication when the profile is active.
 
 Again you can do this either via an `aws configure` wizard, or editing your `/.aws/config` file directly.
 
-<Admonition type="info">
+<Admonition type="tip">
 You can create as many profiles as you like, so repeat this step for as many AWS
 Account / Permission Set pairs that you need.
 </Admonition>


### PR DESCRIPTION
Admonitions without a type cause Docusaurus to print a warning during docs site builds, causing unnecessary noise in build output logs. Adding explicit types also lets us choose the appropriate kind for each Admonition.

Also uses a more appropriate type for one Admonition to be consistent with #62338.