### PR TITLE
[v17] Add missing Admonition types

### DIFF
--- a/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/maintenance.mdx
@@ -27,7 +27,7 @@ flow, as AWS will not display it again.
 
 ## Rotating the token
 
-<Admonition>
+<Admonition type="warning">
 This functionality is only available in `tctl` and cannot yet be done in the Teleport UI.
 </Admonition>
 

--- a/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/aws-iam-identity-center/using-aws-cli.mdx
@@ -86,7 +86,7 @@ which tells the AWS tools to use SSO authentication when the profile is active.
 
 Again you can do this either via an `aws configure` wizard, or editing your `/.aws/config` file directly.
 
-<Admonition type="info">
+<Admonition type="tip">
 You can create as many profiles as you like, so repeat this step for as many AWS
 Account / Permission Set pairs that you need.
 </Admonition>


### PR DESCRIPTION
Admonitions without a type cause Docusaurus to print a warning during docs site builds, causing unnecessary noise in build output logs. Adding explicit types also lets us choose the appropriate kind for each Admonition.

Also uses a more appropriate type for one Admonition to be consistent with #62338.