### PR TITLE
Add OriginTerraform to available origin labels

### DIFF
--- a/api/types/common/constants.go
+++ b/api/types/common/constants.go
@@ -42,6 +42,10 @@ const (
 	// committed as dynamic configuration.
 	OriginDynamic = "dynamic"
 
+	// OriginTerraform is an origin value indicating that the resource was
+	// created from Terraform.
+	OriginTerraform = "terraform"
+
 	// OriginCloud is an origin value indicating that the resource was
 	// imported from a cloud provider.
 	OriginCloud = "cloud"
@@ -93,4 +97,5 @@ var OriginValues = []string{
 	OriginEntraID,
 	OriginAWSIdentityCenter,
 	OriginIntegrationAWSRolesAnywhere,
+	OriginTerraform,
 }

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -791,6 +791,10 @@ const (
 	// committed as dynamic configuration.
 	OriginDynamic = common.OriginDynamic
 
+	// OriginTerraform is an origin value indicating that the resource was
+	// created from Terraform.
+	OriginTerraform = common.OriginTerraform
+
 	// OriginCloud is an origin value indicating that the resource was
 	// imported from a cloud provider.
 	OriginCloud = common.OriginCloud


### PR DESCRIPTION
With our upcoming cloud platform terraform modules, we will add a "teleport.dev/origin:terraform" origin