### PR TITLE
design: use tertiary colors for editor in lightTheme

### DIFF
--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -486,12 +486,12 @@ const colors: ThemeColors = {
   },
 
   editor: {
-    abbey: dataVisualisationColors.primary.abbey,
-    purple: dataVisualisationColors.primary.purple,
-    cyan: dataVisualisationColors.primary.cyan,
-    picton: dataVisualisationColors.primary.picton,
-    sunflower: dataVisualisationColors.primary.sunflower,
-    caribbean: dataVisualisationColors.primary.caribbean,
+    abbey: dataVisualisationColors.tertiary.abbey,
+    purple: dataVisualisationColors.tertiary.purple,
+    cyan: dataVisualisationColors.tertiary.cyan,
+    picton: dataVisualisationColors.tertiary.picton,
+    sunflower: dataVisualisationColors.tertiary.sunflower,
+    caribbean: dataVisualisationColors.tertiary.caribbean,
   },
 
   sessionRecording: {


### PR DESCRIPTION
## Description

Change Light theme editor colors from primary to tertiary to conform to Level AA contrast requirements with the following background colors

Light Theme             |  Dark Theme
:-------------------------:|:-------------------------:
<img width="560" height="1084" alt="Screenshot 2025-12-17 at 11 40 24 AM (1)" src="https://github.com/user-attachments/assets/2b2887eb-77c9-49a5-a3b2-0e3817743f37" />|<img width="558" height="1118" alt="Screenshot 2025-12-17 at 11 40 31 AM (1)" src="https://github.com/user-attachments/assets/c2b3d06d-8a4f-42c2-be87-9d63d4b3e8b5" />
