### PR TITLE
[v18] Organize the Request Access guide

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -3403,6 +3403,11 @@
       "source": "/zero-trust-access/management/operations/breakglass-access/",
       "destination": "/zero-trust-access/deploy-a-cluster/breakglass-access/",
       "permanent": true
+    },
+    {
+      "source": "/connect-your-client/request-access/",
+      "destination": "/connect-your-client/teleport-clients/request-access/",
+      "permanent": true
     }
   ]
 }

--- a/docs/pages/connect-your-client/teleport-clients/request-access.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/request-access.mdx
@@ -1,6 +1,12 @@
 ---
-title: Request Access to Roles and Resources
+title: Requesting Access to Roles and Resources
 description: Explains how to request access to resources that your Teleport user does not have permissions to access.
+sidebar_label: Access Requests
+tags:
+ - access-requests
+ - identity-governance
+ - privileged-access
+ - conceptual
 ---
 
 If you cannot access a Teleport role or resource with your current Teleport

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -498,7 +498,7 @@ spec:
   plugins](../access-requests/plugins/plugins.mdx).
 - For more information about creating and managing Access Requests as an end
   user, read [Request Access to Roles and
-  Resources](../../connect-your-client/request-access.mdx).
+  Resources](../../connect-your-client/teleport-clients/request-access.mdx).
 - Learn about [Access Lists](../access-lists/access-lists.mdx), which allow you
   to assign elevated privileges to a list of Teleport users for a limited time.
 


### PR DESCRIPTION
Update the guide to match changes in #61814 that weren't backported. Move the guide to the appropriate place in Connect your Client. Update the frontmatter to contain appropriate values.