### PR TITLE
fix: Drain participant stdout to prevent blocking in kube join test

### DIFF
--- a/integration/kube_integration_test.go
+++ b/integration/kube_integration_test.go
@@ -2569,6 +2569,9 @@ func testKubeJoin(t *testing.T, suite *KubeSuite) {
 	// send exit command to close the session
 	term.Type("\aexit 0\n\r")
 
+	// drain participant stdout to ensure it doesn't block on writes
+	go io.Copy(io.Discard, participantStdoutR)
+
 	_ = term.Close()
 
 	// wait for all clients to finish


### PR DESCRIPTION
Add goroutine to continuously drain participant stdout stream (net.Pipe) to ensure the test doesn't block on write operations during session cleanup and we can release the resources. This caused a deadlock because the kubesession.Wait was never released.

Fixes https://github.com/gravitational/teleport/issues/55044