### PR TITLE
Warn when connecting to cloud on the wrong port

### DIFF
--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -90,6 +90,13 @@ const (
 	// RDPListenPort is the standard port for RDP servers.
 	RDPListenPort = 3389
 
+	// CloudProxyListenPort is the Proxy Service port when running in Teleport Cloud.
+	CloudProxyListenPort = 443
+
+	// CloudDomainSuffix can be used to identify when an address is a Teleport Cloud domain
+	// and provide helpful Cloud-specific instructions.
+	CloudDomainSuffix = "teleport.sh"
+
 	// BackendDir is a default backend subdirectory
 	BackendDir = "backend"
 

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -21,6 +21,7 @@ package servicecfg
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"net"
@@ -809,6 +810,21 @@ func applyDefaults(cfg *Config) {
 	}
 }
 
+func warnIfUsingCloudOnWrongPort(log *slog.Logger, addr utils.NetAddr, defaultPort int) {
+	ctx := context.Background()
+	isCloud := strings.HasSuffix(addr.Host(), "."+defaults.CloudDomainSuffix)
+
+	if port := addr.Port(defaultPort); isCloud && port != defaults.CloudProxyListenPort {
+		//nolint:sloglint // We want to craft user-friendly and actionable messages here.
+		log.WarnContext(ctx,
+			fmt.Sprintf("Teleport Cloud Proxy Service runs on port 443, but the process is connecting to port %d. This is likely a misconfiguration and will prevent successfully joining the cluster.", port),
+			"port", port,
+			"address", addr.String())
+		//nolint:sloglint // We want to craft user-friendly and actionable messages here.
+		log.WarnContext(ctx, fmt.Sprintf("If you are experiencing connectivity issues, try using the following address: \"%s:%d\".", addr.Host(), defaults.CloudProxyListenPort))
+	}
+}
+
 func validateAuthOrProxyServices(cfg *Config) error {
 	haveAuthServers := len(cfg.authServers) > 0
 	haveProxyServer := !cfg.ProxyServer.IsEmpty()
@@ -837,6 +853,7 @@ func validateAuthOrProxyServices(cfg *Config) error {
 			if port == defaults.AuthListenPort {
 				cfg.Logger.WarnContext(context.Background(), "config: proxy_server is pointing to port 3025, is this the auth server address?")
 			}
+			warnIfUsingCloudOnWrongPort(cfg.Logger, cfg.ProxyServer, defaults.HTTPListenPort)
 		}
 
 		if haveAuthServers {
@@ -859,6 +876,8 @@ func validateAuthOrProxyServices(cfg *Config) error {
 	if !haveAuthServers {
 		return trace.BadParameter("config: auth_servers is required")
 	}
+
+	warnIfUsingCloudOnWrongPort(cfg.Logger, cfg.authServers[0], defaults.AuthListenPort)
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a warning when a user tries to connect an agent to a Teleport Cloud instance on a port which is not 443.

This aims to reduce support load. See: https://gravitational.slack.com/archives/C01TYKHFVTQ/p1765836256504539