### PR TITLE
Update the Splunk audit event export guide

### DIFF
--- a/docs/pages/includes/install-event-handler.mdx
+++ b/docs/pages/includes/install-event-handler.mdx
@@ -53,7 +53,7 @@ $ helm repo update
 
 You will need Go >= (=teleport.golang=) installed.
 
-Run the following commands on your Universal Forwarder host:
+Run the following commands:
 
 ```code
 $ git clone https://github.com/gravitational/teleport.git --depth 1 -b branch/v(=teleport.major_version=)

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -1,49 +1,45 @@
 ---
 title: Export Teleport Audit Events to Splunk
 sidebar_label: Splunk
-description: How to configure the Teleport Event Handler plugin to send audit logs to Splunk
+description: How to configure the Teleport Event Handler plugin to send audit events to Splunk
 tags:
  - how-to
  - zero-trust
  - audit
 ---
 
-Teleport's Event Handler plugin receives audit logs from the Teleport Auth
+Teleport's Event Handler plugin receives audit events from the Teleport Auth
 Service and forwards them to your log management solution, letting you perform
 historical analysis, detect unusual behavior, and form a better understanding of
 how users interact with your Teleport cluster.
 
 In this guide, we will show you how to configure the Teleport Event Handler
-plugin to send your Teleport audit logs to Splunk. 
+plugin to send your Teleport audit events to Splunk. 
 
 ## How it works
 
-In this setup, the Teleport Event Handler plugin forwards audit logs from
-Teleport to Splunk's Universal Forwarder, which stores them in Splunk Cloud
-Platform or Splunk Enterprise for visualization and alerting.
+In this setup, the Teleport Event Handler plugin receives audit events from the
+Teleport Auth Service over a gRPC channel and sends them to a local Fluentd
+instance as HTTP requests. The Fluentd instance forwards these requests to the
+Splunk HTTP Event Collector (HEC), which in turn sends them to Splunk Cloud Platform
+or Splunk Enterprise for visualization and alerting.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
+- (!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
 
 - Splunk Cloud Platform or Splunk Enterprise v9.0.1 or above.
 
 - A Linux host where you will run the Teleport Event Handler plugin and Splunk
-  Universal Forwarder. The Universal Forwarder must be installed on the host.
+  HEC. The HEC must be installed on the host.
 
-  <details>
-  <summary>Running the Teleport Event Handler and Universal Forwarder on separate hosts</summary>
-
-  If you run the Teleport Event Handler and Universal Forwarder on the same
-  host, there is no need to open a port on the host for ingesting logs. However,
-  if you run the Universal Forwarder on a separate host from the Teleport Event
-  Handler, you will need to open a port on the Universal Forwarder host to
-  traffic from the Teleport Event Handler. This guide assumes that the Universal
-  Forwarder is listening on port `9061`.
-
-  </details>
+  <Admonition type="warning">
+  If you run the HEC on a separate host from the Teleport Event Handler, you
+  will need to open a port on the HEC host to traffic from the Teleport Event
+  Handler. This guide assumes that the HEC is listening on port `9061`.
+  </Admonition>
 
 - On Splunk Enterprise, port `8088` should be open to traffic from the host
   running the Teleport Event Handler and Universal Forwarder.
@@ -53,10 +49,10 @@ Platform or Splunk Enterprise for visualization and alerting.
 ## Step 1/4. Set up the Teleport Event Handler plugin
 
 The Event Handler plugin is a binary that runs independently of your Teleport
-cluster. It authenticates to your Teleport cluster and your Splunk Universal
-Forwarder using mutual TLS. In this section, you will install the Teleport Event
-Handler plugin on the Linux host where you are running your Universal Forwarder
-and generate credentials that the plugin will use for authentication.
+cluster. It authenticates to your Teleport cluster using mutual TLS and to the
+HEC using a token. In this section, you will install the Teleport Event Handler
+plugin on the Linux host where you are running your Universal Forwarder and
+generate credentials that the plugin will use for authentication.
 
 ### Install the Teleport Event Handler plugin
 
@@ -70,8 +66,6 @@ Handler plugin on your Universal Forwarder host:
 Generate a configuration file with placeholder values for the Teleport Event Handler plugin. Later in this guide, we will edit the configuration file for your environment.
 
 (!docs/pages/includes/configure-event-handler.mdx!)
-
-We'll re-purpose the files generated for Fluentd in our Universal Forwarder configuration.
 
 ### Define RBAC resources
 
@@ -104,207 +98,55 @@ longer-lived identity files with `tctl`:
 </TabItem>
 </Tabs>
 
-## Step 2/4. Configure the Universal Forwarder
+## Step 2/5. Configure Splunk
 
-In this step, you will configure the Universal Forwarder to receive audit logs
-from the Teleport Event Handler plugin and forward them to Splunk. The Event
-Handler sends audit logs as HTTP POST requests with the content type
-`application/json`.
+In this section, you will configure Splunk to ingest and index Teleport audit
+events, and create a token for the HEC to authenticate to Splunk. All steps
+within this section take place within the Splunk web interface.
 
-We will assume that you assigned `$SPLUNK_HOME` to `/opt/splunkforwarder` when
-installing the Universal Forwarder.
+### Create an index for Teleport audit events
 
-<details>
-<summary>Finding your $SPLUNK_HOME</summary>
+1. Visit the home page of the Splunk UI and navigate to **Settings > Indexes**.
+   Click **New Index**. Name your index `teleport-audit-logs` and assign the
+   **Index Data Type** field to `Events`.
+1. Fill in the values of the remaining fields, **Max raw data size** and
+   **Searchable retention (days)** based on the needs of your organization.
+1. Click **Save**.
 
-To find your `$SPLUNK_HOME`, run the following command to see the location of
-your Universal Forwarder service definition, which the init system systemd uses
-to run the Universal Forwarder:
+### [Optional] Create a source type for Teleport audit events
 
-```code
-$ sudo systemctl status SplunkForwarder.service
-● SplunkForwarder.service - Systemd service file for Splunk, generated by 'splunk enable boot-start'
-     Loaded: loaded (/lib/systemd/system/SplunkForwarder.service; enabled; vendor preset: enabled)
-     Active: active (running) since Fri 2022-10-07 15:57:37 UTC; 2h 18min ago
-   Main PID: 1772 (splunkd)
-      Tasks: 53 (limit: 2309)
-     Memory: 70.8M (limit: 1.8G)
-     CGroup: /system.slice/SplunkForwarder.service
-             ├─1772 splunkd --under-systemd --systemd-delegate=yes -p 8089 _internal_launch_under_systemd
-             └─1810 [splunkd pid=1772] splunkd --under-systemd --systemd-delegate=yes -p 8089 _internal_launch_under_systemd [process-runner]
-```
+By default, Splunk's `_json` source type expects the `time` field to be in a
+different format than that of Teleport audit events. This means that the event
+will show up in Splunk at the time it was ingested, not at the time it was
+generated. Adjust the format of the `time` field in Splunk so Teleport audit
+events appear as expected.
 
-View the file at the path shown in the `Loaded:` field. Your `$SPLUNK_HOME`
-will include the filepath segments in `ExecStart` before `/bin`. In this case,
-`$SPLUNK_HOME` is `/opt/splunkforwarder/`:
+1. Navigate to **Settings -> Source Types**. 
+1. Find the `_json` source type and click **Clone**. 
+1. Name the new source type `_json-gotime`. 
+1. Under **Timestamp** click **Advanced**. 
+1. Input `%Y-%m-%dT%H:%M:%S.%3NZ` and click **Save**.
 
-```text
-ExecStart=/opt/splunkforwarder/bin/splunk _internal_launch_under_systemd
-```
+### Create a token for the HTTP Event Collector
 
-</details>
-
-### Create an index for your audit logs
-
-Create an index for your Teleport audit logs by visiting the home page of the
-Splunk UI and navigating to **Settings** > **Indexes**. Click **New Index**.
-Name your index `teleport-audit-logs` and assign the **Index Data Type** field
-to "Events".
-
-![Creating an Index](../../../img/enterprise/plugins/splunk/new-index.png)
-
-The values of the remaining fields, **Max raw data size** and **Searchable
-retention (days)** depend on your organization's resources and practices for log
-management.
-
-Click **Save**
-
-### Create a token for the Universal Forwarder
-
-The Universal Forwarder authenticates client traffic using a token. To generate
-a token, visit the home page of the Splunk UI. Navigate to **Settings** > **Data
-inputs** In the **Local inputs** table, find the **HTTP Event Collector** row and
-click **Add new**
-
-Enter a name you can use to recognize the token later so you can
-manage it, e.g., `Teleport Audit Events`. Click **Next**.
-
-![Create a Token](../../../img/enterprise/plugins/splunk/new-token.png)
-
-In the **Input Settings** view (above), next to the **Source type** field, click
-**Select**. In the **Select Source Type** dropdown menu, click **Structured**,
-then **_json**. Splunk will index incoming logs as JSON, which is the format the
-Event Handler uses to send logs to the Universal Forwarder.
-
-In the **Index** section, select the `teleport-audit-logs` index you created
-earlier. Click **Review** then view the summary and click **Submit**. Copy the
-**Token Value** field and keep it somewhere safe so you can use it later in this
-guide.
-
-### Prepare a certificate file for the Universal Forwarder
-
-The Universal Forwarder signs TLS certificates using a file that contains both
-an X.509-format certificate and an RSA private key. To prepare this, run the
-following commands on the Universal Forwarder host, where `server.crt` and
-`server.key` are two of the files you generated earlier with the
-`teleport-event-handler configure` the command:
-
-```code
-$ cp server.crt server.pem
-$ cat server.key >> server.pem
-```
-
-Allow the Universal Forwarder to access the certificate file:
-
-```code
-$ sudo chown splunk:splunk server.pem
-```
-
-### Configure the HTTP Event Collector
-
-On your Universal Forwarder host, create a file at
-`/opt/splunkforwarder/etc/system/local/inputs.conf` with the following content:
-
-```ini
-[http]
-port = 9061
-disabled = false
-serverCert = server.pem
-sslPassword =
-requireClientCert = true
-
-[http://audit]
-token =
-index = teleport-audit-logs
-allowQueryStringAuth = true
-```
-
-This configuration enables the HTTP input, which will listen on port `9061` and
-receive logs from the Teleport Event Handler Plugin, assigning them to the
-`teleport-audit-logs` index.
-
-Assign `serverCert` to the path to the `server.pem` file you generated earlier.
-
-To assign `sslPassword`, run the following command in the directory that
-contains `fluent.conf`:
-
-```code
-$ cat fluent.conf | grep passphrase
-private_key_passphrase "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
-```
-
-Copy the passphrase and paste it as the value of `sslPassword`.
-
-The `token` field in the `[http://audit]` section enables the Universal
-Forwarder to collect logs from HTTP clients that present a token. Assign `token`
-to the token you generated earlier.
-
-`allowQueryStringAuth` enables the Teleport Event Handler to include the token
-in a query string, rather than the `Authorization` HTTP header (the default).
-This is necessary because the Teleport Event Handler does not currently support
-custom HTTP headers.
-
-### Configure TLS
-
-To configure secure communications between the Universal Forwarder and the
-Teleport Event Handler, create a file called
-`/opt/splunkforwarder/etc/system/local/server.conf` with the following content
-(if this file already exists, add  the following field in the `[sslConfig]`
-section):
-
-```ini
-[sslConfig]
-sslRootCAPath =
-```
-
-Assign `sslRootCAPath` to the path of the `ca.crt` file you generated earlier.
-
-Ensure that the Universal Forwarder can read the CA certificate:
-
-```code
-$ sudo chmod +r ca.crt
-```
-
-### Configure an output
-
-Instruct the Universal Forwarder to send the logs it collects to Splunk.
-
-Create a file at the path `/opt/splunkforwarder/etc/system/local/outputs.conf`
-with the following content:
-
-```ini
-[tcpout]
-sslVerifyServerCert = true
-
-[httpout]
-httpEventCollectorToken =
-uri =
-```
-
-Fill in `httpEventCollectorToken` with the token you generated earlier.
-
-Assign `uri` to the following, replacing `MYHOST` with the hostname of your
-Splunk instance and `8088` with the port you are using for your Splunk HTTP
-Event Collector.
-
-```text
-https://MYHOST:8088
-```
-
-The format of the URL to use will depend on your Splunk deployment. See the
-[list of acceptable URL
-formats](https://docs.splunk.com/Documentation/Splunk/9.0.1/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector)
-in the Splunk documentation.
-
-Note that you must only include the scheme, host, and port of the URL. The
-Universal Forwarder will append the correct URL path of the Splunk ingestion
-API when forwarding logs.
-
-Finally, restart the Universal Forwarder:
-
-```code
-$ sudo systemctl restart SplunkForwarder
-```
+1. Visit the home page of the Splunk UI. 
+1. Navigate to **Settings > Data inputs**.
+1. In the **Local inputs** table, find the HTTP Event Collector row and click
+   **Add new**.
+1. Enter a name you can use to recognize the token later so you can manage it,
+   e.g., `Teleport Audit Events`. 
+1. **Click Next**.
+1. In the **Input Settings** view, next to the **Source type** field, click
+   **Select**.
+1. In the **Select Source Type** dropdown menu, click **Structured**, then
+   choose the `_json-gotime` type you created earlier. If you skipped that
+   optional step, choose `_json`. Splunk will index incoming logs as JSON, which
+   is the format the Event Handler uses to send logs to Splunk.
+1. In the **Index** section, select the `teleport-audit-logs` index you created
+   earlier. 
+1. Click **Review,** then view the summary and click **Submit**. 
+1. Copy the **Token Value** field and assign <Var name="TOKEN" /> to it so you
+   can use it later in this guide.
 
 ## Step 3/4. Run the Teleport Event Handler plugin
 
@@ -313,62 +155,63 @@ and forward them to Splunk, you will ensure that the Teleport Event Handler
 plugin is configured to authenticate to the Universal Forwarder and your
 Teleport cluster, then run the Teleport Event Handler.
 
-### Configure the Teleport Event Handler
+### Connect Fluentd to the Splunk HTTP Event Collector
 
-In this section, you will configure the Teleport Event Handler for your
-environment.
+While Splunk used to maintain a dedicated output plugin at
+https://github.com/splunk/fluent-plugin-splunk-hec, this has been deprecated.
+We can still connect Fluentd to the HEC using Fluentd's built-in HTTP output
+plugin.
 
-(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
+In Step 1, you generated a configuration file for Fluentd at `fluent.conf`. Edit
+your `fluent.conf` file as follows:
 
-Update the configuration file as follows.
+1. Edit the `<parse>` section to add the following: 
 
-Change `forward.fluentd.url` to the following:
+   ```diff
+       <parse>
+         @type json
+         json_parser oj
+   
+         # This time format is used by the plugin. This field is required.
+         time_type string
+         time_format %Y-%m-%dT%H:%M:%S
+   +     keep_time_key true
+       </parse>
+   ```
 
-```text
-url = "https://localhost:9061/services/collector/raw?token=MYTOKEN"
-```
+   This will preserve the `time` field in the JSON when it is sent to Splunk.
+   Some Fluentd output plugins require having a parsed time available.
 
-Ensure the URL includes the scheme, host and port of your Universal Forwarder's
-HTTP input, plus the URL path that the Universal Forwarder uses for raw data
-(`/services/collector/raw`).
+1. Remove the `stdout` output, and add the following section in its place. This
+   configures Fluentd to authenticate to the HEC using the token you generated
+   earlier:
 
-Replace `MYTOKEN` with the token you generated earlier for the Splunk Universal
-Forwarder. If you are running the Universal Forwarder and Event Handler on
-separate hosts, replace `localhost` with your Universal Forwarder's IP address
-or domain name.
+   ```diff
+    <match test.log>
+   -  @type stdout
+   +  @type http
+   +  endpoint https://splunk-hec.example.com:9061/services/collector/raw
+   +  headers {"Authorization": "Splunk <Var name="TOKEN" />"}
+   +  # tls_verify_mode none
+   +  <buffer>
+   +    flush_interval 2s
+   +  </buffer>
+    </match>
+   ```
 
-Change `forward.fluentd.session-url` to the same value as `forward.fluentd.url`,
-but with the query parameter key `&noop=` appended to the end:
+1. Test your changes by running Fluentd:
 
-```text
-session-url = "https://localhost:9061/services/collector/raw?token=MYTOKEN&noop="
-```
-
-For audit logs related to Teleport sessions, the Teleport Event Handler appends
-routing information to the URL that our HTTP input configuration does not use.
-Adding the `noop` query parameter causes the Teleport Event Handler to append
-the routing information as the parameter's value so the Universal Forwarder can
-discard it.
-
-Next, edit the `teleport` section of the configuration as follows:
-
-(!docs/pages/includes/plugins/config-toml-teleport.mdx!)
-
-(!docs/pages/includes/plugins/machine-id-exporter-config.mdx!)
-
-Ensure that the Teleport Event Handler can read the identity file:
-
-```code
-$ chmod +r auth.pem
-```
+   ```code
+   $ docker run -u $(id -u ${USER}):$(id -g ${USER}) -p 8888:8888 -v $(pwd):/keys -v $(pwd)/fluent.conf:/fluentd/etc/fluent.conf fluent/fluentd:edge
+   ```
 
 ### Start the Teleport Event Handler
 
 (!docs/pages/includes/start-event-handler.mdx!)
 
-## Step 4/4. Visualize your audit logs in Splunk
+## Step 4/4. Visualize your audit events in Splunk
 
-Since our setup forwards audit logs to Splunk in the structured JSON format,
+Since our setup forwards audit events to Splunk in the structured JSON format,
 Splunk automatically indexes them, so fields will be available immediately for
 use in visualizations. You can use these fields to create dashboards that track
 the way users are interacting with your Teleport cluster.
@@ -405,16 +248,6 @@ Teleport Cluster, ensure that:
 
 ## Next steps
 
-Now that you are exporting your audit logs to Splunk, consult our [audit log
-reference](../../reference/deployment/monitoring/audit.mdx) so you can plan visualizations
-and alerts.
-
-In this guide, we made use of impersonation to supply credentials to the
-Teleport Event Handler to communicate with your Teleport cluster. To learn more
-about impersonation, read [our
-guide](../authentication/impersonation.mdx).
-
-While this guide uses the `tctl auth sign` command to issue credentials for the
-Teleport Event Handler, production clusters should use Machine & Workload
-Identity for safer, more reliable renewals. Read [our guide](../../machine-workload-identity/getting-started.mdx)
-to getting started with Machine & Workload Identity.
+Now that you are exporting your audit events to Splunk, consult our [audit event
+reference](../../reference/deployment/monitoring/audit.mdx) so you can plan
+visualizations and alerts.

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -48,7 +48,7 @@ plugin and generate credentials that the plugin will use for authentication.
 ### Install the Event Handler plugin
 
 Follow the instructions for your environment to install the Teleport Event
-Handler plugin on your Universal Forwarder host:
+Handler plugin:
 
 (!docs/pages/includes/install-event-handler.mdx!)
 
@@ -174,6 +174,7 @@ your `fluent.conf` file as follows:
 
 1. Assign <Var name="splunk-endpoint" initial="https://splunk-hec.example.com:8088/services/collector/raw" />
    to your Splunk HTTP Event Collector endpoint.
+
    For Splunk Enterprise, this will be of the format:
    - `https://<host>:8088/services/collector/raw`
 
@@ -183,7 +184,7 @@ your `fluent.conf` file as follows:
    - Free Trial: `https://<host>.splunkcloud.com:8088/services/collector/raw`
 
    For more information on Splunk HEC URIs, see [Splunk HTTP Event Collector
-   ](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/10.2/get-data-with-http-event-collector/set-up-and-use-http-event-collector-in-splunk-web#send-data-to-http-event-collector-on-splunk-cloud-platform-0)
+   ](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/10.2/get-data-with-http-event-collector/set-up-and-use-http-event-collector-in-splunk-web#send-data-to-http-event-collector-on-splunk-cloud-platform-0).
 
 1. Edit the `<match test.log>` section with the following section.
 

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -27,9 +27,7 @@ or Splunk Enterprise for visualization and alerting.
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
-
 - (!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
-
 - Splunk Cloud Platform or Splunk Enterprise v9.0.1 or above.
 - Fluentd version v1.12.4 or greater. The Teleport Event Handler
   will create a new fluent.conf file you can integrate into an existing Fluentd
@@ -38,7 +36,6 @@ or Splunk Enterprise for visualization and alerting.
   Teleport Event Handler plugin.
 - On Splunk Enterprise, port `8088` should be open to traffic from the host
   running the Teleport Event Handler and Fluentd instance.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Event Handler plugin
@@ -115,14 +112,19 @@ will show up in Splunk at the time it was ingested, not at the time it was
 generated. Adjust the format of the `time` field in Splunk so Teleport audit
 events appear as expected.
 
+{/*cSpell:disable*/}
+
 1. Navigate to **Settings -> Source Types**. 
 1. Find the `_json` source type and click **Clone**. 
 1. Name the new source type `_json-gotime`. 
 1. Under **Timestamp** click **Advanced**. 
 1. Input `%Y-%m-%dT%H:%M:%S.%3NZ` and click **Save**.
 
+{/*cSpell:enable*/}
+
 ### Create a token for the HTTP Event Collector
 
+{/*cSpell:disable*/}
 1. Visit the home page of the Splunk UI. 
 1. Navigate to **Settings > Data inputs**.
 1. In the **Local inputs** table, find the HTTP Event Collector row and click
@@ -141,6 +143,7 @@ events appear as expected.
 1. Click **Review,** then view the summary and click **Submit**. 
 1. Copy the **Token Value** field and assign <Var name="TOKEN" /> to it so you
    can use it later in this guide.
+{/*cSpell:enable*/}
 
 ## Step 3/5. Connect Fluentd to the Splunk HTTP Event Collector
 

--- a/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
+++ b/docs/pages/zero-trust-access/export-audit-events/splunk.mdx
@@ -31,30 +31,24 @@ or Splunk Enterprise for visualization and alerting.
 - (!docs/pages/includes/machine-id/plugin-prerequisites.mdx!)
 
 - Splunk Cloud Platform or Splunk Enterprise v9.0.1 or above.
-
-- A Linux host where you will run the Teleport Event Handler plugin and Splunk
-  HEC. The HEC must be installed on the host.
-
-  <Admonition type="warning">
-  If you run the HEC on a separate host from the Teleport Event Handler, you
-  will need to open a port on the HEC host to traffic from the Teleport Event
-  Handler. This guide assumes that the HEC is listening on port `9061`.
-  </Admonition>
-
+- Fluentd version v1.12.4 or greater. The Teleport Event Handler
+  will create a new fluent.conf file you can integrate into an existing Fluentd
+  system, or use with a fresh setup.
+- A server, virtual machine, Kubernetes cluster, or Docker environment to run the
+  Teleport Event Handler plugin.
 - On Splunk Enterprise, port `8088` should be open to traffic from the host
-  running the Teleport Event Handler and Universal Forwarder.
+  running the Teleport Event Handler and Fluentd instance.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-## Step 1/4. Set up the Teleport Event Handler plugin
+## Step 1/5. Set up the Event Handler plugin
 
 The Event Handler plugin is a binary that runs independently of your Teleport
-cluster. It authenticates to your Teleport cluster using mutual TLS and to the
-HEC using a token. In this section, you will install the Teleport Event Handler
-plugin on the Linux host where you are running your Universal Forwarder and
-generate credentials that the plugin will use for authentication.
+cluster. It authenticates to your Teleport cluster and the Fluentd instance
+using mutual TLS. In this section, you will install the Teleport Event Handler
+plugin and generate credentials that the plugin will use for authentication.
 
-### Install the Teleport Event Handler plugin
+### Install the Event Handler plugin
 
 Follow the instructions for your environment to install the Teleport Event
 Handler plugin on your Universal Forwarder host:
@@ -148,14 +142,7 @@ events appear as expected.
 1. Copy the **Token Value** field and assign <Var name="TOKEN" /> to it so you
    can use it later in this guide.
 
-## Step 3/4. Run the Teleport Event Handler plugin
-
-Now that you have configured your Universal Forwarder to receive logs via HTTP
-and forward them to Splunk, you will ensure that the Teleport Event Handler
-plugin is configured to authenticate to the Universal Forwarder and your
-Teleport cluster, then run the Teleport Event Handler.
-
-### Connect Fluentd to the Splunk HTTP Event Collector
+## Step 3/5. Connect Fluentd to the Splunk HTTP Event Collector
 
 While Splunk used to maintain a dedicated output plugin at
 https://github.com/splunk/fluent-plugin-splunk-hec, this has been deprecated.
@@ -165,9 +152,9 @@ plugin.
 In Step 1, you generated a configuration file for Fluentd at `fluent.conf`. Edit
 your `fluent.conf` file as follows:
 
-1. Edit the `<parse>` section to add the following: 
+1. Edit the `<parse>` section with the following section: 
 
-   ```diff
+   ```xml
        <parse>
          @type json
          json_parser oj
@@ -175,29 +162,43 @@ your `fluent.conf` file as follows:
          # This time format is used by the plugin. This field is required.
          time_type string
          time_format %Y-%m-%dT%H:%M:%S
-   +     keep_time_key true
+         keep_time_key true
        </parse>
    ```
 
    This will preserve the `time` field in the JSON when it is sent to Splunk.
    Some Fluentd output plugins require having a parsed time available.
 
-1. Remove the `stdout` output, and add the following section in its place. This
-   configures Fluentd to authenticate to the HEC using the token you generated
-   earlier:
+1. Assign <Var name="splunk-endpoint" initial="https://splunk-hec.example.com:8088/services/collector/raw" />
+   to your Splunk HTTP Event Collector endpoint.
+   For Splunk Enterprise, this will be of the format:
+   - `https://<host>:8088/services/collector/raw`
 
-   ```diff
+   For Splunk Cloud, this will be of the format:
+   - AWS: `https://http-inputs-<host>.splunkcloud.com:443/services/collector/raw`
+   - Google Cloud / Azure: `https://http-inputs.<host>.splunkcloud.com:443/services/collector/raw`
+   - Free Trial: `https://<host>.splunkcloud.com:8088/services/collector/raw`
+
+   For more information on Splunk HEC URIs, see [Splunk HTTP Event Collector
+   ](https://help.splunk.com/en/splunk-enterprise/get-started/get-data-in/10.2/get-data-with-http-event-collector/set-up-and-use-http-event-collector-in-splunk-web#send-data-to-http-event-collector-on-splunk-cloud-platform-0)
+
+1. Edit the `<match test.log>` section with the following section.
+
+   ```xml
     <match test.log>
-   -  @type stdout
-   +  @type http
-   +  endpoint https://splunk-hec.example.com:9061/services/collector/raw
-   +  headers {"Authorization": "Splunk <Var name="TOKEN" />"}
-   +  # tls_verify_mode none
-   +  <buffer>
-   +    flush_interval 2s
-   +  </buffer>
+      @type http
+      endpoint <Var name="splunk-endpoint" />
+      headers {"Authorization": "Splunk <Var name="TOKEN" />"}
+      # tls_verify_mode none
+      <buffer>
+        flush_interval 2s
+      </buffer>
     </match>
    ```
+
+   This configures Fluentd to authenticate to the HEC using the token
+   you generated earlier. If using Splunk Cloud Free Trial, uncomment `tls_verify_mode none`
+   to allow self-signed certificates.
 
 1. Test your changes by running Fluentd:
 
@@ -205,11 +206,30 @@ your `fluent.conf` file as follows:
    $ docker run -u $(id -u ${USER}):$(id -g ${USER}) -p 8888:8888 -v $(pwd):/keys -v $(pwd)/fluent.conf:/fluentd/etc/fluent.conf fluent/fluentd:edge
    ```
 
+## Step 4/5. Run the Teleport Event Handler plugin
+
+Now that you have configured your Fluentd instance to receive logs via HTTP
+and forward them to Splunk, you will modify the Event Handler configuration
+and run the Event Handler to test your configuration.
+
+### Configure the Teleport Event Handler
+
+In this section, you will configure the Teleport Event Handler for your
+environment.
+
+(!docs/pages/includes/plugins/finish-event-handler-config.mdx!)
+
+Next, modify the configuration file as follows:
+
+(!docs/pages/includes/plugins/config-toml-teleport.mdx!)
+
+(!docs/pages/includes/plugins/machine-id-exporter-config.mdx!)
+
 ### Start the Teleport Event Handler
 
 (!docs/pages/includes/start-event-handler.mdx!)
 
-## Step 4/4. Visualize your audit events in Splunk
+## Step 5/5. Visualize your audit events in Splunk
 
 Since our setup forwards audit events to Splunk in the structured JSON format,
 Splunk automatically indexes them, so fields will be available immediately for
@@ -251,3 +271,7 @@ Teleport Cluster, ensure that:
 Now that you are exporting your audit events to Splunk, consult our [audit event
 reference](../../reference/deployment/monitoring/audit.mdx) so you can plan
 visualizations and alerts.
+
+To see all of the options you can set in the values file for the
+`teleport-plugin-event-handler` Helm chart, consult our [reference
+guide](../../reference/helm-reference/teleport-plugin-event-handler.mdx).


### PR DESCRIPTION
Closes #57002

Incorporate instructions from the GitHub discussion #56918. These allow the guide to work with more recent versions of Splunk, since the Universal Forwarder no longer supports the instructions in the current guide.

This change also removs impersonation and Machine ID notes from the "Next steps" section since we already branch on the decision to use Machine ID earlier in the guide.