### PR TITLE
fix: Env var syntax in GHA+K8s guide

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.tsx
@@ -229,14 +229,14 @@ const Container = styled(Flex)`
 `;
 
 const FormContainer = styled(Flex)`
-  flex: 1;
+  flex: 4;
   flex-direction: column;
   overflow: auto;
   padding-right: ${({ theme }) => theme.space[5]}px;
 `;
 
 const CodeContainer = styled(Flex)`
-  flex: 1;
+  flex: 6;
   flex-direction: column;
   overflow: auto;
 `;

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
@@ -89,7 +89,9 @@ describe('ConnectGitHub', () => {
       screen.getByPlaceholderText('https://github.com/gravitational/teleport')
     ).toHaveValue('https://github.com/gravitational/teleport');
 
-    expect(screen.getByPlaceholderText('main')).toHaveValue('main');
+    expect(screen.getAllByPlaceholderText('refs/heads/main')[0]).toHaveValue(
+      'main'
+    );
 
     expect(screen.getByPlaceholderText('my-workflow')).toHaveValue(
       'my-workflow'
@@ -97,7 +99,9 @@ describe('ConnectGitHub', () => {
 
     expect(screen.getByPlaceholderText('production')).toHaveValue('production');
 
-    expect(screen.getByPlaceholderText('ref/heads/main')).toHaveValue('main');
+    expect(screen.getAllByPlaceholderText('refs/heads/main')[1]).toHaveValue(
+      'main'
+    );
 
     expect(screen.getByPlaceholderText('octo-enterprise')).toHaveValue(
       'octo-enterprise'

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.tsx
@@ -120,7 +120,7 @@ export function ConnectGitHub(props: FlowStepProps) {
                 }
                 disabled={state.isBranchDisabled}
                 label="Branch"
-                placeholder="main"
+                placeholder="refs/heads/main"
                 value={state.branch}
                 onChange={e => {
                   dispatch({
@@ -210,7 +210,7 @@ export function ConnectGitHub(props: FlowStepProps) {
                   <FieldInput
                     flex={1}
                     label={'Git Ref'}
-                    placeholder="ref/heads/main"
+                    placeholder="refs/heads/main"
                     value={state.ref}
                     onChange={e => {
                       dispatch({

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.tsx
@@ -346,14 +346,14 @@ const Container = styled(Flex)`
 `;
 
 const FormContainer = styled(Flex)`
-  flex: 1;
+  flex: 4;
   flex-direction: column;
   overflow: auto;
   padding-right: ${({ theme }) => theme.space[5]}px;
 `;
 
 const CodeContainer = styled(Flex)`
-  flex: 1;
+  flex: 6;
   flex-direction: column;
   overflow: auto;
 `;

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.tsx
@@ -63,7 +63,7 @@ export function Finish(props: FlowStepProps) {
 
   return (
     <Container>
-      <Box flex={1}>
+      <Box flex={4}>
         <H2 mb={3} mt={3}>
           Setup Workflow
         </H2>
@@ -157,11 +157,11 @@ export function Finish(props: FlowStepProps) {
 const Container = styled(Flex)`
   flex: 1;
   overflow: auto;
-  gap: ${({ theme }) => theme.space[3]}px;
+  gap: ${({ theme }) => theme.space[5]}px;
 `;
 
 const CodeContainer = styled(Flex)`
-  flex: 1;
+  flex: 6;
   flex-direction: column;
   overflow: auto;
 `;

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/templates.ts
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/templates.ts
@@ -19,14 +19,11 @@
 export function makeGhaWorkflow(params: {
   tokenName: string;
   clusterPublicUrl: string;
-  toolsVersion: string;
 }) {
   return GHA_WORKFLOW.replaceAll(
     ':token_name',
     JSON.stringify(params.tokenName)
-  )
-    .replaceAll(':cluster_public_url', JSON.stringify(params.clusterPublicUrl))
-    .replaceAll(':tools_version', JSON.stringify(params.toolsVersion));
+  ).replaceAll(':cluster_public_url', JSON.stringify(params.clusterPublicUrl));
 }
 
 export const GHA_WORKFLOW = `# This file contains a GitHub Actions workflow which enrolls with Teleport in
@@ -43,7 +40,6 @@ export const GHA_WORKFLOW = `# This file contains a GitHub Actions workflow whic
 on: workflow_dispatch
 
 env:
-  TELEPORT_TOOLS_VERSION: :tools_version
   TELEPORT_PROXY_ADDR: :cluster_public_url
   TELEPORT_JOIN_TOKEN_NAME: :token_name
 
@@ -67,14 +63,15 @@ jobs:
     - name: Fetch Teleport binaries
       uses: teleport-actions/setup@v1
       with:
-        version: $TELEPORT_TOOLS_VERSION
+        version: auto
+        proxy: \${{ env.TELEPORT_PROXY_ADDR }}
 
     - name: Fetch credentials using Machine & Workload Identity
       uses: teleport-actions/auth-k8s@v2
       with:
-        proxy: $TELEPORT_PROXY_ADDR
-        token: $TELEPORT_JOIN_TOKEN_NAME
-        kubernetes-cluster: $TELEPORT_K8S_CLUSTER_NAME
+        proxy: \${{ env.TELEPORT_PROXY_ADDR }}
+        token: \${{ env.TELEPORT_JOIN_TOKEN_NAME }}
+        kubernetes-cluster: \${{ env.TELEPORT_K8S_CLUSTER_NAME }}
         # Enable the submission of anonymous usage telemetry. This helps us
         # shape the future development of \`tbot\`. You can disable this by
         # omitting this.
@@ -83,5 +80,5 @@ jobs:
     # Use kubectl or other compatible tools to interact with your Kubernetes
     # cluster.
     - name: List pods
-      run: kubectl get pods -A
+      run: kubectl version
 `;

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
@@ -75,9 +75,6 @@ describe('useGitHubK8sFlow', () => {
     );
 
     expect(result.current.template.ghaWorkflow).toContain(
-      'TELEPORT_TOOLS_VERSION: "4.4.0-dev"'
-    );
-    expect(result.current.template.ghaWorkflow).toContain(
       'TELEPORT_PROXY_ADDR: "some-long-cluster-public-url-name.cloud.teleport.gravitational.io:1234"'
     );
   });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.tsx
@@ -152,7 +152,6 @@ export function GitHubK8sFlowProvider(
       ghaWorkflow: makeGhaWorkflow({
         tokenName: `gha-${state.info?.owner ?? 'gravitational'}-${state.info?.repository ?? 'teleport'}`,
         clusterPublicUrl: cluster.publicURL,
-        toolsVersion: cluster.authVersion,
       }),
     },
   };


### PR DESCRIPTION
## Summary
This change makes a fix to the syntax used to reference env vars in `with` lines in a GitHub Actions workflow as part of the GitHub Actions + Kubernetes guide. `$NAME` should instead be `${{ env.NAME }}`. There's also a couple of UX improvements bundled in.

Changelog: Fixed the syntax used to reference env vars in the GitHub workflow template as part of the GitHub Actions + Kubernetes guide
Updates: https://github.com/gravitational/teleport/issues/60937

## Changes
- Fix env var syntax in workflow template
- Layout content and code panels 40/60 respectively
- Update input placeholder for branch to indicate that the full ref syntax is required (`refs/heads/main` instead of just `main`)

## Demo
<img width="1346" height="884" alt="Screenshot 2025-12-18 at 17 09 02" src="https://github.com/user-attachments/assets/43f40e27-d6b1-4b58-a1df-b4ec34a92835" />
