### PR TITLE
Speed up discovery tests

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -156,6 +156,8 @@ type Config struct {
 	ServerID string
 	// onDatabaseReconcile is called after each database resource reconciliation.
 	onDatabaseReconcile func()
+	// onKubernetesClusterReconcile is called after each Kubernetes cluster resource reconciliation.
+	onKubernetesClusterReconcile func()
 	// protocolChecker is used by Kubernetes fetchers to check port's protocol if needed.
 	protocolChecker fetchers.ProtocolChecker
 	// DiscoveryGroup is the name of the discovery group that the current

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -125,6 +125,10 @@ func (s *Server) startKubeWatchers() error {
 					s.Log.WarnContext(s.ctx, "Unable to reconcile resources", "error", err)
 				}
 
+				if s.onKubernetesClusterReconcile != nil {
+					s.onKubernetesClusterReconcile()
+				}
+
 			case <-s.ctx.Done():
 				return
 			}


### PR DESCRIPTION
Removes the use of require.Never to reduce the test time by 10 seconds. The usage events should always be recorded synchronously during the reconciliation. By the time the waitForReconcile channel is written to the mock reporter will already have the stats from the reconciliation.