### PR TITLE
Make lib/winpki.crlKeyName strict

### DIFF
--- a/lib/auth/db.go
+++ b/lib/auth/db.go
@@ -170,7 +170,10 @@ func (a *Server) generateDatabaseCert(ctx context.Context, req *proto.DatabaseCe
 		// If there's only 1 active key we don't include SKID in CDP for backward compatibility.
 		if req.CRLDomain != "" {
 			includeSKID := len(ca.GetActiveKeys().TLS) > 1
-			cdp := winpki.CRLDistributionPoint(req.CRLDomain, types.DatabaseClientCA, tlsCA, includeSKID)
+			cdp, err := winpki.CRLDistributionPoint(req.CRLDomain, types.DatabaseClientCA, tlsCA, includeSKID)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
 			certReq.CRLDistributionPoints = []string{cdp}
 		} else if req.CRLEndpoint != "" {
 			// legacy clients will specify CRL endpoint instead of CRL domain

--- a/lib/auth/desktop.go
+++ b/lib/auth/desktop.go
@@ -98,7 +98,10 @@ func (a *Server) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 	// by the client because the CDP is based on the identity of the issuer, which is
 	// necessary in order to support clusters with multiple issuing certs (HSMs).
 	if req.CRLDomain != "" {
-		cdp := winpki.CRLDistributionPoint(req.CRLDomain, types.UserCA, tlsCA, true)
+		cdp, err := winpki.CRLDistributionPoint(req.CRLDomain, types.UserCA, tlsCA, true)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		certReq.CRLDistributionPoints = []string{cdp}
 	} else if req.CRLEndpoint != "" {
 		// Legacy clients will specify CRL endpoint instead of CRL domain.

--- a/lib/winpki/certificate_authority.go
+++ b/lib/winpki/certificate_authority.go
@@ -133,8 +133,14 @@ func (c *CertificateStoreClient) updateCRL(ctx context.Context, issuerCN string,
 	// Teleport cluster name. So, for instance, CRL for cluster "prod" and User
 	// CA will be placed at:
 	// ... > CDP > Teleport > prod
-	containerDN := crlContainerDN(c.cfg.Domain, caType)
-	crlDN := CRLDN(issuerCN, issuerSKID, c.cfg.Domain, caType)
+	containerDN, err := crlContainerDN(c.cfg.Domain, caType)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	crlDN, err := CRLDN(issuerCN, issuerSKID, c.cfg.Domain, caType)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	ldapClient, err := DialLDAP(ctx, c.cfg.LC, tc)
 	if err != nil {

--- a/lib/winpki/windows_test.go
+++ b/lib/winpki/windows_test.go
@@ -44,11 +44,13 @@ func TestCRLDN(t *testing.T) {
 		{
 			name:        "test cluster name",
 			clusterName: "test",
+			caType:      types.UserCA,
 			crlDN:       "CN=test,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
 			name:        "full cluster name",
 			clusterName: "cluster.goteleport.com",
+			caType:      types.UserCA,
 			crlDN:       "CN=cluster.goteleport.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
@@ -87,7 +89,9 @@ func TestCRLDN(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.crlDN, CRLDN(test.clusterName, test.issuerSKID, "test.goteleport.com", test.caType))
+			got, err := CRLDN(test.clusterName, test.issuerSKID, "test.goteleport.com", test.caType)
+			require.NoError(t, err)
+			require.Equal(t, test.crlDN, got)
 		})
 	}
 }


### PR DESCRIPTION
Make lib/winpki.crlKeyName strict, so only mapped CAs may be used to call it.

Prep work for #10111.