### PR TITLE
Emit Audit Log Trail on Session Reject

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -80,6 +80,7 @@ type DeviceAuthorizationOpts struct {
 
 // AuthorizerOpts holds creation options for [NewAuthorizer].
 type AuthorizerOpts struct {
+	TEST                string
 	ClusterName         string
 	AccessPoint         AuthorizerAccessPoint
 	ReadOnlyAccessPoint ReadOnlyAuthorizerAccessPoint
@@ -133,6 +134,7 @@ func newAuthorizer(opts AuthorizerOpts) (*authorizer, error) {
 	}
 
 	return &authorizer{
+		TEST:                    opts.TEST,
 		clusterName:             opts.ClusterName,
 		accessPoint:             opts.AccessPoint,
 		readOnlyAccessPoint:     opts.ReadOnlyAccessPoint,
@@ -226,6 +228,7 @@ type MFAAuthData struct {
 
 // authorizer creates new local authorizer
 type authorizer struct {
+	TEST                string
 	clusterName         string
 	accessPoint         AuthorizerAccessPoint
 	readOnlyAccessPoint ReadOnlyAuthorizerAccessPoint
@@ -443,7 +446,7 @@ func (a *authorizer) Authorize(ctx context.Context) (authCtx *Context, err error
 				}
 			}
 
-			userMsg := fmt.Sprintf("authorization failed for method %s: %s component", methodName, errorMsg)
+		userMsg := fmt.Sprintf("authorization failed for method %s: %s component %s", methodName, errorMsg, a.TEST)
 
 			event := &apievents.AuthAttempt{
 				Metadata: apievents.Metadata{

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -564,6 +564,9 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		return nil, trace.AccessDenied("%s", accessDeniedMsg)
 	}
 
+	kubeMethod := fmt.Sprintf("KUBE: %s %s", req.Method, req.URL.Path)
+	ctx = authz.WithRequestMethod(ctx, kubeMethod)
+
 	userContext, err := f.cfg.Authz.Authorize(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -157,10 +157,12 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(logger *slog
 	clusterName := conn.ClusterName()
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+		TEST:        "desktop",
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
 		Logger:      process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentWindowsDesktop, process.id)),
+		Emitter:     conn.Client,
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			// Ignore the global device_trust.mode toggle, but allow role-based
 			// settings to be applied.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2605,6 +2605,7 @@ func (process *TeleportProcess) initAuthService() error {
 		// Auth Server does explicit device authorization.
 		// Various Auth APIs must allow access to unauthorized devices, otherwise it
 		// is not possible to acquire device-aware certificates in the first place.
+		Emitter: checkingEmitter,
 		DeviceAuthorization: authz.DeviceAuthorizationOpts{
 			DisableGlobalMode: true,
 			DisableRoleMode:   true,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2595,6 +2595,7 @@ func (process *TeleportProcess) initAuthService() error {
 	// client based on their certificate (user, server, admin, etc)
 
 	authorizerOpts := authz.AuthorizerOpts{
+		TEST:                "initauth",
 		ClusterName:         clusterName,
 		AccessPoint:         authServer,
 		ReadOnlyAccessPoint: authServer,
@@ -5286,10 +5287,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+			TEST:          "initproxyapp",
 			ClusterName:   cn.GetClusterName(),
 			AccessPoint:   accessPoint,
 			LockWatcher:   lockWatcher,
 			Logger:        process.logger,
+			Emitter:       asyncEmitter,
 			PermitCaching: process.Config.CachePolicy.Enabled,
 		})
 		if err != nil {
@@ -5776,6 +5779,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	if listeners.kube != nil && !process.Config.Proxy.DisableReverseTunnel {
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+			TEST:          "initproxykub",
 			ClusterName:   clusterName,
 			AccessPoint:   accessPoint,
 			LockWatcher:   lockWatcher,
@@ -5900,6 +5904,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	// framework.
 	if (!listeners.db.Empty() || alpnRouter != nil) && !process.Config.Proxy.DisableReverseTunnel {
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+			TEST:          "initproxydb",
 			ClusterName:   clusterName,
 			AccessPoint:   accessPoint,
 			LockWatcher:   lockWatcher,
@@ -6677,6 +6682,7 @@ func (process *TeleportProcess) initApps() {
 			return trace.Wrap(err)
 		}
 		authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+			TEST:        "initapps",
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
@@ -6686,6 +6692,7 @@ func (process *TeleportProcess) initApps() {
 				// settings to be applied.
 				DisableGlobalMode: true,
 			},
+			Emitter:       asyncEmitter,
 			PermitCaching: process.Config.CachePolicy.Enabled,
 		})
 		if err != nil {
@@ -7235,10 +7242,12 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 	}
 
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
+		TEST:          "initsecureGRPCServer",
 		ClusterName:   clusterName,
 		AccessPoint:   cfg.accessPoint,
 		LockWatcher:   cfg.lockWatcher,
 		Logger:        process.logger.With(teleport.ComponentKey, teleport.Component(teleport.ComponentProxySecureGRPC, process.id)),
+		Emitter:       cfg.emitter,
 		PermitCaching: process.Config.CachePolicy.Enabled,
 	})
 	if err != nil {


### PR DESCRIPTION
Currently, when the Authorizer rejects a connection (e.g., [due to IP pinning](https://github.com/gravitational/teleport/issues/48123)), the Auth Server returns a gRPC error to the client but does not emit an audit event.

Added an auditing block within `authz.Authorizer`. This ensures that any `trace.AccessDenied` error returned when an authorization attempt fails is captured and emitted as a `AuthAttemptFailure` (T3007W) event.

Addresses #48123

Recreation Steps for IP Pinning (Local):
```
// create alias for local computer
sudo ifconfig lo0 alias 192.168.250.250

// login
tsh login --insecure --proxy=192.168.250.250:443 --auth=local --user=testuser --mfa-mode=otp

// delete the ipv6 loopback translation on Mac
sudo ifconfig lo0 inet6 ::1 delete

// try to tsh ssh; should get IP pinning error
tsh ssh --insecure --proxy=localhost:443 --user=testuser root@Kenneths-MacBook-Pro.local 

// add ipv6 loopback translation before logging in to test again
sudo ifconfig lo0 inet6 ::1 add
```

Note: With these changes, we now see multiple of these Session Rejected Events with the same contents, instead of just one. If we look at the `usermessage` of each of these events, we now see the individual RPC calls that are being called/rejected.

<img width="1338" height="97" alt="image" src="https://github.com/user-attachments/assets/486e907f-869f-414c-9044-b43105a79ecb" />


```
{
  "addr.remote": "127.0.0.1:58152",
  "cluster_name": "localhost",
  "code": "T3007W",
  "ei": 0,
  "error": "pinned IP doesn't match observed client IP",
  "event": "auth",
  "message": "access denied to method /proto.AuthService/CreateAuthenticateChallenge: pinned IP doesn't match observed client IP",
  "server_id": "",
  "server_version": "19.0.0-dev",
  "success": false,
  "time": "2026-02-09T17:18:04.791Z",
  "uid": "b6917ed4-7655-4cac-97e0-01b81200d30a",
  "user": "testuser"
}

{
  "addr.remote": "127.0.0.1:58157",
  "cluster_name": "localhost",
  "code": "T3007W",
  "ei": 0,
  "error": "pinned IP doesn't match observed client IP",
  "event": "auth",
  "message": "access denied to method /proto.AuthService/GetSSHTargets: pinned IP doesn't match observed client IP",
  "server_id": "",
  "server_version": "19.0.0-dev",
  "success": false,
  "time": "2026-02-09T17:18:04.795Z",
  "uid": "fb48c72d-91d0-47cc-b3a2-e100d6e35e75",
  "user": "testuser"
}
```

When failing a session due to locks:
<img width="1342" height="98" alt="image" src="https://github.com/user-attachments/assets/99e7b229-0bf1-4890-830d-b5d5f3ffda95" />


```
{
  "addr.remote": "[::1]:57483",
  "cluster_name": "localhost",
  "code": "T3007W",
  "ei": 0,
  "error": "lock targeting User:\"testuser\" is in force: locking testuser",
  "event": "auth",
  "message": "access denied to method /proto.AuthService/CreateAuthenticateChallenge: lock targeting User:\"testuser\" is in force: locking testuser",
  "server_id": "",
  "server_version": "19.0.0-dev",
  "success": false,
  "time": "2026-02-09T17:06:56.645Z",
  "uid": "46775862-a13c-4824-87f0-be646fffe3ae",
  "user": "testuser"
}

{
  "addr.remote": "[::1]:57487",
  "cluster_name": "localhost",
  "code": "T3007W",
  "ei": 0,
  "error": "lock targeting User:\"testuser\" is in force: locking testuser",
  "event": "auth",
  "message": "access denied to method /proto.AuthService/GetSSHTargets: lock targeting User:\"testuser\" is in force: locking testuser",
  "server_id": "",
  "server_version": "19.0.0-dev",
  "success": false,
  "time": "2026-02-09T17:06:56.65Z",
  "uid": "9404d249-d9f6-4a56-8ef1-b9ae737508d1",
  "user": "testuser"
}
```

Test Plan
- [ ] Locks
- `tsh login` as testuser with access privileges to ssh onto a server
- Create a lock targeting testuser
- Attempt to `tsh ssh` onto a server
- We should now see the two audit logs described above
  - [ ] Locks with database
  - Attempt to `tsh db login` to postgres database, and we should observe 1 audit log
  - `"message": "access denied to method /proto.AuthService/ListResources: lock targeting User:\"testuser\" is in force: locking testuser"`
- [ ] IP Pinning
- Follow recreation steps above, we should now see those two audit logs above as well
  - [ ] IP Pinning with database
  - Attempt to `tsh db login` after deleting ipv6 loopback, then we should also observe 1 audit log
  - [ ] IP Pinning with Kubernetes
  - `tsh kube login`, then delete ipv6 loopback, then `kubectl get pods` should give us 5 audit logs
- [ ] Device Trust
- Start Teleport with `auth_service.device_trust.mode: off`, then `tsh login`
- Restart Teleport with `auth_service.device_trust.mode: off`
   - [ ] `tsh ssh` should reject session and leave an audit log
   - [ ] `tsh app login` should not reject session and should not leave audit log (global device trust does not affect app access unless user roles target the app)