### PR TITLE
Use gnu host triple for windows CI builds

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -101,7 +101,11 @@ function Install-Rust {
         Invoke-WebRequest -Uri https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe -OutFile $RustupFile
         $Env:RUSTUP_HOME = "$ToolchainDir/rustup"
         $Env:CARGO_HOME = "$ToolchainDir/cargo"
-        & "$ToolchainDir\rustup-init.exe" --profile minimal -y --default-toolchain "$RustVersion-x86_64-pc-windows-gnu"
+        # we explicitly set the default host triple to the -windows-gnu
+        # toolchain because the default is the -windows-msvc triple and cross
+        # compilation with the -gnu target (which is all we use) fails with the
+        # e/windowsauth build
+        & "$ToolchainDir\rustup-init.exe" --profile minimal -y --default-host x86_64-pc-windows-gnu --default-toolchain "$RustVersion-x86_64-pc-windows-gnu"
         Enable-Rust -ToolchainDir $ToolchainDir
         Write-Host "::endgroup::"
     }
@@ -169,7 +173,7 @@ function Install-WasmDeps {
     .SYNOPSIS
         Builds and installs wasm-bindgen-cli, wasm-opt, and wasm32-unknown-unknown toolchain.
     #>
-    
+
     Write-Host "::group::Installing wasm-bindgen-cli, wasm-opt, and wasm32-unknown-unknown toolchain"
     make -C "$TeleportSourceDirectory" ensure-wasm-deps
     Write-Host "::endgroup::"


### PR DESCRIPTION
This PR changes the Windows build script to install Rust with a default host triple of `x86_64-pc-windows-gnu`, since the default host triple can't be overridden by `rust-toolchain.toml` and it causes problems when building the `e/windowsauth` crate due to some incompatibility of the `-msvc` toolchain cross-compiling for the `-gnu` target with the `embedded-resource` crate (see gravitational/teleport.e#7634).