### PR TITLE
pnpm: Remove `trustPolicy: no-downgrade`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -41,23 +41,6 @@ patchedDependencies:
   jest-canvas-mock@2.5.2: web/patches/jest-canvas-mock@2.5.2.patch
 # Do not install packages released less than 2 days (2880 minutes) ago
 minimumReleaseAge: 2880
-trustPolicy: no-downgrade
-trustPolicyExclude:
-  # semver v6 and v5 is published with no provenance.
-  - semver@6.3.1 || 5.7.2
-  # Subpackages of swc have no provenance. https://github.com/swc-project/swc/issues/11342
-  - "@swc/core-darwin-x64@1.15.3"
-  - "@swc/core-darwin-arm64@1.15.3"
-  - "@swc/core-linux-x64-musl@1.15.3"
-  - "@swc/core-linux-x64-gnu@1.15.3"
-  - "@swc/core-linux-arm64-gnu@1.15.3"
-  - "@swc/core-linux-arm64-musl@1.15.3"
-  - "@swc/core-win32-x64-msvc@1.15.3"
-  - "@swc/core-linux-arm-gnueabihf@1.15.3"
-  - "@swc/core-win32-ia32-msvc@1.15.3"
-  - "@swc/core-win32-arm64-msvc@1.15.3"
-  # undici-types v6 is published with no provenance. https://github.com/nodejs/undici/issues/4666
-  - undici-types@6.21.0
 overrides:
   # styled-components hardcodes specific version of csstype. Our design package also pulls in
   # csstype. Unfortunately, it looks like types from 3.1.3 are incompatible with 3.2.3. Since this


### PR DESCRIPTION
This was originally added in #61884 and then `trustPolicyExclude` was added in #61720.

I was afraid that the setting will interfere with Dependabot and that's exactly what happened. First it failed to install the Storybook security update [because of `minimumReleaseAge`](https://github.com/gravitational/teleport/actions/runs/20348018581/job/58465195244#step:3:643). Once it's been 2 days after the release of 9.1.17, it failed to install it again [because of `trustPolicy`](https://github.com/gravitational/teleport/actions/runs/20374348180/job/58548761795#step:3:654).

But the error doesn't even tell you why exactly it failed:

```
 ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "storybook@9.1.17" (possible package takeover)

This error happened while installing a direct dependency of /home/dependabot/dependabot-updater/repo

Trust checks are based solely on publish date, not semver. A package cannot be installed if any earlier-published version had stronger trust evidence. Earlier versions had trusted publisher, but this version has no trust evidence. A trust downgrade may indicate a supply chain incident.
```

When I was adding packages to `trustPolicyExclude`, I could see that they have e.g. provenance for their v6 versions but not v7, so pnpm was failing. But Storybook seems to have no provenance and the error from pnpm doesn't explain how the trust evidence differs between Storybook releases.

There's an ongoing discussion about making this setting a little less strict (https://github.com/pnpm/pnpm/issues/10202#issuecomment-3672998128). We can see what comes out of this and maybe turn it back on in the future. I'm pretty sure the setting would make monthly updates fail as well.