### PR TITLE
Add session recording support for enhanced BPF session events

### DIFF
--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -26,6 +26,7 @@ import (
 
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -81,6 +82,10 @@ type SessionContext struct {
 
 	// Emitter is used to record events for a particular session
 	Emitter apievents.Emitter
+
+	//  Recorder is a SessionRecorder which is used to record session
+	// events.
+	Recorder events.SessionPreparerRecorder
 
 	// Events is the set of events (command, disk, or network) to record for
 	// this session.

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1443,6 +1443,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		Context:               scx.srv.Context(),
 		PID:                   s.term.PID(),
 		Emitter:               s.emitter,
+		Recorder:              s.Recorder(),
 		Namespace:             scx.srv.GetNamespace(),
 		SessionID:             s.id.String(),
 		ServerID:              scx.srv.ID(),


### PR DESCRIPTION
This change integrates the session recorder with BPF-based enhanced session recording, enabling BPF events (commands, disk, and network operations) to be prepared and recorded for session playback.

Previously, BPF events were only emitted to the audit log. Now these events are also recorded to the session recording.

This enables session recordings to include enhanced session events captured via BPF, providing complete visibility into session activity during playback.