### PR TITLE
Allow nodes to join the cluster based on their AWS Organization using an Integration

### DIFF
--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -146,6 +146,9 @@ type ProvisionToken interface {
 	GetAllowRules() []*TokenRule
 	// SetAllowRules sets the allow rules
 	SetAllowRules([]*TokenRule)
+	// GetIntegration returns the integration name that provides credentials to validate allow rules.
+	// Currently, this is only used to validate the AWS Organization.
+	GetIntegration() string
 	// GetGCPRules will return the GCP rules within this token.
 	GetGCPRules() *ProvisionTokenSpecV2GCP
 	// GetGithubRules will return the GitHub rules within this token.
@@ -605,6 +608,12 @@ func (p *ProvisionTokenV2) GetSuggestedLabels() Labels {
 // They are added to `db_service.resources.0.labels`.
 func (p *ProvisionTokenV2) GetSuggestedAgentMatcherLabels() Labels {
 	return p.Spec.SuggestedAgentMatcherLabels
+}
+
+// GetIntegration returns the integration name that provides credentials to validate allow rules.
+// Currently, this is only used to validate the AWS Organization.
+func (p *ProvisionTokenV2) GetIntegration() string {
+	return p.Spec.Integration
 }
 
 // V1 returns V1 version of the resource

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -114,6 +114,7 @@ import (
 	"github.com/gravitational/teleport/lib/devicetrust/assertserver"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/integrations/awsra/createsession"
 	"github.com/gravitational/teleport/lib/inventory"
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
@@ -581,7 +582,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 			return organizations.NewFromConfig(c)
 		}
 
-		cfg.AWSOrganizationsClientGetter, err = awsOrganizationsClientUsingAmbientCredentials(closeCtx, cfg.Clock, organizationsClientFromSDK)
+		cfg.AWSOrganizationsClientGetter, err = awsOrganizationsClientGetter(closeCtx, cfg.Clock, organizationsClientFromSDK)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -906,9 +907,8 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (as *Server, err error) {
 	return as, nil
 }
 
-// awsOrganizationsClientUsingAmbientCredentials returns an AWS Organizations client getter
-// that uses ambient credentials to create the client.
-func awsOrganizationsClientUsingAmbientCredentials(ctx context.Context, clock clockwork.Clock, organizationsClientFromConfig func(aws.Config) iamjoin.OrganizationsAPI) (iamjoin.OrganizationsAPIGetter, error) {
+// awsOrganizationsClientGetter returns an AWS Organizations client getter.
+func awsOrganizationsClientGetter(ctx context.Context, clock clockwork.Clock, organizationsClientFromConfig func(aws.Config) iamjoin.OrganizationsAPI) (*organizationsClientGetter, error) {
 	awsConfigProvider, err := awsconfig.NewCache()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -935,22 +935,36 @@ type organizationsClientGetter struct {
 	describeAccountAPICache       *utils.FnCache
 	awsConfig                     awsconfig.Provider
 	organizationsClientFromConfig func(aws.Config) iamjoin.OrganizationsAPI
+	// Only used in tests to prevent hitting real AWS endpoints.
+	stsClientFromConfig func(aws.Config) awsconfig.STSClient
 }
 
-func (o *organizationsClientGetter) Get(ctx context.Context) (iamjoin.OrganizationsAPI, error) {
+func (o *organizationsClientGetter) Get(ctx context.Context, integration string, awsOIDCIntegrationClient awsconfig.OIDCIntegrationClient) (iamjoin.OrganizationsAPI, error) {
 	// For IAM Join flow, the join token might allow instances under an Organization to join the cluster.
 	// In order to validate the organization ID of the joining identity, a call to organizations:DescribeAccount is performed.
 	// This requires AWS credentials to be accessible to the Auth Service.
 	//
-	// Currently, only ambient credentials are supported, which are not available when running within Teleport Cloud.
+	// The credentials can come from an integration or from ambient credentials, when an integration is not specified in the join token.
+	//
+	// Using ambient credentials when the Auth Service is running within Teleport Cloud is not supported.
 	// In that scenario a NotImplemented error is returned.
-	if modules.GetModules().Features().Cloud {
-		return nil, trace.NotImplemented("IAM Joins based on AWS Organization ID are not currently supported in Teleport Cloud")
+	if integration == "" && modules.GetModules().Features().Cloud {
+		return nil, trace.NotImplemented("IAM Joins based on AWS Organization ID require an integration")
+	}
+
+	awsConfigOptions := []awsconfig.OptionsFn{
+		awsconfig.WithCredentialsMaybeIntegration(awsconfig.IntegrationMetadata{
+			Name: integration,
+		}),
+		awsconfig.WithOIDCIntegrationClient(awsOIDCIntegrationClient),
+	}
+	if o.stsClientFromConfig != nil {
+		awsConfigOptions = append(awsConfigOptions, awsconfig.WithSTSClientProvider(o.stsClientFromConfig))
 	}
 
 	// Organizations API is global, so we use an empty string for region.
 	const noRegion = ""
-	awsConfig, err := o.awsConfig.GetConfig(ctx, noRegion, awsconfig.WithAmbientCredentials())
+	awsConfig, err := o.awsConfig.GetConfig(ctx, noRegion, awsConfigOptions...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1667,6 +1681,20 @@ func (a *Server) GetDeviceAssertionServer() CreateDeviceAssertionFunc {
 		}
 	}
 	return a.deviceAssertionServer
+}
+
+// GenerateAWSOIDCToken generates a token to be used to execute an AWS OIDC Integration action.
+func (a *Server) GenerateAWSOIDCToken(ctx context.Context, integration string) (string, error) {
+	token, err := awsoidc.GenerateAWSOIDCToken(ctx, a, a.GetKeyStore(), awsoidc.GenerateAWSOIDCTokenRequest{
+		Integration: integration,
+		Username:    a.ServerID,
+		Subject:     types.IntegrationAWSOIDCSubjectAuth,
+		Clock:       a.clock,
+	})
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return token, nil
 }
 
 func (a *Server) SetCreateDeviceWebTokenFunc(f CreateDeviceWebTokenFunc) {

--- a/lib/auth/auth_iamjoin_organizations_test.go
+++ b/lib/auth/auth_iamjoin_organizations_test.go
@@ -29,12 +29,15 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/awsconfig"
+	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 )
 
-func TestAWSOrganizationsClientUsingAmbientCredentials(t *testing.T) {
+func TestAWSOrganizationsClientGetter(t *testing.T) {
 	t.Run("when running in cloud, the client getter returns an error (ambient credentials can't be used in cloud)", func(t *testing.T) {
 		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
@@ -42,14 +45,79 @@ func TestAWSOrganizationsClientUsingAmbientCredentials(t *testing.T) {
 			},
 		})
 
-		clientGetter, err := awsOrganizationsClientUsingAmbientCredentials(t.Context(), clockwork.NewFakeClock(), nil)
+		clientGetter, err := awsOrganizationsClientGetter(t.Context(), clockwork.NewFakeClock(), nil)
 		require.NoError(t, err)
 
-		_, err = clientGetter.Get(t.Context())
+		const noIntegration = ""
+		_, err = clientGetter.Get(t.Context(), noIntegration, nil)
 		require.Error(t, err)
 	})
 
-	t.Run("when running in non-cloud, the getter returns a valid client", func(t *testing.T) {
+	t.Run("when running in cloud and using an integration, the getter returns a valid client", func(t *testing.T) {
+		modulestest.SetTestModules(t, modulestest.Modules{
+			TestFeatures: modules.Features{
+				Cloud: true,
+			},
+		})
+
+		const exampleIntegration = "my-integration"
+		awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(
+			types.Metadata{Name: exampleIntegration},
+			&types.AWSOIDCIntegrationSpecV1{
+				RoleARN: "arn:aws:sts::123456789012:role/TestRole",
+			},
+		)
+		require.NoError(t, err)
+		mockIntegrationClt := &fakeOIDCIntegrationClient{
+			getIntegrationFn: func(context.Context, string) (types.Integration, error) {
+				return awsOIDCIntegration, nil
+			},
+			getTokenFn: func(context.Context, string) (string, error) {
+				return "oidc-token", nil
+			},
+		}
+
+		fakeClock := clockwork.NewFakeClock()
+		mockOrganizationsAPI := &mockOrganizationsAPI{}
+		clientGetter, err := awsOrganizationsClientGetter(t.Context(), fakeClock, func(c aws.Config) iamjoin.OrganizationsAPI {
+			return mockOrganizationsAPI
+		})
+		require.NoError(t, err)
+
+		// Mock the STS client to prevent real AWS calls during tests.
+		clientGetter.stsClientFromConfig = func(_ aws.Config) awsconfig.STSClient {
+			return &mocks.STSClient{}
+		}
+
+		organizationsAPI, err := clientGetter.Get(t.Context(), exampleIntegration, mockIntegrationClt)
+		require.NoError(t, err)
+
+		describeAccountAPIOutput, err := organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected one remote API call")
+
+		// Call again to verify caching works.
+		describeAccountAPIOutput, err = organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 1, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected no additional remote API calls due to caching")
+
+		// However, after the cache expiration time, a new call should be made.
+		fakeClock.Advance(5 * time.Minute)
+		describeAccountAPIOutput, err = organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
+			AccountId: aws.String("123456789012"),
+		})
+		require.NoError(t, err)
+		require.Equal(t, aws.String("123456789012"), describeAccountAPIOutput.Account.Id)
+		require.Equal(t, 2, mockOrganizationsAPI.numberOfRemoteAPICalls, "expected a new remote API call after cache expiration")
+	})
+
+	t.Run("when running in non-cloud with ambient credentials, the getter returns a valid client", func(t *testing.T) {
 		modulestest.SetTestModules(t, modulestest.Modules{
 			TestFeatures: modules.Features{
 				Cloud: false,
@@ -59,12 +127,13 @@ func TestAWSOrganizationsClientUsingAmbientCredentials(t *testing.T) {
 		fakeClock := clockwork.NewFakeClock()
 		mockOrganizationsAPI := &mockOrganizationsAPI{}
 
-		clientGetter, err := awsOrganizationsClientUsingAmbientCredentials(t.Context(), fakeClock, func(c aws.Config) iamjoin.OrganizationsAPI {
+		clientGetter, err := awsOrganizationsClientGetter(t.Context(), fakeClock, func(c aws.Config) iamjoin.OrganizationsAPI {
 			return mockOrganizationsAPI
 		})
 		require.NoError(t, err)
 
-		organizationsAPI, err := clientGetter.Get(t.Context())
+		const noIntegration = ""
+		organizationsAPI, err := clientGetter.Get(t.Context(), noIntegration, nil)
 		require.NoError(t, err)
 
 		describeAccountAPIOutput, err := organizationsAPI.DescribeAccount(t.Context(), &organizations.DescribeAccountInput{
@@ -102,4 +171,17 @@ func (m *mockOrganizationsAPI) DescribeAccount(ctx context.Context, params *orga
 	return &organizations.DescribeAccountOutput{
 		Account: &organizationstypes.Account{Id: aws.String("123456789012")},
 	}, nil
+}
+
+type fakeOIDCIntegrationClient struct {
+	getIntegrationFn func(context.Context, string) (types.Integration, error)
+	getTokenFn       func(context.Context, string) (string, error)
+}
+
+func (f *fakeOIDCIntegrationClient) GetIntegration(ctx context.Context, name string) (types.Integration, error) {
+	return f.getIntegrationFn(ctx, name)
+}
+
+func (f *fakeOIDCIntegrationClient) GenerateAWSOIDCToken(ctx context.Context, integrationName string) (string, error) {
+	return f.getTokenFn(ctx, integrationName)
 }

--- a/lib/auth/join_iam.go
+++ b/lib/auth/join_iam.go
@@ -100,12 +100,13 @@ func (a *Server) RegisterUsingIAMMethod(
 
 	// check that the GetCallerIdentity request is valid and matches the token
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(ctx, &iamjoin.CheckIAMRequestParams{
-		Challenge:              challenge,
-		ProvisionToken:         provisionToken,
-		STSIdentityRequest:     req.StsIdentityRequest,
-		HTTPClient:             a.GetHTTPClientForAWSSTS(),
-		FIPS:                   a.fips,
-		OrganizationsAPIGetter: a.GetAWSOrganizationsClientGetter(),
+		Challenge:                challenge,
+		ProvisionToken:           provisionToken,
+		STSIdentityRequest:       req.StsIdentityRequest,
+		HTTPClient:               a.GetHTTPClientForAWSSTS(),
+		FIPS:                     a.fips,
+		OrganizationsAPIGetter:   a.GetAWSOrganizationsClientGetter(),
+		AWSOIDCIntegrationClient: a,
 	})
 	if verifiedIdentity != nil {
 		joinFailureMetadata = verifiedIdentity

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -59,6 +59,10 @@ func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) 
 			return trace.AccessDenied("%s", requestErr)
 		}
 
+		if strings.Contains(requestErr.Error(), "TooManyRequestsException") {
+			return trace.LimitExceeded("%s", requestErr)
+		}
+
 		if strings.Contains(requestErr.Error(), ecsClusterNotFoundException.ErrorCode()) {
 			return trace.NotFound("%s", requestErr)
 		}

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -88,6 +88,19 @@ func TestConvertRequestFailureError(t *testing.T) {
 			wantIsError: trace.IsAccessDenied,
 		},
 		{
+			name: "StatusBadRequest with TooManyRequestsException",
+			inputError: &awshttp.ResponseError{
+				RequestID: fakeRequestID,
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusBadRequest,
+					}},
+					Err: trace.Errorf("TooManyRequestsException"),
+				},
+			},
+			wantIsError: trace.IsLimitExceeded,
+		},
+		{
 			name:           "not AWS error",
 			inputError:     errors.New("not-aws-error"),
 			wantUnmodified: true,

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -51,4 +51,7 @@ type Token interface {
 	GetAllowRules() []*types.TokenRule
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() types.Duration
+	// GetIntegration returns the integration name that provides credentials to validate allow rules.
+	// Currently, this is only used to validate the AWS Organization.
+	GetIntegration() string
 }

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -92,6 +92,8 @@ type AuthService interface {
 	GetClock() clockwork.Clock
 	GetHTTPClientForAWSSTS() utils.HTTPDoClient
 	GetAWSOrganizationsClientGetter() iamjoin.OrganizationsAPIGetter
+	GenerateAWSOIDCToken(ctx context.Context, integrationName string) (string, error)
+	GetIntegration(ctx context.Context, name string) (types.Integration, error)
 	GetAzureDevopsIDTokenValidator() azuredevops.Validator
 	GetBitbucketIDTokenValidator() bitbucket.Validator
 	GetEC2ClientForEC2JoinMethod() ec2join.EC2Client

--- a/lib/join/server_iam.go
+++ b/lib/join/server_iam.go
@@ -75,12 +75,13 @@ func (s *Server) handleIAMJoin(
 	// Verify the sts:GetCallerIdentity request, send it to AWS, and make sure
 	// the verified identity matches allow rules in the provision token.
 	verifiedIdentity, err := iamjoin.CheckIAMRequest(stream.Context(), &iamjoin.CheckIAMRequestParams{
-		Challenge:              challenge,
-		ProvisionToken:         token,
-		STSIdentityRequest:     solution.STSIdentityRequest,
-		HTTPClient:             s.cfg.AuthService.GetHTTPClientForAWSSTS(),
-		FIPS:                   s.cfg.FIPS,
-		OrganizationsAPIGetter: s.cfg.AuthService.GetAWSOrganizationsClientGetter(),
+		Challenge:                challenge,
+		ProvisionToken:           token,
+		STSIdentityRequest:       solution.STSIdentityRequest,
+		HTTPClient:               s.cfg.AuthService.GetHTTPClientForAWSSTS(),
+		FIPS:                     s.cfg.FIPS,
+		OrganizationsAPIGetter:   s.cfg.AuthService.GetAWSOrganizationsClientGetter(),
+		AWSOIDCIntegrationClient: s.cfg.AuthService,
 	})
 	// An identity will be returned even on error if the sts:GetCallerIdentity
 	// request was completed but no allow rules were matched, include it in the

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -244,6 +244,12 @@ func (t *Token) GetAWSIIDTTL() types.Duration {
 	return types.NewDuration(0)
 }
 
+// GetIntegration returns the Integration field which is used to provide
+// credentials that will be used when validating the AWS Organization if required by an IAM Token.
+func (t *Token) GetIntegration() string {
+	return ""
+}
+
 // GetSecret returns the token's secret value.
 func (t *Token) GetSecret() (string, bool) {
 	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -2590,6 +2590,15 @@ func TestDiscoveryDatabase(t *testing.T) {
 				},
 			}
 
+			// Upsert a fake proxy to ensure we have a public address to use for the
+			// AWS OIDC integration.
+			proxy, err := types.NewServer("proxy", types.KindProxy, types.ServerSpecV2{
+				PublicAddrs: []string{"teleport.example.com"},
+			})
+			require.NoError(t, err)
+			err = tlsServer.Auth().UpsertProxy(ctx, proxy)
+			require.NoError(t, err)
+
 			_, err = tlsServer.Auth().CreateIntegration(ctx, awsOIDCIntegration)
 			require.NoError(t, err)
 

--- a/lib/srv/discovery/kube_integration_watcher_test.go
+++ b/lib/srv/discovery/kube_integration_watcher_test.go
@@ -154,6 +154,17 @@ func TestDiscoveryKubeIntegrationEKS(t *testing.T) {
 		RoleARN: roleArn,
 	})
 	require.NoError(t, err)
+
+	// Upsert a fake proxy to ensure we have a public address to use for the
+	// AWS OIDC integration.
+	proxy, err := types.NewServer("proxy", types.KindProxy, types.ServerSpecV2{
+		PublicAddrs: []string{"teleport.example.com"},
+	})
+	require.NoError(t, err)
+
+	err = testAuthServer.AuthServer.UpsertProxy(t.Context(), proxy)
+	require.NoError(t, err)
+
 	testAuthServer.AuthServer.IntegrationsTokenGenerator = &mockIntegrationsTokenGenerator{
 		proxies: nil,
 		integrations: map[string]types.Integration{


### PR DESCRIPTION
Continuation of #62023
But now with support for using the integration credentials.

This ensures the feature becomes available for Teleport Cloud users, and other users which prefer to use an Integration instead of ambient credentials.

UX:
- Users need to create and AWS OIDC Integration
- Allow the `organizations:DescribeAccount` API in the Integration IAM Role
- Update or create an IAM Join token and add the Organization ID that is allowed to join and set the `spec.integration` field to the Integration defined above.


Changelog: Added support for EC2 instances to join the cluster based on their AWS organization using credentials provided by the AWS OIDC Integration.