### PR TITLE
[v18] fix: sanitize URL when fetching azure attested data intermediate cert

### DIFF
--- a/lib/join/azurejoin/azure_certs.go
+++ b/lib/join/azurejoin/azure_certs.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -47,40 +48,89 @@ func isAllowedDomain(cn string, domains []string) bool {
 	return false
 }
 
+func validateAzureCertIssuerURL(issuerURLString string) (string, error) {
+	// All active issuing certs are listed here
+	// https://www.microsoft.com/pkiops/docs/repository.htm
+	//
+	// The cert path always looks like the following, although this does not
+	// appear to be guaranteed by Microsoft.
+	// url: http://www.microsoft.com/pkiops/certs/<cert-name>.crt
+	//
+	// This code path is only used by the legacy join service which will be
+	// removed in v20, v18+ agents use the new join service where the joining
+	// client sends the intermediate CAs along with the request.
+	const (
+		allowedHost       = "www.microsoft.com"
+		allowedPathPrefix = "/pkiops/certs/"
+		allowedPathSuffix = ".crt"
+	)
+
+	issuerURL, err := url.Parse(issuerURLString)
+	if err != nil {
+		return "", trace.AccessDenied("url failed to parse")
+	}
+
+	switch issuerURL.Scheme {
+	case "http", "https":
+	default:
+		return "", trace.AccessDenied("invalid url scheme %q", issuerURL.Scheme)
+	}
+
+	if issuerURL.Host != allowedHost {
+		return "", trace.AccessDenied("invalid host %q", issuerURL.Host)
+	}
+
+	if !strings.HasPrefix(issuerURL.Path, allowedPathPrefix) ||
+		!strings.HasSuffix(issuerURL.Path, allowedPathSuffix) {
+		return "", trace.AccessDenied("invalid path, must match %s<name>%s",
+			allowedPathPrefix, allowedPathSuffix)
+	}
+
+	// Construct a new URL with only the scheme, host, and path to strip any
+	// possible extra fields like query params or fragments.
+	sanitizedURL := url.URL{
+		Scheme: issuerURL.Scheme,
+		Host:   allowedHost,
+		Path:   issuerURL.Path,
+	}
+	return sanitizedURL.String(), nil
+}
+
 // getAzureIssuerCert fetches a x509 certificate's issuing certificate.
 func getAzureIssuerCert(ctx context.Context, cert *x509.Certificate, httpClient utils.HTTPDoClient) (*x509.Certificate, error) {
 	if len(cert.IssuingCertificateURL) == 0 {
-		return nil, nil
+		return nil, trace.BadParameter("certificate has no issuing certificate URL")
 	}
 
 	// Azure sends only one issuing cert.
 	issuerURL := cert.IssuingCertificateURL[0]
-	commonName := cert.Subject.CommonName
-	if !isAllowedDomain(commonName, allowedAzureCommonNames) {
-		return nil, trace.AccessDenied(
-			"certificate common name does not match allow-list (%s)",
-			commonName,
-		)
+	sanitizedIssuerURL, err := validateAzureCertIssuerURL(issuerURL)
+	if err != nil {
+		return nil, trace.Wrap(err, "validating issuing certificate URL")
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, issuerURL, nil)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sanitizedIssuerURL, nil /*body*/)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "fetching issuing certificate")
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, trace.AccessDenied("failed to fetch issuing cert, got HTTP status code %d", resp.StatusCode)
+	}
+
 	body, err := utils.ReadAtMost(resp.Body, teleport.MaxHTTPResponseSize)
 	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, trace.ReadError(resp.StatusCode, body)
+		return nil, trace.Wrap(err, "reading HTTP response body")
 	}
 
 	issuerCert, err := x509.ParseCertificate(body)
-	return issuerCert, trace.Wrap(err)
+	return issuerCert, trace.Wrap(err, "parsing issuing certificate")
 }
 
 func getAzureRootCerts() ([]*x509.Certificate, error) {


### PR DESCRIPTION
Backport #62158 to branch/v18

### Manual Test Plan
- [x] invalid issuing certificate URLs are rejected
- [x] azure join method still works for agents using legacy join method

changelog: Fixed a potential SSRF vulnerability in the Azure join method implementation
