### PR TITLE
Record Kubernetes session join/leave events to session recordings

### DIFF
--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/rest"
@@ -48,6 +49,7 @@ import (
 	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
+	sessionpkg "github.com/gravitational/teleport/lib/session"
 )
 
 func TestModeratedSessions(t *testing.T) {
@@ -297,6 +299,7 @@ func TestModeratedSessions(t *testing.T) {
 			// moderatorJoined is used to syncronize when the moderator joins the session.
 			moderatorJoined := make(chan struct{})
 			once := sync.Once{}
+			var sessionID string
 			if tt.args.moderator != nil {
 				// generate moderator certs
 				_, config := testCtx.GenTestKubeClientTLSCert(
@@ -308,7 +311,7 @@ func TestModeratedSessions(t *testing.T) {
 				// Simulate a moderator joining the session.
 				group.Go(func() error {
 					// waits for user to send the sessionID of his exec request.
-					sessionID := <-sessionIDC
+					sessionID = <-sessionIDC
 					// validate that the sessionID is valid and the reason is the one we expect.
 					if err := validateSessionTracker(testCtx, sessionID, tt.args.reason, tt.args.invite); err != nil {
 						return trace.Wrap(err)
@@ -472,6 +475,14 @@ func TestModeratedSessions(t *testing.T) {
 			})
 			// wait for every go-routine to finish without errors returned.
 			require.NoError(t, group.Wait())
+
+			if sessionID == "" || !tt.want.sessionEndEvent {
+				// if sessionID is empty, it means that the session never started
+				// (moderated session without the moderator joining)
+				return
+			}
+
+			validateSessionRecordingEvents(t, testCtx, sessionID)
 		})
 	}
 }
@@ -691,4 +702,57 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 			tt.assertErr(t, err)
 		})
 	}
+}
+
+func validateSessionRecordingEvents(t *testing.T, testCtx *TestContext, sessionID string) {
+	t.Helper()
+
+	// validate that session recording was correctly uploaded.
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		err := testCtx.UploadHandler.Download(testCtx.Context, sessionpkg.ID(sessionID), &writerAtDiscarder{})
+		assert.NoError(t, err)
+	}, 10*time.Second, 50*time.Millisecond, "session recording was not uploaded")
+
+	auditsC, errC := testCtx.AuthServer.StreamSessionEvents(testCtx.Context, sessionpkg.ID(sessionID), 0)
+
+	var foundJoinEvent bool
+	var foundLeaveEvent bool
+	var foundEndEvent bool
+loop:
+	for {
+		select {
+		case event, ok := <-auditsC:
+			if !ok {
+				break loop
+			}
+			switch event.GetType() {
+			case events.SessionJoinEvent:
+				foundJoinEvent = true
+			case events.SessionLeaveEvent:
+				foundLeaveEvent = true
+			case events.SessionEndEvent:
+				foundEndEvent = true
+			}
+		case err, ok := <-errC:
+			if !ok {
+				break loop
+			}
+			require.NoError(t, err)
+		}
+	}
+	require.True(t, foundJoinEvent, "session join event not found")
+	require.True(t, foundLeaveEvent, "session leave event not found")
+	require.True(t, foundEndEvent, "session end event not found")
+}
+
+// writerAtDiscarder is a fake implementation of io.WriterAt
+// that discards all data written to it.
+type writerAtDiscarder struct{}
+
+func (f writerAtDiscarder) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (f writerAtDiscarder) WriteAt(p []byte, offset int64) (int, error) {
+	return len(p), nil
 }

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -460,6 +460,26 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 	namespace := params.ByName("podNamespace")
 	podName := params.ByName("podName")
 	container := q.Get("container")
+
+	recorder, err := recorder.New(recorder.Config{
+		SessionID:    tsession.ID(id.String()),
+		ServerID:     forwarder.cfg.HostID,
+		Namespace:    forwarder.cfg.Namespace,
+		Clock:        forwarder.cfg.Clock,
+		ClusterName:  forwarder.cfg.ClusterName,
+		RecordingCfg: ctx.recordingConfig,
+		SyncStreamer: forwarder.cfg.AuthClient,
+		DataDir:      forwarder.cfg.DataDir,
+		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentProxyKube),
+		// Session stream is using server context, not session context,
+		// to make sure that session is uploaded even after it is closed
+		Context: forwarder.ctx,
+	})
+	if err != nil {
+		streamContextCancel()
+		return nil, trace.Wrap(err)
+	}
+
 	s := &session{
 		podName:                        podName,
 		podNamespace:                   namespace,
@@ -489,11 +509,11 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 		partiesWg:                      sync.WaitGroup{},
 		// if session ever starts, emitter and recorder will be replaced
 		// by actual emitter and recorder.
-		emitter: events.NewDiscardEmitter(),
-		recorder: events.WithNoOpPreparer(
-			events.NewDiscardRecorder(),
-		),
+		emitter:  forwarder.cfg.Emitter,
+		recorder: recorder,
 	}
+
+	s.io.AddWriter(sessionRecorderID, recorder)
 
 	s.io.OnWriteError = s.disconnectPartyOnErr
 	s.io.OnReadError = s.disconnectPartyOnErr
@@ -762,7 +782,6 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, eventPodMeta 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	var err error
 	s.started = true
 	sessionStart := s.forwarder.cfg.Clock.Now().UTC()
 
@@ -919,29 +938,6 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, eventPodMeta 
 			s.forwarder.log.WarnContext(s.forwarder.ctx, "Failed to set up session end event - event will not be recorded", "error", err)
 		}
 	}
-
-	recorder, err := recorder.New(recorder.Config{
-		SessionID:    tsession.ID(s.id.String()),
-		ServerID:     s.forwarder.cfg.HostID,
-		Namespace:    s.forwarder.cfg.Namespace,
-		Clock:        s.forwarder.cfg.Clock,
-		ClusterName:  s.forwarder.cfg.ClusterName,
-		RecordingCfg: s.ctx.recordingConfig,
-		SyncStreamer: s.forwarder.cfg.AuthClient,
-		DataDir:      s.forwarder.cfg.DataDir,
-		Component:    teleport.Component(teleport.ComponentSession, teleport.ComponentProxyKube),
-		// Session stream is using server context, not session context,
-		// to make sure that session is uploaded even after it is closed
-		Context: s.forwarder.ctx,
-	})
-	if err != nil {
-		return onFinish, trace.Wrap(err)
-	}
-
-	s.recorder = recorder
-	s.emitter = s.forwarder.cfg.Emitter
-
-	s.io.AddWriter(sessionRecorderID, recorder)
 
 	// If the identity is verified with an MFA device, we enabled MFA-based presence for the session.
 	if s.PresenceEnabled {
@@ -1220,7 +1216,7 @@ func (s *session) prepareAndEmitEvent(evt apievents.AuditEvent) {
 		s.forwarder.log.WarnContext(s.forwarder.ctx, "Failed to prepare event - event will not be recorded into session recording.", "error", err, "event_type", evt.GetType())
 	}
 
-	// Alqyays emit the event to the audit log, even if preparing
+	// Always emit the event to the audit log, even if preparing
 	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, evt); err != nil {
 		s.forwarder.log.WarnContext(s.forwarder.ctx, "Failed to emit event to Audit Log.", "error", err, "event_type", evt.GetType())
 	}
@@ -1405,7 +1401,9 @@ func (s *session) Close() error {
 			// wait for events to be emitted before closing the recorder/emitter.
 			// If we close it immediately we will lose session.end events.
 			s.weakEventsWaiter.Wait()
-			recorder.Close(s.forwarder.ctx)
+			if err := recorder.Complete(s.forwarder.ctx); err != nil {
+				s.log.ErrorContext(s.forwarder.ctx, "Failed to complete session recorder", "error", err)
+			}
 		}
 	})
 


### PR DESCRIPTION
Refactor session join/leave event emission to prepare and record events into session recordings in addition to emitting them to the audit log. This ensures join/leave events are captured in session playback.

This aligns the Kubernetesi sessions behavior with SSH sessions.