### PR TITLE
Mark docs pages as Enterprise-only

### DIFF
--- a/docs/pages/identity-governance/access-lists/access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/access-lists.mdx
@@ -5,6 +5,7 @@ template: "no-toc"
 sidebar_position: 3
 tags:
  - identity-governance
+enterprise: Identity Governance
 ---
 
 Access Lists allow Teleport users to be granted long term access to resources

--- a/docs/pages/identity-governance/access-lists/guide.mdx
+++ b/docs/pages/identity-governance/access-lists/guide.mdx
@@ -6,6 +6,7 @@ tags:
  - get-started
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
+++ b/docs/pages/identity-governance/access-lists/nested-access-lists.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Nested Access Lists allow inclusion of an Access List as a member or owner of another Access List.

--- a/docs/pages/identity-governance/access-lists/reviewing-access-requests.mdx
+++ b/docs/pages/identity-governance/access-lists/reviewing-access-requests.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-governance
  - privileged-access
  - access-requests
+enterprise: Identity Governance
 ---
 
 Access List owners can be automatically assigned as suggested reviewers to

--- a/docs/pages/identity-governance/access-lists/terraform.mdx
+++ b/docs/pages/identity-governance/access-lists/terraform.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 You can manage Access List and their members using Terraform. This guide will help you:

--- a/docs/pages/identity-governance/access-monitoring.mdx
+++ b/docs/pages/identity-governance/access-monitoring.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-governance
  - access-risks
+enterprise: Identity Governance
 ---
 
 Access Monitoring allows users to understand and analyze the access patterns in a Teleport cluster.

--- a/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
+++ b/docs/pages/identity-governance/access-requests/access-request-configuration.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide explains the considerations you should make when configuring Teleport

--- a/docs/pages/identity-governance/access-requests/access-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/access-requests.mdx
@@ -9,6 +9,7 @@ tags:
  - conceptual
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Just-in-time Access Requests allow Teleport users to request access to a

--- a/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
+++ b/docs/pages/identity-governance/access-requests/automatic-reviews.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Teleport supports automatic reviews of Access Requests. This

--- a/docs/pages/identity-governance/access-requests/notification-routing-rules.mdx
+++ b/docs/pages/identity-governance/access-requests/notification-routing-rules.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 With Teleport's Access Monitoring Rules, Access Request notifications can be

--- a/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 With Teleport's Datadog Incident Management integration, engineers can access the

--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 import BotLogo from "/static/avatar_logo.png";

--- a/docs/pages/identity-governance/access-requests/plugins/email.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/email.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide will explain how to set up Teleport to send Just-in-Time Access

--- a/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/how-to-build.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Identity Governance
 ---
 
 With Teleport [Access Requests](../access-requests.mdx), you can

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide explains how to set up the Teleport Access Request plugin for Jira.

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 import BotLogo from "/static/avatar_logo.png";

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide will explain how to set up Microsoft Teams to receive Access Request messages

--- a/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 With Teleport's PagerDuty integration, engineers can access the infrastructure

--- a/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/plugins.mdx
@@ -9,6 +9,7 @@ tags:
  - conceptual
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Teleport Just-in-Time Access Requests allow users to receive temporary elevated

--- a/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 import SlackVideoMp4 from "@version/docs/img/enterprise/plugins/slack/slack.mp4"

--- a/docs/pages/identity-governance/access-requests/resource-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/resource-requests.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/access-requests/role-requests.mdx
+++ b/docs/pages/identity-governance/access-requests/role-requests.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Teleport's Just-in-time Access Requests allow users to request access to

--- a/docs/pages/identity-governance/device-trust/device-management.mdx
+++ b/docs/pages/identity-governance/device-trust/device-management.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 This guide provides instructions for performing Device Trust management

--- a/docs/pages/identity-governance/device-trust/device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/device-trust.mdx
@@ -8,6 +8,7 @@ tags:
  - conceptual
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 Device Trust allows Teleport admins to enforce the use of trusted devices.

--- a/docs/pages/identity-governance/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/identity-governance/device-trust/enforcing-device-trust.mdx
@@ -7,6 +7,7 @@ tags:
  - conceptual
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 <Admonition type="note" title="Supported Resources">

--- a/docs/pages/identity-governance/device-trust/guide.mdx
+++ b/docs/pages/identity-governance/device-trust/guide.mdx
@@ -7,6 +7,7 @@ tags:
  - get-started
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/device-trust/intune-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/intune-integration.mdx
@@ -9,6 +9,7 @@ tags:
  - identity-governance
  - azure
  - resiliency
+enterprise: Identity Governance
 ---
 
 The Device Trust Microsoft Intune integration lets you automatically sync your managed devices from

--- a/docs/pages/identity-governance/device-trust/jamf-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/jamf-integration.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 The Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer

--- a/docs/pages/identity-governance/identity-gov-use-cases.mdx
+++ b/docs/pages/identity-governance/identity-gov-use-cases.mdx
@@ -5,6 +5,7 @@ description: Common use cases with Teleport Identity Governance
 sidebar_position: 1
 tags:
  - identity-governance
+enterprise: Identity Governance
 ---
 
 Teleport Identity Governance helps organizations strengthen security and compliance by centralizing 

--- a/docs/pages/identity-governance/identity-governance.mdx
+++ b/docs/pages/identity-governance/identity-governance.mdx
@@ -4,6 +4,7 @@ description: Provides guides on Teleport Identity Governance.
 template: "landing-page"
 tags:
  - identity-governance
+enterprise: Identity Governance
 ---
 
 import LandingHero from '@site/src/components/Pages/Landing/LandingHero';

--- a/docs/pages/identity-governance/idps/idps.mdx
+++ b/docs/pages/identity-governance/idps/idps.mdx
@@ -5,6 +5,7 @@ description: How to set up Teleport's identity provider functionality
 tags:
  - identity-governance
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 Users can authenticate to both internal and external applications

--- a/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
+++ b/docs/pages/identity-governance/idps/saml-attribute-mapping.mdx
@@ -7,6 +7,7 @@ tags:
  - conceptual
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Attribute mapping configures Teleport SAML Identity Provider to assert custom user attributes in SAML response.

--- a/docs/pages/identity-governance/idps/saml-guide.mdx
+++ b/docs/pages/identity-governance/idps/saml-guide.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - identity-governance
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 This guide details an example on how to use Teleport as a SAML identity provider

--- a/docs/pages/identity-governance/idps/saml-idp-rbac.mdx
+++ b/docs/pages/identity-governance/idps/saml-idp-rbac.mdx
@@ -5,6 +5,7 @@ description: Learn how to manage access to a SAML service provider (SAML applica
 sidebar_position: 2
 tags:
  - identity-governance
+enterprise: Identity Governance
 ---
 
 This page explains how access to a SAML IdP service provider resource (SAML application)

--- a/docs/pages/identity-governance/idps/usage/saml-gcp-workforce-identity-federation.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-gcp-workforce-identity-federation.mdx
@@ -8,6 +8,7 @@ tags:
  - identity-governance
  - google-cloud
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/idps/usage/saml-grafana.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-grafana.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 Grafana is an open source observability platform. Their enterprise version supports

--- a/docs/pages/identity-governance/idps/usage/saml-microsoft-entra-external-id.mdx
+++ b/docs/pages/identity-governance/idps/usage/saml-microsoft-entra-external-id.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/idps/usage/usage.mdx
+++ b/docs/pages/identity-governance/idps/usage/usage.mdx
@@ -2,6 +2,7 @@
 title: Using the Teleport SAML IdP
 sidebar_label: Usage
 description: Explains how to enable Teleport users to authenticate to external services using the Teleport SAML IdP.
+enterprise: Identity Governance
 ---
 
 The guides in this section explain how to set up the Teleport SAML IdP to enable

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/advanced-options.mdx
@@ -5,6 +5,7 @@ description: Describes advanced Identity Center use cases.
 tags:
  - conceptual
  - identity-governance
+enterprise: Identity Governance
 ---
 
 The Identity Center Integration can be configured to handle various advanced use

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/aws-iam-identity-center.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/aws-iam-identity-center.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-governance
  - privileged-access
  - aws
+enterprise: Identity Governance
 ---
 
 Teleport's integration with [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/)

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/guide.mdx
@@ -8,6 +8,7 @@ tags:
  - identity-governance
  - privileged-access
  - aws
+enterprise: Identity Governance
 ---
 
 Teleport's integration with [AWS IAM Identity Center](https://aws.amazon.com/iam/identity-center/)

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/maintenance.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/maintenance.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-governance
  - how-to
  - aws
+enterprise: Identity Governance
 ---
 
 This guide will show you how to rotate the SCIM bearer token in Teleport using `tctl`. 

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/migrating-identity-center-from-okta-to-teleport.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - privileged-access
  - aws
+enterprise: Identity Governance
 ---
 
 This guide describes how to introduce Teleport into an existing Okta-managed AWS

--- a/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
+++ b/docs/pages/identity-governance/integrations/aws-iam-identity-center/using-aws-cli.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - privileged-access
  - aws
+enterprise: Identity Governance
 ---
 
 This guide will show you how to configure the `aws` command-line tool to use

--- a/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/advanced-options.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This page lists advanced configuration options related to the

--- a/docs/pages/identity-governance/integrations/entra-id/configure-access.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/configure-access.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide shows how to setup access for Entra ID imported users based on their Entra

--- a/docs/pages/identity-governance/integrations/entra-id/entra-id.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/entra-id.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 The Entra ID integration enables the following features in Teleport:

--- a/docs/pages/identity-governance/integrations/entra-id/faq.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/faq.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This page provides answers to frequently asked questions about Teleport Entra ID integration. 

--- a/docs/pages/identity-governance/integrations/entra-id/getting-started.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/getting-started.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 

--- a/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/manual-installation.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide shows manual Entra ID configuration steps to set up Teleport Entra ID integration.

--- a/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/setup.mdx
@@ -2,6 +2,7 @@
 title: Setting up the Microsoft Entra ID Integration
 sidebar_label: Setup
 description: Provides instructions for setting up the Microsoft Entra ID integration using various methods.
+enterprise: Identity Governance
 ---
 
 <DocCardList />

--- a/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
+++ b/docs/pages/identity-governance/integrations/entra-id/setup/terraform.mdx
@@ -9,6 +9,7 @@ tags:
  - identity-governance
  - azure
  - privileged-access
+enterprise: Identity Governance
 ---
 
 This guide shows you how to integrate Teleport with Microsoft Entra ID using Terraform and `tctl`.

--- a/docs/pages/identity-governance/integrations/integrations.mdx
+++ b/docs/pages/identity-governance/integrations/integrations.mdx
@@ -5,6 +5,7 @@ description: Shows you how to sync Teleport RBAC resources with third-party tool
 tags:
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 You can configure Teleport to sync role-based access control (RBAC) configurations with

--- a/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/app-and-group-sync.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 Okta has its own permissions system that doesn't directly map into Teleport. This

--- a/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
+++ b/docs/pages/identity-governance/integrations/okta/guided-sso.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/integrations/okta/okta.mdx
+++ b/docs/pages/identity-governance/integrations/okta/okta.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 The Teleport Okta integration can import and grant access to resources from an

--- a/docs/pages/identity-governance/integrations/okta/reference.mdx
+++ b/docs/pages/identity-governance/integrations/okta/reference.mdx
@@ -7,6 +7,7 @@ tags:
  - reference
  - zero-trust
  - infrastructure-identity
+enterprise: Identity Governance
 ---
 
 This guide describes interfaces and options for configuring the Teleport Okta

--- a/docs/pages/identity-governance/integrations/okta/scim-integration.mdx
+++ b/docs/pages/identity-governance/integrations/okta/scim-integration.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 The SCIM (System for Cross-domain Identity Management) integration enables automated user management,

--- a/docs/pages/identity-governance/integrations/okta/user-sync.mdx
+++ b/docs/pages/identity-governance/integrations/okta/user-sync.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - identity-governance
  - privileged-access
+enterprise: Identity Governance
 ---
 
 {/* lint disable page-structure remark-lint */}

--- a/docs/pages/identity-governance/integrations/scim/sailpoint.mdx
+++ b/docs/pages/identity-governance/integrations/scim/sailpoint.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - identity-governance
 - privileged-access
+enterprise: Identity Governance
 ---
 
 

--- a/docs/pages/identity-governance/integrations/scim/scim.mdx
+++ b/docs/pages/identity-governance/integrations/scim/scim.mdx
@@ -6,6 +6,7 @@ tags:
 - how-to
 - identity-governance
 - privileged-access
+enterprise: Identity Governance
 ---
 
 The SCIM integration between **SCIM providers** and **Teleport** enables automated

--- a/docs/pages/identity-governance/locking.mdx
+++ b/docs/pages/identity-governance/locking.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - identity-governance
  - resiliency
+enterprise: Identity Governance
 ---
 
 System administrators can disable a compromised user or Teleport Agent—or

--- a/docs/pages/identity-security/access-graph/access-graph.mdx
+++ b/docs/pages/identity-security/access-graph/access-graph.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
 sidebar_position: 4
+enterprise: Identity Security
 ---
 
 If you run a self-hosted Teleport cluster, using Teleport Identity Security

--- a/docs/pages/identity-security/access-graph/identity-activity-center.mdx
+++ b/docs/pages/identity-security/access-graph/identity-activity-center.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - aws
  - access-risks
+enterprise: Identity Security
 ---
 
 In this guide, you will set up the infrastructure required

--- a/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted-helm.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Using Teleport Identity Security with Access Graph on a self-hosted Teleport cluster requires

--- a/docs/pages/identity-security/access-graph/self-hosted.mdx
+++ b/docs/pages/identity-security/access-graph/self-hosted.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 This guide shows you how to set up Teleport Access Graph in a self-hosted

--- a/docs/pages/identity-security/identity-security.mdx
+++ b/docs/pages/identity-security/identity-security.mdx
@@ -5,6 +5,7 @@ template: landing-page
 tags:
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 import LandingHero from '@site/src/components/Pages/Landing/LandingHero';

--- a/docs/pages/identity-security/integrations/aws-sync.mdx
+++ b/docs/pages/identity-security/integrations/aws-sync.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - aws
  - access-risks
+enterprise: Identity Security
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access relationships in seconds,

--- a/docs/pages/identity-security/integrations/azure-sync.mdx
+++ b/docs/pages/identity-security/integrations/azure-sync.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - azure
  - access-risks
+enterprise: Identity Security
 ---
 
 Identity Security streamlines and centralizes access management across your entire infrastructure. You can view access

--- a/docs/pages/identity-security/integrations/entra-id.mdx
+++ b/docs/pages/identity-security/integrations/entra-id.mdx
@@ -7,6 +7,7 @@ tags:
  - identity-security
  - azure
  - access-risks
+enterprise: Identity Security
 ---
 
 The Microsoft Entra ID integration in Teleport Identity Governance synchronizes your Entra ID directory into your Teleport cluster,

--- a/docs/pages/identity-security/integrations/github.mdx
+++ b/docs/pages/identity-security/integrations/github.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 This guide walks you through configuring Identity Security to import

--- a/docs/pages/identity-security/integrations/gitlab.mdx
+++ b/docs/pages/identity-security/integrations/gitlab.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Gain insights into access patterns within your GitLab account using Identity Security with Access Graph. By scanning all

--- a/docs/pages/identity-security/integrations/integrations.mdx
+++ b/docs/pages/identity-security/integrations/integrations.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Teleport can integrate with identity providers (IdPs) like Okta and AWS OIDC

--- a/docs/pages/identity-security/integrations/netiq.mdx
+++ b/docs/pages/identity-security/integrations/netiq.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Gain insights into your NetIQ organization

--- a/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
+++ b/docs/pages/identity-security/integrations/ssh-keys-scan.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Using Identity Security with Access Graph, you can gain insights on how SSH keys are used within your environment. By scanning

--- a/docs/pages/identity-security/integrations/teleport.mdx
+++ b/docs/pages/identity-security/integrations/teleport.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 In this guide, you will configure your Teleport cluster to forward

--- a/docs/pages/identity-security/session-summaries.mdx
+++ b/docs/pages/identity-security/session-summaries.mdx
@@ -7,6 +7,7 @@ tags:
   - conceptual
   - identity-security
   - ai
+enterprise: Identity Security
 ---
 
 Teleport Identity Security allows you to generate and view session recording

--- a/docs/pages/identity-security/usage/alerts.mdx
+++ b/docs/pages/identity-security/usage/alerts.mdx
@@ -4,6 +4,7 @@ sidebar_label: Alerts
 description: Describes the pre-built security detections that trigger alerts in Teleport Identity Security.
 tags:
  - identity-security
+enterprise: Identity Security
 ---
 
 Teleport Identity Security provides pre-built security detections that automatically create alerts for suspicious identity-related activities across your infrastructure. These detections monitor events from Teleport and integrated services like AWS, GitHub, and Okta to identify potential security risks.

--- a/docs/pages/identity-security/usage/crown-jewels.mdx
+++ b/docs/pages/identity-security/usage/crown-jewels.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Access Graph's Crown Jewels feature allows you to track changes to access for

--- a/docs/pages/identity-security/usage/dashboard.mdx
+++ b/docs/pages/identity-security/usage/dashboard.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
  - conceptual
+enterprise: Identity Security
 ---
 
 The standing privileges dashboard provides an overview of resources that an

--- a/docs/pages/identity-security/usage/graph-explorer.mdx
+++ b/docs/pages/identity-security/usage/graph-explorer.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
  - conceptual
+enterprise: Identity Security
 ---
 
 The Graph Explorer view in Teleport Access Graph reveals access patterns within

--- a/docs/pages/identity-security/usage/investigate.mdx
+++ b/docs/pages/identity-security/usage/investigate.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
  - conceptual
+enterprise: Identity Security
 ---
 
 The Investigate dashboard provides an overview of recent identity activity

--- a/docs/pages/identity-security/usage/sql-editor.mdx
+++ b/docs/pages/identity-security/usage/sql-editor.mdx
@@ -6,6 +6,7 @@ tags:
  - identity-security
  - access-risks
  - conceptual
+enterprise: Identity Security
 ---
 
 The Access Graph SQL Editor allows you to view nodes and edges within Access

--- a/docs/pages/identity-security/usage/usage.mdx
+++ b/docs/pages/identity-security/usage/usage.mdx
@@ -5,6 +5,7 @@ tags:
  - conceptual
  - identity-security
  - access-risks
+enterprise: Identity Security
 ---
 
 Teleport Identity Security helps teams expose and eliminate hidden risk in their infrastructure. 

--- a/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux-tpm.mdx
@@ -6,6 +6,7 @@ tags:
  - how-to
  - mwi
  - infrastructure-identity
+enterprise: The TPM join method
 ---
 
 This page explains how to deploy Machine & Workload Identity's agent, `tbot`, on

--- a/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/issuer-override.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+enterprise: Issuer override
 ---
 
 The X.509 issuer override functionality provides a way to replace the self-signed X.509 certificate used by Teleport as the issuer SPIFFE X509-SVID credentials with an issuing certificate of your choosing, together with an optional certificate chain. After configuring a default `workload_identity_x509_issuer_override` resource, all X509-SVID credentials issued to `tbot` or `tsh` will be issued by one of the issuers specified in the resource, and will include the appropriate certificate chain.

--- a/docs/pages/reference/machine-workload-identity/workload-identity/sigstore-attestation.mdx
+++ b/docs/pages/reference/machine-workload-identity/workload-identity/sigstore-attestation.mdx
@@ -5,6 +5,7 @@ tags:
  - conceptual
  - mwi
  - infrastructure-identity
+enterprise: Sigstore workload attestation
 ---
 
 By using Teleport's integration with [Sigstore](https://sigstore.dev), you can

--- a/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
+++ b/docs/pages/zero-trust-access/authentication/hardware-key-support.mdx
@@ -5,6 +5,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Hardware key support
 ---
 
 This guide explains how to configure Teleport authentication using

--- a/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
+++ b/docs/pages/zero-trust-access/authentication/ip-pinning.mdx
@@ -1,10 +1,11 @@
 ---
-title: "IP Pinning "
+title: "IP Pinning"
 description: How to enable IP pinning for Teleport users
 tags:
  - conceptual
  - zero-trust
  - privileged-access
+enterprise: IP pinning
 ---
 
 <Admonition type="warning">

--- a/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
+++ b/docs/pages/zero-trust-access/authentication/joining-sessions.mdx
@@ -10,6 +10,7 @@ tags:
  - conceptual
  - zero-trust
  - privileged-access
+enterprise: Session joining
 ---
 
 Teleport allows multiple users to join the same SSH or `kubectl exec` session.

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - audit
+enterprise: FedRAMP compliance
 ---
 
 Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure.

--- a/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/soc2.mdx
@@ -6,6 +6,7 @@ tags:
  - conceptual
  - zero-trust
  - audit
+enterprise: SOC 2 compliance
 ---
 
 Teleport is designed to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
@@ -5,6 +5,7 @@ sidebar_position: 2
 tags:
  - conceptual
  - platform-wide
+enterprise: Support for multi-region deployments
 ---
 
 This page describes how to deploy a Teleport cluster in multiple regions to

--- a/docs/pages/zero-trust-access/deploy-a-cluster/hsm.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/hsm.mdx
@@ -4,6 +4,7 @@ description: How to configure Hardware Security Modules to manage your Teleport 
 tags:
  - how-to
  - platform-wide
+enterprise: Hardware security module support
 ---
 
 This guide will show you how to set up the Teleport Auth Service to use a

--- a/docs/pages/zero-trust-access/sso/integrate-idp/adfs.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/adfs.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 This guide will explain how to configure Active Directory Federation Services

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
@@ -7,6 +7,7 @@ tags:
  - zero-trust
  - privileged-access
  - azure
+enterprise: Enterprise SSO
 ---
 
 {/* vale 3rd-party-products.former-names = NO */}

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id.mdx
@@ -8,6 +8,7 @@ tags:
  - zero-trust
  - privileged-access
  - azure
+enterprise: Enterprise SSO
 ---
 
 {/* vale 3rd-party-products.former-names = NO */}

--- a/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 This guide will cover how to configure [GitLab](https://www.gitlab.com/) to issue

--- a/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
@@ -9,6 +9,7 @@ tags:
  - zero-trust
  - privileged-access
  - google-cloud
+enterprise: Enterprise SSO
 ---
 
 This guide explains how to configure [Google Workspace](https://workspace.google.com/)

--- a/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 This guide explains how to configure Keycloak to issue

--- a/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 This guide will explain how to configure an SSO provider using [OpenID

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -8,6 +8,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 This guide covers how to configure [Okta](https://www.okta.com/) to provide

--- a/docs/pages/zero-trust-access/sso/integrate-idp/one-login.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/one-login.mdx
@@ -7,6 +7,7 @@ tags:
  - how-to
  - zero-trust
  - privileged-access
+enterprise: Enterprise SSO
 ---
 
 import SquareIcon from "@version/docs/img/sso/onelogin/teleport.png"


### PR DESCRIPTION
Add the `enterprise: true` frontmatter field to Enterprise-only docs pages so we can include an upsell banner on each page.