### PR TITLE
Add a `ChangelogLink` to changelog.mdx

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -10,4 +10,6 @@ tags:
 
 The Teleport changelog lists changes introduced by each version of Teleport. 
 
+<ChangelogLink />
+
 (!CHANGELOG.md!)


### PR DESCRIPTION
If the changelog is not on the edge version of the docs site, the `ChangelogLink` links to the edge version, which includes release notes for all major versions. Versions of the docs site based on `gravitational/teleport` release branches only include release notes for their corresponding major versions.