### PR TITLE
Add Teleport MCP server for access list reviews

### DIFF
--- a/lib/mcp/access_list_reviews_tools.go
+++ b/lib/mcp/access_list_reviews_tools.go
@@ -1,0 +1,304 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+)
+
+const (
+	// ToolsetAccessListReviews is the name of the category of MCP tools related
+	// to performing access list reviews.
+	ToolsetAccessListReviews = "access-list-reviews"
+	// ToolAccessListReviewInstructions is the name of the MCP tool that
+	// provides access list review instructions.
+	ToolAccessListReviewInstuctions = "teleport-access-list-review-instructions"
+	// ToolAccessListsForReview is the name of the MCP tool that fetches
+	// access lists requiring review.
+	ToolAccessListsForReview = "teleport-get-access-lists-for-review"
+	// ToolReviewAccessList is the name of the MCP tool that submits access list
+	// reviews.
+	ToolReviewAccessList = "teleport-review-access-list"
+)
+
+func init() {
+	RegisterTool(ToolsetAccessListReviews, NewAccessListReviewInstructionsTool)
+	RegisterTool(ToolsetAccessListReviews, NewAccessListsForReviewTool)
+	RegisterTool(ToolsetAccessListReviews, NewReviewAccessListTool)
+}
+
+// NewAccessListReviewInstructionsTool creates an MCP tool that returns
+// access list review instructions.
+func NewAccessListReviewInstructionsTool(cfg Config) (Tool, error) {
+	return &accessListReviewInstructionsTool{cfg}, nil
+}
+
+type accessListReviewInstructionsTool struct {
+	cfg Config
+}
+
+func (s *accessListReviewInstructionsTool) GetTool() mcp.Tool {
+	return mcp.NewTool(ToolAccessListReviewInstuctions,
+		mcp.WithDescription(`Returns analysis instructions for access list
+reviews. Call this tool when asked to view or review Teleport access lists and
+then follow the returned instructions.`))
+}
+
+func (s *accessListReviewInstructionsTool) GetHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText(s.getAccessListReviewInstructions()), nil
+	}
+}
+
+func (s *accessListReviewInstructionsTool) getAccessListReviewInstructions() string {
+	return accessListReviewInstructions
+}
+
+// NewAccessListsForReviewTool creates an MCP tool that fetches access lists
+// requiring review.
+func NewAccessListsForReviewTool(cfg Config) (Tool, error) {
+	return &accessListsForReviewTool{cfg}, nil
+}
+
+type accessListsForReviewTool struct {
+	cfg Config
+}
+
+func (s *accessListsForReviewTool) GetTool() mcp.Tool {
+	return mcp.NewTool(ToolAccessListsForReview,
+		mcp.WithDescription(`Fetch Teleport access lists requiring review,
+along with their details including members, owner/member roles and audit
+history.`))
+}
+
+func (s *accessListsForReviewTool) GetHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		lists, err := s.getAccessListsToReview(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		b, err := json.Marshal(lists)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return mcp.NewToolResultText(string(b)), nil
+	}
+}
+
+// accessListDetails contains information about an access list that an LLM
+// can use to analyze it for review purposes.
+//
+// We avoid returning full yaml resources to eliminate insignificant fields
+// that would just add noise to the LLM context.
+type accessListDetails struct {
+	Name        string
+	Description string
+	Labels      map[string]string
+	Title       string
+	Owners      []accesslist.Owner
+	Audit       accesslist.Audit
+	MemberRoles []*types.RoleV6
+	Members     []*accesslist.AccessListMember
+	Reviews     []*accesslist.Review
+	URL         string
+}
+
+func (s *accessListsForReviewTool) getAccessListsToReview(ctx context.Context) ([]accessListDetails, error) {
+	lists, err := s.cfg.Auth.AccessListClient().GetAccessListsToReview(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var result []accessListDetails
+	for _, list := range lists {
+		details, err := s.getAccessListDetails(ctx, list.GetName())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		result = append(result, *details)
+	}
+	return result, nil
+}
+
+func (s *accessListsForReviewTool) getAccessListDetails(ctx context.Context, name string) (*accessListDetails, error) {
+	list, err := s.cfg.Auth.AccessListClient().GetAccessList(ctx, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	memberRoles, err := s.getAccessListRoles(ctx, list)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(r0mant): 200 members per list max should be fine for now, but we
+	// might want to paginate in the future.
+	members, _, err := s.cfg.Auth.AccessListClient().ListAccessListMembers(ctx, name, 200, "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// TODO(r0mant): similar to the above, 100 reviews should be plenty for now.
+	reviews, _, err := s.cfg.Auth.AccessListClient().ListAccessListReviews(ctx, name, 100, "")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	url := ""
+	if s.cfg.WebProxyAddr != "" {
+		url = fmt.Sprintf(accessListURLTemplate, s.cfg.WebProxyAddr, name)
+	}
+
+	return &accessListDetails{
+		Name:        list.GetName(),
+		Description: list.GetMetadata().Description,
+		Labels:      list.GetMetadata().Labels,
+		Title:       list.Spec.Title,
+		Owners:      list.GetOwners(),
+		Audit:       list.Spec.Audit,
+		MemberRoles: memberRoles,
+		Members:     members,
+		Reviews:     reviews,
+		URL:         url,
+	}, nil
+}
+
+func (s *accessListsForReviewTool) getAccessListRoles(ctx context.Context, list *accesslist.AccessList) ([]*types.RoleV6, error) {
+	var memberRoles []*types.RoleV6
+	for _, roleName := range list.GetGrants().Roles {
+		role, err := s.cfg.Auth.GetRole(ctx, roleName)
+		if err != nil && !trace.IsAccessDenied(err) {
+			return nil, trace.Wrap(err)
+		}
+		// Owners may not have permissions to read roles.
+		if trace.IsAccessDenied(err) {
+			continue
+		}
+		roleV6, ok := role.(*types.RoleV6)
+		if !ok {
+			return nil, trace.BadParameter("expected role %q to be RoleV6, got %T", roleName, role)
+		}
+		memberRoles = append(memberRoles, roleV6)
+	}
+	return memberRoles, nil
+}
+
+// NewReviewAccessListTool creates an MCP tool that submits access list review.
+func NewReviewAccessListTool(cfg Config) (Tool, error) {
+	return &reviewAccessListTool{cfg}, nil
+}
+
+type reviewAccessListTool struct {
+	cfg Config
+}
+
+func (s *reviewAccessListTool) GetTool() mcp.Tool {
+	return mcp.NewTool(ToolReviewAccessList,
+		mcp.WithDescription(`Submit Teleport access lists review.`),
+		mcp.WithString("name", mcp.Required()))
+}
+
+func (s *reviewAccessListTool) GetHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		name := request.GetString("name", "")
+		if name == "" {
+			return nil, trace.BadParameter("missing MCP parameter 'name'")
+		}
+		updatedReview, err := s.reviewAccessList(ctx, name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		b, err := json.Marshal(updatedReview)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return mcp.NewToolResultText(string(b)), nil
+	}
+}
+
+func (s *reviewAccessListTool) reviewAccessList(ctx context.Context, name string) (*accesslist.Review, error) {
+	review, err := accesslist.NewReview(header.Metadata{
+		Name: uuid.NewString(),
+	}, accesslist.ReviewSpec{
+		AccessList: name,
+		ReviewDate: time.Now(),
+		Reviewers:  []string{"mcp"}, // Required by API but does not matter as it'll be set server-side to user identity.
+		Notes:      "Reviewed via MCP",
+		Changes:    accesslist.ReviewChanges{},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	updatedReview, _, err := s.cfg.Auth.AccessListClient().CreateAccessListReview(ctx, review)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return updatedReview, nil
+}
+
+const accessListURLTemplate = "https://%s/web/accesslists/%s"
+const accessListReviewInstructions = `You are helping review Teleport access lists. Follow this workflow:
+
+Step 1: Fetch access lists requiring review
+
+Call the "teleport-get-access-lists-for-review" tool to get access lists
+that require review within the time interval specified by the user. If the
+time interval is not specified, default to the next 2 weeks.
+
+Step 2: Analyze access lists
+
+For each access list, analyze its risk level to determine whether it can be
+auto-recertified or requires human attention. Consider factors such as:
+
+- List name, title, and description
+- Permissions granted to list members via roles, if available
+- Members and owners of the list
+- Past audits and their outcomes
+
+Step 3: Present findings
+
+Display a table categorizing access lists into low-risk lists that can be
+auto-recertified and those that may require human attention. Include the
+following columns in the table:
+
+- List title
+- Review due date
+- Auto-review (✅ or ❌)
+- Risk assessment (concise 1-2 sentence explanation of the decision)
+
+Step 4: Ask for user confirmation
+
+Ask the user if they would like to proceed with auto-reviewing all low-risk
+access lists. If the user confirms:
+
+- Submit reviews for low-risk lists using the "teleport-review-access-list" tool.
+- Display a table with URLs for lists that require human review in Teleport with
+  brief justifications on what to pay attention to for each.
+`

--- a/lib/mcp/access_list_reviews_tools_test.go
+++ b/lib/mcp/access_list_reviews_tools_test.go
@@ -1,0 +1,199 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+)
+
+// TestGetAccessListsForReview tests the "teleport-get-access-lists-for-review" MCP tool.
+func TestGetAccessListsForReview(t *testing.T) {
+	env := newMCPTestEnv(t)
+
+	ownerRole1 := createRole(t, env.ctx, env.authClient, "owner-role-1")
+	memberRole1 := createRole(t, env.ctx, env.authClient, "member-role-1")
+
+	nextAudit := time.Now().UTC().Add(24 * time.Hour)
+	list, member, review := createAccessList(t, env.ctx, env.authClient, accessListConfig{
+		name:        "access-list-1",
+		owner:       "alice",
+		ownerRoles:  []string{ownerRole1.GetName()},
+		member:      "bob",
+		memberRoles: []string{memberRole1.GetName()},
+		nextAudit:   nextAudit,
+	})
+
+	res, err := env.mcpClient.CallTool(env.ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: ToolAccessListsForReview,
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(res.Content))
+	textContent, ok := res.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+
+	var details []accessListDetails
+	err = json.Unmarshal([]byte(textContent.Text), &details)
+	require.NoError(t, err)
+	require.Len(t, details, 1)
+
+	require.Equal(t, []accessListDetails{{
+		Name:        list.GetName(),
+		Description: list.GetMetadata().Description,
+		Labels:      list.GetAllLabels(),
+		Title:       list.Spec.Title,
+		Owners:      []accesslist.Owner{{Name: "alice", MembershipKind: accesslist.MembershipKindUser}},
+		Audit:       list.Spec.Audit,
+		MemberRoles: []*types.RoleV6{memberRole1},
+		Members:     []*accesslist.AccessListMember{member},
+		Reviews:     []*accesslist.Review{review},
+		URL:         "https://mcp.test/web/accesslists/" + list.GetName(),
+	}}, details)
+}
+
+// TestReviewAccessList tests the "teleport-review-access-list" MCP tool.
+func TestReviewAccessList(t *testing.T) {
+	env := newMCPTestEnv(t)
+
+	ownerRole := createRole(t, env.ctx, env.authClient, "owner-role-review")
+	memberRole := createRole(t, env.ctx, env.authClient, "member-role-review")
+
+	list, _, _ := createAccessList(t, env.ctx, env.authClient, accessListConfig{
+		name:        "access-list-1",
+		owner:       "alice",
+		ownerRoles:  []string{ownerRole.GetName()},
+		member:      "bob",
+		memberRoles: []string{memberRole.GetName()},
+		skipReview:  true,
+	})
+
+	_, err := env.mcpClient.CallTool(env.ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: ToolReviewAccessList,
+			Arguments: map[string]any{
+				"name": list.GetName(),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	reviews, _, err := env.authClient.AccessListClient().ListAccessListReviews(env.ctx, list.GetName(), 10, "")
+	require.NoError(t, err)
+	require.Len(t, reviews, 1)
+	require.Equal(t, list.GetName(), reviews[0].Spec.AccessList)
+	require.Equal(t, "Reviewed via MCP", reviews[0].Spec.Notes)
+}
+
+type accessListConfig struct {
+	name        string
+	owner       string
+	ownerRoles  []string
+	member      string
+	memberRoles []string
+	nextAudit   time.Time
+	skipReview  bool
+}
+
+func createRole(t *testing.T, ctx context.Context, clt authclient.ClientI, name string) *types.RoleV6 {
+	role, err := authtest.CreateRole(ctx, clt, name, types.RoleSpecV6{})
+	require.NoError(t, err)
+	roleV6, ok := role.(*types.RoleV6)
+	require.True(t, ok, "expected role to be RoleV6, got %T", role)
+	// Reset namespaces since they are ignored during unmarshal and otherwise
+	// comparison in the tests would fail.
+	roleV6.Metadata.Namespace = ""
+	roleV6.Spec.Allow.Namespaces = []string(nil)
+	roleV6.Spec.Deny.Namespaces = []string(nil)
+	return roleV6
+}
+
+func createAccessList(t *testing.T, ctx context.Context, authClient authclient.ClientI, cfg accessListConfig) (*accesslist.AccessList, *accesslist.AccessListMember, *accesslist.Review) {
+	list, err := accesslist.NewAccessList(header.Metadata{
+		Name:        cfg.name,
+		Description: cfg.name + " description",
+		Labels: map[string]string{
+			"name": cfg.name,
+		},
+	}, accesslist.Spec{
+		Title: cfg.name + " title",
+		Audit: accesslist.Audit{
+			NextAuditDate: cfg.nextAudit,
+			Recurrence: accesslist.Recurrence{
+				Frequency:  accesslist.SixMonths,
+				DayOfMonth: accesslist.FirstDayOfMonth,
+			},
+			Notifications: accesslist.Notifications{
+				Start: 24 * time.Hour,
+			},
+		},
+		Owners: []accesslist.Owner{{Name: cfg.owner}},
+		OwnerGrants: accesslist.Grants{
+			Roles: cfg.ownerRoles,
+		},
+		Grants: accesslist.Grants{
+			Roles: cfg.memberRoles,
+		},
+	})
+	require.NoError(t, err)
+
+	list, err = authClient.AccessListClient().UpsertAccessList(ctx, list)
+	require.NoError(t, err)
+
+	member, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: cfg.member,
+	}, accesslist.AccessListMemberSpec{
+		AccessList: list.GetName(),
+		Name:       cfg.member,
+	})
+	require.NoError(t, err)
+
+	member, err = authClient.AccessListClient().UpsertAccessListMember(ctx, member)
+	require.NoError(t, err)
+
+	var review *accesslist.Review
+	if !cfg.skipReview {
+		review, err = accesslist.NewReview(header.Metadata{
+			Name: cfg.name + "-review",
+		}, accesslist.ReviewSpec{
+			AccessList: list.GetName(),
+			ReviewDate: time.Now().UTC(),
+			Reviewers:  []string{"test"},
+			Notes:      "looks good",
+		})
+		require.NoError(t, err)
+
+		_, _, err = authClient.AccessListClient().CreateAccessListReview(ctx, review)
+		require.NoError(t, err)
+	}
+
+	return list, member, review
+}

--- a/lib/mcp/mcp.go
+++ b/lib/mcp/mcp.go
@@ -1,0 +1,142 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+)
+
+// Tool defines an interface an MCP tool being registered with Teleport MCP
+// server must implement.
+type Tool interface {
+	// GetTool returns the MCP tool definition.
+	GetTool() mcp.Tool
+	// GetHandler returns the MCP tool handler.
+	GetHandler() server.ToolHandlerFunc
+}
+
+type toolMaker func(cfg Config) (Tool, error)
+
+var mu sync.Mutex
+var toolsRegistry map[string][]toolMaker = make(map[string][]toolMaker)
+
+// RegisterTool adds an MCP tool to the registry of available tools for the
+// server to register.
+func RegisterTool(toolset string, t toolMaker) {
+	mu.Lock()
+	defer mu.Unlock()
+	toolsRegistry[toolset] = append(toolsRegistry[toolset], t)
+}
+
+func getToolsRegistry() map[string][]toolMaker {
+	mu.Lock()
+	defer mu.Unlock()
+	return toolsRegistry
+}
+
+// Config is the Teleport MCP server configuration.
+type Config struct {
+	// Auth is the cluster's auth client.
+	Auth authclient.ClientI
+	// WebProxyAddr is the web proxy address. Used to build web UI URLs.
+	WebProxyAddr string
+	// Log is the server logger.
+	Log *slog.Logger
+	// Toolsets is the list of toolsets to register. This allows to selectively
+	// toggle certain groups of tools to avoid LLM tool context pollution.
+	//
+	// Empty means all available tools.
+	Toolsets []string
+}
+
+// CheckAndSetDefaults checks the MCP server config and sets default values.
+func (c *Config) CheckAndSetDefaults() error {
+	if c.Auth == nil {
+		return trace.BadParameter("missing auth client")
+	}
+	if c.WebProxyAddr == "" {
+		return trace.BadParameter("missing web proxy address")
+	}
+	if c.Log == nil {
+		return trace.BadParameter("missing logger")
+	}
+	return nil
+}
+
+// Server is the Teleport MCP server.
+type Server struct {
+	// MCPServer is the underlying MCP server.
+	*server.MCPServer
+	// cfg is the MCP server configuration.
+	cfg Config
+}
+
+// MCPServerName is the name of the Teleport MCP server.
+const MCPServerName = "teleport"
+
+// NewMCPServer builds an MCP server and registers all tools.
+func NewMCPServer(cfg Config) (*Server, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	server := &Server{
+		MCPServer: server.NewMCPServer(MCPServerName, teleport.Version),
+		cfg:       cfg,
+	}
+	for _, toolMaker := range getToolsToRegister(cfg) {
+		tool, err := toolMaker(cfg)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		cfg.Log.Info("Registering MCP tool", "tool", tool.GetTool().Name)
+		server.AddTool(tool.GetTool(), tool.GetHandler())
+	}
+	return server, nil
+}
+
+// ListenStdio starts the MCP server on stdio.
+func (s *Server) ListenStdio(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
+	return server.NewStdioServer(s.MCPServer).Listen(ctx, stdin, stdout)
+}
+
+// getToolsToRegister returns the list of tools to register based on the enabled
+// toolsets in the config.
+func getToolsToRegister(cfg Config) (tools []toolMaker) {
+	registry := getToolsRegistry()
+	if len(cfg.Toolsets) == 0 {
+		for _, tool := range registry {
+			tools = append(tools, tool...)
+		}
+		return tools
+	}
+	for _, toolset := range cfg.Toolsets {
+		tools = append(tools, registry[toolset]...)
+	}
+	return tools
+}

--- a/lib/mcp/mcp_test.go
+++ b/lib/mcp/mcp_test.go
@@ -1,0 +1,201 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package mcp
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/gravitational/trace"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/accesslist"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/gravitational/teleport/lib/utils/mcptest"
+)
+
+type mcpTestEnv struct {
+	ctx        context.Context
+	cancel     context.CancelFunc
+	authClient authclient.ClientI
+	mcpClient  *mcpclient.Client
+}
+
+func newMCPTestEnv(t *testing.T) *mcpTestEnv {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "mcp.test",
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	authClient, err := tlsServer.NewClient(authtest.TestAdmin())
+	require.NoError(t, err)
+
+	wrappedAuthClient := newWrappedAuthClient(authClient)
+
+	mcpServer, err := NewMCPServer(Config{
+		Auth:         wrappedAuthClient,
+		WebProxyAddr: "mcp.test",
+		Log:          logtest.NewLogger(),
+	})
+	require.NoError(t, err)
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() {
+		clientConn.Close()
+		serverConn.Close()
+	})
+
+	go mcpServer.ListenStdio(ctx, serverConn, serverConn)
+
+	mcpClient := mcptest.NewStdioClient(t, clientConn, clientConn)
+	mcptest.MustInitializeClient(t, mcpClient)
+
+	return &mcpTestEnv{
+		ctx:        ctx,
+		cancel:     cancel,
+		authClient: wrappedAuthClient,
+		mcpClient:  mcpClient,
+	}
+}
+
+// wrappedAuthClient wraps an auth client with an override to a mock access
+// lists client since auth server in open-source Teleport does implement
+// access lists service.
+type wrappedAuthClient struct {
+	authclient.ClientI
+	accessLists *mockAccessListClient
+}
+
+func newWrappedAuthClient(authClient authclient.ClientI) *wrappedAuthClient {
+	return &wrappedAuthClient{
+		ClientI:     authClient,
+		accessLists: newMockAccessListClient(),
+	}
+}
+
+func (m *wrappedAuthClient) AccessListClient() services.AccessLists {
+	return m.accessLists
+}
+
+type mockAccessList struct {
+	accessList *accesslist.AccessList
+	members    map[string]*accesslist.AccessListMember
+	reviews    []*accesslist.Review
+}
+
+type mockAccessListClient struct {
+	services.AccessLists
+	lists map[string]*mockAccessList
+}
+
+func newMockAccessListClient() *mockAccessListClient {
+	return &mockAccessListClient{
+		lists: make(map[string]*mockAccessList),
+	}
+}
+
+func (m *mockAccessListClient) GetAccessLists(ctx context.Context) ([]*accesslist.AccessList, error) {
+	var lists []*accesslist.AccessList
+	for _, list := range m.lists {
+		lists = append(lists, list.accessList)
+	}
+	return lists, nil
+}
+
+func (m *mockAccessListClient) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
+	list, ok := m.lists[name]
+	if !ok {
+		return nil, trace.NotFound("access list %q not found", name)
+	}
+	return list.accessList, nil
+}
+
+func (m *mockAccessListClient) GetAccessListsToReview(ctx context.Context) ([]*accesslist.AccessList, error) {
+	var lists []*accesslist.AccessList
+	for _, list := range m.lists {
+		lists = append(lists, list.accessList)
+	}
+	return lists, nil
+}
+
+func (m *mockAccessListClient) UpsertAccessList(ctx context.Context, list *accesslist.AccessList) (*accesslist.AccessList, error) {
+	if _, ok := m.lists[list.GetName()]; ok {
+		m.lists[list.GetName()].accessList = list
+	} else {
+		m.lists[list.GetName()] = &mockAccessList{
+			accessList: list,
+			members:    make(map[string]*accesslist.AccessListMember),
+			reviews:    []*accesslist.Review{},
+		}
+	}
+	return list, nil
+}
+
+func (m *mockAccessListClient) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
+	_, ok := m.lists[member.Spec.AccessList]
+	if !ok {
+		return nil, trace.NotFound("access list %q not found", member.Spec.AccessList)
+	}
+	m.lists[member.Spec.AccessList].members[member.GetName()] = member
+	return member, nil
+}
+
+func (m *mockAccessListClient) ListAccessListMembers(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.AccessListMember, string, error) {
+	list, ok := m.lists[accessListName]
+	if !ok {
+		return nil, "", trace.NotFound("access list %q not found", accessListName)
+	}
+	var members []*accesslist.AccessListMember
+	for _, member := range list.members {
+		members = append(members, member)
+	}
+	return members, "", nil
+}
+
+func (m *mockAccessListClient) CreateAccessListReview(ctx context.Context, review *accesslist.Review) (*accesslist.Review, time.Time, error) {
+	list, ok := m.lists[review.Spec.AccessList]
+	if !ok {
+		return nil, time.Time{}, trace.NotFound("access list %q not found", review.Spec.AccessList)
+	}
+	list.reviews = append(list.reviews, review)
+	return review, time.Time{}, nil
+}
+
+func (m *mockAccessListClient) ListAccessListReviews(ctx context.Context, accessListName string, pageSize int, pageToken string) ([]*accesslist.Review, string, error) {
+	list, ok := m.lists[accessListName]
+	if !ok {
+		return nil, "", trace.NotFound("access list %q not found", accessListName)
+	}
+	return list.reviews, "", nil
+}

--- a/tool/tsh/common/mcp.go
+++ b/tool/tsh/common/mcp.go
@@ -36,11 +36,16 @@ type mcpCommands struct {
 	config  *mcpConfigCommand
 	list    *mcpListCommand
 	connect *mcpConnectCommand
+
+	teleportInstall   *kingpin.CmdClause
+	teleportRun       *kingpin.CmdClause
+	teleportUninstall *kingpin.CmdClause
 }
 
 func newMCPCommands(app *kingpin.Application, cf *CLIConf) *mcpCommands {
 	mcp := app.Command("mcp", "View and control proxied MCP servers.")
 	db := mcp.Command("db", "Database access for MCP servers.")
+	teleport := mcp.Command("teleport", "MCP server for operating Teleport.")
 	return &mcpCommands{
 		dbStart:  newMCPDBCommand(db, cf),
 		dbConfig: newMCPDBconfigCommand(db, cf),
@@ -48,6 +53,10 @@ func newMCPCommands(app *kingpin.Application, cf *CLIConf) *mcpCommands {
 		list:    newMCPListCommand(mcp, cf),
 		config:  newMCPConfigCommand(mcp, cf),
 		connect: newMCPConnectCommand(mcp, cf),
+
+		teleportInstall:   newMCPTeleportInstallCmd(teleport),
+		teleportRun:       newMCPTeleportRunCmd(teleport),
+		teleportUninstall: newMCPTeleportUninstallCmd(teleport),
 	}
 }
 

--- a/tool/tsh/common/mcp_teleport.go
+++ b/tool/tsh/common/mcp_teleport.go
@@ -1,0 +1,142 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/client"
+	mcpconfig "github.com/gravitational/teleport/lib/client/mcp/config"
+	libmcp "github.com/gravitational/teleport/lib/mcp"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func newMCPTeleportInstallCmd(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return parent.Command("install", "Install Teleport MCP server to the local Claude Desktop config")
+}
+
+func newMCPTeleportRunCmd(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return parent.Command("run", "Run local Teleport MCP server")
+}
+
+func newMCPTeleportUninstallCmd(parent *kingpin.CmdClause) *kingpin.CmdClause {
+	return parent.Command("uninstall", "Uninstall Teleport MCP server from the local Claude Desktop config")
+}
+
+type mcpTeleportInstaller struct {
+}
+
+func (i *mcpTeleportInstaller) printInstructions(io.Writer, mcpconfig.ConfigFormat) error {
+	return trace.NotImplemented("not implemented")
+}
+
+func (i *mcpTeleportInstaller) updateConfig(w io.Writer, config *mcpconfig.FileConfig) error {
+	if _, ok := config.GetMCPServers()["teleport"]; ok {
+		return trace.AlreadyExists("❌ Teleport MCP server is already installed")
+	}
+	self, err := os.Executable()
+	if err != nil {
+		return trace.ConvertSystemError(err)
+	}
+	err = config.PutMCPServer("teleport", mcpconfig.MCPServer{
+		Command: self,
+		Args:    []string{"mcp", "teleport", "run"},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = config.Save("")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("✅ Successfully installed Teleport MCP server!")
+	return nil
+}
+
+func onMCPTeleportInstall(cf *CLIConf) error {
+	return runMCPConfig(cf, &mcpClientConfigFlags{
+		clientConfig: mcpClientConfigClaude,
+	}, &mcpTeleportInstaller{})
+}
+
+type mcpTeleportUninstaller struct {
+}
+
+func (i *mcpTeleportUninstaller) printInstructions(io.Writer, mcpconfig.ConfigFormat) error {
+	return trace.NotImplemented("not implemented")
+}
+
+func (i *mcpTeleportUninstaller) updateConfig(w io.Writer, config *mcpconfig.FileConfig) error {
+	if _, ok := config.GetMCPServers()["teleport"]; !ok {
+		return trace.NotFound("❌ Teleport MCP server is not installed")
+	}
+	err := config.RemoveMCPServer("teleport")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	err = config.Save("")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("✅ Successfully uninstalled Teleport MCP server!")
+	return nil
+}
+
+func onMCPTeleportUninstall(cf *CLIConf) error {
+	return runMCPConfig(cf, &mcpClientConfigFlags{
+		clientConfig: mcpClientConfigClaude,
+	}, &mcpTeleportUninstaller{})
+}
+
+func onMCPTeleportRun(cf *CLIConf) error {
+	log, err := initLogger(cf, utils.LoggingForMCP, getLoggingOptsForMCPServer(cf))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var clusterClient *client.ClusterClient
+	if err := client.RetryWithRelogin(cf.Context, tc, func() error {
+		clusterClient, err = tc.ConnectToCluster(cf.Context)
+		return trace.Wrap(err)
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	defer clusterClient.Close()
+
+	mcpServer, err := libmcp.NewMCPServer(libmcp.Config{
+		Auth:         clusterClient.AuthClient,
+		WebProxyAddr: tc.WebProxyAddr,
+		Log:          log,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return mcpServer.ListenStdio(cf.Context, cf.Stdin(), cf.Stdout())
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1951,6 +1951,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = mcpCmd.list.run()
 	case mcpCmd.config.FullCommand():
 		err = mcpCmd.config.run()
+	case mcpCmd.teleportInstall.FullCommand():
+		err = onMCPTeleportInstall(&cf)
+	case mcpCmd.teleportUninstall.FullCommand():
+		err = onMCPTeleportUninstall(&cf)
+	case mcpCmd.teleportRun.FullCommand():
+		err = onMCPTeleportRun(&cf)
 	case updateCommand.update.FullCommand():
 		err = updateCommand.update.run(&cf)
 	default:


### PR DESCRIPTION
## Description

This PR adds local Teleport MCP server with a set of tools that enable the workflow for performing access list reviews using Claude Desktop. It exposes 3 tools:

- `teleport-access-list-review-instructions`: Provides LLM with instructions on what to do when a user asks to review Teleport access lists. It also instructs LLM to analyze available access lists metadata and provide suggestions on which lists it deems low-risk/suitable for auto-recertification and which ones may require human review.
- `teleport-get-access-lists-for-review`: Returns a list of access lists that the user owns that have an upcoming (< 2 weeks) recertification deadline.
- `teleport-review-access-list`: Submits a review for an access list.

Future PRs will also extend this MCP server to support more functionality like reviewing or submitting access requests as well. To avoid LLM context pollution with many tool we'll eventually expose, I've grouped existing tools under the "access-list-reviews" toolset - in future we can let users toggle specific toolsets they need on/off (GitHub MCP server uses [similar approach](https://github.com/github/github-mcp-server?tab=readme-ov-file#special-toolsets)).

### Disclaimer

"Low-risk" classification is obviously up to the LLM and should not be taken at face value. It currently only takes into account readily-available access lists information like title, description, members, granted roles (with their specs, subject to our usual API RBAC checks), past review history, etc - things that we, human reviewers, also look at doing while these reviews quarterly. It doesn't currently consider more advanced scenarios like usage patterns, recommendations to remove people from lists and so on - these will likely require more Teleport instrumentation to support and can be looked at in future iterations.

For now, the goal is to just provide a more manageable UX for doing list recertifications in bulk without tons of click-ops but the burden of validating LLM's reasoning and making the decision of what to let it submit reviews for still rests with the reviewer.

## Usage

1. Sign into your Teleport cluster with `tsh login`.
2. Install Teleport MCP server to your local Claude config:
```
➜  tsh mcp teleport install
✅ Successfully installed Teleport MCP server!
```
3. Launch (or re-launch) Claude Desktop.
4. Ask it to help you review Teleport access lists, for example "Let's review Teleport access lists".

## Demo

https://github.com/user-attachments/assets/754c4bb6-fa9d-420f-89c5-7e769ce6f211


