### PR TITLE
[v17] fix: sanitize URL when fetching azure attested data intermediate cert

### DIFF
--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -451,6 +451,12 @@ func WithAuthVersion(v *semver.Version) iamRegisterOption {
 	return withAuthVersion(v)
 }
 
+func WithAzureIssuerHTTPClient(httpClient utils.HTTPDoClient) AzureRegisterOption {
+	return func(cfg *AzureRegisterConfig) {
+		cfg.issuerHTTPClient = httpClient
+	}
+}
+
 func (s *TLSServer) GRPCServer() *GRPCServer {
 	return s.grpcServer
 }


### PR DESCRIPTION
Backport #62158 to branch/v17

### Manual Test Plan
- [x] invalid issuing certificate URLs are rejected
- [x] azure join method still works for agents using legacy join method

changelog: Fixed a potential SSRF vulnerability in the Azure join method implementation