### PR TITLE
docs: remove references to v13

### DIFF
--- a/docs/pages/enroll-resources/agents/aws-iam.mdx
+++ b/docs/pages/enroll-resources/agents/aws-iam.mdx
@@ -42,9 +42,6 @@ pre-signed `sts:GetCallerIdentity` request to the Teleport Auth Service. The
 service's identity must match an allow rule configured in your AWS service
 joining token.
 
-Support for joining a cluster with the Proxy Service behind a layer 7 load
-balancer or reverse proxy is available in Teleport 13.0+.
-
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -14,8 +14,7 @@ Teleport instances to join your Teleport cluster without sharing any secrets
 when they are running in an Azure Virtual Machine.
 
 The Azure join method is available to any Teleport process running in an
-Azure Virtual Machine. Support for joining a cluster with the Proxy Service
-behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
+Azure Virtual Machine.
 
 For other methods of joining a Teleport process to a cluster, see [Joining
 Teleport Services to a Cluster](agents.mdx).

--- a/docs/pages/reference/deployment/backends.mdx
+++ b/docs/pages/reference/deployment/backends.mdx
@@ -425,7 +425,7 @@ teleport:
     # use a different user or different settings for the connection used
     # to set up and make use of logical decoding. If specified, Teleport
     # will use the connection string in change_feed_conn_string for that,
-    # instead of the one in conn_string. Available in Teleport 13.4 and later.
+    # instead of the one in conn_string.
     change_feed_conn_string: postgresql://replication_user_name@database-address/teleport_backend?sslmode=verify-full
 
     # An audit_events_uri with a scheme of postgresql:// will use the

--- a/docs/pages/reference/deployment/join-methods.mdx
+++ b/docs/pages/reference/deployment/join-methods.mdx
@@ -339,8 +339,7 @@ method](#aws-iam-role-iam) or [ephemeral secret tokens](#ephemeral-tokens).
 ### Azure managed identity: `azure`
 
 The Azure join method is available to any Teleport process running in an
-Azure Virtual Machine. Support for joining a cluster with the Proxy Service
-behind a layer 7 load balancer or reverse proxy is available in Teleport 13.0+.
+Azure Virtual Machine.
 
 (!docs/pages/includes/provision-token/azure-spec.mdx!)
 


### PR DESCRIPTION
The current supported versions (17, 18) are more then 2 versions higher then the reference to version 13.