### PR TITLE
docs: include user local windows provisioning in overall roles reference

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -103,6 +103,8 @@ spec:
     # Defaults to true if unspecified.
     # If one or more of the user's roles has disabled directory sharing, then it will be disabled.
     desktop_directory_sharing: true
+    # Specify whether this role supports auto-provisioning of local Windows users.
+    create_desktop_user: true
     # enterprise-only: when enabled, the source IP that was used to log in is embedded in the user
     # certificates, preventing a compromised certificate from being used on another
     # network. The default is false.
@@ -170,6 +172,16 @@ spec:
       # with the logged in username.
       "ALL = (root) NOPASSWD: /usr/bin/systemctl restart nginx.service"
     ]
+
+    # List of local Windows groups the created user will be added to.
+    # Any that don't already exist are created. Only applies when
+    # create_desktop_user is 'true'.
+    desktop_groups:
+    - developers
+    # to make the newly-created user an administrator
+    - Administrators
+    # IdP trait templating is also supported
+    - '{{external.desktop_groups}}'
 
     # kubernetes_groups specifies Kubernetes groups a user with this role will assume.
     # You can refer to a SAML/OIDC trait via the 'external' property bag.

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -74,7 +74,7 @@ user:
 | `record_session` |Defines the [Session recording mode](../deployment/monitoring/audit.mdx).|The strictest value takes precedence.|
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
 | `desktop_directory_sharing` | Allows sharing local workstation directory to remote desktop | Logical "AND" i.e. evaluates to "yes" if all roles enable directory sharing |
-| `create_desktop_user` | Allows [desktop auto user creation](../../enroll-resources/desktop-access/reference/user-creation.mdx) on a local Windows desktop. | Logical "AND" i.e. if all roles matching a desktop set auto user creation (`false`, `true`), it will evaluate to the option specified by all of the roles. |
+| `create_desktop_user` | Allows [desktop auto user creation](../../enroll-resources/desktop-access/reference/user-creation.mdx) on a local Windows desktop. |  Logical "AND" i.e. for all roles matching a desktop resource. If all roles that allow access to the resource are set to `true` that will allow user creation. If any are set to `false` user auto creation will be denied. |
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `keep`, `insecure-drop`), it will evaluate to the option specified by all of the roles. If some roles specify both `insecure-drop` or `keep` it will evaluate to `keep`|

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -74,7 +74,7 @@ user:
 | `record_session` |Defines the [Session recording mode](../deployment/monitoring/audit.mdx).|The strictest value takes precedence.|
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
 | `desktop_directory_sharing` | Allows sharing local workstation directory to remote desktop | Logical "AND" i.e. evaluates to "yes" if all roles enable directory sharing |
-| `create_desktop_user` | Allows users to be automatically created on a local Windows desktop. | Logical "AND" i.e. if all roles allow creating desktop users, it's allowed. |
+| `create_desktop_user` | Allows [desktop auto user creation](../../enroll-resources/desktop-access/reference/user-creation.mdx) on a local Windows desktop. | Logical "AND" i.e. if all roles matching a desktop set auto user creation (`false`, `true`), it will evaluate to the option specified by all of the roles. |
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `keep`, `insecure-drop`), it will evaluate to the option specified by all of the roles. If some roles specify both `insecure-drop` or `keep` it will evaluate to `keep`|

--- a/docs/pages/reference/access-controls/roles.mdx
+++ b/docs/pages/reference/access-controls/roles.mdx
@@ -74,6 +74,7 @@ user:
 | `record_session` |Defines the [Session recording mode](../deployment/monitoring/audit.mdx).|The strictest value takes precedence.|
 | `desktop_clipboard` | Allow clipboard sharing for desktop sessions | Logical "AND" i.e. evaluates to "yes" if all roles enable clipboard sharing |
 | `desktop_directory_sharing` | Allows sharing local workstation directory to remote desktop | Logical "AND" i.e. evaluates to "yes" if all roles enable directory sharing |
+| `create_desktop_user` | Allows users to be automatically created on a local Windows desktop. | Logical "AND" i.e. if all roles allow creating desktop users, it's allowed. |
 | `pin_source_ip` | Enable source IP pinning for SSH certificates. | Logical "OR" i.e. evaluates to "yes" if at least one role requires session termination |
 | `cert_extensions` | Specifies extensions to be included in SSH certificates | |
 | `create_host_user_mode` | Allow users to be automatically created on a host |  Logical "AND" i.e. if all roles matching a server specify host user creation (`off`, `keep`, `insecure-drop`), it will evaluate to the option specified by all of the roles. If some roles specify both `insecure-drop` or `keep` it will evaluate to `keep`|


### PR DESCRIPTION
Desktop provisioning role options were not in the overall roles reference.