### PR TITLE
[v18] desktop access: add static labels for discovered desktops

### DIFF
--- a/docs/pages/enroll-resources/desktop-access/active-directory.mdx
+++ b/docs/pages/enroll-resources/desktop-access/active-directory.mdx
@@ -771,6 +771,21 @@ For example, if an AD computer object had a location attribute with a value of O
 and a department attribute with a value of Engineering, the Teleport resource for this
 host would have both `ldap/location=Oakland` and `ldap/department=Engineering` labels.
 
+In addition, you can also specify a set of static labels that apply to all hosts discovered
+via this policy:
+
+```yaml
+windows_desktop_service:
+  enabled: true
+  discovery_configs:
+    - base_dn: 'OU=Engineering,OU=Servers,DC=example,DC=com'
+      labels:
+        team: engineering
+    - base_dn: 'OU=Sales,OU=Servers,DC=example,DC=com'
+      labels:
+        team: sales
+```
+
 ## Security hardening
 
 By default, the Default Domain Policy grants the **Add workstations to domain
@@ -870,14 +885,14 @@ NLA will be performed against the highest-priority and reachable KDC.
 ```yaml
 windows_desktop_service:
    enabled: true
-    
-   locate_server: 
+
+   locate_server:
       enabled: true
       site: "my-site" # optional
    domain: example.com
 ```
 
-If server location is disabled and `kdc_address` isn't specified, with the following configuration, 
+If server location is disabled and `kdc_address` isn't specified, with the following configuration,
 Teleport will attempt to perform NLA against `example.com:88`.
 
 ```yaml

--- a/docs/pages/enroll-resources/desktop-access/rbac.mdx
+++ b/docs/pages/enroll-resources/desktop-access/rbac.mdx
@@ -189,6 +189,24 @@ discovery:
 For a desktop with a `location` attribute of `Oakland`, Teleport would apply a
 label with key `ldap/location` and value `Oakland`.
 
+You can also specify a set of static labels that apply to all hosts discovered
+via this policy:
+
+```yaml
+windows_desktop_service:
+  enabled: true
+  discovery_configs:
+    - base_dn: 'OU=Engineering,OU=Servers,DC=example,DC=com'
+      labels:
+        team: engineering
+    - base_dn: 'OU=Sales,OU=Servers,DC=example,DC=com'
+      labels:
+         team: sales
+```
+
+In this example, all hosts in the Engineering OU would have `team: engineering`
+while the hosts in the Sales OU would have `team: sales`.
+
 ## Logins
 
 The `windows_desktop_logins` role setting lists the Windows user accounts that

--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -19,9 +19,9 @@ windows_desktop_service:
     # For best results, this address should point to a highly-available
     # endpoint rather than a single domain controller.
     addr: "$LDAP_SERVER_ADDRESS"
-    # locate_server gets a list of available LDAP servers from the AD 
+    # locate_server gets a list of available LDAP servers from the AD
     # domain's SRV records. When enabled, addr is ignored.
-    locate_server: 
+    locate_server:
       enabled: true
       # Optional: Site is the logical AD site that locate_server should return.
       # Ignored if locate_server is false.
@@ -113,6 +113,9 @@ windows_desktop_service:
       # The key of the label will be "ldap/" + the value of the attribute.
       label_attributes:
         - location
+      # (optional) static labels to apply to all hosts discovered via this policy
+      labels:
+        env: prod
       # (optional) The port to use for RDP.
       # Defaults to 3389 if unspecified.
       rdp_port: 3389

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2242,6 +2242,19 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 				return trace.BadParameter("WindowsDesktopService specifies invalid LDAP filter %q", filter)
 			}
 		}
+		for k := range discoveryConfig.Labels {
+			if !types.IsValidLabelKey(k) {
+				return trace.BadParameter("WindowsDesktopService specifies label %q which is not a valid label key", k)
+			}
+		}
+		for _, attributeName := range discoveryConfig.LabelAttributes {
+			if !types.IsValidLabelKey(attributeName) {
+				return trace.BadParameter("WindowsDesktopService specifies label_attribute %q which is not a valid label key", attributeName)
+			}
+		}
+		if p := discoveryConfig.RDPPort; p < 0 || p > 65535 {
+			return trace.BadParameter("WindowsDesktopService specifies invalid RDP port %d", p)
+		}
 	}
 
 	// append the old (singular) discovery config to the new format that supports multiple configs
@@ -2258,6 +2271,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 			servicecfg.LDAPDiscoveryConfig{
 				BaseDN:          dc.BaseDN,
 				Filters:         dc.Filters,
+				Labels:          dc.Labels,
 				LabelAttributes: dc.LabelAttributes,
 				RDPPort:         cmp.Or(dc.RDPPort, int(defaults.RDPListenPort)),
 			},

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -2400,6 +2400,33 @@ func TestWindowsDesktopService(t *testing.T) {
 			},
 		},
 		{
+			desc:        "NOK - invalid RDP port",
+			expectError: require.Error,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.DiscoveryConfigs = []LDAPDiscoveryConfig{
+					{
+						BaseDN:  "*",
+						RDPPort: 99999,
+					},
+				}
+			},
+		},
+		{
+			desc:        "NOK - invalid static label",
+			expectError: require.Error,
+			mutate: func(fc *FileConfig) {
+				fc.WindowsDesktop.DiscoveryConfigs = []LDAPDiscoveryConfig{
+					{
+						BaseDN: "*",
+						Labels: map[string]string{
+							"foo":               "bar",
+							"invalid label key": "test",
+						},
+					},
+				}
+			},
+		},
+		{
 			desc:        "OK - valid config",
 			expectError: require.NoError,
 			mutate: func(fc *FileConfig) {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2893,6 +2893,9 @@ type LDAPDiscoveryConfig struct {
 	// Filters are additional LDAP filters to apply to the search.
 	// See: https://ldap.com/ldap-filters/
 	Filters []string `yaml:"filters"`
+	// Labels are static labels applied to all hosts discovered via
+	// this policy.
+	Labels map[string]string `yaml:"labels,omitempty"`
 	// LabelAttributes are LDAP attributes to apply to hosts discovered
 	// via LDAP. Teleport labels hosts by prefixing the attribute with
 	// "ldap/" - for example, a value of "location" here would result in

--- a/lib/service/servicecfg/windows.go
+++ b/lib/service/servicecfg/windows.go
@@ -98,6 +98,8 @@ type LDAPDiscoveryConfig struct {
 	// Filters are additional LDAP filters to apply to the search.
 	// See: https://ldap.com/ldap-filters/
 	Filters []string
+	// Labels are static labels to apply to hosts discovered via LDAP.
+	Labels map[string]string
 	// LabelAttributes are LDAP attributes to apply to hosts discovered
 	// via LDAP. Teleport labels hosts by prefixing the attribute with
 	// "ldap/" - for example, a value of "location" here would result in

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -222,6 +222,7 @@ func (s *WindowsService) getDesktopsFromLDAP() (result map[string]types.WindowsD
 				s.cfg.Logger.WarnContext(s.closeCtx, "could not create Windows Desktop from LDAP entry", "error", err)
 				continue
 			}
+			maps.Copy(desktop.GetMetadata().Labels, discoveryConfig.Labels)
 			discovered[desktop.GetName()] = desktop
 		}
 	}


### PR DESCRIPTION
Backport #62439 to branch/v18

changelog: Each Windows desktop `discovery_config` can now include a set of static labels to apply to discovered hosts.

Test plan: ✅ 

1. Run `windows_desktop_service` in an AD environment with LDAP discovery enabled.
2. Add static labels to the configuration:
```
windows_desktop_service:
  enabled: true
  discovery_configs:
    - base_dn: '*'
      labels:
        team: engineering
```
3. Verify that all discovered desktops have the `team: engineering` label.
