### PR TITLE
fix: add availability checks for instance metadata methods

### DIFF
--- a/lib/cloud/imds/azure/imds.go
+++ b/lib/cloud/imds/azure/imds.go
@@ -163,8 +163,9 @@ func (client *InstanceMetadataClient) getVersions(ctx context.Context) ([]string
 	return versions.APIVersions, nil
 }
 
-// IsAvailable checks if instance metadata is available based on the API version.
-// It also initializes the API version itself, so it must be called before other methods.
+// IsAvailable reports whether the Azure Instance Metadata Service is reachable.
+// On first use it discovers and caches a supported IMDS API version (via /versions).
+// Other methods call this internally to ensure the client is initialized.
 func (client *InstanceMetadataClient) IsAvailable(ctx context.Context) bool {
 	if client.GetAPIVersion() != "" {
 		return true

--- a/lib/cloud/imds/azure/imds_test.go
+++ b/lib/cloud/imds/azure/imds_test.go
@@ -79,10 +79,9 @@ func TestAzureIsInstanceMetadataAvailable(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
 			server := httptest.NewServer(tc.handler)
 			clt := tc.client(t, server)
-			tc.assertion(t, clt.IsAvailable(ctx))
+			tc.assertion(t, clt.IsAvailable(t.Context()))
 		})
 	}
 }
@@ -171,6 +170,56 @@ func TestParseMetadataClientError(t *testing.T) {
 	}
 }
 
+type mockIMDS struct {
+	t              *testing.T
+	versionsCalled bool
+	lastAPIVersion string
+}
+
+func newMockIMDS(t *testing.T, overrides map[string]http.Handler) (*mockIMDS, *httptest.Server) {
+	t.Helper()
+
+	m := &mockIMDS{t: t}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		m.lastAPIVersion = r.URL.Query().Get("api-version")
+
+		// /versions doesn't require api-version; all other endpoints do
+		if r.URL.Path != "/versions" && m.lastAPIVersion == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"Bad request. api-version is invalid or was not specified in the request.","newest-versions":["2023-07-01","2021-02-01"]}`))
+			return
+		}
+
+		if overrides != nil {
+			handler, ok := overrides[r.URL.Path]
+			if ok {
+				handler.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		switch r.URL.Path {
+		case "/versions":
+			m.versionsCalled = true
+			w.Write([]byte(`{"apiVersions":["2021-02-01","2023-07-01"]}`))
+		case "/instance/compute":
+			w.Write([]byte(`{"resourceId":"/subscriptions/test","location":"eastus"}`))
+		case "/instance/compute/tagsList":
+			w.Write([]byte(`[{"name":"foo","value":"bar"}]`))
+		case "/attested/document":
+			w.Write([]byte(`{"signature":"test"}`))
+		case "/identity/oauth2/token":
+			w.Write([]byte(`{"access_token":"test-token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	t.Cleanup(srv.Close)
+
+	return m, srv
+}
+
 func TestGetInstanceInfo(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct {
@@ -178,7 +227,7 @@ func TestGetInstanceInfo(t *testing.T) {
 		statusCode           int
 		body                 []byte
 		expectedInstanceInfo *InstanceInfo
-		errAssertion         require.ErrorAssertionFunc
+		wantErr              string
 	}{
 		{
 			name:       "with resource ID",
@@ -187,7 +236,7 @@ func TestGetInstanceInfo(t *testing.T) {
 			expectedInstanceInfo: &InstanceInfo{
 				ResourceID: "test-id",
 			},
-			errAssertion: require.NoError,
+			wantErr: "",
 		},
 		{
 			name:       "all fields",
@@ -201,35 +250,37 @@ func TestGetInstanceInfo(t *testing.T) {
 				SubscriptionID:    "5187AF11-3581-4AB6-A654-59405CD40C44",
 				VMID:              "ED7DAC09-6E73-447F-BD18-AF4D1196C1E4",
 			},
-			errAssertion: require.NoError,
+			wantErr: "",
 		},
 		{
 			name:       "request error",
 			statusCode: http.StatusNotFound,
-			errAssertion: func(tt require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "not found")
-			},
+			wantErr:    "not found",
 		},
 		{
 			name:       "empty body returns an error",
 			statusCode: http.StatusOK,
-			errAssertion: func(tt require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "error found in #0 byte")
-			},
+			wantErr:    "error found in #0 byte",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tc.statusCode)
-				w.Write(tc.body)
-			}))
+
+			_, server := newMockIMDS(t, map[string]http.Handler{
+				"/instance/compute": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.statusCode)
+					w.Write(tc.body)
+				}),
+			})
 
 			client := NewInstanceMetadataClient(WithBaseURL(server.URL))
-			instanceInfo, err := client.GetInstanceInfo(context.Background())
-			tc.errAssertion(t, err)
-			if tc.expectedInstanceInfo != nil {
+			instanceInfo, err := client.GetInstanceInfo(t.Context())
+			if tc.wantErr == "" {
+				require.NoError(t, err)
 				require.Equal(t, tc.expectedInstanceInfo, instanceInfo)
+			} else {
+				require.Nil(t, instanceInfo)
+				require.ErrorContains(t, err, tc.wantErr)
 			}
 		})
 	}
@@ -267,15 +318,65 @@ func TestGetInstanceID(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(tc.statusCode)
-				w.Write(tc.body)
-			}))
+
+			_, server := newMockIMDS(t, map[string]http.Handler{
+				"/instance/compute": http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tc.statusCode)
+					w.Write(tc.body)
+				}),
+			})
 
 			client := NewInstanceMetadataClient(WithBaseURL(server.URL))
-			resourceID, err := client.GetID(context.Background())
+			resourceID, err := client.GetID(t.Context())
 			tc.errAssertion(t, err)
 			require.Equal(t, tc.expectedResourceID, resourceID)
+		})
+	}
+}
+
+func TestMethodsEnsureInitialization(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(ctx context.Context, c *InstanceMetadataClient) error
+	}{
+		{"GetInstanceInfo", func(ctx context.Context, c *InstanceMetadataClient) error {
+			_, err := c.GetInstanceInfo(ctx)
+			return err
+		}},
+		{"GetID", func(ctx context.Context, c *InstanceMetadataClient) error {
+			_, err := c.GetID(ctx)
+			return err
+		}},
+		{"GetTags", func(ctx context.Context, c *InstanceMetadataClient) error {
+			_, err := c.GetTags(ctx)
+			return err
+		}},
+		{"GetAttestedData", func(ctx context.Context, c *InstanceMetadataClient) error {
+			_, err := c.GetAttestedData(ctx, "")
+			return err
+		}},
+		{"GetAccessToken", func(ctx context.Context, c *InstanceMetadataClient) error {
+			_, err := c.GetAccessToken(ctx, "")
+			return err
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock, srv := newMockIMDS(t, nil)
+			defer srv.Close()
+
+			client := NewInstanceMetadataClient(WithBaseURL(srv.URL))
+			require.Empty(t, client.GetAPIVersion(), "client should start uninitialized")
+
+			err := tc.call(t.Context(), client)
+			require.NoError(t, err)
+			require.True(t, mock.versionsCalled, "should call /versions to initialize")
+			require.Equal(t, "2023-07-01", mock.lastAPIVersion, "should use negotiated api-version")
+			require.Equal(t, "2023-07-01", client.GetAPIVersion(), "client should be initialized")
 		})
 	}
 }


### PR DESCRIPTION
Ensures proper initialization of `api-version` by calling `IsAvailable()`.

Fixes https://github.com/gravitational/teleport/issues/62379.

Changelog: Fixed missing initialization of Azure IMDS clients, which could cause operational failures in some Teleport configurations deployed to Azure, in particular when accessing Azure SQL Server.