### PR TITLE
Remove some circular JS imports

### DIFF
--- a/web/packages/design/src/DataTable/Cells.tsx
+++ b/web/packages/design/src/DataTable/Cells.tsx
@@ -22,6 +22,7 @@ import { Theme } from 'design/theme';
 
 import { displayDate } from '../datetime';
 import Flex from '../Flex';
+import { makeLabelTag } from '../formatters';
 import * as Icons from '../Icon';
 import Label from '../Label';
 import {
@@ -129,7 +130,7 @@ export const ClickableLabelCell = ({
   onClick: (label: LabelDescription) => void;
 }) => {
   const $labels = labels.map((label, index) => {
-    const labelText = `${label.name}: ${label.value}`;
+    const labelText = makeLabelTag(label);
 
     return (
       <Label

--- a/web/packages/design/src/formatters.ts
+++ b/web/packages/design/src/formatters.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Label } from 'teleport/types';
-
-export function makeLabelTag(label: Label) {
+export function makeLabelTag(label: { name: string; value: string }): string {
   return `${label.name}: ${label.value}`;
 }

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -21,12 +21,10 @@ import styled, { css } from 'styled-components';
 
 import { Box, ButtonLink, Flex, Text } from 'design';
 import { CheckboxInput } from 'design/Checkbox';
+import { makeLabelTag } from 'design/formatters';
 import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
-
-// eslint-disable-next-line no-restricted-imports -- FIXME
-import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../../CopyButton/CopyButton';
 import {

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -21,13 +21,11 @@ import styled, { css } from 'styled-components';
 
 import { Box, ButtonIcon, Flex, Text } from 'design';
 import { CheckboxInput } from 'design/Checkbox';
+import { makeLabelTag } from 'design/formatters';
 import { Tags, Warning } from 'design/Icon';
 import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
-
-// eslint-disable-next-line no-restricted-imports -- FIXME
-import { makeLabelTag } from 'teleport/components/formatters';
 
 import { CopyButton } from '../../CopyButton/CopyButton';
 import {

--- a/web/packages/teleport/src/Discover/Database/common.tsx
+++ b/web/packages/teleport/src/Discover/Database/common.tsx
@@ -17,6 +17,7 @@
  */
 
 import { Box, Mark, Label as Pill } from 'design';
+import { makeLabelTag } from 'design/formatters';
 import * as Icons from 'design/Icon';
 import { P } from 'design/Text/Text';
 
@@ -81,7 +82,7 @@ export const Labels = ({
           </P>
           <Box mb={3}>
             {dbLabels.map((label, index) => {
-              const labelText = `${label.name}: ${label.value}`;
+              const labelText = makeLabelTag(label);
               return (
                 <Pill
                   key={`${label.name}${label.value}${index}`}

--- a/web/packages/teleport/src/Discover/Shared/Aws/Labels.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Aws/Labels.tsx
@@ -17,12 +17,13 @@
  */
 
 import { Flex, Label as Pill } from 'design';
+import { makeLabelTag } from 'design/formatters';
 
 import { Label } from 'teleport/types';
 
 export const Labels = ({ labels }: { labels: Label[] }) => {
   const $labels = labels.map((label, index) => {
-    const labelText = `${label.name}: ${label.value}`;
+    const labelText = makeLabelTag(label);
 
     return (
       <Pill key={`${label.name}${label.value}${index}`} mr="1" kind="secondary">

--- a/web/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
+++ b/web/packages/teleport/src/components/SelectFilters/SelectFilters.tsx
@@ -21,13 +21,13 @@ import { components } from 'react-select';
 import styled from 'styled-components';
 
 import { Box, ButtonBorder, ButtonIcon, Flex, Text } from 'design';
+import { makeLabelTag } from 'design/formatters';
 import { Add, Cross } from 'design/Icon';
 import Select, {
   ActionMeta,
   Option as BaseOption,
 } from 'shared/components/Select';
 
-import { makeLabelTag } from 'teleport/components/formatters';
 import { Filter } from 'teleport/types';
 
 import Pager from './Pager';

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputer/Status.tsx
@@ -31,13 +31,12 @@ import {
   MenuItem,
   Text,
 } from 'design';
+import { makeLabelTag } from 'design/formatters';
 import * as icons from 'design/Icon';
 import type { IconProps } from 'design/Icon/Icon';
 import Indicator from 'design/Indicator';
 import { MenuIcon } from 'shared/components/MenuAction';
 
-// eslint-disable-next-line no-restricted-imports -- FIXME
-import { makeLabelTag } from 'teleport/components/formatters';
 import type * as tsh from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -20,6 +20,7 @@ import React, { ReactElement, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 
 import { Box, ButtonBorder, Label as DesignLabel, Flex, Text } from 'design';
+import { makeLabelTag } from 'design/formatters';
 import * as icons from 'design/Icon';
 import { Cross as CloseIcon } from 'design/Icon';
 import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
@@ -1138,11 +1139,7 @@ function Label(props: {
     .map(match => match.searchTerm);
 
   return (
-    <DesignLabel
-      key={label.name}
-      kind="secondary"
-      title={`${label.name}: ${label.value}`}
-    >
+    <DesignLabel key={label.name} kind="secondary" title={makeLabelTag(label)}>
       <Highlight text={label.name} keywords={nameMatches} />:{' '}
       <Highlight text={label.value} keywords={valueMatches} />
     </DesignLabel>


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/54872

This PR removes come circular JS imports by moving `makeLabelTag` from `packages/teleport` to `packages/design`.

