### PR TITLE
Reintroduce tsh recordings export for RemoteFX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "picky-asn1-der",
  "picky-asn1-x509",
  "rand 0.9.2",
+ "rdp-decoder",
  "reqwest",
  "rsa",
  "rustls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rdp-decoder"
+version = "0.1.0"
+dependencies = [
+ "ironrdp-core",
+ "ironrdp-graphics",
+ "ironrdp-session",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["lib/srv/desktop/rdp/rdpclient", "web/packages/shared/libs/ironrdp"]
+members = ["lib/srv/desktop/rdp/rdpclient", "lib/srv/desktop/rdp/decoder","web/packages/shared/libs/ironrdp"]
 
 [workspace.package]
 edition = "2021"
@@ -36,4 +36,3 @@ ironrdp-tls = { git = "https://github.com/Devolutions/IronRDP", rev = "a0a3e750c
     "rustls",
 ] }
 ironrdp-tokio = { git = "https://github.com/Devolutions/IronRDP", rev = "a0a3e750c9e4ee9c73b957fbcb26dbc59e57d07d" }
-

--- a/go.mod
+++ b/go.mod
@@ -248,6 +248,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0
 	golang.org/x/crypto v0.45.0
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6
+	golang.org/x/image v0.33.0
 	golang.org/x/mod v0.30.0
 	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -2427,6 +2427,8 @@ golang.org/x/image v0.0.0-20210607152325-775e3b0c77b9/go.mod h1:023OzeP/+EPmXeap
 golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.0.0-20211028202545-6944b10bf410/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
 golang.org/x/image v0.0.0-20220302094943-723b81ca9867/go.mod h1:023OzeP/+EPmXeapQh35lcL3II3LrY8Ic+EFFKVhULM=
+golang.org/x/image v0.33.0 h1:LXRZRnv1+zGd5XBUVRFmYEphyyKJjQjCRiOuAP3sZfQ=
+golang.org/x/image v0.33.0/go.mod h1:DD3OsTYT9chzuzTQt+zMcOlBHgfoKQb1gry8p76Y1sc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/lib/srv/desktop/rdp/decoder/Cargo.toml
+++ b/lib/srv/desktop/rdp/decoder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rdp-decoder"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish.workspace = true
+
+[lib]
+crate-type = ["staticlib"]
+
+[dependencies]
+ironrdp-core.workspace = true
+ironrdp-graphics.workspace = true
+ironrdp-session.workspace = true

--- a/lib/srv/desktop/rdp/decoder/Cargo.toml
+++ b/lib/srv/desktop/rdp/decoder/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 publish.workspace = true
 
 [lib]
-crate-type = ["staticlib"]
+crate-type = ["staticlib", "lib"]
 
 [dependencies]
 ironrdp-core.workspace = true

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -19,7 +19,16 @@
 package decoder
 
 /*
-#cgo LDFLAGS: -L${SRCDIR}/../../../../../target/release -lrdp_decoder
+#cgo linux,386 LDFLAGS: -L${SRCDIR}/../../../../../target/i686-unknown-linux-gnu/release
+#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
+#cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
+#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
+#cgo linux LDFLAGS: -lrdp_decoder
+
+#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
+#cgo darwin LDFLAGS: -lrdp_decoder
+
 #include <stdint.h>
 
 typedef struct RdpDecoder RdpDecoder;

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -30,10 +30,15 @@ package decoder
 #cgo darwin LDFLAGS: -lrdp_decoder
 
 #cgo nocallback rdp_decoder_new
+#cgo noescape rdp_decoder_new
 #cgo nocallback rdp_decoder_free
+#cgo noescape rdp_decoder_free
 #cgo nocallback rdp_decoder_resize
+#cgo noescape rdp_decoder_resize
 #cgo nocallback rdp_decoder_process
+#cgo noescape rdp_decoder_process
 #cgo nocallback rdp_decoder_image_data
+#cgo noescape rdp_decoder_image_data
 
 #include <stdint.h>
 
@@ -77,7 +82,7 @@ func New(width, height uint16) (*Decoder, error) {
 	}, nil
 }
 
-func (d *Decoder) Free() {
+func (d *Decoder) Release() {
 	if d.ptr == nil {
 		return
 	}
@@ -102,7 +107,7 @@ func (d *Decoder) Process(frame []byte) {
 	}
 
 	data := unsafe.SliceData(frame)
-	C.rdp_decoder_process(d.ptr, (*C.uint8_t)(unsafe.Pointer(data)), C.size_t(len(frame)))
+	C.rdp_decoder_process(d.ptr, (*C.uint8_t)(data), C.size_t(len(frame)))
 }
 
 // Image produces an RGBA image for the current state of the screen.
@@ -128,7 +133,7 @@ func (d *Decoder) Image() *image.RGBA {
 	rgba := image.NewRGBA(image.Rect(0, 0, w, h))
 
 	// Copy from the Rust-owned memory into Go memory.
-	copy(rgba.Pix, unsafe.Slice((*uint8)(unsafe.Pointer(data)), outLen))
+	copy(rgba.Pix, unsafe.Slice((*uint8)(data), outLen))
 
 	return rgba
 }

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -1,0 +1,159 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package decoder
+
+/*
+#cgo LDFLAGS: -L${SRCDIR}/../../../../../target/release -lrdp_decoder
+#include <stdint.h>
+
+typedef struct RdpDecoder RdpDecoder;
+
+RdpDecoder* rdp_decoder_new(uint16_t width, uint16_t height);
+void rdp_decoder_free(RdpDecoder* ptr);
+
+int rdp_decoder_resize(RdpDecoder* ptr, uint16_t width, uint16_t height);
+int rdp_decoder_process(RdpDecoder* ptr, const uint8_t* data, size_t len);
+const uint8_t* rdp_decoder_image_data(RdpDecoder* ptr, size_t* out_len);
+*/
+import "C"
+
+import (
+	"errors"
+	"image"
+	"math"
+	"unsafe"
+
+	"golang.org/x/image/draw"
+)
+
+// TODO: build tag?
+
+type Decoder struct {
+	ptr    *C.RdpDecoder
+	width  uint16
+	height uint16
+}
+
+func New(width, height uint16) (*Decoder, error) {
+	ptr := C.rdp_decoder_new(C.uint16_t(width), C.uint16_t(height))
+	if ptr == nil {
+		return nil, errors.New("failed to create decoder")
+	}
+	return &Decoder{
+		ptr:    ptr,
+		width:  width,
+		height: height,
+	}, nil
+}
+
+func (d *Decoder) Free() {
+	if d.ptr == nil {
+		return
+	}
+	C.rdp_decoder_free(d.ptr)
+	d.ptr = nil
+}
+
+func (d *Decoder) Resize(width, height uint16) {
+	if d.ptr == nil {
+		return
+	}
+	d.width = width
+	d.height = height
+	C.rdp_decoder_resize(d.ptr, C.uint16_t(width), C.uint16_t(height))
+}
+
+// Process processes an RDP fast path frame, updating the state of
+// the decoder and its internal frame buffer.
+func (d *Decoder) Process(frame []byte) {
+	if d.ptr == nil {
+		return
+	}
+
+	data := unsafe.SliceData(frame)
+	C.rdp_decoder_process(d.ptr, (*C.uint8_t)(unsafe.Pointer(data)), C.size_t(len(frame)))
+}
+
+// Image produces an RGBA image for the current state of the screen.
+// Callers should check that the resulting image is not nil before
+// attempting to operate on it.
+func (d *Decoder) Image() *image.RGBA {
+	if d == nil || d.ptr == nil {
+		return nil
+	}
+
+	var outLen C.size_t
+	data := C.rdp_decoder_image_data(d.ptr, &outLen)
+	if data == nil || outLen == 0 {
+		return nil
+	}
+
+	w := int(d.width)
+	h := int(d.height)
+	if w == 0 || h == 0 {
+		return nil
+	}
+
+	rgba := image.NewRGBA(image.Rect(0, 0, w, h))
+
+	// Copy from the Rust-owned memory into Go memory.
+	copy(rgba.Pix, unsafe.Slice((*uint8)(unsafe.Pointer(data)), outLen))
+
+	return rgba
+}
+
+// Thumbnail produces a scaled image of the current state of the screen.
+// It uses a low-quality interpolator so it shouldn't be used for large
+// size images.
+func (d *Decoder) Thumbnail(width, height int) *image.RGBA {
+	fullSize := d.Image()
+	if fullSize == nil || width <= 0 || height <= 0 {
+		return nil
+	}
+
+	srcBounds := fullSize.Bounds()
+	srcW := srcBounds.Dx()
+	srcH := srcBounds.Dy()
+	if srcW == 0 || srcH == 0 {
+		return nil
+	}
+
+	// Compute scale to fit the source inside the requested thumbnail
+	// while preserving aspect ratio.
+	scaleW := float64(width) / float64(srcW)
+	scaleH := float64(height) / float64(srcH)
+	scale := math.Min(scaleW, scaleH)
+
+	// Calculate destination size after scaling.
+	dstW := int(math.Max(1, math.Floor(float64(srcW)*scale+0.5)))
+	dstH := int(math.Max(1, math.Floor(float64(srcH)*scale+0.5)))
+
+	thumbnail := image.NewRGBA(image.Rect(0, 0, width, height))
+
+	// Center the scaled image within the thumbnail.
+	offsetX := (width - dstW) / 2
+	offsetY := (height - dstH) / 2
+	dstRect := image.Rect(offsetX, offsetY, offsetX+dstW, offsetY+dstH)
+
+	// Note: the nearest neighbor interpolator is fast, but produces the lowest quality
+	// results. We're okay with this for thumbnails.
+	draw.NearestNeighbor.Scale(thumbnail, dstRect, fullSize, srcBounds, draw.Over, nil)
+
+	return thumbnail
+}

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -29,6 +29,12 @@ package decoder
 #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
 #cgo darwin LDFLAGS: -lrdp_decoder
 
+#cgo nocallback rdp_decoder_new
+#cgo nocallback rdp_decoder_free
+#cgo nocallback rdp_decoder_resize
+#cgo nocallback rdp_decoder_process
+#cgo nocallback rdp_decoder_image_data
+
 #include <stdint.h>
 
 typedef struct RdpDecoder RdpDecoder;

--- a/lib/srv/desktop/rdp/decoder/decoder.go
+++ b/lib/srv/desktop/rdp/decoder/decoder.go
@@ -16,19 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Package decoder implements a RDP fast path decoder by calling into IronRDP via CGo.
+//
+// When used by Teleport, this package links its symbols from librdp (the Rust library
+// that Teleport already links).
+//
+// When used by other client tools (tsh), we link to a separate librdp_decoder library
+// to avoid linking in extra RDP code that we don't need.
 package decoder
 
 /*
-#cgo linux,386 LDFLAGS: -L${SRCDIR}/../../../../../target/i686-unknown-linux-gnu/release
-#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
-#cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
-#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
-#cgo linux LDFLAGS: -lrdp_decoder
-
-#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
-#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
-#cgo darwin LDFLAGS: -lrdp_decoder
-
 #cgo nocallback rdp_decoder_new
 #cgo noescape rdp_decoder_new
 #cgo nocallback rdp_decoder_free

--- a/lib/srv/desktop/rdp/decoder/decoder_nordpclient.go
+++ b/lib/srv/desktop/rdp/decoder/decoder_nordpclient.go
@@ -1,0 +1,32 @@
+//go:build !desktop_access_rdp
+
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package decoder
+
+/*
+#cgo linux,386 LDFLAGS: -L${SRCDIR}/../../../../../target/i686-unknown-linux-gnu/release
+#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-unknown-linux-gnu/release
+#cgo linux,arm LDFLAGS: -L${SRCDIR}/../../../../../target/arm-unknown-linux-gnueabihf/release
+#cgo linux,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-unknown-linux-gnu/release
+#cgo linux LDFLAGS: -lrdp_decoder
+
+#cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/../../../../../target/x86_64-apple-darwin/release
+#cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/../../../../../target/aarch64-apple-darwin/release
+#cgo darwin LDFLAGS: -lrdp_decoder
+*/
+import "C"

--- a/lib/srv/desktop/rdp/decoder/decoder_rdpclient.go
+++ b/lib/srv/desktop/rdp/decoder/decoder_rdpclient.go
@@ -1,0 +1,21 @@
+//go:build desktop_access_rdp
+
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package decoder
+
+import _ "github.com/gravitational/teleport/lib/srv/desktop/rdp/rdpclient"

--- a/lib/srv/desktop/rdp/decoder/decodertool/main.go
+++ b/lib/srv/desktop/rdp/decoder/decodertool/main.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package main
 
 import (

--- a/lib/srv/desktop/rdp/decoder/decodertool/main.go
+++ b/lib/srv/desktop/rdp/decoder/decodertool/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+
+	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/srv/desktop/rdp/decoder"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
+)
+
+func main() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	fname := os.Args[1]
+	f, err := os.Open(fname)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	pr := events.NewProtoReader(f, nil /* decrypter */)
+	defer pr.Close()
+
+	count := 0
+
+	var (
+		width, height uint32
+		rdpDecoder    *decoder.Decoder
+	)
+
+	for {
+		evt, err := pr.Read(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		} else if err != nil {
+			log.Fatal(err)
+		}
+
+		count++
+
+		recordingEvent, ok := evt.(*apievents.DesktopRecording)
+		if !ok {
+			log.Printf("skipping %v event (%d)", evt.GetType(), count)
+			continue
+		}
+
+		msg, err := tdp.Decode(recordingEvent.Message)
+		if err != nil {
+			log.Println("failed to decode message, skipping it")
+			continue
+		}
+
+		switch msg := msg.(type) {
+		case tdp.ConnectionActivated:
+			width, height = uint32(msg.ScreenWidth), uint32(msg.ScreenHeight)
+
+		case tdp.ClientScreenSpec:
+			width, height = msg.Width, msg.Height
+			if rdpDecoder != nil {
+				rdpDecoder.Resize(uint16(msg.Width), uint16(msg.Height))
+			}
+
+		case tdp.RDPFastPathPDU:
+			if rdpDecoder == nil {
+				var err error
+				rdpDecoder, err = decoder.New(uint16(width), uint16(height))
+				if err != nil {
+					log.Fatalf("couldn't create decoder: %v", err)
+				}
+			}
+
+			rdpDecoder.Process([]byte(msg))
+
+			if count%100 == 0 {
+				writeImages(rdpDecoder.Image(), rdpDecoder.Thumbnail(1000, 600), count)
+			}
+		}
+	}
+
+	writeImages(rdpDecoder.Image(), rdpDecoder.Thumbnail(1000, 600), count)
+}
+
+func writeImages(img, thumb *image.RGBA, index int) error {
+	if img == nil {
+		return errors.New("nil image")
+	}
+	f, err := os.Create(fmt.Sprintf("screen-%08d.png", index))
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	if err := png.Encode(f, img); err != nil {
+		return err
+	}
+
+	t, err := os.Create(fmt.Sprintf("thumb-%08d.png", index))
+	if err != nil {
+		return err
+	}
+
+	defer t.Close()
+
+	if err := png.Encode(t, thumb); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/srv/desktop/rdp/decoder/src/lib.rs
+++ b/lib/srv/desktop/rdp/decoder/src/lib.rs
@@ -1,0 +1,144 @@
+// Teleport
+// Copyright (C) 2025  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//! This crate contains an RDP decoder which can produce images given
+//! a series of RDP fast path PDUs. It exposes a small C API so that
+//! Go (via cgo) can create a decoder and call its methods.
+
+use ironrdp_core::WriteBuf;
+use ironrdp_graphics::image_processing::PixelFormat;
+use ironrdp_session::{
+    fast_path::{Processor, ProcessorBuilder, UpdateKind},
+    image::DecodedImage,
+};
+
+pub struct RdpDecoder {
+    image: DecodedImage,
+    fast_path_processor: Processor,
+}
+
+impl RdpDecoder {
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            image: DecodedImage::new(PixelFormat::RgbA32, width, height),
+            fast_path_processor: ProcessorBuilder {
+                // These channel IDs only matter in a real RDP session when we have
+                // to send responses back to the server. We can safely leave them
+                // set to 0 when decoding session recordings.
+                io_channel_id: 0,
+                user_channel_id: 0,
+                // TODO: what does this change?
+                enable_server_pointer: false,
+                pointer_software_rendering: false,
+            }
+            .build(),
+        }
+    }
+
+    pub fn resize(&mut self, width: u16, height: u16) {
+        self.image = DecodedImage::new(PixelFormat::RgbA32, width, height);
+    }
+
+    pub fn image_data(&self) -> &[u8] {
+        self.image.data()
+    }
+
+    pub fn process(&mut self, tdp_fast_path_frame: &[u8]) {
+        let mut output = WriteBuf::new();
+
+        // TODO: need error handling here
+        let updates = self
+            .fast_path_processor
+            .process(&mut self.image, tdp_fast_path_frame, &mut output)
+            .unwrap_or_default();
+
+        for update in updates {
+            match update {
+                UpdateKind::None => {}
+                UpdateKind::Region(inclusive_rectangle) => {
+                    if inclusive_rectangle.right > self.image.width()
+                        || inclusive_rectangle.bottom >= self.image.height()
+                    {
+                        todo!("Region exceeds bounds, needs resize!")
+                    }
+                }
+                // We don't care about the mouse pointer.
+                UpdateKind::PointerDefault => {}
+                UpdateKind::PointerHidden => {}
+                UpdateKind::PointerPosition { x: _, y: _ } => {}
+                UpdateKind::PointerBitmap(_) => {}
+            }
+        }
+    }
+}
+
+/// Create a new decoder and return an owned pointer to it.
+/// The caller is responsible for calling rdp_decoder_free
+/// when the decoder is no longer needed.
+#[no_mangle]
+pub extern "C" fn rdp_decoder_new(width: u16, height: u16) -> *mut RdpDecoder {
+    Box::into_raw(Box::new(RdpDecoder::new(width, height)))
+}
+
+/// Frees the memory associated with a decoder.
+#[no_mangle]
+pub extern "C" fn rdp_decoder_free(ptr: *mut RdpDecoder) {
+    unsafe {
+        let _ = Box::from_raw(ptr);
+    }
+}
+
+/// Resizes the decoder's internal image buffer.
+#[no_mangle]
+pub extern "C" fn rdp_decoder_resize(ptr: *mut RdpDecoder, width: u16, height: u16) {
+    unsafe {
+        let decoder = &mut *ptr;
+        decoder.resize(width, height);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rdp_decoder_process(ptr: *mut RdpDecoder, data: *const u8, len: usize) {
+    if ptr.is_null() || data.is_null() || len == 0 {
+        return;
+    }
+    unsafe {
+        let decoder = &mut *ptr;
+        let slice = std::slice::from_raw_parts(data, len);
+        decoder.process(slice);
+    }
+}
+
+/// Returns a pointer to the decoder's internal image buffer and writes its length to `out_len`.
+/// The pointer is valid as long as the decoder is alive and is not mutated by other calls
+/// (e.g. `process`, `resize` may reallocate). Caller should copy the data if it needs to keep it.
+#[no_mangle]
+pub extern "C" fn rdp_decoder_image_data(ptr: *mut RdpDecoder, out_len: *mut usize) -> *const u8 {
+    if ptr.is_null() {
+        if !out_len.is_null() {
+            unsafe { *out_len = 0 };
+        }
+        return std::ptr::null();
+    }
+    unsafe {
+        let decoder = &*ptr;
+        let data = decoder.image_data();
+        if !out_len.is_null() {
+            *out_len = data.len();
+        }
+        data.as_ptr()
+    }
+}

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -30,6 +30,7 @@ iso7816 = "0.1.4"
 iso7816-tlv = "0.4.4"
 log = "0.4.28"
 rand = { version = "0.9.2", features = ["os_rng"] }
+rdp-decoder = { path = "../decoder" }
 rsa = "0.9.9"
 sspi = { version = "0.16.1", features = ["network_client"] }
 tokio = { version = "1.48", features = ["full"] }

--- a/lib/srv/desktop/rdp/rdpclient/src/lib.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/lib.rs
@@ -24,6 +24,9 @@
 //! - Structs for passing between the two (those prefixed with the `#[repr(C)]` macro
 //!   and whose name begins with `CGO`)
 
+// bring in rdp-decoder to export its unmangled symbols in the staticlib
+extern crate rdp_decoder as _;
+
 use crate::client::global::get_client_handle;
 use crate::client::Client;
 use crate::rdpdr::tdp::SharedDirectoryAnnounce;

--- a/tool/tsh/common/recording_export_test.go
+++ b/tool/tsh/common/recording_export_test.go
@@ -136,7 +136,7 @@ func writeMovieWrapper(t *testing.T, ctx context.Context, ss events.SessionStrea
 
 	tempDir := t.TempDir()
 	prefix = filepath.Join(tempDir, prefix)
-	frames, err := writeMovie(ctx, ss, sid, prefix, write, "")
+	frames, err := writeMovie(ctx, ss, sid, prefix, write)
 	return frames, prefix, err
 }
 


### PR DESCRIPTION
The tsh recordings export command exports a Windows desktop session recording to an AVI file that can be played outside Teleport. It was built prior to our RemoteFX support, and to this day only works on legacy PNG recordings.

This commit allows us to export RemoteFX recordings by leveraging the Rust RDP decoder library in tsh. This will be the first time tsh links to Rust libraries.

Closes #45388
Requires #61858