### PR TITLE
Sort generated CLI docs flag and argument tables

### DIFF
--- a/lib/utils/usage_docs.go
+++ b/lib/utils/usage_docs.go
@@ -28,6 +28,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -35,12 +36,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// formatThreeColMarkdownTable formats the provided row data into a three-column
-// Markdown table, minus the header.
-func formatThreeColMarkdownTable(rows [][3]string) string {
-	var buf bytes.Buffer
+var nonLetters = regexp.MustCompile(`\W`)
 
-	for _, r := range rows {
+// lowerWordChars returns only the word characters (\w) from in, in lowercase,
+// so we can sort short-format flags alongside long-format flags in tables.
+func lowerWordChars(in string) string {
+	return strings.ToLower(nonLetters.ReplaceAllString(in, ""))
+}
+
+// formatThreeColMarkdownTable formats the provided row data into a three-column
+// Markdown table, minus the header, sorted lexicographically by the values of
+// the first column.
+func formatThreeColMarkdownTable(rows [][3]string) string {
+	newRows := slices.Clone(rows)
+	slices.SortFunc(newRows, func(a, b [3]string) int {
+		return strings.Compare(
+			lowerWordChars(a[0]),
+			lowerWordChars(b[0]),
+		)
+	})
+
+	var buf bytes.Buffer
+	for _, r := range newRows {
 		fmt.Fprintf(&buf, "\n|%v|%v|%v|", r[0], r[1], r[2])
 	}
 	return buf.String()


### PR DESCRIPTION
Sort the flag and argument tables of generated CLI docs. Do so alphabetically by the value of the first column, disregarding non-word characters and character case.