### PR TITLE
[v17] RBAC: make acking an alert only require update permissions

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -969,7 +969,7 @@ func (a *ServerWithRoles) UpsertClusterAlert(ctx context.Context, alert types.Cl
 
 func (a *ServerWithRoles) CreateAlertAck(ctx context.Context, ack types.AlertAcknowledgement) error {
 	// we treat alert acks as an extension of the cluster alert resource rather than its own resource
-	if err := a.action(apidefaults.Namespace, types.KindClusterAlert, types.VerbCreate, types.VerbUpdate); err != nil {
+	if err := a.action(apidefaults.Namespace, types.KindClusterAlert, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Acknowledging an alert always operates on an existing cluster alert, so it seems reasonable to require only update permission instead of requiring both create and update.

Backports #62436

Changelog: Acking a cluster alert no longer requires the create permission.