### PR TITLE
[v17] Don't wipe out discovered desktops when LDAP dial fails

### DIFF
--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth/windows"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
@@ -98,14 +99,44 @@ const (
 	readOnlyDomainControllerGroupID = "521"
 )
 
+// currentDesktops returns the set of desktops that exist in the backend which were both:
+// 1. Registered by this agent.
+// 2. Registered with a dynamic origin (either via LDAP discovery or dynamic registration)
+func (s *WindowsService) currentDesktops(ctx context.Context) map[string]types.WindowsDesktop {
+	result := make(map[string]types.WindowsDesktop)
+
+	for desktop, err := range clientutils.Resources(
+		ctx,
+		func(ctx context.Context, pageSize int, pageToken string) ([]types.WindowsDesktop, string, error) {
+			resp, err := s.cfg.AccessPoint.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
+				WindowsDesktopFilter: types.WindowsDesktopFilter{HostID: s.cfg.Heartbeat.HostUUID},
+				Labels:               map[string]string{types.OriginLabel: types.OriginDynamic},
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			return resp.Desktops, resp.NextKey, nil
+		}) {
+		if err != nil {
+			return result
+		}
+		result[desktop.GetName()] = desktop
+	}
+
+	return result
+}
+
 // startDesktopDiscovery starts fetching desktops from LDAP, periodically
 // registering and unregistering them as necessary.
 func (s *WindowsService) startDesktopDiscovery() error {
 	reconciler, err := services.NewReconciler(services.ReconcilerConfig[types.WindowsDesktop]{
-		// Use a matcher that matches all resources, since our desktops are
-		// pre-filtered by nature of using an LDAP search with filters.
-		Matcher:             func(d types.WindowsDesktop) bool { return true },
-		GetCurrentResources: func() map[string]types.WindowsDesktop { return s.lastDiscoveryResults },
+		// Match all desktops with one of our LDAP labels.
+		// This ensures the desktop was discovered via LDAP and not created with dynamic registration.
+		Matcher: func(d types.WindowsDesktop) bool {
+			_, ok := d.GetLabel(types.DiscoveryLabelWindowsOS)
+			return ok
+		},
+		GetCurrentResources: func() map[string]types.WindowsDesktop { return s.currentDesktops(s.closeCtx) },
 		GetNewResources:     s.getDesktopsFromLDAP,
 		OnCreate:            s.upsertDesktop,
 		OnUpdate:            s.updateDesktop,
@@ -183,8 +214,11 @@ func (s *WindowsService) getDesktopsFromLDAP() map[string]types.WindowsDesktop {
 		}
 		return s.lastDiscoveryResults
 	} else if err != nil {
-		s.cfg.Logger.WarnContext(context.Background(), "could not discover Windows Desktops", "error", err)
-		return nil
+		s.cfg.Logger.WarnContext(context.Background(), "could not discover Windows Desktops, using last known results", "error", err)
+		for _, d := range s.lastDiscoveryResults {
+			d.SetExpiry(s.cfg.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL * 3))
+		}
+		return s.lastDiscoveryResults
 	}
 
 	s.cfg.Logger.DebugContext(context.Background(), "discovered Windows Desktops", "count", len(entries))

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/services"
@@ -392,4 +393,186 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestCurrentDesktops(t *testing.T) {
+	t.Parallel()
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	hostUUID := "test-host-id"
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	s := &WindowsService{
+		cfg: WindowsServiceConfig{
+			Heartbeat: HeartbeatConfig{
+				HostUUID: hostUUID,
+			},
+			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Clock:       clockwork.NewFakeClock(),
+			AccessPoint: client,
+		},
+	}
+
+	desktops := []struct {
+		name   string
+		hostID string
+		origin string
+		expect bool
+	}{
+		{
+			name:   "dynamic-same-host",
+			hostID: hostUUID,
+			origin: types.OriginDynamic,
+			expect: true, // Should be included
+		},
+		{
+			name:   "static-same-host",
+			hostID: hostUUID,
+			origin: types.OriginConfigFile,
+			expect: false, // Wrong origin
+		},
+		{
+			name:   "dynamic-different-host",
+			hostID: "other-host",
+			origin: types.OriginDynamic,
+			expect: false, // Wrong host
+		},
+		{
+			name:   "dynamic-same-host-2",
+			hostID: hostUUID,
+			origin: types.OriginDynamic,
+			expect: true, // Should be included
+		},
+	}
+
+	for _, d := range desktops {
+		desktop, err := types.NewWindowsDesktopV3(d.name, map[string]string{
+			types.OriginLabel: d.origin,
+		}, types.WindowsDesktopSpecV3{
+			Addr:   "addr-" + d.name,
+			HostID: d.hostID,
+		})
+		require.NoError(t, err)
+		err = tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop)
+		require.NoError(t, err)
+	}
+
+	// Call currentDesktops and verify results
+	result := s.currentDesktops(t.Context())
+
+	// Count expected desktops
+	var expectedCount int
+	for _, d := range desktops {
+		if d.expect {
+			expectedCount++
+		}
+	}
+
+	require.Len(t, result, expectedCount)
+
+	// Verify only the expected desktops are returned
+	for _, d := range desktops {
+		if d.expect {
+			desktop, ok := result[d.name]
+			require.True(t, ok, "expected desktop %s to be in results", d.name)
+			require.Equal(t, d.name, desktop.GetName())
+			require.Equal(t, d.hostID, desktop.GetHostID())
+			originLabel, _ := desktop.GetLabel(types.OriginLabel)
+			require.Equal(t, types.OriginDynamic, originLabel)
+		} else {
+			_, ok := result[d.name]
+			require.False(t, ok, "desktop %s should not be in results", d.name)
+		}
+	}
+}
+
+func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
+	t.Parallel()
+
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	const hostUUID = "test-host-uuid"
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	clock := clockwork.NewFakeClock()
+
+	s := &WindowsService{
+		closeCtx: t.Context(),
+		cfg: WindowsServiceConfig{
+			Heartbeat:   HeartbeatConfig{HostUUID: hostUUID},
+			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Clock:       clock,
+			AccessPoint: client,
+			AuthClient:  client,
+		},
+	}
+
+	originalExpiry := clock.Now().Add(apidefaults.ServerAnnounceTTL * 3)
+
+	// Populate last discovery results with some desktops
+	lastDiscoveryResults := map[string]types.WindowsDesktop{}
+	for i := 1; i <= 3; i++ {
+		name := "desktop-" + strconv.Itoa(i)
+		desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
+			types.OriginLabel:                      types.OriginDynamic,
+			types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
+			types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
+		}, types.WindowsDesktopSpecV3{
+			HostID: hostUUID,
+			Addr:   name + ".example.com:3389",
+		})
+		require.NoError(t, err)
+		desktop.SetExpiry(originalExpiry)
+		lastDiscoveryResults[name] = desktop
+
+		require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
+	}
+	s.lastDiscoveryResults = lastDiscoveryResults
+
+	// Force the reconciler to run.
+	// It will fail because we aren't running a real LDAP server in the test.
+	require.NoError(t, s.startDesktopDiscovery())
+	clock.BlockUntil(1)
+	clock.Advance(15 * time.Second)
+	preReconcile := clock.Now()
+	clock.BlockUntil(1)
+
+	// Verify that the reconciler failure did not delete desktops and that
+	// their expiry times were updated.
+	for i := 1; i <= 3; i++ {
+		name := "desktop-" + strconv.Itoa(i)
+		desktops, err := client.GetWindowsDesktops(
+			t.Context(),
+			types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
+		)
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
+		require.Equal(t, name, desktops[0].GetName())
+
+		// Verify the TTL was updated (3x the announce TTL).
+		actualExpiry := desktops[0].Expiry()
+		require.Equal(t, 3*apidefaults.ServerAnnounceTTL, actualExpiry.Sub(preReconcile))
+	}
 }


### PR DESCRIPTION
Partial backport of #62283 (we don't have a SID cache or configurable discovery interval in v17).

Backports #63603

changelog: fixed a bug that could cause Windows desktops discovered via LDAP to be removed in error.

The test plan for this one is a little different than the v18 version since we don't have SID caching or a configurable discovery interval in v17, and because we maintain a long-lived LDAP Connection:

- enable LDAP discovery
- wait for the first discovery pass to succeed, verify that discovered host shows up (roughly 30 second)
- configure firewall to block access to LDAP server
- reboot the LDAP server (this is the only way to close the existing connection and force Teleport to reconnect)
- wait 10 minutes(2 * discovery interval) and verify that the hosts are still present, even though logs show discovery failures
- restore firewall so that connectivity is allowed
- wait for next discovery and verify that it succeeded