### PR TITLE
Change the Self-Hosting docs index page title

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deploy-a-cluster.mdx
@@ -1,5 +1,5 @@
 ---
-title: Self-Hosting Teleport Enterprise
+title: Self-Hosting Teleport
 sidebar_label: Self-Hosting
 sidebar_position: 5
 description: "Guides to running a self-hosted Teleport cluster in production."
@@ -7,8 +7,7 @@ tags:
  - platform-wide
 ---
 
-These guides show you how to run a self-hosted Teleport Enterprise cluster in
-production.
+These guides show you how to run a self-hosted Teleport cluster in production.
 
 ## Getting started
 


### PR DESCRIPTION
The content in this section is not entirely for Teleport Enterprise users, so change the title to make this clearer.