### PR TITLE
[v17] Include roles in server side match for users

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -252,6 +252,7 @@ func (u *UserV2) SetStaticLabels(sl map[string]string) {
 // match against the list of search values.
 func (u *UserV2) MatchSearch(values []string) bool {
 	fieldVals := append(utils.MapToStrings(u.Metadata.Labels), u.GetName())
+	fieldVals = append(fieldVals, u.GetRoles()...)
 	return MatchSearch(fieldVals, values, nil)
 }
 


### PR DESCRIPTION
Backport #62466 to branch/v17

changelog: Fixed an issue that prevented searching for users by role in the web UI
