### PR TITLE
fix: Prevent TextEditor content update when non-readonly

### DIFF
--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -62,7 +62,9 @@ class TextEditor extends Component {
 
     // If the data changes, reset the value in each session so changes are
     // rendered.
-    if (prevProps.data !== this.props.data) {
+    // Only update the content if the editor is read-only to prevent
+    // interrupting the editing experience.
+    if (this.props.readOnly && prevProps.data !== this.props.data) {
       this.props.data.forEach((doc, i) => {
         this.sessions[i].setValue(doc.content);
       });


### PR DESCRIPTION
## Summary
This change fixes an issue preventing editing the content of `TextEditor` components in non-readonly mode. The cursor is reset to the beginning of the content on every edit making typing impossible beyond the first character. Pasting works fine, although only the first edit, which can be used as a workaround.

This issue was caused by [a change](https://github.com/gravitational/teleport/pull/62119) to allow the content of the editor to be updated by changing the `data` prop.

Fixes: https://github.com/gravitational/teleport/issues/62481
Changelog: Fixed an issue preventing text editors in the Web UI from allowing edits

## Changes
- Only process change to the `data` prop when in readonly mode

## Testing
The `TextEditor` component is not easily testable through tests. I've tested manually to ensure editors that should allow edits do not exhibit the broken behaviour.