### PR TITLE
More performant resource discovery and reconciliation 

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6603,7 +6603,7 @@ func (process *TeleportProcess) initApps() {
 		}
 
 		// Loop over each application and create a server.
-		var applications types.Apps
+		var applications []types.Application
 		for _, app := range process.Config.Apps.Apps {
 			publicAddr, err := getPublicAddr(process.ExitContext(), accessPoint, app)
 			if err != nil {

--- a/lib/services/reconciler_test.go
+++ b/lib/services/reconciler_test.go
@@ -417,3 +417,11 @@ func (r testResource) GetName() string {
 func (r testResource) GetKind() string {
 	return "testResource"
 }
+
+func (r testResource) GetSubKind() string {
+	return ""
+}
+
+func (r testResource) GetVersion() string {
+	return "1"
+}

--- a/lib/services/resource_monitor.go
+++ b/lib/services/resource_monitor.go
@@ -1,0 +1,382 @@
+//
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"iter"
+	"log/slog"
+	"sync"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/defaults"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
+)
+
+// ResourceMonitorConfig holds the dependencies required by a [ResourceMonitor].
+type ResourceMonitorConfig[T any] struct {
+	// Kind dictates the monitored resource's kind.
+	Kind string
+	// Key determines the unique key for a given resource.
+	Key func(T) string
+	// ResourceHeaderKey determines the unique key for a header that may be
+	// emitted during a delete event. If delete events emit the full resource
+	// instead of the [types.ResourceHeader] this may be omitted and Key will be used.
+	ResourceHeaderKey func(*types.ResourceHeader) string
+	// CurrentResources an iterator that provides the current set of resources that exist.
+	// This iterator may be called multiple times if the state needs to be reloaded.
+	CurrentResources func(context.Context) iter.Seq2[T, error]
+	// Events is the source watchers are created from to observe events for a particular
+	// resource.
+	Events types.Events
+	// Matches determines if a resource should be processed or not.
+	Matches func(T) bool
+	// CompareResources determines if two resources are equivalent. This is used to determine
+	// whether a change has been made to an existing resource.
+	CompareResources func(T, T) int
+	// AllowOriginChanges determines whether changes to a resources origin should be allowed.
+	AllowOriginChanges bool
+	// DeleteResource is called in response to a [types.OpDelete] event being received for an existing resource.
+	DeleteResource func(context.Context, T) error
+	// CreateResource is called in response to a [types.OpPut] event being received for a new resource.
+	CreateResource func(context.Context, T) error
+	// UpdateResource is called in response to a [types.OpPut] event being received for an existing resource.
+	// Both the existing resource and the updated resource are provided for inspection.
+	UpdateResource func(ctx context.Context, new, existing T) error
+}
+
+// ResourceMonitor tracks that cluster state for a particular backend resource. It monitors the
+// cluster event stream to maintain the current view of a resource set. Any changes to the
+// state can be watched by supplying callbacks for creat, update, or delete of a resource.
+//
+// The [ResourceMonitor] provides the same functionality of a [GenericWatcher] that feeds all changes to
+// a [GenericReconciler] in a more performant manner.
+type ResourceMonitor[T any] struct {
+	cfg    ResourceMonitorConfig[T]
+	logger *slog.Logger
+
+	retry retryutils.Retry
+
+	initChan chan struct{}
+	initOnce sync.Once
+
+	closed    chan struct{}
+	closeOnce sync.Once
+
+	mu        sync.Mutex
+	resources map[string]T
+}
+
+// NewResourceMonitor creates a [ResourceMonitor] from the provided configuration.
+func NewResourceMonitor[T any](cfg ResourceMonitorConfig[T]) (*ResourceMonitor[T], error) {
+	switch {
+	case cfg.Kind == "":
+		return nil, trace.BadParameter("ResourceMonitor kind not provided")
+	case cfg.CurrentResources == nil:
+		return nil, trace.BadParameter("ResourceMonitor current resources not provided")
+	case cfg.Events == nil:
+		return nil, trace.BadParameter("ResourceMonitor events not provided")
+	case cfg.DeleteResource == nil:
+		return nil, trace.BadParameter("ResourceMonitor delete resource not provided")
+	case cfg.CreateResource == nil:
+		return nil, trace.BadParameter("ResourceMonitor create resource not provided")
+	case cfg.UpdateResource == nil:
+		return nil, trace.BadParameter("ResourceMonitor update resource not provided")
+	case cfg.Matches == nil:
+		return nil, trace.BadParameter("ResourceMonitor matches not provided")
+	case cfg.CompareResources == nil:
+		return nil, trace.BadParameter("ResourceMonitor compare resources not provided")
+	}
+
+	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
+		First:  retryutils.FullJitter(defaults.MaxWatcherBackoff / 10),
+		Step:   defaults.MaxWatcherBackoff / 5,
+		Max:    defaults.MaxWatcherBackoff,
+		Jitter: retryutils.HalfJitter,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ResourceMonitor[T]{
+		cfg:      cfg,
+		initChan: make(chan struct{}),
+		closed:   make(chan struct{}),
+		retry:    retry,
+		logger:   slog.With(teleport.ComponentKey, "resourcemonitor", "kind", cfg.Kind),
+	}, nil
+}
+
+// Close terminates an ongoing [Run] operation.
+func (p *ResourceMonitor[T]) Close() error {
+	p.closeOnce.Do(func() {
+		close(p.closed)
+	})
+
+	return nil
+}
+
+func (p *ResourceMonitor[T]) Initialized() <-chan struct{} {
+	return p.initChan
+}
+
+// Run monitors resources until the context is canceled or [Close] is called.
+func (p *ResourceMonitor[T]) Run(ctx context.Context) {
+	for {
+		err := p.watch(ctx)
+
+		select {
+		case <-p.closed:
+			return
+		case <-ctx.Done():
+			return
+		case <-p.retry.After():
+			p.retry.Inc()
+		}
+
+		if err != nil {
+			p.logger.WarnContext(ctx, "Restart watch on error", "error", err)
+		}
+	}
+}
+
+// watch monitors new resource updates, maintains a local view and broadcasts
+// notifications to connected agents.
+func (p *ResourceMonitor[T]) watch(ctx context.Context) error {
+	watch := types.Watch{
+		Name:            "resource.monitor",
+		MetricComponent: "resource.monitor",
+		Kinds:           []types.WatchKind{{Kind: p.cfg.Kind}},
+	}
+
+	watcher, err := p.cfg.Events.NewWatcher(ctx, watch)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer watcher.Close()
+
+	// before fetch, make sure watcher is synced by receiving init event,
+	// to avoid the scenario:
+	// 1. Cache process:   w = NewWatcher()
+	// 2. Cache process:   c.fetch()
+	// 3. Backend process: addItem()
+	// 4. Cache process:   <- w.Events()
+	//
+	// If there is a way that NewWatcher() on line 1 could
+	// return without subscription established first,
+	// Code line 3 could execute and line 4 could miss event,
+	// wrapping up with out of sync replica.
+	// To avoid this, before doing fetch,
+	// cache process makes sure the connection is established
+	// by receiving init event first.
+	select {
+	case <-p.closed:
+		return nil
+	case <-watcher.Done():
+		return trace.ConnectionProblem(watcher.Error(), "watcher is closed: %v", watcher.Error())
+	case <-ctx.Done():
+		return trace.ConnectionProblem(ctx.Err(), "context is closing")
+	case event := <-watcher.Events():
+		if event.Type != types.OpInit {
+			return trace.BadParameter("expected init event, got %v instead", event.Type)
+		}
+	}
+
+	if err := p.getCurrentResources(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+
+	for {
+		select {
+		case <-p.closed:
+			return nil
+		case <-watcher.Done():
+			return trace.ConnectionProblem(watcher.Error(), "watcher is closed: %v", watcher.Error())
+		case <-ctx.Done():
+			return trace.ConnectionProblem(ctx.Err(), "context is closing")
+		case event := <-watcher.Events():
+			p.handleEvent(ctx, event)
+		}
+	}
+}
+
+func (p *ResourceMonitor[T]) getCurrentResources(ctx context.Context) error {
+	// Collect the current set of resources to compare against
+	// the previously known set of resources.
+	resources := map[string]T{}
+	for resource, err := range p.cfg.CurrentResources(ctx) {
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		key := p.cfg.Key(resource)
+		resources[key] = resource
+	}
+
+	// Determine which resources used to exist but no longer do.
+	// Note, that deletion does not happen directly to avoid
+	// performing operations while holding the lock.
+	var toDelete map[string]T
+	p.mu.Lock()
+	for key, resource := range p.resources {
+		if _, ok := resources[key]; !ok {
+			if toDelete == nil {
+				toDelete = map[string]T{}
+			}
+			toDelete[key] = resource
+		}
+	}
+
+	p.initOnce.Do(func() { close(p.initChan) })
+	p.resources = resources
+	p.mu.Unlock()
+
+	// Delete any resources that have been marked for removal.
+	for key, resource := range toDelete {
+		p.logger.InfoContext(ctx, "Resource was removed, deleting", "name", key)
+		if err := p.cfg.DeleteResource(ctx, resource); err != nil {
+			level := slog.LevelWarn
+			if trace.IsNotFound(err) {
+				level = logutils.TraceLevel
+			}
+			p.logger.Log(ctx, level, "Failed to delete resource", "name", key, "err", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *ResourceMonitor[T]) handleEvent(ctx context.Context, event types.Event) {
+	switch event.Type {
+	case types.OpDelete:
+		var key string
+		switch res := event.Resource.(type) {
+		case T:
+			key = p.cfg.Key(res)
+		case interface{ UnwrapT() T }:
+			key = p.cfg.Key(res.UnwrapT())
+		case *types.ResourceHeader:
+			key = p.cfg.ResourceHeaderKey(res)
+		}
+
+		p.mu.Lock()
+		deleted, ok := p.resources[key]
+		delete(p.resources, key)
+		p.mu.Unlock()
+		if !p.cfg.Matches(deleted) && !ok {
+			return
+		}
+
+		p.logger.InfoContext(ctx, "Resource was removed, deleting", "name", key)
+		if err := p.cfg.DeleteResource(ctx, deleted); err != nil {
+			level := slog.LevelWarn
+			if trace.IsNotFound(err) {
+				level = logutils.TraceLevel
+			}
+			p.logger.Log(ctx, level, "Failed to delete resource", "name", key, "err", err)
+		}
+	case types.OpPut:
+		var key string
+		var t T
+		switch res := event.Resource.(type) {
+		case T:
+			key = p.cfg.Key(res)
+			t = res
+		case interface{ UnwrapT() T }:
+			key = p.cfg.Key(res.UnwrapT())
+			t = res.UnwrapT()
+		default:
+			p.logger.WarnContext(ctx, "Unexpected resource type", "type", logutils.TypeAttr(event.Resource))
+			return
+		}
+
+		matches := p.cfg.Matches(t)
+
+		p.mu.Lock()
+		existing, ok := p.resources[key]
+		if matches {
+			p.resources[key] = t
+		}
+		p.mu.Unlock()
+
+		if ok {
+			if err := p.updateResource(ctx, matches, key, existing, t); err != nil {
+				p.logger.Log(ctx, logutils.TraceLevel, "Failed to update resource", "name", key, "err", err)
+			}
+		} else {
+			if err := p.createResource(ctx, matches, key, t); err != nil {
+				p.logger.Log(ctx, logutils.TraceLevel, "Failed to create resource", "name", key, "err", err)
+			}
+		}
+	default:
+		p.logger.WarnContext(ctx, "unknown event type received", "type", event.Type)
+	}
+}
+
+func (p *ResourceMonitor[T]) createResource(ctx context.Context, matches bool, key string, new T) error {
+	if !matches {
+		p.logger.DebugContext(ctx, "New resource doesn't match, not creating", "name", key)
+		return nil
+	}
+
+	p.logger.InfoContext(ctx, "New resource matches, creating", "name", key)
+
+	return trace.Wrap(p.cfg.CreateResource(ctx, new))
+}
+
+func (p *ResourceMonitor[T]) updateResource(ctx context.Context, matches bool, key string, current, new T) error {
+	if !p.cfg.AllowOriginChanges {
+		currentOrigin, err := types.GetOrigin(current)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		newOrigin, err := types.GetOrigin(new)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if currentOrigin != newOrigin {
+			p.logger.WarnContext(ctx, "New resource has different origin, not updating",
+				"name", key, "new_origin", newOrigin, "existing_origin", currentOrigin)
+			return nil
+		}
+	}
+
+	if p.cfg.CompareResources(new, current) == 0 {
+		p.logger.Log(ctx, logutils.TraceLevel, "Existing resource is already registered", "name", key, "new_resource", new, "current", current)
+		return nil
+	}
+
+	if matches {
+		p.logger.InfoContext(ctx, "Existing resource updated, updating", "name", key)
+		return trace.Wrap(p.cfg.UpdateResource(ctx, new, current))
+	}
+
+	p.logger.InfoContext(ctx, "Existing resource updated and no longer matches, deleting", "name", key)
+	if err := p.cfg.DeleteResource(ctx, current); err != nil {
+		p.logger.Log(ctx, logutils.TraceLevel, "Failed to delete resource", "name", key, "err", err)
+		if trace.IsNotFound(err) {
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/services/resource_monitor_test.go
+++ b/lib/services/resource_monitor_test.go
@@ -1,0 +1,371 @@
+//
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package services
+
+import (
+	"context"
+	"iter"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type fakeEvents struct {
+	events chan types.Event
+}
+
+// NewWatcher implements [types.Events].
+func (f *fakeEvents) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	return &fakeWatcher{
+		events: f.events,
+		doneCh: make(chan struct{}),
+	}, nil
+}
+
+type fakeWatcher struct {
+	events <-chan types.Event
+	once   sync.Once
+	doneCh chan struct{}
+}
+
+// Close implements [types.Watcher].
+func (f *fakeWatcher) Close() error {
+	f.once.Do(func() { close(f.doneCh) })
+	return nil
+}
+
+// Done implements [types.Watcher].
+func (f *fakeWatcher) Done() <-chan struct{} {
+	return f.doneCh
+}
+
+// Error implements [types.Watcher].
+func (f *fakeWatcher) Error() error {
+	return nil
+}
+
+// Events implements [types.Watcher].
+func (f *fakeWatcher) Events() <-chan types.Event {
+	return f.events
+}
+
+func putEvent(r testResource) types.Event {
+	return types.Event{
+		Type:     types.OpPut,
+		Resource: types.Resource153ToLegacy(r),
+	}
+}
+
+func deleteEvent(r testResource) types.Event {
+	return types.Event{
+		Type:     types.OpDelete,
+		Resource: types.Resource153ToLegacy(r),
+	}
+}
+
+// TestReconciler makes sure appropriate callbacks are called during reconciliation.
+func TestResourceMonitor(t *testing.T) {
+	type modifiedResource struct{ New, Old testResource }
+	tests := []struct {
+		description              string
+		selectors                []ResourceMatcher
+		existingResources        []testResource
+		events                   []types.Event
+		expectedCreatedResources []testResource
+		expectedUpdatedResources []modifiedResource
+		expectedDeletedResources []testResource
+		configure                func(cfg *ResourceMonitorConfig[testResource])
+		resourceCompare          func(testResource, testResource) int
+	}{
+		{
+			description: "new matching resource should be registered",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			events:                   []types.Event{putEvent(makeDynamicResource("res1", nil))},
+			expectedCreatedResources: []testResource{makeDynamicResource("res1", nil)},
+		},
+		{
+			description: "new non-matching resource should not be registered",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
+			}},
+			events: []types.Event{putEvent(makeDynamicResource("res1", map[string]string{"env": "dev"}))},
+		},
+		{
+			description: "resources that equal don't overwrite each other",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			existingResources: []testResource{makeDynamicResource("res1", nil)},
+			events: []types.Event{
+				putEvent(makeDynamicResource("res1", nil, func(r *testResource) {
+					r.Metadata.Labels = map[string]string{"env": "dev"}
+				})),
+			},
+		},
+		{
+			description: "resources with different origins don't overwrite each other by default",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			existingResources: []testResource{makeStaticResource("res1", nil)},
+			events:            []types.Event{putEvent(makeDynamicResource("res1", nil))},
+		},
+		{
+			description: "resources with different origins overwrite each other when allowed",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			configure: func(cfg *ResourceMonitorConfig[testResource]) {
+				cfg.AllowOriginChanges = true
+			},
+			existingResources: []testResource{makeStaticResource("res1", nil)},
+			events:            []types.Event{putEvent(makeDynamicResource("res1", nil))},
+			expectedUpdatedResources: []modifiedResource{
+				{
+					Old: makeStaticResource("res1", nil),
+					New: makeDynamicResource("res1", nil),
+				},
+			},
+		},
+		{
+			description: "resource that's no longer present should be removed",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			existingResources:        []testResource{makeDynamicResource("res1", nil)},
+			events:                   []types.Event{deleteEvent(makeDynamicResource("res1", nil))},
+			expectedDeletedResources: []testResource{makeDynamicResource("res1", nil)},
+		},
+		{
+			description: "removing a resource that doesn't exist is not an error",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"foo": []string{"bar"}},
+			}},
+			// Note the label change below. This means the resource no longer matches and should be removed.
+			existingResources: []testResource{makeDynamicResource("res1", map[string]string{"foo": "bar"})},
+			events:            []types.Event{putEvent(makeDynamicResource("res1", map[string]string{"baz": "quux"}))},
+
+			// Simulate the resource having already expired from the backend.
+			configure: func(cfg *ResourceMonitorConfig[testResource]) {
+				originalDelete := cfg.DeleteResource
+				cfg.DeleteResource = func(ctx context.Context, tr testResource) error {
+					originalDelete(ctx, tr)
+					return trace.NotFound("resource does not exist")
+				}
+			},
+
+			expectedDeletedResources: []testResource{makeDynamicResource("res1", map[string]string{"foo": "bar"})},
+		},
+		{
+			description: "resource with updated matching labels should be updated",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"*": []string{"*"}},
+			}},
+			existingResources: []testResource{makeDynamicResource("res1", nil)},
+			events:            []types.Event{putEvent(makeDynamicResource("res1", map[string]string{"env": "dev"}))},
+			expectedUpdatedResources: []modifiedResource{
+				{
+					Old: makeDynamicResource("res1", nil),
+					New: makeDynamicResource("res1", map[string]string{"env": "dev"}),
+				},
+			},
+		},
+		{
+			description: "non-matching updated resource should be removed",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
+			}},
+			existingResources:        []testResource{makeDynamicResource("res1", map[string]string{"env": "prod"})},
+			events:                   []types.Event{putEvent(makeDynamicResource("res1", map[string]string{"env": "dev"}))},
+			expectedDeletedResources: []testResource{makeDynamicResource("res1", map[string]string{"env": "prod"})},
+		},
+		{
+			description: "complex scenario with multiple created/updated/deleted resources",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
+			}},
+			existingResources: []testResource{
+				makeStaticResource("res0", nil),
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+				makeDynamicResource("res2", map[string]string{"env": "prod"}),
+				makeDynamicResource("res3", map[string]string{"env": "prod"}),
+				makeDynamicResource("res4", map[string]string{"env": "prod"}),
+			},
+			events: []types.Event{
+				deleteEvent(makeDynamicResource("res1", nil)),
+				putEvent(makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"})),
+				putEvent(makeDynamicResource("res5", map[string]string{"env": "prod"})),
+				deleteEvent(makeDynamicResource("res4", nil)),
+			},
+			expectedCreatedResources: []testResource{
+				makeDynamicResource("res5", map[string]string{"env": "prod"}),
+			},
+			expectedUpdatedResources: []modifiedResource{
+				{
+					New: makeDynamicResource("res2", map[string]string{"env": "prod", "a": "b"}),
+					Old: makeDynamicResource("res2", map[string]string{"env": "prod"}),
+				},
+			},
+			expectedDeletedResources: []testResource{
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+				makeDynamicResource("res4", map[string]string{"env": "prod"}),
+			},
+		}, {
+			description: "custom comparison function",
+			selectors: []ResourceMatcher{{
+				Labels: types.Labels{"env": []string{"prod"}},
+			}},
+			existingResources: []testResource{
+				makeDynamicResource("res0", map[string]string{"env": "prod"}),
+				makeDynamicResource("res1", map[string]string{"env": "prod"}),
+				makeDynamicResource("res2", map[string]string{"env": "prod"}),
+				makeDynamicResource("res3", map[string]string{"env": "prod"}),
+				makeDynamicResource("res4", map[string]string{"env": "prod"}),
+			},
+			events: []types.Event{
+				putEvent(makeDynamicResource("res0", map[string]string{"env": "prod", "updated": "yes"})),
+				putEvent(makeDynamicResource("res1", map[string]string{"env": "prod", "updated": "no"})),
+				putEvent(makeDynamicResource("res2", map[string]string{"env": "prod", "updated": "no"})),
+				putEvent(makeDynamicResource("res3", map[string]string{"env": "prod", "updated": "yes"})),
+				putEvent(makeDynamicResource("res4", map[string]string{"env": "prod", "updated": "yes"})),
+			},
+			resourceCompare: func(a, b testResource) int {
+				updated, ok := a.Metadata.Labels["updated"]
+				if !ok {
+					updated, ok = b.Metadata.Labels["updated"]
+					if !ok {
+						panic(`neither resource has "updated" label`)
+					}
+				}
+
+				if updated == "yes" {
+					return Different
+				}
+				return Equal
+			},
+			expectedUpdatedResources: []modifiedResource{
+				{
+					New: makeDynamicResource("res0", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res0", map[string]string{"env": "prod"}),
+				}, {
+					New: makeDynamicResource("res3", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res3", map[string]string{"env": "prod"}),
+				}, {
+					New: makeDynamicResource("res4", map[string]string{"env": "prod", "updated": "yes"}),
+					Old: makeDynamicResource("res4", map[string]string{"env": "prod"}),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+
+			fakeEvents := &fakeEvents{
+				events: make(chan types.Event, 1),
+			}
+
+			fakeEvents.events <- types.Event{Type: types.OpInit}
+
+			// All events defined in the test case are sent first. Once they
+			// have all been processed a final OpUnreliable is sent to validate
+			// that all prior events have been consumed. This prevents any races
+			// with canceling the context when this function returns and processing
+			// the final test event.
+			go func() {
+				defer cancel()
+				for _, e := range test.events {
+					select {
+					case fakeEvents.events <- e:
+					case <-ctx.Done():
+					}
+				}
+
+				select {
+				case fakeEvents.events <- types.Event{Type: types.OpUnreliable}:
+				case <-ctx.Done():
+				}
+			}()
+
+			var created, deleted []testResource
+			var updated []modifiedResource
+			cfg := ResourceMonitorConfig[testResource]{
+				Kind:   "testResource",
+				Key:    testResource.GetName,
+				Events: fakeEvents,
+				ResourceHeaderKey: func(rh *types.ResourceHeader) string {
+					return rh.GetName()
+				},
+				Matches: func(tr testResource) bool {
+					return MatchResourceLabels(test.selectors, tr.GetMetadata().Labels)
+				},
+				CompareResources: func(tr1, tr2 testResource) int {
+					if test.resourceCompare == nil {
+						return CompareResources(tr1.Metadata, tr2.Metadata)
+					}
+
+					return test.resourceCompare(tr1, tr2)
+				},
+				DeleteResource: func(ctx context.Context, tr testResource) error {
+					deleted = append(deleted, tr)
+					return nil
+				},
+				CreateResource: func(ctx context.Context, tr testResource) error {
+					created = append(created, tr)
+					return nil
+				},
+				UpdateResource: func(ctx context.Context, new, old testResource) error {
+					updated = append(updated, modifiedResource{New: new, Old: old})
+					return nil
+				},
+				CurrentResources: func(ctx context.Context) iter.Seq2[testResource, error] {
+					return func(yield func(testResource, error) bool) {
+						for _, r := range test.existingResources {
+							if !yield(r, nil) {
+								return
+							}
+						}
+					}
+				},
+			}
+
+			if test.configure != nil {
+				test.configure(&cfg)
+			}
+
+			monitor, err := NewResourceMonitor(cfg)
+			require.NoError(t, err)
+
+			// Reconcile and make sure we got all expected callback calls.
+			monitor.Run(ctx)
+
+			require.Empty(t, cmp.Diff(test.expectedCreatedResources, created, protocmp.Transform()))
+			require.Empty(t, cmp.Diff(test.expectedUpdatedResources, updated, protocmp.Transform()))
+			require.Empty(t, cmp.Diff(test.expectedDeletedResources, deleted, protocmp.Transform()))
+		})
+	}
+}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -138,8 +138,6 @@ func (s *Suite) TearDown(t *testing.T) {
 type suiteConfig struct {
 	// ResourceMatchers are resource watcher matchers.
 	ResourceMatchers []services.ResourceMatcher
-	// OnReconcile sets app resource reconciliation callback.
-	OnReconcile func(types.Apps)
 	// Apps are the apps to configure.
 	Apps types.Apps
 	// ServerStreamer is the auth server session events streamer.
@@ -357,7 +355,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		lockWatcher.Close()
 	})
 
-	apps := types.Apps{s.appFoo.Copy(), s.appAWS.Copy(), s.appAWSWithIntegration.Copy()}
+	apps := []types.Application{s.appFoo.Copy(), s.appAWS.Copy(), s.appAWSWithIntegration.Copy()}
 	if len(config.Apps) > 0 {
 		apps = config.Apps
 	}
@@ -405,7 +403,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		Apps:                 apps,
 		OnHeartbeat:          func(err error) {},
 		ResourceMatchers:     config.ResourceMatchers,
-		OnReconcile:          config.OnReconcile,
 		CloudLabels:          config.CloudImporter,
 		ConnectionsHandler:   connectionsHandler,
 		InventoryHandle:      inventoryHandle,


### PR DESCRIPTION
Today, most reconciliation is done by creating a watcher that is managed in a goroutine. Any time a single resource changes, the entire new set of the resources and the old set of resources is analyzed by a reconciler running in another goroutine. This requires careful coordanation of the two objects and consumes excessive memory constantly making copies.

The new ResourceMonitor achieves the same behavior within a single object. It reduces the number of goroutines and the number of copies of a resource set from three down to one for the same use case.

To validate functionality and provide an example for how to leverage a ResourceMonitor the app.Server has been updated to replace its ResourceWatcher and Reconciler with a ResourceMonitor.