### PR TITLE
[v18] fix: Prevent TextEditor content update when non-readonly

### DIFF
--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -62,7 +62,9 @@ class TextEditor extends Component {
 
     // If the data changes, reset the value in each session so changes are
     // rendered.
-    if (prevProps.data !== this.props.data) {
+    // Only update the content if the editor is read-only to prevent
+    // interrupting the editing experience.
+    if (this.props.readOnly && prevProps.data !== this.props.data) {
       this.props.data.forEach((doc, i) => {
         this.sessions[i].setValue(doc.content);
       });


### PR DESCRIPTION
Backport #62484 to branch/v18

changelog: Fixed an issue preventing text editors in the Web UI from allowing edits
