### PR TITLE
Add `teleport debug readyz` command

### DIFF
--- a/tool/teleport/common/debug.go
+++ b/tool/teleport/common/debug.go
@@ -44,6 +44,8 @@ type DebugClient interface {
 	GetLogLevel(context.Context) (string, error)
 	// CollectProfile collects a pprof profile.
 	CollectProfile(context.Context, string, int) ([]byte, error)
+	// GetReadiness checks if the instance is ready to serve requests.
+	GetReadiness(context.Context) (debugclient.Readiness, error)
 	SocketPath() string
 }
 
@@ -164,6 +166,34 @@ func collectProfiles(ctx context.Context, clt DebugClient, buf io.Writer, rawPro
 	}
 
 	return trace.NewAggregate(tw.Close(), gw.Close())
+}
+
+// onReadyz checks if the instance is ready to serve requests.
+func onReadyz(ctx context.Context, configPath string) error {
+	clt, dataDir, err := newDebugClient(configPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := readyz(ctx, clt); err != nil {
+		return convertToReadableErr(err, dataDir, clt.SocketPath())
+	}
+
+	return nil
+}
+
+func readyz(ctx context.Context, clt DebugClient) error {
+	readiness, err := clt.GetReadiness(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if !readiness.Ready {
+		return trace.Errorf("not ready (PID:%d): %s", readiness.PID, readiness.Status)
+	}
+
+	fmt.Printf("ready (PID:%d)\n", readiness.PID)
+	return nil
 }
 
 // newDebugClient initializes the debug client based on the Teleport

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -617,6 +617,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	collectProfilesCmd.Alias(collectProfileUsageExamples) // We're using "alias" section to display usage examples.
 	collectProfilesCmd.Arg("PROFILES", fmt.Sprintf("Comma-separated profile names to be exported. Supported profiles: %s. Default: %s", strings.Join(slices.Collect(maps.Keys(debugclient.SupportedProfiles)), ","), strings.Join(defaultCollectProfiles, ","))).StringVar(&ccf.Profiles)
 	collectProfilesCmd.Flag("seconds", "For CPU and trace profiles, profile for the given duration (if set to 0, it returns a profile snapshot). For other profiles, return a delta profile. Default: 0").Short('s').Default("0").IntVar(&ccf.ProfileSeconds)
+	readyzCmd := debugCmd.Command("readyz", "Checks if the instance is ready to serve requests.")
 
 	selinuxCmd := app.Command("selinux-ssh", "Commands related to SSH SELinux module.").Hidden()
 	selinuxCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
@@ -810,6 +811,8 @@ Examples:
 		err = onGetLogLevel(ccf.ConfigFile)
 	case collectProfilesCmd.FullCommand():
 		err = onCollectProfiles(ccf.ConfigFile, ccf.Profiles, ccf.ProfileSeconds)
+	case readyzCmd.FullCommand():
+		err = onReadyz(ctx, ccf.ConfigFile)
 	case moduleSourceCmd.FullCommand():
 		if runtime.GOOS != "linux" {
 			break


### PR DESCRIPTION
## Purpose

Adds a command to the `teleport` cli to query the `/readyz` endpoint to accommodate restricted environments, e.g. `curl` unavailable.

resolves #62176 

## Notes

Exits with code 0 and prints to stdout on success
Exits with non-zero code and prints readyz status or associated error to stderr on failure

## Manual Testing

The below snippets will work for a quick validation of both good and bad cases. There seemed to be little benefit to automated tests, as the logic is very simple and we'd be mocking the service side.

Sample testing output can be found here: https://github.com/gravitational/teleport/pull/62491#issuecomment-3697631963

1. Start `teleport` and run the new `teleport debug readyz` command before it's ready.
```bash
# hacky, but should hit before the service is ready
./build/teleport start &
teleport_pid=$!
sleep 0.5
./build/teleport debug readyz
```

2. Wait a few seconds for the service to be ready and then run again to see the "success" case.
```bash
./build/teleport debug readyz
```

3. Cleanup the `teleport` process.
```bash
kill $teleport_pid
```

changelog: Added `teleport debug readyz` command