### PR TITLE
Clean up tctl comands for joining agents

### DIFF
--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -138,7 +138,7 @@ Fill out and run this command on a node to make the application available:
 > teleport app start \
    --token={{.token}} \{{range .ca_pins}}
    --ca-pin={{.}} \{{end}}
-   --auth-server={{.proy_server}} \
+   --auth-server={{.proxy_server}} \
    --name={{printf "%-30v" .app_name}} ` + "`" + `# Change "{{.app_name}}" to the name of your application.` + "`" + ` \
    --uri={{printf "%-31v" .app_uri}} ` + "`" + `# Change "{{.app_uri}}" to the address of your application.` + "`" + `
 

--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -138,7 +138,7 @@ Fill out and run this command on a node to make the application available:
 > teleport app start \
    --token={{.token}} \{{range .ca_pins}}
    --ca-pin={{.}} \{{end}}
-   --auth-server={{.auth_server}} \
+   --auth-server={{.proy_server}} \
    --name={{printf "%-30v" .app_name}} ` + "`" + `# Change "{{.app_name}}" to the name of your application.` + "`" + ` \
    --uri={{printf "%-31v" .app_uri}} ` + "`" + `# Change "{{.app_uri}}" to the address of your application.` + "`" + `
 
@@ -147,7 +147,7 @@ Your application will be available at {{.app_public_addr}}.
 Please note:
 
   - This invitation token will expire in {{.minutes}} minutes.
-  - {{.auth_server}} must be reachable from the new application service.
+  - {{.proxy_server}} must be reachable from the new application service.
   - Update DNS to point {{.app_public_addr}} to the Teleport proxy.
   - Add a TLS certificate for {{.app_public_addr}} to the Teleport proxy under "https_keypairs".
 `))

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -130,7 +130,7 @@ Generate the configuration and start a Teleport agent using it:
 > teleport db configure create \
    --token={{.token}} \{{range .ca_pins}}
    --ca-pin={{.}} \{{end}}
-   --proxy={{.auth_server}} \
+   --proxy={{.proxy_server}} \
    --name={{.db_name}} \
    --protocol={{.db_protocol}} \
    --uri={{.db_uri}} \

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -134,7 +134,7 @@ helm repo update
 > helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=cluster ` + "`" + `# Change kubeClusterName variable to your preferred name.` + "`" + ` \
   --set roles="{{.set_roles}}" \
-  --set proxyAddr={{.auth_server}} \
+  --set proxyAddr={{.proxy_server}} \
   --set authToken={{.token}} \
   --set updater.enabled=true \
   --create-namespace \
@@ -144,7 +144,7 @@ helm repo update
 Please note:
 
   - This invitation token will expire in {{.minutes}} minutes.
-  - {{.auth_server}} must be reachable from Kubernetes cluster.
+  - {{.proxy_server}} must be reachable from Kubernetes cluster.
   - The token is usable in a standalone Linux server with kubernetes_service.
   - See https://goteleport.com/docs/kubernetes-access/ for detailed installation information.
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 	"text/template"
@@ -205,32 +204,12 @@ func (c *NodeCommand) Invite(ctx context.Context, client *authclient.Client) err
 		if roles.Include(types.RoleTrustedCluster) {
 			fmt.Printf(trustedClusterMessage, token, int(c.ttl.Minutes()))
 		} else {
-			authServer := authServers[0].GetAddr()
-
-			pingResponse, err := client.Ping(ctx)
-			if err != nil {
-				slog.DebugContext(ctx, "unable to ping auth client", "error", err)
-			}
-
-			if err == nil && pingResponse.GetServerFeatures().Cloud {
-				proxies, err := clientutils.CollectWithFallback(ctx, client.ListProxyServers, func(context.Context) ([]types.Server, error) {
-					//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-					return client.GetProxies()
-				})
-				if err != nil {
-					return trace.Wrap(err)
-				}
-
-				if len(proxies) != 0 {
-					authServer = proxies[0].GetPublicAddr()
-				}
-			}
 			return nodeMessageTemplate.Execute(os.Stdout, map[string]any{
 				"token":       token,
 				"minutes":     int(c.ttl.Minutes()),
 				"roles":       strings.ToLower(roles.String()),
 				"ca_pins":     caPins,
-				"auth_server": authServer,
+				"auth_server": controlPlaneAddr(ctx, client, authServers[0].GetAddr()),
 			})
 		}
 	} else {

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"os/exec"
 	"slices"
@@ -275,6 +274,17 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 		return trace.Wrap(err, "creating token")
 	}
 
+	// Calculate the CA pins for this cluster. The CA pins are used by the
+	// client to verify the identity of the Auth Server.
+	localCAResponse, err := client.GetClusterCACert(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	caPins, err := tlsca.CalculatePins(localCAResponse.TLSCA)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Print token information formatted with JSON, YAML, or just print the raw token.
 	switch c.format {
 	case teleport.JSON, teleport.YAML:
@@ -283,6 +293,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 			"token":   token,
 			"roles":   roles,
 			"expires": expires,
+			"ca_pins": caPins,
 		}
 
 		var (
@@ -316,6 +327,7 @@ func (c *TokensCommand) Add(ctx context.Context, client *authclient.Client) erro
 		dbName:     c.dbName,
 		dbURI:      c.dbURI,
 		dbProtocol: c.dbProtocol,
+		caPins:     caPins,
 	}))
 }
 
@@ -901,20 +913,10 @@ type joinInstructionsInput struct {
 	dbName     string
 	dbURI      string
 	dbProtocol string
+	caPins     []string
 }
 
 func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
-	// Calculate the CA pins for this cluster. The CA pins are used by the
-	// client to verify the identity of the Auth Server.
-	localCAResponse, err := in.client.GetClusterCACert(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	caPins, err := tlsca.CalculatePins(localCAResponse.TLSCA)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Get list of auth servers. Used to print friendly signup message.
 	authServers, err := clientutils.CollectWithFallback(
 		ctx,
@@ -945,11 +947,11 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 		setRoles := strings.ToLower(strings.Join(in.roles.StringSlice(), "\\,"))
 		return kubeMessageTemplate.Execute(in.out,
 			map[string]any{
-				"auth_server": proxies[0].GetPublicAddr(),
-				"token":       in.tokenName,
-				"minutes":     in.ttl.Minutes(),
-				"set_roles":   setRoles,
-				"version":     proxies[0].GetTeleportVersion(),
+				"proxy_server": proxies[0].GetPublicAddr(),
+				"token":        in.tokenName,
+				"minutes":      in.ttl.Minutes(),
+				"set_roles":    setRoles,
+				"version":      proxies[0].GetTeleportVersion(),
 			})
 	case in.roles.Include(types.RoleApp):
 		proxies, err := clientutils.CollectWithFallback(ctx, in.client.ListProxyServers, func(context.Context) ([]types.Server, error) {
@@ -968,8 +970,8 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 			map[string]any{
 				"token":           in.tokenName,
 				"minutes":         in.ttl.Minutes(),
-				"ca_pins":         caPins,
-				"auth_server":     proxies[0].GetPublicAddr(),
+				"ca_pins":         in.caPins,
+				"proxy_server":    proxies[0].GetPublicAddr(),
 				"app_name":        in.appName,
 				"app_uri":         in.appURI,
 				"app_public_addr": appPublicAddr,
@@ -987,13 +989,13 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 		}
 		return dbMessageTemplate.Execute(in.out,
 			map[string]any{
-				"token":       in.tokenName,
-				"minutes":     in.ttl.Minutes(),
-				"ca_pins":     caPins,
-				"auth_server": proxies[0].GetPublicAddr(),
-				"db_name":     in.dbName,
-				"db_protocol": in.dbProtocol,
-				"db_uri":      in.dbURI,
+				"token":        in.tokenName,
+				"minutes":      in.ttl.Minutes(),
+				"ca_pins":      in.caPins,
+				"proxy_server": proxies[0].GetPublicAddr(),
+				"db_name":      in.dbName,
+				"db_protocol":  in.dbProtocol,
+				"db_uri":       in.dbURI,
 			})
 	case in.roles.Include(types.RoleTrustedCluster):
 		fmt.Fprintf(in.out, trustedClusterMessage,
@@ -1009,38 +1011,31 @@ func showJoinInstructions(ctx context.Context, in joinInstructionsInput) error {
 		return mdmTokenAddTemplate.Execute(in.out, map[string]any{
 			"token":   in.tokenName,
 			"minutes": in.ttl.Minutes(),
-			"ca_pins": caPins,
+			"ca_pins": in.caPins,
 		})
 	default:
-		authServer := authServers[0].GetAddr()
-
-		pingResponse, err := in.client.Ping(ctx)
-		if err != nil {
-			slog.DebugContext(ctx, "unable to ping auth client", "error", err)
-		}
-
-		if err == nil && pingResponse.GetServerFeatures().Cloud {
-			proxies, err := clientutils.CollectWithFallback(ctx, in.client.ListProxyServers, func(context.Context) ([]types.Server, error) {
-				//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
-				return in.client.GetProxies()
-			})
-			if err != nil {
-				return trace.Wrap(err)
-			}
-
-			if len(proxies) != 0 {
-				authServer = proxies[0].GetPublicAddr()
-			}
-		}
-
 		return nodeMessageTemplate.Execute(in.out, map[string]any{
 			"token":       in.tokenName,
 			"roles":       strings.ToLower(in.roles.String()),
 			"minutes":     int(in.ttl.Minutes()),
-			"ca_pins":     caPins,
-			"auth_server": authServer,
+			"ca_pins":     in.caPins,
+			"auth_server": controlPlaneAddr(ctx, in.client, authServers[0].GetAddr()),
 		})
 	}
 
 	return nil
+}
+
+// controlPlaneAddr gets the address of the cluster control plane for
+// agent joining, preferring the proxy public address.
+func controlPlaneAddr(ctx context.Context, client *authclient.Client, authAddr string) string {
+	proxies, err := clientutils.CollectWithFallback(ctx, client.ListProxyServers, func(context.Context) ([]types.Server, error) {
+		//nolint:staticcheck // TODO(kiosion) DELETE IN 21.0.0
+		return client.GetProxies()
+	})
+	if err == nil && len(proxies) > 0 {
+		return proxies[0].GetPublicAddr()
+	}
+
+	return authAddr
 }


### PR DESCRIPTION
- Rename template var from auth_server to proxy_server in cases where we know we're always passing a proxy address.
- Include CA pins when --format flag specifies json or yaml format
- Prefer the proxy address in the joining instructions we print. Previously, we would prefer the auth server but would suggest the proxy server when we knew we were targeting a cloud cluster.

Closes #11458

Changelog: the `tctl tokens add` command now includes the CA pins in JSON and YAML output.