### PR TITLE
Azure VM discovery: stats, refactor, add test coverage

### DIFF
--- a/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
+++ b/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
@@ -346,7 +346,9 @@ type IntegrationDiscoveredSummary struct {
 	// AWSRDS contains the summary for the AWS RDS discovered databases.
 	AwsRds *ResourcesDiscoveredSummary `protobuf:"bytes,2,opt,name=aws_rds,json=awsRds,proto3" json:"aws_rds,omitempty"`
 	// AWSEKS contains the summary for the AWS EKS discovered clusters.
-	AwsEks        *ResourcesDiscoveredSummary `protobuf:"bytes,3,opt,name=aws_eks,json=awsEks,proto3" json:"aws_eks,omitempty"`
+	AwsEks *ResourcesDiscoveredSummary `protobuf:"bytes,3,opt,name=aws_eks,json=awsEks,proto3" json:"aws_eks,omitempty"`
+	// The summary for the Azure VM discovered instances.
+	AzureVms      *ResourcesDiscoveredSummary `protobuf:"bytes,4,opt,name=azure_vms,json=azureVms,proto3" json:"azure_vms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -398,6 +400,13 @@ func (x *IntegrationDiscoveredSummary) GetAwsRds() *ResourcesDiscoveredSummary {
 func (x *IntegrationDiscoveredSummary) GetAwsEks() *ResourcesDiscoveredSummary {
 	if x != nil {
 		return x.AwsEks
+	}
+	return nil
+}
+
+func (x *IntegrationDiscoveredSummary) GetAzureVms() *ResourcesDiscoveredSummary {
+	if x != nil {
+		return x.AzureVms
 	}
 	return nil
 }
@@ -492,11 +501,12 @@ const file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc = "" +
 	"#IntegrationDiscoveredResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
 	"\x05value\x18\x02 \x01(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\x05value:\x028\x01B\x10\n" +
-	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"\x94\x02\n" +
+	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"\xea\x02\n" +
 	"\x1cIntegrationDiscoveredSummary\x12P\n" +
 	"\aaws_ec2\x18\x01 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEc2\x12P\n" +
 	"\aaws_rds\x18\x02 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsRds\x12P\n" +
-	"\aaws_eks\x18\x03 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEks\"f\n" +
+	"\aaws_eks\x18\x03 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEks\x12T\n" +
+	"\tazure_vms\x18\x04 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\bazureVms\"f\n" +
 	"\x1aResourcesDiscoveredSummary\x12\x14\n" +
 	"\x05found\x18\x01 \x01(\x04R\x05found\x12\x1a\n" +
 	"\benrolled\x18\x02 \x01(\x04R\benrolled\x12\x16\n" +
@@ -552,12 +562,13 @@ var file_teleport_discoveryconfig_v1_discoveryconfig_proto_depIdxs = []int32{
 	5,  // 11: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
 	5,  // 12: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
 	5,  // 13: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	4,  // 14: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	5,  // 14: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	4,  // 15: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	16, // [16:16] is the sub-list for method output_type
+	16, // [16:16] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_teleport_discoveryconfig_v1_discoveryconfig_proto_init() }

--- a/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
+++ b/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
@@ -97,6 +97,9 @@ message IntegrationDiscoveredSummary {
 
   // AWSEKS contains the summary for the AWS EKS discovered clusters.
   ResourcesDiscoveredSummary aws_eks = 3;
+
+  // The summary for the Azure VM discovered instances.
+  ResourcesDiscoveredSummary azure_vms = 4;
 }
 
 // ResourcesDiscoveredSummary represents the AWS resources that were discovered.

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
@@ -39,7 +40,7 @@ const virtualScaleSetUniformVMResourceType = "virtualMachineScaleSets/virtualMac
 type armCompute interface {
 	// Get retrieves information about an Azure virtual machine.
 	Get(ctx context.Context, resourceGroupName string, vmName string, options *armcompute.VirtualMachinesClientGetOptions) (armcompute.VirtualMachinesClientGetResponse, error)
-	// NewListPagers lists Azure virtual Machines.
+	// NewListPager lists Azure virtual Machines.
 	NewListPager(resourceGroup string, opts *armcompute.VirtualMachinesClientListOptions) *runtime.Pager[armcompute.VirtualMachinesClientListResponse]
 	// NewListAllPager lists Azure virtual machines in any resource group.
 	NewListAllPager(opts *armcompute.VirtualMachinesClientListAllOptions) *runtime.Pager[armcompute.VirtualMachinesClientListAllResponse]
@@ -78,7 +79,7 @@ type VirtualMachine struct {
 	Identities []Identity
 }
 
-// Identitiy represents an Azure virtual machine identity.
+// Identity represents an Azure virtual machine identity.
 type Identity struct {
 	// ResourceID the identity resource ID.
 	ResourceID string
@@ -314,7 +315,10 @@ func NewRunCommandClient(subscription string, cred azcore.TokenCredential, optio
 
 // Run runs a command on a virtual machine.
 func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) error {
-	poller, err := c.api.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.VMName, "RunShellScript", armcompute.VirtualMachineRunCommand{
+	// TODO(Tener): make the run command name actual parameter.
+	const runCommandName = "teleport-install"
+
+	poller, err := c.api.BeginCreateOrUpdate(ctx, req.ResourceGroup, req.VMName, runCommandName, armcompute.VirtualMachineRunCommand{
 		Location: to.Ptr(req.Region),
 		Properties: &armcompute.VirtualMachineRunCommandProperties{
 			AsyncExecution: to.Ptr(false),
@@ -327,6 +331,36 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) error
 		return trace.Wrap(err)
 	}
 
-	_, err = poller.PollUntilDone(ctx, nil /* options */)
-	return trace.Wrap(err)
+	_, err = poller.PollUntilDone(ctx, &runtime.PollUntilDoneOptions{Frequency: 10 * time.Second})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// note: we are not guaranteed to receive the output of the command above if the req.Name is not unique.
+	resp, err := c.api.GetByVirtualMachine(ctx, req.ResourceGroup, req.VMName, runCommandName, &armcompute.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{
+		Expand: to.Ptr("instanceView"),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if resp.Properties != nil && resp.Properties.InstanceView != nil {
+		iv := resp.Properties.InstanceView
+		execState := fromPtr(iv.ExecutionState)
+		if execState != armcompute.ExecutionStateSucceeded {
+			return trace.BadParameter("execution failed; exec state: %v, output: %v, stderr: %v, exit code: %v", execState, fromPtr(iv.Output), fromPtr(iv.Error), fromPtr(iv.ExitCode))
+		}
+	} else {
+		return trace.BadParameter("unable to query command execution state, failure assumed")
+	}
+
+	return nil
+}
+
+func fromPtr[T any](ptr *T) T {
+	var out T
+	if ptr != nil {
+		out = *ptr
+	}
+	return out
 }

--- a/lib/cloud/azure/vm.go
+++ b/lib/cloud/azure/vm.go
@@ -344,16 +344,14 @@ func (c *runCommandClient) Run(ctx context.Context, req RunCommandRequest) error
 		return trace.Wrap(err)
 	}
 
-	if resp.Properties != nil && resp.Properties.InstanceView != nil {
-		iv := resp.Properties.InstanceView
-		execState := fromPtr(iv.ExecutionState)
-		if execState != armcompute.ExecutionStateSucceeded {
-			return trace.BadParameter("execution failed; exec state: %v, output: %v, stderr: %v, exit code: %v", execState, fromPtr(iv.Output), fromPtr(iv.Error), fromPtr(iv.ExitCode))
-		}
-	} else {
+	if resp.Properties == nil || resp.Properties.InstanceView == nil {
 		return trace.BadParameter("unable to query command execution state, failure assumed")
 	}
-
+	iv := resp.Properties.InstanceView
+	execState := fromPtr(iv.ExecutionState)
+	if execState != armcompute.ExecutionStateSucceeded {
+		return trace.BadParameter("execution failed; exec state: %v, output: %v, stderr: %v, exit code: %v", execState, fromPtr(iv.Output), fromPtr(iv.Error), fromPtr(iv.ExitCode))
+	}
 	return nil
 }
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -27,6 +27,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
@@ -104,12 +105,6 @@ func (m Matchers) IsEmpty() bool {
 // ssmInstaller handles running SSM commands that install Teleport on EC2 instances.
 type ssmInstaller interface {
 	Run(ctx context.Context, req server.SSMRunRequest) error
-}
-
-// azureInstaller handles running commands that install Teleport on Azure
-// virtual machines.
-type azureInstaller interface {
-	Run(ctx context.Context, req server.AzureRunRequest) error
 }
 
 // gcpInstaller handles running commands that install Teleport on GCP
@@ -402,11 +397,6 @@ type Server struct {
 	ec2Watcher *server.Watcher[*server.EC2Instances]
 	// ec2Installer is used to start the installation process on discovered EC2 nodes
 	ec2Installer ssmInstaller
-	// azureWatcher periodically retrieves Azure virtual machines.
-	azureWatcher *server.Watcher[*server.AzureInstances]
-	// azureInstaller is used to start the installation process on discovered Azure
-	// virtual machines.
-	azureInstaller azureInstaller
 	// gcpWatcher periodically retrieves GCP virtual machines.
 	gcpWatcher *server.Watcher[*server.GCPInstances]
 	// gcpInstaller is used to start the installation process on discovered GCP
@@ -456,6 +446,7 @@ type Server struct {
 	awsEC2Tasks           awsEC2Tasks
 	awsEKSTasks           awsEKSTasks
 	awsRDSTasks           awsRDSTasks
+	azureVMStatus         atomic.Pointer[resourceStatusMap]
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -506,7 +497,7 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.initAzureWatchers(s.ctx, cfg.Matchers.Azure, noDiscoveryConfig); err != nil {
+	if err := s.initAzureWatchers(s.ctx, cfg.Matchers.Azure); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -514,10 +505,8 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if s.ec2Watcher != nil || s.azureWatcher != nil || s.gcpWatcher != nil {
-		if err := s.initTeleportNodeWatcher(); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	if err := s.initTeleportNodeWatcher(); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	if err := s.initKubeAppWatchers(cfg.Matchers.Kubernetes); err != nil {
@@ -867,32 +856,11 @@ func (s *Server) getAzureClients(ctx context.Context, integration string) (azure
 }
 
 // initAzureWatchers starts Azure resource watchers based on types provided.
-func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMatcher, discoveryConfigName string) error {
-	vmMatchers, otherMatchers := splitMatchers(matchers, func(matcherType string) bool {
+func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMatcher) error {
+	// Filter out VM matchers
+	_, otherMatchers := splitMatchers(matchers, func(matcherType string) bool {
 		return matcherType == types.AzureMatcherVM
 	})
-
-	// VM watcher.
-	s.azureWatcher = server.NewWatcher[*server.AzureInstances](
-		s.ctx,
-		server.WithPreFetchHookFn[*server.AzureInstances](func(fetchers []server.Fetcher[*server.AzureInstances]) {
-			if len(fetchers) > 0 {
-				s.submitFetchEvent(types.CloudAzure, types.AzureMatcherVM)
-			}
-		}),
-		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
-		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),
-		server.WithClock[*server.AzureInstances](s.clock),
-	)
-
-	staticFetchers := server.MatchersToAzureInstanceFetchers(s.Log, vmMatchers, s.getAzureClients, discoveryConfigName)
-	s.azureWatcher.SetFetchers(noDiscoveryConfig, staticFetchers)
-
-	if s.azureInstaller == nil {
-		s.azureInstaller = &server.AzureInstaller{
-			Emitter: s.Emitter,
-		}
-	}
 
 	// Database fetchers were added in databaseFetchersFromMatchers.
 	_, otherMatchers = splitMatchers(otherMatchers, db.IsAzureMatcherType)
@@ -922,7 +890,7 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMa
 						FilterLabels:        matcher.ResourceTags,
 						ResourceGroups:      matcher.ResourceGroups,
 						Logger:              s.Log,
-						DiscoveryConfigName: discoveryConfigName,
+						DiscoveryConfigName: noDiscoveryConfig,
 						Integration:         matcher.Integration,
 					})
 					if err != nil {
@@ -1067,20 +1035,28 @@ func genGCPInstancesLogStr(instances []*gcpimds.Instance) string {
 	})
 }
 
+// genInstancesLogStr builds a bracketed, comma-separated log string of instance identifiers.
+// It displays up to 10 IDs; if more exist, it appends a count of omitted entries.
 func genInstancesLogStr[T any](instances []T, getID func(T) string) string {
-	var logInstances strings.Builder
-	for idx, inst := range instances {
-		if idx == 10 || idx == (len(instances)-1) {
-			logInstances.WriteString(getID(inst))
-			break
-		}
-		logInstances.WriteString(getID(inst) + ", ")
-	}
-	if len(instances) > 10 {
-		logInstances.WriteString(fmt.Sprintf("... + %d instance IDs truncated", len(instances)-10))
+	const maxInstances = 10
+
+	n := len(instances)
+	if n == 0 {
+		return "[]"
 	}
 
-	return fmt.Sprintf("[%s]", logInstances.String())
+	limit := min(n, maxInstances)
+	ids := make([]string, limit)
+	for i := range limit {
+		ids[i] = getID(instances[i])
+	}
+
+	result := strings.Join(ids, ", ")
+	if n > maxInstances {
+		result += fmt.Sprintf("... + %d instance IDs truncated", n-maxInstances)
+	}
+
+	return "[" + result + "]"
 }
 
 func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
@@ -1384,99 +1360,197 @@ func (s *Server) handleEC2Discovery() {
 	}
 }
 
-func (s *Server) filterExistingAzureNodes(instances *server.AzureInstances) error {
-	nodes, err := s.nodeWatcher.CurrentResourcesWithFilter(s.ctx, func(n readonly.Server) bool {
-		labels := n.GetAllLabels()
-		_, subscriptionOK := labels[types.SubscriptionIDLabel]
-		_, vmOK := labels[types.VMIDLabel]
-		return subscriptionOK && vmOK
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	var filtered []*armcompute.VirtualMachine
-outer:
-	for _, inst := range instances.Instances {
-		for _, node := range nodes {
-			var vmID string
-			if inst.Properties != nil {
-				vmID = aws.ToString(inst.Properties.VMID)
-			}
-			match := types.MatchLabels(node, map[string]string{
-				types.SubscriptionIDLabel: instances.SubscriptionID,
-				types.VMIDLabel:           vmID,
-			})
-			if match {
-				continue outer
-			}
-		}
-		filtered = append(filtered, inst)
-	}
-	instances.Instances = filtered
-	return nil
-}
-
-func (s *Server) handleAzureInstances(instances *server.AzureInstances) error {
+func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.AzureInstances) (int, error) {
 	azureClients, err := s.getAzureClients(s.ctx, instances.Integration)
 	if err != nil {
-		return trace.Wrap(err)
+		return 0, trace.Wrap(err)
 	}
 
 	runClient, err := azureClients.GetRunCommandClient(s.ctx, instances.SubscriptionID)
 	if err != nil {
-		return trace.Wrap(err)
+		return 0, trace.Wrap(err)
 	}
 
-	err = s.filterExistingAzureNodes(instances)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if len(instances.Instances) == 0 {
-		return trace.Wrap(errNoInstances)
-	}
-
-	s.Log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "subscription_id", instances.SubscriptionID, "vms", genAzureInstancesLogStr(instances.Instances))
-	req := server.AzureRunRequest{
-		Client:          runClient,
+	req := server.AzureInstallRequest{
 		Instances:       instances.Instances,
 		Region:          instances.Region,
 		ResourceGroup:   instances.ResourceGroup,
 		InstallerParams: instances.InstallerParams,
 		ProxyAddrGetter: s.publicProxyAddress,
 	}
-	if err := s.azureInstaller.Run(s.ctx, req); err != nil {
-		return trace.Wrap(err)
+
+	result, err := req.Run(s.ctx, runClient)
+	if err != nil {
+		return 0, trace.Wrap(err)
 	}
-	if err := s.emitUsageEvents(instances.MakeEvents()); err != nil {
-		s.Log.DebugContext(s.ctx, "Error emitting usage event", "error", err)
+
+	const maxReportedErrors = 10
+
+	if omitted := len(result.Failures) - maxReportedErrors; omitted > 0 {
+		log.WarnContext(s.ctx, "Too many install failures; reporting only a subset",
+			"reported", maxReportedErrors,
+			"total", len(result.Failures),
+			"omitted", omitted,
+		)
 	}
-	return nil
+
+	reported := 0
+	for vmID, installErr := range result.Failures {
+		if reported >= maxReportedErrors {
+			break
+		}
+		log.WarnContext(s.ctx, "Failed to install on VM",
+			"vm_id", vmID,
+			"install_error", installErr,
+		)
+		reported++
+	}
+
+	err = s.emitUsageEvents(instances.MakeEvents(result))
+	if err != nil {
+		log.WarnContext(s.ctx, "Error emitting usage event", "error", err)
+	}
+	return len(result.Failures), nil
 }
 
-func (s *Server) handleAzureDiscovery() {
+// startAzureServerDiscovery starts the Azure VM discovery.
+// It needs to be run asynchronously as it waits on node watcher initialization before proceeding.
+func (s *Server) startAzureServerDiscovery() {
 	if err := s.nodeWatcher.WaitInitialization(); err != nil {
 		s.Log.ErrorContext(s.ctx, "Failed to initialize nodeWatcher", "error", err)
 		return
 	}
 
-	go s.azureWatcher.Run()
-	for {
-		select {
-		case instances := <-s.azureWatcher.InstancesC:
-			s.Log.DebugContext(s.ctx, "Azure instances discovered, starting installation", "subscription_id", instances.SubscriptionID, "instances", genAzureInstancesLogStr(instances.Instances))
-			if err := s.handleAzureInstances(instances); err != nil {
-				if errors.Is(err, errNoInstances) {
-					s.Log.DebugContext(s.ctx, "All discovered Azure VMs are already part of the cluster")
-				} else {
-					s.Log.ErrorContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err)
-				}
-			}
-		case <-s.ctx.Done():
-			s.azureWatcher.Stop()
-			return
+	var azureWatcher *server.Watcher[*server.AzureInstances]
+
+	// a full refresh is somewhat wasteful, however not overly so due to inexpensive operations involved.
+	// a more selective approach would necessitate deeper refactoring.
+	fullRefresh := func() {
+		// static fetchers.
+		staticFetchers := s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
+		replaceMap := make(map[string][]server.Fetcher[*server.AzureInstances])
+		replaceMap[noDiscoveryConfig] = staticFetchers
+
+		s.dynamicDiscoveryConfigMu.RLock()
+		for _, config := range s.dynamicDiscoveryConfig {
+			replaceMap[config.GetName()] = s.azureServerFetchersFromMatchers(config.Spec.Azure, config.GetName())
 		}
+		s.dynamicDiscoveryConfigMu.RUnlock()
+		azureWatcher.ReplaceFetchers(replaceMap)
 	}
+
+	var sm *resourceStatusMap
+
+	azureWatcher = server.NewWatcher(
+		s.ctx,
+		server.WithPreFetchHookFn(func(fetchers []server.Fetcher[*server.AzureInstances]) {
+			if len(fetchers) > 0 {
+				s.submitFetchEvent(types.CloudAzure, types.AzureMatcherVM)
+			}
+			sm = newStatusMap(types.AzureMatcherVM)
+
+			// Initialize the status map with an entry per fetcher (discoveryConfig + integration).
+			// The per-instance hook only receives the slice of instance groups; when a fetcher
+			// returns zero groups, the hook has nothing to iterate and cannot introduce the key
+			// into sm.results. Creating the key here ensures we still write an explicit
+			// "0 found/enrolled/failed" update instead of leaving stale non-zero status from a
+			// previous iteration.
+			for _, fetcher := range fetchers {
+				fgKey := fetcherGroupKey{
+					discoveryConfigName: fetcher.GetDiscoveryConfigName(),
+					integration:         fetcher.IntegrationName(),
+				}
+				sm.add(fgKey, make(map[statusType]int))
+			}
+		}),
+		server.WithPerInstanceHookFn(func(instanceGroups []*server.AzureInstances) {
+			s.Log.DebugContext(s.ctx, "Processing instances", "groups", len(instanceGroups))
+			for _, group := range instanceGroups {
+				fgKey := fetcherGroupKey{
+					discoveryConfigName: group.DiscoveryConfigName,
+					integration:         group.Integration,
+				}
+				s.Log.DebugContext(s.ctx, "Processing instance group", "group", fgKey, "instances", len(group.Instances))
+				results := s.installAzureServers(group)
+				sm.add(fgKey, results)
+			}
+		}),
+		server.WithPostFetchHookFn[*server.AzureInstances](func() {
+			// update statuses of relevant discovery configs.
+			s.azureVMStatus.Store(sm)
+			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
+		}),
+		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
+		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),
+		server.WithTriggerFetchHookFn[*server.AzureInstances](fullRefresh),
+		server.WithClock[*server.AzureInstances](s.clock),
+	)
+
+	// refresh dynamic fetchers once at the beginning.
+	fullRefresh()
+
+	s.Log.DebugContext(s.ctx, "Azure VM watcher starting.")
+	go azureWatcher.Run()
+}
+
+func (s *Server) installAzureServers(instances *server.AzureInstances) (results map[statusType]int) {
+	results = make(map[statusType]int)
+
+	log := s.Log.With(
+		"discovery_config", instances.DiscoveryConfigName,
+		"integration", instances.Integration,
+		"subscription_id", instances.SubscriptionID,
+		"region", instances.Region,
+		"resource_group", instances.ResourceGroup,
+	)
+
+	allFound := len(instances.Instances)
+	results[found] = allFound
+
+	if allFound == 0 {
+		log.DebugContext(s.ctx, "No Azure instances found, skipping installation")
+		return
+	}
+
+	nodes, err := s.nodeWatcher.CurrentResources(s.ctx)
+	if err != nil {
+		log.WarnContext(s.ctx, "Failed to get current node resources", "error", err)
+		return
+	}
+	instances.FilterExistingNodes(nodes)
+
+	// count machines that have already been enrolled in previous cycles.
+	needInstall := len(instances.Instances)
+	results[enrolled] = allFound - needInstall
+
+	if len(instances.Instances) == 0 {
+		log.DebugContext(s.ctx, "No Azure instances remain to enroll, skipping installation")
+		return
+	}
+
+	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
+	failedCount, err := s.enrollAzureVirtualMachines(log, instances)
+	if err != nil {
+		// we don't expect err to be non-nil for individual enrollment failures.
+		// we will assume all of them failed e.g. due to API-level permission issue.
+		log.ErrorContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err)
+		results[failed] = needInstall
+		return
+	}
+	// count individual failed enrollments.
+	results[failed] = failedCount
+
+	pendingCount := len(instances.Instances) - failedCount
+	if pendingCount > 0 {
+		// Note: we have no "installation in progress" or "installation succeeded" counter, so we ignore those.
+		// If the installation went fine the "enrolled" counter will increase during next iteration.
+		// Otherwise, we will try to enroll those once again, possibly failing.
+		// There is a gap here: we will ignore join failures as those happen out of our sight.
+		// There is no easy way to close that gap in the current architecture.
+		log.DebugContext(s.ctx, "Installation attempt finished. If the machines have joined the cluster successfully, they will be counted as enrolled during the next iteration.", "pending", pendingCount)
+	}
+
+	return
 }
 
 func (s *Server) filterExistingGCPNodes(instances *server.GCPInstances) error {
@@ -1632,9 +1706,7 @@ func (s *Server) Start() error {
 		go s.handleEC2Discovery()
 		go s.reconciler.run(s.ctx)
 	}
-	if s.azureWatcher != nil {
-		go s.handleAzureDiscovery()
-	}
+	go s.startAzureServerDiscovery()
 	if s.gcpWatcher != nil {
 		go s.handleGCPDiscovery()
 	}
@@ -1794,7 +1866,6 @@ func (s *Server) deleteDynamicFetchers(name string) {
 	s.muDynamicDatabaseFetchers.Unlock()
 
 	s.ec2Watcher.DeleteFetchers(name)
-	s.azureWatcher.DeleteFetchers(name)
 	s.gcpWatcher.DeleteFetchers(name)
 
 	s.muDynamicTAGAWSFetchers.Lock()
@@ -1812,14 +1883,15 @@ func (s *Server) deleteDynamicFetchers(name string) {
 
 // upsertDynamicMatchers upserts the internal set of dynamic matchers given a particular discovery config.
 func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.DiscoveryConfig) error {
-	matchers := Matchers{
+	matchers := &Matchers{
 		AWS:         dc.Spec.AWS,
 		Azure:       dc.Spec.Azure,
 		GCP:         dc.Spec.GCP,
 		Kubernetes:  dc.Spec.Kube,
 		AccessGraph: dc.Spec.AccessGraph,
 	}
-	s.discardUnsupportedMatchers(&matchers)
+
+	s.discardUnsupportedMatchers(matchers)
 
 	dcName := dc.GetName()
 
@@ -1829,16 +1901,13 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	}
 	s.ec2Watcher.SetFetchers(dcName, awsServerFetchers)
 
-	azureServerFetchers := s.azureServerFetchersFromMatchers(matchers.Azure, dcName)
-	s.azureWatcher.SetFetchers(dcName, azureServerFetchers)
-
 	gcpServerFetchers, err := s.gcpServerFetchersFromMatchers(s.ctx, matchers.GCP, dcName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	s.gcpWatcher.SetFetchers(dcName, gcpServerFetchers)
 
-	databaseFetchers, err := s.databaseFetchersFromMatchers(matchers, dcName)
+	databaseFetchers, err := s.databaseFetchersFromMatchers(*matchers, dcName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1848,7 +1917,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.muDynamicDatabaseFetchers.Unlock()
 
 	awsSyncMatchers, err := s.accessGraphAWSFetchersFromMatchers(
-		ctx, matchers, dcName,
+		ctx, *matchers, dcName,
 	)
 	if err != nil {
 		return trace.Wrap(err)
@@ -1857,7 +1926,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.dynamicTAGAWSFetchers[dcName] = awsSyncMatchers
 	s.muDynamicTAGAWSFetchers.Unlock()
 
-	azureSyncMatchers, err := s.accessGraphAzureFetchersFromMatchers(matchers, dcName)
+	azureSyncMatchers, err := s.accessGraphAzureFetchersFromMatchers(*matchers, dcName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1865,7 +1934,7 @@ func (s *Server) upsertDynamicMatchers(ctx context.Context, dc *discoveryconfig.
 	s.dynamicTAGAzureFetchers[dcName] = azureSyncMatchers
 	s.muDynamicTAGAzureFetchers.Unlock()
 
-	kubeFetchers, err := s.kubeFetchersFromMatchers(matchers, dcName)
+	kubeFetchers, err := s.kubeFetchersFromMatchers(*matchers, dcName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1922,9 +1991,6 @@ func (s *Server) Stop() {
 	s.cancelfn()
 	if s.ec2Watcher != nil {
 		s.ec2Watcher.Stop()
-	}
-	if s.azureWatcher != nil {
-		s.azureWatcher.Stop()
 	}
 	if s.gcpWatcher != nil {
 		s.gcpWatcher.Stop()

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1421,11 +1421,12 @@ func (s *Server) startAzureServerDiscovery() {
 
 	var azureWatcher *server.Watcher[*server.AzureInstances]
 
+	// static fetchers; can be cached, any changes require service restart.
+	staticFetchers := s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
+
 	// a full refresh is somewhat wasteful, however not overly so due to inexpensive operations involved.
 	// a more selective approach would necessitate deeper refactoring.
 	fullRefresh := func() {
-		// static fetchers.
-		staticFetchers := s.azureServerFetchersFromMatchers(s.Matchers.Azure, noDiscoveryConfig)
 		replaceMap := make(map[string][]server.Fetcher[*server.AzureInstances])
 		replaceMap[noDiscoveryConfig] = staticFetchers
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"os"
 	"regexp"
@@ -2993,10 +2994,26 @@ func mustNewDatabase(t *testing.T, meta types.Metadata, spec types.DatabaseSpecV
 	return database
 }
 
-type mockAzureRunCommandClient struct{}
+type mockAzureRunCommandClient struct {
+	mu                 sync.Mutex
+	installedInstances map[string]struct{}
+}
 
-func (m *mockAzureRunCommandClient) Run(_ context.Context, _ azure.RunCommandRequest) error {
+func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) error {
+	m.mu.Lock()
+	if m.installedInstances == nil {
+		m.installedInstances = make(map[string]struct{})
+	}
+	m.installedInstances[req.VMName] = struct{}{}
+	m.mu.Unlock()
 	return nil
+}
+
+func (m *mockAzureRunCommandClient) getInstalled() []string {
+	m.mu.Lock()
+	elems := slices.Sorted(maps.Keys(m.installedInstances))
+	m.mu.Unlock()
+	return elems
 }
 
 type mockAzureClient struct {
@@ -3013,30 +3030,6 @@ func (m *mockAzureClient) GetByVMID(_ context.Context, _ string) (*azure.Virtual
 
 func (m *mockAzureClient) ListVirtualMachines(_ context.Context, _ string) ([]*armcompute.VirtualMachine, error) {
 	return m.vms, nil
-}
-
-type mockAzureInstaller struct {
-	mu                 sync.Mutex
-	installedInstances map[string]struct{}
-}
-
-func (m *mockAzureInstaller) Run(_ context.Context, req server.AzureRunRequest) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, inst := range req.Instances {
-		m.installedInstances[*inst.Name] = struct{}{}
-	}
-	return nil
-}
-
-func (m *mockAzureInstaller) GetInstalledInstances() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	keys := make([]string, 0, len(m.installedInstances))
-	for k := range m.installedInstances {
-		keys = append(keys, k)
-	}
-	return keys
 }
 
 func TestAzureVMDiscovery(t *testing.T) {
@@ -3174,21 +3167,33 @@ func TestAzureVMDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
+			runClient := &mockAzureRunCommandClient{}
+
 			initAzureClients := func(opts ...azure.ClientsOption) (azure.Clients, error) {
 				return &azuretest.Clients{
 					AzureVirtualMachines: &mockAzureClient{
 						vms: foundAzureVMs(),
 					},
-					AzureRunCommand: &mockAzureRunCommandClient{},
+					AzureRunCommand: runClient,
 				}, nil
 			}
 
-			ctx := context.Background()
 			testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
 				Dir: t.TempDir(),
 			})
 			require.NoError(t, err)
 			t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+			err = testAuthServer.AuthServer.UpsertProxy(t.Context(), &types.ServerV2{
+				Kind: types.KindProxy,
+				Metadata: types.Metadata{
+					Name: "proxy",
+				},
+				Spec: types.ServerSpecV2{
+					PublicAddrs: []string{"proxy.example.com:443"},
+				},
+			})
+			require.NoError(t, err)
 
 			tlsServer, err := testAuthServer.NewTestTLSServer()
 			require.NoError(t, err)
@@ -3201,7 +3206,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 			t.Cleanup(func() { require.NoError(t, authClient.Close()) })
 
 			for _, instance := range tc.presentVMs {
-				_, err := tlsServer.Auth().UpsertNode(ctx, instance)
+				_, err := tlsServer.Auth().UpsertNode(t.Context(), instance)
 				require.NoError(t, err)
 			}
 
@@ -3210,9 +3215,6 @@ func TestAzureVMDiscovery(t *testing.T) {
 
 			emitter := &mockEmitter{}
 			reporter := &mockUsageReporter{}
-			installer := &mockAzureInstaller{
-				installedInstances: make(map[string]struct{}),
-			}
 			tlsServer.Auth().SetUsageReporter(reporter)
 			server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
 				initAzureClients: initAzureClients,
@@ -3226,14 +3228,13 @@ func TestAzureVMDiscovery(t *testing.T) {
 			})
 
 			require.NoError(t, err)
-			server.azureInstaller = installer
 			emitter.server = server
 			emitter.t = t
 
 			if tc.discoveryConfig != nil {
 				sub := server.newDiscoveryConfigChangedSub()
 
-				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, tc.discoveryConfig)
+				_, err := tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), tc.discoveryConfig)
 				require.NoError(t, err)
 
 				// wait for discovery config update
@@ -3250,8 +3251,11 @@ func TestAzureVMDiscovery(t *testing.T) {
 			t.Cleanup(server.Stop)
 
 			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				require.ElementsMatch(c, tc.wantInstalledInstances, installer.GetInstalledInstances())
-
+				if len(tc.wantInstalledInstances) == 0 {
+					require.Empty(c, runClient.getInstalled())
+				} else {
+					require.Equal(c, tc.wantInstalledInstances, runClient.getInstalled())
+				}
 				// all current tests install at least one VM, so this cannot be zero.
 				// multiple installations will trigger just one event.
 				const expectedEventCount = 1
@@ -4064,4 +4068,45 @@ func (f fakeAWSClients) GetRedshiftClient(cfg aws.Config, optFns ...func(*redshi
 
 func (f fakeAWSClients) GetRedshiftServerlessClient(cfg aws.Config, optFns ...func(*rss.Options)) db.RSSClient {
 	return f.rssClient
+}
+
+func TestGenInstancesLogStr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected string
+	}{
+		{
+			name:     "empty slice",
+			input:    []string{},
+			expected: "[]",
+		},
+		{
+			name:     "single item",
+			input:    []string{"a"},
+			expected: "[a]",
+		},
+		{
+			name:     "few items",
+			input:    []string{"a", "b", "c"},
+			expected: "[a, b, c]",
+		},
+		{
+			name:     "exactly 10 items",
+			input:    []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"},
+			expected: "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]",
+		},
+		{
+			name:     "truncated",
+			input:    []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"},
+			expected: "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10... + 2 instance IDs truncated]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := genInstancesLogStr(tt.input, func(s string) string { return s })
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -946,9 +946,9 @@ func (s *Server) discoverRDSUserTaskAddExistingDatabases(currentUserTask *userta
 type statusType int
 
 const (
-	found statusType = iota
-	enrolled
-	failed
+	statusFound statusType = iota
+	statusEnrolled
+	statusFailed
 )
 
 type fetcherGroupKey struct {
@@ -995,7 +995,7 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		}
 
 		// Update global discovered resources count.
-		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[found])
+		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[statusFailed])
 
 		// Initialize map if needed.
 		if existingStatus.IntegrationDiscoveredResources == nil {
@@ -1010,9 +1010,9 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		}
 
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
-			Found:    uint64(results[found]),
-			Enrolled: uint64(results[enrolled]),
-			Failed:   uint64(results[failed]),
+			Found:    uint64(results[statusFound]),
+			Enrolled: uint64(results[statusEnrolled]),
+			Failed:   uint64(results[statusFailed]),
 		}
 
 		integrationDiscoveredSummaryUpdate(summary, s.resourceType, resourcesSummary)

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -20,6 +20,9 @@ package discovery
 
 import (
 	"context"
+	"log/slog"
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -60,7 +63,7 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		// Static configurations (ie those in `teleport.yaml/discovery_config.<cloud>.matchers`) do not have a DiscoveryConfig resource.
 		// Those are discarded because there's no Status to update.
 		if discoveryConfigName == "" {
-			return
+			continue
 		}
 
 		discoveryConfigStatus := discoveryconfig.Status{
@@ -81,20 +84,25 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		// Merge AWS EKS clusters (auto discovery) status
 		discoveryConfigStatus = s.awsEKSResourcesStatus.mergeIntoGlobalStatus(discoveryConfigName, discoveryConfigStatus)
 
+		// Merge Azure VMs discovery status.
+		discoveryConfigStatus = s.azureVMStatus.Load().mergeIntoGlobalStatus(discoveryConfigName, discoveryConfigStatus)
+
 		// Ensure the error message is truncated to the maximum allowed size.
 		// Too large error messages will cause failures when clients (which use the default MaxCallRecvMsgSize of 4MB) try to read DiscoveryConfigs.
 		discoveryConfigStatus.ErrorMessage = truncateErrorMessage(discoveryConfigStatus)
 
-		ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-		defer cancel()
+		func() {
+			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
+			defer cancel()
 
-		_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus)
-		switch {
-		case trace.IsNotImplemented(err):
-			s.Log.WarnContext(ctx, "UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
-		case err != nil:
-			s.Log.WarnContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
-		}
+			_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus)
+			switch {
+			case trace.IsNotImplemented(err):
+				s.Log.WarnContext(ctx, "UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
+			case err != nil:
+				s.Log.WarnContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
+			}
+		}()
 	}
 }
 
@@ -299,14 +307,8 @@ func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string,
 			Failed:   uint64(groupResult.failed),
 		}
 
-		switch ars.resourceType {
-		case types.AWSMatcherEC2:
-			existingIntegrationResources.AwsEc2 = resourcesSummary
-		case types.AWSMatcherRDS:
-			existingIntegrationResources.AwsRds = resourcesSummary
-		case types.AWSMatcherEKS:
-			existingIntegrationResources.AwsEks = resourcesSummary
-		}
+		integrationDiscoveredSummaryUpdate(existingIntegrationResources, ars.resourceType, resourcesSummary)
+
 		existingStatus.IntegrationDiscoveredResources[group.integration] = existingIntegrationResources
 	}
 
@@ -939,4 +941,111 @@ func (s *Server) discoverRDSUserTaskAddExistingDatabases(currentUserTask *userta
 		failedDatabases.Databases[existingDatabaseName] = existingDatabase
 	}
 	return failedDatabases
+}
+
+type statusType int
+
+const (
+	found statusType = iota
+	enrolled
+	failed
+)
+
+type fetcherGroupKey struct {
+	discoveryConfigName string
+	integration         string
+}
+
+// resourceStatusMap tracks discovery status (found/enrolled/failed counts)
+// per fetcher group key (discovery config + integration combination).
+type resourceStatusMap struct {
+	resourceType string
+	results      map[fetcherGroupKey]map[statusType]int
+}
+
+func newStatusMap(resourceType string) *resourceStatusMap {
+	return &resourceStatusMap{
+		resourceType: resourceType,
+		results:      make(map[fetcherGroupKey]map[statusType]int),
+	}
+}
+
+func (s *resourceStatusMap) add(key fetcherGroupKey, results map[statusType]int) {
+	if s.results[key] == nil {
+		s.results[key] = make(map[statusType]int)
+	}
+	for k, v := range results {
+		s.results[key][k] += v
+	}
+}
+
+func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, existingStatus discoveryconfig.Status) discoveryconfig.Status {
+	if s == nil {
+		// nil resourceStatusMap is valid, just empty.
+		return existingStatus
+	}
+
+	for key, results := range s.results {
+		if key.discoveryConfigName != discoveryConfigName {
+			continue
+		}
+
+		if results == nil {
+			continue
+		}
+
+		// Update global discovered resources count.
+		existingStatus.DiscoveredResources = existingStatus.DiscoveredResources + uint64(results[found])
+
+		// Initialize map if needed.
+		if existingStatus.IntegrationDiscoveredResources == nil {
+			existingStatus.IntegrationDiscoveredResources = make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummary)
+		}
+
+		// Update counters specific to resources discovered.
+		var summary *discoveryconfigv1.IntegrationDiscoveredSummary
+		summary = existingStatus.IntegrationDiscoveredResources[key.integration]
+		if summary == nil {
+			summary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+		}
+
+		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
+			Found:    uint64(results[found]),
+			Enrolled: uint64(results[enrolled]),
+			Failed:   uint64(results[failed]),
+		}
+
+		integrationDiscoveredSummaryUpdate(summary, s.resourceType, resourcesSummary)
+
+		existingStatus.IntegrationDiscoveredResources[key.integration] = summary
+	}
+
+	return existingStatus
+}
+
+func (s *resourceStatusMap) discoveryConfigs() []string {
+	if s == nil {
+		return nil
+	}
+
+	names := map[string]struct{}{}
+	for key := range s.results {
+		names[key.discoveryConfigName] = struct{}{}
+	}
+	return slices.Collect(maps.Keys(names))
+}
+
+func integrationDiscoveredSummaryUpdate(summary *discoveryconfigv1.IntegrationDiscoveredSummary, resourceType string, resourcesSummary *discoveryconfigv1.ResourcesDiscoveredSummary) {
+	switch resourceType {
+	case types.AWSMatcherEC2:
+		summary.AwsEc2 = resourcesSummary
+	case types.AWSMatcherRDS:
+		summary.AwsRds = resourcesSummary
+	case types.AWSMatcherEKS:
+		summary.AwsEks = resourcesSummary
+	case types.AzureMatcherVM:
+		summary.AzureVms = resourcesSummary
+	default:
+		slog.WarnContext(context.Background(), "Unknown integration discovered summary resource type (this is a bug)", "resource_type", resourceType)
+	}
 }

--- a/lib/srv/server/azure_installer.go
+++ b/lib/srv/server/azure_installer.go
@@ -44,7 +44,7 @@ type AzureInstallRequest struct {
 type AzureInstallFailure struct {
 	// Instance is the VM instance for which the installation failed.
 	Instance *armcompute.VirtualMachine
-	// Error is the ecountered error.
+	// Error is the encountered error.
 	Error error
 }
 

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -1,0 +1,150 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+)
+
+type mockRunCommandClient struct {
+	runFunc func(ctx context.Context, req azure.RunCommandRequest) error
+}
+
+func (m *mockRunCommandClient) Run(ctx context.Context, req azure.RunCommandRequest) error {
+	if m.runFunc != nil {
+		return m.runFunc(ctx, req)
+	}
+	return nil
+}
+
+func TestAzureInstallRequestRun(t *testing.T) {
+	makeVMs := func(names ...string) []*armcompute.VirtualMachine {
+		vms := make([]*armcompute.VirtualMachine, len(names))
+		for i, name := range names {
+			vms[i] = &armcompute.VirtualMachine{
+				ID:   &name,
+				Name: &name,
+			}
+		}
+		return vms
+	}
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		instances       []*armcompute.VirtualMachine
+		runFunc         func(ctx context.Context, req azure.RunCommandRequest) error
+		proxyAddrGetter func(context.Context) (string, error)
+		wantErr         string
+		wantFailedVMs   []string
+	}{
+		{
+			name:      "no instances",
+			instances: nil,
+		},
+		{
+			name:      "single instance success",
+			instances: makeVMs("vm-1"),
+		},
+		{
+			name:      "single instance failure",
+			instances: makeVMs("vm-1"),
+			runFunc: func(ctx context.Context, req azure.RunCommandRequest) error {
+				return errors.New("install failed")
+			},
+			wantFailedVMs: []string{"vm-1"},
+		},
+		{
+			name:      "multiple instances all success",
+			instances: makeVMs("vm-1", "vm-2", "vm-3"),
+		},
+		{
+			name:      "multiple instances some failures",
+			instances: makeVMs("vm-1", "vm-2", "vm-3"),
+			runFunc: func(ctx context.Context, req azure.RunCommandRequest) error {
+				if req.VMName == "vm-2" {
+					return errors.New("install failed")
+				}
+				return nil
+			},
+			wantFailedVMs: []string{"vm-2"},
+		},
+		{
+			name:      "multiple instances all failures",
+			instances: makeVMs("vm-1", "vm-2", "vm-3"),
+			runFunc: func(ctx context.Context, req azure.RunCommandRequest) error {
+				return errors.New("install failed")
+			},
+			wantFailedVMs: []string{"vm-1", "vm-2", "vm-3"},
+		},
+		{
+			name:      "proxy addr getter error",
+			instances: makeVMs("vm-1"),
+			proxyAddrGetter: func(ctx context.Context) (string, error) {
+				return "", errors.New("proxy lookup failed")
+			},
+			wantErr: "proxy lookup failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &mockRunCommandClient{runFunc: tt.runFunc}
+			proxyAddrGetter := tt.proxyAddrGetter
+			if proxyAddrGetter == nil {
+				proxyAddrGetter = func(ctx context.Context) (string, error) {
+					return "proxy.example.com:443", nil
+				}
+			}
+
+			req := &AzureInstallRequest{
+				Instances: tt.instances,
+				InstallerParams: &types.InstallerParams{
+					JoinMethod: types.JoinMethodAzure,
+					JoinToken:  "test-token",
+				},
+				ProxyAddrGetter: proxyAddrGetter,
+				Region:          "eastus",
+				ResourceGroup:   "test-rg",
+			}
+
+			result, err := req.Run(t.Context(), client)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			require.Equal(t, tt.wantFailedVMs, slices.Sorted(maps.Keys(result.Failures)))
+		})
+	}
+}

--- a/lib/srv/server/azure_installer_test.go
+++ b/lib/srv/server/azure_installer_test.go
@@ -19,7 +19,6 @@ package server
 import (
 	"context"
 	"errors"
-	"maps"
 	"slices"
 	"testing"
 
@@ -134,7 +133,7 @@ func TestAzureInstallRequestRun(t *testing.T) {
 				ResourceGroup:   "test-rg",
 			}
 
-			result, err := req.Run(t.Context(), client)
+			failures, err := req.Run(t.Context(), client)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -142,9 +141,14 @@ func TestAzureInstallRequestRun(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, result)
 
-			require.Equal(t, tt.wantFailedVMs, slices.Sorted(maps.Keys(result.Failures)))
+			var failedNames []string
+			for _, vm := range failures {
+				failedNames = append(failedNames, *vm.Instance.Name)
+			}
+			slices.Sort(failedNames)
+
+			require.Equal(t, tt.wantFailedVMs, failedNames)
 		})
 	}
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -38,35 +38,70 @@ const azureEventPrefix = "azure/"
 
 // AzureInstances contains information about discovered Azure virtual machines.
 type AzureInstances struct {
+	// DiscoveryConfigName is the name of discovery config.
+	DiscoveryConfigName string
+	// Integration is the optional name of the integration to use for auth.
+	Integration string
+
 	// Region is the Azure region where the instances are located.
 	Region string
 	// SubscriptionID is the subscription ID for the instances.
 	SubscriptionID string
 	// ResourceGroup is the resource group for the instances.
 	ResourceGroup string
+
 	// InstallerParams are the installer parameters used for installation.
 	InstallerParams *types.InstallerParams
 	// Instances is a list of discovered Azure virtual machines.
 	Instances []*armcompute.VirtualMachine
-	// Integration is the optional name of the integration to use for auth.
-	Integration string
 }
 
 // MakeEvents generates MakeEvents for these instances.
-func (instances *AzureInstances) MakeEvents() map[string]*usageeventsv1.ResourceCreateEvent {
+func (instances *AzureInstances) MakeEvents(result *AzureInstallResult) map[string]*usageeventsv1.ResourceCreateEvent {
 	resourceType := types.DiscoveredResourceNode
 	if instances.InstallerParams != nil && instances.InstallerParams.ScriptName == installers.InstallerScriptNameAgentless {
 		resourceType = types.DiscoveredResourceAgentlessNode
 	}
-	events := make(map[string]*usageeventsv1.ResourceCreateEvent, len(instances.Instances))
+	expectedSize := len(instances.Instances) - len(result.Failures)
+	events := make(map[string]*usageeventsv1.ResourceCreateEvent, expectedSize)
 	for _, inst := range instances.Instances {
-		events[azureEventPrefix+azure.StringVal(inst.ID)] = &usageeventsv1.ResourceCreateEvent{
+		id := azure.StringVal(inst.ID)
+		// skip failed
+		if result.Failures[id] != nil {
+			continue
+		}
+		events[azureEventPrefix+id] = &usageeventsv1.ResourceCreateEvent{
 			ResourceType:   resourceType,
 			ResourceOrigin: types.OriginCloud,
 			CloudProvider:  types.CloudAzure,
 		}
 	}
 	return events
+}
+
+// FilterExistingNodes removes instances matching existing nodes in place.
+func (instances *AzureInstances) FilterExistingNodes(existingNodes []types.Server) {
+	vmIDs := make(map[string]struct{})
+	for _, node := range existingNodes {
+		labels := node.GetAllLabels()
+		subscriptionID := labels[types.SubscriptionIDLabel]
+		if subscriptionID != instances.SubscriptionID {
+			continue
+		}
+		vmID := labels[types.VMIDLabel]
+		if vmID != "" {
+			vmIDs[vmID] = struct{}{}
+		}
+	}
+
+	instances.Instances = slices.DeleteFunc(instances.Instances, func(instance *armcompute.VirtualMachine) bool {
+		var vmID string
+		if instance.Properties != nil && instance.Properties.VMID != nil {
+			vmID = *instance.Properties.VMID
+		}
+		_, found := vmIDs[vmID]
+		return found
+	})
 }
 
 type azureClientGetter func(ctx context.Context, integration string) (azure.Clients, error)
@@ -211,12 +246,13 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 	var instances []*AzureInstances
 	for batchGroup, vms := range instancesByRegionAndResourceGroup {
 		instances = append(instances, &AzureInstances{
-			SubscriptionID:  f.Subscription,
-			Region:          batchGroup.location,
-			ResourceGroup:   batchGroup.resourceGroup,
-			Instances:       vms,
-			Integration:     f.Integration,
-			InstallerParams: f.InstallerParams,
+			SubscriptionID:      f.Subscription,
+			Region:              batchGroup.location,
+			ResourceGroup:       batchGroup.resourceGroup,
+			Instances:           vms,
+			Integration:         f.Integration,
+			InstallerParams:     f.InstallerParams,
+			DiscoveryConfigName: f.DiscoveryConfigName,
 		})
 	}
 

--- a/lib/srv/server/watcher_test.go
+++ b/lib/srv/server/watcher_test.go
@@ -1,0 +1,383 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type mockInstance struct {
+	ID string
+}
+
+type mockFetcher struct {
+	instances []mockInstance
+	err       error
+}
+
+func (m *mockFetcher) GetInstances(ctx context.Context, rotation bool) ([]mockInstance, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.instances, nil
+}
+
+func (m *mockFetcher) GetMatchingInstances(ctx context.Context, nodes []types.Server, rotation bool) ([]mockInstance, error) {
+	return nil, trace.NotImplemented("GetMatchingInstances not implemented")
+}
+
+func (m *mockFetcher) GetDiscoveryConfigName() string {
+	panic("GetDiscoveryConfigName should not be called")
+}
+
+func (m *mockFetcher) IntegrationName() string {
+	panic("IntegrationName should not be called")
+}
+
+func TestWatcherFetchAndSubmit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		fetchers    map[string][]Fetcher[mockInstance]
+		expectedIDs []string
+	}{
+		{
+			name:        "no fetchers",
+			fetchers:    nil,
+			expectedIDs: nil,
+		},
+		{
+			name: "single fetcher single instance",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{instances: []mockInstance{{ID: "i-1"}}}},
+			},
+			expectedIDs: []string{"i-1"},
+		},
+		{
+			name: "single fetcher multiple instances",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{instances: []mockInstance{{ID: "i-1"}, {ID: "i-2"}}}},
+			},
+			expectedIDs: []string{"i-1", "i-2"},
+		},
+		{
+			name: "multiple fetchers multiple configs",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{instances: []mockInstance{{ID: "i-1"}}}},
+				"dc2": {&mockFetcher{instances: []mockInstance{{ID: "i-2"}, {ID: "i-3"}}}},
+			},
+			expectedIDs: []string{"i-1", "i-2", "i-3"},
+		},
+		{
+			name: "fetcher with error continues to next",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {
+					&mockFetcher{err: trace.BadParameter("fail")},
+					&mockFetcher{instances: []mockInstance{{ID: "good"}}},
+				},
+			},
+			expectedIDs: []string{"good"},
+		},
+		{
+			name: "fetcher with NotFound error silent",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{err: trace.NotFound("gone")}},
+			},
+			expectedIDs: nil,
+		},
+		{
+			name: "fetcher returns nil slice",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{instances: nil}},
+			},
+			expectedIDs: nil,
+		},
+		{
+			name: "fetcher returns empty slice",
+			fetchers: map[string][]Fetcher[mockInstance]{
+				"dc1": {&mockFetcher{instances: []mockInstance{}}},
+			},
+			expectedIDs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var collected []mockInstance
+			var mu sync.Mutex
+
+			w := NewWatcher[mockInstance](t.Context(),
+				WithPerInstanceHookFn[mockInstance](func(inst []mockInstance) {
+					mu.Lock()
+					collected = append(collected, inst...)
+					mu.Unlock()
+				}),
+			)
+
+			for dc, f := range tt.fetchers {
+				w.SetFetchers(dc, f)
+			}
+
+			w.fetchAndSubmit()
+
+			var ids []string
+			for _, inst := range collected {
+				ids = append(ids, inst.ID)
+			}
+			assert.ElementsMatch(t, tt.expectedIDs, ids)
+		})
+	}
+}
+
+func TestWatcherRunLoop(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		pollInterval time.Duration
+		run          func(t *testing.T, w *Watcher[mockInstance], triggerC chan struct{}, fetchCount *atomic.Int32)
+		wantFetches  int32
+	}{
+		{
+			name:         "poll timer triggers fetch",
+			pollInterval: 10 * time.Second,
+			run: func(t *testing.T, w *Watcher[mockInstance], triggerC chan struct{}, fetchCount *atomic.Int32) {
+				go w.Run()
+				synctest.Wait()
+				assert.Equal(t, int32(1), fetchCount.Load())
+
+				time.Sleep(10 * time.Second)
+				synctest.Wait()
+			},
+			wantFetches: 2,
+		},
+		{
+			name:         "manual trigger fetches",
+			pollInterval: time.Hour,
+			run: func(t *testing.T, w *Watcher[mockInstance], triggerC chan struct{}, fetchCount *atomic.Int32) {
+				go w.Run()
+				synctest.Wait()
+				assert.Equal(t, int32(1), fetchCount.Load())
+
+				triggerC <- struct{}{}
+				synctest.Wait()
+			},
+			wantFetches: 2,
+		},
+		{
+			name:         "multiple poll cycles",
+			pollInterval: 10 * time.Second,
+			run: func(t *testing.T, w *Watcher[mockInstance], triggerC chan struct{}, fetchCount *atomic.Int32) {
+				go w.Run()
+				synctest.Wait()
+				assert.Equal(t, int32(1), fetchCount.Load())
+
+				time.Sleep(10 * time.Second)
+				synctest.Wait()
+				assert.Equal(t, int32(2), fetchCount.Load())
+
+				time.Sleep(10 * time.Second)
+				synctest.Wait()
+			},
+			wantFetches: 3,
+		},
+		{
+			name:         "manual trigger resets poll timer",
+			pollInterval: 10 * time.Second,
+			run: func(t *testing.T, w *Watcher[mockInstance], triggerC chan struct{}, fetchCount *atomic.Int32) {
+				go w.Run()
+				synctest.Wait()
+				assert.Equal(t, int32(1), fetchCount.Load())
+
+				time.Sleep(5 * time.Second)
+				triggerC <- struct{}{}
+				synctest.Wait()
+				assert.Equal(t, int32(2), fetchCount.Load())
+
+				time.Sleep(5 * time.Second)
+				synctest.Wait()
+				assert.Equal(t, int32(2), fetchCount.Load())
+
+				time.Sleep(5 * time.Second)
+				synctest.Wait()
+			},
+			wantFetches: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				triggerC := make(chan struct{}, 10)
+				var fetchCount atomic.Int32
+
+				w := NewWatcher[mockInstance](t.Context(),
+					WithPollInterval[mockInstance](tt.pollInterval),
+					WithTriggerFetchC[mockInstance](triggerC),
+					WithPerInstanceHookFn[mockInstance](func([]mockInstance) {
+						fetchCount.Add(1)
+					}),
+				)
+				w.SetFetchers("dc1", []Fetcher[mockInstance]{&mockFetcher{instances: []mockInstance{{ID: "x"}}}})
+
+				tt.run(t, w, triggerC, &fetchCount)
+				w.Stop()
+
+				assert.Equal(t, tt.wantFetches, fetchCount.Load())
+			})
+		})
+	}
+}
+
+func TestWatcherHooks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		trigger   func(triggerC chan struct{})
+		wantOrder []string
+	}{
+		{
+			name:      "poll triggers pre/per/post hooks in order",
+			trigger:   func(triggerC chan struct{}) {},
+			wantOrder: []string{"pre", "per", "post"},
+		},
+		{
+			name: "manual trigger calls trigger hook first",
+			trigger: func(triggerC chan struct{}) {
+				triggerC <- struct{}{}
+				synctest.Wait()
+			},
+			wantOrder: []string{"pre", "per", "post", "trigger", "pre", "per", "post"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				triggerC := make(chan struct{}, 1)
+				var order []string
+
+				w := NewWatcher[mockInstance](t.Context(),
+					WithPollInterval[mockInstance](time.Hour),
+					WithTriggerFetchC[mockInstance](triggerC),
+					WithTriggerFetchHookFn[mockInstance](func() { order = append(order, "trigger") }),
+					WithPreFetchHookFn[mockInstance](func([]Fetcher[mockInstance]) { order = append(order, "pre") }),
+					WithPerInstanceHookFn[mockInstance](func([]mockInstance) { order = append(order, "per") }),
+					WithPostFetchHookFn[mockInstance](func() { order = append(order, "post") }),
+				)
+				w.SetFetchers("dc1", []Fetcher[mockInstance]{&mockFetcher{instances: []mockInstance{{ID: "x"}}}})
+
+				done := make(chan struct{})
+				go func() {
+					w.Run()
+					close(done)
+				}()
+
+				synctest.Wait()
+
+				tt.trigger(triggerC)
+				w.Stop()
+
+				select {
+				case <-done:
+					// ok, Run exited
+				case <-time.After(time.Second):
+					t.Fatal("watcher didn't exit after shutdown")
+				}
+
+				assert.Equal(t, tt.wantOrder, order)
+			})
+		})
+	}
+}
+
+func TestWatcherShutdown(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		shutdown func(w *Watcher[mockInstance], cancel context.CancelFunc)
+	}{
+		{
+			name: "Stop method",
+			shutdown: func(w *Watcher[mockInstance], cancel context.CancelFunc) {
+				w.Stop()
+			},
+		},
+		{
+			name: "context cancellation",
+			shutdown: func(w *Watcher[mockInstance], cancel context.CancelFunc) {
+				cancel()
+			},
+		},
+		{
+			name: "multiple Stop calls are safe",
+			shutdown: func(w *Watcher[mockInstance], cancel context.CancelFunc) {
+				w.Stop()
+				w.Stop()
+				w.Stop()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(t.Context())
+				defer cancel()
+
+				w := NewWatcher[mockInstance](ctx,
+					WithPollInterval[mockInstance](time.Hour),
+				)
+
+				done := make(chan struct{})
+				go func() {
+					w.Run()
+					close(done)
+				}()
+
+				synctest.Wait()
+				tt.shutdown(w, cancel)
+				synctest.Wait()
+
+				select {
+				case <-done:
+					// ok, Run exited
+				case <-time.After(time.Second):
+					t.Fatal("watcher didn't exit after shutdown")
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
Updates https://github.com/gravitational/teleport/issues/60817

This addresses the "stats" part of the issue. User tasks will require additional changes, but will fit right into the updated code.

Some supporting changes:
- Watcher hooks
- Azure installer improvements: fixed generic command name to Teleport-specific, added result monitoring, partial failures
- Test coverage
- Extra refactoring/typos/minor bugfixes

Notes:
- Making Azure watcher hook-based design concentrates the discovery loop into single place. Once that design is settled we can propagate it to other cloud watchers, reducing the coupling within discovery server.

Changelog: Azure VM discovery will wait for installation and collect potential errors. The results will update discovery config statistics.