### PR TITLE
[v17] docs: update FIPS info

### DIFF
--- a/api/utils/sshutils/checker.go
+++ b/api/utils/sshutils/checker.go
@@ -34,7 +34,7 @@ type CertChecker struct {
 	ssh.CertChecker
 
 	// FIPS means in addition to checking the validity of the key or
-	// certificate, also check that FIPS 140-2 algorithms were used.
+	// certificate, also check that FIPS algorithms were used.
 	FIPS bool
 
 	// OnCheckCert is called when validating host certificate.

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -39,6 +39,7 @@
     "CHANGEID",
     "CHANGEME",
     "CLOUDSDK",
+    "CMVP",
     "CREATEDB",
     "CTAP",
     "CXXXXXXXXX",

--- a/docs/pages/includes/tpm-joining-background.mdx
+++ b/docs/pages/includes/tpm-joining-background.mdx
@@ -28,5 +28,5 @@ such as Ansible to query the TPMs across your fleet and then generate join
 tokens.
 
 <Admonition type="warning">
-The `tpm` join method is currently not compatible with FIPS 140-2.
+The `tpm` join method is currently not compatible with FIPS.
 </Admonition>

--- a/docs/pages/reference/agent-services/database-access-reference/cli.mdx
+++ b/docs/pages/reference/agent-services/database-access-reference/cli.mdx
@@ -61,7 +61,7 @@ $ teleport db start \
 | `--ca-pin` | CA pin to validate the Auth Service. |
 | `-c/--config` | Path to a configuration file (default `/etc/teleport.yaml`). |
 | `--labels` | Comma-separated list of labels for this node, for example `env=dev,app=web`. |
-| `--fips` | Start Teleport in FedRAMP/FIPS 140-2 mode. |
+| `--fips` | Start Teleport in FedRAMP/FIPS mode. |
 | `--name` | Name of the proxied database. |
 | `--description` | Description of the proxied database. |
 | `--protocol` | Proxied database protocol. Supported are: `postgres` and `mysql`. |
@@ -432,4 +432,3 @@ $ tsh db config --format=cmd example
 | Flag | Description |
 | - | - |
 | `--format` | Output format: `text` is default, `cmd` to print native database client connect command. |
-

--- a/docs/pages/reference/cli/teleport.mdx
+++ b/docs/pages/reference/cli/teleport.mdx
@@ -69,7 +69,7 @@ we recommend using a [configuration file](../config.mdx) in production.
 | `--bootstrap` | none | **string** `.yaml` filepath | bootstrap configured YAML resources {/* TODO link how to configure this file */} |
 | `--labels` | none | **string** comma-separated list | assigns a set of labels to a node, for example env=dev,app=web. See the explanation of labeling mechanism in the [Labeling Nodes](../../zero-trust-access/management/admin/labels.mdx) section. |
 | `--insecure` | none | none | disable certificate validation on Proxy Service, validation still occurs on Auth Service. |
-| `--fips` | none | none | start Teleport in FedRAMP/FIPS 140-2 mode. |
+| `--fips` | none | none | start Teleport in FedRAMP/FIPS mode. |
 | `--skip-version-check` | `false` | `true` or `false` | Skips version checks between the Auth Service and this Teleport instance |
 | `--diag-addr` | none | none | Enable diagnostic endpoints |
 | `--permit-user-env` | none | none | flag reads in environment variables from `~/.tsh/environment` when creating a session. |

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -1,20 +1,26 @@
 ---
 title: FedRAMP Compliance for Infrastructure Access
-description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140-2.
+description: How to configure SSH, Kubernetes, database, and web app access to be FedRAMP compliant, including support for FIPS 140.
 tags:
  - conceptual
  - zero-trust
 ---
 
 Teleport provides the foundation to meet FedRAMP requirements for the purposes of accessing infrastructure.
-This includes support for the Federal Information Processing Standard [FIPS 140-2](https://en.wikipedia.org/wiki/FIPS\_140-2).
+This includes support for the [Federal Information Processing Standard [FIPS 140](https://en.wikipedia.org/wiki/FIPS_140).
 This standard is the US government approved standard for cryptographic modules. This document explains how
 Teleport FIPS mode works and how it can help your company to become FedRAMP authorized.
 
+## FIPS Module
+
+Teleport Enterprise FIPS builds are compiled against a FIPS 140 validated module.
+
+- Teleport releases from 17.7.3+ and 18.0.0+ use BoringCrypto tag `fips-20220613` (CMVP certificate #4735, FIPS 140-3)
+- Teleport releases prior to 17.7.3 use BoringCrypto tag `fips-20210429` (CMVP certificate #4407, FIPS 140-2)
+
 ## Obtain FedRAMP authorization with Teleport
 
-Teleport includes FedRAMP and FIPS 140-2 features to support companies that sell into
-government agencies.
+Teleport includes FedRAMP and FIPS features to support companies that sell into government agencies.
 
 ### Access controls
 
@@ -56,8 +62,8 @@ government agencies.
 | Control | Teleport Features |
 | - | - |
 | [SC-10 Network Disconnection]((=fedramp.control_url=)SC-10) | Teleport requires valid X.509 or SSH certificates issued by a Teleport Certificate Authority (CA) to establish a network connection for device-to-device network connection between Teleport components. |
-| [SC-12 Cryptographic Key Establish and Management]((=fedramp.control_url=)SC-12) | Teleport initializes cryptographic keys that act as a Certificate Authority (CA) to further issue x509 and SSH certificates. SSH and x509 user certificates that are issued are signed by the CA and are (by default) short-lived. SSH host certificates are also signed by the CA. Teleport supports Hardware Security Modules (HSM).<br/>Teleport Enterprise builds against a FIPS 140-2 compliant library (BoringCrypto) is available. <br/>In addition, when Teleport Enterprise is in FedRAMP/FIPS 140-2 mode, Teleport will only start and use FIPS 140-2 compliant cryptography. |
-| [SC-13 Use of Cryptography]((=fedramp.control_url=)SC-13) | Teleport Enterprise builds against a FIPS 140-2 compliant library (BoringCrypto). In addition, when Teleport Enterprise is in FedRAMP/FIPS 140-2 mode, Teleport will only start and use FIPS 140-2 compliant cryptography. |
+| [SC-12 Cryptographic Key Establish and Management]((=fedramp.control_url=)SC-12) | Teleport initializes cryptographic keys that act as a Certificate Authority (CA) to further issue x509 and SSH certificates. SSH and x509 user certificates that are issued are signed by the CA and are (by default) short-lived. SSH host certificates are also signed by the CA. Teleport supports Hardware Security Modules (HSM).<br/>Teleport Enterprise builds against a FIPS 140 compliant library are available. <br/>In addition, when Teleport Enterprise is in FedRAMP/FIPS mode, Teleport will only start and use FIPS 140 compliant cryptography. |
+| [SC-13 Use of Cryptography]((=fedramp.control_url=)SC-13) | Teleport Enterprise builds against a FIPS 140 compliant library. In addition, when Teleport Enterprise is in FedRAMP/FIPS mode, Teleport will only start and use FIPS 140 compliant cryptography. |
 | [SC-17 Public Key Infrastructure]((=fedramp.control_url=)SC-17) | Certificates Teleport initializes cryptographic keys that act as a Certificate Authority (CA) to further issue X.509 and SSH certificates. SSH and X.509 user certificates that are issued are signed by the CA and are (by default) short-lived. SSH host certificates are also signed by the CA. |
 | [SC-23 Session Authenticity]((=fedramp.control_url=)SC-23) | Teleport SSH and TLS sessions are protected with SSH user and X.509 client certificates. For access to the Web UI, Teleport uses bearer token auth stored in a browser token to authenticate a session. Upon user logout, SSH and TLS certificates are deleted from disk and cookies are removed from the browser. |
 
@@ -78,12 +84,12 @@ Inside the ATO boundary, mTLS is used for communication between the Teleport pro
 
 #### FIPS mTLS details
 
-In FIPS builds, Teleport uses Go’s BoringCrypto-based networking stack for all protocols.
+In FIPS builds, Teleport uses a FIPS 140 validated networking stack for all protocols.
 
 For a detailed list of cryptographic algorithms used in FIPS mode please consult [Teleport FIPS documentation](#default-cryptographic-algorithms).
 
 You also can follow the [Installation instructions](../../installation/installation.mdx) for
-Teleport Enterprise edition to download and install the appropriate FIPS-compliant binaries for
+Teleport Enterprise edition to download and install the appropriate FIPS  binaries for
 your operating environment and package manager or from compressed archive (tarball).
 
 For example, you can download and install from the compressed archive by running the following commands:
@@ -106,7 +112,7 @@ $ sudo ./install
 ```
 
 After you download and install, all of the Teleport Enterprise binaries are
-installed in the `/usr/local/bin` directory. You can verify you have FIPS-compliant
+installed in the `/usr/local/bin` directory. You can verify you have FIPS
 binaries installed by running the `teleport version` command and verifying that
 the `X:boringcrypto` library is listed. For example:
 
@@ -204,11 +210,10 @@ $ sudo systemctl enable teleport
 When using `teleport start --fips`, Teleport will start in FIPS mode.
 
 - If the `--fips` flag is selected, Teleport will fail to start unless the
-  binaries are compiled with the appropriate cryptographic module
-  (BoringCrypto).
+  binaries are compiled with the appropriate cryptographic module.
 - If no TLS or SSH cryptographic primitives are specified, Teleport will
   default to FIPS-compliant cryptographic algorithms.
-- If TLS or SSH cryptographic primitives are not FIPS 140-2 compliant, Teleport
+- If TLS or SSH cryptographic primitives are not FIPS 140 compliant, Teleport
   will fail to start.
 - Teleport will always enable at-rest encryption for both DynamoDB and S3.
 - If recording proxy mode is selected, validation of host certificates should
@@ -283,7 +288,7 @@ is emitted to the Audit Log.
 
 - TLS protocol version is restricted to TLS 1.2 and TLS 1.3.
 - All uses of non-compliant algorithms such as NaCl are removed and replaced with compliant algorithms such as AES-GCM.
-- Teleport is compiled with [BoringCrypto](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4407).
+- Teleport is compiled with a FIPS 140 validated cryptographic module.
 - User, host, and CA certificates (and host keys for recording proxy mode) only use ECDSA keys on the NIST-P256 curve or 2048-bit RSA private keys.
 
 ## Remote desktop access
@@ -296,14 +301,14 @@ Note that `arm64` FIPS builds do not support access to Windows desktops.
 
 ## Migrating from non-FIPS to FIPS
 
-As of v17, new installations of Teleport default to using Ed25519 keys.  This is currently not supported 
-by FIPS binaries.  If the Teleport Auth Service was already deployed with a standard binary or without 
-the `--fips` flag, you must update the certificate authorities.  Otherwise, the error `User Message: only RSA and 
-ECDSA keys supported` is produced.  
+As of v17, new installations of Teleport default to using Ed25519 keys.  This is currently not supported
+by FIPS binaries.  If the Teleport Auth Service was already deployed with a standard binary or without
+the `--fips` flag, you must update the certificate authorities.  Otherwise, the error `User Message: only RSA and
+ECDSA keys supported` is produced.
 
 To migrate to a FIPS installation, [set the signature algorithm suite](../../reference/signature-algorithms.mdx)
-to `fips-v1`.  Then, any CA with an Ed25519 key must undergo a [CA rotation](../management/operations/ca-rotation.mdx).  The 
-command `tctl status` can be used on v17+ to confirm the signature algorithms in use.  After all CA rotations are 
+to `fips-v1`.  Then, any CA with an Ed25519 key must undergo a [CA rotation](../management/operations/ca-rotation.mdx).  The
+command `tctl status` can be used on v17+ to confirm the signature algorithms in use.  After all CA rotations are
 complete, proceed with installing the FIPS binary.
 
 ## Tradeoffs of using the Teleport FIPS binary

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-ha-autoscale-cluster-terraform.mdx
@@ -35,11 +35,11 @@ This guide also requires the following:
   and macOS Homebrew as the `awscli` package.
 
   Fedora/CentOS: `yum -y install awscli`
-  
+
   Ubuntu/Debian: `apt-get -y install awscli`
-  
+
   macOS (with [Homebrew](https://brew.sh/)): `brew install awscli`
-  
+
   When possible, installing via a package is always preferable. If you can't
   find a package available for your distribution, you can also download the tool
   from [https://aws.amazon.com/cli/](https://aws.amazon.com/cli/)
@@ -179,12 +179,12 @@ cluster from scratch, so choose carefully. A good example might be something lik
 $ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)-x86_64"
 ```
 
-Teleport (Gravitational) automatically builds and publishes Teleport Community Edition, Enterprise, and Enterprise FIPS 140-2
+Teleport (Gravitational) automatically builds and publishes Teleport Community Edition, Enterprise, and Enterprise FIPS
 AMIs when we release a new version of Teleport. The AMI names follow the format: `teleport-<type>-<version>-<arch>`
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+FIPS 140 compatible AMIs (which deploy Teleport in FIPS mode by default) have the `-fips` suffix after `<arch>`,
 e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
@@ -204,7 +204,7 @@ the example `awscli` commands below. The output is in JSON format by default.
   $ aws --region <Var name="us-west-2" /> ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-(=teleport.version=)-*'
   ```
 
-  Enterprise FIPS 140-2 AMIs<br/>
+  Enterprise FIPS AMIs<br/>
   ```code
   $ aws --region <Var name="us-west-2" /> ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-(=teleport.version=)-*-fips-*'
   ```

--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/aws-starter-cluster-terraform.mdx
@@ -192,12 +192,12 @@ cluster from scratch, so choose carefully. A good example might be something lik
 $ export TF_VAR_ami_name="teleport-ent-(=teleport.version=)-x86_64"
 ```
 
-Teleport (Gravitational) automatically builds and publishes OSS, Enterprise and Enterprise FIPS 140-2 AMIs when we
+Teleport (Gravitational) automatically builds and publishes OSS, Enterprise and Enterprise FIPS AMIs when we
 release a new version of Teleport. The AMI names follow the format: `teleport-<type>-<version>-<arch>`
 where `<type>` is either `oss` or `ent` (Enterprise), `<version>` is the version of Teleport, e.g. `(=teleport.version=)`,
 and `<arch>` is either `x86_64` or `arm64`.
 
-FIPS 140-2 compatible AMIs (which deploy Teleport in FIPS 140-2 mode by default) have the `-fips` suffix after `<arch>`,
+FIPS compatible AMIs (which deploy Teleport in FIPS mode by default) have the `-fips` suffix after `<arch>`,
 e.g. `teleport-ent-(=teleport.version=)-x86_64-fips`.
 
 The AWS account ID that publishes these AMIs is `146628656107`. You can list the available AMIs with
@@ -217,7 +217,7 @@ the example `awscli` commands below. The output is in JSON format by default.
   $ aws --region <Var name="us-west-2" /> ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-(=teleport.version=)-*'
   ```
 
-  Enterprise FIPS 140-2 AMIs<br/>
+  Enterprise FIPS AMIs<br/>
   ```code
   $ aws --region <Var name="us-west-2" /> ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-(=teleport.version=)-*-fips-*'
   ```

--- a/examples/aws/terraform/ha-autoscale-cluster/Makefile
+++ b/examples/aws/terraform/ha-autoscale-cluster/Makefile
@@ -9,7 +9,7 @@ TF_VAR_cluster_name ?=
 # AWS SSH key name to provision in installed instances, should be available in the region
 TF_VAR_key_name ?=
 
-# Full absolute path to the license file for Teleport Enterprise 
+# Full absolute path to the license file for Teleport Enterprise
 # This license will be copied into SSM and then pulled down on the auth nodes to enable Enterprise functionality
 TF_VAR_license_path ?=
 
@@ -18,7 +18,7 @@ TF_VAR_license_path ?=
 # To list available AMIs:
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
-# FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
+# FIPS images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 TF_VAR_ami_name ?=
 
 

--- a/examples/aws/terraform/ha-autoscale-cluster/README.md
+++ b/examples/aws/terraform/ha-autoscale-cluster/README.md
@@ -45,7 +45,7 @@ export TF_VAR_cluster_name="teleport.example.com"
 # To list available AMIs:
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
-# FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
+# FIPS images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 export TF_VAR_ami_name="teleport-ent-16.4.6-arm64"
 
 # Instance types used for authentication server auto scaling group

--- a/examples/aws/terraform/starter-cluster/README.md
+++ b/examples/aws/terraform/starter-cluster/README.md
@@ -97,7 +97,7 @@ TF_VAR_license_path ?= "/path/to/license"
 # To list available AMIs:
 # OSS: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-oss-*'
 # Enterprise: aws ec2 describe-images --owners 146628656107 --filters 'Name=name,Values=teleport-ent-*'
-# FIPS 140-2 images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
+# FIPS images are also available for Enterprise customers, look for '-fips' on the end of the AMI's name
 TF_VAR_ami_name ?= "teleport-ent-16.4.6-arm64"
 
 # Route 53 hosted zone to use, must be a root zone registered in AWS, e.g. example.com

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1136,7 +1136,7 @@ type Server struct {
 	// within the cluster that don't have a direct connection to said collector
 	traceClient otlptrace.Client
 
-	// fips means FedRAMP/FIPS 140-2 compliant configuration was requested.
+	// fips means FedRAMP/FIPS compliant configuration was requested.
 	fips bool
 
 	// ghaIDTokenValidator allows ID tokens from GitHub Actions to be validated

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -266,7 +266,7 @@ type InitConfig struct {
 	// AssertionReplayService is a service that mitigates SSO assertion replay.
 	*local.AssertionReplayService
 
-	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested.
 	FIPS bool
 
 	// UsageReporter is a service that forwards cluster usage events.

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -160,7 +160,7 @@ type RegisterParams struct {
 	// CircuitBreakerConfig defines how the circuit breaker should behave.
 	// Ignored if AuthClient is provided.
 	CircuitBreakerConfig breaker.Config
-	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested.
 	// Ignored if AuthClient is provided.
 	FIPS bool
 	// IDToken is a token retrieved from a workload identity provider for

--- a/lib/auth/keystore/manager.go
+++ b/lib/auth/keystore/manager.go
@@ -159,7 +159,7 @@ type Options struct {
 	Logger *slog.Logger
 	// AuthPreferenceGetter provides the current cluster auth preference.
 	AuthPreferenceGetter cryptosuites.AuthPreferenceGetter
-	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested.
 	FIPS bool
 	// RSAKeyPairSource is an optional function used by the software keystore when
 	// generating RSA keys.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5196,8 +5196,8 @@ func InsecureSkipHostKeyChecking(host string, remote net.Addr, key ssh.PublicKey
 	return nil
 }
 
-// isFIPS returns if the binary was build with BoringCrypto, which implies
-// FedRAMP/FIPS 140-2 mode for tsh.
+// isFIPS returns if the binary was built with a FIPS validated
+// module, which implies FedRAMP/FIPS mode for tsh.
 func isFIPS() bool {
 	return modules.GetModules().IsBoringBinary()
 }

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -131,7 +131,7 @@ type CommandLineFlags struct {
 	// It's useful for learning Teleport (following quick starts, etc).
 	InsecureMode bool
 
-	// FIPS mode means Teleport starts in a FedRAMP/FIPS 140-2 compliant
+	// FIPS mode means Teleport starts in a FedRAMP/FIPS 140 compliant
 	// configuration.
 	FIPS bool
 
@@ -2569,8 +2569,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 		return trace.Wrap(err)
 	}
 
-	// If FIPS mode is specified, validate Teleport configuration is FedRAMP/FIPS
-	// 140-2 compliant.
+	// If FIPS mode is specified, validate Teleport uses a FIPS-validated module
 	if clf.FIPS {
 		// Make sure all cryptographic primitives are FIPS compliant.
 		err = utils.UintSliceSubset(defaults.FIPSCipherSuites, cfg.CipherSuites)
@@ -2590,10 +2589,10 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 			return trace.BadParameter("non-FIPS compliant SSH mac algorithm selected: %v", err)
 		}
 
-		// Make sure cluster settings are also FedRAMP/FIPS 140-2 compliant.
+		// Make sure cluster settings are also FedRAMP/FIPS compliant.
 		if cfg.Auth.Enabled {
 			// Only SSO based authentication is supported. The SSO provider is where
-			// any FedRAMP/FIPS 140-2 compliance (like password complexity) should be
+			// any FedRAMP/FIPS compliance (like password complexity) should be
 			// enforced.
 			if cfg.Auth.Preference.GetAllowLocalAuth() {
 				return trace.BadParameter("non-FIPS compliant authentication setting: \"local_auth\" must be false")

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1997,7 +1997,7 @@ func TestLicenseFileNoConfig(t *testing.T) {
 }
 
 // TestFIPS makes sure configuration is correctly updated/enforced when in
-// FedRAMP/FIPS 140-2 mode.
+// FedRAMP/FIPS mode.
 func TestFIPS(t *testing.T) {
 	tests := []struct {
 		inConfigString string

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -138,7 +138,7 @@ type Config struct {
 	// WriteTargetValue is the ratio of consumed write to provisioned capacity.
 	WriteTargetValue float64
 
-	// UseFIPSEndpoint uses AWS FedRAMP/FIPS 140-2 mode endpoints.
+	// UseFIPSEndpoint uses AWS FedRAMP/FIPS mode endpoints.
 	// to determine its behavior:
 	// Unset - allows environment variables or AWS config to set the value
 	// Enabled - explicitly enabled

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -86,7 +86,7 @@ type Config struct {
 	// SSEKMSKey specifies the optional custom CMK used for KMS SSE.
 	SSEKMSKey string
 
-	// UseFIPSEndpoint uses AWS FedRAMP/FIPS 140-2 mode endpoints.
+	// UseFIPSEndpoint uses AWS FedRAMP/FIPS mode endpoints.
 	// to determine its behavior:
 	// Unset - allows environment variables or AWS config to set the value
 	// Enabled - explicitly enabled

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -192,8 +192,7 @@ type Config struct {
 	// Log specifies the logger
 	Log log.FieldLogger
 
-	// FIPS means Teleport was started in a FedRAMP/FIPS 140-2 compliant
-	// configuration.
+	// FIPS means Teleport was started in FedRAMP/FIPS mode.
 	FIPS bool
 
 	// Emitter is event emitter

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -208,7 +208,7 @@ type Config struct {
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
 
-	// FIPS means FedRAMP/FIPS 140-2 compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested.
 	FIPS bool
 
 	// SkipVersionCheck means the version checking between server and client
@@ -485,7 +485,7 @@ func (cfg *Config) DebugDumpToYAML() string {
 	return string(out)
 }
 
-// ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS 140-2
+// ApplyFIPSDefaults updates default configuration to be FedRAMP/FIPS
 // compliant.
 func ApplyFIPSDefaults(cfg *Config) {
 	cfg.FIPS = true
@@ -497,12 +497,12 @@ func ApplyFIPSDefaults(cfg *Config) {
 	cfg.MACAlgorithms = defaults.FIPSMACAlgorithms
 
 	// Only SSO based authentication is supported in FIPS mode. The SSO
-	// provider is where any FedRAMP/FIPS 140-2 compliance (like password
+	// provider is where any FedRAMP/FIPS compliance (like password
 	// complexity) should be enforced.
 	cfg.Auth.Preference.SetAllowLocalAuth(false)
 
 	// Update cluster configuration to record sessions at node, this way the
-	// entire cluster is FedRAMP/FIPS 140-2 compliant.
+	// entire cluster is FedRAMP/FIPS compliant.
 	cfg.Auth.SessionRecordingConfig.SetMode(types.RecordAtNode)
 }
 

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -84,8 +84,7 @@ type AuthHandlerConfig struct {
 	// or an agentless server.
 	TargetServer types.Server
 
-	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
-	// configuration.
+	// FIPS mode means Teleport started in FedRAMP/FIPS mode.
 	FIPS bool
 
 	// Clock specifies the time provider. Will be used to override the time anchor

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -224,7 +224,7 @@ type ServerConfig struct {
 	// Clock is an optoinal clock to override default real time clock
 	Clock clockwork.Clock
 
-	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// FIPS mode means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	FIPS bool
 

--- a/lib/srv/git/forward.go
+++ b/lib/srv/git/forward.go
@@ -120,7 +120,7 @@ type ForwardServerConfig struct {
 	// MACAlgorithms is a list of message authentication codes (MAC) that
 	// the server supports. If omitted the defaults will be used.
 	MACAlgorithms []string
-	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// FIPS mode means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	FIPS bool
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -169,7 +169,7 @@ type Server struct {
 	// requesting connections to it come over a reverse tunnel.
 	useTunnel bool
 
-	// fips means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// fips means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	fips bool
 

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -92,7 +92,7 @@ type Server struct {
 	// they are a valid certificate. Used in tests.
 	insecureSkipHostValidation bool
 
-	// fips means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// fips means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	fips bool
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -256,7 +256,7 @@ type Config struct {
 	// CipherSuites is the list of cipher suites Teleport suppports.
 	CipherSuites []uint16
 
-	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// FIPS mode means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	FIPS bool
 
@@ -2392,7 +2392,7 @@ type AuthParams struct {
 	HostSigners []types.CertAuthority
 	// ClientRedirectURL is a URL to redirect client to
 	ClientRedirectURL string
-	// FIPS mode means Teleport started in a FedRAMP/FIPS 140-2 compliant
+	// FIPS mode means Teleport started in a FedRAMP/FIPS compliant
 	// configuration.
 	FIPS bool
 	// MFAToken is an SSO MFA token.

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -162,7 +162,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	start.Flag("insecure",
 		"Insecure mode disables certificate validation").BoolVar(&ccf.InsecureMode)
 	start.Flag("fips",
-		"Start Teleport in FedRAMP/FIPS 140-2 mode.").
+		"Start Teleport in FedRAMP/FIPS 140 mode.").
 		Default("false").
 		BoolVar(&ccf.FIPS)
 	start.Flag("skip-version-check",
@@ -213,7 +213,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	appStartCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
 	appStartCmd.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
 	appStartCmd.Flag("labels", "Comma-separated list of labels for this node, for example env=dev,app=web.").StringVar(&ccf.Labels)
-	appStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140-2 mode.").Default("false").BoolVar(&ccf.FIPS)
+	appStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140 mode.").Default("false").BoolVar(&ccf.FIPS)
 	appStartCmd.Flag("name", "Name of the application to start.").StringVar(&ccf.AppName)
 	appStartCmd.Flag("uri", "Internal address of the application to proxy.").StringVar(&ccf.AppURI)
 	appStartCmd.Flag("cloud", fmt.Sprintf("Set to one of %v if application should proxy particular cloud API", []string{types.CloudAWS, types.CloudAzure, types.CloudGCP})).StringVar(&ccf.AppCloud)
@@ -235,7 +235,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbStartCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
 	dbStartCmd.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(defaults.ConfigEnvar).StringVar(&ccf.ConfigString)
 	dbStartCmd.Flag("labels", "Comma-separated list of labels for this node, for example env=dev,app=web.").StringVar(&ccf.Labels)
-	dbStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140-2 mode.").Default("false").BoolVar(&ccf.FIPS)
+	dbStartCmd.Flag("fips", "Start Teleport in FedRAMP/FIPS 140 mode.").Default("false").BoolVar(&ccf.FIPS)
 	dbStartCmd.Flag("name", "Name of the proxied database.").StringVar(&ccf.DatabaseName)
 	dbStartCmd.Flag("description", "Description of the proxied database.").StringVar(&ccf.DatabaseDescription)
 	dbStartCmd.Flag("protocol", fmt.Sprintf("Proxied database protocol. Supported are: %v.", defaults.DatabaseProtocols)).StringVar(&ccf.DatabaseProtocol)


### PR DESCRIPTION
This consolidates all references to BoringCrypto and FIPS-140-2 to a single section of the docs, using more generic FIPS terminology elsewhere. As a result, we only need to change one place when we update our FIPS module in the future.

In addition, mention the specific versions of BoringCrypto and associated CMVP certificate numbers.

Backports #61973 