### PR TITLE
Add IaC label and usertasks to integration stats

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -779,6 +779,8 @@ const (
 	// ADLabel is a resource metadata label name used to identify if resource is part of Active Directory
 	ADLabel = TeleportNamespace + "/ad"
 
+	// CreatedByIaCLabel is a resource metadata label name used to identify if resource was created by IaC tooling.
+	CreatedByIaCLabel = TeleportNamespace + "/iac-tool"
 	// OriginDefaults is an origin value indicating that the resource was
 	// constructed as a default value.
 	OriginDefaults = common.OriginDefaults

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -317,6 +317,13 @@ func TestCollectIntegrationStats(t *testing.T) {
 			userTasksList = append(userTasksList, &usertasksv1.UserTask{Spec: &usertasksv1.UserTaskSpec{State: usertasks.TaskStateResolved, TaskType: usertasks.TaskTypeDiscoverEC2}})
 		}
 
+		var openUserTasksList []*usertasksv1.UserTask
+		for _, ut := range userTasksList {
+			if ut.GetSpec().GetState() == usertasks.TaskStateOpen {
+				openUserTasksList = append(openUserTasksList, ut)
+			}
+		}
+
 		userTasksClient := &mockUserTasksLister{
 			defaultPageSize: 3,
 			userTasks:       userTasksList,
@@ -339,6 +346,7 @@ func TestCollectIntegrationStats(t *testing.T) {
 				AWSOIDC: &ui.IntegrationAWSOIDCSpec{RoleARN: "arn:role"},
 			},
 			UnresolvedUserTasks: ec2UserTasks + rdsUserTasks,
+			UserTasks:           ui.MakeUserTasks(openUserTasksList),
 			AWSEC2: ui.ResourceTypeSummary{
 				UnresolvedUserTasks: ec2UserTasks,
 			},

--- a/lib/web/ui/integration_test.go
+++ b/lib/web/ui/integration_test.go
@@ -47,6 +47,19 @@ func TestMakeIntegration(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	terraformManagedIntegration, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{
+			Name: "terraform-managed",
+			Labels: map[string]string{
+				types.CreatedByIaCLabel: IaCTerraformLabel,
+			},
+		},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN: "arn:aws:iam::123456789012:role/TerraformRole",
+		},
+	)
+	require.NoError(t, err)
+
 	testCases := []struct {
 		integration types.Integration
 		want        Integration
@@ -69,6 +82,17 @@ func TestMakeIntegration(t *testing.T) {
 				GitHub: &IntegrationGitHub{
 					Organization: "my-org",
 				},
+			},
+		},
+		{
+			integration: terraformManagedIntegration,
+			want: Integration{
+				Name:    "terraform-managed",
+				SubKind: types.IntegrationSubKindAWSOIDC,
+				AWSOIDC: &IntegrationAWSOIDCSpec{
+					RoleARN: "arn:aws:iam::123456789012:role/TerraformRole",
+				},
+				IsManagedByTerraform: true,
 			},
 		},
 	}


### PR DESCRIPTION
Two small changes combined into one. This supports https://github.com/gravitational/teleport/issues/60819 and https://github.com/gravitational/teleport/issues/60818 (is required by https://github.com/gravitational/teleport/pull/62145)

This adds a new label to mark when a resource has been created by IaC of some form. We originally wanted to add this to the `Origin` label, but https://github.com/gravitational/teleport/blob/840b60d05896bd34ab7cc57f9527d36b32f909a5/api/types/header/header.go#L274-L278 makes any new labels incompatible with older clusters. We will form a plan to get this check out eventually, but for now, we can create a new label (and migrate later easily, without breaking clusters).

Also, adds the user tasks to the `stats` endpoint response, in order to support the overview page.