### PR TITLE
[v17] ExternalAuditStorage: Utilize region field for audit logs and session handler

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -444,6 +444,7 @@ func (cfg *Config) UpdateForExternalAuditStorage(ctx context.Context, externalAu
 	cfg.QueryResultsS3 = spec.AthenaResultsURI
 	cfg.Database = spec.GlueDatabase
 	cfg.TableName = spec.GlueTable
+	cfg.Region = spec.Region
 
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(cfg.Region),

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1830,10 +1830,12 @@ func initAuthUploadHandler(ctx context.Context, auditConfig types.ClusterAuditCo
 		config := s3sessions.Config{
 			UseFIPSEndpoint: auditConfig.GetUseFIPSEndpoint(),
 		}
+		region := auditConfig.Region()
 		if externalAuditStorage.IsUsed() {
 			config.CredentialsProvider = externalAuditStorage.CredentialsProvider()
+			region = externalAuditStorage.GetSpec().Region
 		}
-		if err := config.SetFromURL(uri, auditConfig.Region()); err != nil {
+		if err := config.SetFromURL(uri, region); err != nil {
 			return nil, trace.Wrap(err)
 		}
 


### PR DESCRIPTION
Backport #62503 to branch/v17

changelog: Audit log and session uploader now respect region field of external_audit_storage resource when present
