### PR TITLE
Unify device verification logic under lib/devicetrust/authz

### DIFF
--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -152,7 +152,7 @@ func VerifyTrustedDeviceMode(
 		return nil // Equivalent to mode=off.
 	}
 
-	// Assume required so it fails closed.
+	// Assume required so it denies by default.
 	required := true
 
 	// Switch on mode before any exemptions so we catch unknown modes.

--- a/lib/devicetrust/authz/authz.go
+++ b/lib/devicetrust/authz/authz.go
@@ -169,11 +169,11 @@ func VerifyTrustedDeviceMode(
 		// Only trusted devices allowed for bot human and bot users.
 
 	default:
-		// Unknown mode. Trusted devices are allowed to pass.
 		slog.WarnContext(context.Background(),
-			"Unknown device trust mode, treating enforcement as required",
+			"Unknown device trust mode, treating device as untrusted",
 			"mode", enforcementMode,
 		)
+		return trace.Wrap(ErrTrustedDeviceRequired)
 	}
 
 	if required && !params.IsTrustedDevice {

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -379,7 +379,7 @@ func TestVerifyTrustedDeviceMode(t *testing.T) {
 	tests = append(tests,
 		testCase{
 			name:    "empty mode: AllowEmptyMode=false",
-			wantErr: true, // Strict.
+			wantErr: true, // Unknown mode always errors.
 		},
 		testCase{
 			name: "empty mode: AllowEmptyMode=true",
@@ -395,7 +395,7 @@ func TestVerifyTrustedDeviceMode(t *testing.T) {
 		testCase{
 			name:    "unknown mode: untrusted human",
 			mode:    "llama",
-			wantErr: true, // Strict.
+			wantErr: true, // Unknown mode always errors.
 		},
 		testCase{
 			name: "unknown mode: trusted human",
@@ -403,7 +403,7 @@ func TestVerifyTrustedDeviceMode(t *testing.T) {
 			params: authz.VerifyTrustedDeviceModeParams{
 				IsTrustedDevice: true,
 			},
-			wantErr: false, // Trusted device allowed.
+			wantErr: true, // Unknown mode always errors.
 		},
 	)
 

--- a/lib/devicetrust/authz/authz_test.go
+++ b/lib/devicetrust/authz/authz_test.go
@@ -20,6 +20,7 @@ package authz_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -274,6 +275,148 @@ func runVerifyUserTest(t *testing.T, method string, verify func(dt *types.Device
 			}
 
 			test.assertErr(t, verify(test.dt, test.ext, botName))
+		})
+	}
+}
+
+func TestVerifyTrustedDeviceMode(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name    string
+		mode    constants.DeviceTrustMode
+		params  authz.VerifyTrustedDeviceModeParams
+		wantErr bool
+	}
+
+	var tests []testCase
+
+	// Mode "off"/"optional" matrix. Always passes.
+	for _, mode := range []constants.DeviceTrustMode{
+		constants.DeviceTrustModeOff,
+		constants.DeviceTrustModeOptional,
+	} {
+		for _, trusted := range []bool{false, true} {
+			for _, bot := range []bool{false, true} {
+				tests = append(tests, testCase{
+					name: fmt.Sprintf("%s: trusted=%v bot=%v", mode, trusted, bot),
+					mode: mode,
+					params: authz.VerifyTrustedDeviceModeParams{
+						IsTrustedDevice: trusted,
+						IsBot:           bot,
+					},
+					wantErr: false, // Allowed.
+				})
+			}
+		}
+	}
+
+	// Mode "required" matrix.
+	tests = append(tests,
+		testCase{
+			name:    "required: untrusted human",
+			mode:    constants.DeviceTrustModeRequired,
+			wantErr: true,
+		},
+		testCase{
+			name: "required: untrusted bot",
+			mode: constants.DeviceTrustModeRequired,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsBot: true,
+			},
+			wantErr: true,
+		},
+		testCase{
+			name: "required: trusted human",
+			mode: constants.DeviceTrustModeRequired,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: true,
+			},
+		},
+		testCase{
+			name: "required: trusted bot",
+			mode: constants.DeviceTrustModeRequired,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: true,
+				IsBot:           true,
+			},
+		},
+	)
+
+	// Mode "required-for-humans" matrix.
+	tests = append(tests,
+		testCase{
+			name:    "required-for-humans: untrusted human",
+			mode:    constants.DeviceTrustModeRequiredForHumans,
+			wantErr: true,
+		},
+		testCase{
+			name: "required-for-humans: untrusted bot",
+			mode: constants.DeviceTrustModeRequiredForHumans,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsBot: true,
+			},
+			wantErr: false, // Allowed because bot.
+		},
+		testCase{
+			name: "required-for-humans: trusted human",
+			mode: constants.DeviceTrustModeRequiredForHumans,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: true,
+			},
+		},
+		testCase{
+			name: "required-for-humans: trusted bot",
+			mode: constants.DeviceTrustModeRequiredForHumans,
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: true,
+				IsBot:           true,
+			},
+		},
+	)
+
+	// mode="".
+	tests = append(tests,
+		testCase{
+			name:    "empty mode: AllowEmptyMode=false",
+			wantErr: true, // Strict.
+		},
+		testCase{
+			name: "empty mode: AllowEmptyMode=true",
+			params: authz.VerifyTrustedDeviceModeParams{
+				AllowEmptyMode: true,
+			},
+			wantErr: false, // Treated as mode="off".
+		},
+	)
+
+	// Unknown modes.
+	tests = append(tests,
+		testCase{
+			name:    "unknown mode: untrusted human",
+			mode:    "llama",
+			wantErr: true, // Strict.
+		},
+		testCase{
+			name: "unknown mode: trusted human",
+			mode: "llama",
+			params: authz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: true,
+			},
+			wantErr: false, // Trusted device allowed.
+		},
+	)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := authz.VerifyTrustedDeviceMode(test.mode, test.params)
+			if test.wantErr {
+				assert.ErrorIs(t, got, authz.ErrTrustedDeviceRequired)
+				return
+			}
+			assert.NoError(t, got)
 		})
 	}
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2770,23 +2770,18 @@ func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state 
 		}
 
 		// Device verification.
-		var deviceVerificationPassed bool
-		switch role.GetOptions().DeviceTrustMode {
-		case constants.DeviceTrustModeOff, constants.DeviceTrustModeOptional, "":
-			// OK, extensions not enforced.
-			deviceVerificationPassed = true
-		case constants.DeviceTrustModeRequiredForHumans:
-			// Humans must use trusted devices, bots can use untrusted devices.
-			deviceVerificationPassed = deviceTrusted || state.IsBot
-		case constants.DeviceTrustModeRequired:
-			// Only trusted devices allowed for bot human and bot users.
-			deviceVerificationPassed = deviceTrusted
-		}
-		if !deviceVerificationPassed {
+		if err := dtauthz.VerifyTrustedDeviceMode(
+			role.GetOptions().DeviceTrustMode,
+			dtauthz.VerifyTrustedDeviceModeParams{
+				IsTrustedDevice: deviceTrusted,
+				IsBot:           state.IsBot,
+				AllowEmptyMode:  true, // Empty mode on roles is equivalent to "off".
+			},
+		); err != nil {
 			logger.LogAttrs(ctx, logutils.TraceLevel, "Access to resource denied, role requires a trusted device",
 				slog.String("role", role.GetName()),
 			)
-			return ErrTrustedDeviceRequired
+			return trace.Wrap(err)
 		}
 
 		// Current role allows access, but keep looking for a more restrictive


### PR DESCRIPTION
Unifies duplicate device authz logic under lib/services/role.go by reusing a newly-exposed function under lib/devicetrust/authz.

This is a noop in terms of behavior, but an improvement in terms of maintenance.