### PR TITLE
Remove session summarizer warning log

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1991,15 +1991,10 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 	disableRoleVisualizer, _ := strconv.ParseBool(os.Getenv("TELEPORT_UNSTABLE_DISABLE_ROLE_VISUALIZER"))
 
 	sessionSummarizerEnabled := false
-	isEnabledRes, err := h.cfg.ProxyClient.SummarizerServiceClient().IsEnabled(
-		r.Context(), &summarizerv1.IsEnabledRequest{},
-	)
-	if err != nil {
-		h.logger.ErrorContext(r.Context(),
-			"Cannot tell if the session summarizer is enabled, session summarizations won't show up in the UI",
-			"error", err,
-		)
-	} else {
+	if isEnabledRes, err := h.cfg.ProxyClient.SummarizerServiceClient().IsEnabled(
+		r.Context(),
+		&summarizerv1.IsEnabledRequest{},
+	); err == nil {
 		sessionSummarizerEnabled = isEnabledRes.Enabled
 	}
 


### PR DESCRIPTION
If Identity Security (AKA "Policy" in the entitlement) is not enabled on the cluster, then the summarizer gRPC service is never instantiated.

This is expected behavior, but we log a warning that has caused confusion. Remove the warning since there's nothing exceptional about this case.

Closes #62310