### PR TITLE
Add `teleport debug metrics` command

### DIFF
--- a/lib/client/debug/debug.go
+++ b/lib/client/debug/debug.go
@@ -202,6 +202,15 @@ func (c *Client) GetMetrics(ctx context.Context) (map[string]*dto.MetricFamily, 
 	return metrics, nil
 }
 
+// GetRawMetrics returns unprocessed prometheus metrics from the /metrics endpoint.
+func (c *Client) GetRawMetrics(ctx context.Context) (io.ReadCloser, error) {
+	resp, err := c.do(ctx, http.MethodGet, url.URL{Path: "/metrics"}, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp.Body, nil
+}
+
 func (c *Client) do(ctx context.Context, method string, u url.URL, body []byte) (*http.Response, error) {
 	u.Scheme = "http"
 	u.Host = "debug"

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -618,6 +618,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	collectProfilesCmd.Arg("PROFILES", fmt.Sprintf("Comma-separated profile names to be exported. Supported profiles: %s. Default: %s", strings.Join(slices.Collect(maps.Keys(debugclient.SupportedProfiles)), ","), strings.Join(defaultCollectProfiles, ","))).StringVar(&ccf.Profiles)
 	collectProfilesCmd.Flag("seconds", "For CPU and trace profiles, profile for the given duration (if set to 0, it returns a profile snapshot). For other profiles, return a delta profile. Default: 0").Short('s').Default("0").IntVar(&ccf.ProfileSeconds)
 	readyzCmd := debugCmd.Command("readyz", "Checks if the instance is ready to serve requests.")
+	metricsCmd := debugCmd.Command("metrics", "Fetches the cluster's Prometheus metrics.")
 
 	selinuxCmd := app.Command("selinux-ssh", "Commands related to SSH SELinux module.").Hidden()
 	selinuxCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').ExistingFileVar(&ccf.ConfigFile)
@@ -813,6 +814,8 @@ Examples:
 		err = onCollectProfiles(ccf.ConfigFile, ccf.Profiles, ccf.ProfileSeconds)
 	case readyzCmd.FullCommand():
 		err = onReadyz(ctx, ccf.ConfigFile)
+	case metricsCmd.FullCommand():
+		err = onMetrics(ctx, ccf.ConfigFile)
 	case moduleSourceCmd.FullCommand():
 		if runtime.GOOS != "linux" {
 			break


### PR DESCRIPTION
## Purpose

Adds a command to the teleport cli to query the `/metrics` endpoint to accommodate restricted environments, e.g. `curl` unavailable.

resolves #62175

## Testing

1. Start Teleport
```bash
./build/teleport start --diag-addr=127.0.0.1:3001
```

2. Run metrics command and save output to file
```bash
./build/teleport debug metrics > metrics.txt
```

3. Compare command output with output from metrics endpoint
```bash
curl http://127.0.0.1:3001/metrics
```

Example output (truncated for brevity):
```text
# HELP audit_failed_disk_monitoring Number of times disk monitoring failed.
# TYPE audit_failed_disk_monitoring counter
audit_failed_disk_monitoring 0
# HELP audit_failed_emit_events Number of times emitting audit event failed.
# TYPE audit_failed_emit_events counter
audit_failed_emit_events 0
# HELP audit_percentage_disk_space_used Percentage disk space used.
# TYPE audit_percentage_disk_space_used gauge
audit_percentage_disk_space_used 0
# HELP audit_server_open_files Number of open audit files
# TYPE audit_server_open_files gauge
audit_server_open_files 0
# HELP auth_generate_requests Number of current generate requests for server keys
# TYPE auth_generate_requests gauge
auth_generate_requests 0
# HELP auth_generate_requests_throttled_total Number of throttled requests to generate new server keys
# TYPE auth_generate_requests_throttled_total counter
auth_generate_requests_throttled_total 0
# HELP auth_generate_requests_total Number of requests to generate new server keys
# TYPE auth_generate_requests_total counter
auth_generate_requests_total 0
# HELP auth_generate_seconds Latency for generate requests for server keys
# TYPE auth_generate_seconds histogram
auth_generate_seconds_bucket{le="0.001"} 0
auth_generate_seconds_bucket{le="0.002"} 0
auth_generate_seconds_bucket{le="0.004"} 0
auth_generate_seconds_bucket{le="0.008"} 0
auth_generate_seconds_bucket{le="0.016"} 0
auth_generate_seconds_bucket{le="0.032"} 0
auth_generate_seconds_bucket{le="0.064"} 0
auth_generate_seconds_bucket{le="0.128"} 0
auth_generate_seconds_bucket{le="0.256"} 0
auth_generate_seconds_bucket{le="0.512"} 0
auth_generate_seconds_bucket{le="1.024"} 0
auth_generate_seconds_bucket{le="2.048"} 0
auth_generate_seconds_bucket{le="4.096"} 0
auth_generate_seconds_bucket{le="8.192"} 0
auth_generate_seconds_bucket{le="16.384"} 0
auth_generate_seconds_bucket{le="32.768"} 0
auth_generate_seconds_bucket{le="+Inf"} 0
auth_generate_seconds_sum 0
auth_generate_seconds_count 0
# HELP backend_batch_read_requests_total Number of read requests to the backend
# TYPE backend_batch_read_requests_total counter
backend_batch_read_requests_total{component="backend"} 31
# HELP backend_batch_read_seconds Latency for batch read operations
# TYPE backend_batch_read_seconds histogram
backend_batch_read_seconds_bucket{component="backend",le="0.001"} 31
backend_batch_read_seconds_bucket{component="backend",le="0.002"} 31
backend_batch_read_seconds_bucket{component="backend",le="0.004"} 31
...
```

changelog: Added `teleport debug metrics` command