### PR TITLE
Create new IaC Integration Overview page

### DIFF
--- a/web/packages/design/src/Tabs/useSlidingBottomBorderTabs.ts
+++ b/web/packages/design/src/Tabs/useSlidingBottomBorderTabs.ts
@@ -51,7 +51,7 @@ export function useSlidingBottomBorderTabs<T>({ activeTab }: { activeTab: T }) {
       borderRef.current.style.left = `${left}px`;
       borderRef.current.style.width = `${width}px`;
     }
-  }, [activeTab]);
+  });
 
   return { borderRef, parentRef };
 }

--- a/web/packages/shared/components/ToastNotification/ToastNotifications.tsx
+++ b/web/packages/shared/components/ToastNotification/ToastNotifications.tsx
@@ -52,7 +52,8 @@ const TopRightStickyContainer = styled.div`
   position: sticky;
   top: 0;
   right: 0;
-  z-index: 1;
+  // this is to make the toasts show over "drawer" dialogs, which are at z-index 1000
+  z-index: 1001;
 `;
 
 const TopRightFlexedContainer = styled.div`

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.story.tsx
@@ -1,0 +1,170 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import { Route } from 'react-router-dom';
+
+import { ToastNotificationProvider } from 'shared/components/ToastNotification';
+
+import cfg from 'teleport/config';
+import { IntegrationKind } from 'teleport/services/integrations';
+
+import { IaCIntegrationOverview } from './IaCIntegrationOverview';
+
+export default {
+  title: 'Teleport/IaCIntegrationOverview',
+};
+
+const integrationName = 'my-terraform-integration';
+const initialEntries = [
+  cfg.getIaCIntegrationRoute(IntegrationKind.AwsOidc, integrationName),
+];
+const path = cfg.routes.integrationOverview;
+
+export function Default() {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ToastNotificationProvider>
+        <Route path={path}>
+          <IaCIntegrationOverview />
+        </Route>
+      </ToastNotificationProvider>
+    </MemoryRouter>
+  );
+}
+Default.parameters = {
+  msw: {
+    handlers: [
+      http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
+        return HttpResponse.json({
+          name: integrationName,
+          subKind: IntegrationKind.AwsOidc,
+          unresolvedUserTasks: 2,
+          userTasks: [
+            {
+              name: 'task-1',
+              taskType: 'discover-ec2',
+              state: 'OPEN',
+              issueType: 'ec2-ssm-invocation-failure',
+              title: 'EC2 SSM Invocation Failure',
+              integration: integrationName,
+              lastStateChange: new Date().toISOString(),
+            },
+            {
+              name: 'task-2',
+              taskType: 'discover-rds',
+              state: 'OPEN',
+              issueType: 'rds-agent-not-connecting',
+              title: 'RDS Agent Not Connecting',
+              integration: integrationName,
+              lastStateChange: new Date(
+                Date.now() - 24 * 60 * 60 * 1000
+              ).toISOString(),
+            },
+          ],
+          awsoidc: {
+            roleArn: 'arn:aws:iam::123456789012:role/TeleportRole',
+          },
+          awsec2: { enrolled: 5, failed: 1 },
+          awsrds: { enrolled: 3, failed: 0 },
+          awseks: { enrolled: 2, failed: 0 },
+          isManagedByTerraform: true,
+        });
+      }),
+    ],
+  },
+};
+
+export function Healthy() {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ToastNotificationProvider>
+        <Route path={path}>
+          <IaCIntegrationOverview />
+        </Route>
+      </ToastNotificationProvider>
+    </MemoryRouter>
+  );
+}
+Healthy.parameters = {
+  msw: {
+    handlers: [
+      http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
+        return HttpResponse.json({
+          name: integrationName,
+          subKind: IntegrationKind.AwsOidc,
+          unresolvedUserTasks: 0,
+          userTasks: [],
+          awsoidc: {
+            roleArn: 'arn:aws:iam::123456789012:role/TeleportRole',
+          },
+          awsec2: { enrolled: 10, failed: 0 },
+          awsrds: { enrolled: 5, failed: 0 },
+          awseks: { enrolled: 3, failed: 0 },
+          isManagedByTerraform: true,
+        });
+      }),
+    ],
+  },
+};
+
+export function Loading() {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ToastNotificationProvider>
+        <Route path={path}>
+          <IaCIntegrationOverview />
+        </Route>
+      </ToastNotificationProvider>
+    </MemoryRouter>
+  );
+}
+Loading.parameters = {
+  msw: {
+    handlers: [
+      http.get(cfg.getIntegrationStatsUrl(integrationName), async () => {
+        await new Promise(() => {}); // Never resolves
+      }),
+    ],
+  },
+};
+
+export function Error() {
+  return (
+    <MemoryRouter initialEntries={initialEntries}>
+      <ToastNotificationProvider>
+        <Route path={path}>
+          <IaCIntegrationOverview />
+        </Route>
+      </ToastNotificationProvider>
+    </MemoryRouter>
+  );
+}
+Error.parameters = {
+  msw: {
+    handlers: [
+      http.get(cfg.getIntegrationStatsUrl(integrationName), () => {
+        return HttpResponse.json(
+          { error: { message: 'Failed to fetch integration stats' } },
+          { status: 500 }
+        );
+      }),
+    ],
+  },
+};

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
@@ -1,0 +1,427 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { formatDistanceToNowStrict } from 'date-fns';
+import { useState, type ReactNode } from 'react';
+import { useParams } from 'react-router';
+import { Link as RouterLink } from 'react-router-dom';
+
+import { Box, Card, Flex, H2, Indicator, Text } from 'design';
+import { Danger } from 'design/Alert';
+import { ButtonPrimaryBorder, ButtonText } from 'design/Button';
+import ButtonIcon from 'design/ButtonIcon';
+import { displayDateTime } from 'design/datetime';
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronRight,
+  CircleCheck,
+  CircleCross,
+  Warning,
+} from 'design/Icon';
+import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
+import { TabBorder, useSlidingBottomBorderTabs } from 'design/Tabs';
+import { HoverTooltip } from 'design/Tooltip';
+import { pluralize } from 'shared/utils/text';
+
+import { FeatureBox } from 'teleport/components/Layout';
+import cfg from 'teleport/config';
+import {
+  IntegrationKind,
+  integrationService,
+  IntegrationWithSummary,
+} from 'teleport/services/integrations';
+
+// import { ActivityTab } from './ActivityTab';
+import { SmallTab, SmallTabsContainer } from './SmallTabs';
+
+export function formatRelativeDate(value?: string | Date): string {
+  if (!value) {
+    return '-';
+  }
+
+  const date = value instanceof Date ? value : new Date(Date.parse(value));
+  if (Number.isNaN(date.getTime())) {
+    return typeof value === 'string' ? value : '-';
+  }
+
+  try {
+    return `${formatDistanceToNowStrict(date)} ago`;
+  } catch {
+    return displayDateTime(date);
+  }
+}
+type TabId = 'overview' | 'activity';
+
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  // add activity tab in next PR
+  // { id: 'activity', label: 'Activity' },
+] as const;
+
+export function IaCIntegrationOverview() {
+  const { name } = useParams<{ name: string }>();
+
+  const {
+    data: stats,
+    error,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['integrationStats', name],
+    queryFn: () => integrationService.fetchIntegrationStats(name),
+    enabled: !!name,
+  });
+
+  const [activeTab, setActiveTab] = useState<TabId>('overview');
+  const { borderRef, parentRef } = useSlidingBottomBorderTabs({ activeTab });
+
+  if (isLoading) {
+    return (
+      <FeatureBox pt={3}>
+        <Flex justifyContent="center" mt={6}>
+          <Indicator delay="long" />
+        </Flex>
+      </FeatureBox>
+    );
+  }
+
+  if (isError) {
+    return (
+      <FeatureBox maxWidth="1400px" pt={3}>
+        <Danger>{error?.message || 'Failed to load integration stats'}</Danger>
+      </FeatureBox>
+    );
+  }
+
+  return (
+    <FeatureBox maxWidth="1400px" pt={3}>
+      <Flex alignItems="center" justifyContent="space-between" mb={3}>
+        <Flex alignItems="center">
+          <HoverTooltip placement="bottom" tipContent="Back to Integrations">
+            <ButtonIcon as={RouterLink} to={cfg.routes.integrations} mr={2}>
+              <ArrowLeft size="medium" />
+            </ButtonIcon>
+          </HoverTooltip>
+          <Text bold fontSize={6} mr={2}>
+            {stats.name}
+          </Text>
+        </Flex>
+      </Flex>
+      <SmallTabsContainer ref={parentRef} mb={4}>
+        {TABS.map(t => (
+          <SmallTab
+            key={t.id}
+            data-tab-id={t.id}
+            selected={activeTab === t.id}
+            onClick={() => setActiveTab(t.id)}
+          >
+            {t.label}
+          </SmallTab>
+        ))}
+        <TabBorder ref={borderRef} />
+      </SmallTabsContainer>
+
+      {activeTab === 'overview' && (
+        <OverviewTab
+          stats={stats}
+          // onViewIssues={() => setActiveTab('activity')}
+          onViewIssues={() => alert('setting to activity tab in next PR')}
+        />
+      )}
+      {/* enabled in next PR */}
+      {/* {activeTab === 'activity' && <ActivityTab stats={stats} />} */}
+    </FeatureBox>
+  );
+}
+
+function OverviewTab({
+  stats,
+  onViewIssues,
+}: {
+  stats: IntegrationWithSummary;
+  onViewIssues: () => void;
+}) {
+  return (
+    <Flex flexDirection="column" gap={4}>
+      <IntegrationHealthCard stats={stats} onViewIssues={onViewIssues} />
+      <IssuesCard stats={stats} onViewIssues={onViewIssues} />
+    </Flex>
+  );
+}
+
+function IntegrationHealthCard({
+  stats,
+  onViewIssues,
+}: {
+  stats: IntegrationWithSummary;
+  onViewIssues: () => void;
+}) {
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
+
+  const hasIssues = stats.unresolvedUserTasks > 0;
+  const lastScanDate = getIntegrationLastScan(stats);
+  const lastScanText = formatRelativeDate(lastScanDate);
+  const configDetails = getIntegrationConfigDetails(stats);
+
+  return (
+    <Card p={4}>
+      <Flex alignItems="center" justifyContent="space-between" mb={3}>
+        <H2>Integration Health</H2>
+      </Flex>
+
+      <Flex flexDirection="column" gap={2}>
+        <StatusRow label="Status:">
+          <Flex alignItems="center" gap={2} flexWrap="wrap">
+            <LabelButtonWithIcon
+              IconLeft={hasIssues ? Warning : CircleCheck}
+              kind={hasIssues ? 'outline-warning' : 'outline-success'}
+            >
+              {hasIssues ? 'Issues' : 'Healthy'}
+            </LabelButtonWithIcon>
+            {hasIssues && (
+              <>
+                <Text typography="body3">
+                  ({stats.unresolvedUserTasks}{' '}
+                  {pluralize(stats.unresolvedUserTasks, 'Issue')} detected)
+                </Text>
+                <ButtonText
+                  intent="primary"
+                  size="small"
+                  onClick={onViewIssues}
+                >
+                  <Flex alignItems="center" gap={1}>
+                    View Issues <ArrowRight color="text.brand" size={16} />
+                  </Flex>
+                </ButtonText>
+              </>
+            )}
+          </Flex>
+        </StatusRow>
+
+        <StatusRow label="Last verified:">
+          <Text typography="body3">{lastScanText}</Text>
+        </StatusRow>
+
+        <StatusRow label="Resources:">
+          <Text typography="body3">{formatResourceCounts(stats)}</Text>
+        </StatusRow>
+      </Flex>
+
+      <Box mt={3} ml={-2}>
+        <Flex
+          alignItems="center"
+          onClick={() => setIsConfigOpen(v => !v)}
+          role="button"
+          tabIndex={0}
+          style={{ cursor: 'pointer' }}
+        >
+          <ButtonIcon
+            aria-label={
+              isConfigOpen
+                ? 'Collapse configuration details'
+                : 'Expand configuration details'
+            }
+            onClick={e => {
+              e.stopPropagation();
+              setIsConfigOpen(v => !v);
+            }}
+          >
+            <ChevronRight
+              size={16}
+              style={{
+                // point right for closed, down for open
+                transform: isConfigOpen ? 'rotate(90deg)' : undefined,
+                transition: 'transform 150ms ease',
+              }}
+            />
+          </ButtonIcon>
+          <Text typography="body3">Configuration details</Text>
+        </Flex>
+
+        {isConfigOpen && (
+          <Box mt={1} ml={5}>
+            {configDetails.map(detail => (
+              <KeyValue
+                key={`${detail.label}-${detail.value}`}
+                label={detail.label}
+                value={detail.value}
+              />
+            ))}
+            <KeyValue label="Last scan:" value={lastScanText} />
+          </Box>
+        )}
+      </Box>
+    </Card>
+  );
+}
+
+function IssuesCard({
+  stats,
+  onViewIssues,
+}: {
+  stats: IntegrationWithSummary;
+  onViewIssues: () => void;
+}) {
+  const issueCount = stats.unresolvedUserTasks;
+  const issues = stats.userTasks ?? [];
+
+  return (
+    <Card p={4}>
+      <Flex alignItems="center" justifyContent="space-between" mb={3}>
+        <Flex alignItems="center" gap={2}>
+          <Warning size={18} color="text.slightlyMuted" />
+          <H2>Issues ({issueCount})</H2>
+        </Flex>
+        {issueCount > 0 && (
+          <ButtonPrimaryBorder size="small" onClick={onViewIssues}>
+            View Issues
+          </ButtonPrimaryBorder>
+        )}
+      </Flex>
+
+      <Flex flexDirection="column" gap={2}>
+        {issues.map(issue => (
+          <IssueItem key={issue.name} text={issue.title} />
+        ))}
+      </Flex>
+    </Card>
+  );
+}
+
+function StatusRow(props: { label: string; children: ReactNode }) {
+  return (
+    <Flex gap={2} flexWrap="wrap" alignItems="center">
+      <Text typography="body2">{props.label}</Text>
+      {props.children}
+    </Flex>
+  );
+}
+
+function KeyValue(props: { label: string; value: string }) {
+  return (
+    <Flex gap={2} flexWrap="wrap" mb={1}>
+      <Text typography="body3">{props.label}</Text>
+      <Text typography="body3">{props.value}</Text>
+    </Flex>
+  );
+}
+
+function IssueItem(props: { text: string }) {
+  return (
+    <Flex gap={2} alignItems="flex-start">
+      <Box mt="2px">
+        <CircleCross size={18} color="error.main" />
+      </Box>
+      <Text typography="body3">{props.text}</Text>
+    </Flex>
+  );
+}
+
+function getIntegrationLastScan(
+  stats: IntegrationWithSummary
+): Date | undefined {
+  const lastScan = Math.max(
+    getTimestamp(stats.awsec2?.discoverLastSync),
+    getTimestamp(stats.awsrds?.discoverLastSync),
+    getTimestamp(stats.awseks?.discoverLastSync),
+    getTimestamp(stats.rolesAnywhereProfileSync?.syncEndTime)
+  );
+
+  return lastScan ? new Date(lastScan) : undefined;
+}
+
+function getIntegrationConfigDetails(
+  stats: IntegrationWithSummary
+): Array<{ label: string; value: string }> {
+  if (stats.subKind === IntegrationKind.AwsOidc) {
+    const details = [
+      { label: 'Role ARN:', value: stats.awsoidc?.roleArn || '-' },
+      { label: 'Issuer S3 bucket:', value: stats.awsoidc?.issuerS3Bucket },
+      { label: 'Issuer S3 prefix:', value: stats.awsoidc?.issuerS3Prefix },
+      { label: 'Audience:', value: stats.awsoidc?.audience },
+    ];
+
+    return details.filter(detail => detail.value);
+  }
+
+  if (stats.subKind === IntegrationKind.AwsRa) {
+    const profileSync = stats.awsra?.profileSyncConfig;
+    const details = [
+      { label: 'Trust anchor ARN:', value: stats.awsra?.trustAnchorARN || '-' },
+      {
+        label: 'Profile sync enabled:',
+        value: profileSync ? (profileSync.enabled ? 'Yes' : 'No') : '-',
+      },
+      { label: 'Profile ARN:', value: profileSync?.profileArn },
+      { label: 'Role ARN:', value: profileSync?.roleArn },
+      {
+        label: 'Profile name filters:',
+        value: profileSync?.filters?.length
+          ? profileSync.filters.join(', ')
+          : undefined,
+      },
+    ];
+
+    return details.filter(detail => detail.value);
+  }
+
+  return [];
+}
+
+function formatResourceCounts(stats: IntegrationWithSummary): string {
+  const ec2Count = stats.awsec2?.resourcesFound || 0;
+  const rdsCount = stats.awsrds?.resourcesFound || 0;
+  const eksCount = stats.awseks?.resourcesFound || 0;
+  const total = ec2Count + rdsCount + eksCount;
+
+  if (total === 0) {
+    return 'No resources discovered';
+  }
+
+  const parts: string[] = [];
+  if (ec2Count > 0) {
+    parts.push(`EC2: ${ec2Count}`);
+  }
+  if (rdsCount > 0) {
+    parts.push(`RDS: ${rdsCount}`);
+  }
+  if (eksCount > 0) {
+    parts.push(`EKS: ${eksCount}`);
+  }
+
+  return `${total} Discovered (${parts.join(', ')})`;
+}
+
+function getTimestamp(value: unknown): number {
+  if (!value) {
+    return 0;
+  }
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+  }
+  return 0;
+}

--- a/web/packages/teleport/src/Discover/Overview/MarkAsResolvedDialog.tsx
+++ b/web/packages/teleport/src/Discover/Overview/MarkAsResolvedDialog.tsx
@@ -1,0 +1,64 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Alert, Text } from 'design';
+import { ButtonPrimary, ButtonSecondary } from 'design/Button';
+import Dialog, {
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from 'design/DialogConfirmation';
+
+export function MarkAsResolvedDialog(props: {
+  isProcessing: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  confirmDisabled?: boolean;
+}) {
+  const { isProcessing, onCancel, onConfirm, confirmDisabled } = props;
+
+  return (
+    <Dialog onClose={onCancel} open={true}>
+      <DialogHeader>
+        <DialogTitle>Mark as Resolved</DialogTitle>
+      </DialogHeader>
+      <DialogContent width="450px">
+        <Alert kind="warning" mb={3}>
+          These issues will reappear if the underlying problems are not fixed.
+        </Alert>
+        <Text typography="body3">
+          Teleport will automatically retry enrolling these resources in the
+          next discovery scan.
+        </Text>
+      </DialogContent>
+      <DialogFooter>
+        <ButtonPrimary
+          mr="3"
+          disabled={isProcessing || confirmDisabled}
+          onClick={onConfirm}
+        >
+          Mark as Resolved
+        </ButtonPrimary>
+        <ButtonSecondary disabled={isProcessing} onClick={onCancel}>
+          Cancel
+        </ButtonSecondary>
+      </DialogFooter>
+    </Dialog>
+  );
+}

--- a/web/packages/teleport/src/Discover/Overview/SmallTabs.ts
+++ b/web/packages/teleport/src/Discover/Overview/SmallTabs.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -15,11 +15,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { getErrorMessage } from './error';
 
-export {
-  /**
-   * @deprecated Import `getErrorMessage` from 'shared/utils/error.ts'
-   */
-  getErrorMessage as getErrMessage,
-};
+import styled from 'styled-components';
+
+import { TabContainer, TabsContainer } from 'design/Tabs';
+
+export const SmallTabsContainer = styled(TabsContainer)`
+  gap: ${p => p.theme.space[3]}px;
+`;
+
+export const SmallTab = styled(TabContainer)`
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+  padding: ${p => p.theme.space[2]}px ${p => p.theme.space[2]}px;
+`;

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -67,13 +67,25 @@ export function IntegrationList(props: Props) {
   const history = useHistory();
 
   function handleRowClick(row: IntegrationLike) {
+    // TODO (avatus) enable this feature by checking isManagedByTerraform.
+    // Leaving commented until IaC form and settings page are implemented
+
+    // if ('isManagedByTerraform' in row && row.isManagedByTerraform) {
+    //   history.push(cfg.getIaCIntegrationRoute(row.kind, row.name));
+    //   return;
+    // }
+
     if (!statusKinds.includes(row.kind)) return;
     history.push(cfg.getIntegrationStatusRoute(row.kind, row.name));
   }
 
   function getRowStyle(row: IntegrationLike): React.CSSProperties {
-    if (!statusKinds.includes(row.kind)) return;
-    return { cursor: 'pointer' };
+    if (
+      ('isManagedByTerraform' in row && row.isManagedByTerraform) ||
+      statusKinds.includes(row.kind)
+    ) {
+      return { cursor: 'pointer' };
+    }
   }
 
   const [downloadAttempt, download] = useAsync(

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -217,6 +217,7 @@ const cfg = {
     kubernetes: '/web/cluster/:clusterId/kubernetes',
     headlessSso: `/web/headless/:requestId`,
     integrations: '/web/integrations',
+    integrationOverview: '/web/integrations/overview/:type/:name',
     integrationStatus: '/web/integrations/status/:type/:name/:subPage?',
     integrationTasks: '/web/integrations/status/:type/:name/tasks',
     integrationStatusResources:
@@ -760,6 +761,10 @@ const cfg = {
     subPage?: string
   ) {
     return generatePath(cfg.routes.integrationStatus, { type, name, subPage });
+  },
+
+  getIaCIntegrationRoute(type: PluginKind | IntegrationKind, name: string) {
+    return generatePath(cfg.routes.integrationOverview, { type, name });
   },
 
   getIntegrationStatusResourcesRoute(

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -42,6 +42,7 @@ import {
 
 import { IntegrationEnroll } from '@gravitational/teleport/src/Integrations/Enroll';
 import cfg, { Cfg } from 'teleport/config';
+import { IaCIntegrationOverview } from 'teleport/Discover/Overview/IaCIntegrationOverview';
 import { IntegrationStatus } from 'teleport/Integrations/IntegrationStatus';
 import {
   NavigationCategory,
@@ -819,6 +820,20 @@ class FeatureIntegrationStatus implements TeleportFeature {
   }
 }
 
+export class FeatureIntegrationOverview implements TeleportFeature {
+  parent = FeatureIntegrations;
+
+  route = {
+    title: 'Integration Overview',
+    path: cfg.routes.integrationOverview,
+    component: IaCIntegrationOverview,
+  };
+
+  hasAccess() {
+    return true;
+  }
+}
+
 // ****************************
 // Other Features
 // ****************************
@@ -904,6 +919,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureClusters(),
     new FeatureTrust(),
     new FeatureIntegrationStatus(),
+    new FeatureIntegrationOverview(),
 
     // - Identity
     new AccessRequests(),

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -505,8 +505,11 @@ export const integrationService = {
       });
   },
 
-  fetchUserTask(name: string): Promise<UserTaskDetail> {
-    return api.get(cfg.getUserTaskUrl(name)).then(resp => {
+  fetchUserTask(
+    name: string,
+    abortSignal?: AbortSignal
+  ): Promise<UserTaskDetail> {
+    return api.get(cfg.getUserTaskUrl(name), abortSignal).then(resp => {
       return {
         name: resp.name,
         taskType: resp.taskType,
@@ -517,20 +520,20 @@ export const integrationService = {
         description: resp.description,
         title: resp.title,
         discoverEc2: {
-          instances: resp.discoverEc2?.instances,
+          instances: resp.discoverEc2?.instances || {},
           account_id: resp.discoverEc2?.account_id,
           region: resp.discoverEc2?.region,
           ssm_document: resp.discoverEc2?.ssm_document,
           installer_script: resp.discoverEc2?.installer_script,
         },
         discoverEks: {
-          clusters: resp.discoverEks?.clusters,
+          clusters: resp.discoverEks?.clusters || {},
           account_id: resp.discoverEks?.account_id,
           region: resp.discoverEks?.region,
           app_auto_discover: resp.discoverEks?.app_auto_discover,
         },
         discoverRds: {
-          databases: resp.discoverRds?.databases,
+          databases: resp.discoverRds?.databases || {},
           account_id: resp.discoverRds?.account_id,
           region: resp.discoverRds?.region,
         },
@@ -626,7 +629,7 @@ export function makeIntegrations(json: any): Integration[] {
 
 function makeIntegration(json: any): Integration {
   json = json || {};
-  const { name, subKind, awsoidc, github, awsra } = json;
+  const { name, subKind, awsoidc, github, awsra, isManagedByTerraform } = json;
 
   const commonFields = {
     name,
@@ -637,6 +640,7 @@ function makeIntegration(json: any): Integration {
     // supported status for integration is `Running` for now:
     // https://github.com/gravitational/teleport/pull/22556#discussion_r1158674300
     statusCode: IntegrationStatusCode.Running,
+    isManagedByTerraform,
   };
 
   if (subKind === IntegrationKind.AwsOidc) {

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -582,6 +582,8 @@ export type IntegrationWithSummary = {
   subKind: string;
   // unresolvedUserTasks contains the count of unresolved user tasks related to this integration.
   unresolvedUserTasks: number;
+  // userTasks contains the list of unresolved user tasks related to this integration.
+  userTasks?: UserTask[];
   // awsra contains the fields for `aws-ra` subkind integration.
   awsra: IntegrationSpecAwsRa;
   // awsoidc contains the fields for `aws-oidc` subkind integration.
@@ -594,6 +596,7 @@ export type IntegrationWithSummary = {
   awseks: ResourceTypeSummary;
   // rolesAnywhereProfileSync contains the summary for the AWS Roles Anywhere Profile Sync.
   rolesAnywhereProfileSync: RolesAnywhereProfileSync;
+  isManagedByTerraform?: boolean;
 };
 
 // IntegrationDiscoveryRules contains the list of discovery rules for a given Integration.


### PR DESCRIPTION
This for now only supports AWS but is created in a way to extend into Azure integrations quickly after.

to view, open your integration page `/web/integrations/status/aws-oidc/teleport-aws-account-278576220453` replace `status` with `overview` to view the new page. navigation is currently disabled while we wait for settings tab and `isManagedByTerraform` fields to be returned from the backend (backend PR here https://github.com/gravitational/teleport/pull/62518)

part of https://github.com/gravitational/teleport/issues/60819 and https://github.com/gravitational/teleport/issues/60812

activity tab coming in next stacked PR, split to make reviewing easier https://github.com/gravitational/teleport/pull/62534

e buddy https://github.com/gravitational/teleport.e/pull/7773