### PR TITLE
Prevent session uploads from infinitely retrying

### DIFF
--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -67,10 +67,10 @@ const (
 	// valuable info.
 	CorruptedSessionsDir = "corrupted"
 
-	// CorruptedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/abandoned)
-	// where abandoned session recordings are placed (i.e. uploading the session failed, but not
-	// due to corruption).
-	AbandonedSessionsDir = "abandoned"
+	// DelayedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/delayed)
+	// where delayed session recordings are placed (i.e. uploading the session failed non-permanently
+	// and will be retried at a reduced frequency).
+	DelayedSessionsDir = "delayed"
 
 	// RecordsDir is an auth server subdirectory with session recordings that is used
 	// when the auth server is not configured for external cloud storage. It is not

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -67,6 +67,11 @@ const (
 	// valuable info.
 	CorruptedSessionsDir = "corrupted"
 
+	// CorruptedSessionsDir is a subdirectory of sessions (/var/lib/teleport/log/upload/abandoned)
+	// where abandoned session recordings are placed (i.e. uploading the session failed, but not
+	// due to corruption).
+	AbandonedSessionsDir = "abandoned"
+
 	// RecordsDir is an auth server subdirectory with session recordings that is used
 	// when the auth server is not configured for external cloud storage. It is not
 	// used by nodes, proxies, or other Teleport services.

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -246,7 +246,9 @@ func (u *Uploader) Serve(ctx context.Context) error {
 					u.log.WarnContext(ctx, "Failed to write session", "error", err, "session_id", event.SessionID)
 				}
 			default:
-				u.uploadAttempts[event.SessionID]++
+				if !trace.IsAccessDenied(event.Error) && !trace.IsNotFound(event.Error) {
+					u.uploadAttempts[event.SessionID]++
+				}
 				u.backoff.Inc()
 				u.log.WarnContext(ctx, "Increasing session upload backoff due to error, applying backoff before retrying", "backoff", u.backoff.Duration())
 			}

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -271,7 +271,8 @@ func (u *Uploader) Serve(ctx context.Context) error {
 				}
 			case u.cfg.MaxUploadAttempts != 0 && u.uploadAttempts[event.SessionID] >= u.cfg.MaxUploadAttempts:
 				delete(u.uploadAttempts, event.SessionID)
-				u.log.WarnContext(ctx, fmt.Sprintf("Failed to upload session after %d attempts, will skip future uploads.", u.uploadAttempts[event.SessionID]), "session_id", event.SessionID)
+				u.log.WarnContext(ctx, "Failed to upload session, will skip future uploads.",
+					"session_id", event.SessionID, "error", event.Error, "attempts", u.uploadAttempts[event.SessionID])
 				if err := u.writeAbandonedError(session.ID(event.SessionID), event.Error); err != nil {
 					u.log.WarnContext(ctx, "Failed to write session", "error", err, "session_id", event.SessionID)
 				}

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -104,7 +104,7 @@ func TestChaosUpload(t *testing.T) {
 	uploader, err := NewUploader(UploaderConfig{
 		ScanDir:      scanDir,
 		CorruptedDir: corruptedDir,
-		AbandonedDir: t.TempDir(),
+		DelayedDir:   t.TempDir(),
 		ScanPeriod:   100 * time.Millisecond,
 		Streamer:     faultyStreamer,
 		Clock:        clockwork.NewRealClock(),

--- a/lib/events/filesessions/fileasync_chaos_test.go
+++ b/lib/events/filesessions/fileasync_chaos_test.go
@@ -104,6 +104,7 @@ func TestChaosUpload(t *testing.T) {
 	uploader, err := NewUploader(UploaderConfig{
 		ScanDir:      scanDir,
 		CorruptedDir: corruptedDir,
+		AbandonedDir: t.TempDir(),
 		ScanPeriod:   100 * time.Millisecond,
 		Streamer:     faultyStreamer,
 		Clock:        clockwork.NewRealClock(),

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -476,7 +476,7 @@ func (e *retryErrorStreamer) ResumeAuditStream(ctx context.Context, sid session.
 	return nil, trace.Errorf("test error")
 }
 
-func TestUploadRetryLimit(t *testing.T) {
+func TestUploadMaxAttempts(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		ctx := t.Context()
 

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -472,6 +472,9 @@ const (
 	checkpointExt = ".checkpoint"
 	// errorExt is a suffix for files storing session errors
 	errorExt = ".error"
+	// abandonedErrorExt is a suffix for files storing session errors due to
+	// abandoning an upload.
+	abandonedErrorExt = ".abandoned" + errorExt
 	// reservationExt is part reservation extension.
 	reservationExt = ".reservation"
 )

--- a/lib/events/filesessions/filestream.go
+++ b/lib/events/filesessions/filestream.go
@@ -472,9 +472,9 @@ const (
 	checkpointExt = ".checkpoint"
 	// errorExt is a suffix for files storing session errors
 	errorExt = ".error"
-	// abandonedErrorExt is a suffix for files storing session errors due to
-	// abandoning an upload.
-	abandonedErrorExt = ".abandoned" + errorExt
+	// delayedErrorExt is a suffix for files storing session errors due to
+	// delaying an upload.
+	delayedErrorExt = ".delayed" + errorExt
 	// reservationExt is part reservation extension.
 	reservationExt = ".reservation"
 )

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -783,6 +783,7 @@ func (w *sliceWriter) newSlice() (*slice, error) {
 		// Return the unused buffer to the pool.
 		w.proto.cfg.BufferPool.Put(buffer)
 		writer.Close()
+		slog.WarnContext(w.proto.cancelCtx, "Failed to reserve upload part.", "error", err)
 		return nil, trace.ConnectionProblem(err, uploaderReservePartErrorMessage)
 	}
 

--- a/lib/events/stream.go
+++ b/lib/events/stream.go
@@ -783,7 +783,8 @@ func (w *sliceWriter) newSlice() (*slice, error) {
 		// Return the unused buffer to the pool.
 		w.proto.cfg.BufferPool.Put(buffer)
 		writer.Close()
-		slog.WarnContext(w.proto.cancelCtx, "Failed to reserve upload part.", "error", err)
+		slog.WarnContext(w.proto.cancelCtx, "Failed to reserve upload part.",
+			"session_id", w.proto.cfg.Upload.SessionID, "error", err)
 		return nil, trace.ConnectionProblem(err, uploaderReservePartErrorMessage)
 	}
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3831,7 +3831,7 @@ func (process *TeleportProcess) initUploaderService() error {
 	paths := [][]string{
 		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingSessionsDir, apidefaults.Namespace},
 		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.CorruptedSessionsDir, apidefaults.Namespace},
-		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.AbandonedSessionsDir, apidefaults.Namespace},
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.DelayedSessionsDir, apidefaults.Namespace},
 	}
 	for _, path := range paths {
 		for i := 1; i < len(path); i++ {
@@ -3854,13 +3854,13 @@ func (process *TeleportProcess) initUploaderService() error {
 
 	uploadsDir := filepath.Join(paths[0]...)
 	corruptedDir := filepath.Join(paths[1]...)
-	abandonedDir := filepath.Join(paths[2]...)
+	delayedDir := filepath.Join(paths[2]...)
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
 		Streamer:                        uploaderClient,
 		ScanDir:                         uploadsDir,
 		CorruptedDir:                    corruptedDir,
-		AbandonedDir:                    abandonedDir,
+		DelayedDir:                      delayedDir,
 		EventsC:                         process.Config.Testing.UploadEventsC,
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3831,6 +3831,7 @@ func (process *TeleportProcess) initUploaderService() error {
 	paths := [][]string{
 		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.StreamingSessionsDir, apidefaults.Namespace},
 		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.CorruptedSessionsDir, apidefaults.Namespace},
+		{process.Config.DataDir, teleport.LogsDir, teleport.ComponentUpload, events.AbandonedSessionsDir, apidefaults.Namespace},
 	}
 	for _, path := range paths {
 		for i := 1; i < len(path); i++ {
@@ -3853,11 +3854,13 @@ func (process *TeleportProcess) initUploaderService() error {
 
 	uploadsDir := filepath.Join(paths[0]...)
 	corruptedDir := filepath.Join(paths[1]...)
+	abandonedDir := filepath.Join(paths[2]...)
 
 	fileUploader, err := filesessions.NewUploader(filesessions.UploaderConfig{
 		Streamer:                        uploaderClient,
 		ScanDir:                         uploadsDir,
 		CorruptedDir:                    corruptedDir,
+		AbandonedDir:                    abandonedDir,
 		EventsC:                         process.Config.Testing.UploadEventsC,
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3862,7 +3862,7 @@ func (process *TeleportProcess) initUploaderService() error {
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,
 		EncryptedRecordingUploadMaxSize: encryptedRecordingMaxUploadSize,
-		RetryLimit:                      10,
+		MaxUploadAttempts:               10,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3862,6 +3862,7 @@ func (process *TeleportProcess) initUploaderService() error {
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,
 		EncryptedRecordingUploadMaxSize: encryptedRecordingMaxUploadSize,
+		RetryLimit:                      10,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/utils/aws/s3.go
+++ b/lib/utils/aws/s3.go
@@ -29,6 +29,7 @@ import (
 	s3v2 "github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	awshttp "github.com/aws/smithy-go/transport/http"
 	"github.com/gravitational/trace"
 )
 
@@ -67,6 +68,11 @@ func ConvertS3Error(err error) error {
 	var opError *smithy.OperationError
 	if errors.As(err, &opError) && strings.Contains(opError.Err.Error(), "FIPS") {
 		return trace.BadParameter("%s", opError)
+	}
+
+	var httpError *awshttp.ResponseError
+	if errors.As(err, &httpError) {
+		return trace.ReadError(httpError.HTTPStatusCode(), []byte(err.Error()))
 	}
 
 	return err


### PR DESCRIPTION
This change updates the session uploader to mark sessions as corrupted if the upload fails too many times.

Resolves #60981.

Changelog: Fixed session uploader trying to upload sessions with unrecoverable errors indefinitely

# Test plan
- [x] Create a session that fails to upload (I did this by misconfiguring AWS credentials). Verify that the uploader doesn't attempt to upload it more times than the limit