### PR TITLE
fix some auto update audit events showing up as unknown

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -497,6 +497,13 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 	case AutoUpdateVersionDeleteEvent:
 		e = &events.AutoUpdateVersionDelete{}
 
+	case AutoUpdateAgentRolloutTriggerEvent:
+		e = &events.AutoUpdateAgentRolloutTrigger{}
+	case AutoUpdateAgentRolloutForceDoneEvent:
+		e = &events.AutoUpdateAgentRolloutForceDone{}
+	case AutoUpdateAgentRolloutRollbackEvent:
+		e = &events.AutoUpdateAgentRolloutRollback{}
+
 	case ContactCreateEvent:
 		e = &events.ContactCreate{}
 	case ContactDeleteEvent:


### PR DESCRIPTION
Looks like this was just missed in #52934.

Closes #61779

Changelog: fixed some auto update audit events showing up as unknown in the web UI.