### PR TITLE
[v18] fix some auto update audit events showing up as unknown

### DIFF
--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -493,6 +493,13 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 	case AutoUpdateVersionDeleteEvent:
 		e = &events.AutoUpdateVersionDelete{}
 
+	case AutoUpdateAgentRolloutTriggerEvent:
+		e = &events.AutoUpdateAgentRolloutTrigger{}
+	case AutoUpdateAgentRolloutForceDoneEvent:
+		e = &events.AutoUpdateAgentRolloutForceDone{}
+	case AutoUpdateAgentRolloutRollbackEvent:
+		e = &events.AutoUpdateAgentRolloutRollback{}
+
 	case ContactCreateEvent:
 		e = &events.ContactCreate{}
 	case ContactDeleteEvent:


### PR DESCRIPTION
Backport #62546 to branch/v18

changelog: fixed some auto update audit events showing up as unknown in the web UI.
