### PR TITLE
Added `--status` flag to `tctl db ls`

### DIFF
--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -182,6 +182,7 @@ func MatchResourceByFilters(resource types.ResourceWithLabels, filter MatchResou
 	}
 	switch kind {
 	case types.KindNode,
+		types.KindDatabase,
 		types.KindDatabaseService,
 		types.KindKubernetesCluster,
 		types.KindWindowsDesktop, types.KindWindowsDesktopService,

--- a/lib/services/matchers_test.go
+++ b/lib/services/matchers_test.go
@@ -665,6 +665,23 @@ func TestMatchResourceByFilters(t *testing.T) {
 				PredicateExpression: filterExpression,
 			},
 		},
+		{
+			name: "db",
+			resource: func() types.ResourceWithLabels {
+				db, err := types.NewDatabaseV3(types.Metadata{
+					Name: "foo",
+				}, types.DatabaseSpecV3{
+					URI:      "localhost:12345",
+					Protocol: "postgres",
+				})
+				require.NoError(t, err)
+				return db
+			},
+			filters: MatchResourceFilter{
+				ResourceKind:        types.KindDatabase,
+				PredicateExpression: filterExpression,
+			},
+		},
 
 		{
 			name: "kube cluster",

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -279,3 +279,32 @@ func PrintYAML(w io.Writer, v any) error {
 	_, err = fmt.Fprintln(w, string(out))
 	return trace.Wrap(err)
 }
+
+// MakePredicateConjunction combines two predicate expressions into one
+// expression as a conjunction (logical AND) of the expressions.
+func MakePredicateConjunction(a, b string) string {
+	return combinePredicateExpressions(a, b, "&&")
+}
+
+// MakePredicateDisjunction combines two predicate expressions into one
+// expression as a disjunction (logical OR) of the expressions.
+func MakePredicateDisjunction(a, b string) string {
+	return combinePredicateExpressions(a, b, "||")
+}
+
+// combinePredicateExpressions combines two predicate expressions into one
+// expression with the given operator.
+func combinePredicateExpressions(a, b, op string) string {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	switch {
+	case a == "":
+		return b
+	case b == "":
+		return a
+	case a == b:
+		return a
+	default:
+		return fmt.Sprintf("(%v) %v (%v)", a, op, b)
+	}
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -256,7 +256,8 @@ func (c *netRestrictionsCollection) WriteText(w io.Writer, verbose bool) error {
 }
 
 type databaseServerCollection struct {
-	servers []types.DatabaseServer
+	servers             []types.DatabaseServer
+	allowStatusFootnote bool
 }
 
 func (c *databaseServerCollection) Resources() (r []types.Resource) {
@@ -268,18 +269,26 @@ func (c *databaseServerCollection) Resources() (r []types.Resource) {
 
 func (c *databaseServerCollection) WriteText(w io.Writer, verbose bool) error {
 	var rows [][]string
+	var showUnclaimedFootnote bool
 	for _, server := range c.servers {
 		labels := common.FormatLabels(server.GetDatabase().GetAllLabels(), verbose)
+		status := string(server.GetTargetHealthStatus())
+		if status == dbStatusUnclaimed && c.allowStatusFootnote {
+			showUnclaimedFootnote = true
+			status = status + " [*]"
+		}
+
 		rows = append(rows, []string{
 			server.GetHostname(),
 			common.FormatResourceName(server.GetDatabase(), verbose),
+			status,
 			server.GetDatabase().GetProtocol(),
 			server.GetDatabase().GetURI(),
 			labels,
 			server.GetTeleportVersion(),
 		})
 	}
-	headers := []string{"Host", "Name", "Protocol", "URI", "Labels", "Version"}
+	headers := []string{"Host", "Name", "Status", "Protocol", "URI", "Labels", "Version"}
 	var t asciitable.Table
 	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
@@ -289,6 +298,12 @@ func (c *databaseServerCollection) WriteText(w io.Writer, verbose bool) error {
 	// stable sort by hostname then by name.
 	t.SortRowsBy([]int{0, 1}, true)
 	_, err := t.AsBuffer().WriteTo(w)
+
+	if showUnclaimedFootnote {
+		if _, err := w.Write([]byte("\n[*]: \"unclaimed\" are dynamic database resources (e.g. tctl get db) that are not claimed by any database service.\n")); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	return trace.Wrap(err)
 }
 

--- a/tool/tctl/common/db_command_test.go
+++ b/tool/tctl/common/db_command_test.go
@@ -1,0 +1,189 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	sliceutils "github.com/gravitational/teleport/lib/utils/slices"
+)
+
+type mockAuthClientForDBCommand struct {
+	authclient.ClientI
+
+	dbServers []types.DatabaseServer
+	dbs       []types.Database
+}
+
+func (m *mockAuthClientForDBCommand) GetResources(_ context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+	filter, err := services.MatchResourceFilterFromListResourceRequest(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	filtered, err := services.MatchResourcesByFilters(m.dbServers, filter)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	for _, dbServer := range filtered {
+		if _, ok := dbServer.(*types.DatabaseServerV3); !ok {
+			return nil, trace.BadParameter("expected types.DatabaseServerV3, got %T", dbServer)
+		}
+	}
+	return &proto.ListResourcesResponse{
+		Resources: sliceutils.Map(filtered, func(dbServer types.DatabaseServer) *proto.PaginatedResource {
+			return &proto.PaginatedResource{
+				Resource: &proto.PaginatedResource_DatabaseServer{
+					DatabaseServer: dbServer.(*types.DatabaseServerV3),
+				},
+			}
+		}),
+		TotalCount: int32(len(filtered)),
+	}, nil
+}
+
+func (m *mockAuthClientForDBCommand) ListDatabases(context.Context, int, string) ([]types.Database, string, error) {
+	return slices.Clone(m.dbs), "", nil
+}
+
+func TestDBCommand_listDatabases(t *testing.T) {
+	db1 := mustCreateNewDatabase(t, "db1", "postgres", "localhost:5432", map[string]string{"env": "dev"})
+	db2 := mustCreateNewDatabase(t, "db2", "postgres", "localhost:5432", map[string]string{"env": "staging"})
+	db3 := mustCreateNewDatabase(t, "db3", "mysql", "localhost:5432", map[string]string{"env": "prod"})
+	db4 := mustCreateNewDatabase(t, "db4", "postgres", "localhost:5432", map[string]string{"env": "dev"})
+
+	db1Server1 := mustCreateDatabaseServerFromDB(t, db1, "server1")
+	db1Server2 := mustCreateDatabaseServerFromDB(t, db1, "server2")
+	db2Server1 := mustCreateDatabaseServerFromDB(t, db2, "server1")
+
+	// These don't exist in backend but used for validating output.
+	db3Server, err := toUnregisteredDBServer(db3)
+	require.NoError(t, err)
+	db4Server, err := toUnregisteredDBServer(db4)
+	require.NoError(t, err)
+
+	authClient := &mockAuthClientForDBCommand{
+		dbServers: []types.DatabaseServer{db1Server1, db1Server2, db2Server1},
+		dbs:       []types.Database{db1, db2, db3, db4},
+	}
+
+	tests := []struct {
+		name      string
+		dbCommand *DBCommand
+		wantDBs   []types.DatabaseServer
+		wantErr   bool
+	}{
+		{
+			name: "registered",
+			dbCommand: &DBCommand{
+				listRegistered: true,
+			},
+			wantDBs: []types.DatabaseServer{db1Server1, db1Server2, db2Server1},
+		},
+		{
+			name: "unregistered",
+			dbCommand: &DBCommand{
+				listUnregistered: true,
+			},
+			wantDBs: []types.DatabaseServer{db3Server, db4Server},
+		},
+		{
+			name: "registered and unregistered",
+			dbCommand: &DBCommand{
+				listRegistered:   true,
+				listUnregistered: true,
+			},
+			wantDBs: []types.DatabaseServer{db1Server1, db1Server2, db2Server1, db3Server, db4Server},
+		},
+		{
+			name: "unregistered with search keywords",
+			dbCommand: &DBCommand{
+				listUnregistered: true,
+				searchKeywords:   "mysql",
+			},
+			wantDBs: []types.DatabaseServer{db3Server},
+		},
+		{
+			name: "unregistered with predicate",
+			dbCommand: &DBCommand{
+				listUnregistered: true,
+				predicateExpr:    `name == "db4"`,
+			},
+			wantDBs: []types.DatabaseServer{db4Server},
+		},
+		{
+			name: "registered and unregistered with label",
+			dbCommand: &DBCommand{
+				listUnregistered: true,
+				listRegistered:   true,
+				labels:           "env=dev",
+			},
+			wantDBs: []types.DatabaseServer{db1Server1, db1Server2, db4Server},
+		},
+		{
+			name:      "no registered or unregistered",
+			dbCommand: &DBCommand{},
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			actualDBs, err := tt.dbCommand.listDatabases(t.Context(), authClient)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t,
+					slices.Collect(types.ResourceNames(tt.wantDBs)),
+					slices.Collect(types.ResourceNames(actualDBs)),
+				)
+			}
+		})
+	}
+}
+
+func mustCreateDatabaseServerFromDB(t *testing.T, db types.Database, host string) types.DatabaseServer {
+	t.Helper()
+	dbV3, ok := db.(*types.DatabaseV3)
+	require.True(t, ok)
+	dbServer, err := types.NewDatabaseServerV3(
+		types.Metadata{
+			Name: db.GetName(),
+		},
+		types.DatabaseServerSpecV3{
+			Version:  teleport.Version,
+			Hostname: host,
+			HostID:   host,
+			Database: dbV3,
+		},
+	)
+	require.NoError(t, err)
+	return dbServer
+}

--- a/tool/tsh/common/db_exec.go
+++ b/tool/tsh/common/db_exec.go
@@ -192,7 +192,7 @@ func (c *databaseExecCommand) getDatabasesByNames() ([]types.Database, error) {
 	for page := range slices.Chunk(names, 100) {
 		var predicate string
 		for _, name := range page {
-			predicate = makePredicateDisjunction(predicate, makeDiscoveredNameOrNamePredicate(name))
+			predicate = common.MakePredicateDisjunction(predicate, makeDiscoveredNameOrNamePredicate(name))
 		}
 
 		logger.DebugContext(c.cf.Context, "Getting database by name", "databases", page)

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1692,7 +1692,7 @@ func (c *kubeLoginCommand) accessRequestForKubeCluster(ctx context.Context, cf *
 		Namespace:           apidefaults.Namespace,
 		ResourceType:        types.KindKubernetesCluster,
 		UseSearchAsRoles:    true,
-		PredicateExpression: makePredicateConjunction(predicate, tc.PredicateExpression),
+		PredicateExpression: common.MakePredicateConjunction(predicate, tc.PredicateExpression),
 		Labels:              tc.Labels,
 	})
 	if err != nil {

--- a/tool/tsh/common/mcp_app.go
+++ b/tool/tsh/common/mcp_app.go
@@ -191,7 +191,7 @@ func fetchMCPServers(ctx context.Context, tc *client.TeleportClient, auth apicli
 }
 
 func withMCPServerAppFilter(predicateExpression string) string {
-	return makePredicateConjunction(
+	return common.MakePredicateConjunction(
 		predicateExpression,
 		`resource.sub_kind == "mcp"`,
 	)


### PR DESCRIPTION
Closes #61627

changelog: Added `--status` flag to `tctl db ls` that allows filtering databases by status (`healthy`, `unhealthy`, `unknown`, `unclaimed`)

examples:
```bash
$ tctl db ls -h
usage: tctl db ls [<flags>] [<labels>]

List all databases registered with the cluster.

Flags:
...
      --status=STATUS      If specified, list only databases with a specific status (healthy, unhealthy, unknown, unclaimed).

Examples:
  Search databases with keywords:
  $ tctl db ls --search foo,bar

  Filter databases with labels:
  $ tctl db ls key1=value1,key2=value2

  Find databases that failed health check
  $ tctl db ls --status unhealthy

  Find dynamic database resources that are not claimed by any database service
  $ tctl db ls --status unclaimed

$ tctl db ls  --search postgres
Host Name              Status        Protocol URI                                       Labels            Version    
---- ----------------- ------------- -------- ----------------------------------------- ----------------- ---------- 
     db-test           unclaimed [*] postgres localhost:5432                                                         
mac  bad-postgres      unhealthy     postgres external-pg:5432                          env=dev           19.0.0-dev 
mac  cloud-redshift    unhealthy     postgres matheus-redshift-migrate.278576220453.... env=dev           19.0.0-dev 
mac  my-postgres-auto  healthy       postgres localhost:5432                            auto=drop,env=dev 19.0.0-dev 
mac  my-postgres-sales healthy       postgres localhost:5432                            env=dev           19.0.0-dev 

[*]: "unclaimed" are dynamic database resources (e.g. tctl get db) that are not claimed by any database service.

$ tctl db ls --status unhealthy --search postgres
Host Name           Status    Protocol URI                                       Labels  Version    
---- -------------- --------- -------- ----------------------------------------- ------- ---------- 
mac  bad-postgres   unhealthy postgres external-pg:5432                          env=dev 19.0.0-dev 
mac  cloud-redshift unhealthy postgres matheus-redshift-migrate.278576220453.... env=dev 19.0.0-dev 

$ tctl db ls --status unclaimed
Host Name    Status    Protocol URI            Labels Version 
---- ------- --------- -------- -------------- ------ ------- 
     db-test unclaimed postgres localhost:5432                
```