### PR TITLE
Don't show the CTA in the role editor when feature hiding is enabled

### DIFF
--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -57,6 +57,13 @@ export function PolicyPlaceholder({
   roleDiffProps?: RoleDiffProps;
 }) {
   const theme = useTheme();
+
+  // We don't show the Identity Security CTA when
+  // feature hiding is enabled.
+  if (cfg.hideInaccessibleFeatures) {
+    return;
+  }
+
   const waitingForSync =
     roleDiffProps?.roleDiffState === RoleDiffState.WaitingForSync;
   const loading =


### PR DESCRIPTION
Closes #58284