### PR TITLE
fix: Teleport Installer doesn't detect RPM installation on Fedora

### DIFF
--- a/lib/web/scripts/install/install.sh
+++ b/lib/web/scripts/install/install.sh
@@ -333,8 +333,8 @@ install_teleport() {
   debian | ubuntu | kali | linuxmint | pop | raspbian | neon | zorin | parrot | elementary)
     install_via_apt_get
     ;;
-  # if ID is amazon Linux 2/RHEL/etc, run yum
-  centos | rhel | rocky | almalinux | amzn)
+  # if ID is amazon Linux 2/RHEL/Fedora/etc, run yum
+  centos | rhel | fedora | rocky | almalinux | amzn)
     install_via_yum "$ID"
     ;;
   sles)

--- a/lib/web/scripts/install/install.sh
+++ b/lib/web/scripts/install/install.sh
@@ -333,9 +333,14 @@ install_teleport() {
   debian | ubuntu | kali | linuxmint | pop | raspbian | neon | zorin | parrot | elementary)
     install_via_apt_get
     ;;
-  # if ID is amazon Linux 2/RHEL/Fedora/etc, run yum
-  centos | rhel | fedora | rocky | almalinux | amzn)
+  # if ID is amazon Linux 2/RHEL/etc, run yum
+  centos | rhel | rocky | almalinux | amzn)
     install_via_yum "$ID"
+    ;;
+  # Fedora uses dnf but there is no dedicated Fedora repository,
+  # so we use the RHEL repository which is compatible.
+  fedora)
+    install_via_yum rhel
     ;;
   sles)
     install_via_zypper


### PR DESCRIPTION
Fixes #46852

## Changes
- Add Fedora to the case statement for RPM-based distros in the installer script
- Use RHEL repository for Fedora (since there is no dedicated Fedora repository)
- This matches the existing behavior in the `ID_LIKE` fallback branch

This ensures Fedora is correctly detected and uses a compatible repository for yum/dnf installation.