### PR TITLE
[v18] SPIFFE Daemon Set Helm Chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -930,6 +930,7 @@ test-helm: helmunit/installed
 	helm unittest -3 --with-subchart=false examples/chart/access/*
 	helm unittest -3 --with-subchart=false examples/chart/event-handler
 	helm unittest -3 --with-subchart=false examples/chart/tbot
+	helm unittest -3 --with-subchart=false examples/chart/tbot-spiffe-daemon-set
 
 .PHONY: test-helm-update-snapshots
 test-helm-update-snapshots: helmunit/installed
@@ -940,6 +941,7 @@ test-helm-update-snapshots: helmunit/installed
 	helm unittest -3 -u --with-subchart=false examples/chart/access/*
 	helm unittest -3 -u --with-subchart=false examples/chart/event-handler
 	helm unittest -3 -u --with-subchart=false examples/chart/tbot
+	helm unittest -3 -u --with-subchart=false examples/chart/tbot-spiffe-daemon-set
 
 #
 # Runs all Go tests except integration, called by CI/CD.
@@ -1344,7 +1346,7 @@ lint-helm:
 		if [ "$${CI}" = "true" ]; then echo "This is a failure when running in CI." && exit 1; fi; \
 		exit 0; \
 	fi; \
-	for CHART in ./examples/chart/teleport-cluster ./examples/chart/teleport-kube-agent ./examples/chart/teleport-relay ./examples/chart/teleport-cluster/charts/teleport-operator ./examples/chart/tbot; do \
+	for CHART in ./examples/chart/teleport-cluster ./examples/chart/teleport-kube-agent ./examples/chart/teleport-relay ./examples/chart/teleport-cluster/charts/teleport-operator ./examples/chart/tbot ./examples/chart/tbot-spiffe-daemon-set; do \
 		if [ -d $${CHART}/.lint ]; then \
 			for VALUES in $${CHART}/.lint/*.yaml; do \
 				export HELM_TEMP=$$(mktemp); \

--- a/docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx
@@ -1,0 +1,475 @@
+
+{/* Generated file. Do not edit.*/}
+{/* Generate this file by navigating to examples/chart and running  make render-chart-ref*/}
+## `image`
+
+| Type | Default |
+|------|---------|
+| `string` | `"public.ecr.aws/gravitational/tbot-distroless"` |
+
+`image` sets the container image used for tbot pods created by this
+chart.
+
+You can override this to use your own tbot image rather than a
+Teleport-published image.
+
+## `clusterName`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`clusterName` should be the name of the Teleport cluster that your
+Bot will join. You can retrieve it by running `tctl status`.
+
+For example: `clusterName: "test.teleport.sh"`
+
+## `teleportProxyAddress`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`teleportProxyAddress` is the teleport Proxy Service address the bot will connect to.
+This must contain the port number, usually 443 or 3080 for Proxy Service.
+Connecting to the Proxy Service is the most common and recommended way to connect to Teleport.
+This is mandatory to connect to Teleport Enterprise (Cloud)
+
+This setting is mutually exclusive with teleportProxyAddress and is ignored if `tbotConfig` is set.
+
+For example:
+```yaml
+teleportProxyAddress: "test.teleport.sh:443"
+```
+
+## `workloadIdentitySelector`
+
+| Type | Default |
+|------|---------|
+| `object` | `{"labels":{},"name":""}` |
+
+`workloadIdentitySelector` controls which WorkloadIdentity resources
+will be used when issuing SVIDs via the SPIFFE Workload API. You must set
+either name or labels.
+
+### `workloadIdentitySelector.name`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`workloadIdentitySelector.name` selects the WorkloadIdentity resource by name.
+
+### `workloadIdentitySelector.labels`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`workloadIdentitySelector.labels` selects the WorkloadIdentity resource by labels.
+
+## `tbotConfig`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`tbotConfig` contains YAML teleport configuration to pass to the
+tbot pods. The configuration will be merged with the chart-generated
+configuration and will take precedence in case of conflict. Try to prefer to
+use the more specific configuration values throughout this chart.
+
+## `joinMethod`
+
+| Type | Default |
+|------|---------|
+| `string` | `"kubernetes"` |
+
+`joinMethod` describes how tbot joins the Teleport cluster.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+Ignored if `tbotConfig` is set.
+
+## `token`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`token` is the name of the token used by tbot to join the Teleport cluster.
+This value is not sensitive unless the `joinMethod` is set to `"token"`.
+Ignored if `tbotConfig` is set.
+
+## `teleportVersionOverride`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`teleportVersionOverride` controls the tbot image version deployed by
+the chart.
+
+Normally, the version of tbot matches the version of the chart. If you install
+chart version 15.0.0, you'll use tbot version 15.0.0. Upgrading tbot is done
+by upgrading the chart.
+
+<Admonition type="warning">
+`teleportVersionOverride` is intended for development and MUST NOT be
+used to control the Teleport version in a typical deployment. This
+chart is designed to run a specific Teleport version. You will face
+compatibility issues trying to run a different Teleport version with it.
+
+If you want to run Teleport version `X.Y.Z`, you should use
+`helm install --version X.Y.Z` instead.
+
+</Admonition>
+
+## `anonymousTelemetry`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`anonymousTelemetry` controls whether anonymous telemetry is enabled.
+
+## `debug`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`debug` controls whether the tbot agent runs in debug mode.
+
+## `serviceAccount`
+
+`serviceAccount` controls the Kubernetes ServiceAccounts deployed and used by
+the chart.
+
+### `serviceAccount.create`
+
+| Type | Default |
+|------|---------|
+| `bool` | `true` |
+
+`serviceAccount.create` controls whether Helm Chart creates the
+Kubernetes `ServiceAccount` resources for the agent.
+When off, you are responsible for creating the appropriate ServiceAccount
+resources.
+
+### `serviceAccount.name`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`serviceAccount.name` sets the name of the `ServiceAccount` resource
+used by the chart. By default, the `ServiceAccount` has the name of the
+Helm release.
+
+## `rbac`
+
+`rbac` controls the Kubernetes Role and RoleBinding creation
+used by the serviceAccount
+
+### `rbac.create`
+
+| Type | Default |
+|------|---------|
+| `bool` | `true` |
+
+`rbac.create` controls whether Helm Chart creates the
+Kubernetes `Role` & `RoleBindings` resources for the Kubernetes SA.
+When off, you are responsible for creating the appropriate resources.
+
+## `imagePullPolicy`
+
+| Type | Default |
+|------|---------|
+| `string` | `"IfNotPresent"` |
+
+`imagePullPolicy` sets the pull policy for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+for more details.
+
+## `extraLabels`
+
+`extraLabels` contains additional Kubernetes labels to apply on the resources
+created by the chart.
+See [the Kubernetes label documentation
+](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+for more information.
+
+### `extraLabels.role`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.role` are labels to set on the Role.
+
+### `extraLabels.roleBinding`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.roleBinding` are labels to set on the RoleBinding.
+
+### `extraLabels.config`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.config` are labels to set on the ConfigMap.
+
+### `extraLabels.daemonSet`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.daemonSet` are labels to set on the DaemonSet.
+
+### `extraLabels.pod`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.pod` are labels to set on the Pods created by the
+Deployment or StatefulSet.
+
+### `extraLabels.serviceAccount`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.serviceAccount` are labels to set on the ServiceAccount.
+
+### `extraLabels.clusterRole`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.clusterRole` are labels to set on the ClusterRole
+
+### `extraLabels.clusterRoleBinding`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.clusterRoleBinding` are labels to set on the
+ClusterRoleBinding
+
+## `annotations`
+
+`annotations` contains annotations to apply to the different Kubernetes
+objects created by the chart. See [the Kubernetes annotation
+documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+for more details.
+
+### `annotations.role`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.role` are annotations to set on the Role.
+
+### `annotations.roleBinding`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.roleBinding` are annotations to set on the RoleBinding.
+
+### `annotations.config`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.config` contains the Kubernetes annotations
+put on the `ConfigMap` resource created by the chart.
+
+### `annotations.daemonSet`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.daemonSet` contains the Kubernetes annotations
+put on the `DaemonSet` resource created by the chart.
+
+### `annotations.pod`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.pod` contains the Kubernetes annotations
+put on the `Pod` resources created by the chart.
+
+### `annotations.serviceAccount`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.serviceAccount` contains the Kubernetes annotations
+put on the `ServiceAccount` resource created by the chart.
+
+### `extraLabels.clusterRole`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.clusterRole` are annotations to set on the ClusterRole
+
+### `extraLabels.clusterRoleBinding`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.clusterRoleBinding` are annotations to set on the
+ClusterRoleBinding
+
+## `resources`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`resources` sets the resource requests/limits for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+for more details.
+
+## `affinity`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`affinity` sets the affinities for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+for more details.
+
+## `tolerations`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`tolerations` sets the tolerations for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+for more details.
+
+## `nodeSelector`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`nodeSelector` sets the node selector for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+for more details.
+
+## `imagePullSecrets`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`imagePullSecrets` sets the image pull secrets for any pods created by the chart.
+See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod)
+for more details.
+
+## `extraVolumes`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraVolumes` contains extra volumes to mount into the Teleport pods.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+extraVolumes:
+- name: myvolume
+  secret:
+    secretName: testSecret
+```
+
+## `extraVolumeMounts`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraVolumeMounts` contains extra volumes mounts for the main Teleport container.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+extraVolumesMounts:
+- name: myvolume
+  mountPath: /path/on/host
+```
+
+## `extraArgs`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraArgs` contains extra arguments to pass to `tbot start` for
+the main tbot pod
+
+## `extraEnv`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`extraEnv` contains extra environment variables to set in the main
+tbot pod.
+
+For example:
+```yaml
+extraEnv:
+  - name: HTTPS_PROXY
+    value: "http://username:password@my.proxy.host:3128"
+```
+
+## `securityContext`
+
+| Type | Default |
+|------|---------|
+| `object` | `{"privileged":true}` |
+
+`securityContext` sets the container security context for any pods created by the chart.
+The default high level of privileges are necessary to support the workload attestation feature of `tbot` as this
+requires the ability to read sensitive information about other processes running on the system.
+See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+for more details.
+
+## `podSecurityContext`
+
+| Type | Default |
+|------|---------|
+| `object` | `{"runAsGroup":0,"runAsUser":0}` |
+
+`podSecurityContext` sets the pod security context for any pods created by the chart.
+The default high level of privileges are necessary to support the workload attestation feature of `tbot` as this
+requires the ability to read sensitive information about other processes running on the system.
+See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+for more details.

--- a/examples/chart/Makefile
+++ b/examples/chart/Makefile
@@ -7,7 +7,7 @@ check_access = $(addprefix check-chart-ref-access-,$(access))
 render_access = $(addprefix render-chart-ref-access-,$(access))
 
 .PHONY: render-chart-ref
-render-chart-ref: render-chart-ref-example render-chart-ref-teleport-operator render-chart-ref-teleport-kube-agent render-chart-ref-teleport-relay render-chart-ref-tbot $(render_access) render-chart-ref-event-handler # render-chart-ref-teleport-cluster
+render-chart-ref: render-chart-ref-example render-chart-ref-teleport-operator render-chart-ref-teleport-kube-agent render-chart-ref-teleport-relay render-chart-ref-tbot render-chart-ref-tbot-spiffe-daemon-set $(render_access) render-chart-ref-event-handler # render-chart-ref-teleport-cluster
 
 .PHONY: render-chart-ref-example
 render-chart-ref-example:
@@ -40,6 +40,11 @@ render-chart-ref-tbot:
 	cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/tbot -output ../../docs/pages/includes/helm-reference/zz_generated.tbot.mdx
 
+.PHONY: render-chart-ref-tbot-spiffe-daemon-set
+render-chart-ref-tbot-spiffe-daemon-set:
+	cd ../../build.assets/tooling && \
+	go run ./cmd/render-helm-ref -chart ../../examples/chart/tbot-spiffe-daemon-set -output ../../docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx
+
 .PHONY: render-chart-ref-access-%
 render-chart-ref-access-%:
 	cd ../../build.assets/tooling && \
@@ -51,7 +56,7 @@ render-chart-ref-event-handler:
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/event-handler -output ../../docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
 
 .PHONY: check-chart-ref
-check-chart-ref: check-chart-ref-example check-chart-ref-teleport-operator check-chart-ref-teleport-kube-agent check-chart-ref-teleport-relay check-chart-ref-tbot $(check_access) check-chart-ref-event-handler #check-chart-ref-teleport-cluster
+check-chart-ref: check-chart-ref-example check-chart-ref-teleport-operator check-chart-ref-teleport-kube-agent check-chart-ref-teleport-relay check-chart-ref-tbot check-chart-ref-tbot-spiffe-daemon-set $(check_access) check-chart-ref-event-handler #check-chart-ref-teleport-cluster
 
 .PHONY: check-chart-ref-example
 check-chart-ref-example:
@@ -93,6 +98,13 @@ check-chart-ref-tbot:
 	@echo "Checking tbot reference"
 	@ cd ../../build.assets/tooling && \
 	go run ./cmd/render-helm-ref -chart ../../examples/chart/tbot -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.tbot.mdx - || \
+	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
+
+.PHONY: check-chart-ref-tbot-spiffe-daemon-set
+check-chart-ref-tbot-spiffe-daemon-set:
+	@echo "Checking tbot-spiffe-daemon-set reference"
+	@ cd ../../build.assets/tooling && \
+	go run ./cmd/render-helm-ref -chart ../../examples/chart/tbot-spiffe-daemon-set -output - | diff ../../docs/pages/includes/helm-reference/zz_generated.tbot-spiffe-daemon-set.mdx - || \
 	( echo "Chart values.yaml and reference differ, please run 'make render-chart-ref'" && exit 1 )
 
 .PHONY: check-chart-ref-access-%

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -80,6 +80,18 @@
         --set teleportProxyAddress="${TELEPORT_ADDR?}" \
         --set token="${TELEPORT_TOKEN?}"</pre>
     <br />
+    <pre><b><a href="https://github.com/gravitational/teleport/tree/master/examples/chart/tbot-spiffe-daemon-set">tbot-spiffe-daemon-set:</a></b>
+      # Install the tbot-spiffe-daemon-set chart to deploy tbot into your Kubernetes cluster and configure it for issuing SPIFFE SVIDs to other Kubernetes workloads.
+      # Click the link above to see the README.
+
+      helm install ${RELEASE_NAME?} teleport/tbot-spiffe-daemon-set \
+        --create-namespace \
+        --namespace ${NAMESPACE?} \
+        --set teleportProxyAddress="${TELEPORT_ADDR?}" \
+        --set clusterName="${CLUSTER_NAME?}" \
+        --set workloadIdentitySelector.name="${WORKLOAD_IDENTITY_NAME?}" \
+        --set token="${TELEPORT_TOKEN?}"</pre>
+    <br />
     <h3>Changelog</h3>
     <pre>See the <a href="https://goteleport.com/docs/changelog/">Teleport Changelog</a> for a list of important changes between Helm chart versions.</pre>
   </body>

--- a/examples/chart/tbot-spiffe-daemon-set/.lint/full.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/.lint/full.yaml
@@ -1,0 +1,8 @@
+clusterName: example.teleport.sh
+token: example-token
+teleportProxyAddress: example.teleport.sh:443
+debug: true
+workloadIdentitySelector:
+  labels:
+    foo: bar
+    fizz: buzz

--- a/examples/chart/tbot-spiffe-daemon-set/.lint/simple.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/.lint/simple.yaml
@@ -1,0 +1,10 @@
+# Set to the name of your Teleport cluster.
+clusterName: example.teleport.sh
+# Set to the name of the token you created.
+token: example-token
+# Set to the address of your Teleport Proxy Service.
+teleportProxyAddress: example.teleport.sh:443
+workloadIdentitySelector:
+  # Set to the name of the WorkloadIdentity resource you'd like to use when
+  # issuing SVIDs.
+  name: example-workload-identity

--- a/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/Chart.yaml
@@ -1,0 +1,10 @@
+.version: &version "19.0.0-dev"
+
+name: tbot-spiffe-daemon-set
+apiVersion: v2
+version: *version
+appVersion: *version
+description: This chart deploys the Machine & Workload Identity agent, `tbot`, into your Kubernetes cluster and configures it for issuing SPIFFE SVIDs to other Kubernetes workloads.
+icon: https://goteleport.com/static/teleport-symbol-bimi.svg
+keywords:
+  - Teleport

--- a/examples/chart/tbot-spiffe-daemon-set/README.md
+++ b/examples/chart/tbot-spiffe-daemon-set/README.md
@@ -1,0 +1,37 @@
+# TBot SPIFFE Daemon Set 
+
+This chart deploys a daemon set of `tbot` agents which are configured to expose
+the SPIFFE Workload API via a Unix Domain Socket. This socket can then be
+mounted into pods to allow them to receive SPIFFE SVIDs issued by Teleport
+Machine & Workload Identity.
+
+## How To
+
+### Basic configuration
+
+Follow steps 1 and 2 from the
+[Deploying `tbot` on Kubernetes guide](https://goteleport.com/docs/machine-workload-identity/deployment/kubernetes/)
+to create a Bot and Join Token for your `tbot` daemon set to use for
+authentication.
+
+The following are the minimal values you must set on the chart for it to 
+function correctly:
+
+```yaml
+# Set to the name of your Teleport cluster.
+clusterName: example.teleport.sh 
+# Set to the name of the token you created.
+token: example-token
+# Set to the address of your Teleport Proxy Service.
+teleportProxyAddress: example.teleport.sh:443
+workloadIdentitySelector:
+  # Set to the name of the WorkloadIdentity resource you'd like to use when 
+  # issuing SVIDs.
+  name: example-workload-identity 
+```
+
+See [values.yaml](./values.yaml) for a full reference of the available values.
+
+## Contributing to the chart
+
+Please read [CONTRIBUTING.md](../CONTRIBUTING.md) before raising a pull request to this chart.

--- a/examples/chart/tbot-spiffe-daemon-set/templates/_config.tpl
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/_config.tpl
@@ -1,0 +1,35 @@
+{{ if not .Values.teleportProxyAddress }}
+  {{- $_ := required "`teleportProxyAddress` must be provided" "" }}
+{{ end }}
+{{ if not .Values.clusterName }}
+  {{- $_ := required "`clusterName` must be provided" "" }}
+{{ end }}
+{{ if not .Values.token }}
+  {{- $_ := required "`token` must be provided" "" }}
+{{ end }}
+{{ if and (not .Values.workloadIdentitySelector.name) (not .Values.workloadIdentitySelector.labels) }}
+  {{- $_ := required "`workloadIdentitySelector.name` or `workloadIdentitySelector.labels` must be provided" "" }}
+{{ end }}
+{{ if and (.Values.workloadIdentitySelector.name) (.Values.workloadIdentitySelector.labels) }}
+  {{- $_ := required "Either `workloadIdentitySelector.name` or `workloadIdentitySelector.labels` can be provided, not both" "" }}
+{{ end }}
+{{- define "tbot-spiffe-daemon-set.config" -}}
+version: v2
+{{- if .Values.teleportProxyAddress }}
+proxy_server: {{ .Values.teleportProxyAddress }}
+{{- end }}
+onboarding:
+  join_method: {{ .Values.joinMethod }}
+  token: {{ .Values.token }}
+storage:
+  type: memory
+services:
+- type: workload-identity-api
+  listen: unix:///run/tbot/sockets/workload.sock
+  selector: {{ toYaml .Values.workloadIdentitySelector | nindent 4 }}
+  attestors:
+    kubernetes:
+      enabled: true
+      kubelet:
+        skip_verify: true
+{{- end -}}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/_helpers.tpl
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/_helpers.tpl
@@ -1,0 +1,56 @@
+{{- define "tbot-spiffe-daemon-set.serviceAccountName" -}}
+{{- coalesce .Values.serviceAccount.name (include "tbot-spiffe-daemon-set.fullname" .) -}}
+{{- end -}}
+
+{{- define "tbot-spiffe-daemon-set.selectorLabels" -}}
+app.kubernetes.io/name: '{{ include "tbot-spiffe-daemon-set.name" . }}'
+app.kubernetes.io/instance: '{{ .Release.Name }}'
+app.kubernetes.io/component: 'tbot-spiffe-daemon-set'
+{{- end -}}
+
+{{- define "tbot-spiffe-daemon-set.labels" -}}
+{{ include "tbot-spiffe-daemon-set.selectorLabels" . }}
+helm.sh/chart: '{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}'
+app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tbot-spiffe-daemon-set.name" -}}
+    {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+This is a modified version of the default fully qualified app name helper.
+We diverge by always honouring "nameOverride" when it's set, as opposed to the
+default behaviour of shortening if `nameOverride` is included in chart name.
+This is done to avoid naming conflicts when including the chart in other charts.
+*/}}
+{{- define "tbot-spiffe-daemon-set.fullname" -}}
+    {{- if .Values.fullnameOverride }}
+        {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+    {{- else }}
+        {{- if .Values.nameOverride }}
+            {{- printf "%s-%s" .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+        {{- else }}
+            {{- if contains .Chart.Name .Release.Name }}
+                {{- .Release.Name | trunc 63 | trimSuffix "-" }}
+            {{- else }}
+                {{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+            {{- end }}
+        {{- end }}
+    {{- end }}
+{{- end }}
+
+{{- define "tbot-spiffe-daemon-set.version" -}}
+{{- if .Values.teleportVersionOverride -}}
+  {{- .Values.teleportVersionOverride -}}
+{{- else -}}
+  {{- .Chart.Version -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "tbot-spiffe-daemon-set.defaultOutputName" -}}
+{{- include "tbot-spiffe-daemon-set.fullname" . }}-out
+{{- end -}}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/clusterrole.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.rbac.create -}}
+# This role grants our tbot the ability to query the Kubernetes API for
+# information about pods, this is necessary for the kubernetes workload
+# attestation.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+{{- if .Values.extraLabels.clusterRole }}
+  labels: {{- toYaml .Values.extraLabels.clusterRole | nindent 4 }}
+{{- end }}
+{{- if .Values.annotations.clusterRole }}
+  annotations: {{- toYaml .Values.annotations.clusterRole | nindent 4 }}
+{{- end}}
+rules:
+  - resources: [ "pods","nodes","nodes/proxy" ]
+    apiGroups: [ "" ]
+    verbs: [ "get" ]
+{{ end }}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/clusterrolebinding.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{ if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+{{- if .Values.extraLabels.clusterRoleBinding }}
+  labels: {{- toYaml .Values.extraLabels.clusterRoleBinding | nindent 4 }}
+{{- end }}
+{{- if .Values.annotations.clusterRoleBinding }}
+  annotations: {{- toYaml .Values.annotations.clusterRoleBinding | nindent 4 }}
+{{- end}}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "tbot-spiffe-daemon-set.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/config.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.annotations.config }}
+  annotations: {{- toYaml .Values.annotations.config | nindent 8 }}
+{{- end }}
+{{- if .Values.extraLabels.config }}
+  labels: {{- toYaml .Values.extraLabels.config | nindent 8 }}
+{{- end }}
+data:
+  tbot.yaml: |
+    {{- mustMergeOverwrite (include "tbot-spiffe-daemon-set.config" . | fromYaml) .Values.tbotConfig | toYaml | nindent 4 -}}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/daemonset.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/daemonset.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}
+  {{- if .Values.extraLabels.daemonSet }}
+    {{- toYaml .Values.extraLabels.daemonSet | nindent 4 }}
+  {{- end }}
+  {{- if .Values.annotations.daemonSet }}
+  annotations: {{- toYaml .Values.annotations.daemonSet | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "tbot-spiffe-daemon-set.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+      {{- if .Values.annotations.pod }}
+        {{- toYaml .Values.annotations.pod | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "tbot-spiffe-daemon-set.labels" . | nindent 8 }}
+      {{- if .Values.extraLabels.pod }}
+        {{- toYaml .Values.extraLabels.pod | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      # Must be in host PID namespace for workload attestation to behave
+      # correctly.
+      hostPID: true
+      containers:
+        - name: tbot
+          image: {{ .Values.image }}:{{ template "tbot-spiffe-daemon-set.version" . }}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - start
+            - -c
+            - /config/tbot.yaml
+            - --log-format
+            - json
+          {{- if .Values.debug }}
+            - --debug
+          {{- end }}
+          {{- if .Values.extraArgs }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+            - name: tbot-sockets
+              mountPath: /run/tbot/sockets
+              readOnly: false
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          env:
+            - name: TELEPORT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+      serviceAccountName: {{ template "tbot-spiffe-daemon-set.serviceAccountName" . }}
+      volumes:
+        - name: tbot-sockets
+          hostPath:
+            path: /run/tbot/sockets
+            type: DirectoryOrCreate
+        - name: config
+          configMap:
+            name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+        - name: join-sa-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: join-sa-token
+                  # 600 seconds is the minimum that Kubernetes supports. We
+                  # recommend this value is used.
+                  expirationSeconds: 600
+                  audience: {{ .Values.clusterName }}
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/role.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/role.yaml
@@ -1,0 +1,20 @@
+# This role grants the ability to manage secrets within the namespace - this is
+# necessary for the `kubernetes_secret` destination to work correctly.
+{{ if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.extraLabels.role }}
+  labels:
+  {{- toYaml .Values.extraLabels.role | nindent 4 }}
+{{- end }}
+{{- if .Values.annotations.role }}
+  annotations: {{- toYaml .Values.annotations.role | nindent 4 }}
+{{- end}}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+{{ end }}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/rolebinding.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/rolebinding.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.rbac.create -}}
+# Bind the role to the service account created for tbot.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.extraLabels.roleBinding }}
+  labels:
+  {{- toYaml .Values.extraLabels.roleBinding | nindent 4 }}
+{{- end }}
+{{- if .Values.annotations.roleBinding }}
+  annotations: {{- toYaml .Values.annotations.roleBinding | nindent 4 }}
+{{- end}}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "tbot-spiffe-daemon-set.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name:  {{ include "tbot-spiffe-daemon-set.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{ end }}

--- a/examples/chart/tbot-spiffe-daemon-set/templates/serviceaccount.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "tbot-spiffe-daemon-set.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if .Values.extraLabels.serviceAccount }}
+  labels:
+  {{- toYaml .Values.extraLabels.serviceAccount | nindent 4 }}
+{{- end }}
+{{- if .Values.annotations.serviceAccount }}
+  annotations:
+{{- toYaml .Values.annotations.serviceAccount | nindent 4 }}
+{{- end -}}
+{{ end }}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/clusterrole_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/clusterrole_test.yaml.snap
@@ -1,0 +1,30 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - nodes/proxy
+      verbs:
+      - get
+should match the snapshot (simple):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      - nodes
+      - nodes/proxy
+      verbs:
+      - get

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/clusterrolebinding_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/clusterrolebinding_test.yaml.snap
@@ -1,0 +1,28 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    subjects:
+    - kind: ServiceAccount
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+should match the snapshot (simple):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    subjects:
+    - kind: ServiceAccount
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/config_test.yaml.snap
@@ -1,0 +1,56 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: v1
+    data:
+      tbot.yaml: |-
+        onboarding:
+          join_method: kubernetes
+          token: example-token
+        proxy_server: example.teleport.sh:443
+        services:
+        - attestors:
+            kubernetes:
+              enabled: true
+              kubelet:
+                skip_verify: true
+          listen: unix:///run/tbot/sockets/workload.sock
+          selector:
+            labels:
+              fizz: buzz
+              foo: bar
+            name: ""
+          type: workload-identity-api
+        storage:
+          type: memory
+        version: v2
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+should match the snapshot (simple):
+  1: |
+    apiVersion: v1
+    data:
+      tbot.yaml: |-
+        onboarding:
+          join_method: kubernetes
+          token: example-token
+        proxy_server: example.teleport.sh:443
+        services:
+        - attestors:
+            kubernetes:
+              enabled: true
+              kubelet:
+                skip_verify: true
+          listen: unix:///run/tbot/sockets/workload.sock
+          selector:
+            labels: {}
+            name: example-workload-identity
+          type: workload-identity-api
+        storage:
+          type: memory
+        version: v2
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/daemonset_test.yaml.snap
@@ -1,0 +1,145 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app.kubernetes.io/name: RELEASE-NAME
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: tbot-spiffe-daemon-set
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: tbot-spiffe-daemon-set
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app.kubernetes.io/component: tbot-spiffe-daemon-set
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: tbot-spiffe-daemon-set
+            helm.sh/chart: tbot-spiffe-daemon-set-19.0.0-dev
+        spec:
+          containers:
+          - args:
+            - start
+            - -c
+            - /config/tbot.yaml
+            - --log-format
+            - json
+            - --debug
+            env:
+            - name: TELEPORT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+            image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-dev
+            imagePullPolicy: IfNotPresent
+            name: tbot
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+            - mountPath: /run/tbot/sockets
+              name: tbot-sockets
+              readOnly: false
+          hostPID: true
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          serviceAccountName: RELEASE-NAME-tbot-spiffe-daemon-set
+          volumes:
+          - hostPath:
+              path: /run/tbot/sockets
+              type: DirectoryOrCreate
+            name: tbot-sockets
+          - configMap:
+              name: RELEASE-NAME-tbot-spiffe-daemon-set
+            name: config
+          - name: join-sa-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  audience: example.teleport.sh
+                  expirationSeconds: 600
+                  path: join-sa-token
+should match the snapshot (simple):
+  1: |
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      labels:
+        app.kubernetes.io/name: RELEASE-NAME
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    spec:
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: tbot-spiffe-daemon-set
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: tbot-spiffe-daemon-set
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app.kubernetes.io/component: tbot-spiffe-daemon-set
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: tbot-spiffe-daemon-set
+            helm.sh/chart: tbot-spiffe-daemon-set-19.0.0-dev
+        spec:
+          containers:
+          - args:
+            - start
+            - -c
+            - /config/tbot.yaml
+            - --log-format
+            - json
+            env:
+            - name: TELEPORT_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBERNETES_TOKEN_PATH
+              value: /var/run/secrets/tokens/join-sa-token
+            image: public.ecr.aws/gravitational/tbot-distroless:19.0.0-dev
+            imagePullPolicy: IfNotPresent
+            name: tbot
+            securityContext:
+              privileged: true
+            volumeMounts:
+            - mountPath: /config
+              name: config
+            - mountPath: /var/run/secrets/tokens
+              name: join-sa-token
+            - mountPath: /run/tbot/sockets
+              name: tbot-sockets
+              readOnly: false
+          hostPID: true
+          securityContext:
+            runAsGroup: 0
+            runAsUser: 0
+          serviceAccountName: RELEASE-NAME-tbot-spiffe-daemon-set
+          volumes:
+          - hostPath:
+              path: /run/tbot/sockets
+              type: DirectoryOrCreate
+            name: tbot-sockets
+          - configMap:
+              name: RELEASE-NAME-tbot-spiffe-daemon-set
+            name: config
+          - name: join-sa-token
+            projected:
+              sources:
+              - serviceAccountToken:
+                  audience: example.teleport.sh
+                  expirationSeconds: 600
+                  path: join-sa-token

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/role_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/role_test.yaml.snap
@@ -1,0 +1,28 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - '*'
+should match the snapshot (simple):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - '*'

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/rolebinding_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/rolebinding_test.yaml.snap
@@ -1,0 +1,30 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    subjects:
+    - kind: ServiceAccount
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+should match the snapshot (simple):
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+    subjects:
+    - kind: ServiceAccount
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE

--- a/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/serviceaccount_test.yaml.snap
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/__snapshot__/serviceaccount_test.yaml.snap
@@ -1,0 +1,14 @@
+should match the snapshot (full):
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE
+should match the snapshot (simple):
+  1: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: RELEASE-NAME-tbot-spiffe-daemon-set
+      namespace: NAMESPACE

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrole_test.yaml
@@ -1,0 +1,16 @@
+suite: Test ClusterRole
+templates:
+  - clusterrole.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: clusterrole.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: clusterrole.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/clusterrolebinding_test.yaml
@@ -1,0 +1,16 @@
+suite: Test ClusterRoleBinding
+templates:
+  - clusterrolebinding.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: clusterrolebinding.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: clusterrolebinding.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/config_test.yaml
@@ -1,0 +1,16 @@
+suite: Test Config
+templates:
+  - config.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: config.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: config.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/daemonset_test.yaml
@@ -1,0 +1,16 @@
+suite: Test Daemonset
+templates:
+  - daemonset.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: daemonset.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: daemonset.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/role_test.yaml
@@ -1,0 +1,16 @@
+suite: Test Role
+templates:
+  - role.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: role.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: role.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/rolebinding_test.yaml
@@ -1,0 +1,16 @@
+suite: Test RoleBinding
+templates:
+  - rolebinding.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: rolebinding.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: rolebinding.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/tests/serviceaccount_test.yaml
@@ -1,0 +1,16 @@
+suite: Test ServiceAccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: should match the snapshot (simple)
+    template: serviceaccount.yaml
+    values:
+      - ../.lint/simple.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: should match the snapshot (full)
+    template: serviceaccount.yaml
+    values:
+      - ../.lint/full.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot-spiffe-daemon-set/values.yaml
+++ b/examples/chart/tbot-spiffe-daemon-set/values.yaml
@@ -1,0 +1,236 @@
+# image(string) -- sets the container image used for tbot pods created by this
+# chart.
+#
+# You can override this to use your own tbot image rather than a
+# Teleport-published image.
+image: public.ecr.aws/gravitational/tbot-distroless
+# clusterName(string) -- should be the name of the Teleport cluster that your
+# Bot will join. You can retrieve it by running `tctl status`.
+#
+# For example: `clusterName: "test.teleport.sh"`
+clusterName: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+# teleportProxyAddress(string) -- is the teleport Proxy Service address the bot will connect to.
+# This must contain the port number, usually 443 or 3080 for Proxy Service.
+# Connecting to the Proxy Service is the most common and recommended way to connect to Teleport.
+# This is mandatory to connect to Teleport Enterprise (Cloud)
+#
+# This setting is mutually exclusive with teleportProxyAddress and is ignored if `tbotConfig` is set.
+#
+# For example:
+# ```yaml
+# teleportProxyAddress: "test.teleport.sh:443"
+# ```
+teleportProxyAddress: ""
+
+# workloadIdentitySelector(object) -- controls which WorkloadIdentity resources
+# will be used when issuing SVIDs via the SPIFFE Workload API. You must set
+# either name or labels.
+workloadIdentitySelector:
+  # workloadIdentitySelector.name(string) -- selects the WorkloadIdentity resource by name.
+  name: ""
+  # workloadIdentitySelector.labels(object) -- selects the WorkloadIdentity resource by labels.
+  labels: {}
+
+# tbotConfig(object) -- contains YAML teleport configuration to pass to the
+# tbot pods. The configuration will be merged with the chart-generated
+# configuration and will take precedence in case of conflict. Try to prefer to
+# use the more specific configuration values throughout this chart.
+tbotConfig: {}
+
+# joinMethod(string) -- describes how tbot joins the Teleport cluster.
+# See [the join method reference](../../reference/deployment/join-methods.mdx) for a list fo supported values and detailed explanations.
+# Ignored if `tbotConfig` is set.
+joinMethod: "kubernetes"
+
+# token(string) -- is the name of the token used by tbot to join the Teleport cluster.
+# This value is not sensitive unless the `joinMethod` is set to `"token"`.
+# Ignored if `tbotConfig` is set.
+token: ""
+
+# teleportVersionOverride(string) -- controls the tbot image version deployed by
+# the chart.
+#
+# Normally, the version of tbot matches the version of the chart. If you install
+# chart version 15.0.0, you'll use tbot version 15.0.0. Upgrading tbot is done
+# by upgrading the chart.
+#
+# <Admonition type="warning">
+# `teleportVersionOverride` is intended for development and MUST NOT be
+# used to control the Teleport version in a typical deployment. This
+# chart is designed to run a specific Teleport version. You will face
+# compatibility issues trying to run a different Teleport version with it.
+#
+# If you want to run Teleport version `X.Y.Z`, you should use
+# `helm install --version X.Y.Z` instead.
+#
+# </Admonition>
+teleportVersionOverride: ""
+
+# anonymousTelemetry(bool) -- controls whether anonymous telemetry is enabled.
+anonymousTelemetry: false
+# debug(bool) -- controls whether the tbot agent runs in debug mode.
+debug: false
+
+# serviceAccount -- controls the Kubernetes ServiceAccounts deployed and used by
+# the chart.
+serviceAccount:
+  # serviceAccount.create(bool) -- controls whether Helm Chart creates the
+  # Kubernetes `ServiceAccount` resources for the agent.
+  # When off, you are responsible for creating the appropriate ServiceAccount
+  # resources.
+  create: true
+  # serviceAccount.name(string) -- sets the name of the `ServiceAccount` resource
+  # used by the chart. By default, the `ServiceAccount` has the name of the
+  # Helm release.
+  name: ""
+
+# rbac -- controls the Kubernetes Role and RoleBinding creation
+# used by the serviceAccount
+rbac:
+  # rbac.create(bool) -- controls whether Helm Chart creates the
+  # Kubernetes `Role` & `RoleBindings` resources for the Kubernetes SA.
+  # When off, you are responsible for creating the appropriate resources.
+  create: true
+
+# imagePullPolicy(string) -- sets the pull policy for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+# for more details.
+imagePullPolicy: IfNotPresent
+
+# extraLabels -- contains additional Kubernetes labels to apply on the resources
+# created by the chart.
+# See [the Kubernetes label documentation
+# ](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+# for more information.
+extraLabels:
+  # extraLabels.role(object) -- are labels to set on the Role.
+  role: {}
+  # extraLabels.roleBinding(object) -- are labels to set on the RoleBinding.
+  roleBinding: {}
+  # extraLabels.config(object) -- are labels to set on the ConfigMap.
+  config: {}
+  # extraLabels.daemonSet(object) -- are labels to set on the DaemonSet.
+  daemonSet: {}
+  # extraLabels.pod(object) -- are labels to set on the Pods created by the
+  # Deployment or StatefulSet.
+  pod: {}
+  # extraLabels.serviceAccount(object) -- are labels to set on the ServiceAccount.
+  serviceAccount: {}
+  # extraLabels.clusterRole(object) -- are labels to set on the ClusterRole
+  clusterRole: {}
+  # extraLabels.clusterRoleBinding(object) -- are labels to set on the
+  # ClusterRoleBinding
+  clusterRoleBinding: {}
+
+# annotations -- contains annotations to apply to the different Kubernetes
+# objects created by the chart. See [the Kubernetes annotation
+# documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+# for more details.
+annotations:
+  # annotations.role(object) -- are annotations to set on the Role.
+  role: {}
+  # annotations.roleBinding(object) -- are annotations to set on the RoleBinding.
+  roleBinding: {}
+  # annotations.config(object) -- contains the Kubernetes annotations
+  # put on the `ConfigMap` resource created by the chart.
+  config: {}
+  # annotations.daemonSet(object) -- contains the Kubernetes annotations
+  # put on the `DaemonSet` resource created by the chart.
+  daemonSet: {}
+  # annotations.pod(object) -- contains the Kubernetes annotations
+  # put on the `Pod` resources created by the chart.
+  pod: {}
+  # annotations.serviceAccount(object) -- contains the Kubernetes annotations
+  # put on the `ServiceAccount` resource created by the chart.
+  serviceAccount: {}
+  # extraLabels.clusterRole(object) -- are annotations to set on the ClusterRole
+  clusterRole: {}
+  # extraLabels.clusterRoleBinding(object) -- are annotations to set on the
+  # ClusterRoleBinding
+  clusterRoleBinding: {}
+
+# resources(object) -- sets the resource requests/limits for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+# for more details.
+resources: {}
+
+# affinity(object) -- sets the affinities for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+# for more details.
+affinity: {}
+
+# tolerations(list) -- sets the tolerations for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+# for more details.
+tolerations: []
+
+# nodeSelector(object) -- sets the node selector for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
+# for more details.
+nodeSelector: {}
+
+# imagePullSecrets(list) -- sets the image pull secrets for any pods created by the chart.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/concepts/containers/images/#referring-to-an-imagepullsecrets-on-a-pod)
+# for more details.
+imagePullSecrets: []
+
+# extraVolumes(list) -- contains extra volumes to mount into the Teleport pods.
+# See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+# for more details.
+#
+# For example:
+# ```yaml
+# extraVolumes:
+# - name: myvolume
+#   secret:
+#     secretName: testSecret
+# ```
+extraVolumes: []
+
+# extraVolumeMounts(list) -- contains extra volumes mounts for the main Teleport container.
+# See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+# for more details.
+#
+# For example:
+# ```yaml
+# extraVolumesMounts:
+# - name: myvolume
+#   mountPath: /path/on/host
+# ```
+extraVolumeMounts: []
+
+# extraArgs(list) -- contains extra arguments to pass to `tbot start` for
+# the main tbot pod
+extraArgs: []
+
+# extraEnv(list) -- contains extra environment variables to set in the main
+# tbot pod.
+#
+# For example:
+# ```yaml
+# extraEnv:
+#   - name: HTTPS_PROXY
+#     value: "http://username:password@my.proxy.host:3128"
+# ```
+extraEnv: []
+
+# securityContext(object) -- sets the container security context for any pods created by the chart.
+# The default high level of privileges are necessary to support the workload attestation feature of `tbot` as this
+# requires the ability to read sensitive information about other processes running on the system.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)
+# for more details.
+securityContext:
+  privileged: true
+
+# podSecurityContext(object) -- sets the pod security context for any pods created by the chart.
+# The default high level of privileges are necessary to support the workload attestation feature of `tbot` as this
+# requires the ability to read sensitive information about other processes running on the system.
+# See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+# for more details.
+podSecurityContext:
+  runAsUser: 0
+  runAsGroup: 0


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/61424

changelog: Introduced tbot-spiffe-daemon-set helm chart for deploying a Daemon Set of tbot agents which serve SPIFFE SVIDs to Kubernetes pods via the SPIFFE Workload API.