### PR TITLE
[v18] implement app server watcher

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -186,6 +186,11 @@ func (s *localSite) NodeWatcher() (*services.GenericWatcher[types.Server, readon
 	return s.srv.NodeWatcher, nil
 }
 
+// AppServerWatcher returns the watcher that maintains the app server set for the cluster
+func (s *localSite) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return s.srv.AppServerWatcher, nil
+}
+
 // GitServerWatcher returns a Git server watcher for this cluster.
 func (s *localSite) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return s.srv.GitServerWatcher, nil

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -98,6 +98,14 @@ func (p *clusterPeers) NodeWatcher() (*services.GenericWatcher[types.Server, rea
 	return peer.NodeWatcher()
 }
 
+func (p *clusterPeers) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	peer, err := p.pickPeer()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return peer.AppServerWatcher()
+}
+
 func (p *clusterPeers) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	peer, err := p.pickPeer()
 	if err != nil {
@@ -215,6 +223,10 @@ func (s *clusterPeer) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, e
 
 func (s *clusterPeer) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return nil, s.discoveryError("unable to fetch node watcher for leaf cluster")
+}
+
+func (s *clusterPeer) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return nil, s.discoveryError("unable to fetch app server watcher for leaf cluster")
 }
 
 func (s *clusterPeer) GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -92,6 +92,9 @@ type remoteSite struct {
 	// databaseServerWatcher is a database server watcher.
 	databaseServerWatcher *services.GenericWatcher[types.DatabaseServer, readonly.DatabaseServer]
 
+	// appServerWatcher is a app server watcher.
+	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// remoteCA is the last remote certificate authority recorded by the client.
 	// It is used to detect CA rotation status changes. If the rotation
 	// state has been changed, the tunnel will reconnect to re-create the client
@@ -171,6 +174,10 @@ func (s *remoteSite) CachingAccessPoint() (authclient.RemoteProxyAccessPoint, er
 // NodeWatcher returns the services.NodeWatcher for the remote cluster.
 func (s *remoteSite) NodeWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error) {
 	return s.nodeWatcher, nil
+}
+
+func (s *remoteSite) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return s.appServerWatcher, nil
 }
 
 // GitServerWatcher returns the Git server watcher for the remote cluster.

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -218,6 +218,9 @@ type Config struct {
 	// DatabaseServerWatcher is a database server watcher.
 	DatabaseServerWatcher *services.GenericWatcher[types.DatabaseServer, readonly.DatabaseServer]
 
+	// AppServerWatcher is a app server watcher.
+	AppServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// CircuitBreakerConfig configures the auth client circuit breaker
 	CircuitBreakerConfig breaker.Config
 
@@ -291,6 +294,9 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 	if cfg.DatabaseServerWatcher == nil {
 		return trace.BadParameter("missing parameter DatabaseServerWatcher")
+	}
+	if cfg.AppServerWatcher == nil {
+		return trace.BadParameter("missing parameter AppServerWatcher")
 	}
 	return nil
 }
@@ -1291,6 +1297,18 @@ func newRemoteSite(srv *server, domainName string, sconn ssh.Conn) (*remoteSite,
 		return nil, trace.Wrap(err)
 	}
 	remoteSite.databaseServerWatcher = databaseServerWatcher
+
+	appServerWatcher, err := services.NewAppServersWatcher(closeContext, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: srv.Component,
+			Logger:    srv.Logger,
+			Client:    accessPoint,
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	remoteSite.appServerWatcher = appServerWatcher
 
 	// instantiate a cache of host certificates for the forwarding server. the
 	// certificate cache is created in each site (instead of creating it in

--- a/lib/reversetunnelclient/api.go
+++ b/lib/reversetunnelclient/api.go
@@ -126,6 +126,8 @@ type Cluster interface {
 	GitServerWatcher() (*services.GenericWatcher[types.Server, readonly.Server], error)
 	// DatabaseServerWatcher returns the watcher that maintains the database server set for the cluster
 	DatabaseServerWatcher() (*services.GenericWatcher[types.DatabaseServer, readonly.DatabaseServer], error)
+	// AppServerWatcher returns the watcher that maintains the app server set for the cluster
+	AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error)
 	// GetTunnelsCount returns the amount of active inbound tunnels
 	// from the remote cluster
 	GetTunnelsCount() int

--- a/lib/reversetunnelclient/fake.go
+++ b/lib/reversetunnelclient/fake.go
@@ -73,11 +73,19 @@ type FakeCluster struct {
 	closed bool
 	// databaseServerWatcher is a database server watcher to speed up database server look up.
 	databaseServerWatcher *services.GenericWatcher[types.DatabaseServer, readonly.DatabaseServer]
+	// appServerWatcher ia a app server watcher to speed up app look up.
+	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
 }
 
 // NewFakeCluster is a FakeCluster constructor.
 func NewFakeCluster(clusterName string, accessPoint authclient.RemoteProxyAccessPoint) *FakeCluster {
 	databaseServerWatcher, _ := services.NewDatabaseServerWatcher(context.TODO(), services.DatabaseServerWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "FakeCluster",
+			Client:    accessPoint,
+		},
+	})
+	appServerWatcher, _ := services.NewAppServersWatcher(context.TODO(), services.AppServersWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: "FakeCluster",
 			Client:    accessPoint,
@@ -89,12 +97,18 @@ func NewFakeCluster(clusterName string, accessPoint authclient.RemoteProxyAccess
 		connCh:                make(chan net.Conn),
 		AccessPoint:           accessPoint,
 		databaseServerWatcher: databaseServerWatcher,
+		appServerWatcher:      appServerWatcher,
 	}
 }
 
 // DatabaseServerWatcher returns the watcher that maintains the database server set for the cluster
 func (s *FakeCluster) DatabaseServerWatcher() (*services.GenericWatcher[types.DatabaseServer, readonly.DatabaseServer], error) {
 	return s.databaseServerWatcher, nil
+}
+
+// AppServerWatcher returns the watcher that maintains the app server set for the cluster
+func (s *FakeCluster) AppServerWatcher() (*services.GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	return s.appServerWatcher, nil
 }
 
 // CachingAccessPoint returns caching auth server client.

--- a/lib/service/acme.go
+++ b/lib/service/acme.go
@@ -34,8 +34,6 @@ import (
 type hostPolicyCheckerConfig struct {
 	// publicAddrs is a list of pubic addresses to support acme for
 	publicAddrs []utils.NetAddr
-	// clt is used to get the list of registered applications
-	clt app.Getter
 	// clusterGetter is used to retrieve connected Teleport clusters.
 	clusterGetter reversetunnelclient.ClusterGetter
 	// clusterName is a name of this cluster
@@ -60,7 +58,7 @@ func (h *hostPolicyChecker) checkHost(ctx context.Context, host string) error {
 		return nil
 	}
 
-	_, _, err := app.ResolveFQDN(ctx, h.cfg.clt, h.cfg.clusterGetter, h.dnsNames, host)
+	_, _, err := app.ResolveFQDN(ctx, h.cfg.clusterGetter, h.cfg.clusterName, h.dnsNames, host)
 	if err == nil {
 		return nil
 	}
@@ -87,10 +85,6 @@ func newHostPolicyChecker(cfg hostPolicyCheckerConfig) (*hostPolicyChecker, erro
 }
 
 func (h *hostPolicyCheckerConfig) CheckAndSetDefaults() ([]string, error) {
-	if h.clt == nil {
-		return nil, trace.BadParameter("missing parameter clt")
-	}
-
 	if h.clusterGetter == nil {
 		return nil, trace.BadParameter("missing parameter clusterGetter")
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5094,6 +5094,18 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	appServerWatcher, err := services.NewAppServersWatcher(process.ExitContext(), services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Logger:    process.logger.With(teleport.ComponentKey, teleport.ComponentProxy),
+			Client:    accessPoint,
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	alpnRouter, reverseTunnelALPNRouter, appHTTPSTunnelHandler := setupALPNRouter(listeners, serverTLSConfig, cfg, conn.ClusterName())
 	alpnAddr := ""
 	if listeners.alpn != nil {
@@ -5362,6 +5374,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				NodeWatcher:             nodeWatcher,
 				GitServerWatcher:        gitServerWatcher,
 				DatabaseServerWatcher:   databaseServerWatcher,
+				AppServerWatcher:        appServerWatcher,
 				CertAuthorityWatcher:    caWatcher,
 				CircuitBreakerConfig:    process.Config.CircuitBreakerConfig,
 				LocalAuthAddresses:      utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
@@ -5536,17 +5549,15 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 		connectionsHandler.SetApplicationsProvider(func(ctx context.Context, publicAddr string) (types.Application, error) {
-			allAppServers, err := accessPoint.GetApplicationServers(ctx, apidefaults.Namespace)
+			allAppServers, err := appServerWatcher.CurrentResourcesWithFilter(ctx, webapp.MatchPublicAddr(publicAddr))
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			publicAddressMatches := webapp.MatchPublicAddr(publicAddr)
-			for _, a := range allAppServers {
-				if publicAddressMatches(ctx, a) {
-					return a.GetApp(), nil
-				}
+			if len(allAppServers) == 0 {
+				return nil, trace.NotFound("no app found for endpoint %q", publicAddr)
 			}
-			return nil, trace.NotFound("no app found for endpoint %q", publicAddr)
+			// TODO(okraport): determine if we should shuffle app servers here.
+			return allAppServers[0].GetApp(), nil
 		})
 
 		if !cfg.Proxy.DisableTLS && cfg.Proxy.DisableALPNSNIListener {
@@ -5601,6 +5612,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			}),
 			PROXYSigner:               proxySigner,
 			NodeWatcher:               nodeWatcher,
+			AppServerWatcher:          appServerWatcher,
 			AccessGraphAddr:           accessGraphAddr,
 			TracerProvider:            process.TracingProvider,
 			AutomaticUpgradesChannels: cfg.Proxy.AutomaticUpgradesChannels,
@@ -6420,7 +6432,6 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 		}
 		hostChecker, err := newHostPolicyChecker(hostPolicyCheckerConfig{
 			publicAddrs:   process.Config.Proxy.PublicAddrs,
-			clt:           conn.Client,
 			clusterGetter: tsrv,
 			clusterName:   conn.ClusterName(),
 		})

--- a/lib/services/readonly/readonly.go
+++ b/lib/services/readonly/readonly.go
@@ -270,6 +270,50 @@ func NewDatabaseServer(server types.DatabaseServer) DatabaseServer {
 	return DatabaseServer{inner: server}
 }
 
+// ProxiedService is a read only variant of [types.ProxiedService].
+type ProxiedService interface {
+	// GetProxyIDs returns a list of proxy ids this service is connected to.
+	GetProxyIDs() []string
+}
+
+var _ ProxiedService = types.ProxiedService(nil)
+
+// AppServer is a read only variant of [types.AppServer].
+type AppServer interface {
+	// ResourceWithLabels provides common resource methods.
+	ResourceWithLabels
+	// GetNamespace returns server namespace.
+	GetNamespace() string
+	// GetTeleportVersion returns the teleport version the server is running on.
+	GetTeleportVersion() string
+	// GetHostname returns the server hostname.
+	GetHostname() string
+	// GetHostID returns ID of the host the server is running on.
+	GetHostID() string
+	// GetRotation gets the state of certificate authority rotation.
+	GetRotation() types.Rotation
+	// String returns string representation of the server.
+	String() string
+	// Copy returns a copy of this app server object.
+	Copy() types.AppServer
+	// GetApp returns the app this app server proxies.
+	GetApp() types.Application
+	// GetTunnelType returns the tunnel type associated with the app server.
+	GetTunnelType() types.TunnelType
+	// ProxiedService provides common methods for a proxied service.
+	ProxiedService
+	// GetRelayGroup returns the name of the Relay group that the app server is
+	// connected to.
+	GetRelayGroup() string
+	// GetRelayIDs returns the list of Relay host IDs that the app server is
+	// connected to.
+	GetRelayIDs() []string
+	// GetScope returns the scope this server belongs to.
+	GetScope() string
+}
+
+var _ AppServer = types.AppServer(nil)
+
 // KubeServer is a read only variant of [types.KubeServer].
 type KubeServer interface {
 	// ResourceWithLabels provides common resource methods.

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -505,16 +505,17 @@ func (cfg *DatabaseServerWatcherConfig) CheckAndSetDefaults() error {
 		const databaseServerMaxStaleness = time.Minute
 		cfg.MaxStaleness = databaseServerMaxStaleness
 	}
-
 	if cfg.DatabaseServersGetter == nil {
 		getter, ok := cfg.Client.(DatabaseServersGetter)
 		if !ok {
 			return trace.BadParameter("missing parameter DatabaseServersGetter and Client not usable as DatabaseServersGetter")
 		}
 		cfg.DatabaseServersGetter = getter
+		const appServerMaxStaleness = time.Minute
+		cfg.MaxStaleness = appServerMaxStaleness
 	}
-
 	return nil
+
 }
 
 func NewDatabaseServerWatcher(ctx context.Context, cfg DatabaseServerWatcherConfig) (*GenericWatcher[types.DatabaseServer, readonly.DatabaseServer], error) {
@@ -539,6 +540,61 @@ func NewDatabaseServerWatcher(ctx context.Context, cfg DatabaseServerWatcherConf
 		DisableUpdateBroadcast: true,
 		CloneFunc:              types.DatabaseServer.Copy,
 		ReadOnlyFunc:           readonly.NewDatabaseServer,
+	})
+
+	return w, trace.Wrap(err)
+}
+
+type AppServersWatcherConfig struct {
+	AppServersGetter
+	ResourceWatcherConfig
+}
+
+func (cfg *AppServersWatcherConfig) CheckAndSetDefaults() error {
+	if err := cfg.ResourceWatcherConfig.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if cfg.MaxStaleness == 0 {
+		const databaseServerMaxStaleness = time.Minute
+		cfg.MaxStaleness = databaseServerMaxStaleness
+	}
+
+	if cfg.AppServersGetter == nil {
+		getter, ok := cfg.Client.(AppServersGetter)
+		if !ok {
+			return trace.BadParameter("missing parameter AppServersGetter and Client not usable as AppServersGetter")
+		}
+		cfg.AppServersGetter = getter
+	}
+
+	return nil
+}
+
+func NewAppServersWatcher(ctx context.Context, cfg AppServersWatcherConfig) (*GenericWatcher[types.AppServer, readonly.AppServer], error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	w, err := NewGenericResourceWatcher(ctx, GenericWatcherConfig[types.AppServer, readonly.AppServer]{
+		ResourceWatcherConfig: cfg.ResourceWatcherConfig,
+		ResourceKind:          types.KindAppServer,
+		ResourceKey: func(r types.AppServer) string {
+			// the host ID is guaranteed not to contain "/"
+			return r.GetHostID() + "/" + r.GetName()
+		},
+		DeleteKey: func(r types.Resource) string {
+			// the host ID is stored in metadata.description in app server delete events
+			return r.GetMetadata().Description + "/" + r.GetName()
+		},
+		ResourceGetter: func(ctx context.Context) ([]types.AppServer, error) {
+			return cfg.AppServersGetter.GetApplicationServers(ctx, apidefaults.Namespace)
+		},
+		DisableUpdateBroadcast: true,
+		CloneFunc:              types.AppServer.Copy,
+		ReadOnlyFunc: func(resource types.AppServer) readonly.AppServer {
+			return resource
+		},
 	})
 
 	return w, trace.Wrap(err)

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"testing/synctest"
@@ -1850,4 +1851,123 @@ func newHealthCheckConfig(t *testing.T, name string) *healthcheckconfigv1.Health
 	)
 	require.NoError(t, err)
 	return c
+}
+
+func TestAppServerWatcher(t *testing.T) {
+	synctest.Test(t, syncTestAppServerWatcher)
+}
+
+func syncTestAppServerWatcher(t *testing.T) {
+	ctx := t.Context()
+
+	bk, err := memory.New(memory.Config{Context: ctx})
+	require.NoError(t, err)
+	defer bk.Close()
+	type client struct {
+		services.Presence
+		types.Events
+	}
+
+	presence := local.NewPresenceService(bk)
+	w, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client: &client{
+				Presence: presence,
+				Events:   local.NewEventsService(bk),
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	require.NoError(t, w.WaitInitialization())
+
+	newAppServer := func(t *testing.T, name, hostId, appName string) *types.AppServerV3 {
+		s, err := types.NewAppServerV3(types.Metadata{
+			Name:      name,
+			Namespace: apidefaults.Namespace,
+		}, types.AppServerSpecV3{
+			HostID: hostId,
+
+			App: newApp(t, appName),
+		})
+		require.NoError(t, err)
+		return s
+	}
+
+	diffAppServers := func(a, b []types.AppServer) string {
+		return cmp.Diff(a, b,
+			cmpopts.IgnoreFields(types.Metadata{}, "Revision"),
+			cmpopts.EquateEmpty(),
+			cmpopts.SortSlices(func(a, b types.AppServer) bool {
+				if c := strings.Compare(a.GetHostID(), b.GetHostID()); c != 0 {
+					return c < 0
+				}
+				return a.GetName() < b.GetName()
+			}),
+		)
+	}
+
+	appServers := make([]types.AppServer, 0, 10)
+	for i := range 10 {
+		appServer := newAppServer(t,
+			fmt.Sprintf("app-%d", i%5),
+			fmt.Sprintf("host-%d", i), // Multiple hosts per app
+			fmt.Sprintf("app-%d", i%5))
+		_, err = presence.UpsertApplicationServer(ctx, appServer)
+		require.NoError(t, err)
+		appServers = append(appServers, appServer)
+	}
+
+	// Check all registered app servers are returned by the watcher.
+	synctest.Wait()
+	current, err := w.CurrentResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, current, len(appServers))
+	require.Empty(t, diffAppServers(appServers, current))
+
+	// Delete the first app server, ensure watcher correctly removes the entry
+	err = presence.DeleteApplicationServer(ctx, "default", appServers[0].GetHostID(), appServers[0].GetName())
+	require.NoError(t, err)
+
+	synctest.Wait()
+
+	appServers = appServers[1:]
+	current, err = w.CurrentResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, current, len(appServers))
+	require.Empty(t, diffAppServers(appServers, current))
+
+	// Overwrite existing
+	_, err = presence.UpsertApplicationServer(ctx, newAppServer(t, "app-1", "host-1", "app-1"))
+	require.NoError(t, err)
+
+	synctest.Wait()
+
+	current, err = w.CurrentResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, current, len(appServers))
+	require.Empty(t, diffAppServers(appServers, current))
+
+	// New server with the same app name but different host is added to the list
+	appServer := newAppServer(t, "app-1", "host-20", "app-1")
+	_, err = presence.UpsertApplicationServer(ctx, appServer)
+	require.NoError(t, err)
+	appServers = append(appServers, appServer)
+
+	synctest.Wait()
+
+	current, err = w.CurrentResources(ctx)
+	require.NoError(t, err)
+	require.Len(t, current, len(appServers))
+	require.Empty(t, diffAppServers(appServers, current))
+
+	// Ensure filtering works
+	filtered, err := w.CurrentResourcesWithFilter(context.Background(), func(s readonly.AppServer) bool {
+		return s.GetName() == appServers[0].GetName()
+	})
+	require.NoError(t, err)
+	require.Len(t, filtered, 3)
 }

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1846,6 +1846,7 @@ func TestProxyRoundRobin(t *testing.T) {
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
 		DatabaseServerWatcher: newDatabaseServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 	})
@@ -1987,6 +1988,7 @@ func TestProxyDirectAccess(t *testing.T) {
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
 		DatabaseServerWatcher: newDatabaseServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 	})
@@ -2659,6 +2661,7 @@ func TestParseSubsystemRequest(t *testing.T) {
 			NodeWatcher:           nodeWatcher,
 			GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
 			DatabaseServerWatcher: newDatabaseServerWatcher(ctx, t, proxyClient),
+			AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 			CertAuthorityWatcher:  caWatcher,
 		})
 		require.NoError(t, err)
@@ -2914,6 +2917,7 @@ func TestIgnorePuTTYSimpleChannel(t *testing.T) {
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
 		DatabaseServerWatcher: newDatabaseServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 	})
 	require.NoError(t, err)
@@ -3277,10 +3281,23 @@ func newDatabaseServerWatcher(ctx context.Context, t *testing.T, client *authcli
 			Client:    client,
 		},
 	})
-
 	require.NoError(t, err)
 	t.Cleanup(databaseServerWatcher.Close)
 	return databaseServerWatcher
+}
+
+func newAppServerWatcher(ctx context.Context, t *testing.T, client *authclient.Client) *services.GenericWatcher[types.AppServer, readonly.AppServer] {
+	t.Helper()
+
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client:    client,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+	return appServerWatcher
 }
 
 // newSigner creates a new SSH signer that can be used by the Server.
@@ -3355,6 +3372,7 @@ func TestHostUserCreationProxy(t *testing.T) {
 		NodeWatcher:           nodeWatcher,
 		GitServerWatcher:      newGitServerWatcher(ctx, t, proxyClient),
 		DatabaseServerWatcher: newDatabaseServerWatcher(ctx, t, proxyClient),
+		AppServerWatcher:      newAppServerWatcher(ctx, t, proxyClient),
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 	})

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -179,6 +179,9 @@ type Handler struct {
 	// the proxy's cache and get nodes in real time.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
+	// appServerWatcher ia a app server watcher to speed up app look up.
+	appServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// tracer is used to create spans.
 	tracer oteltrace.Tracer
 
@@ -310,6 +313,9 @@ type Config struct {
 	// the proxy's cache and get nodes in real time.
 	NodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
+	// AppServerWatcher ia a app server watcher to speed up app look up.
+	AppServerWatcher *services.GenericWatcher[types.AppServer, readonly.AppServer]
+
 	// PresenceChecker periodically runs the mfa ceremony for moderated
 	// sessions.
 	PresenceChecker PresenceChecker
@@ -372,7 +378,7 @@ func (h *APIHandler) handlePreflight(w http.ResponseWriter, r *http.Request) {
 	}
 	publicAddr := raddr.Host()
 
-	servers, err := app.MatchUnshuffled(r.Context(), h.handler.cfg.AccessPoint, app.MatchPublicAddr(publicAddr))
+	servers, err := h.handler.appServerWatcher.CurrentResourcesWithFilter(r.Context(), app.MatchPublicAddr(publicAddr))
 	if err != nil {
 		h.handler.logger.InfoContext(r.Context(), "failed to match application with public addr", "public_addr", publicAddr)
 		return
@@ -647,6 +653,10 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 	if cfg.NodeWatcher != nil {
 		h.nodeWatcher = cfg.NodeWatcher
+	}
+
+	if cfg.AppServerWatcher != nil {
+		h.appServerWatcher = cfg.AppServerWatcher
 	}
 
 	const v1Prefix = "/v1"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -235,6 +235,7 @@ type webSuiteConfig struct {
 }
 
 func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
+	t.Helper()
 	mockU2F, err := mocku2f.Create()
 	require.NoError(t, err)
 	require.NotNil(t, mockU2F)
@@ -451,6 +452,15 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 	require.NoError(t, err)
 	t.Cleanup(databaseServerWatcher.Close)
 
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    s.proxyClient,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ID:       node.ID(),
 		Listener: revTunListener,
@@ -468,6 +478,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		NodeWatcher:           proxyNodeWatcher,
 		GitServerWatcher:      proxyGitServerWatcher,
 		DatabaseServerWatcher: databaseServerWatcher,
+		AppServerWatcher:      appServerWatcher,
 		CertAuthorityWatcher:  caWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		LocalAuthAddresses:    []string{s.server.TLS.Addr().String()},
@@ -8706,6 +8717,7 @@ func withKubeProxy() proxyOption {
 func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regular.Server, authServer *authtest.TLSServer,
 	hostSigners []ssh.Signer, clock *clockwork.FakeClock, opts ...proxyOption,
 ) *testProxy {
+	t.Helper()
 	cfg := proxyConfig{}
 	for _, opt := range opts {
 		opt(&cfg)
@@ -8785,6 +8797,15 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	require.NoError(t, err)
 	t.Cleanup(databaseServerWatcher.Close)
 
+	appServerWatcher, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: teleport.ComponentProxy,
+			Client:    client,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(appServerWatcher.Close)
+
 	revTunServer, err := reversetunnel.NewServer(reversetunnel.Config{
 		ID:       node.ID(),
 		Listener: revTunListener,
@@ -8803,6 +8824,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		GitServerWatcher:      proxyGitServerWatcher,
 		CertAuthorityWatcher:  proxyCAWatcher,
 		DatabaseServerWatcher: databaseServerWatcher,
+		AppServerWatcher:      appServerWatcher,
 		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
 		LocalAuthAddresses:    []string{authServer.Addr().String()},
 	})

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -43,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -225,17 +227,23 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, publicAddr string, c
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	accessPoint, err := clusterClient.CachingAccessPoint()
+
+	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(publicAddr))
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// At least one AppServer needs to be present to serve the requests. Using
-	// MatchOne can reduce the amount of work required by the app matcher by not
-	// dialing every AppServer.
-	_, err = MatchOne(ctx, accessPoint, appServerMatcher(h.c.ClusterGetter, publicAddr, clusterName))
-	if err != nil {
-		return trace.Wrap(err)
+	if len(servers) == 0 {
+		// This error path is unexpected as the healthcheck is typically performed post resolution.
+		return trace.NotFound("failed to match applications with public addr %s", publicAddr)
+	}
+
+	// At least one AppServer needs to be present to serve the requests.
+	i := slices.IndexFunc(servers, func(appServer types.AppServer) bool {
+		return isAppServerDialable(ctx, clusterClient, appServer)
+	})
+	if i < 0 {
+		return trace.NotFound("all app servers unheatlhy")
 	}
 
 	return nil
@@ -809,6 +817,6 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, addr string, req launc
 
 // redirectInsteadOfForward returns true if an application shouldn't be forwarded, but
 // should be redirected directly to the public address instead.
-func redirectInsteadOfForward(appServer types.AppServer) bool {
+func redirectInsteadOfForward(appServer readonly.AppServer) bool {
 	return appServer.GetApp().Origin() == types.OriginOkta
 }

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -26,117 +26,40 @@ import (
 
 	"github.com/gravitational/trace"
 
-	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/utils"
 )
-
-// Getter returns a list of registered apps and the local cluster name.
-type Getter interface {
-	// GetApplicationServers returns registered application servers.
-	GetApplicationServers(context.Context, string) ([]types.AppServer, error)
-
-	// GetClusterName returns cluster name
-	GetClusterName(ctx context.Context) (types.ClusterName, error)
-}
 
 // MatchUnshuffled will match a list of applications with the passed in matcher
 // function. Matcher functions that can match on public address and name are
 // available.
-func MatchUnshuffled(ctx context.Context, authClient Getter, fn Matcher) ([]types.AppServer, error) {
-	servers, err := authClient.GetApplicationServers(ctx, defaults.Namespace)
+func MatchUnshuffled(ctx context.Context, cluster reversetunnelclient.Cluster, fn Matcher) ([]types.AppServer, error) {
+	watcher, err := cluster.AppServerWatcher()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	var as []types.AppServer
-	for _, server := range servers {
-		if fn(ctx, server) {
-			as = append(as, server)
-		}
-	}
-
-	return as, nil
+	servers, err := watcher.CurrentResourcesWithFilter(ctx, fn)
+	return servers, trace.Wrap(err)
 }
 
-// MatchOne will match a single AppServer with the provided matcher function.
-// If no AppServer are matched, it will return an error.
-func MatchOne(ctx context.Context, authClient Getter, fn Matcher) (types.AppServer, error) {
-	servers, err := authClient.GetApplicationServers(ctx, defaults.Namespace)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	for _, server := range servers {
-		if fn(ctx, server) {
-			return server, nil
-		}
-	}
-
-	return nil, trace.NotFound("couldn't match any types.AppServer")
-}
-
-// Matcher allows matching on different properties of an application.
-type Matcher func(context.Context, types.AppServer) bool
+// Matcher allows matching on different properties of an app server.
+type Matcher func(readonly.AppServer) bool
 
 // MatchPublicAddr matches on the public address of an application.
 func MatchPublicAddr(publicAddr string) Matcher {
-	return func(_ context.Context, appServer types.AppServer) bool {
+	return func(appServer readonly.AppServer) bool {
 		return appServer.GetApp().GetPublicAddr() == publicAddr
 	}
 }
 
 // MatchName matches on the name of an application.
 func MatchName(name string) Matcher {
-	return func(_ context.Context, appServer types.AppServer) bool {
+	return func(appServer readonly.AppServer) bool {
 		return appServer.GetApp().GetName() == name
 	}
-}
-
-// MatchHealthy tries to establish a connection with the server using the
-// `dialAppServer` function. The app server is matched if the function call
-// doesn't return any error.
-func MatchHealthy(clusterGetter reversetunnelclient.ClusterGetter, clusterName string) Matcher {
-	return func(ctx context.Context, appServer types.AppServer) bool {
-		// Redirected apps don't need to be dialed, as the proxy will redirect to them.
-		if redirectInsteadOfForward(appServer) {
-			return true
-		}
-
-		// Apps that use the Integration should use its credentials which are obtained in Proxy.
-		// There's no need for an ApplicationService in this scenario.
-		if appServer.GetApp().GetIntegration() != "" {
-			return true
-		}
-
-		conn, err := dialAppServer(ctx, clusterGetter, clusterName, appServer)
-		if err != nil {
-			return false
-		}
-
-		conn.Close()
-		return true
-	}
-}
-
-// MatchAll matches if all the Matcher functions return true.
-func MatchAll(matchers ...Matcher) Matcher {
-	return func(ctx context.Context, appServer types.AppServer) bool {
-		for _, fn := range matchers {
-			if !fn(ctx, appServer) {
-				return false
-			}
-		}
-
-		return true
-	}
-}
-
-// ClusterGetter provides a means to retrieve all connected
-// Teleport clusters - either local or remote.
-type ClusterGetter interface {
-	Clusters(context.Context) ([]reversetunnelclient.Cluster, error)
 }
 
 // ResolveFQDN makes a best effort attempt to resolve FQDN to an application
@@ -147,15 +70,16 @@ type ClusterGetter interface {
 // cluster, this method will always return "acme" running within the root
 // cluster. Always supply public address and cluster name to deterministically
 // resolve an application.
-func ResolveFQDN(ctx context.Context, clt Getter, clusterGetter ClusterGetter, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, localClusterName string, proxyDNSNames []string, fqdn string) (types.AppServer, string, error) {
+	clusterClient, err := clusterGetter.Cluster(ctx, localClusterName)
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+
 	// Try and match FQDN to public address of application within cluster.
-	servers, err := MatchUnshuffled(ctx, clt, MatchPublicAddr(fqdn))
+	servers, err := MatchUnshuffled(ctx, clusterClient, MatchPublicAddr(fqdn))
 	if err == nil && len(servers) > 0 {
-		clusterName, err := clt.GetClusterName(ctx)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		return servers[rand.N(len(servers))], clusterName.GetClusterName(), nil
+		return servers[rand.N(len(servers))], localClusterName, nil
 	}
 
 	proxyPublicAddr := utils.FindMatchingProxyDNS(fqdn, proxyDNSNames)
@@ -171,12 +95,7 @@ func ResolveFQDN(ctx context.Context, clt Getter, clusterGetter ClusterGetter, p
 		return nil, "", trace.Wrap(err)
 	}
 	for _, clusterClient := range clusterClients {
-		authClient, err := clusterClient.CachingAccessPoint()
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-
-		servers, err = MatchUnshuffled(ctx, authClient, MatchName(appName))
+		servers, err = MatchUnshuffled(ctx, clusterClient, MatchName(appName))
 		if err == nil && len(servers) > 0 {
 			return servers[rand.N(len(servers))], clusterClient.GetName(), nil
 		}

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -21,13 +21,13 @@ package app
 import (
 	"context"
 	"math/rand/v2"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
-	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -67,22 +67,29 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	accessPoint, err := clusterClient.CachingAccessPoint()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	servers, err := MatchUnshuffled(
 		ctx,
-		accessPoint,
-		appServerMatcher(h.c.ClusterGetter, identity.RouteToApp.PublicAddr, identity.RouteToApp.ClusterName),
+		clusterClient,
+		MatchPublicAddr(identity.RouteToApp.PublicAddr),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
 	if len(servers) == 0 {
 		return nil, trace.NotFound("failed to match applications")
+	}
+
+	// Match healthy servers. Having a list of only healthy
+	// servers helps the transport fail before the request is forwarded to a
+	// server (in cases where there are no healthy servers). This process might
+	// take an additional time to execute, but since it is cached, only a few
+	// requests need to perform it.
+	servers = slices.DeleteFunc(servers, func(appServer types.AppServer) bool {
+		return !isAppServerDialable(ctx, clusterClient, appServer)
+	})
+	if len(servers) == 0 {
+		return nil, trace.NotFound("all app servers unheatlhy")
 	}
 
 	rand.Shuffle(len(servers), func(i, j int) {
@@ -128,20 +135,4 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 		ws:  ws,
 		tr:  transport,
 	}, nil
-}
-
-// appServerMatcher returns a Matcher function used to find which AppServer can
-// handle the application requests.
-func appServerMatcher(clusterGetter reversetunnelclient.ClusterGetter, publicAddr string, clusterName string) Matcher {
-	// Match healthy and PublicAddr servers. Having a list of only healthy
-	// servers helps the transport fail before the request is forwarded to a
-	// server (in cases where there are no healthy servers). This process might
-	// take an additional time to execute, but since it is cached, only a few
-	// requests need to perform it.
-	return MatchAll(
-		MatchPublicAddr(publicAddr),
-		// NOTE: Try to leave this matcher as the last one to dial only the
-		// application servers that match the requested application.
-		MatchHealthy(clusterGetter, clusterName),
-	)
 }

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -21,7 +21,6 @@ package app
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -42,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -354,6 +354,11 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 	copy(servers, t.c.servers)
 	t.mu.Unlock()
 
+	clusterClient, err := t.c.clusterGetter.Cluster(ctx, t.c.identity.RouteToApp.ClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	var i int
 	for ; i < len(servers); i++ {
 		appServer := servers[i]
@@ -379,7 +384,7 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn
 			return dst, nil
 		}
 
-		conn, err = dialAppServer(ctx, t.c.clusterGetter, t.c.identity.RouteToApp.ClusterName, appServer)
+		conn, err = dialAppServer(ctx, clusterClient, appServer)
 		if err != nil && isReverseTunnelDownError(err) {
 			t.c.log.WarnContext(ctx, "Failed to connect to application server",
 				"app_server", appServer.GetName(), "host_id", appServer.GetHostID(), "error", err)
@@ -435,12 +440,7 @@ func (t *transport) DialWebsocket(network, address string) (net.Conn, error) {
 
 // dialAppServer dial and connect to the application service over the reverse
 // tunnel subsystem.
-func dialAppServer(ctx context.Context, clusterGetter reversetunnelclient.ClusterGetter, clusterName string, server types.AppServer) (net.Conn, error) {
-	clusterClient, err := clusterGetter.Cluster(ctx, clusterName)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
+func dialAppServer(ctx context.Context, clusterClient reversetunnelclient.Cluster, server readonly.AppServer) (net.Conn, error) {
 	var from net.Addr
 	from = &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"}
 	clientSrcAddr, originalDst := authz.ClientAddrsFromContext(ctx)
@@ -452,11 +452,34 @@ func dialAppServer(ctx context.Context, clusterGetter reversetunnelclient.Cluste
 		From:                  from,
 		To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnelclient.LocalNode},
 		OriginalClientDstAddr: originalDst,
-		ServerID:              fmt.Sprintf("%v.%v", server.GetHostID(), clusterName),
+		ServerID:              server.GetHostID() + "." + clusterClient.GetName(),
 		ConnType:              server.GetTunnelType(),
 		ProxyIDs:              server.GetProxyIDs(),
 	})
 	return conn, trace.Wrap(err)
+}
+
+// isAppServerDialable tries to establish a connection with the server using the
+// `dialAppServer` function.
+func isAppServerDialable(ctx context.Context, clusterClient reversetunnelclient.Cluster, appServer readonly.AppServer) bool {
+	// Redirected apps don't need to be dialed, as the proxy will redirect to them.
+	if redirectInsteadOfForward(appServer) {
+		return true
+	}
+
+	// Apps that use the Integration should use its credentials which are obtained in Proxy.
+	// There's no need for an ApplicationService in this scenario.
+	if appServer.GetApp().GetIntegration() != "" {
+		return true
+	}
+
+	conn, err := dialAppServer(ctx, clusterClient, appServer)
+	if err != nil {
+		return false
+	}
+
+	conn.Close()
+	return true
 }
 
 // configureTLS creates and configures a *tls.Config that will be used for

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -522,3 +522,59 @@ func Test_transport_with_integration(t *testing.T) {
 
 	require.Equal(t, message, string(bs))
 }
+
+func Test_isAppServerDialable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string // description of this test case
+		dialErr error
+		match   bool
+		app     func() types.AppServer
+	}{
+		{
+			name:  "WithHealthyApp",
+			match: true,
+			app:   mustNewAppServer(t, types.OriginDynamic),
+		},
+		{
+			name:    "WithUnhealthyApp",
+			dialErr: errors.New("failed to connect"),
+			match:   false,
+			app:     mustNewAppServer(t, types.OriginDynamic),
+		},
+		{
+			name:    "WithUnhealthyOktaApp",
+			dialErr: errors.New("failed to connect"),
+			match:   true,
+			app:     mustNewAppServer(t, types.OriginOkta),
+		},
+		{
+			name:    "WithIntegrationApp",
+			dialErr: errors.New("failed to connect"),
+			match:   true,
+			app: func() types.AppServer {
+				appServer := mustNewAppServer(t, types.OriginDynamic)()
+				app := appServer.GetApp().Copy()
+				app.Spec.Integration = "my-integration"
+				appServer.SetApp(app)
+
+				return appServer
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := t.Context()
+			clusterGetter := &mockClusterGetter{
+				cluster: &mockCluster{
+					dialErr: tt.dialErr,
+				},
+			}
+
+			clusterClient, _ := clusterGetter.Cluster(ctx, "")
+			got := isAppServerDialable(ctx, clusterClient, tt.app())
+			require.Equal(t, tt.match, got, tt.app())
+		})
+	}
+}


### PR DESCRIPTION
Backport #62128, #64167 to branch/v18

Changelog: Improved application server resolution times for large number of applications.

## Manual Test Plan
### Test Environment
- Teleport v18 cluster with proxy, auth, and app agent
- Multiple registered applications

### Test Cases
- [x] Access an existing app via `tsh` and Web UI — confirm it loads successfully
- [x] Register a new app, confirm it becomes accessible without restarting the proxy
- [x] Remove an app, confirm it is no longer accessible