### PR TITLE
refactor `tsh request ls`

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -59,7 +59,7 @@ func onRequestList(cf *CLIConf) error {
 
 	var reqs []types.AccessRequest
 
-	// TODO: consider useing the AccessRequestFilter below to filter server side rather than client side.
+	// TODO: consider using the AccessRequestFilter below to filter server side rather than client side.
 	err = tc.WithRootClusterClient(cf.Context, func(clt authclient.ClientI) error {
 		reqs, err = clt.GetAccessRequests(cf.Context, types.AccessRequestFilter{})
 		return trace.Wrap(err)


### PR DESCRIPTION
Stumbled upon this complicated code while looking into a support issue.

Use slices.DeleteFunc for filtering rather than manual nested loops, reslicing, and labels.

No functional changes.