### PR TITLE
Web: add a inverse link color for tooltip

### DIFF
--- a/web/packages/design/src/Tooltip/HoverTooltip.tsx
+++ b/web/packages/design/src/Tooltip/HoverTooltip.tsx
@@ -244,6 +244,9 @@ const StyledTooltip = styled.div`
   pointer-events: none;
   filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.15));
   backdrop-filter: blur(2px);
+  a {
+    color: ${props => props.theme.colors.tooltip.inverseLinkDefault};
+  }
 `;
 
 const StyledContent = styled(Text)`

--- a/web/packages/design/src/Tooltip/IconTooltip.story.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.story.tsx
@@ -18,7 +18,7 @@
 
 import styled, { useTheme } from 'styled-components';
 
-import { ButtonPrimary, Flex, Text } from 'design';
+import { Box, ButtonPrimary, Flex, Link, Text } from 'design';
 import AGPLLogoDark from 'design/assets/images/agpl-dark.svg';
 import AGPLLogoLight from 'design/assets/images/agpl-light.svg';
 import { P } from 'design/Text/Text';
@@ -36,25 +36,33 @@ export const ShortContent = () => (
       <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
         Hover the icon
       </span>
-      <IconTooltip position="bottom">"some popover content"</IconTooltip>
+      <IconTooltip position="bottom">
+        <TooltipContent />
+      </IconTooltip>
     </div>
     <div style={{ gridColumn: '1/2' }}>
       <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
         Hover the icon
       </span>
-      <IconTooltip position="right">"some popover content"</IconTooltip>
+      <IconTooltip position="right">
+        <TooltipContent />
+      </IconTooltip>
     </div>
     <div style={{ gridColumn: '3/4' }}>
       <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
         Hover the icon
       </span>
-      <IconTooltip position="left">"some popover content"</IconTooltip>
+      <IconTooltip position="left">
+        <TooltipContent />
+      </IconTooltip>
     </div>
     <div style={{ gridColumn: '2/3' }}>
       <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
         Hover the icon
       </span>
-      <IconTooltip position="top">"some popover content"</IconTooltip>
+      <IconTooltip position="top">
+        <TooltipContent />
+      </IconTooltip>
     </div>
   </Grid>
 );
@@ -118,7 +126,9 @@ export const WithMutedIconColor = () => (
     <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
       Hover the icon
     </span>
-    <IconTooltip muteIconColor>"some popover content"</IconTooltip>
+    <IconTooltip muteIconColor>
+      <TooltipContent />
+    </IconTooltip>
   </>
 );
 
@@ -127,7 +137,9 @@ export const WithKindWarning = () => (
     <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
       Hover the icon
     </span>
-    <IconTooltip kind="warning">"some popover content"</IconTooltip>
+    <IconTooltip kind="warning">
+      <TooltipContent />
+    </IconTooltip>
   </>
 );
 
@@ -136,15 +148,23 @@ export const WithKindError = () => (
     <span css={{ marginRight: '4px', verticalAlign: 'middle' }}>
       Hover the icon
     </span>
-    <IconTooltip kind="error">"some popover content"</IconTooltip>
+    <IconTooltip kind="error">
+      <TooltipContent />
+    </IconTooltip>
   </>
 );
 
 export const HoverToolTip = () => (
   <Flex alignItems="baseline" gap={2}>
     <span>Hover the</span>
-    <HoverTooltip placement="bottom" tipContent="some popover content">
+    <HoverTooltip placement="bottom" tipContent={<TooltipContent />}>
       <ButtonPrimary>button</ButtonPrimary>
     </HoverTooltip>
   </Flex>
+);
+
+const TooltipContent = () => (
+  <Box>
+    some popover content with <Link>link color testing</Link>
+  </Box>
 );

--- a/web/packages/design/src/Tooltip/IconTooltip.tsx
+++ b/web/packages/design/src/Tooltip/IconTooltip.tsx
@@ -128,6 +128,9 @@ const ToolTipIcon = ({
 const StyledOnHover = styled(Text)<{ $maxWidth: number }>`
   color: ${props => props.theme.colors.text.primaryInverse};
   max-width: ${p => p.$maxWidth}px;
+  a {
+    color: ${props => props.theme.colors.tooltip.inverseLinkDefault};
+  }
 `;
 
 const InfoIcon = styled(Icons.Info)<{ $muteIconColor?: boolean }>`

--- a/web/packages/design/src/theme/themes/bblpTheme.ts
+++ b/web/packages/design/src/theme/themes/bblpTheme.ts
@@ -204,6 +204,7 @@ const colors: ThemeColors = {
   tooltip: {
     background: 'rgba(255, 255, 255, 0.8)',
     inverseBackground: 'rgba(0, 0, 0, 0.5)',
+    inverseLinkDefault: '#0073BA',
   },
 
   progressBarColor: '#00BFA5',

--- a/web/packages/design/src/theme/themes/darkTheme.ts
+++ b/web/packages/design/src/theme/themes/darkTheme.ts
@@ -207,6 +207,7 @@ const colors: ThemeColors = {
   tooltip: {
     background: 'rgba(255, 255, 255, 0.8)',
     inverseBackground: 'rgba(0, 0, 0, 0.5)',
+    inverseLinkDefault: '#0073BA',
   },
 
   progressBarColor: '#00BFA5',

--- a/web/packages/design/src/theme/themes/lightTheme.ts
+++ b/web/packages/design/src/theme/themes/lightTheme.ts
@@ -202,6 +202,7 @@ const colors: ThemeColors = {
   tooltip: {
     background: 'rgba(0, 0, 0, 0.80)',
     inverseBackground: 'rgba(255, 255, 255, 0.5)',
+    inverseLinkDefault: '#009EFF',
   },
 
   progressBarColor: '#007D6B',

--- a/web/packages/design/src/theme/themes/types.ts
+++ b/web/packages/design/src/theme/themes/types.ts
@@ -142,6 +142,7 @@ export type ThemeColors = {
   tooltip: {
     background: string;
     inverseBackground: string;
+    inverseLinkDefault: string;
   };
 
   progressBarColor: string;


### PR DESCRIPTION
link color were washed out and hard to see inside tooltips so i added inverse link color (btw tooltips uses `primaryInverse` for the text color)