### PR TITLE
Fix capitalisation on upcoming releases page

### DIFF
--- a/docs/pages/upcoming-releases.mdx
+++ b/docs/pages/upcoming-releases.mdx
@@ -12,7 +12,7 @@ support each major version for 24 months.
 
 The most recent major version of Teleport, referred to as the **current version**,
 is the only major version of Teleport that will receive new features. The
-previous major version, referred to as the **stable Version**, will only receive
+previous major version, referred to as the **stable version**, will only receive
 bug fixes and security patches.
 
 ## Teleport


### PR DESCRIPTION
Fixes a spurious capital in "stable Version" on the Upcoming Releases page