### PR TITLE
Refactor Access Graph client connection management

### DIFF
--- a/lib/accessgraph/config.go
+++ b/lib/accessgraph/config.go
@@ -1,0 +1,132 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"os"
+
+	"github.com/gravitational/trace"
+
+	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+)
+
+// ClusterClientGetter is a function that returns a ClusterConfigServiceClient
+type ClusterClientGetter = func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error)
+
+// AccessGraphConfig represents the Access Graph configuration.
+type AccessGraphConfig struct {
+	// Enabled indicates whether Access Graph is enabled locally or in the cluster.
+	Enabled bool
+	// Addr is the address of the Access Graph service.
+	Addr string
+	// Insecure is true if the connection to the Access Graph service should be insecure.
+	Insecure bool
+	// CA is the PEM-encoded CA certificate used to verify the Access Graph GRPC connection.
+	CA []byte
+	// CipherSuites is the list of TLS cipher suites to use for the connection.
+	CipherSuites []uint16
+}
+
+// GetAccessGraphSettingsConfig represents the Access Graph configuration
+// that can be read from the local config file.
+type GetAccessGraphSettingsConfig struct {
+	// LocallyEnabled indicates whether Access Graph reporting is enabled locally
+	// via the config file.
+	LocallyEnabled bool
+
+	// Addr of the Access Graph service addr
+	Addr string
+
+	// CA is the path to the CA certificate file
+	CA string
+
+	// Insecure is true if the connection to the Access Graph service should be insecure
+	Insecure bool
+
+	// CipherSuites is the list of TLS cipher suites to use for the connection
+	CipherSuites []uint16
+
+	// IsAuthServer indicates whether this config is for an auth server
+	IsAuthServer bool
+
+	// ClusterClientGetter is a function that returns a ClusterConfigServiceClient
+	ClusterClientGetter ClusterClientGetter
+}
+
+// GetAccessGraphSettings retrieves Access Graph configuration either from local
+// config or from the cluster via the auth server.
+func GetAccessGraphSettings(ctx context.Context, config GetAccessGraphSettingsConfig) (AccessGraphConfig, error) {
+	if config.ClusterClientGetter == nil {
+		return AccessGraphConfig{}, trace.BadParameter("missing ClusterClientGetter")
+	}
+	if config.LocallyEnabled {
+		var ca []byte
+		if config.CA != "" {
+			caBytes, err := os.ReadFile(config.CA)
+			if err != nil {
+				return AccessGraphConfig{}, trace.Wrap(err, "failed to read access graph CA from path %q", config.CA)
+			}
+			ca = caBytes
+		}
+		return AccessGraphConfig{
+			Enabled:      true,
+			Addr:         config.Addr,
+			Insecure:     config.Insecure,
+			CipherSuites: config.CipherSuites,
+			CA:           ca,
+		}, nil
+	}
+
+	// Fetch settings from the cluster if not enabled locally.
+	return getAccessGraphSettingsFromCluster(ctx, config)
+}
+
+// getAccessGraphSettingsFromCluster fetches Access Graph configuration from the cluster
+// via the auth server.
+func getAccessGraphSettingsFromCluster(ctx context.Context, config GetAccessGraphSettingsConfig) (AccessGraphConfig, error) {
+	if config.IsAuthServer {
+		return AccessGraphConfig{}, nil
+	}
+
+	client, err := config.ClusterClientGetter(ctx)
+	if err != nil {
+		return AccessGraphConfig{}, trace.Wrap(err, "failed to create cluster config client")
+	}
+	resp, err := client.GetClusterAccessGraphConfig(
+		ctx,
+		&clusterconfigv1.GetClusterAccessGraphConfigRequest{},
+	)
+	if err != nil {
+		return AccessGraphConfig{}, trace.Wrap(err, "failed to get access graph settings from auth server")
+	}
+
+	agConfig := resp.GetAccessGraph()
+	if agConfig == nil || !agConfig.GetEnabled() {
+		return AccessGraphConfig{}, trace.BadParameter("access graph is not enabled in the cluster")
+	}
+
+	return AccessGraphConfig{
+		Enabled:      agConfig.GetEnabled(),
+		Addr:         agConfig.GetAddress(),
+		Insecure:     agConfig.GetInsecure(),
+		CA:           agConfig.GetCa(),
+		CipherSuites: config.CipherSuites,
+	}, nil
+}

--- a/lib/accessgraph/config_test.go
+++ b/lib/accessgraph/config_test.go
@@ -1,0 +1,250 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
+)
+
+func TestGetAccessGraphSettings(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create a temporary CA file for testing
+	tempDir := t.TempDir()
+	caFilePath := filepath.Join(tempDir, "ca.pem")
+	caContent := []byte("test-ca-certificate")
+	err := os.WriteFile(caFilePath, caContent, 0o600)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		config      GetAccessGraphSettingsConfig
+		expectError bool
+		errorMsg    string
+		validate    func(t *testing.T, result AccessGraphConfig)
+	}{
+		{
+			name: "missing ClusterClientGetter",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: true,
+			},
+			expectError: true,
+			errorMsg:    "missing ClusterClientGetter",
+		},
+		{
+			name: "locally enabled with CA file",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: true,
+				Addr:           "localhost:50051",
+				CA:             caFilePath,
+				Insecure:       false,
+				CipherSuites:   []uint16{0x1301, 0x1302},
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return nil, nil
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result AccessGraphConfig) {
+				require.True(t, result.Enabled)
+				require.Equal(t, "localhost:50051", result.Addr)
+				require.False(t, result.Insecure)
+				require.Equal(t, caContent, result.CA)
+				require.Equal(t, []uint16{0x1301, 0x1302}, result.CipherSuites)
+			},
+		},
+		{
+			name: "locally enabled without CA file",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: true,
+				Addr:           "localhost:50051",
+				CA:             "",
+				Insecure:       true,
+				CipherSuites:   []uint16{0x1301},
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return nil, nil
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result AccessGraphConfig) {
+				require.True(t, result.Enabled)
+				require.Equal(t, "localhost:50051", result.Addr)
+				require.True(t, result.Insecure)
+				require.Nil(t, result.CA)
+				require.Equal(t, []uint16{0x1301}, result.CipherSuites)
+			},
+		},
+		{
+			name: "locally enabled with invalid CA path",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: true,
+				Addr:           "localhost:50051",
+				CA:             "/nonexistent/path/ca.pem",
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return nil, nil
+				},
+			},
+			expectError: true,
+			errorMsg:    "failed to read access graph CA from path",
+		},
+		{
+			name: "not locally enabled - auth server",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   true,
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return nil, nil
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result AccessGraphConfig) {
+				require.False(t, result.Enabled)
+				require.Empty(t, result.Addr)
+				require.Nil(t, result.CA)
+			},
+		},
+		{
+			name: "not locally enabled - cluster client getter fails",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   false,
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return nil, trace.ConnectionProblem(nil, "connection failed")
+				},
+			},
+			expectError: true,
+			errorMsg:    "failed to create cluster config client",
+		},
+		{
+			name: "not locally enabled - GetClusterAccessGraphConfig fails",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   false,
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return &mockClusterConfigClient{
+						getClusterAccessGraphConfigErr: trace.NotFound("config not found"),
+					}, nil
+				},
+			},
+			expectError: true,
+			errorMsg:    "failed to get access graph settings from auth server",
+		},
+		{
+			name: "not locally enabled - access graph nil in response",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   false,
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return &mockClusterConfigClient{
+						getClusterAccessGraphConfigResp: &clusterconfigv1.GetClusterAccessGraphConfigResponse{},
+					}, nil
+				},
+			},
+			expectError: true,
+			errorMsg:    "access graph is not enabled in the cluster",
+		},
+		{
+			name: "not locally enabled - access graph disabled in cluster",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   false,
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return &mockClusterConfigClient{
+						getClusterAccessGraphConfigResp: &clusterconfigv1.GetClusterAccessGraphConfigResponse{
+							AccessGraph: &clusterconfigv1.AccessGraphConfig{
+								Enabled: false,
+							},
+						},
+					}, nil
+				},
+			},
+			expectError: true,
+			errorMsg:    "access graph is not enabled in the cluster",
+		},
+		{
+			name: "not locally enabled - successful cluster fetch",
+			config: GetAccessGraphSettingsConfig{
+				LocallyEnabled: false,
+				IsAuthServer:   false,
+				CipherSuites:   []uint16{0x1303},
+				ClusterClientGetter: func(ctx context.Context) (clusterconfigv1.ClusterConfigServiceClient, error) {
+					return &mockClusterConfigClient{
+						getClusterAccessGraphConfigResp: &clusterconfigv1.GetClusterAccessGraphConfigResponse{
+							AccessGraph: &clusterconfigv1.AccessGraphConfig{
+								Enabled:  true,
+								Address:  "cluster.example.com:443",
+								Insecure: false,
+								Ca:       []byte("cluster-ca-cert"),
+							},
+						},
+					}, nil
+				},
+			},
+			expectError: false,
+			validate: func(t *testing.T, result AccessGraphConfig) {
+				require.True(t, result.Enabled)
+				require.Equal(t, "cluster.example.com:443", result.Addr)
+				require.False(t, result.Insecure)
+				require.Equal(t, []byte("cluster-ca-cert"), result.CA)
+				require.Equal(t, []uint16{0x1303}, result.CipherSuites)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetAccessGraphSettings(ctx, tt.config)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.ErrorContains(t, err, tt.errorMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			if tt.validate != nil {
+				tt.validate(t, result)
+			}
+		})
+	}
+}
+
+// mockClusterConfigClient is a mock implementation of ClusterConfigServiceClient
+type mockClusterConfigClient struct {
+	clusterconfigv1.ClusterConfigServiceClient
+	getClusterAccessGraphConfigResp *clusterconfigv1.GetClusterAccessGraphConfigResponse
+	getClusterAccessGraphConfigErr  error
+}
+
+func (m *mockClusterConfigClient) GetClusterAccessGraphConfig(ctx context.Context, req *clusterconfigv1.GetClusterAccessGraphConfigRequest, opts ...grpc.CallOption) (*clusterconfigv1.GetClusterAccessGraphConfigResponse, error) {
+	if m.getClusterAccessGraphConfigErr != nil {
+		return nil, m.getClusterAccessGraphConfigErr
+	}
+	return m.getClusterAccessGraphConfigResp, nil
+}

--- a/lib/accessgraph/connect.go
+++ b/lib/accessgraph/connect.go
@@ -64,9 +64,8 @@ type Connector interface {
 	ClientGetCertificate() (*tls.Certificate, error)
 }
 
-// AccessGraphClientGetterForEvent is a function that returns an AccessGraphClientGetter for a given event.
-// This allows different parts of the system to get access graph clients with different certificates based on the event
-// associated with the connector.
+// AccessGraphClientGetterForConnector is a function that returns an AccessGraphClientGetter for a given connector.
+// This allows different parts of the system to get access graph clients with different certificates based on the connector.
 type AccessGraphClientGetterForConnector = func(connector Connector) AccessGraphClientGetter
 
 // AccessGraphClientGetter is a function that returns a new access graph service client connection.

--- a/lib/accessgraph/connect.go
+++ b/lib/accessgraph/connect.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/grpc/stats"
 
 	"github.com/gravitational/teleport/api/metadata"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -57,6 +58,16 @@ type GRPCClientConnInterface interface {
 	grpc.ClientConnInterface
 	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
 }
+
+type Connector interface {
+	Role() types.SystemRole
+	ClientGetCertificate() (*tls.Certificate, error)
+}
+
+// AccessGraphClientGetterForEvent is a function that returns an AccessGraphClientGetter for a given event.
+// This allows different parts of the system to get access graph clients with different certificates based on the event
+// associated with the connector.
+type AccessGraphClientGetterForConnector = func(connector Connector) AccessGraphClientGetter
 
 // AccessGraphClientGetter is a function that returns a new access graph service client connection.
 type AccessGraphClientGetter = func(ctx context.Context) (GRPCClientConnInterface, error)

--- a/lib/accessgraph/connect.go
+++ b/lib/accessgraph/connect.go
@@ -1,0 +1,125 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc/filters"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/stats"
+
+	"github.com/gravitational/teleport/api/metadata"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// AccessGraphClientConfig is the configuration for the access graph service client.
+type AccessGraphClientConfig struct {
+	// Addr is the address of the access graph service.
+	Addr string
+	// CA is the PEM-encoded CA certificate used to verify the access graph GRPC connection.
+	CA []byte
+	// Insecure is true if the access graph GRPC connection should be insecure.
+	// Do not use in production.
+	Insecure bool
+	// CipherSuites is the list of TLS cipher suites to use for the connection.
+	CipherSuites []uint16
+	// ClientCredentials is a function that returns the client TLS certificate.
+	ClientCredentials ClientCredentialsGetter
+}
+
+// GRPCClientConnInterface is an interface that extends grpc.ClientConnInterface
+// with the ability to wait for state changes.
+type GRPCClientConnInterface interface {
+	grpc.ClientConnInterface
+	WaitForStateChange(ctx context.Context, sourceState connectivity.State) bool
+}
+
+// AccessGraphClientGetter is a function that returns a new access graph service client connection.
+type AccessGraphClientGetter = func(ctx context.Context) (GRPCClientConnInterface, error)
+
+// ClientCredentialsGetter is a function that returns the client TLS certificate.
+type ClientCredentialsGetter = func() (*tls.Certificate, error)
+
+// NewAccessGraphClient returns a new access graph service client.
+func NewAccessGraphClient(ctx context.Context, config AccessGraphClientConfig, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	credsOpt, err := grpcCredentials(config, config.ClientCredentials)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	otelOpt := grpc.WithStatsHandler(otelgrpc.NewClientHandler(
+		otelgrpc.WithFilter(filters.All(
+			filters.Not(filters.HealthCheck()),
+			func(i *stats.RPCTagInfo) bool {
+				return !strings.Contains(i.FullMethodName, "Stream")
+			},
+		)),
+	))
+
+	opts = append([]grpc.DialOption{credsOpt, otelOpt}, opts...)
+	conn, err := dial(ctx, config.Addr, opts...)
+	return conn, trace.Wrap(err)
+}
+
+func dial(ctx context.Context, addr string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	const maxMessageSize = 50 * 1024 * 1024 // 50MB
+	opts = append(opts,
+		grpc.WithUnaryInterceptor(metadata.UnaryClientInterceptor),
+		grpc.WithStreamInterceptor(metadata.StreamClientInterceptor),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(maxMessageSize),
+			grpc.MaxCallSendMsgSize(maxMessageSize),
+		),
+	)
+
+	conn, err := grpc.DialContext(ctx, addr, opts...)
+	return conn, trace.Wrap(err)
+}
+
+// grpcCredentials returns a grpc.DialOption configured with TLS credentials.
+func grpcCredentials(config AccessGraphClientConfig, getCreds ClientCredentialsGetter) (grpc.DialOption, error) {
+	if getCreds == nil {
+		return nil, trace.BadParameter("missing credential getter")
+	}
+
+	var pool *x509.CertPool
+	if len(config.CA) > 0 {
+		pool = x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(config.CA) {
+			return nil, trace.BadParameter("failed to append CA certificate to pool")
+		}
+	}
+
+	tlsConfig := utils.TLSConfig(config.CipherSuites)
+	tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+		return getCreds()
+	}
+	tlsConfig.InsecureSkipVerify = config.Insecure
+	tlsConfig.RootCAs = pool
+
+	return grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)), nil
+}

--- a/lib/accessgraph/connect_test.go
+++ b/lib/accessgraph/connect_test.go
@@ -1,0 +1,223 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package accessgraph
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/gravitational/teleport/lib/fixtures"
+)
+
+func TestGrpcCredentials(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      AccessGraphClientConfig
+		getCreds    ClientCredentialsGetter
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "valid config with CA",
+			config: AccessGraphClientConfig{
+				Addr: "localhost:50051",
+				CA:   []byte(fixtures.TLSCACertPEM),
+			},
+			getCreds: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+			expectError: false,
+		},
+		{
+			name: "valid config without CA",
+			config: AccessGraphClientConfig{
+				Addr: "localhost:50051",
+			},
+			getCreds: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+			expectError: false,
+		},
+		{
+			name: "insecure config",
+			config: AccessGraphClientConfig{
+				Addr:     "localhost:50051",
+				Insecure: true,
+			},
+			getCreds: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+			expectError: false,
+		},
+		{
+			name: "missing credential getter",
+			config: AccessGraphClientConfig{
+				Addr: "localhost:50051",
+				CA:   []byte(fixtures.TLSCACertPEM),
+			},
+			getCreds:    nil,
+			expectError: true,
+			errorMsg:    "missing credential getter",
+		},
+		{
+			name: "invalid CA certificate",
+			config: AccessGraphClientConfig{
+				Addr: "localhost:50051",
+				CA:   []byte("invalid ca cert"),
+			},
+			getCreds: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+			expectError: true,
+			errorMsg:    "failed to append CA certificate to pool",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt, err := grpcCredentials(tt.config, tt.getCreds)
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorMsg != "" {
+					require.ErrorContains(t, err, tt.errorMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, opt)
+		})
+	}
+}
+
+func TestNewAccessGraphClient(t *testing.T) {
+	ctx := context.Background()
+
+	const bufSize = 1024 * 1024
+	lis := bufconn.Listen(bufSize)
+
+	serverCert, err := tls.X509KeyPair(
+		[]byte(fixtures.TLSCACertPEM),
+		[]byte(fixtures.TLSCAKeyPEM),
+	)
+	require.NoError(t, err)
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAnyClientCert,
+	}
+
+	grpcServer := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
+	t.Cleanup(func() {
+		grpcServer.Stop()
+	})
+
+	healthServer := health.NewServer()
+	healthpb.RegisterHealthServer(grpcServer, healthServer)
+	healthServer.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Logf("Server exited with error: %v", err)
+		}
+	}()
+
+	t.Run("missing credential getter", func(t *testing.T) {
+		config := AccessGraphClientConfig{
+			Addr: "localhost:50051",
+			CA:   []byte(fixtures.TLSCACertPEM),
+		}
+		conn, err := NewAccessGraphClient(ctx, config)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "missing credential getter")
+		require.Nil(t, conn)
+	})
+
+	t.Run("successful connection with health check", func(t *testing.T) {
+		config := AccessGraphClientConfig{
+			Addr:     "bufconn",
+			Insecure: true,
+			ClientCredentials: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+		}
+
+		conn, err := NewAccessGraphClient(
+			ctx,
+			config,
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		healthClient := healthpb.NewHealthClient(conn)
+		resp, err := healthClient.Check(ctx, &healthpb.HealthCheckRequest{})
+		require.NoError(t, err)
+		require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+	})
+
+	t.Run("successful connection with additional dial options", func(t *testing.T) {
+		config := AccessGraphClientConfig{
+			Addr:     "bufconn",
+			Insecure: true,
+			ClientCredentials: func() (*tls.Certificate, error) {
+				cert, err := tls.X509KeyPair([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
+				return &cert, err
+			},
+		}
+
+		conn, err := NewAccessGraphClient(
+			ctx,
+			config,
+			grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return lis.DialContext(ctx)
+			}),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, conn)
+		t.Cleanup(func() {
+			require.NoError(t, conn.Close())
+		})
+
+		healthClient := healthpb.NewHealthClient(conn)
+		resp, err := healthClient.Check(ctx, &healthpb.HealthCheckRequest{})
+		require.NoError(t, err)
+		require.Equal(t, healthpb.HealthCheckResponse_SERVING, resp.Status)
+	})
+}

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -43,6 +43,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
+	accessgraphclient "github.com/gravitational/teleport/lib/accessgraph"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/accesspoint"
 	"github.com/gravitational/teleport/lib/auth/authcatest"
@@ -899,6 +900,8 @@ type TLSServerConfig struct {
 	Listener net.Listener
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
+	// AccessGraphClientGetter is a function to get access graph client
+	AccessGraphClientGetter accessgraphclient.AccessGraphClientGetter
 }
 
 // Auth returns auth server used by this TLS server
@@ -964,21 +967,25 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		return nil, trace.Wrap(err)
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
-	tlsCert := tlsConfig.Certificates[0]
 
 	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
+	accessGraphClientGetter := cfg.AccessGraphClientGetter
+	if accessGraphClientGetter == nil {
+		accessGraphClientGetter = func(context.Context) (accessgraphclient.GRPCClientConnInterface, error) {
+			return nil, trace.NotImplemented("access graph client getter is not implemented")
+		}
+	}
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
-		Listener:             srv.Listener,
-		AccessPoint:          srv.AuthServer.AuthServer.Cache,
-		TLS:                  tlsConfig,
-		GetClientCertificate: func() (*tls.Certificate, error) { return &tlsCert, nil },
-		APIConfig:            *srv.APIConfig,
-		LimiterConfig:        *srv.Limiter,
-		AcceptedUsage:        cfg.AcceptedUsage,
+		Listener:                srv.Listener,
+		AccessPoint:             srv.AuthServer.AuthServer.Cache,
+		TLS:                     tlsConfig,
+		AccessGraphClientGetter: accessGraphClientGetter,
+		APIConfig:               *srv.APIConfig,
+		LimiterConfig:           *srv.Limiter,
+		AcceptedUsage:           cfg.AcceptedUsage,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/plugin/registry.go
+++ b/lib/plugin/registry.go
@@ -20,12 +20,11 @@ package plugin
 
 import (
 	"context"
-	"crypto/tls"
 
 	"github.com/gravitational/trace"
-)
 
-type getCertFunc = func() (*tls.Certificate, error)
+	accessgraphclient "github.com/gravitational/teleport/lib/accessgraph"
+)
 
 // Plugin describes interfaces of the teleport core plugin
 type Plugin interface {
@@ -36,7 +35,7 @@ type Plugin interface {
 	// RegisterAuthWebHandlers registers new methods with the Auth Web Handler
 	RegisterAuthWebHandlers(service any) error
 	// RegisterAuthServices registers new services on the AuthServer
-	RegisterAuthServices(ctx context.Context, server any, getClientCert getCertFunc) error
+	RegisterAuthServices(ctx context.Context, server any, getAccessGraphClient accessgraphclient.AccessGraphClientGetter) error
 }
 
 // Registry is the plugin registry
@@ -50,7 +49,7 @@ type Registry interface {
 	// RegisterAuthWebHandlers registers Teleport Auth web handlers
 	RegisterAuthWebHandlers(handler any) error
 	// RegisterAuthServices registers Teleport AuthServer services
-	RegisterAuthServices(ctx context.Context, server any, getClientCert getCertFunc) error
+	RegisterAuthServices(ctx context.Context, server any, getAccessGraphClient accessgraphclient.AccessGraphClientGetter) error
 }
 
 // NewRegistry creates an instance of the Registry
@@ -112,9 +111,9 @@ func (r *registry) RegisterAuthWebHandlers(handler any) error {
 	return nil
 }
 
-func (r *registry) RegisterAuthServices(ctx context.Context, server any, getClientCert getCertFunc) error {
+func (r *registry) RegisterAuthServices(ctx context.Context, server any, getAccessGraphClient accessgraphclient.AccessGraphClientGetter) error {
 	for _, p := range r.plugins {
-		if err := p.RegisterAuthServices(ctx, server, getClientCert); err != nil {
+		if err := p.RegisterAuthServices(ctx, server, getAccessGraphClient); err != nil {
 			return trace.Wrap(err, "plugin %v failed to register", p.GetName())
 		}
 	}

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -66,7 +66,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	} else {
 		discoveryAccessGraphCfg = discovery.AccessGraphConfig{
 			Enabled:              accessGraphCfg.Enabled,
-			GetAccessGraphClient: process.GetAccessGraphConnection,
+			GetAccessGraphClient: process.GetAccessGraphConnectionForConnector(conn),
 		}
 	}
 

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -19,18 +19,11 @@
 package service
 
 import (
-	"context"
-	"log/slog"
-	"os"
-	"time"
-
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
 )
 
@@ -65,14 +58,16 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		return trace.Wrap(err)
 	}
 
-	accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
-		process.ExitContext(),
-		process.Config,
-		conn.Client,
-		logger,
-	)
+	var discoveryAccessGraphCfg discovery.AccessGraphConfig
+	accessGraphCfg, err := process.GetAccessGraphSettings()
 	if err != nil {
-		return trace.Wrap(err, "failed to build access graph configuration")
+		logger.WarnContext(process.ExitContext(),
+			"Failed to get Access Graph settings. Access Graph integration will be disabled.", "error", err)
+	} else {
+		discoveryAccessGraphCfg = discovery.AccessGraphConfig{
+			Enabled:              accessGraphCfg.Enabled,
+			GetAccessGraphClient: process.GetAccessGraphConnection,
+		}
 	}
 
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
@@ -93,7 +88,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		ClusterFeatures:   process.GetClusterFeatures,
 		PollInterval:      process.Config.Discovery.PollInterval,
 		GetClientCert:     conn.ClientGetCertificate,
-		AccessGraphConfig: accessGraphCfg,
+		AccessGraphConfig: discoveryAccessGraphCfg,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -137,46 +132,4 @@ func (process *TeleportProcess) initDiscoveryService() error {
 // Setting IntegrationOnlyCredentials to true, will prevent usage of the ambient credentials.
 func (process *TeleportProcess) integrationOnlyCredentials() bool {
 	return process.Config.Auth.Enabled && modules.GetModules().Features().Cloud
-}
-
-// buildAccessGraphFromTAGOrFallbackToAuth builds the AccessGraphConfig from the Teleport Agent configuration or falls back to the Auth server's configuration.
-// If the AccessGraph configuration is not enabled locally, it will fall back to the Auth server's configuration.
-func buildAccessGraphFromTAGOrFallbackToAuth(ctx context.Context, config *servicecfg.Config, client authclient.ClientI, logger *slog.Logger) (discovery.AccessGraphConfig, error) {
-	var (
-		accessGraphCAData []byte
-		err               error
-	)
-	if config == nil {
-		return discovery.AccessGraphConfig{}, trace.BadParameter("config is nil")
-	}
-	if config.AccessGraph.CA != "" {
-		accessGraphCAData, err = os.ReadFile(config.AccessGraph.CA)
-		if err != nil {
-			return discovery.AccessGraphConfig{}, trace.Wrap(err, "failed to read access graph CA file")
-		}
-	}
-	accessGraphCfg := discovery.AccessGraphConfig{
-		Enabled:  config.AccessGraph.Enabled,
-		Addr:     config.AccessGraph.Addr,
-		Insecure: config.AccessGraph.Insecure,
-		CA:       accessGraphCAData,
-	}
-	if !accessGraphCfg.Enabled {
-		logger.DebugContext(ctx, "Access graph is disabled or not configured. Falling back to the Auth server's access graph configuration.")
-		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		rsp, err := client.GetClusterAccessGraphConfig(ctx)
-		cancel()
-		switch {
-		case trace.IsNotImplemented(err):
-			logger.DebugContext(ctx, "Auth server does not support access graph's GetClusterAccessGraphConfig RPC")
-		case err != nil:
-			return discovery.AccessGraphConfig{}, trace.Wrap(err)
-		default:
-			accessGraphCfg.Enabled = rsp.Enabled
-			accessGraphCfg.Addr = rsp.Address
-			accessGraphCfg.CA = rsp.Ca
-			accessGraphCfg.Insecure = rsp.Insecure
-		}
-	}
-	return accessGraphCfg, nil
 }

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -19,19 +19,13 @@
 package service
 
 import (
-	"context"
-	"log/slog"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
-	clusterconfigpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
-	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/srv/discovery"
 )
 
 func TestTeleportProcessIntegrationsOnly(t *testing.T) {
@@ -76,105 +70,4 @@ func TestTeleportProcessIntegrationsOnly(t *testing.T) {
 			require.Equal(t, tt.integrationOnly, p.integrationOnlyCredentials())
 		})
 	}
-}
-
-func TestTeleportProcess_initDiscoveryService(t *testing.T) {
-
-	tests := []struct {
-		name      string
-		cfg       servicecfg.AccessGraphConfig
-		rsp       *clusterconfigpb.AccessGraphConfig
-		err       error
-		want      discovery.AccessGraphConfig
-		assertErr require.ErrorAssertionFunc
-	}{
-		{
-			name: "local access graph",
-			cfg: servicecfg.AccessGraphConfig{
-				Enabled:  true,
-				Addr:     "localhost:5000",
-				Insecure: true,
-			},
-			rsp: nil,
-			err: nil,
-			want: discovery.AccessGraphConfig{
-				Enabled:  true,
-				Addr:     "localhost:5000",
-				Insecure: true,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			name: "access graph disabled locally but enabled in auth",
-			cfg: servicecfg.AccessGraphConfig{
-				Enabled: false,
-			},
-			rsp: &clusterconfigpb.AccessGraphConfig{
-				Enabled:  true,
-				Address:  "localhost:5000",
-				Insecure: true,
-			},
-			err: nil,
-			want: discovery.AccessGraphConfig{
-				Enabled:  true,
-				Addr:     "localhost:5000",
-				Insecure: true,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			name: "access graph disabled locally and auth doesn't implement GetClusterAccessGraphConfig",
-			cfg: servicecfg.AccessGraphConfig{
-				Enabled: false,
-			},
-			rsp: nil,
-			err: trace.NotImplemented("err"),
-			want: discovery.AccessGraphConfig{
-				Enabled: false,
-			},
-			assertErr: require.NoError,
-		},
-		{
-			name: "access graph disabled locally and auth call fails",
-			cfg: servicecfg.AccessGraphConfig{
-				Enabled: false,
-			},
-			rsp: nil,
-			err: trace.BadParameter("err"),
-			want: discovery.AccessGraphConfig{
-				Enabled: false,
-			},
-			assertErr: require.Error,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			accessGraphCfg, err := buildAccessGraphFromTAGOrFallbackToAuth(
-				context.Background(),
-				&servicecfg.Config{
-					AccessGraph: tt.cfg,
-				},
-				&fakeClient{
-					rsp: tt.rsp,
-					err: tt.err,
-				},
-				slog.Default(),
-			)
-			tt.assertErr(t, err)
-			require.Equal(t, tt.want, accessGraphCfg)
-		})
-	}
-}
-
-type fakeClient struct {
-	authclient.ClientI
-	rsp *clusterconfigpb.AccessGraphConfig
-	err error
-}
-
-func (f *fakeClient) GetClusterAccessGraphConfig(ctx context.Context) (*clusterconfigpb.AccessGraphConfig, error) {
-	if f.err != nil {
-		return nil, f.err
-	}
-	return f.rsp, nil
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -7522,6 +7522,10 @@ func (process *TeleportProcess) createAccessGraphConnection(ctx context.Context,
 	}
 }`
 
+	if settings.Insecure {
+		process.logger.WarnContext(ctx, "Access Graph connection using insecure mode, do not use in production", "addr", settings.Addr)
+	}
+
 	conn, err := accessgraph.NewAccessGraphClient(ctx,
 		accessgraph.AccessGraphClientConfig{
 			Addr:              settings.Addr,

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -54,6 +54,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	ossaccessgraphclient "github.com/gravitational/teleport/lib/accessgraph"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/cloud/azure"
@@ -204,14 +205,7 @@ type AccessGraphConfig struct {
 	// Enabled indicates if Access Graph reporting is enabled.
 	Enabled bool
 
-	// Addr of the Access Graph service.
-	Addr string
-
-	// CA is the CA in PEM format used by the Access Graph service.
-	CA []byte
-
-	// Insecure is true if the connection to the Access Graph service should be insecure.
-	Insecure bool
+	GetAccessGraphClient ossaccessgraphclient.AccessGraphClientGetter
 }
 
 type awsFetchersClientsGetter struct {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -78,6 +78,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
+	accessgraphclient "github.com/gravitational/teleport/lib/accessgraph"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/moderation"
@@ -189,6 +190,13 @@ type Handler struct {
 	findEndpointCache *utils.FnCache
 
 	autoUpdateResolver *autoupdatelookup.Resolver
+}
+
+func (h *Handler) GetAccessGraphConfig() (accessgraphclient.AccessGraphConfig, error) {
+	if h.cfg.AccessGraphConfigGetter == nil {
+		return accessgraphclient.AccessGraphConfig{}, nil
+	}
+	return h.cfg.AccessGraphConfigGetter()
 }
 
 // HandlerOption is a functional argument - an option that can be passed
@@ -335,6 +343,9 @@ type Config struct {
 
 	// DatabaseREPLRegistry is used for retrieving database REPL.
 	DatabaseREPLRegistry dbrepl.REPLRegistry
+
+	// AccessGraphConfigGetter is a function that returns the Access Graph configuration.
+	AccessGraphConfigGetter func() (accessgraphclient.AccessGraphConfig, error)
 }
 
 // SetDefaults ensures proper default values are set if
@@ -2074,7 +2085,8 @@ func globMatch(pattern, str string) (bool, error) {
 // userMatchesConnector is a helper function to check if a user matches any of a connector's user matchers.
 func userMatchesConnector(username string, connector interface {
 	GetUserMatchers() []string
-}) (isMatch bool, isFallback bool, err error) {
+},
+) (isMatch bool, isFallback bool, err error) {
 	matchers := connector.GetUserMatchers()
 	for _, pattern := range matchers {
 		matched, err := globMatch(pattern, username)
@@ -3794,7 +3806,6 @@ func (h *Handler) getClusterLocks(
 			return clt.GetLocks(ctx, inForceOnlyFalse)
 		},
 	)
-
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/tool/tctl/common/resources/resource_test.go
+++ b/tool/tctl/common/resources/resource_test.go
@@ -20,7 +20,6 @@ package resources
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -34,6 +33,7 @@ import (
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/usertasks"
+	accessgraphclient "github.com/gravitational/teleport/lib/accessgraph"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -360,7 +360,7 @@ func (m *mockServicesPlugin) RegisterAuthWebHandlers(service any) error {
 	return nil
 }
 
-func (m *mockServicesPlugin) RegisterAuthServices(ctx context.Context, server any, _ func() (*tls.Certificate, error)) error {
+func (m *mockServicesPlugin) RegisterAuthServices(ctx context.Context, server any, _ accessgraphclient.AccessGraphClientGetter) error {
 	authServer, ok := server.(*auth.GRPCServer)
 	if !ok {
 		return trace.BadParameter("expected auth.GRPCServer, got %T", server)


### PR DESCRIPTION
Extracts Access Graph configuration and connection logic into a dedicated lib/accessgraph package. Replaces the GetClientCertificate pattern with AccessGraphClientGetter throughout the codebase, providing a centralized way to obtain Access Graph gRPC clients. This ensures each Teleport process creates a single reusable Access Graph client connection instead of multiple connections, improving resource efficiency and connection management.

Configuration can now be sourced from local config files or fetched from the cluster via the auth server.