### PR TITLE
[Web UI] IaC First Discover Flow - terraform module support

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.story.tsx
@@ -1,0 +1,151 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Meta } from '@storybook/react-vite';
+
+import Flex from 'design/Flex';
+
+import LiveTextEditor from './LiveTextEditor';
+import { hcl } from './terraform';
+
+type RegionCount = 'none' | '1' | '2' | '5';
+type TagsOption = 'none' | 'many';
+
+type StoryProps = {
+  cluster_name: string;
+  region_count: RegionCount;
+  is_enabled: boolean;
+  tags: TagsOption;
+};
+
+const meta: Meta<StoryProps> = {
+  title: 'Teleport/Integrations/LiveTextEditor',
+  component: TerraformModule,
+  argTypes: {
+    cluster_name: {
+      control: { type: 'text' },
+    },
+    region_count: {
+      control: { type: 'select' },
+      options: ['none', '1', '2', '5'],
+    },
+    is_enabled: {
+      control: { type: 'boolean' },
+    },
+    tags: {
+      control: { type: 'select' },
+      options: ['none', 'many'],
+    },
+  },
+  args: {
+    cluster_name: 'teleport-cluster',
+    region_count: '2',
+    is_enabled: false,
+    tags: 'none',
+  },
+};
+export default meta;
+
+const getRegions = (regionCount: RegionCount): string[] | null => {
+  switch (regionCount) {
+    case 'none':
+      return null;
+    case '1':
+      return ['us-east-1'];
+    case '2':
+      return ['us-east-1', 'us-west-2'];
+    case '5':
+      return [
+        'us-east-1',
+        'us-west-2',
+        'eu-west-1',
+        'ap-southeast-1',
+        'ca-central-1',
+      ];
+    default:
+      return null;
+  }
+};
+
+const getTags = (tagsOption: TagsOption): Record<string, string> | null => {
+  switch (tagsOption) {
+    case 'none':
+      return null;
+    case 'many':
+      return {
+        Environment: 'production',
+        Team: 'platform',
+        'teleport.dev/example': 'testing',
+      };
+    default:
+      return null;
+  }
+};
+
+const generateTerraformModule = (props: StoryProps): string => {
+  const clusterName = props.cluster_name || null;
+  const regions = getRegions(props.region_count);
+  const tags = getTags(props.tags);
+  const complexType = [
+    { testing: ['1', 2, false, { Test: 'example' }] },
+    { enabled: true },
+  ];
+
+  const multiline = `hello
+  world`;
+  return hcl`# Example Terraform Module
+
+module "example" {
+  source = "../"
+  
+  cluster_name  = ${clusterName}
+
+  # array type
+  regions = ${regions}
+
+  # map type
+  tags = ${tags}
+
+  # multiline string
+  multiline = ${multiline}
+
+  # boolean
+  enabled = ${props.is_enabled}
+
+  # complex type
+  complex_type = ${complexType}
+}`;
+};
+
+export function TerraformModule(props: StoryProps) {
+  const terraformContent = generateTerraformModule(props);
+
+  return (
+    <Flex height="600px" width="800px" py={3} pr={3} bg="levels.deep">
+      <LiveTextEditor
+        bg="levels.deep"
+        data={[
+          {
+            content: terraformContent,
+            type: 'terraform',
+          },
+        ]}
+      />
+    </Flex>
+  );
+}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Component, createRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 import TextEditor from 'shared/components/TextEditor';
 
@@ -27,22 +27,18 @@ type LiveTextEditorProps = Omit<
   data: [{ content: string; type?: 'terraform' | 'json' | 'yaml' }];
 };
 
-export default class LiveTextEditor extends Component<LiveTextEditorProps> {
-  private editorRef = createRef<TextEditor>();
+export default function LiveTextEditor(props: LiveTextEditorProps) {
+  const editorRef = useRef<TextEditor>(null);
 
-  componentDidUpdate(prevProps: LiveTextEditorProps) {
-    const prevContent = prevProps.data?.[0]?.content;
-    const currentContent = this.props.data?.[0]?.content;
-    const contentChanged = prevContent !== currentContent;
+  useEffect(() => {
+    const currentContent = props.data[0].content;
 
-    if (contentChanged && currentContent && this.editorRef.current?.editor) {
-      this.editorRef.current.setActiveSession(0);
-      this.editorRef.current.editor.session.setValue(currentContent);
-      this.editorRef.current.editor.session.getUndoManager().markClean();
+    if (currentContent && editorRef.current?.editor) {
+      editorRef.current.setActiveSession(0);
+      editorRef.current.editor.session.setValue(currentContent);
+      editorRef.current.editor.session.getUndoManager().markClean();
     }
-  }
+  }, [props.data[0].content]);
 
-  render() {
-    return <TextEditor ref={this.editorRef} readOnly={true} {...this.props} />;
-  }
+  return <TextEditor ref={editorRef} readOnly={true} {...props} />;
 }

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/LiveTextEditor.tsx
@@ -1,0 +1,48 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component, createRef } from 'react';
+
+import TextEditor from 'shared/components/TextEditor';
+
+type LiveTextEditorProps = Omit<
+  React.ComponentProps<typeof TextEditor>,
+  'readOnly'
+> & {
+  data: [{ content: string; type?: 'terraform' | 'json' | 'yaml' }];
+};
+
+export default class LiveTextEditor extends Component<LiveTextEditorProps> {
+  private editorRef = createRef<TextEditor>();
+
+  componentDidUpdate(prevProps: LiveTextEditorProps) {
+    const prevContent = prevProps.data?.[0]?.content;
+    const currentContent = this.props.data?.[0]?.content;
+    const contentChanged = prevContent !== currentContent;
+
+    if (contentChanged && currentContent && this.editorRef.current?.editor) {
+      this.editorRef.current.setActiveSession(0);
+      this.editorRef.current.editor.session.setValue(currentContent);
+      this.editorRef.current.editor.session.getUndoManager().markClean();
+    }
+  }
+
+  render() {
+    return <TextEditor ref={this.editorRef} readOnly={true} {...this.props} />;
+  }
+}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.test.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { hcl } from './terraform';
+
+describe('hcl', () => {
+  test('renders escaped strings', () => {
+    const ami = 'ami-12345';
+    const instanceType = 't2.micro';
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  ami           = ${ami}
+  instance_type = ${instanceType}
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  ami           = "ami-12345"
+  instance_type = "t2.micro"
+}`);
+  });
+
+  test('renders numbers', () => {
+    const count = 3;
+    const maxPrice = 0.0031;
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  count = ${count}
+
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      max_price = ${maxPrice}
+    }
+  }
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  count = 3
+
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      max_price = ${maxPrice}
+    }
+  }
+}`);
+  });
+
+  test('renders booleans', () => {
+    const enabled = true;
+    const disabled = false;
+
+    const result = hcl`
+module "example" {
+  is_enabled  = ${enabled}
+  is_disabled = ${disabled}
+}`;
+
+    expect(result).toBe(`
+module "example" {
+  is_enabled  = ${enabled}
+  is_disabled = ${disabled}
+}`);
+  });
+
+  test('renders arrays with proper formatting', () => {
+    const regions = ['us-east-1', 'us-west-2'];
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  availability_zones = ${regions}
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  availability_zones = ["us-east-1", "us-west-2"]
+}`);
+  });
+
+  test('breaks arrays exceeding 40 chars into multiple lines', () => {
+    const moreRegions = [
+      'us-east-1',
+      'us-west-2',
+      'eu-west-1',
+      'ap-southeast-1',
+      'ca-central-1',
+    ];
+
+    const result = hcl`
+module "region_example" {
+  example_regions = ${moreRegions}
+}`;
+
+    expect(result).toBe(`
+module "region_example" {
+  example_regions = [
+    "us-east-1",
+    "us-west-2",
+    "eu-west-1",
+    "ap-southeast-1",
+    "ca-central-1"
+  ]
+}`);
+  });
+
+  test('renders objects with proper indentation and alignment', () => {
+    const tags = {
+      Environment: 'production',
+      Team: 'infrastructure',
+      Project: 'teleport',
+    };
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  tags = ${tags}
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  tags = {
+    Environment = "production"
+    Team        = "infrastructure"
+    Project     = "teleport"
+  }
+}`);
+  });
+
+  test('quotes object keys when necessary', () => {
+    const tags = {
+      'dash-identifier-ok': 'value1',
+      'with spaces': 'value2',
+      '123startswithnumber': 'value3',
+      valid_key: 'value4',
+      normal: 'value5',
+    };
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  tags = ${tags}
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  tags = {
+    dash-identifier-ok    = "value1"
+    "with spaces"         = "value2"
+    "123startswithnumber" = "value3"
+    valid_key             = "value4"
+    normal                = "value5"
+  }
+}`);
+  });
+
+  test('removes preceding lines with only whitespace or comments when null value used', () => {
+    const regions = null;
+    const tags = { Environment: 'test' };
+
+    const result = hcl`
+module "test_module" {
+    
+  # remove me  
+  regions = ${regions}
+
+  # this stays
+  tags = ${tags}
+}`;
+
+    expect(result).toBe(`
+module "test_module" {
+
+  # this stays
+  tags = {
+    Environment = "test"
+  }
+}`);
+  });
+
+  test('preserves indentation with nested structures', () => {
+    const config = {
+      vpc: {
+        cidr_block: '10.0.0.0/16',
+        enable_dns: true,
+      },
+      subnets: ['10.0.1.0/24', '10.0.2.0/24'],
+    };
+
+    const result = hcl`
+resource "aws_vpc" "main" {
+  network_config = ${config}
+}`;
+
+    expect(result).toBe(`
+resource "aws_vpc" "main" {
+  network_config = {
+    vpc     = {
+      cidr_block = "10.0.0.0/16"
+      enable_dns = true
+    }
+    subnets = ["10.0.1.0/24", "10.0.2.0/24"]
+  }
+}`);
+  });
+
+  test('renders empty arrays and objects', () => {
+    const emptyArray = [];
+    const emptyObject = {};
+
+    const result = hcl`
+resource "aws_instance" "example" {
+  security_groups = ${emptyArray}
+  tags            = ${emptyObject}
+}`;
+
+    expect(result).toBe(`
+resource "aws_instance" "example" {
+  security_groups = []
+  tags            = {}
+}`);
+  });
+
+  test('handles multiline string values', () => {
+    const value = `hello
+  world`;
+
+    const result = hcl`
+resource "multiline_string" "example" {
+  example = ${value}
+}`;
+
+    expect(result).toBe(`
+resource "multiline_string" "example" {
+  example = "hello\\n  world"
+}`);
+  });
+
+  test('handles example terraform module configuration', () => {
+    const integrationName = 'my-integration';
+    const clusterName = 'teleport.example.com';
+    const matchAwsTypes = ['ec2'];
+    const regions = null;
+    const tags = {
+      Environment: 'production',
+      Owner: 'platform-team',
+    };
+
+    const result = hcl`# Terraform Module
+module "test_module" {
+  teleport_integration_name     = ${integrationName}
+  teleport_cluster_name         = ${clusterName}
+
+  match_aws_types  = ${matchAwsTypes}
+
+  # AWS regions
+  match_aws_regions = ${regions}
+  match_aws_tags = ${tags}
+}`;
+
+    expect(result).toBe(`# Terraform Module
+module "test_module" {
+  teleport_integration_name     = "my-integration"
+  teleport_cluster_name         = "teleport.example.com"
+
+  match_aws_types  = ["ec2"]
+  match_aws_tags = {
+    Environment = "production"
+    Owner       = "platform-team"
+  }
+}`);
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/terraform.ts
@@ -1,0 +1,160 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+interface TFObject {
+  readonly [key: string]: TFValue;
+}
+
+type TFValue = string | number | boolean | TFValue[] | TFObject | null;
+
+/**
+ * hcl is a tagged template function for generating Terraform HCL
+ * configuration. Formats objects, arrays and primitives. If a null value is
+ * used, it will omit the current line and preceding whitespace and single-line
+ * comments.
+ *
+ * @example
+ * const teleportAddr = "teleport.mycluster.example"
+ * const clientIdList = ["discover.teleport"];
+ * const tags         = null;
+ *
+ * const config = hcl`
+ * resource "aws_iam_openid_connect_provider" "teleport_oidc_provider" {
+ *   url             = ${teleportAddr}
+ *   client_id_list  = ${clientIdList}
+ *   tags            = ${tags}
+ * }
+ * `;
+ *
+ *
+ * // Generates:
+ * // resource "aws_iam_openid_connect_provider" "teleport_oidc_provider" {
+ * //   url            = "teleport.mycluster.example"
+ * //   client_id_list = ["discover.teleport"]
+ * // }
+ *
+ * TODO(alexhemard): this covers a pretty narrow use case for formatting
+ * simple Terraform module configuration examples. should look at moving this to the
+ * backend and leveraging the official hcl go package for anything more sophisticated.
+ **/
+export const hcl = (
+  strings: TemplateStringsArray,
+  ...values: TFValue[]
+): string => {
+  let result = '';
+
+  strings.forEach((str, i) => {
+    if (i < values.length && values[i] === null) {
+      // If null, remove current line, preceding whitespace, and single line comments
+      const lines = str.split('\n').slice(0, -1);
+
+      // find last non-whitespace, non-comment line
+      const lastContentIndex = lines.findLastIndex(line => {
+        const trimmed = line.trim();
+        return trimmed !== '' && !trimmed.startsWith('#');
+      });
+
+      result += lines.slice(0, lastContentIndex + 1).join('\n');
+
+      return;
+    }
+
+    result += str;
+
+    if (i < values.length) {
+      const value = values[i];
+
+      const lines = result.split('\n');
+      const lastLine = lines[lines.length - 1];
+      const currentIndent = lastLine.match(/^(\s*)/)?.[1] || '';
+      const indentLevel = Math.floor(currentIndent.length / 2);
+
+      if (typeof value === 'string') {
+        result += JSON.stringify(value);
+      } else {
+        result += renderValue(value, indentLevel);
+      }
+    }
+  });
+
+  return result;
+};
+
+const renderValue = (value: TFValue, indent: number): string => {
+  if (value === null) return '';
+
+  // string, boolean, number
+  if (typeof value !== 'object') return JSON.stringify(value);
+
+  // TFValue[]
+  if (Array.isArray(value)) {
+    return renderArray(value, indent);
+  }
+
+  // TFObject
+  if (typeof value === 'object') {
+    return renderObject(value, indent);
+  }
+
+  return '';
+};
+
+const renderArray = (value: TFValue[], indent: number): string => {
+  if (value.length === 0) return '[]';
+  if (value.every(v => typeof v !== 'object' || v === null)) {
+    // render array as a single line if small enough
+    const breakLength = 40;
+
+    const singleLine =
+      '[' + value.map(v => renderValue(v, indent + 1)).join(', ') + ']';
+    if (singleLine.length <= breakLength) {
+      return singleLine;
+    }
+  }
+
+  const spaces = '  '.repeat(indent + 1);
+  const items = value.map(v => renderValue(v, indent + 1));
+  return `[\n${spaces}${items.join(`,\n${spaces}`)}\n${'  '.repeat(indent)}]`;
+};
+
+const renderObject = (value: TFObject, indent: number): string => {
+  if (Object.keys(value).length === 0) return '{}';
+
+  const maxLength = Math.max(
+    ...Object.keys(value).map(k => renderKey(k).length)
+  );
+
+  const spaces = '  '.repeat(indent + 1);
+  const entries = Object.entries(value).map(([key, value]) => {
+    const padding = ' '.repeat(maxLength - renderKey(key).length);
+    return `${renderKey(key)}${padding} = ${renderValue(value, indent + 1)}`;
+  });
+  return `{\n${spaces}${entries.join(`\n${spaces}`)}\n${'  '.repeat(indent)}}`;
+};
+
+const renderKey = (key: string): string => {
+  // Source: https://developer.hashicorp.com/terraform/language/syntax/configuration#identifiers
+  // Keys can be left unquoted if they are a valid identifier
+  //
+  // Identifiers can contain letters, digits, underscores (_), and hyphens
+  // (-). The first character of an identifier must not be a digit, to avoid
+  // ambiguity with literal numbers.
+
+  const needsQuotes = !/^[a-zA-Z_][a-zA-Z0-9_-]*$/.test(key);
+  return needsQuotes ? JSON.stringify(key) : key;
+};


### PR DESCRIPTION
## Description
Issue: https://github.com/gravitational/teleport/issues/60813
Figma: https://www.figma.com/design/3JcCgPFtJqCG68GWmMXIfn/Root-Account-Discovery?node-id=1514-36624&m=dev

Supporting functionality for generating example Terraform configuration for IaC-first Discover Flow

- Adds a`hcl` tag function to render, indent typescript values to generate example terraform configuration using tagged template literals
- Adds LiveTextEditor component to update when content is changed