### PR TITLE
Cleanup scheme usage in operator

### DIFF
--- a/integrations/operator/apis/resources/scheme.go
+++ b/integrations/operator/apis/resources/scheme.go
@@ -1,0 +1,44 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"github.com/gravitational/trace"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
+	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
+	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
+	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
+)
+
+func AddToScheme(scheme *runtime.Scheme) error {
+	return trace.NewAggregate(
+		resourcesv1.AddToScheme(scheme),
+		resourcesv2.AddToScheme(scheme),
+		resourcesv3.AddToScheme(scheme),
+		resourcesv5.AddToScheme(scheme),
+	)
+}
+
+func NewScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	return scheme, trace.Wrap(err)
+}

--- a/integrations/operator/apis/resources/teleportcr/constants.go
+++ b/integrations/operator/apis/resources/teleportcr/constants.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package resources
+package teleportcr
 
 const (
 	GroupName      = "resources.teleport.dev"

--- a/integrations/operator/apis/resources/teleportcr/status.go
+++ b/integrations/operator/apis/resources/teleportcr/status.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package resources
+package teleportcr
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/integrations/operator/apis/resources/v1/accesslist_types.go
+++ b/integrations/operator/apis/resources/v1/accesslist_types.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	accesslist "github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -38,7 +38,7 @@ type TeleportAccessList struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportAccessListSpec `json:"spec"`
-	Status resources.Status       `json:"status"`
+	Status teleportcr.Status      `json:"status"`
 }
 
 // TeleportAccessListSpec defines the desired state of TeleportProvisionToken
@@ -64,7 +64,7 @@ func (l TeleportAccessList) ToTeleport() *accesslist.AccessList {
 			Version: types.V1,
 			Metadata: header.Metadata{
 				Name:        l.Name,
-				Description: l.Annotations[resources.DescriptionKey],
+				Description: l.Annotations[teleportcr.DescriptionKey],
 				Labels:      l.Labels,
 			},
 		},

--- a/integrations/operator/apis/resources/v1/appv3_types.go
+++ b/integrations/operator/apis/resources/v1/appv3_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportAppV3 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportAppV3Spec `json:"spec"`
-	Status resources.Status  `json:"status"`
+	Status teleportcr.Status `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportAppV3) ToTeleport() types.Application {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.AppSpecV3(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/autoupdateconfigv1_types.go
+++ b/integrations/operator/apis/resources/v1/autoupdateconfigv1_types.go
@@ -26,7 +26,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -48,7 +48,7 @@ type TeleportAutoupdateConfigV1 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   *TeleportAutoupdateConfigV1Spec `json:"spec,omitempty"`
-	Status resources.Status                `json:"status"`
+	Status teleportcr.Status               `json:"status"`
 }
 
 // TeleportAutoupdateConfigV1Spec defines the desired state of TeleportAutoupdateConfigV1
@@ -70,7 +70,7 @@ func (l *TeleportAutoupdateConfigV1) ToTeleport() *autoupdatev1pb.AutoUpdateConf
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*autoupdatev1pb.AutoUpdateConfigSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/autoupdateversionv1_types.go
+++ b/integrations/operator/apis/resources/v1/autoupdateversionv1_types.go
@@ -26,7 +26,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -48,7 +48,7 @@ type TeleportAutoupdateVersionV1 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   *TeleportAutoupdateVersionV1Spec `json:"spec,omitempty"`
-	Status resources.Status                 `json:"status"`
+	Status teleportcr.Status                `json:"status"`
 }
 
 // TeleportAutoupdateVersionV1Spec defines the desired state of TeleportAutoupdateVersionV1
@@ -70,7 +70,7 @@ func (l *TeleportAutoupdateVersionV1) ToTeleport() *autoupdatev1pb.AutoUpdateVer
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*autoupdatev1pb.AutoUpdateVersionSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/botv1_types.go
+++ b/integrations/operator/apis/resources/v1/botv1_types.go
@@ -26,7 +26,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -42,7 +42,7 @@ type TeleportBotV1 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   *TeleportBotV1Spec `json:"spec,omitempty"`
-	Status resources.Status   `json:"status"`
+	Status teleportcr.Status  `json:"status"`
 }
 
 // TeleportBotV1Spec defines the desired state of TeleportBotV1
@@ -66,7 +66,7 @@ func (l *TeleportBotV1) ToTeleport() *machineidv1.Bot {
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*machineidv1.BotSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/databasev3_types.go
+++ b/integrations/operator/apis/resources/v1/databasev3_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportDatabaseV3 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportDatabaseV3Spec `json:"spec"`
-	Status resources.Status       `json:"status"`
+	Status teleportcr.Status      `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportDatabaseV3) ToTeleport() types.Database {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.DatabaseSpecV3(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/groupversion_info.go
+++ b/integrations/operator/apis/resources/v1/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v1/loginrule_types.go
+++ b/integrations/operator/apis/resources/v1/loginrule_types.go
@@ -24,7 +24,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,7 +40,7 @@ type TeleportLoginRule struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportLoginRuleSpec `json:"spec"`
-	Status resources.Status      `json:"status"`
+	Status teleportcr.Status     `json:"status"`
 }
 
 // TeleportLoginRuleSpec matches the JSON of generated CRD spec
@@ -69,7 +69,7 @@ func (l TeleportLoginRule) ToTeleport() *LoginRuleResource {
 			Metadata: &types.Metadata{
 				Name:        l.Name,
 				Labels:      l.Labels,
-				Description: l.Annotations[resources.DescriptionKey],
+				Description: l.Annotations[teleportcr.DescriptionKey],
 			},
 			Version:          types.V1,
 			Priority:         l.Spec.Priority,

--- a/integrations/operator/apis/resources/v1/okta_import_rule.go
+++ b/integrations/operator/apis/resources/v1/okta_import_rule.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,7 +40,7 @@ type TeleportOktaImportRule struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportOktaImportRuleSpec `json:"spec"`
-	Status resources.Status           `json:"status"`
+	Status teleportcr.Status          `json:"status"`
 }
 
 // TeleportOktaImportRuleSpec matches the JSON of generated CRD spec
@@ -81,7 +81,7 @@ func (o TeleportOktaImportRule) ToTeleport() types.OktaImportRule {
 			Metadata: types.Metadata{
 				Name:        o.Name,
 				Labels:      o.Labels,
-				Description: o.Annotations[resources.DescriptionKey],
+				Description: o.Annotations[teleportcr.DescriptionKey],
 			},
 			Version: types.V1,
 		},

--- a/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportOpenSSHEICEServerV2 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportOpenSSHEICEServerV2Spec `json:"spec"`
-	Status resources.Status                `json:"status"`
+	Status teleportcr.Status               `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -61,7 +61,7 @@ func (r TeleportOpenSSHEICEServerV2) ToTeleport() types.Server {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ServerSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/opensshserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/opensshserverv2_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportOpenSSHServerV2 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportOpenSSHServerV2Spec `json:"spec"`
-	Status resources.Status            `json:"status"`
+	Status teleportcr.Status           `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -61,7 +61,7 @@ func (r TeleportOpenSSHServerV2) ToTeleport() types.Server {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ServerSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev6_types.go
+++ b/integrations/operator/apis/resources/v1/rolev6_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV6 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportRoleV6Spec `json:"spec"`
-	Status resources.Status   `json:"status"`
+	Status teleportcr.Status  `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV6) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev7_types.go
+++ b/integrations/operator/apis/resources/v1/rolev7_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV7 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportRoleV7Spec `json:"spec"`
-	Status resources.Status   `json:"status"`
+	Status teleportcr.Status  `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV7) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev8_types.go
+++ b/integrations/operator/apis/resources/v1/rolev8_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV8 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportRoleV8Spec `json:"spec"`
-	Status resources.Status   `json:"status"`
+	Status teleportcr.Status  `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV8) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/trusted_cluster_types.go
+++ b/integrations/operator/apis/resources/v1/trusted_cluster_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -38,7 +38,7 @@ type TeleportTrustedClusterV2 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportTrustedClusterV2Spec `json:"spec"`
-	Status resources.Status             `json:"status"`
+	Status teleportcr.Status            `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -58,7 +58,7 @@ func (r TeleportTrustedClusterV2) ToTeleport() types.TrustedCluster {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.TrustedClusterSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/workload_identityv1_types.go
+++ b/integrations/operator/apis/resources/v1/workload_identityv1_types.go
@@ -26,7 +26,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -43,7 +43,7 @@ type TeleportWorkloadIdentityV1 struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   *TeleportWorkloadIdentityV1Spec `json:"spec,omitempty"`
-	Status resources.Status                `json:"status"`
+	Status teleportcr.Status               `json:"status"`
 }
 
 // TeleportWorkloadIdentityV1Spec defines the desired state of TeleportWorkloadIdentityV1
@@ -67,7 +67,7 @@ func (l *TeleportWorkloadIdentityV1) ToTeleport() *workloadidentityv1.WorkloadId
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*workloadidentityv1.WorkloadIdentitySpec)(l.Spec),

--- a/integrations/operator/apis/resources/v2/groupversion_info.go
+++ b/integrations/operator/apis/resources/v2/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v2"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v2/provisiontoken_types.go
+++ b/integrations/operator/apis/resources/v2/provisiontoken_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportProvisionToken struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportProvisionTokenSpec `json:"spec"`
-	Status resources.Status           `json:"status"`
+	Status teleportcr.Status          `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportProvisionToken) ToTeleport() types.ProvisionToken {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ProvisionTokenSpecV2(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v2/samlconnector_types.go
+++ b/integrations/operator/apis/resources/v2/samlconnector_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportSAMLConnector struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportSAMLConnectorSpec `json:"spec"`
-	Status resources.Status          `json:"status"`
+	Status teleportcr.Status         `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportSAMLConnector) ToTeleport() types.SAMLConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.SAMLConnectorSpecV2(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v2/user_types.go
+++ b/integrations/operator/apis/resources/v2/user_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,8 +40,8 @@ type TeleportUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   TeleportUserSpec `json:"spec"`
-	Status resources.Status `json:"status"`
+	Spec   TeleportUserSpec  `json:"spec"`
+	Status teleportcr.Status `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (u TeleportUser) ToTeleport() types.User {
 		Metadata: types.Metadata{
 			Name:        u.Name,
 			Labels:      u.Labels,
-			Description: u.Annotations[resources.DescriptionKey],
+			Description: u.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.UserSpecV2(u.Spec),
 	}

--- a/integrations/operator/apis/resources/v3/githubconnector_types.go
+++ b/integrations/operator/apis/resources/v3/githubconnector_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportGithubConnector struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportGithubConnectorSpec `json:"spec"`
-	Status resources.Status            `json:"status"`
+	Status teleportcr.Status           `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportGithubConnector) ToTeleport() types.GithubConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.GithubConnectorSpecV3(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v3/groupversion_info.go
+++ b/integrations/operator/apis/resources/v3/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v3"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v3"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v3/oidcconnector_types.go
+++ b/integrations/operator/apis/resources/v3/oidcconnector_types.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -44,7 +44,7 @@ type TeleportOIDCConnector struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	Spec   TeleportOIDCConnectorSpec `json:"spec"`
-	Status resources.Status          `json:"status"`
+	Status teleportcr.Status         `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -63,7 +63,7 @@ func (c TeleportOIDCConnector) ToTeleport() types.OIDCConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.OIDCConnectorSpecV3(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v5/groupversion_info.go
+++ b/integrations/operator/apis/resources/v5/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v5"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v5"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v5/role_types.go
+++ b/integrations/operator/apis/resources/v5/role_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,8 +40,8 @@ type TeleportRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   TeleportRoleSpec `json:"spec"`
-	Status resources.Status `json:"status"`
+	Spec   TeleportRoleSpec  `json:"spec"`
+	Status teleportcr.Status `json:"status"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRole) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/controllers/reconcilers/generic_test.go
+++ b/integrations/operator/controllers/reconcilers/generic_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 // newFakeTeleportResource creates a fakeTeleportResource
@@ -118,7 +118,7 @@ func (f *fakeTeleportResourceClient) resourceExists(name string) bool {
 // Its corresponding TeleportResource is fakeTeleportResource.
 type fakeTeleportKubernetesResource struct {
 	kclient.Object
-	status resources.Status
+	status teleportcr.Status
 }
 
 // ToTeleport implements the TeleportKubernetesResource interface.

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 )
@@ -410,7 +410,7 @@ func k8sCreateRole(ctx context.Context, t *testing.T, kc kclient.Client, role *r
 
 func getRoleStatusConditionError(object map[string]any) []metav1.Condition {
 	var conditionsWithError []metav1.Condition
-	var status apiresources.Status
+	var status teleportcr.Status
 	_ = mapstructure.Decode(object["status"], &status)
 
 	for _, condition := range status.Conditions {

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,10 +47,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
-	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
-	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
-	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
-	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
@@ -63,14 +58,6 @@ import (
 // scheme is our own test-specific scheme to avoid using the global
 // unprotected scheme.Scheme that triggers the race detector
 var scheme = controllers.Scheme
-
-func init() {
-	utilruntime.Must(core.AddToScheme(scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(scheme))
-	utilruntime.Must(resourcesv5.AddToScheme(scheme))
-}
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 	ns := &core.Namespace{

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -37,7 +37,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/types"
-	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	v2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
@@ -400,7 +400,7 @@ func k8sCreateUser(ctx context.Context, t *testing.T, kc kclient.Client, user *v
 
 func getUserStatusConditionError(object map[string]any) []metav1.Condition {
 	var conditionsWithError []metav1.Condition
-	var status apiresources.Status
+	var status teleportcr.Status
 	_ = mapstructure.Decode(object["status"], &status)
 
 	for _, condition := range status.Conditions {

--- a/integrations/operator/controllers/scheme.go
+++ b/integrations/operator/controllers/scheme.go
@@ -24,20 +24,14 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
-	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
-	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
-	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
+	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 )
 
 // Scheme is a singleton scheme for all controllers
 var Scheme = runtime.NewScheme()
 
 func init() {
-	utilruntime.Must(resourcesv5.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(Scheme))
+	utilruntime.Must(apiresources.AddToScheme(Scheme))
 
 	// Not needed to reconcile the teleport CRs, but needed for the controller manager.
 	// We are not doing something very kubernetes friendly, but it's easier to have a single

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -36,8 +36,8 @@ import (
 
 const (
 	k8sKindPrefix     = "Teleport"
-	statusPackagePath = "github.com/gravitational/teleport/integrations/operator/apis"
-	statusPackageName = "resources"
+	statusPackagePath = "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	statusPackageName = "teleportcr"
 	statusPackage     = statusPackagePath + "/" + statusPackageName
 	statusTypeName    = "Status"
 )
@@ -573,7 +573,7 @@ func getStatusSchema(parser *crdtools.Parser) (apiextv1.JSONSchemaProps, error) 
 	}
 	var statusType crdtools.TypeIdent
 	for _, pkg := range pkgs {
-		if pkg.Name == "resources" {
+		if pkg.Name == statusPackageName {
 			parser.NeedPackage(pkg)
 			statusType = crdtools.TypeIdent{
 				Package: pkg,


### PR DESCRIPTION
I was debugging a flaky test and found the operator scheme usage confusing (I will also send other PRs interacting with the scheme, so I really want to have a single scheme here). This PR  adds a global `AddToScheme` in `api/resources` and moves all common api resource logic into `api/resources/common` (to avoid a cyclic dependency).

Tests were adding the GVK to the controller scheme a second time, which was useless.

The `NewScheme()` function is not used in this PR but will be needed in my next ones so I bundled it.