### PR TITLE
Fix make build-binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1269,7 +1269,7 @@ lint-go:
 
 .PHONY: fix-imports
 fix-imports:
-	$(MAKE) -C build.assets/ fix-imports
+	$(MAKE) -C build.assets fix-imports
 
 .PHONY: fix-imports/host
 fix-imports/host:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ that docker is installed and running, and execute:
 make -C build.assets build-binaries
 ```
 
+This command will build Linux binaries matching the host architecture.
+It is not possible to cross-compile to a different target architecture.
+
 ### Local Build
 
 #### Dependencies

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -78,12 +78,15 @@ build: buildbox-centos7 webassets
 		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) release-unix-preserving-webassets
 
 #
-# Build 'teleport' release inside a docker container
+# Build 'teleport' binaries inside a docker container
 #
 .PHONY:build-binaries
 build-binaries: buildbox-centos7 webassets
-	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
-		make -C $(SRCDIR) ADDFLAGS='$(ADDFLAGS)' PIV=$(PIV) full
+	$(LOG_GROUP_START)
+	$(REQUIRE_HOST_ARCH)
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
+		/usr/bin/scl enable $(DEVTOOLSET) 'make clean-build full -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
+	$(LOG_GROUP_END)
 
 #
 # Build 'teleport' Enterprise release inside a docker container

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -82,19 +82,22 @@ build: buildbox-centos7 webassets
 #
 .PHONY:build-binaries
 build-binaries: buildbox-centos7 webassets
-	$(LOG_GROUP_START)
+	$(call LOG_GROUP_START)
 	$(REQUIRE_HOST_ARCH)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
 		/usr/bin/scl enable $(DEVTOOLSET) 'make clean-build full -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
-	$(LOG_GROUP_END)
+	$(call LOG_GROUP_END)
 
 #
-# Build 'teleport' Enterprise release inside a docker container
+# Build 'teleport' Enterprise binaries inside a docker container
 #
 .PHONY:build-enterprise-binaries
 build-enterprise-binaries: buildbox-centos7 webassets
+	$(call LOG_GROUP_START)
+	$(REQUIRE_HOST_ARCH)
 	docker run $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_CENTOS7) \
-		make -C $(SRCDIR)/e ADDFLAGS='$(ADDFLAGS)' VERSION=$(VERSION) GITTAG=v$(VERSION) PIV=$(PIV) clean full
+		/usr/bin/scl enable $(DEVTOOLSET) 'make clean-build full-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
+	$(call LOG_GROUP_END)
 
 #
 # Build 'teleport' FIPS release inside a docker container
@@ -681,11 +684,11 @@ release-fips: buildbox-centos7-fips webassets
 #
 .PHONY:release-centos7
 release-centos7: buildbox-centos7 webassets
-	$(LOG_GROUP_START)
+	$(call LOG_GROUP_START)
 	$(REQUIRE_HOST_ARCH)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7) \
 		/usr/bin/scl enable $(DEVTOOLSET) 'make release-unix-preserving-webassets -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no'
-	$(LOG_GROUP_END)
+	$(call LOG_GROUP_END)
 
 #
 # Create a Teleport FIPS package for CentOS 7 using the build container.
@@ -697,10 +700,10 @@ release-centos7: buildbox-centos7 webassets
 #
 .PHONY:release-centos7-fips
 release-centos7-fips: buildbox-centos7-fips webassets
-	$(LOG_GROUP_START)
+	$(call LOG_GROUP_START)
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
 		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
-	$(LOG_GROUP_END)
+	$(call LOG_GROUP_END)
 
 #
 # Create a Windows Teleport package using the build container.


### PR DESCRIPTION
The dockerized build (make -C build.assets build-binaries) fails with GLIBC errors because it is a multi-stage build that runs across several different containers.

First, we build the webassets in buildbox-node. Then we build the Teleport binaries in buildbox-centos7, reusing the webassets built previously.

The issue arises because buildbox-node runs a newer version of GLIBC than buildbox-centos7, and we weren't properly cleaning some build artifacts when switching from one builder to another. As a result, the centos7 builder would see intermediate artifacts with a dependency on a GLIBC version that is too new.

Fix the issue by ensuring we run a clean-build after hopping into the centos7 container.

Closes #62594