### PR TITLE
[Web] Fix desktop icon and label in Instance Inventory

### DIFF
--- a/web/packages/teleport/src/Instances/InstancesList.tsx
+++ b/web/packages/teleport/src/Instances/InstancesList.tsx
@@ -309,7 +309,7 @@ function getServiceIcon(service: string): React.ComponentType<any> {
     kube: Icons.Kubernetes,
     app: Icons.Application,
     db: Icons.Database,
-    windows_desktop: Icons.Desktop,
+    windowsdesktop: Icons.Desktop,
     proxy: Icons.Network,
     auth: Icons.Keypair,
   };
@@ -323,7 +323,7 @@ function getServiceDisplayName(service: string): string {
     kube: 'Kubernetes',
     app: 'Application',
     db: 'Database',
-    windows_desktop: 'Windows Desktop',
+    windowsdesktop: 'Windows Desktop',
     proxy: 'Proxy',
     auth: 'Auth',
   };


### PR DESCRIPTION
## Purpose

This PR fixes a minor bug which incorrectly displayed the desktop service in the instance inventory list.

The logic expected `windows_desktop` as the service name in the response, however what is actually returned is `WindowsDesktop`.

## Demo

### Before

<img width="153" height="104" alt="image" src="https://github.com/user-attachments/assets/7710e331-82f2-4202-be6e-1ebbcd894149" />

### After

<img width="153" height="104" alt="image" src="https://github.com/user-attachments/assets/dd1596f9-5f94-42cb-837e-20d4603a4ffe" />
