### PR TITLE
Web: allow customizing unified resource

### DIFF
--- a/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/CardsView.tsx
@@ -36,6 +36,7 @@ export function CardsView({
   isProcessing,
   pinningSupport,
   visibleInputFields,
+  showResourcesSelectedIcon,
   resourceLabelConfig,
 }: ResourceViewProps) {
   return (
@@ -55,6 +56,7 @@ export function CardsView({
             showingStatusInfo={showingStatusInfo}
             visibleInputFields={visibleInputFields}
             resourceLabelConfig={resourceLabelConfig}
+            showResourceSelectedIcon={showResourcesSelectedIcon}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.story.tsx
@@ -92,7 +92,10 @@ const additionalResources = [
 type StoryProps = {
   withCheckbox: boolean;
   withPin: boolean;
+  withCopy: boolean;
+  withHoverState: boolean;
   withLabelIcon: boolean;
+  showResourceSelectedIcon: boolean;
   labelIconPlacement: 'left' | 'right';
   labelKind: LabelKind;
 };
@@ -106,7 +109,16 @@ const meta: Meta<StoryProps> = {
     withPin: {
       control: { type: 'boolean' },
     },
+    withCopy: {
+      control: { type: 'boolean' },
+    },
+    withHoverState: {
+      control: { type: 'boolean' },
+    },
     withLabelIcon: {
+      control: { type: 'boolean' },
+    },
+    showResourceSelectedIcon: {
       control: { type: 'boolean' },
     },
     labelIconPlacement: {
@@ -123,6 +135,9 @@ const meta: Meta<StoryProps> = {
     withCheckbox: true,
     withPin: true,
     withLabelIcon: false,
+    withCopy: true,
+    withHoverState: true,
+    showResourceSelectedIcon: false,
   },
 };
 export default meta;
@@ -176,9 +191,12 @@ export function Cards(props: StoryProps) {
               onShowStatusInfo={() => null}
               showingStatusInfo={false}
               viewItem={res}
+              showResourceSelectedIcon={props.showResourceSelectedIcon}
               visibleInputFields={{
                 checkbox: props.withCheckbox,
                 pin: props.withPin,
+                copy: props.withCopy,
+                hoverState: props.withHoverState,
               }}
               {...((props.withLabelIcon || props.labelKind) && {
                 resourceLabelConfig: {

--- a/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
+++ b/web/packages/shared/components/UnifiedResources/CardsView/ResourceCard.tsx
@@ -22,6 +22,7 @@ import styled, { css } from 'styled-components';
 import { Box, ButtonLink, Flex, Text } from 'design';
 import { CheckboxInput } from 'design/Checkbox';
 import { makeLabelTag } from 'design/formatters';
+import { LabelKind } from 'design/Label';
 import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
@@ -34,6 +35,7 @@ import {
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
+import { ResourceSelectedIcon } from '../shared/ResourceSelectedIcon';
 import { SingleLineBox } from '../shared/SingleLineBox';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
@@ -65,8 +67,14 @@ export function ResourceCard({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
-  visibleInputFields = { pin: true, checkbox: true },
+  visibleInputFields = {
+    pin: true,
+    checkbox: true,
+    copy: true,
+    hoverState: true,
+  },
   resourceLabelConfig,
+  showResourceSelectedIcon,
 }: Omit<ResourceItemProps, 'expandAllLabels'>) {
   const {
     name,
@@ -177,12 +185,15 @@ export function ResourceCard({
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
       showingStatusInfo={showingStatusInfo}
+      showHoverState={visibleInputFields.hoverState}
     >
       <CardOuterContainer
         showAllLabels={showAllLabels}
         shouldDisplayWarning={shouldDisplayStatusWarning}
+        showHoverState={visibleInputFields.hoverState}
       >
         <CardInnerContainer
+          showHoverState={visibleInputFields.hoverState}
           ref={innerContainer}
           p={3}
           // we set padding left a bit larger so we can have space to absolutely
@@ -242,10 +253,13 @@ export function ResourceCard({
                   <Text typography="body1">{name}</Text>
                 </HoverTooltip>
               </SingleLineBox>
-              {hovered && <CopyButton value={name} />}
+              {visibleInputFields.copy && hovered && (
+                <CopyButton value={name} />
+              )}
               <ResourceActionButtonWrapper requiresRequest={requiresRequest}>
                 {ActionButton}
               </ResourceActionButtonWrapper>
+              {showResourceSelectedIcon && <ResourceSelectedIcon />}
             </Flex>
             <Flex flexDirection="row" alignItems="center">
               <ResTypeIconBox>
@@ -283,6 +297,11 @@ export function ResourceCard({
                   + {numMoreLabels} more
                 </MoreLabelsButton>
                 {labels.map((label, i) => {
+                  let kind: LabelKind = 'secondary';
+                  if (resourceLabelConfig?.processLabel) {
+                    kind = resourceLabelConfig.processLabel(label).kind;
+                  }
+
                   const labelText = makeLabelTag(label);
                   return (
                     <StyledLabel
@@ -290,7 +309,7 @@ export function ResourceCard({
                       title={labelText}
                       onClick={() => onLabelClick?.(label)}
                       withHoverState={!!onLabelClick}
-                      kind="secondary"
+                      kind={kind}
                       data-is-label=""
                       {...resourceLabelConfig}
                     >
@@ -359,6 +378,7 @@ const WarningRightEdgeBadgeIcon = ({
  */
 const CardContainer = styled(Box)<{
   showingStatusInfo: boolean;
+  showHoverState: boolean;
 }>`
   height: 110px;
 
@@ -372,16 +392,22 @@ const CardContainer = styled(Box)<{
         ? p.theme.colors.interactive.solid.alert.active
         : p.theme.colors.interactive.solid.alert.default};
   }
-  &:hover {
-    .resource-health-status-svg {
-      fill: ${p => p.theme.colors.interactive.solid.alert.hover};
-    }
-  }
+
+  ${p =>
+    p.showHoverState &&
+    css`
+      &:hover {
+        .resource-health-status-svg {
+          fill: ${p => p.theme.colors.interactive.solid.alert.hover};
+        }
+      }
+    `}
 `;
 
 const CardOuterContainer = styled(Box)<{
   showAllLabels?: boolean;
   shouldDisplayWarning: boolean;
+  showHoverState: boolean;
 }>`
   border-radius: ${props => props.theme.radii[3]}px;
 
@@ -396,24 +422,28 @@ const CardOuterContainer = styled(Box)<{
     `}
   transition: all 150ms;
 
-  // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
-  ${CardContainer}:hover && {
-    background-color: ${props => props.theme.colors.levels.surface};
+  ${p =>
+    p.showHoverState &&
+    css`
+      // Using double ampersand because of https://github.com/styled-components/styled-components/issues/3678.
+      ${CardContainer}:hover && {
+        background-color: ${props => props.theme.colors.levels.surface};
 
-    // We use a pseudo element for the shadow with position: absolute in order to prevent
-    // the shadow from increasing the size of the layout and causing scrollbar flicker.
-    &:after {
-      box-shadow: ${props => props.theme.boxShadow[3]};
-      border-radius: ${props => props.theme.radii[3]}px;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: -1;
-      width: 100%;
-      height: 100%;
-    }
-  }
+        // We use a pseudo element for the shadow with position: absolute in order to prevent
+        // the shadow from increasing the size of the layout and causing scrollbar flicker.
+        &:after {
+          box-shadow: ${props => props.theme.boxShadow[3]};
+          border-radius: ${props => props.theme.radii[3]}px;
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: -1;
+          width: 100%;
+          height: 100%;
+        }
+      }
+    `}
 `;
 
 /**
@@ -425,7 +455,9 @@ const CardOuterContainer = styled(Box)<{
  * layout; we may need to globally set the card height to fixed size on the
  * outer container.
  */
-const CardInnerContainer = styled(Flex)<BackgroundColorProps>`
+const CardInnerContainer = styled(Flex)<
+  BackgroundColorProps & { showHoverState: boolean }
+>`
   border: ${props => props.theme.borders[2]}
     ${props => props.theme.colors.spotBackground[0]};
   border-radius: ${props => props.theme.radii[3]}px;
@@ -448,13 +480,19 @@ const CardInnerContainer = styled(Flex)<BackgroundColorProps>`
     css`
       border: 2px solid ${p.theme.colors.interactive.solid.alert.active};
     `}
+    
 
   &:hover {
     // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
-    border: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
+    ${p =>
+      p.showHoverState &&
+      css`
+        border: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
+      `}
 
     ${p =>
       p.shouldDisplayWarning &&
+      p.showHoverState &&
       css`
         border-color: ${p.theme.colors.interactive.solid.alert.hover};
         background-color: ${getStatusBackgroundColor({

--- a/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/shared/components/UnifiedResources/FilterPanel.tsx
@@ -117,6 +117,7 @@ export function FilterPanel({
     healthStatusOpts: true,
     resourceTypeOpts: true,
     resourceAvailabilityOpts: true,
+    collapseLabelBtn: true,
   },
 }: FilterPanelProps) {
   const { sort, kinds, statuses } = params;
@@ -231,30 +232,31 @@ export function FilterPanel({
         </HoverTooltip>
         {!hideViewModeOptions && (
           <>
-            {currentViewMode === ViewMode.LIST && (
-              <ButtonBorder
-                size="small"
-                css={`
-                  border: none;
-                  color: ${props => props.theme.colors.text.slightlyMuted};
-                  text-transform: none;
-                  padding-left: ${props => props.theme.space[2]}px;
-                  padding-right: ${props => props.theme.space[2]}px;
-                  height: 22px;
-                  font-size: 12px;
-                `}
-                onClick={() => setExpandAllLabels(!expandAllLabels)}
-              >
-                <Flex alignItems="center" width="100%">
-                  {expandAllLabels ? (
-                    <ArrowsIn size="small" mr={1} />
-                  ) : (
-                    <ArrowsOut size="small" mr={1} />
-                  )}
-                  {expandAllLabels ? 'Collapse ' : 'Expand '} All Labels
-                </Flex>
-              </ButtonBorder>
-            )}
+            {currentViewMode === ViewMode.LIST &&
+              visibleFilterPanelFields.collapseLabelBtn && (
+                <ButtonBorder
+                  size="small"
+                  css={`
+                    border: none;
+                    color: ${props => props.theme.colors.text.slightlyMuted};
+                    text-transform: none;
+                    padding-left: ${props => props.theme.space[2]}px;
+                    padding-right: ${props => props.theme.space[2]}px;
+                    height: 22px;
+                    font-size: 12px;
+                  `}
+                  onClick={() => setExpandAllLabels(!expandAllLabels)}
+                >
+                  <Flex alignItems="center" width="100%">
+                    {expandAllLabels ? (
+                      <ArrowsIn size="small" mr={1} />
+                    ) : (
+                      <ArrowsOut size="small" mr={1} />
+                    )}
+                    {expandAllLabels ? 'Collapse ' : 'Expand '} All Labels
+                  </Flex>
+                </ButtonBorder>
+              )}
             <ViewModeSwitch
               currentViewMode={currentViewMode}
               setCurrentViewMode={setCurrentViewMode}

--- a/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ListView.tsx
@@ -35,6 +35,7 @@ export function ListView({
   isProcessing,
   expandAllLabels,
   visibleInputFields,
+  showResourcesSelectedIcon,
   resourceLabelConfig,
 }: ResourceViewProps) {
   return (
@@ -55,6 +56,7 @@ export function ListView({
             showingStatusInfo={showingStatusInfo}
             visibleInputFields={visibleInputFields}
             resourceLabelConfig={resourceLabelConfig}
+            showResourceSelectedIcon={showResourcesSelectedIcon}
           />
         )
       )}

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.story.tsx
@@ -86,6 +86,9 @@ type StoryProps = {
   withCheckbox: boolean;
   withPin: boolean;
   withLabelIcon: boolean;
+  withCopy: boolean;
+  withHoverState: boolean;
+  showSelectedResourceIcon: boolean;
   labelIconPlacement: 'left' | 'right';
   labelKind: LabelKind;
 };
@@ -97,6 +100,15 @@ const meta: Meta<StoryProps> = {
       control: { type: 'boolean' },
     },
     withPin: {
+      control: { type: 'boolean' },
+    },
+    withCopy: {
+      control: { type: 'boolean' },
+    },
+    withHoverState: {
+      control: { type: 'boolean' },
+    },
+    showSelectedResourceIcon: {
       control: { type: 'boolean' },
     },
     withLabelIcon: {
@@ -116,6 +128,9 @@ const meta: Meta<StoryProps> = {
     withCheckbox: true,
     withPin: true,
     withLabelIcon: false,
+    withCopy: true,
+    withHoverState: true,
+    showSelectedResourceIcon: false,
   },
 };
 export default meta;
@@ -158,9 +173,12 @@ export function ListItems(props: StoryProps) {
           onShowStatusInfo={() => null}
           showingStatusInfo={false}
           viewItem={res}
+          showResourceSelectedIcon={props.showSelectedResourceIcon}
           visibleInputFields={{
             checkbox: props.withCheckbox,
             pin: props.withPin,
+            copy: props.withCopy,
+            hoverState: props.withHoverState,
           }}
           {...((props.withLabelIcon || props.labelKind) && {
             resourceLabelConfig: {

--- a/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
+++ b/web/packages/shared/components/UnifiedResources/ListView/ResourceListItem.tsx
@@ -23,6 +23,7 @@ import { Box, ButtonIcon, Flex, Text } from 'design';
 import { CheckboxInput } from 'design/Checkbox';
 import { makeLabelTag } from 'design/formatters';
 import { Tags, Warning } from 'design/Icon';
+import { LabelKind } from 'design/Label';
 import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIcon } from 'design/ResourceIcon';
 import { HoverTooltip } from 'design/Tooltip';
@@ -35,6 +36,7 @@ import {
 } from '../shared/getBackgroundColor';
 import { PinButton } from '../shared/PinButton';
 import { ResourceActionButtonWrapper } from '../shared/ResourceActionButton';
+import { ResourceSelectedIcon } from '../shared/ResourceSelectedIcon';
 import { shouldWarnResourceStatus } from '../shared/StatusInfo';
 import { ResourceItemProps } from '../types';
 
@@ -49,8 +51,14 @@ export function ResourceListItem({
   onShowStatusInfo,
   showingStatusInfo,
   viewItem,
-  visibleInputFields = { pin: true, checkbox: true },
+  visibleInputFields = {
+    pin: true,
+    checkbox: true,
+    copy: true,
+    hoverState: true,
+  },
   resourceLabelConfig,
+  showResourceSelectedIcon,
 }: ResourceItemProps) {
   const {
     name,
@@ -95,6 +103,8 @@ export function ResourceListItem({
       onMouseLeave={() => setHovered(false)}
       shouldDisplayWarning={shouldDisplayStatusWarning}
       showingStatusInfo={showingStatusInfo}
+      showHoverState={visibleInputFields.hoverState}
+      data-testid={name}
     >
       <RowInnerContainer
         requiresRequest={requiresRequest}
@@ -105,6 +115,7 @@ export function ResourceListItem({
         showingStatusInfo={showingStatusInfo}
         hideCheckbox={!visibleInputFields.checkbox}
         hidePin={!visibleInputFields.pin}
+        showHoverState={visibleInputFields.hoverState}
       >
         {/* checkbox */}
         {visibleInputFields.checkbox && (
@@ -161,7 +172,10 @@ export function ResourceListItem({
             `}
           >
             <HoverTooltip tipContent={name} showOnlyOnOverflow>
-              <Name>{name}</Name>
+              <Flex alignItems="center" gap={2}>
+                <Name>{name}</Name>
+                {showResourceSelectedIcon && <ResourceSelectedIcon />}
+              </Flex>
             </HoverTooltip>
             <HoverTooltip tipContent={description} showOnlyOnOverflow>
               <Description>{description}</Description>
@@ -172,7 +186,9 @@ export function ResourceListItem({
               align-self: start;
             `}
           >
-            {hovered && <CopyButton value={name} ml={1} />}
+            {visibleInputFields.copy && hovered && (
+              <CopyButton value={name} ml={1} />
+            )}
           </Box>
         </Flex>
 
@@ -280,6 +296,11 @@ export function ResourceListItem({
             mb={2}
           >
             {labels.map((label, i) => {
+              let kind: LabelKind = 'secondary';
+              if (resourceLabelConfig?.processLabel) {
+                kind = resourceLabelConfig.processLabel(label).kind;
+              }
+
               const labelText = makeLabelTag(label);
               return (
                 <LabelButtonWithIcon
@@ -287,7 +308,7 @@ export function ResourceListItem({
                   title={labelText}
                   onClick={() => onLabelClick?.(label)}
                   withHoverState={!!onLabelClick}
-                  kind="secondary"
+                  kind={kind}
                   mr={2}
                   css={`
                     cursor: pointer;
@@ -318,6 +339,7 @@ const ResTypeIconBox = styled(Box)`
 const RowContainer = styled(Box)<{
   shouldDisplayWarning: boolean;
   showingStatusInfo: boolean;
+  showHoverState: boolean;
 }>`
   transition: all 150ms;
   position: relative;
@@ -334,10 +356,12 @@ const RowContainer = styled(Box)<{
     `}
 
   &:hover {
-    background-color: ${props => props.theme.colors.levels.surface};
+    background-color: ${props =>
+      props.showHoverState ? props.theme.colors.levels.surface : 'transparent'};
 
     ${p =>
       p.shouldDisplayWarning &&
+      p.showHoverState &&
       css`
         background-color: ${getStatusBackgroundColor({
           showingStatusInfo: p.showingStatusInfo,
@@ -347,22 +371,28 @@ const RowContainer = styled(Box)<{
         })};
       `}
 
-    // We use a pseudo element for the shadow with position: absolute in order to prevent
-    // the shadow from increasing the size of the layout and causing scrollbar flicker.
-    &:after {
-      box-shadow: ${props => props.theme.boxShadow[3]};
-      content: '';
-      position: absolute;
-      top: 0;
-      left: 0;
-      z-index: -1;
-      width: 100%;
-      height: 100%;
-    }
+    ${p =>
+      p.showHoverState &&
+      css`
+        // We use a pseudo element for the shadow with position: absolute in order to prevent
+        // the shadow from increasing the size of the layout and causing scrollbar flicker.
+        &:after {
+          box-shadow: ${props => props.theme.boxShadow[3]};
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          z-index: -1;
+          width: 100%;
+          height: 100%;
+        }
+      `}
   }
 `;
 
-const RowInnerContainer = styled(Flex)<BackgroundColorProps>`
+const RowInnerContainer = styled(Flex)<
+  BackgroundColorProps & { showHoverState: boolean }
+>`
   display: grid;
   column-gap: ${props => props.theme.space[3]}px;
   grid-template-rows: 56px min-content;
@@ -377,10 +407,14 @@ const RowInnerContainer = styled(Flex)<BackgroundColorProps>`
   border-bottom: ${props => props.theme.borders[2]}
     ${props => props.theme.colors.spotBackground[0]};
 
-  &:hover {
-    // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
-    border-bottom: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
-  }
+  ${p =>
+    p.showHoverState &&
+    css`
+      &:hover {
+        // Make the border invisible instead of removing it, this is to prevent things from shifting due to the size change.
+        border-bottom: ${props => props.theme.borders[2]} rgba(0, 0, 0, 0);
+      }
+    `}
 
   grid-template-columns: 22px 24px 36px 2fr 1fr 1fr 32px min-content;
   grid-template-areas:

--- a/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
+++ b/web/packages/shared/components/UnifiedResources/UnifiedResources.tsx
@@ -193,6 +193,7 @@ export interface UnifiedResourcesProps {
    * regardless of internal "no result" checks.
    */
   forceNoResources?: boolean;
+  noResultCustomText?: string;
   /**
    * If pinning is supported, the functions to get and update pinned resources
    * can be passed here.
@@ -258,6 +259,12 @@ export interface UnifiedResourcesProps {
    * Applies to row item elements (CardView or ListView).
    */
   visibleResourceItemFields?: VisibleResourceItemFields;
+  /**
+   * If true, renders a check icon at the top right corner of cards
+   * or right next to resource name for list view rows for all
+   * resources.
+   */
+  showResourcesSelectedIcon?: boolean;
 }
 
 export function UnifiedResources(props: UnifiedResourcesProps) {
@@ -282,6 +289,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
     resourceLabelConfig,
     className,
     forceNoResources,
+    noResultCustomText,
+    showResourcesSelectedIcon,
   } = props;
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -539,6 +548,7 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
         <NoResults
           isPinnedTab={params.pinnedOnly}
           query={params?.query || params?.search}
+          customText={noResultCustomText}
         />
       );
     }
@@ -685,6 +695,8 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                   query: makeAdvancedSearchQueryForLabel(label, params),
                 })
         }
+        showResourcesSelectedIcon={showResourcesSelectedIcon}
+        resourceLabelConfig={resourceLabelConfig}
         pinnedResources={pinnedResources}
         selectedResources={selectedResources}
         onSelectResource={handleSelectResource}
@@ -720,7 +732,6 @@ export function UnifiedResources(props: UnifiedResourcesProps) {
                       availabilityFilter?.mode === 'requestable',
                   },
                 }),
-                resourceLabelConfig,
                 key: generateUnifiedResourceKey(resource),
                 onShowStatusInfo: () => onShowStatusInfo(resource),
                 showingStatusInfo:
@@ -803,9 +814,11 @@ function NoPinned() {
 function NoResults({
   query,
   isPinnedTab,
+  customText,
 }: {
   query: string;
   isPinnedTab: boolean;
+  customText?: string;
 }) {
   if (query) {
     return (
@@ -821,19 +834,25 @@ function NoResults({
         as={Flex}
       >
         <Magnifier mr={2} />
-        No {isPinnedTab ? 'pinned ' : ''}resources were found for&nbsp;
-        <Text
-          as="span"
-          bold
-          css={`
-            max-width: 270px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
-          `}
-        >
-          {query}
-        </Text>
+        {customText ? (
+          <>{customText}</>
+        ) : (
+          <>
+            No {isPinnedTab ? 'pinned ' : ''}resources were found for&nbsp;
+            <Text
+              as="span"
+              bold
+              css={`
+                max-width: 270px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              `}
+            >
+              {query}
+            </Text>
+          </>
+        )}
       </Text>
     );
   }

--- a/web/packages/shared/components/UnifiedResources/shared/ResourceSelectedIcon.tsx
+++ b/web/packages/shared/components/UnifiedResources/shared/ResourceSelectedIcon.tsx
@@ -1,0 +1,37 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components';
+
+import { CheckThick } from 'design/Icon';
+
+const AccessCheckBackground = styled.div`
+  border-radius: 999px;
+  background-color: ${({ theme }) =>
+    theme.colors.interactive.solid.success.default};
+  line-height: 0;
+  color: white;
+  border: 2px solid
+    ${({ theme }) => theme.colors.interactive.solid.success.default};
+`;
+
+export const ResourceSelectedIcon = () => (
+  <AccessCheckBackground>
+    <CheckThick size="small" />
+  </AccessCheckBackground>
+);

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -19,6 +19,7 @@
 import React, { ComponentProps } from 'react';
 
 import { Icon } from 'design/Icon';
+import { LabelKind } from 'design/Label';
 import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIconName } from 'design/ResourceIcon';
 import { TargetHealth } from 'gen-proto-ts/teleport/lib/teleterm/v1/target_health_pb';
@@ -186,12 +187,10 @@ export type UnifiedResourcesQueryParams = {
   kinds?: string[];
   includedResourceMode?: IncludedResourceMode;
 };
+
 export interface UnifiedResourceViewItem {
   name: string;
-  labels: {
-    name: string;
-    value: string;
-  }[];
+  labels: ResourceLabel[];
   primaryIconName: ResourceIconName;
   SecondaryIcon: typeof Icon;
   ActionButton: React.ReactElement;
@@ -207,11 +206,17 @@ export type VisibleFilterPanelFields = {
   healthStatusOpts: boolean;
   resourceTypeOpts: boolean;
   resourceAvailabilityOpts: boolean;
+  collapseLabelBtn: boolean;
 };
 
 export type VisibleResourceItemFields = {
   checkbox: boolean;
   pin: boolean;
+  copy: boolean;
+  /**
+   * If false, removes any hover state.
+   */
+  hoverState: boolean;
 };
 
 export enum PinningSupport {
@@ -234,6 +239,13 @@ export type IncludedResourceMode =
   | 'accessible';
 
 /**
+ * The return value after processing a label.
+ */
+export type ProcessedLabel = {
+  kind: LabelKind;
+};
+
+/**
  * If this field is not provided, the default config will be:
  * - No icon, just text label
  * - Label kind is "secondary"
@@ -242,7 +254,16 @@ export type IncludedResourceMode =
 export type ResourceLabelConfig = Omit<
   ComponentProps<typeof LabelButtonWithIcon>,
   'children'
->;
+> & {
+  /**
+   * Provide an optional callback against a label
+   * to change appearance of the label e.g:
+   * if the label is determined to be selected by
+   * the caller, then provide a LabelKind that
+   * makes it apparent it's been "selected".
+   */
+  processLabel?(label: ResourceLabel): ProcessedLabel;
+};
 
 export type ResourceItemProps = {
   onLabelClick?: (label: ResourceLabel) => void;
@@ -271,6 +292,11 @@ export type ResourceItemProps = {
    * provided.
    */
   resourceLabelConfig?: ResourceLabelConfig;
+  /**
+   * If true, render a check icon at the top right corner of cards
+   * and right next to resource name for list view rows.
+   */
+  showResourceSelectedIcon?: boolean;
 };
 
 // Props that are needed for the Card view.
@@ -326,6 +352,11 @@ export type ResourceViewProps = {
    * provided.
    */
   resourceLabelConfig?: ResourceLabelConfig;
+  /**
+   * If true, renders a check icon at the top right corner of cards
+   * and right next to resource name for list view rows.
+   */
+  showResourcesSelectedIcon?: boolean;
 };
 
 /**


### PR DESCRIPTION
part of https://github.com/gravitational/teleport.e/issues/7183

Allow [further](https://github.com/gravitational/teleport/pull/61646) customizing unified resource (all `opt-in` changes, this PR does not change the default behavior)

- Allow conditional rendering of copy and label buttons
- Optionally render selected icon to indicate a resource was selected
- Optional callback when processing labels to provide further label customizing

<img width="475" height="139" alt="image" src="https://github.com/user-attachments/assets/1ce587e5-2d06-4dec-8afa-7416e062f508" />

<img width="365" height="176" alt="image" src="https://github.com/user-attachments/assets/17b94460-bac7-488e-8344-f496bdb20558" />


Especially with the card view, the selected icon is used more like this (without any action buttons) and an example of the label callback allowing to customize label appearance:

https://github.com/user-attachments/assets/47659d74-8b8f-431d-8389-b6c32fb32ae7

