### PR TITLE
Fix memory leak in access list reminder notifications

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -192,9 +192,6 @@ const (
 const (
 	notificationsPageReadInterval = 5 * time.Millisecond
 	notificationsWriteInterval    = 40 * time.Millisecond
-
-	accessListsPageReadInterval = 5 * time.Millisecond
-	accessListsPageSize         = 20
 )
 
 const (

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7008,17 +7008,18 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 
 		// Fetch all identifiers for this treshold prefix.
 		var identifiers []*notificationsv1.UniqueNotificationIdentifier
-		var nextKey string
+		var notificationsPageKey string
 		for {
-			identifiersResp, nextKey, err := a.ListUniqueNotificationIdentifiersForPrefix(ctx, threshold.prefix, 0, nextKey)
+			identifiersResp, nextKey, err := a.ListUniqueNotificationIdentifiersForPrefix(ctx, threshold.prefix, 0, notificationsPageKey)
 			if err != nil {
 				a.logger.WarnContext(ctx, "failed to list notification identifiers", "error", err, "prefix", threshold.prefix)
-				continue
+				break
 			}
 			identifiers = append(identifiers, identifiersResp...)
 			if nextKey == "" {
 				break
 			}
+			notificationsPageKey = nextKey
 		}
 
 		accessListIDs := set.New[string]()

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4876,34 +4876,34 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	// Run CreateAccessListReminderNotifications()
 	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
-	identifiers := collectAllUniqueNotificationIdentifiers(t, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
+	identifiers := collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
 	require.Len(t, identifiers, numAccessLists,
 		"should have created unique identifiers for all %d overdue access lists", numAccessLists)
 
 	// Run CreateAccessListReminderNotifications() again to verify it can read multiple pages of identifiers without memory leak
 	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
-	identifiers = collectAllUniqueNotificationIdentifiers(t, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
+	identifiers = collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
 	require.Len(t, identifiers, numAccessLists,
 		"should have created unique identifiers for all %d overdue access lists", numAccessLists)
-
 }
 
-func collectAllUniqueNotificationIdentifiers(t *testing.T, authServer *auth.Server, prefix string) []*notificationsv1.UniqueNotificationIdentifier {
+func collectAllUniqueNotificationIdentifiers(t *testing.T, ctx context.Context, authServer *auth.Server, prefix string) []*notificationsv1.UniqueNotificationIdentifier {
 	t.Helper()
-	var allIdentifiers []*notificationsv1.UniqueNotificationIdentifier
-	var nextKey string
 
-	for {
-		identifiers, next, err := authServer.ListUniqueNotificationIdentifiersForPrefix(t.Context(), prefix, 100, nextKey)
-		require.NoError(t, err)
-		allIdentifiers = append(allIdentifiers, identifiers...)
-		if next == "" {
-			break
+	var identifiers []*notificationsv1.UniqueNotificationIdentifier
+	iterator := clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+		return authServer.ListUniqueNotificationIdentifiersForPrefix(ctx, prefix, pageSize, pageKey)
+	})
+
+	for identifiersResp, err := range iterator {
+		if err != nil {
+			require.NoError(t, err, "listing unique notification identifiers for prefix %q", prefix)
 		}
-		nextKey = next
+		identifiers = append(identifiers, identifiersResp)
 	}
-	return allIdentifiers
+
+	return identifiers
 }
 
 func TestServer_GetAnonymizationKey(t *testing.T) {


### PR DESCRIPTION
Fixes a memory leak caused by variable shadowing where `nextKey` was redeclared in the pagination loop instead of being assigned. This caused the loop to always pass an empty pagination token, fetching the same page repeatedly and never terminating for tenants with more than 1000 pending access list review notifications.

The fix renames the loop variable to `notificationsPageKey` to avoid shadowing and properly updates it with the next page token.

Changelog: Fixed a memory leak in access list reminder notifications affecting clusters with more than 1000 pending Access List reviews.