### PR TITLE
Revert concurrent uploads limit for v18

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3815,7 +3815,6 @@ func (process *TeleportProcess) initUploaderService() error {
 		InitialScanDelay:                15 * time.Second,
 		EncryptedRecordingUploader:      uploaderClient,
 		EncryptedRecordingUploadMaxSize: encryptedRecordingMaxUploadSize,
-		ConcurrentUploads:               2,
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This change to `ConcurrentUploads` was mistakenly merged into `branch/v18` while backporting a bugfix for session recording uploads. This PR removes the explicit config to force a fallback to the default value (currently `10`) which is in line with what can currently be found in [master](https://github.com/gravitational/teleport/blob/d4d5d13139a5f812ba799f74ba53a554206cd0b1/lib/service/service.go#L3890-L3897)