### PR TITLE
docs: remove misleading IAM join statement

### DIFF
--- a/docs/pages/enroll-resources/agents/aws-iam.mdx
+++ b/docs/pages/enroll-resources/agents/aws-iam.mdx
@@ -93,9 +93,6 @@ Install Teleport on your AWS EC2 instance.
 
 ## Step 4/5. Configure your services
 
-The IAM join method can be used for Teleport processes running the SSH, Proxy,
-Kubernetes, Application, or Database Service.
-
 Configure your Teleport service with a custom `teleport.yaml` file. Use the
 `join_params` section with `token_name` matching your token created in Step 2
 and `method: iam` as shown in the following example config:
@@ -127,4 +124,4 @@ port of your Teleport Proxy Service or Teleport Enterprise Cloud tenant, e.g.,
 (!docs/pages/includes/start-teleport.mdx!)
 
 Once you have started Teleport, confirm that your service is able to connect to and
-join your cluster. 
+join your cluster.


### PR DESCRIPTION
Some users took the existing wording to mean that IAM join only works for some services, which is not true. IAM joining works for all services.