### PR TITLE
Refactor dynamoDB event queries to use proper pagination solution

### DIFF
--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -1008,42 +1008,44 @@ func Test_querier_streamEventsFromChunk(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// add event parquets (in one .parquet file) to mock S3 getter
-		payloads, err := auditEventsToParquet(tt.events)
-		require.NoError(t, err)
+		t.Run(tt.name, func(t *testing.T) {
+			// add event parquets (in one .parquet file) to mock S3 getter
+			payloads, err := auditEventsToParquet(tt.events)
+			require.NoError(t, err)
 
-		buf := new(bytes.Buffer)
-		writer := parquet.NewGenericWriter[eventParquet](buf)
-		_, err = writer.Write(payloads)
-		require.NoError(t, err)
-		require.NoError(t, writer.Close())
+			buf := new(bytes.Buffer)
+			writer := parquet.NewGenericWriter[eventParquet](buf)
+			_, err = writer.Write(payloads)
+			require.NoError(t, err)
+			require.NoError(t, writer.Close())
 
-		key := fmt.Sprintf("%s/%s/%s.parquet", prefix, date, chunkID)
-		file := filepath.Join(bucketName, key)
-		mockS3 := &mockS3Getter{
-			files: map[string][]byte{
-				file: buf.Bytes(),
-			},
-		}
+			key := fmt.Sprintf("%s/%s/%s.parquet", prefix, date, chunkID)
+			file := filepath.Join(bucketName, key)
+			mockS3 := &mockS3Getter{
+				files: map[string][]byte{
+					file: buf.Bytes(),
+				},
+			}
 
-		q := &querier{
-			querierConfig: querierConfig{
-				tablename:        tableName,
-				locationS3Bucket: bucketName,
-				locationS3Prefix: prefix,
-				logger:           slog.Default(),
-				tracer:           tracing.NoopTracer(teleport.ComponentAthena),
-			},
-			s3Getter: mockS3,
-		}
+			q := &querier{
+				querierConfig: querierConfig{
+					tablename:        tableName,
+					locationS3Bucket: bucketName,
+					locationS3Prefix: prefix,
+					logger:           slog.Default(),
+					tracer:           tracing.NoopTracer(teleport.ComponentAthena),
+				},
+				s3Getter: mockS3,
+			}
 
-		eventStream := q.streamEventsFromChunk(t.Context(), date, chunkID)
-		eventParquets, err := stream.Collect(eventStream)
-		require.NoError(t, err)
-		require.Len(t, eventParquets, len(payloads))
-		for i, e := range eventParquets {
-			require.Equal(t, payloads[i].UID, e.UID)
-		}
+			eventStream := q.streamEventsFromChunk(t.Context(), date, chunkID)
+			eventParquets, err := stream.Collect(eventStream)
+			require.NoError(t, err)
+			require.Len(t, eventParquets, len(payloads))
+			for i, e := range eventParquets {
+				require.Equal(t, payloads[i].UID, e.UID)
+			}
+		})
 	}
 }
 

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1711,14 +1711,14 @@ dateLoop:
 				"iterator", l.checkpoint.Iterator,
 			)
 
-			result, stopped, err := l.processQueryOutput(out)
+			result, limitReached, err := l.processQueryOutput(out)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			values = append(values, result...)
 
 			// Return all currently processed events.
-			if stopped {
+			if limitReached {
 				return values, nil
 			}
 			// An empty iterator indicates that there are no more events to fetch from the current date.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1624,21 +1624,19 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		// create a checkpoint from the last processed event.
 		// This overrides LastEvaluatedKey to resume processing from this checkpoint.
 		if l.totalSize+len(data) >= events.MaxEventBytesInResponse {
-			if len(out) > 0 {
-				lastEvent := out[len(out)-1]
-				iterator, err := lastEvent.toIterator()
-				if err != nil {
-					return nil, false, trace.Wrap(err)
-				}
-
-				// If we stopped because of the size limit, we know that at least one event has to be fetched from the
-				// current date, so we must set it to true independently of the hasLeftFun.
-				l.checkpoint.Iterator = iterator
-				l.hasLeft = true
-
-				l.log.DebugContext(context.Background(), "fetcher's total size exceeds response size limit (sub-page break), creating new checkpoint", "iterator", iterator)
-				return out, true, nil
+			lastEvent := out[len(out)-1]
+			iterator, err := lastEvent.toIterator()
+			if err != nil {
+				return nil, false, trace.Wrap(err)
 			}
+
+			// If we stopped because of the size limit, we know that at least one event has to be fetched from the
+			// current date, so we must set it to true independently of the hasLeftFun.
+			l.checkpoint.Iterator = iterator
+			l.hasLeft = true
+
+			l.log.DebugContext(context.Background(), "fetcher's total size exceeds response size limit (sub-page break), creating new checkpoint", "iterator", iterator)
+			return out, true, nil
 		}
 		l.totalSize += len(data)
 		out = append(out, e)

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -34,6 +34,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -41,6 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -155,7 +161,7 @@ func TestCheckpointOutsideOfWindow(t *testing.T) {
 func TestSizeBreak(t *testing.T) {
 	tt := setupDynamoContext(t)
 
-	const eventSize = 50 * 1024
+	const eventSize = 200 * 1024
 	blob := randStringAlpha(eventSize)
 
 	const eventCount int = 10
@@ -192,7 +198,7 @@ func TestSizeBreak(t *testing.T) {
 			break
 		}
 	}
-
+	require.Len(t, gotEvents, eventCount)
 	lastTime := tt.suite.Clock.Now().UTC().Add(time.Hour)
 
 	for _, event := range gotEvents {
@@ -826,7 +832,6 @@ func TestStartKeyBackCompat(t *testing.T) {
 
 	// we must check the iterator field equality separately because it's a string
 	// containing a JSON-encoded event and field ordering might not be consistent.
-	require.Equal(t, oldCP.EventKey, newCP.EventKey)
 	require.Equal(t, oldCP.Date, newCP.Date)
 
 	var oldIterator, newIterator event
@@ -911,4 +916,247 @@ func TestCursorIteratorPrecision(t *testing.T) {
 		require.Contains(t, eventsSeen, id, "eventsSeen should contain %q", id)
 	}
 
+}
+
+func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
+	event1 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-1",
+		},
+	}
+	event2 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-2",
+		},
+	}
+	event3 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-3",
+		},
+	}
+	event4 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-4",
+		},
+	}
+
+	// have a deterministic session ID (UID) when used in test cases
+	key1 := eventToKey(event1)
+	key3 := eventToKey(event3)
+	key4 := eventToKey(event4)
+
+	tests := []struct {
+		name          string
+		limit         int32
+		mockResponses map[EventKey]mockResponse
+		wantEvents    []apievents.AuditEvent
+		wantKey       *EventKey
+	}{
+		{
+			name:  "no data returned from query, return empty results",
+			limit: 10,
+		},
+		{
+			name:  "paginated events less than limit",
+			limit: 10,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3},
+					returnKey: &key3,
+				},
+				key3: {
+					events:    []apievents.AuditEvent{event4},
+					returnKey: nil,
+				},
+			},
+			wantEvents: []apievents.AuditEvent{event1, event2, event3, event4},
+		},
+		{
+			name:  "number of events equals limit, should return last key",
+			limit: 4,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3, event4},
+					returnKey: nil,
+				},
+			},
+			wantEvents: []apievents.AuditEvent{event1, event2, event3, event4},
+			wantKey:    &key4,
+		},
+		{
+			name:  "number of events exceeds limit",
+			limit: 3,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3, event4},
+					returnKey: nil,
+				},
+			},
+			// we don't expect event4 because it should go to next batch
+			wantEvents: []apievents.AuditEvent{event1, event2, event3},
+			wantKey:    &key3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &mockQuery{
+				responses: test.mockResponses,
+			}
+
+			ef := eventsFetcher{
+				log:        slog.Default(),
+				api:        mock,
+				dates:      []string{"2025-02-05"},
+				fromUTC:    time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+				toUTC:      time.Date(2025, 2, 6, 0, 0, 0, 0, time.UTC),
+				checkpoint: &checkpointKey{},
+				left:       test.limit,
+				filter:     searchEventsFilter{},
+			}
+
+			gotRawEvents, err := ef.QueryByDateIndex(t.Context(), getExprFilter(ef.filter))
+			require.NoError(t, err)
+
+			if test.wantKey != nil {
+				var gotKey EventKey
+				require.NotEmpty(t, ef.checkpoint.Iterator)
+				require.NoError(t, json.Unmarshal([]byte(ef.checkpoint.Iterator), &gotKey))
+				require.Equal(t, *test.wantKey, gotKey)
+			}
+
+			got := make([]events.EventFields, 0, len(gotRawEvents))
+			for _, rawEvent := range gotRawEvents {
+				got = append(got, rawEvent.FieldsMap)
+			}
+
+			want := make([]events.EventFields, 0, len(test.wantEvents))
+			for _, event := range test.wantEvents {
+				fields, err := events.ToEventFields(event)
+				require.NoError(t, err)
+				want = append(want, fields)
+			}
+
+			require.Empty(t, cmp.Diff(want, got, cmpopts.EquateEmpty()))
+		})
+	}
+}
+
+type mockQuery struct {
+	query
+	responses map[EventKey]mockResponse
+}
+
+type mockResponse struct {
+	events    []apievents.AuditEvent
+	returnKey *EventKey
+}
+
+// Query is a simple mock implementation that does not distinguish queries by date.
+func (m *mockQuery) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if m.responses == nil {
+		return &dynamodb.QueryOutput{}, nil
+	}
+
+	var currentKey EventKey
+	if params.ExclusiveStartKey != nil {
+		if err := attributevalue.UnmarshalMap(params.ExclusiveStartKey, &currentKey); err != nil {
+			return nil, err
+		}
+	}
+
+	response, ok := m.responses[currentKey]
+	if !ok {
+		return nil, trace.Errorf("return parameter not defined in mockQuery")
+	}
+
+	items, err := eventsToItems(response.events)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastKey map[string]dynamodbtypes.AttributeValue
+	if response.returnKey != nil {
+		e := *response.returnKey
+		lastKey, err = attributevalue.MarshalMap(&e)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &dynamodb.QueryOutput{
+		Items:            items,
+		LastEvaluatedKey: lastKey,
+	}, nil
+}
+
+func eventsToItems(in []apievents.AuditEvent) ([]map[string]dynamodbtypes.AttributeValue, error) {
+	items := make([]map[string]dynamodbtypes.AttributeValue, 0, len(in))
+	for _, e := range in {
+		fieldsMap, err := events.ToEventFields(e)
+		if err != nil {
+			return nil, err
+		}
+
+		event := event{
+			EventKey: EventKey{
+				SessionID:     e.GetID(), // to make testing deterministic, use ID
+				EventIndex:    e.GetIndex(),
+				CreatedAt:     e.GetTime().Unix(),
+				CreatedAtDate: e.GetTime().Format(iso8601DateFormat),
+			},
+			EventType:      e.GetType(),
+			EventNamespace: apidefaults.Namespace,
+			FieldsMap:      fieldsMap,
+		}
+		item, err := attributevalue.MarshalMap(event)
+		if err != nil {
+			return nil, err
+		}
+
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+func eventToKey(e apievents.AuditEvent) EventKey {
+	return EventKey{
+		SessionID:     e.GetID(), // to make testing deterministic, use ID
+		EventIndex:    e.GetIndex(),
+		CreatedAt:     e.GetTime().Unix(),
+		CreatedAtDate: e.GetTime().Format(iso8601DateFormat),
+	}
 }

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -1075,7 +1075,6 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 }
 
 type mockQuery struct {
-	query
 	responses map[EventKey]mockResponse
 }
 


### PR DESCRIPTION
Fixes #58888

This PR replaces the old pagination solution in DynamoDB events that relied on re-scanning the entire page to match a hashed checkpoint. This caused a performance hit from computing hashes to find a match and potential query processing errors if returning an empty `Iterator`.

The new solution uses the existing `checkpointKey.Iterator` to perform pagination by creating a new checkpoint at the last processed event, which is triggered if the max response size (1 MiB) is reached or the query limit is reached.

A follow-up PR will add logic to handle large events (single events > 1 MiB), which uses this refactor. The test mock `mockQuery` is included in this PR (to be used to test large event handling), which allows querying arbitrarily large events without using a dedicated DynamoDB instance. Current behavior only allows storing audit events of size <= 400 KiB (via `maxItemSize`) into a DynamoDB instance.

changelog: Improved performance of large search queries for DynamoDB event backend