### PR TITLE
[v17] Fix memory leak in access list reminder notifications

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -81,6 +81,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/api/utils/retryutils"
@@ -174,9 +175,6 @@ const (
 const (
 	notificationsPageReadInterval = 5 * time.Millisecond
 	notificationsWriteInterval    = 40 * time.Millisecond
-
-	accessListsPageReadInterval = 5 * time.Millisecond
-	accessListsPageSize         = 20
 )
 
 const (
@@ -1751,7 +1749,7 @@ func (a *Server) runPeriodicOperations() {
 }
 
 func (a *Server) tallyRoles(ctx context.Context) {
-	var count = 0
+	count := 0
 	a.logger.DebugContext(ctx, "tallying roles")
 	defer func() {
 		a.logger.DebugContext(ctx, "tallying roles completed", "role_count", count)
@@ -6445,8 +6443,31 @@ const (
 	accessListReminderSemaphoreMaxLeases = 1
 )
 
+// createAccessListReminderNotificationsOptions defines the optional parameters for CreateAccessListReminderNotifications.
+type createAccessListReminderNotificationsOptions struct {
+	createNotificationInterval time.Duration
+}
+
+// CreateAccessListReminderNotificationsOptions is a functional option for CreateAccessListReminderNotifications.
+type CreateAccessListReminderNotificationsOptions func(*createAccessListReminderNotificationsOptions)
+
+// WithCreateNotificationInterval sets the interval between creating notifications.
+func WithCreateNotificationInterval(d time.Duration) CreateAccessListReminderNotificationsOptions {
+	return func(o *createAccessListReminderNotificationsOptions) {
+		o.createNotificationInterval = d
+	}
+}
+
 // CreateAccessListReminderNotifications checks if there are any access lists expiring soon and creates notifications to remind their owners if so.
-func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
+func (a *Server) CreateAccessListReminderNotifications(ctx context.Context, opts ...CreateAccessListReminderNotificationsOptions) {
+	opt := &createAccessListReminderNotificationsOptions{
+		// defaults to notificationsWriteInterval aka 40ms
+		createNotificationInterval: notificationsWriteInterval,
+	}
+	for _, o := range opts {
+		o(opt)
+	}
+
 	// Ensure only one auth server is running this check at a time.
 	lease, err := services.AcquireSemaphoreLock(ctx, services.SemaphoreLockConfig{
 		Service: a,
@@ -6479,31 +6500,21 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 
 	// Fetch all access lists
 	var accessLists []*accesslist.AccessList
-	var accessListsPageKey string
-	accessListsReadLimiter := time.NewTicker(accessListsPageReadInterval)
-	defer accessListsReadLimiter.Stop()
-	for {
-		select {
-		case <-accessListsReadLimiter.C:
-		case <-ctx.Done():
-			return
-		}
-		response, nextKey, err := a.Cache.ListAccessLists(ctx, accessListsPageSize, accessListsPageKey)
-		if err != nil {
-			a.logger.WarnContext(ctx, "failed to list access lists for periodic reminder notification check", "error", err)
+	err = clientutils.IterateResources(ctx, a.Cache.ListAccessLists, func(al *accesslist.AccessList) error {
+		if !al.IsReviewable() {
+			return nil
 		}
 
-		for _, al := range response {
-			// Only keep access lists that fall within our thresholds in memory
-			if al.Spec.Audit.NextAuditDate.Sub(now) <= 15*24*time.Hour {
-				accessLists = append(accessLists, al)
-			}
+		// Only keep access lists that fall within our thresholds in memory
+		if al.Spec.Audit.NextAuditDate.Sub(now) <= 15*24*time.Hour {
+			accessLists = append(accessLists, al)
 		}
-
-		if nextKey == "" {
-			break
-		}
-		accessListsPageKey = nextKey
+		return nil
+	})
+	if err != nil {
+		a.logger.WarnContext(ctx, "failed to list access lists for periodic reminder notification check",
+			"error", err)
+		return
 	}
 
 	reminderThresholds := []struct {
@@ -6541,17 +6552,16 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 
 		// Fetch all identifiers for this treshold prefix.
 		var identifiers []*notificationsv1.UniqueNotificationIdentifier
-		var nextKey string
-		for {
-			identifiersResp, nextKey, err := a.ListUniqueNotificationIdentifiersForPrefix(ctx, threshold.prefix, 0, nextKey)
+		iterator := clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+			return a.ListUniqueNotificationIdentifiersForPrefix(ctx, threshold.prefix, pageSize, pageKey)
+		})
+
+		for identifiersResp, err := range iterator {
 			if err != nil {
 				a.logger.WarnContext(ctx, "failed to list notification identifiers", "error", err, "prefix", threshold.prefix)
-				continue
-			}
-			identifiers = append(identifiers, identifiersResp...)
-			if nextKey == "" {
 				break
 			}
+			identifiers = append(identifiers, identifiersResp)
 		}
 
 		// Create a map of identifiers for quick lookup
@@ -6567,7 +6577,7 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context) {
 		// Check for access lists which haven't already been accounted for in a notification
 		var needsNotification bool
 
-		writeLimiter := time.NewTicker(notificationsWriteInterval)
+		writeLimiter := time.NewTicker(opt.createNotificationInterval)
 		for _, accessList := range relevantLists {
 			select {
 			case <-writeLimiter.C:

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -175,6 +175,9 @@ const (
 const (
 	notificationsPageReadInterval = 5 * time.Millisecond
 	notificationsWriteInterval    = 40 * time.Millisecond
+
+	accessListsPageReadInterval = 5 * time.Millisecond
+	accessListsPageSize         = 20
 )
 
 const (
@@ -6445,7 +6448,8 @@ const (
 
 // createAccessListReminderNotificationsOptions defines the optional parameters for CreateAccessListReminderNotifications.
 type createAccessListReminderNotificationsOptions struct {
-	createNotificationInterval time.Duration
+	createNotificationInterval  time.Duration
+	accessListsPageReadInterval time.Duration
 }
 
 // CreateAccessListReminderNotificationsOptions is a functional option for CreateAccessListReminderNotifications.
@@ -6458,11 +6462,19 @@ func WithCreateNotificationInterval(d time.Duration) CreateAccessListReminderNot
 	}
 }
 
+// WithAccessListsPageReadInterval sets the interval between reading pages of access lists.
+func WithAccessListsPageReadInterval(d time.Duration) CreateAccessListReminderNotificationsOptions {
+	return func(o *createAccessListReminderNotificationsOptions) {
+		o.accessListsPageReadInterval = d
+	}
+}
+
 // CreateAccessListReminderNotifications checks if there are any access lists expiring soon and creates notifications to remind their owners if so.
 func (a *Server) CreateAccessListReminderNotifications(ctx context.Context, opts ...CreateAccessListReminderNotificationsOptions) {
 	opt := &createAccessListReminderNotificationsOptions{
 		// defaults to notificationsWriteInterval aka 40ms
-		createNotificationInterval: notificationsWriteInterval,
+		createNotificationInterval:  notificationsWriteInterval,
+		accessListsPageReadInterval: accessListsPageReadInterval,
 	}
 	for _, o := range opts {
 		o(opt)
@@ -6500,21 +6512,36 @@ func (a *Server) CreateAccessListReminderNotifications(ctx context.Context, opts
 
 	// Fetch all access lists
 	var accessLists []*accesslist.AccessList
-	err = clientutils.IterateResources(ctx, a.Cache.ListAccessLists, func(al *accesslist.AccessList) error {
-		if !al.IsReviewable() {
-			return nil
+	var accessListsPageKey string
+	accessListsReadLimiter := time.NewTicker(opt.accessListsPageReadInterval)
+	defer accessListsReadLimiter.Stop()
+	for {
+		select {
+		case <-accessListsReadLimiter.C:
+		case <-ctx.Done():
+			return
 		}
 
-		// Only keep access lists that fall within our thresholds in memory
-		if al.Spec.Audit.NextAuditDate.Sub(now) <= 15*24*time.Hour {
-			accessLists = append(accessLists, al)
+		response, nextKey, err := a.Cache.ListAccessLists(ctx, accessListsPageSize, accessListsPageKey)
+		if err != nil {
+			a.logger.WarnContext(ctx, "failed to list access lists for periodic reminder notification check", "error", err)
 		}
-		return nil
-	})
-	if err != nil {
-		a.logger.WarnContext(ctx, "failed to list access lists for periodic reminder notification check",
-			"error", err)
-		return
+
+		for _, al := range response {
+			if !al.IsReviewable() {
+				continue
+			}
+
+			// Only keep access lists that fall within our thresholds in memory
+			if al.Spec.Audit.NextAuditDate.Sub(now) <= 15*24*time.Hour {
+				accessLists = append(accessLists, al)
+			}
+		}
+
+		if nextKey == "" {
+			break
+		}
+		accessListsPageKey = nextKey
 	}
 
 	reminderThresholds := []struct {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -63,6 +63,7 @@ import (
 	"github.com/gravitational/teleport/api/types/trait"
 	"github.com/gravitational/teleport/api/types/userloginstate"
 	"github.com/gravitational/teleport/api/types/wrappers"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/entitlements"
@@ -4710,7 +4711,7 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	}
 
 	// Run CreateAccessListReminderNotifications()
-	authServer.CreateAccessListReminderNotifications(ctx)
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
 	reminderNotificationSubKind := func(n *notificationsv1.Notification) string { return n.GetSubKind() }
 	expectedSubKinds := []string{
@@ -4728,13 +4729,155 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	require.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind))
 
 	// Run CreateAccessListReminderNotifications() again to verify no duplicates are created
-	authServer.CreateAccessListReminderNotifications(ctx)
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
 	// Check notifications again, counts should remain the same.
 	resp, err = client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
 	require.NoError(t, err)
 	require.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind),
 		"notifications should not have changed after second reconciliation")
+}
+
+type createAccessListOptions struct {
+	typ           accesslist.Type
+	nextAuditDate time.Time
+	owners        []accesslist.Owner
+}
+
+type createAccessListOpt func(*createAccessListOptions)
+
+func withType(typ accesslist.Type) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.typ = typ
+	}
+}
+
+func withNextAuditDate(nextAuditDate time.Time) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.nextAuditDate = nextAuditDate
+	}
+}
+
+func withOwners(owners []accesslist.Owner) createAccessListOpt {
+	return func(o *createAccessListOptions) {
+		o.owners = owners
+	}
+}
+
+func createAccessList(t *testing.T, authServer *auth.Server, name string, opts ...createAccessListOpt) {
+	t.Helper()
+	ctx := t.Context()
+
+	options := createAccessListOptions{}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	al, err := accesslist.NewAccessList(header.Metadata{
+		Name: name,
+	}, accesslist.Spec{
+		Type:        options.typ,
+		Title:       fmt.Sprintf("Test Access List %s", name),
+		Description: fmt.Sprintf("Test Access List %s description", name),
+		Owners:      options.owners,
+		Audit: accesslist.Audit{
+			NextAuditDate: options.nextAuditDate,
+			Recurrence:    accesslist.Recurrence{},
+			Notifications: accesslist.Notifications{},
+		},
+		Grants: accesslist.Grants{
+			Roles: []string{"grant"},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = authServer.UpsertAccessList(ctx, al)
+	require.NoError(t, err)
+}
+
+func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
+	ctx := t.Context()
+
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity: {Enabled: true},
+			},
+		},
+	})
+
+	// Setup test auth server
+	testServer := newTestTLSServer(t)
+	authServer := testServer.Auth()
+
+	testRole, err := types.NewRole("test", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:         []string{"user"},
+			ReviewRequests: &types.AccessReviewConditions{},
+		},
+	})
+	require.NoError(t, err)
+	_, err = authServer.UpsertRole(ctx, testRole)
+	require.NoError(t, err)
+
+	testUsername := "user1"
+	user, err := types.NewUser(testUsername)
+	require.NoError(t, err)
+	user.SetRoles([]string{"test"})
+	_, err = authServer.UpsertUser(ctx, user)
+	require.NoError(t, err)
+
+	// Create 2001overdue access lists
+	// All are overdue by 10 days, which should trigger "overdue by more than 7 days" notification
+	const numAccessLists = 2001
+	overdueBy := -10 // 10 days overdue
+	nextAuditDate := authServer.GetClock().Now().Add(time.Duration(overdueBy) * 24 * time.Hour)
+
+	for i := range numAccessLists {
+		createAccessList(t, authServer, fmt.Sprintf("al-overdue-%d", i),
+			withOwners([]accesslist.Owner{{Name: testUsername}}),
+			withNextAuditDate(nextAuditDate),
+		)
+	}
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		lists, err := testServer.Auth().Cache.GetAccessLists(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, lists, numAccessLists, "should have created all %d overdue access lists", numAccessLists)
+	}, 3*time.Second, 100*time.Millisecond)
+
+	// Run CreateAccessListReminderNotifications()
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
+
+	identifiers := collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
+	require.Len(t, identifiers, numAccessLists,
+		"should have created unique identifiers for all %d overdue access lists", numAccessLists)
+
+	// Run CreateAccessListReminderNotifications() again to verify it can read multiple pages of identifiers without memory leak
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
+
+	identifiers = collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
+	require.Len(t, identifiers, numAccessLists,
+		"should have created unique identifiers for all %d overdue access lists", numAccessLists)
+}
+
+func collectAllUniqueNotificationIdentifiers(t *testing.T, ctx context.Context, authServer *auth.Server, prefix string) []*notificationsv1.UniqueNotificationIdentifier {
+	t.Helper()
+
+	var identifiers []*notificationsv1.UniqueNotificationIdentifier
+	iterator := clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+		return authServer.ListUniqueNotificationIdentifiersForPrefix(ctx, prefix, pageSize, pageKey)
+	})
+
+	for identifiersResp, err := range iterator {
+		if err != nil {
+			require.NoError(t, err, "listing unique notification identifiers for prefix %q", prefix)
+		}
+		identifiers = append(identifiers, identifiersResp)
+	}
+
+	return identifiers
 }
 
 func TestServer_GetAnonymizationKey(t *testing.T) {

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -55,6 +55,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
+	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	apievents "github.com/gravitational/teleport/api/types/events"

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4828,7 +4828,7 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	_, err = authServer.UpsertUser(ctx, user)
 	require.NoError(t, err)
 
-	// Create 2001overdue access lists
+	// Create 2001 overdue access lists
 	// All are overdue by 10 days, which should trigger "overdue by more than 7 days" notification
 	const numAccessLists = 2001
 	overdueBy := -10 // 10 days overdue
@@ -4848,14 +4848,14 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 	}, 3*time.Second, 100*time.Millisecond)
 
 	// Run CreateAccessListReminderNotifications()
-	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond), auth.WithAccessListsPageReadInterval(time.Nanosecond))
 
 	identifiers := collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
 	require.Len(t, identifiers, numAccessLists,
 		"should have created unique identifiers for all %d overdue access lists", numAccessLists)
 
 	// Run CreateAccessListReminderNotifications() again to verify it can read multiple pages of identifiers without memory leak
-	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
+	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond), auth.WithAccessListsPageReadInterval(time.Nanosecond))
 
 	identifiers = collectAllUniqueNotificationIdentifiers(t, ctx, authServer, types.NotificationIdentifierPrefixAccessListOverdue7d)
 	require.Len(t, identifiers, numAccessLists,
@@ -4865,17 +4865,10 @@ func TestCreateAccessListReminderNotifications_LargeOverdueSet(t *testing.T) {
 func collectAllUniqueNotificationIdentifiers(t *testing.T, ctx context.Context, authServer *auth.Server, prefix string) []*notificationsv1.UniqueNotificationIdentifier {
 	t.Helper()
 
-	var identifiers []*notificationsv1.UniqueNotificationIdentifier
-	iterator := clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
+	identifiers, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*notificationsv1.UniqueNotificationIdentifier, string, error) {
 		return authServer.ListUniqueNotificationIdentifiersForPrefix(ctx, prefix, pageSize, pageKey)
-	})
-
-	for identifiersResp, err := range iterator {
-		if err != nil {
-			require.NoError(t, err, "listing unique notification identifiers for prefix %q", prefix)
-		}
-		identifiers = append(identifiers, identifiersResp)
-	}
+	}))
+	require.NoError(t, err, "listing unique notification identifiers for prefix %q", prefix)
 
 	return identifiers
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -55,7 +55,6 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	mfav1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/mfa/v1"
 	notificationsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/notifications/v1"
-	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -83,6 +82,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/modules/modulestest"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -4746,12 +4746,6 @@ type createAccessListOptions struct {
 }
 
 type createAccessListOpt func(*createAccessListOptions)
-
-func withType(typ accesslist.Type) createAccessListOpt {
-	return func(o *createAccessListOptions) {
-		o.typ = typ
-	}
-}
 
 func withNextAuditDate(nextAuditDate time.Time) createAccessListOpt {
 	return func(o *createAccessListOptions) {


### PR DESCRIPTION
Backport #62649 to branch/v17

changelog: Fixed a memory leak in access list reminder notifications affecting clusters with more than 1000 pending Access List reviews.
