### PR TITLE
Fix issuance of wildcard DNS SANs for X509 SVIDs

### DIFF
--- a/lib/auth/machineid/workloadidentityv1/decision_test.go
+++ b/lib/auth/machineid/workloadidentityv1/decision_test.go
@@ -69,7 +69,7 @@ func Test_decide(t *testing.T) {
 			attrs:     standardAttrs,
 			wantIssue: false,
 			assertReason: func(t require.TestingT, err error, i ...any) {
-				require.ErrorContains(t, err, "templating spec.spiffe.x509.dns_sans[0] resulted in an invalid DNS name")
+				require.ErrorContains(t, err, "templating spec.spiffe.x509.dns_sans[0] resulted in an invalid DNS SAN")
 			},
 		},
 	}

--- a/lib/auth/machineid/workloadidentityv1/decision_test.go
+++ b/lib/auth/machineid/workloadidentityv1/decision_test.go
@@ -599,3 +599,44 @@ func TestTemplateExtraClaims_TooDeeplyNested(t *testing.T) {
 	_, err = templateExtraClaims(rawClaims, &workloadidentityv1pb.Attrs{})
 	require.ErrorContains(t, err, "cannot contain more than 10 levels of nesting")
 }
+
+func Test_validDNSSAN(t *testing.T) {
+	tests := []struct {
+		str  string
+		want bool
+	}{
+		{
+			str:  "example.com",
+			want: true,
+		},
+		{
+			// Single-label domain name. An unusual case but important since we
+			// may be issuing certs for hostnames in a local network (which will
+			// not abide by usual public internet dns semantics).
+			str:  "example",
+			want: true,
+		},
+		{
+			// DNS 1123 permits numeric characters at start (unlike RFC 1035)
+			str:  "123-example.com",
+			want: true,
+		},
+		{
+			str:  "*.example.com",
+			want: true,
+		},
+		{
+			str:  "*example.com",
+			want: false,
+		},
+		{
+			str:  ".example.com",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			require.Equal(t, tt.want, validDNSSAN(tt.str))
+		})
+	}
+}

--- a/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
+++ b/lib/auth/machineid/workloadidentityv1/workloadidentityv1_test.go
@@ -505,7 +505,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 				Hint: "Wow - what a lovely hint, {{user.name}}!",
 				X509: &workloadidentityv1pb.WorkloadIdentitySPIFFEX509{
 					DnsSans: []string{
-						"example.com",
+						"*.example.com",
 						"{{user.name}}.example.com",
 					},
 				},
@@ -849,7 +849,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 				require.WithinDuration(t, tp.clock.Now().Add(-1*time.Minute), cert.NotBefore, time.Second)
 				// Check cert TTL
 				require.Equal(t, cert.NotAfter.Sub(cert.NotBefore), wantTTL+time.Minute)
-				require.Equal(t, []string{"example.com", "dog.example.com"}, cert.DNSNames)
+				require.Equal(t, []string{"*.example.com", "dog.example.com"}, cert.DNSNames)
 
 				// Check against SPIFFE SPEC
 				// References are to https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md
@@ -902,7 +902,7 @@ func TestIssueWorkloadIdentity(t *testing.T) {
 						WorkloadIdentity:         full.GetMetadata().GetName(),
 						WorkloadIdentityRevision: full.GetMetadata().GetRevision(),
 						DNSSANs: []string{
-							"example.com",
+							"*.example.com",
 							"dog.example.com",
 						},
 						NameSelector: full.GetMetadata().GetName(),


### PR DESCRIPTION
Our validation of DNS SANs was overly restrictive and prevented the issuance of wildcard DNS SANs (e.g `*.example.com`). Whilst looking at the code, I also noticed we were relying on `utils.IsValidHostname` which is also overly restrictive about numeric characters at the start of DNS labels (it enforced RFC 1035 rather than RFC 1123 rules).

Tested locally w/ :

```yaml
kind: workload_identity
metadata:
  name: workload-identity
  labels:
    test: bar
spec:
  spiffe:
    id: /foo/bar/{{ join.kubernetes.pod.name }}/{{ join.kubernetes.service_account.name }}
    x509:
      maximum_ttl: 259200s
      subject_template:
        common_name: "foo"
      dns_sans:
        - "example.com"
        - "*.example.com"
version: v1
```

```
Version:          3 (0x02)
Serial number:    322083245263597614786199268933600838325 (0x00f24efa06a481b97d02999a7e03d482b5)
Algorithm ID:     SHA256withRSA
Validity
  Not Before:     07/01/2026 10:49:42 (dd-mm-yyyy hh:mm:ss) (260107104942Z)
  Not After:      09/01/2026 10:50:42 (dd-mm-yyyy hh:mm:ss) (260109105042Z)
Issuer
  O            = leaf.tele.ottr.sh
  CN           = leaf.tele.ottr.sh
  serialNumber = 329196207528801678979858243766463713168
Subject
  CN = foo
Fingerprints
  MD5:            d4a5d46b9d36740dab1e6c77875764a2
  SHA1:           ac263754fcf895ec8d2bc561ed507e13612b1cdf
  SHA256:         7c7fbb5aa5ae237fd391d9948bd826a361d2a6230b9d8956c347365d20612eff
Public Key
  Algorithm:      RSA
  Length:         2048 bits
  Modulus:        a5:1d:c0:00:f7:26:0f:e2:16:72:0f:ad:da:1e:83:fb:
                  e8:df:4a:46:e8:79:00:df:81:65:e7:48:95:af:76:20:
                  2a:50:55:a8:e2:d4:28:b4:12:94:29:e8:7c:ed:76:5e:
                  0d:d3:49:4c:58:3f:9f:22:93:2e:7d:83:32:4d:09:6f:
                  d0:99:61:8c:11:29:70:dc:61:1a:73:54:9b:a9:8b:1a:
                  fe:61:72:51:2d:b5:c6:3c:b8:3e:6f:43:e0:42:f0:dd:
                  d9:63:20:dc:1c:ac:aa:0f:4f:45:8c:f5:29:4a:dd:29:
                  48:34:2c:b3:b5:e3:62:a3:6c:c4:08:2d:ed:25:ab:2d:
                  bc:d3:f9:fe:52:c5:46:7d:bb:74:80:64:fe:4b:0c:c0:
                  f3:6c:fe:39:07:12:b0:4f:f1:11:9e:91:1f:db:e8:d5:
                  2c:d4:bf:7a:95:96:4a:28:b8:8a:84:c0:52:16:d9:09:
                  44:4f:d0:9c:c8:7b:7c:83:7d:b8:a0:cf:7c:6e:17:03:
                  bf:3e:1f:5f:27:7e:00:3c:91:db:b4:dc:79:ee:a2:2c:
                  19:23:24:68:aa:15:2b:17:2e:b7:b7:7f:fe:6c:85:e5:
                  9f:fd:9f:17:1e:6f:45:fb:95:69:da:6b:d1:9c:ce:05:
                  bb:6f:9f:4c:76:2e:53:a9:0b:26:0c:13:7b:55:4e:4d
  Exponent:       65537 (0x10001)
Certificate Signature
  Algorithm:      SHA256withRSA
  Signature:      82:01:0e:24:1a:b0:ab:88:fe:8d:90:d2:8d:32:93:71:
                  d0:c9:16:e0:0f:52:bf:7f:26:26:ae:e7:4a:bb:db:f8:
                  26:dd:c1:21:91:62:11:ff:2b:26:6d:d3:cb:dc:5f:d1:
                  26:4c:68:f6:27:71:7c:77:20:02:76:a5:70:39:3a:fd:
                  05:3a:74:cb:45:95:91:d0:f6:29:0e:43:53:48:35:e5:
                  a2:27:fd:a3:37:d7:a2:9a:13:11:d1:8c:48:e0:e7:ee:
                  fa:61:29:74:47:34:78:20:b7:76:9d:ef:cf:04:97:31:
                  b7:71:d4:98:b3:cd:6d:14:6e:c6:b9:f6:2d:60:09:a7:
                  98:65:00:58:3b:f6:c1:da:1f:85:26:c1:a3:92:dc:64:
                  3d:b4:59:76:0b:e4:c9:67:6d:94:d3:90:f5:89:6d:9d:
                  13:46:f4:15:67:36:7f:b7:f9:22:d5:6b:47:a5:7c:15:
                  1a:cf:5e:7f:33:cc:5a:c2:17:60:1e:d1:ff:ca:67:6f:
                  51:bb:44:3f:ed:99:bc:02:c0:3b:6c:8d:3b:c3:db:cf:
                  0e:77:1a:72:0d:80:6f:4a:08:1d:5b:f7:09:f0:26:34:
                  62:f4:d7:ce:82:a8:ed:b7:a8:2e:01:9d:4e:90:f4:4e:
                  de:84:9f:27:db:b2:df:9f:b4:a7:12:37:88:37:6f:98

Extensions
  keyUsage CRITICAL:
    digitalSignature,keyEncipherment,keyAgreement
  extKeyUsage :
    serverAuth, clientAuth
  basicConstraints CRITICAL:
    {}
  authorityKeyIdentifier :
    kid=4bdd2c359ac96d49e90ead78e10702d487eabe2f
  subjectAltName :
    dns: example.com
    dns: *.example.com
    uri: spiffe://leaf.tele.ottr.sh/foo/bar/my-lovely-pod/bar
```


changelog: Fixed issuance of wildcard DNS SANs with Workload Identity