### PR TITLE
docs: fix role setting for terraform long-lived credential

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/long-lived-credentials.mdx
@@ -110,7 +110,7 @@ cluster. You will create a local Teleport user for this purpose.
        # named "terraform".
        impersonate:
          users: ['terraform']
-         roles: ['terraform']
+         roles: ['terraform-provider']
    ```
 
 1. Create the `terraform-impersonator` role by running the following command:


### PR DESCRIPTION
The role is `terraform-provider`, not `terrafrom` as used in the other docs.