### PR TITLE
docs: add checkpoints to desktop getting started guide

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -385,6 +385,7 @@
     "centralus",
     "certificatekey",
     "certificatesigningrequest",
+    "certlm",
     "certutil",
     "cfpassword",
     "cfsdf",

--- a/docs/pages/enroll-resources/desktop-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/desktop-access/getting-started.mdx
@@ -114,6 +114,21 @@ an administrative Command Prompt or PowerShell console with the following comman
 $ teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe install --cert=teleport.cer -r
 ```
 
+<Checkpoint
+  title="Verify Windows is prepared"
+  description="Confirm that the Windows computer has restarted and the Teleport authentication package is loaded."
+>
+
+Verify the Teleport authentication package is loaded by running the following command in a Command Prompt:
+
+  ```code
+  $ REG QUERY "HKLM\SYSTEM\CurrentControlSet\Control\Lsa" /v "Authentication Packages"
+  ```
+
+The output should include `teleport` in the list of authentication packages. If it doesn't, either the Teleport Windows Auth Setup program didn't run successfully or the computer hasn't been restarted after installation.
+
+</Checkpoint>
+
 ## Step 2/4. Configure the Windows Desktop Service
 
 Now that you have prepared the Windows computer to enroll in the cluster, the next steps
@@ -241,6 +256,29 @@ following for the Windows Desktop Service:
 
 1. (!docs/pages/includes/start-teleport.mdx service="the Teleport Windows Desktop Service"!)
 
+<Checkpoint
+  title="Verify the Windows Desktop Service is running"
+  description="Confirm that the Teleport Windows Desktop Service has started and connected to your cluster."
+>
+  Here are some troubleshooting tips:
+  - Check the service status on the Linux server: 
+  
+    ```code
+    $ systemctl status teleport
+    ```
+
+  - Review logs for connection errors: 
+  
+    ```code
+    $ sudo journalctl -u teleport
+    ```
+
+  - Verify the token hasn't expired (tokens are valid for 30 minutes by default).
+
+  - Ensure the Linux server can reach the Teleport Proxy Service.
+
+</Checkpoint>
+
 ## Step 3/4. Configure remote Windows desktop access
 
 To access a remote desktop, a Teleport user must have a role with the
@@ -312,6 +350,26 @@ Windows login to use for the connection.
    ![Disconnect from a Windows desktop ](../../../img/desktop-access/desktop-disconnect.png)
 
    To view the recording, select **Audit** in the Teleport Web UI, then click **Session Recordings** in the menu.
+
+<Checkpoint
+  title="Verify Windows desktop access"
+  description="Confirm that you can connect to the Windows desktop and see the Windows login screen or desktop."
+>
+  Here are some troubleshooting tips:
+  
+  - Ensure your Teleport user is assigned the `windows-desktop-admins` role (or equivalent role with desktop permissions).
+
+  - Verify the Windows login you selected exists on the Windows computer.
+
+  - Check that RDP port 3389 is open between the Linux server running the Desktop Service and the Windows host.
+
+  - If the connection fails, review the Windows Desktop Service logs on the Linux server: 
+  
+    ```code
+    $ sudo journalctl -u teleport
+    ```
+
+</Checkpoint>
 
 ## Uninstall
 


### PR DESCRIPTION
This commit adds interactive checkpoints to the docs/pages/enroll-resources/desktop-access/getting-started guide with troubleshooting tips.