### PR TITLE
Resource reference generator: use package paths

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -5,31 +5,31 @@ examples_directory: "./resource_examples"
 # Please alphabetize the resource list by type name.
 resources:
   - type: AppV3
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: app
     yaml_version: v3
   - type: DatabaseServerV3
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: db_server
     yaml_version: v3
   - type: DiscoveryConfig
-    package: discoveryconfig
+    package: github.com/gravitational/teleport/api/types/discoveryconfig
     yaml_kind: discovery_config
     yaml_version: v1
   - type: InstallerV1
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: installer
     yaml_version: v1
   - type: OIDCConnectorV3
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: oidc
     yaml_version: v3
   - type: SAMLConnectorV2
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: saml
     yaml_version: v2
   - type: SAMLIdPServiceProviderV1
-    package: types
+    package: github.com/gravitational/teleport/api/types
     yaml_kind: saml_idp_service_provider
     yaml_version: v1
 

--- a/build.assets/tooling/cmd/resource-ref-generator/main.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/main.go
@@ -28,11 +28,13 @@ import (
 	"github.com/gravitational/teleport/build.assets/tooling/cmd/resource-ref-generator/reference"
 )
 
-const tmplBase = "reference.tmpl"
-
 var tmplPath = filepath.Join("reference", tmplBase)
 
-const configHelp string = `The path to a YAML configuration file (see the README)`
+const (
+	tmplBase              = "reference.tmpl"
+	configHelp            = `The path to a YAML configuration file (see the README)`
+	teleportPackagePrefix = "github.com/gravitational/teleport"
+)
 
 func main() {
 	conf := flag.String("config", "conf.yaml", configHelp)
@@ -56,7 +58,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = reference.Generate(genconf, tmpl)
+	err = reference.Generate(teleportPackagePrefix, genconf, tmpl)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not generate the resource reference: %v\n", err)
 		os.Exit(1)

--- a/build.assets/tooling/cmd/resource-ref-generator/resource/resource.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource/resource.go
@@ -26,6 +26,7 @@ import (
 	"go/token"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -35,8 +36,12 @@ import (
 // PackageInfo is used to look up a Go declaration in a map of declaration names
 // to resource data.
 type PackageInfo struct {
-	DeclName    string
-	PackageName string
+	// DeclName is the name of a Go declaration.
+	DeclName string
+	// PackagePath is the full path of a Go package containing the
+	// declaration, e.g.,
+	// "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	PackagePath string
 }
 
 // ReferenceEntry represents a section in the resource reference docs.
@@ -78,7 +83,10 @@ type SourceData struct {
 	TypeDecls map[PackageInfo]DeclarationInfo
 }
 
-func NewSourceData(rootPath string) (SourceData, error) {
+// NewSourceData extracts type declarations from the Go files rooted at
+// rootPath. Uses prefix, e.g., github.com/gravitational/teleport, to construct
+// package paths.
+func NewSourceData(prefix string, rootPath string) (SourceData, error) {
 	// All declarations within the source tree. We use this to extract
 	// information about dynamic resource fields, which we can look up by
 	// package and declaration name.
@@ -100,6 +108,17 @@ func NewSourceData(rootPath string) (SourceData, error) {
 		if filepath.Ext(info.Name()) != ".go" {
 			return nil
 		}
+
+		// Find the Go package path corresponding to the current file.
+		rel, err := filepath.Rel(rootPath, currentPath)
+		if err != nil {
+			return fmt.Errorf("unable to find a relative path between %v and %v: %w", rootPath, currentPath, err)
+		}
+		pkg := path.Join(
+			prefix,
+			filepath.Base(rootPath),
+			filepath.Dir(rel),
+		)
 
 		// Open the file so we can pass it to ParseFile. Otherwise,
 		// ParseFile always reads from the OS FS, not from fs.
@@ -142,11 +161,11 @@ func NewSourceData(rootPath string) (SourceData, error) {
 
 			typeDecls[PackageInfo{
 				DeclName:    spec.Name.Name,
-				PackageName: file.Name.Name,
+				PackagePath: pkg,
 			}] = DeclarationInfo{
 				Decl:         l,
 				FilePath:     relDeclPath,
-				PackageName:  file.Name.Name,
+				PackageName:  pkg,
 				NamedImports: pn,
 			}
 		}
@@ -564,7 +583,7 @@ func getYAMLTypeForExpr(exp ast.Expr, pkg string, allDecls map[PackageInfo]Decla
 		default:
 			info := PackageInfo{
 				DeclName:    t.Name,
-				PackageName: pkg,
+				PackagePath: pkg,
 			}
 			if _, ok := allDecls[info]; !ok {
 				return nonYAMLKind{}, nil
@@ -612,7 +631,7 @@ func getYAMLTypeForExpr(exp ast.Expr, pkg string, allDecls map[PackageInfo]Decla
 		}
 		info := PackageInfo{
 			DeclName:    t.Sel.Name,
-			PackageName: pkg,
+			PackagePath: pkg,
 		}
 		if _, ok := allDecls[info]; !ok {
 			return nonYAMLKind{}, nil
@@ -659,11 +678,20 @@ func makeRawField(field *ast.Field, packageName string, allDecls map[PackageInfo
 	s, ok := field.Type.(*ast.SelectorExpr)
 	if ok {
 		i, ok := s.X.(*ast.Ident)
-		if ok {
-			pkg = i.Name
+		// Not an identifier, so don't look up imports
+		if !ok {
+			goto assignTag
 		}
+
+		p, imp := namedImports[i.Name]
+		if !imp {
+			return rawField{}, fmt.Errorf("package %v does not include an import with name %v", packageName, i.Name)
+		}
+
+		pkg = p
 	}
 
+assignTag:
 	var tag string
 	if field.Tag != nil {
 		tag = field.Tag.Value
@@ -797,7 +825,7 @@ func allFieldsForDecl(decl DeclarationInfo, fld []rawField, allDecls map[Package
 		}
 		p := PackageInfo{
 			DeclName:    c.declarationInfo.DeclName,
-			PackageName: pkg,
+			PackagePath: pkg,
 		}
 
 		// We expect to find a declaration of the embedded struct.
@@ -828,28 +856,26 @@ func allFieldsForDecl(decl DeclarationInfo, fld []rawField, allDecls map[Package
 }
 
 // NamedImports creates a mapping from the provided name of each package import
-// to the original package path.
+// to the original package path. If the package does not have an explicit name,
+// map the full path to the final path segment instead.
 func NamedImports(file *ast.File) map[string]string {
 	m := make(map[string]string)
 	for _, i := range file.Imports {
+		pkgPath := strings.Trim(i.Path.Value, "\"")
 		if i.Name == nil {
-			continue
+			m[path.Base(pkgPath)] = pkgPath
+		} else {
+			m[i.Name.Name] = pkgPath
 		}
-		s := strings.Trim(i.Path.Value, "\"")
-		p := strings.Split(s, "/")
-		// Consumers check the named imports map against the final path
-		// segment of a package path.
-		if len(p) > 1 {
-			s = p[len(p)-1]
-		}
-		m[i.Name.Name] = s
 	}
 	return m
 }
 
 // ReferenceDataFromDeclaration gets data for the reference by examining decl.
-// Looks up decl's fields in allDecls and methods in allMethods.
+// Looks up decl's fields in allDecls and methods in allMethods. Uses prefix,
+// e.g., "github.com/gravitational/teleport", to construct package paths
 func ReferenceDataFromDeclaration(
+	prefix string,
 	decl DeclarationInfo,
 	allDecls map[PackageInfo]DeclarationInfo,
 	camelCaseExceptions []string,
@@ -885,7 +911,7 @@ func ReferenceDataFromDeclaration(
 	}
 	key := PackageInfo{
 		DeclName:    rs.name,
-		PackageName: decl.PackageName,
+		PackagePath: decl.PackageName,
 	}
 
 	fld, err := makeFieldTableInfo(fieldsToProcess, camelCaseExceptions)
@@ -913,12 +939,12 @@ func ReferenceDataFromDeclaration(
 		for _, d := range c {
 			// Find the package name to use to look up the declaration from
 			// its identifier.
-			i, ok := decl.NamedImports[d.PackageName]
+			i, ok := decl.NamedImports[d.PackagePath]
 			// The file that made the declaration provided a name for the
 			// package associated with the identifier, so find the full
 			// package path and use that to look up the declaration.
 			if ok {
-				d.PackageName = i
+				d.PackagePath = i
 			}
 
 			// Get information about the field type's declaration.
@@ -930,7 +956,7 @@ func ReferenceDataFromDeclaration(
 			if !ok {
 				continue
 			}
-			r, err := ReferenceDataFromDeclaration(gd, allDecls, camelCaseExceptions)
+			r, err := ReferenceDataFromDeclaration(prefix, gd, allDecls, camelCaseExceptions)
 			if errors.As(err, &NotAGenDeclError{}) {
 				continue
 			}

--- a/build.assets/tooling/cmd/resource-ref-generator/resource/resource_test.go
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource/resource_test.go
@@ -53,7 +53,7 @@ func TestReferenceDataFromDeclaration(t *testing.T) {
 			description: "scalar fields with one field ignored",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -76,7 +76,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -115,7 +115,7 @@ active: true
 			description: "sequences of scalars",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -134,7 +134,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -176,7 +176,7 @@ booleans:
 			description: "a map of strings to sequences",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -191,7 +191,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -224,10 +224,12 @@ type Metadata struct {
 			description: "an undeclared custom type field",
 			declInfo: PackageInfo{
 				DeclName:    "Server",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import "types"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -240,7 +242,7 @@ type Server struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -264,10 +266,13 @@ type Server struct {
 		{
 			description: "named scalar type",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Server",
 			},
 			source: `package mypkg
+
+import types "github.com/gravitational/teleport/src"
+
 // Server includes information about a server registered with Teleport.
 type Server struct {
     // Name is the name of the resource.
@@ -288,7 +293,7 @@ type Labels []string
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -314,7 +319,7 @@ type Labels []string
 				},
 				PackageInfo{
 					DeclName:    "Labels",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Labels",
 					Description: "A slice of strings that we'll process downstream",
@@ -328,10 +333,12 @@ type Labels []string
 			description: "custom type fields with a custom JSON unmarshaller",
 			declInfo: PackageInfo{
 				DeclName:    "Server",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -352,7 +359,7 @@ func (s *Server) UnmarshalJSON (b []byte) error {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -377,10 +384,12 @@ func (s *Server) UnmarshalJSON (b []byte) error {
 			description: "custom type with custom YAML unmarshaller",
 			declInfo: PackageInfo{
 				DeclName:    "Application",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Application includes information about an application registered with Teleport.
 type Application struct {
@@ -401,7 +410,7 @@ func (a *Application) UnmarshalYAML(value *yaml.Node) error {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Application",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Application",
 					Description: "Includes information about an application registered with Teleport.",
@@ -426,10 +435,12 @@ func (a *Application) UnmarshalYAML(value *yaml.Node) error {
 			description: "a custom type field declared in a second source file",
 			declInfo: PackageInfo{
 				DeclName:    "Server",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -453,7 +464,7 @@ type ServerSpecV1 struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -476,7 +487,7 @@ spec: # [...]
 				},
 				PackageInfo{
 					DeclName:    "ServerSpecV1",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server Spec V1",
 					Description: "Includes aspects of a proxied server.",
@@ -509,10 +520,12 @@ is_active: true
 			description: "composite field type with named scalar type",
 			declInfo: PackageInfo{
 				DeclName:    "Server",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -537,7 +550,7 @@ type Label string
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -572,7 +585,7 @@ label_maps:
 				},
 				PackageInfo{
 					DeclName:    "ServerSpecV1",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server Spec V1",
 					Description: "Includes aspects of a proxied server.",
@@ -589,7 +602,7 @@ label_maps:
 				},
 				PackageInfo{
 					DeclName:    "Label",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Label",
 					Description: "A custom type that we unmarshal in a non-default way.",
@@ -602,7 +615,7 @@ label_maps:
 			description: "struct type with an interface field",
 			declInfo: PackageInfo{
 				DeclName:    "Server",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -625,7 +638,7 @@ type ServerImplementation interface{
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -648,7 +661,7 @@ impl: # [...]
 				},
 				PackageInfo{
 					DeclName:    "ServerImplementation",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Server Implementation",
 					Description: "A remote service with a URL.",
@@ -662,9 +675,12 @@ impl: # [...]
 			description: "embedded struct",
 			declInfo: PackageInfo{
 				DeclName:    "MyResource",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package mypkg
+
+import types "github.com/gravitational/teleport/src"
+
 // MyResource is a resource declared for testing.
 type MyResource struct{
   // Alias is another name to call the resource.
@@ -687,7 +703,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "MyResource",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "My Resource",
 					Description: "A resource declared for testing.",
@@ -720,9 +736,12 @@ active: true
 			description: "embedded struct with struct field",
 			declInfo: PackageInfo{
 				DeclName:    "MyResource",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package mypkg
+
+import types "github.com/gravitational/teleport/src"
+
 // MyResource is a resource declared for testing.
 type MyResource struct{
   // Alias is another name to call the resource.
@@ -749,7 +768,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "MyResource",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "My Resource",
 					Description: "A resource declared for testing.",
@@ -772,7 +791,7 @@ metadata: # [...]
 				},
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					SourcePath:  "src/myfile0.go",
@@ -799,7 +818,7 @@ active: true
 			description: "embedded struct with base in the same package",
 			declInfo: PackageInfo{
 				DeclName:    "MyResource",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package mypkg
 // MyResource is a resource declared for testing.
@@ -824,7 +843,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "MyResource",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "My Resource",
 					Description: "A resource declared for testing.",
@@ -857,9 +876,13 @@ active: true
 			description: "struct with two embedded structs",
 			declInfo: PackageInfo{
 				DeclName:    "MyResource",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package mypkg
+
+import moretypes "github.com/gravitational/teleport/src"
+import types "github.com/gravitational/teleport/src"
+
 // MyResource is a resource declared for testing.
 type MyResource struct{
   // Alias is another name to call the resource.
@@ -888,7 +911,7 @@ type ActivityStatus struct{
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "MyResource",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "My Resource",
 					Description: "A resource declared for testing.",
@@ -921,9 +944,12 @@ active: true
 			description: "embedded struct with an embedded struct",
 			declInfo: PackageInfo{
 				DeclName:    "MyResource",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package mypkg
+
+import types "github.com/gravitational/teleport/src"
+
 // MyResource is a resource declared for testing.
 type MyResource struct{
   // Alias is another name to call the resource.
@@ -933,6 +959,8 @@ type MyResource struct{
 `,
 			declSources: []string{
 				`package types
+
+import moretypes "github.com/gravitational/teleport/src"
 
 // Metadata describes information about a dynamic resource. Every dynamic
 // resource in Teleport has a metadata object.
@@ -952,7 +980,7 @@ type ActivityStatus struct{
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "MyResource",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "My Resource",
 					Description: "A resource declared for testing.",
@@ -985,7 +1013,7 @@ active: true
 			description: "ignored fields with non-YAML-comptabible types",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -1003,7 +1031,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -1024,7 +1052,7 @@ type Metadata struct {
 			description: "non-embedded custom field type declared in the same package as the containing struct",
 			declInfo: PackageInfo{
 				DeclName:    "DatabaseServerV3",
-				PackageName: "typestest",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package typestest
 
@@ -1050,7 +1078,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "DatabaseServerV3",
-					PackageName: "typestest",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Database Server V3",
 					Description: "Represents a database access server.",
@@ -1073,7 +1101,7 @@ metadata: # [...]
 				},
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "typestest",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Metadata",
 					Description: "Resource metadata",
@@ -1100,7 +1128,7 @@ description: "string"
 			description: "pointer field",
 			declInfo: PackageInfo{
 				DeclName:    "DatabaseServerV3",
-				PackageName: "typestest",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `package typestest
 
@@ -1122,7 +1150,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "DatabaseServerV3",
-					PackageName: "typestest",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Database Server V3",
 					Description: "Represents a database access server.",
@@ -1139,7 +1167,7 @@ type Metadata struct {
 				},
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "typestest",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: ReferenceEntry{
 					SectionName: "Metadata",
 					Description: "Resource metadata",
@@ -1159,7 +1187,7 @@ type Metadata struct {
 		{
 			description: "map of strings to an undeclared field",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Server",
 			},
 			source: `
@@ -1183,7 +1211,7 @@ type ServerSpecV1 struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -1220,7 +1248,7 @@ label_maps:
 		{
 			description: "type parameter",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Resource",
 			},
 			source: `package mypkg
@@ -1248,7 +1276,7 @@ func (stream *streamFunc[T]) Next() bool {
 			},
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 					DeclName:    "Resource",
 				}: ReferenceEntry{
 					SectionName: "Resource",
@@ -1269,10 +1297,12 @@ func (stream *streamFunc[T]) Next() bool {
 		{
 			description: "field type not declared in a loaded package",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Resource",
 			},
 			source: `package mypkg
+
+import "time"
 
 // Resource is a resource.
 type Resource struct {
@@ -1284,7 +1314,7 @@ type Resource struct {
 `,
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 					DeclName:    "Resource",
 				}: ReferenceEntry{
 					SectionName: "Resource",
@@ -1312,7 +1342,7 @@ expiry: # See description
 		{
 			description: "byte slice",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Metadata",
 			},
 			source: `
@@ -1330,7 +1360,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -1356,11 +1386,13 @@ private_key: BASE64_STRING
 		{
 			description: "named import in embedded struct field",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Server",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -1372,7 +1404,7 @@ type Server struct {
 `,
 			declSources: []string{`package types
 
-import alias "otherpkg"
+import alias "github.com/gravitational/teleport/src"
 
 // ServerSpecV1 includes aspects of a proxied server.
 type ServerSpecV1 struct {
@@ -1388,7 +1420,7 @@ type ServerSpec struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -1411,7 +1443,7 @@ spec: # [...]
 				},
 				PackageInfo{
 					DeclName:    "ServerSpecV1",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server Spec V1",
 					Description: "Includes aspects of a proxied server.",
@@ -1431,11 +1463,13 @@ spec: # [...]
 		{
 			description: "named import in named struct field",
 			declInfo: PackageInfo{
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 				DeclName:    "Server",
 			},
 			source: `
 package mypkg
+
+import types "github.com/gravitational/teleport/src"
 
 // Server includes information about a server registered with Teleport.
 type Server struct {
@@ -1444,7 +1478,7 @@ type Server struct {
 }
 `,
 			declSources: []string{`package types
-import alias "otherpkg"
+import alias "github.com/gravitational/teleport/src"
 
 // ServerSpecV1 includes aspects of a proxied server.
 type ServerSpecV1 struct {
@@ -1462,7 +1496,7 @@ type AddressInfo struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "AddressInfo",
-					PackageName: "otherpkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Address Info",
 					Description: "Provides information about an address.",
@@ -1478,7 +1512,7 @@ type AddressInfo struct {
 				},
 				PackageInfo{
 					DeclName:    "Server",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server",
 					Description: "Includes information about a server registered with Teleport.",
@@ -1494,7 +1528,7 @@ type AddressInfo struct {
 				},
 				PackageInfo{
 					DeclName:    "ServerSpecV1",
-					PackageName: "types",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Server Spec V1",
 					Description: "Includes aspects of a proxied server.",
@@ -1515,10 +1549,12 @@ type AddressInfo struct {
 			description: "scalar fields with two unexported fields",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
+
+import "protoimpl"
 
 // Metadata describes information about a dynamic resource. Every dynamic
 // resource in Teleport has a metadata object.
@@ -1535,7 +1571,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a dynamic resource. Every dynamic resource in Teleport has a metadata object.",
@@ -1562,7 +1598,7 @@ description: "string"
 			description: "curly braces in descriptions",
 			declInfo: PackageInfo{
 				DeclName:    "Metadata",
-				PackageName: "mypkg",
+				PackagePath: "github.com/gravitational/teleport/src",
 			},
 			source: `
 package mypkg
@@ -1577,7 +1613,7 @@ type Metadata struct {
 			expected: map[PackageInfo]ReferenceEntry{
 				PackageInfo{
 					DeclName:    "Metadata",
-					PackageName: "mypkg",
+					PackagePath: "github.com/gravitational/teleport/src",
 				}: {
 					SectionName: "Metadata",
 					Description: "Describes information about a `{dynamic resource}`. Every dynamic resource in Teleport has a metadata object.",
@@ -1622,17 +1658,26 @@ type Metadata struct {
 				}
 			}
 
-			sourceData, err := NewSourceData(tmp)
+			sourceData, err := NewSourceData("github.com/gravitational/teleport", tmp)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			di, ok := sourceData.TypeDecls[tc.declInfo]
-			if !ok {
-				t.Fatalf("expected data for %v.%v not found in the source", tc.declInfo.PackageName, tc.declInfo.DeclName)
+			// Remove the temporary directory from package paths
+			// since we can't know it in advance in test cases.
+			declsWithoutTmp := make(map[PackageInfo]DeclarationInfo)
+			for k, d := range sourceData.TypeDecls {
+				k.PackagePath = strings.ReplaceAll(k.PackagePath, filepath.Base(tmp)+"/", "")
+				d.PackageName = strings.ReplaceAll(k.PackagePath, filepath.Base(tmp)+"/", "")
+				declsWithoutTmp[k] = d
 			}
 
-			r, err := ReferenceDataFromDeclaration(di, sourceData.TypeDecls, camelCaseExceptions)
+			di, ok := declsWithoutTmp[tc.declInfo]
+			if !ok {
+				t.Fatalf("expected data for %v.%v not found in the source", tc.declInfo.PackagePath, tc.declInfo.DeclName)
+			}
+
+			r, err := ReferenceDataFromDeclaration("github.com/gravitational/teleport", di, declsWithoutTmp, camelCaseExceptions)
 			if tc.errorSubstring == "" {
 				assert.NoError(t, err)
 			} else {
@@ -1678,7 +1723,16 @@ import (
 import alias "my/multi/segment/package"
 `,
 			expected: map[string]string{
-				"alias": "package",
+				"alias": "my/multi/segment/package",
+			},
+		},
+		{
+			description: "no explicit name",
+			input: `package mypkg
+import "my/multi/segment/pkg"
+`,
+			expected: map[string]string{
+				"pkg": "my/multi/segment/pkg",
 			},
 		},
 	}
@@ -1737,7 +1791,7 @@ func TestMakeFieldTableInfo(t *testing.T) {
 						name: "LockingMode",
 						declarationInfo: PackageInfo{
 							DeclName:    "LockingMode",
-							PackageName: "mypkg",
+							PackagePath: "mypkg",
 						},
 					},
 					name:     "LockingMode",
@@ -2017,7 +2071,7 @@ my_string: "string"
 							name: "label",
 							declarationInfo: PackageInfo{
 								DeclName:    "label",
-								PackageName: "mypkg",
+								PackagePath: "mypkg",
 							},
 						},
 					},
@@ -2043,7 +2097,7 @@ my_string: "string"
 							name: "label",
 							declarationInfo: PackageInfo{
 								DeclName:    "label",
-								PackageName: "mypkg",
+								PackagePath: "mypkg",
 							},
 						},
 					},

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -601,6 +601,27 @@ http_proxy_settings: # [...]
 |suffix|Indicates the installation suffix for the teleport installation. Set this value if you want multiple installations of Teleport. See --install-suffix flag in teleport-update program. Note: only supported for Amazon EC2. Suffix name can only contain alphanumeric characters and hyphens.|string|
 |update_group|Indicates the update group for the teleport installation. This value is used to group installations in order to update them in batches. See --group flag in teleport-update program. Note: only supported for Amazon EC2. Group name can only contain alphanumeric characters and hyphens.|string|
 
+## Integration Discovered Summary
+
+Contains the a summary for each resource type that was discovered.
+
+
+Example:
+
+```yaml
+aws_ec2: # [...]
+aws_rds: # [...]
+aws_eks: # [...]
+azure_vms: # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|aws_ec2|AWSEC2 contains the summary for the AWS EC2 discovered instances.|[Resources Discovered Summary](#resources-discovered-summary)|
+|aws_eks|AWSEKS contains the summary for the AWS EKS discovered clusters.|[Resources Discovered Summary](#resources-discovered-summary)|
+|aws_rds|AWSRDS contains the summary for the AWS RDS discovered databases.|[Resources Discovered Summary](#resources-discovered-summary)|
+|azure_vms|The summary for the Azure VM discovered instances.|[Resources Discovered Summary](#resources-discovered-summary)|
+
 ## Join Method
 
 The method used for new nodes to join the cluster.
@@ -662,6 +683,25 @@ revision: "string"
 |name|An object name|string|
 |revision|An opaque identifier which tracks the versions of a resource over time. Clients should ignore and not alter its value but must return the revision in any updates of a resource.|string|
 
+## Resources Discovered Summary
+
+Represents the AWS resources that were discovered.
+
+
+Example:
+
+```yaml
+found: 1
+enrolled: 1
+failed: 1
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|enrolled|Holds the count of the resources that were successfully enrolled.|number|
+|failed|Holds the count of the resources that failed to enroll.|number|
+|found|Holds the count of resources found. After a resource is found, it starts the sync process and ends in either an enrolled or a failed resource.|number|
+
 ## Spec
 
 The specification for a discovery config.
@@ -712,16 +752,16 @@ error_message: "string"
 discovered_resources: 1
 last_sync_time: # See description
 integration_discovered_resources: 
-  "string": # See description
-  "string": # See description
-  "string": # See description
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
 ```
 
 |Field Name|Description|Type|
 |---|---|---|
 |discovered_resources|Holds the count of the discovered resources in the previous iteration.|number|
 |error_message|Holds the error message when state is DISCOVERY_CONFIG_STATE_ERROR.|string|
-|integration_discovered_resources|Maps an integration to a summary of resources that were found using that integration.|map[string]|
+|integration_discovered_resources|Maps an integration to a summary of resources that were found using that integration.|map[string][Integration Discovered Summary](#integration-discovered-summary)|
 |last_sync_time|The timestamp when the Discovery Config was last sync.||
 |state|The current state of the discovery config.|string|
 


### PR DESCRIPTION
The resource reference generator currently assembles a mapping of package names and declarations to declaration data. The assumption is that the name of each package is the same is the final segment in its package path.

If a source file contains a field type that is a selector expression with a package name, the generator fetches the corresponding type by looking up the package name from the mapping.

The downside of this approach is that Go package names do not need to correspond to their directory paths, so the logic the generator uses for looking up imported packages often fails.

This change edits the resource reference generator to use full import paths to assemble the mapping and look up field types.

- When gathering the imports in a file that declares a given type (the `NamedImports` function), if there is no explicit name for an import, map the final import path segment to the full path. Currently, the reference generator only registers a named import if it has a declared name. This way, we can always use this mapping to find a full package path for a given field type selector expression.
- Pass a package prefix to `Generate` so we can construct Go package paths from a given directory path.
- Edit the generator config to use full package paths.