### PR TITLE
[Web UI] Add Region MultiSelector component

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/regions.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/regions.ts
@@ -1,0 +1,88 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { awsRegionMap } from 'teleport/services/integrations';
+
+import { Region, RegionGroup, RegionId } from '../RegionMultiSelector/types';
+
+const regions: { name: string; regions: RegionId[] }[] = [
+  {
+    name: 'North America',
+    regions: [
+      'us-east-1',
+      'us-east-2',
+      'us-west-1',
+      'us-west-2',
+      'ca-central-1',
+    ],
+  },
+  {
+    name: 'South America',
+    regions: ['sa-east-1'],
+  },
+  {
+    name: 'Asia Pacific',
+    regions: [
+      'ap-east-1',
+      'ap-northeast-1',
+      'ap-northeast-2',
+      'ap-northeast-3',
+      'ap-south-1',
+      'ap-south-2',
+      'ap-southeast-1',
+      'ap-southeast-2',
+      'ap-southeast-3',
+      'ap-southeast-4',
+    ],
+  },
+  {
+    name: 'Europe',
+    regions: [
+      'eu-central-1',
+      'eu-central-2',
+      'eu-north-1',
+      'eu-south-1',
+      'eu-south-2',
+      'eu-west-1',
+      'eu-west-2',
+      'eu-west-3',
+    ],
+  },
+  {
+    name: 'Middle East',
+    regions: ['me-south-1', 'me-central-1', 'il-central-1'],
+  },
+  {
+    name: 'Africa',
+    regions: ['af-south-1'],
+  },
+];
+
+function createAwsRegionGroups(): readonly RegionGroup[] {
+  return regions.map(({ name, regions }) => ({
+    name,
+    regions: regions
+      .filter(id => id in awsRegionMap)
+      .map(id => ({
+        id,
+        name: awsRegionMap[id],
+      })) as Region[],
+  }));
+}
+
+export const awsRegionGroups = createAwsRegionGroups();

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.story.tsx
@@ -1,0 +1,50 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+
+import Validation from 'shared/components/Validation';
+import { requiredField } from 'shared/components/Validation/rules';
+
+import { Regions as AwsRegion } from 'teleport/services/integrations';
+
+import { awsRegionGroups } from '../Aws/regions';
+import { RegionMultiSelector } from './RegionMultiSelector';
+
+export default {
+  title: 'RegionMultiSelector',
+  component: RegionMultiSelector,
+};
+
+export const AWS = () => {
+  const [selectedRegions, setSelectedRegions] = useState<AwsRegion[]>([]);
+
+  return (
+    <Validation>
+      <RegionMultiSelector
+        regionGroups={awsRegionGroups}
+        selectedRegions={selectedRegions}
+        onChange={setSelectedRegions}
+        label="Select AWS regions"
+        placeholder="Select AWS regions..."
+        required={true}
+        rule={requiredField('At least one region is required')}
+      />
+    </Validation>
+  );
+};

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.tsx
@@ -1,0 +1,165 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { components, OptionProps, ValueContainerProps } from 'react-select';
+import styled from 'styled-components';
+
+import { Box, Flex, LabelInput, Text } from 'design';
+import { CheckboxInput } from 'design/Checkbox';
+import { LabelContent } from 'design/LabelInput/LabelInput';
+import { HelperTextLine } from 'shared/components/FieldInput/FieldInput';
+import Select, { Option } from 'shared/components/Select';
+import { useRule } from 'shared/components/Validation';
+import { Rule } from 'shared/components/Validation/rules';
+
+import { RegionGroup, RegionId } from './types';
+
+type RegionOption = Option<RegionId>;
+type RegionOptionGroup = {
+  label: string;
+  options: RegionOption[];
+};
+
+function MultiRegionValueContainer(
+  props: ValueContainerProps<RegionOption, true, RegionOptionGroup>
+) {
+  const { children, selectProps } = props;
+  const selectedCount = Array.isArray(selectProps.value)
+    ? selectProps.value.length
+    : 0;
+
+  return (
+    <components.ValueContainer {...props}>
+      {selectedCount > 0 && (
+        <Text fontSize={2} fontWeight="light" color="muted">
+          {`${selectedCount} region${selectedCount !== 1 ? 's' : ''} selected`}
+        </Text>
+      )}
+      {children}
+    </components.ValueContainer>
+  );
+}
+
+function OptionWithCheckbox(
+  props: OptionProps<RegionOption, true, RegionOptionGroup>
+) {
+  return (
+    <components.Option {...props}>
+      <Flex alignItems="center" gap={2}>
+        <CheckboxInput checked={props.isSelected} />
+        <span>{props.children}</span>
+      </Flex>
+    </components.Option>
+  );
+}
+
+function defaultRule(): Rule<RegionId[]> {
+  return () => () => ({ valid: true });
+}
+
+export interface RegionMultiSelectorProps {
+  regionGroups: readonly RegionGroup[];
+  selectedRegions: RegionId[];
+  onChange(regions: RegionId[]): void;
+  label?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  required?: boolean;
+  rule?: Rule<RegionId[]>;
+}
+
+export function RegionMultiSelector({
+  regionGroups,
+  selectedRegions,
+  onChange,
+  label = 'Select regions',
+  placeholder = 'Select regions...',
+  disabled = false,
+  required = false,
+  rule = defaultRule(),
+}: RegionMultiSelectorProps) {
+  const { valid, message } = useRule(rule(selectedRegions));
+
+  const groups: RegionOptionGroup[] = regionGroups.map(regionGroup => ({
+    label: regionGroup.name,
+    options: regionGroup.regions.map(region => ({
+      value: region.id,
+      label: region.name,
+    })),
+  }));
+
+  const selectedOptions: RegionOption[] = groups
+    .flatMap(group => group.options)
+    .filter(option => selectedRegions.includes(option.value));
+
+  const handleChange = (options: RegionOption[]) => {
+    const regions = options ? options.map(option => option.value) : [];
+    onChange(regions);
+  };
+
+  const hasError = !valid;
+
+  return (
+    <Container>
+      <LabelInput mb={0}>
+        <LabelContent required={required} mb={1}>
+          {label}
+        </LabelContent>
+        <StyledSelect
+          isMulti
+          options={groups}
+          value={selectedOptions}
+          onChange={handleChange}
+          placeholder={placeholder}
+          isDisabled={disabled}
+          isSearchable={false}
+          closeMenuOnSelect={false}
+          hideSelectedOptions={false}
+          size="large"
+          hasError={hasError}
+          components={{
+            Option: OptionWithCheckbox,
+            ValueContainer: MultiRegionValueContainer,
+            MultiValue: () => null,
+          }}
+        />
+      </LabelInput>
+      <HelperTextLine
+        hasError={hasError}
+        helperTextId="regions-error"
+        errorMessage={message}
+      />
+    </Container>
+  );
+}
+
+const Container = styled(Box)`
+  width: 400px;
+`;
+
+const StyledSelect = styled(Select)`
+  .react-select__group-heading {
+    font-size: ${p => p.theme.fontSizes[1]}px;
+    color: ${p => p.theme.colors.text.slightlyMuted};
+  }
+
+  .react-select__placeholder {
+    font-size: ${p => p.theme.fontSizes[2]}px;
+    color: ${p => p.theme.colors.text.slightlyMuted};
+  }
+`;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/index.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { RegionMultiSelector } from './RegionMultiSelector';
+export type { RegionMultiSelectorProps } from './RegionMultiSelector';

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/types.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Regions as AwsRegion } from 'teleport/services/integrations';
+
+export type RegionId = AwsRegion; // | AzureRegion | GcpRegion, etc
+
+export interface Region {
+  id: RegionId;
+  name: string;
+}
+
+export interface RegionGroup {
+  name: string;
+  regions: readonly Region[];
+}


### PR DESCRIPTION
Description
Issue: https://github.com/gravitational/teleport/issues/60813
Figma: https://www.figma.com/design/3JcCgPFtJqCG68GWmMXIfn/Root-Account-Discovery?node-id=1514-37582&t=c4F1TiiDP0LmzDya-0

Adds a region multiselector component based on the linked designs to be used in a follow up PR for the IaC discover flow

### Screenshot
<img width="459" height="428" alt="image" src="https://github.com/user-attachments/assets/5505d3fe-05c8-44c5-8958-d71445eeb23c" />
