### PR TITLE
docs: add checkpoints to internal web applications guide

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -816,6 +816,7 @@
     "notifempty",
     "notionhq",
     "nowait",
+    "nslookup",
     "ntauth",
     "nvme",
     "obtainlicense",

--- a/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
+++ b/docs/pages/enroll-resources/application-access/protect-apps/connecting-apps.mdx
@@ -157,6 +157,36 @@ Application Service:
 
 (!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
+<Checkpoint
+  title="Verify the Application Service is running"
+  description="Confirm that the Teleport Application Service has started and connected to your cluster."
+>
+  Here are some troubleshooting tips:
+
+  - Check the service status on the Application Service host:
+
+    ```code
+    $ systemctl status teleport
+    ```
+
+  - Review logs for connection errors:
+
+    ```code
+    $ sudo journalctl -u teleport
+    ```
+
+  - Verify the token hasn't expired (tokens are valid for 30 minutes by default).
+
+  - Ensure the Linux server can reach both the Teleport Proxy and the target application.
+
+  - Verify the application is registered in the cluster:
+
+    ```code
+    $ tctl apps ls
+    ```
+
+</Checkpoint>
+
 ## Step 2/2. Configure RBAC and access the application
 
 1. Create a role called `demo-app-access` that allows access to applications
@@ -191,6 +221,34 @@ Application Service:
 
 1. Sign in to the Teleport Web UI as `appuser`. You should see the option to
    visit the web application that you enrolled.
+
+<Checkpoint
+  title="Verify application access"
+  description="Confirm that you can access the web application through the Teleport Web UI."
+>
+  Here are some troubleshooting tips:
+
+  - Ensure the `appuser` account has the `demo-app-access` role assigned.
+
+  - If the application doesn't appear in the **Applications** tab, verify that the role's `app_labels` match the labels assigned to your application:
+
+    ```code
+    $ tctl get roles/demo-app-access
+    ```
+
+  - Review Application Service logs for connection errors:
+
+    ```code
+    $ sudo journalctl -u teleport
+    ```
+  
+  - Test connectivity to the target app from the Application Service host: 
+  
+    ```code
+    $ curl -v http://app.example.com:3000
+    ```
+  
+</Checkpoint>
 
 ## Advanced options
 


### PR DESCRIPTION
This PR adds interactive checkpoints to the
/docs/enroll-resources/application-access/protect-apps/connecting-apps/ with troubleshooting tips.