### PR TITLE
Add SSH client keyboard-interactive auth handler

### DIFF
--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -62,7 +62,7 @@ func KeyboardInteractive(ctx context.Context, p MFACeremonyPerformer, m ssh.Conn
 					answers = append(answers, answer)
 
 				default:
-					return nil, trace.Errorf("invalid or unsupported auth prompt type: %T", pr)
+					return nil, trace.BadParameter("invalid or unsupported auth prompt type: %T", pr)
 				}
 			}
 

--- a/lib/client/ssh/ssh.go
+++ b/lib/client/ssh/ssh.go
@@ -1,0 +1,98 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ssh
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
+)
+
+// MFACeremonyPerformer performs a session-bound MFA ceremony with the user and returns the solved challenge name.
+type MFACeremonyPerformer interface {
+	PerformSessionMFACeremony(ctx context.Context, sessionID []byte) (challengeName string, err error)
+}
+
+// KeyboardInteractive returns an ssh.AuthMethod that performs any additional verification requested by the server via
+// the keyboard-interactive authentication method. This method is intended to be used with the
+// x/crypto/ssh#ClientConfig.AuthCallback field as proposed in https://github.com/golang/go/issues/76146.
+func KeyboardInteractive(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) ssh.AuthMethod {
+	return ssh.KeyboardInteractive(
+		func(_ string, _ string, questions []string, _ []bool) ([]string, error) {
+			answers := make([]string, 0, len(questions))
+
+			// Handle each question from the server before returning all answers.
+			for _, question := range questions {
+				pr := &sshpb.AuthPrompt{}
+
+				if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(question), pr); err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				if pr.GetPrompt() == nil {
+					return nil, trace.BadParameter("received sshpb.AuthPrompt with nil Prompt field")
+				}
+
+				switch pr.GetPrompt().(type) {
+				case *sshpb.AuthPrompt_MfaPrompt:
+					answer, err := handleMFAPrompt(ctx, p, m)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+					answers = append(answers, answer)
+
+				default:
+					return nil, trace.Errorf("invalid or unsupported auth prompt type: %T", pr)
+				}
+			}
+
+			return answers, nil
+		},
+	)
+}
+
+// handleMFAPrompt returns an answer to a keyboard-interactive question requiring MFA by performing a session-bound MFA
+// ceremony with the user. The answer is a JSON-marshaled sshpb.MFAPromptResponse referencing the solved challenge.
+func handleMFAPrompt(ctx context.Context, p MFACeremonyPerformer, m ssh.ConnMetadata) (string, error) {
+	name, err := p.PerformSessionMFACeremony(ctx, m.SessionID())
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// Construct the response referencing the challenge solved by the user.
+	resp := &sshpb.MFAPromptResponse{
+		Response: &sshpb.MFAPromptResponse_Reference{
+			Reference: &sshpb.MFAPromptResponseReference{
+				ChallengeName: name,
+			},
+		},
+	}
+
+	// Marshal the response to JSON since the authentication method only supports UTF-8 strings.
+	answerBytes, err := protojson.Marshal(resp)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return string(answerBytes), nil
+}

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -55,8 +55,8 @@ func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.True(t, ok, "authMethod should be KeyboardInteractiveChallenge")
+	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.NoError(t, err)
@@ -89,8 +89,8 @@ func TestKeyboardInteractive_FailedMFA(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.True(t, ok, "authMethod should be KeyboardInteractiveChallenge")
+	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.ErrorContains(t, err, "a-wild-error-appeared!")
@@ -106,8 +106,8 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
 	require.NotNil(t, authMethod)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.True(t, ok)
+	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
 
 	answers, err := ki("", "", []string{"invalid-auth-prompt"}, []bool{})
 	require.ErrorContains(t, err, "invalid value invalid-auth-prompt")
@@ -129,8 +129,8 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
 	require.NoError(t, err)
 
 	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
-	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
-	require.True(t, ok)
+	ki := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.IsType(t, ssh.KeyboardInteractiveChallenge(nil), ki)
 
 	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
 	require.ErrorIs(t, err, trace.BadParameter("received sshpb.AuthPrompt with nil Prompt field"))

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -20,7 +20,6 @@ package ssh_test
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -29,13 +28,13 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
-	client_ssh "github.com/gravitational/teleport/lib/client/ssh"
+	clientssh "github.com/gravitational/teleport/lib/client/ssh"
 )
 
 func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
-	challengeName := "test-challenge-name"
+	const challengeName = "test-challenge-name"
 
-	authMethod := client_ssh.KeyboardInteractive(
+	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
 		&mockMFACeremonyPerformer{
 			challengeName: challengeName,
@@ -69,7 +68,7 @@ func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
 }
 
 func TestKeyboardInteractive_FailedMFA(t *testing.T) {
-	authMethod := client_ssh.KeyboardInteractive(
+	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
 		&mockMFACeremonyPerformer{
 			err: trace.Errorf("a-wild-error-appeared!"),
@@ -98,7 +97,7 @@ func TestKeyboardInteractive_FailedMFA(t *testing.T) {
 }
 
 func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
-	authMethod := client_ssh.KeyboardInteractive(
+	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
 		nil,
 		nil,
@@ -115,7 +114,7 @@ func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
 }
 
 func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
-	authMethod := client_ssh.KeyboardInteractive(
+	authMethod := clientssh.KeyboardInteractive(
 		t.Context(),
 		nil,
 		nil,
@@ -142,7 +141,7 @@ type mockMFACeremonyPerformer struct {
 	err           error
 }
 
-var _ client_ssh.MFACeremonyPerformer = (*mockMFACeremonyPerformer)(nil)
+var _ clientssh.MFACeremonyPerformer = (*mockMFACeremonyPerformer)(nil)
 
 func (m *mockMFACeremonyPerformer) PerformSessionMFACeremony(_ context.Context, _ []byte) (string, error) {
 	if m.err != nil {
@@ -153,14 +152,9 @@ func (m *mockMFACeremonyPerformer) PerformSessionMFACeremony(_ context.Context, 
 }
 
 type mockConnMetadata struct {
+	ssh.ConnMetadata
+
 	sessionID []byte
 }
 
-var _ ssh.ConnMetadata = (*mockConnMetadata)(nil)
-
-func (m *mockConnMetadata) User() string          { return "" }
-func (m *mockConnMetadata) SessionID() []byte     { return m.sessionID }
-func (m *mockConnMetadata) ClientVersion() []byte { return nil }
-func (m *mockConnMetadata) ServerVersion() []byte { return nil }
-func (m *mockConnMetadata) RemoteAddr() net.Addr  { return nil }
-func (m *mockConnMetadata) LocalAddr() net.Addr   { return nil }
+func (m *mockConnMetadata) SessionID() []byte { return m.sessionID }

--- a/lib/client/ssh/ssh_test.go
+++ b/lib/client/ssh/ssh_test.go
@@ -1,0 +1,166 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package ssh_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	sshpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/ssh/v1"
+	client_ssh "github.com/gravitational/teleport/lib/client/ssh"
+)
+
+func TestKeyboardInteractive_SuccessfulMFA(t *testing.T) {
+	challengeName := "test-challenge-name"
+
+	authMethod := client_ssh.KeyboardInteractive(
+		t.Context(),
+		&mockMFACeremonyPerformer{
+			challengeName: challengeName,
+		},
+		&mockConnMetadata{
+			sessionID: []byte("test-session-id"),
+		},
+	)
+	require.NotNil(t, authMethod)
+
+	mfaPrompt := &sshpb.AuthPrompt{
+		Prompt: &sshpb.AuthPrompt_MfaPrompt{
+			MfaPrompt: &sshpb.MFAPrompt{},
+		},
+	}
+	mfaPromptJSON, err := protojson.Marshal(mfaPrompt)
+	require.NoError(t, err)
+
+	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok, "authMethod should be KeyboardInteractiveChallenge")
+
+	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
+	require.NoError(t, err)
+	require.Len(t, answers, 1, "expected exactly 1 answer in response")
+
+	resp := &sshpb.MFAPromptResponse{}
+	err = (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal([]byte(answers[0]), resp)
+	require.NoError(t, err)
+	require.Equal(t, challengeName, resp.GetReference().GetChallengeName())
+}
+
+func TestKeyboardInteractive_FailedMFA(t *testing.T) {
+	authMethod := client_ssh.KeyboardInteractive(
+		t.Context(),
+		&mockMFACeremonyPerformer{
+			err: trace.Errorf("a-wild-error-appeared!"),
+		},
+		&mockConnMetadata{
+			sessionID: []byte("test-session-id"),
+		},
+	)
+	require.NotNil(t, authMethod)
+
+	mfaPrompt := &sshpb.AuthPrompt{
+		Prompt: &sshpb.AuthPrompt_MfaPrompt{
+			MfaPrompt: &sshpb.MFAPrompt{},
+		},
+	}
+	mfaPromptJSON, err := protojson.Marshal(mfaPrompt)
+	require.NoError(t, err)
+
+	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok, "authMethod should be KeyboardInteractiveChallenge")
+
+	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
+	require.ErrorContains(t, err, "a-wild-error-appeared!")
+	require.Nil(t, answers)
+}
+
+func TestKeyboardInteractive_InvalidAuthPrompt_NonProtoQuestion(t *testing.T) {
+	authMethod := client_ssh.KeyboardInteractive(
+		t.Context(),
+		nil,
+		nil,
+	)
+	require.NotNil(t, authMethod)
+
+	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
+
+	answers, err := ki("", "", []string{"invalid-auth-prompt"}, []bool{})
+	require.ErrorContains(t, err, "invalid value invalid-auth-prompt")
+	require.Nil(t, answers)
+}
+
+func TestKeyboardInteractive_InvalidAuthPrompt_NilPromptField(t *testing.T) {
+	authMethod := client_ssh.KeyboardInteractive(
+		t.Context(),
+		nil,
+		nil,
+	)
+	require.NotNil(t, authMethod)
+
+	mfaPrompt := &sshpb.AuthPrompt{
+		Prompt: nil,
+	}
+	mfaPromptJSON, err := protojson.Marshal(mfaPrompt)
+	require.NoError(t, err)
+
+	// Extract the KeyboardInteractiveChallenge function from the AuthMethod so it can be tested.
+	ki, ok := authMethod.(ssh.KeyboardInteractiveChallenge)
+	require.True(t, ok)
+
+	answers, err := ki("", "", []string{string(mfaPromptJSON)}, []bool{})
+	require.ErrorIs(t, err, trace.BadParameter("received sshpb.AuthPrompt with nil Prompt field"))
+	require.Nil(t, answers)
+}
+
+type mockMFACeremonyPerformer struct {
+	challengeName string
+	err           error
+}
+
+var _ client_ssh.MFACeremonyPerformer = (*mockMFACeremonyPerformer)(nil)
+
+func (m *mockMFACeremonyPerformer) PerformSessionMFACeremony(_ context.Context, _ []byte) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+
+	return m.challengeName, nil
+}
+
+type mockConnMetadata struct {
+	sessionID []byte
+}
+
+var _ ssh.ConnMetadata = (*mockConnMetadata)(nil)
+
+func (m *mockConnMetadata) User() string          { return "" }
+func (m *mockConnMetadata) SessionID() []byte     { return m.sessionID }
+func (m *mockConnMetadata) ClientVersion() []byte { return nil }
+func (m *mockConnMetadata) ServerVersion() []byte { return nil }
+func (m *mockConnMetadata) RemoteAddr() net.Addr  { return nil }
+func (m *mockConnMetadata) LocalAddr() net.Addr   { return nil }


### PR DESCRIPTION
Resolves [#61544](https://github.com/gravitational/teleport/issues/61544)

Implements the Teleport client library side of [RFD 0234's SSH Keyboard-Interactive Authentication](https://github.com/gravitational/teleport/blob/master/rfd/0234-in-band-mfa-ssh-sessions.md#ssh-keyboard-interactive-authentication). The web UI, `tsh`, and Teleport Connect clients will all use this keyboard-interactive auth method handler to implement in-band MFA for SSH.

In the future when the `x/crypto/ssh#ClientConfig.AuthCallback` field as proposed in https://github.com/golang/go/issues/76146 makes it into a [x/crypto/ssh](https://pkg.go.dev/golang.org/x/crypto/ssh) release, this will configure [TeleportClient](https://github.com/gravitational/teleport/blob/4204a34ffb7358a2717b2d514878a9c7b47802c4/lib/client/api.go#L1270) to solve the in-band MFA keyboard-interactive prompt during SSH connection establishment.
