### PR TITLE
tctl resources: convert relay_server to new handler format

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -50,24 +50,6 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
-// namedResourceCollection is an implementation of [resources.Collection] that
-// displays resources in a table as a list of names and nothing else.
-type namedResourceCollection []types.Resource
-
-// Resources implements [resources.Collection].
-func (c namedResourceCollection) Resources() []types.Resource {
-	return c
-}
-
-// WriteText implements [resources.Collection].
-func (c namedResourceCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Name"})
-	for _, override := range c {
-		t.AddRow([]string{override.GetName()})
-	}
-	return trace.Wrap(t.WriteTo(w))
-}
-
 func printMetadataLabels(labels map[string]string) string {
 	pairs := []string{}
 	for key, value := range labels {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -997,11 +997,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 		)
 	case types.KindHealthCheckConfig:
 		return trace.Wrap(rc.deleteHealthCheckConfig(ctx, client))
-	case types.KindRelayServer:
-		if err := client.DeleteRelayServer(ctx, rc.ref.Name); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("relay_server %+q has been deleted\n", rc.ref.Name)
 	case types.KindInferencePolicy:
 		return trace.Wrap(rc.deleteInferencePolicy(ctx, client))
 	default:
@@ -1524,22 +1519,6 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &scopedRoleAssignmentCollection{items: items}, nil
-	case types.KindRelayServer:
-		if rc.ref.Name != "" {
-			rs, err := client.GetRelayServer(ctx, rc.ref.Name)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			return namedResourceCollection{types.ProtoResource153ToLegacy(rs)}, nil
-		}
-		var c namedResourceCollection
-		for rs, err := range clientutils.Resources(ctx, client.ListRelayServers) {
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			c = append(c, types.ProtoResource153ToLegacy(rs))
-		}
-		return c, nil
 	case types.KindInferencePolicy:
 		policies, err := rc.getInferencePolicies(ctx, client)
 		return policies, trace.Wrap(err)

--- a/tool/tctl/common/resources/relay_server.go
+++ b/tool/tctl/common/resources/relay_server.go
@@ -1,0 +1,95 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type relayServerCollection struct {
+	relayServers []*presencev1.RelayServer
+}
+
+func (c *relayServerCollection) Resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.relayServers))
+	for _, resource := range c.relayServers {
+		r = append(r, types.ProtoResource153ToLegacy(resource))
+	}
+	return r
+}
+
+func (c *relayServerCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name", "Hostname", "Relay Group", "Peer Address"})
+	for _, relay := range c.relayServers {
+		t.AddRow([]string{
+			relay.GetMetadata().GetName(),
+			relay.GetSpec().GetHostname(),
+			relay.GetSpec().GetRelayGroup(),
+			relay.GetSpec().GetPeerAddr(),
+		})
+	}
+	return trace.Wrap(t.WriteTo(w))
+}
+
+func relayServerHandler() Handler {
+	return Handler{
+		getHandler:    getRelayServer,
+		deleteHandler: deleteRelayServer,
+		singleton:     false,
+		mfaRequired:   false,
+		description:   "A lightweight proxy that routes connections from clients to resources without the need for the connection to go through the broader control plane",
+	}
+}
+
+func getRelayServer(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		rs, err := client.GetRelayServer(ctx, ref.Name)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &relayServerCollection{relayServers: []*presencev1.RelayServer{rs}}, nil
+	}
+
+	resources, err := stream.Collect(
+		clientutils.Resources(ctx, client.ListRelayServers),
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &relayServerCollection{relayServers: resources}, nil
+}
+
+func deleteRelayServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.DeleteRelayServer(ctx, ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("relay_server %+q has been deleted\n", ref.Name)
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -66,6 +66,7 @@ func Handlers() map[string]Handler {
 		types.KindNode:                               serverHandler(),
 		types.KindOIDCConnector:                      oidcConnectorHandler(),
 		types.KindProxy:                              proxyHandler(),
+		types.KindRelayServer:                        relayServerHandler(),
 		types.KindRole:                               roleHandler(),
 		types.KindSAMLConnector:                      samlConnectorHandler(),
 		types.KindSAMLIdPServiceProvider:             samlIdPServiceProviderHandler(),


### PR DESCRIPTION
Updates #60370

### Manual Testing

1. Start `./build/teleport` with `relay_service` enabled, ex:
```yaml
...
relay_service:
  enabled: true
  relay_group: myrelaygroup
  target_connection_count: 2
  public_hostnames:
    - myrelaygroup.example.com
  transport_listen_addr: 0.0.0.0:3040
  peer_listen_addr: 0.0.0.0:3041
  tunnel_listen_addr: 0.0.0.0:3042
...
```
2. Run
```bash
> ./build/tctl get relay_server

kind: relay_server
metadata:
  expires: "2026-01-08T14:14:37.399884757Z"
  name: 0149c19f-657b-415f-abb5-9dd7241a595f
  revision: 2193fbcb-9682-4a85-a4f3-b565b8eaebb6
spec:
  hostname: my-machine.localdomain
  nonce: 55ba76bd-b0fd-40d9-a3ae-7f6d60fd8976
  peer_addr: 192.168.1.7:3041
  relay_group: myrelaygroup
version: v1
```