### PR TITLE
[v18] tctl: Add support for rm okta_assignment

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -2219,6 +2219,11 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Okta import rule %q has been deleted\n", rc.ref.Name)
+	case types.KindOktaAssignment:
+		if err := client.OktaClient().DeleteOktaAssignment(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Okta assignment %q has been deleted\n", rc.ref.Name)
 	case types.KindUserGroup:
 		if err := client.DeleteUserGroup(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
Backport #62391 to branch/v18

changelog: Added `tctl` support for removing `okta_assingment` internal resource should it be needed.