### PR TITLE
[v18][18.6.2] bump cloud docs version (#62551)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "18.2.8",
+      "version": "18.6.2",
       "major_version": "18",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Manually backport #62551 to branch/v18 due to merge conflicts