### PR TITLE
[v18] [buddy] tbot: Support templating annotations in `kubernetes/argo-cd` output

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -148,7 +148,16 @@ If the label value is empty, the label will not be added to the secret.
 | `object` | `{}` |
 
 `argocd.secretAnnotations` provides a set of annotations that will
-be applied to cluster secrets.
+be applied to cluster secrets. Annotation values can be Go template strings
+(rendered by tbot, not Helm) with the following variables:
+
+  - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+    resource that can be indexed using `\{\{index .Labels "key"\}\}`
+
+If the annotation value is empty, the annotation will not be added to the
+secret.
 
 ### `argocd.project`
 

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -509,6 +509,15 @@ secret_labels:
 #   - "teleport.dev/updated"                 - RFC3339-formatted timestamp
 #   - "teleport.dev/tbot-version"            - Version of tbot running
 #   - "teleport.dev/teleport-cluster-name"   - Name of the Teleport cluster
+#
+# Annotation values can be Go template strings with the following variables:
+#
+#   - {{.ClusterName}} - Name of the Teleport cluster
+#   - {{.KubeName}} - Name of the Kubernetes cluster resource
+#   - {{.Labels}} - Map of labels applied to the Kubernetes cluster
+# 	   resource that can be indexed using `{{index .Labels "key"}}`
+#
+# If the annotation value is empty, the annotation will not be added to the secret
 secret_annotations:
   creator: bob
 

--- a/examples/chart/tbot/.lint/argocd.yaml
+++ b/examples/chart/tbot/.lint/argocd.yaml
@@ -16,6 +16,8 @@ argocd:
       {{index .Labels "region"}}
   secretAnnotations:
     chunky: bacon
+    cluster-region: |-
+      {{index .Labels "region"}}
   project: my-argo-project
   namespaces:
     - dev

--- a/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
@@ -42,6 +42,7 @@ should match the snapshot (argocd):
           project: my-argo-project
           secret_annotations:
             chunky: bacon
+            cluster-region: '{{index .Labels "region"}}'
           secret_labels:
             baz: qux
             cluster-region: '{{index .Labels "region"}}'

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -81,7 +81,16 @@ argocd:
   # If the label value is empty, the label will not be added to the secret.
   secretLabels: {}
   # argocd.secretAnnotations(object) -- provides a set of annotations that will
-  # be applied to cluster secrets.
+  # be applied to cluster secrets. Annotation values can be Go template strings
+  # (rendered by tbot, not Helm) with the following variables:
+  #
+  #   - \{\{.ClusterName\}\} - Name of the Teleport cluster
+  #   - \{\{.KubeName\}\} - Name of the Kubernetes cluster resource
+  #   - \{\{.Labels\}\} - Map of labels applied to the Kubernetes cluster
+  #     resource that can be indexed using `\{\{index .Labels "key"\}\}`
+  #
+  # If the annotation value is empty, the annotation will not be added to the
+  # secret.
   secretAnnotations: {}
   # argocd.project(string) -- sets the Argo CD project with which the Kubernetes
   # clusters will be associated.

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -344,7 +344,14 @@ func (s *ArgoCDOutput) renderSecret(cluster *argoClusterCredentials) (*corev1.Se
 	}
 	for k, v := range s.cfg.SecretAnnotations {
 		// Do not overwrite any of "our" annotations.
-		if _, ok := annotations[k]; !ok {
+		if _, ok := annotations[k]; ok {
+			continue
+		}
+		v, err := renderTemplate(v, cluster)
+		if err != nil {
+			return nil, trace.Wrap(err, "templating secret annotation %q", k)
+		}
+		if v != "" {
 			annotations[k] = v
 		}
 	}

--- a/lib/tbot/services/k8s/argocd_output_test.go
+++ b/lib/tbot/services/k8s/argocd_output_test.go
@@ -84,7 +84,7 @@ func TestArgoCDOutput_EndToEnd(t *testing.T) {
 		kubeCluster, err := types.NewKubernetesClusterV3(
 			types.Metadata{
 				Name:   name,
-				Labels: map[string]string{"department": "engineering"},
+				Labels: map[string]string{"department": "engineering", "url": "https://fake.org"},
 			},
 			types.KubernetesClusterSpecV3{},
 		)
@@ -125,7 +125,9 @@ func TestArgoCDOutput_EndToEnd(t *testing.T) {
 				"non-existent":       `{{ index .Labels "non-existent" }}`,
 			},
 			SecretAnnotations: map[string]string{
-				"managed-by": "ninjas",
+				"managed-by":   "ninjas",
+				"cluster-url":  `{{ index .Labels "url" }}`,
+				"non-existent": `{{ index .Labels "non-existent" }}`,
 			},
 			Selectors: []*KubernetesSelector{
 				{Labels: map[string]string{"department": "engineering"}},
@@ -222,6 +224,7 @@ func TestArgoCDOutput_EndToEnd(t *testing.T) {
 		"teleport.dev/tbot-version":            teleport.Version,
 		"teleport.dev/teleport-cluster-name":   "root",
 		"managed-by":                           "ninjas",
+		"cluster-url":                          "https://fake.org",
 	}
 	for k, v := range expectedAnnotations {
 		require.Equal(t, v, secret.Annotations[k])


### PR DESCRIPTION
Backport #62668 to branch/v18

changelog: MWI: Add support for templating secret annotations in the tbot's `kubernetes/argo-cd` service
