### PR TITLE
Add EqualAppServers

### DIFF
--- a/api/types/appserveropts/app_server_opts.go
+++ b/api/types/appserveropts/app_server_opts.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package appserveropts
+
+type EqualOptions struct {
+	SkipClone    bool
+	IgnoreHostID bool
+}
+
+func NewEqual(opts []EqualOpt) EqualOptions {
+	opt := EqualOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+type EqualOpt func(*EqualOptions)
+
+// WithSkipClone configures EqualAppServers to skip cloning and directly mutate the input app
+// servers if necessary. Use this option only when you're certain the input app servers can be
+// safely modified (e.g., they're already clones or will be discarded after comparison).
+func WithSkipClone(skipClone bool) EqualOpt {
+	return func(c *EqualOptions) {
+		c.SkipClone = skipClone
+	}
+}
+
+// WithIgnoreHostID when set to true forces to ignore differences in Spec.HostID while checking
+// AppServer equality.
+//
+// NOTE: When specified the app servers passed to the EqualAppServers will be cloned. To avoid that
+// [WithSkipClone] can be passed.
+func WithIgnoreHostID(ignoreHostID bool) EqualOpt {
+	return func(o *EqualOptions) {
+		o.IgnoreHostID = ignoreHostID
+	}
+}

--- a/api/types/derived.gen.go
+++ b/api/types/derived.gen.go
@@ -4,6 +4,7 @@ package types
 
 import (
 	"bytes"
+	componentfeaturesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/componentfeatures/v1"
 )
 
 // deriveTeleportEqualAccessReviewThreshold returns whether this and that are equal.
@@ -27,26 +28,38 @@ func deriveTeleportEqualAppV3(this, that *AppV3) bool {
 			deriveTeleportEqual(&this.Spec, &that.Spec)
 }
 
+// deriveTeleportEqualAppServer returns whether this and that are equal.
+func deriveTeleportEqualAppServer(this, that *AppServerV3) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Kind == that.Kind &&
+			this.SubKind == that.SubKind &&
+			this.Version == that.Version &&
+			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata) &&
+			deriveTeleportEqual_(&this.Spec, &that.Spec) &&
+			this.Scope == that.Scope
+}
+
 // deriveTeleportEqualAWS returns whether this and that are equal.
 func deriveTeleportEqualAWS(this, that *AWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Region == that.Region &&
-			deriveTeleportEqual_(&this.Redshift, &that.Redshift) &&
-			deriveTeleportEqual_1(&this.RDS, &that.RDS) &&
+			deriveTeleportEqual_1(&this.Redshift, &that.Redshift) &&
+			deriveTeleportEqual_2(&this.RDS, &that.RDS) &&
 			this.AccountID == that.AccountID &&
-			deriveTeleportEqual_2(&this.ElastiCache, &that.ElastiCache) &&
-			deriveTeleportEqual_3(&this.SecretStore, &that.SecretStore) &&
-			deriveTeleportEqual_4(&this.MemoryDB, &that.MemoryDB) &&
-			deriveTeleportEqual_5(&this.RDSProxy, &that.RDSProxy) &&
-			deriveTeleportEqual_6(&this.RedshiftServerless, &that.RedshiftServerless) &&
+			deriveTeleportEqual_3(&this.ElastiCache, &that.ElastiCache) &&
+			deriveTeleportEqual_4(&this.SecretStore, &that.SecretStore) &&
+			deriveTeleportEqual_5(&this.MemoryDB, &that.MemoryDB) &&
+			deriveTeleportEqual_6(&this.RDSProxy, &that.RDSProxy) &&
+			deriveTeleportEqual_7(&this.RedshiftServerless, &that.RedshiftServerless) &&
 			this.ExternalID == that.ExternalID &&
 			this.AssumeRoleARN == that.AssumeRoleARN &&
-			deriveTeleportEqual_7(&this.OpenSearch, &that.OpenSearch) &&
+			deriveTeleportEqual_8(&this.OpenSearch, &that.OpenSearch) &&
 			this.IAMPolicyStatus == that.IAMPolicyStatus &&
-			deriveTeleportEqual_8(this.SessionTags, that.SessionTags) &&
-			deriveTeleportEqual_9(&this.DocumentDB, &that.DocumentDB) &&
-			deriveTeleportEqual_10(&this.ElastiCacheServerless, &that.ElastiCacheServerless)
+			deriveTeleportEqual_9(this.SessionTags, that.SessionTags) &&
+			deriveTeleportEqual_10(&this.DocumentDB, &that.DocumentDB) &&
+			deriveTeleportEqual_11(&this.ElastiCacheServerless, &that.ElastiCacheServerless)
 }
 
 // deriveTeleportEqualGCPCloudSQL returns whether this and that are equal.
@@ -72,7 +85,7 @@ func deriveTeleportEqualAzure(this, that *Azure) bool {
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.ResourceID == that.ResourceID &&
-			deriveTeleportEqual_11(&this.Redis, &that.Redis) &&
+			deriveTeleportEqual_12(&this.Redis, &that.Redis) &&
 			this.IsFlexiServer == that.IsFlexiServer
 }
 
@@ -84,7 +97,7 @@ func deriveTeleportEqualDatabaseV3(this, that *DatabaseV3) bool {
 			this.SubKind == that.SubKind &&
 			this.Version == that.Version &&
 			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata) &&
-			deriveTeleportEqual_12(&this.Spec, &that.Spec)
+			deriveTeleportEqual_13(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqualDynamicWindowsDesktopV1 returns whether this and that are equal.
@@ -92,7 +105,7 @@ func deriveTeleportEqualDynamicWindowsDesktopV1(this, that *DynamicWindowsDeskto
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqualResourceHeader(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_13(&this.Spec, &that.Spec)
+			deriveTeleportEqual_14(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqualWindowsDesktopV3 returns whether this and that are equal.
@@ -100,7 +113,7 @@ func deriveTeleportEqualWindowsDesktopV3(this, that *WindowsDesktopV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqualResourceHeader(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_14(&this.Spec, &that.Spec)
+			deriveTeleportEqual_15(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqualKubeAzure returns whether this and that are equal.
@@ -139,14 +152,14 @@ func deriveTeleportEqualKubernetesClusterV3(this, that *KubernetesClusterV3) boo
 			this.SubKind == that.SubKind &&
 			this.Version == that.Version &&
 			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata) &&
-			deriveTeleportEqual_15(&this.Spec, &that.Spec)
+			deriveTeleportEqual_16(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqualKubernetesClusterStatus returns whether this and that are equal.
 func deriveTeleportEqualKubernetesClusterStatus(this, that *KubernetesClusterStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_16(this.Discovery, that.Discovery)
+			deriveTeleportEqual_17(this.Discovery, that.Discovery)
 }
 
 // deriveTeleportEqualKubernetesServerV3 returns whether this and that are equal.
@@ -157,7 +170,7 @@ func deriveTeleportEqualKubernetesServerV3(this, that *KubernetesServerV3) bool 
 			this.SubKind == that.SubKind &&
 			this.Version == that.Version &&
 			deriveTeleportEqualMetadata(&this.Metadata, &that.Metadata) &&
-			deriveTeleportEqual_17(&this.Spec, &that.Spec) &&
+			deriveTeleportEqual_18(&this.Spec, &that.Spec) &&
 			this.Scope == that.Scope
 }
 
@@ -166,7 +179,7 @@ func deriveTeleportEqualAWSOrganizationMatcher(this, that *AWSOrganizationMatche
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.OrganizationID == that.OrganizationID &&
-			deriveTeleportEqual_18(this.OrganizationalUnits, that.OrganizationalUnits)
+			deriveTeleportEqual_19(this.OrganizationalUnits, that.OrganizationalUnits)
 }
 
 // deriveTeleportEqualOktaAssignmentV1 returns whether this and that are equal.
@@ -174,7 +187,7 @@ func deriveTeleportEqualOktaAssignmentV1(this, that *OktaAssignmentV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqualResourceHeader(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_19(&this.Spec, &that.Spec)
+			deriveTeleportEqual_20(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqualResourceHeader returns whether this and that are equal.
@@ -194,7 +207,7 @@ func deriveTeleportEqualMetadata(this, that *Metadata) bool {
 			this.Name == that.Name &&
 			this.Namespace == that.Namespace &&
 			this.Description == that.Description &&
-			deriveTeleportEqual_8(this.Labels, that.Labels) &&
+			deriveTeleportEqual_9(this.Labels, that.Labels) &&
 			((this.Expires == nil && that.Expires == nil) || (this.Expires != nil && that.Expires != nil && (*(this.Expires)).Equal(*(that.Expires))))
 }
 
@@ -203,7 +216,7 @@ func deriveTeleportEqualUserGroupV1(this, that *UserGroupV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			deriveTeleportEqualResourceHeader(&this.ResourceHeader, &that.ResourceHeader) &&
-			deriveTeleportEqual_20(&this.Spec, &that.Spec)
+			deriveTeleportEqual_21(&this.Spec, &that.Spec)
 }
 
 // deriveTeleportEqual returns whether this and that are equal.
@@ -212,61 +225,76 @@ func deriveTeleportEqual(this, that *AppSpecV3) bool {
 		this != nil && that != nil &&
 			this.URI == that.URI &&
 			this.PublicAddr == that.PublicAddr &&
-			deriveTeleportEqual_21(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_22(this.DynamicLabels, that.DynamicLabels) &&
 			this.InsecureSkipVerify == that.InsecureSkipVerify &&
-			deriveTeleportEqual_22(this.Rewrite, that.Rewrite) &&
-			deriveTeleportEqual_23(this.AWS, that.AWS) &&
+			deriveTeleportEqual_23(this.Rewrite, that.Rewrite) &&
+			deriveTeleportEqual_24(this.AWS, that.AWS) &&
 			this.Cloud == that.Cloud &&
-			deriveTeleportEqual_24(this.UserGroups, that.UserGroups) &&
+			deriveTeleportEqual_25(this.UserGroups, that.UserGroups) &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_24(this.RequiredAppNames, that.RequiredAppNames) &&
-			deriveTeleportEqual_25(this.CORS, that.CORS) &&
-			deriveTeleportEqual_26(this.IdentityCenter, that.IdentityCenter) &&
-			deriveTeleportEqual_27(this.TCPPorts, that.TCPPorts) &&
+			deriveTeleportEqual_25(this.RequiredAppNames, that.RequiredAppNames) &&
+			deriveTeleportEqual_26(this.CORS, that.CORS) &&
+			deriveTeleportEqual_27(this.IdentityCenter, that.IdentityCenter) &&
+			deriveTeleportEqual_28(this.TCPPorts, that.TCPPorts) &&
 			this.UseAnyProxyPublicAddr == that.UseAnyProxyPublicAddr &&
-			deriveTeleportEqual_28(this.MCP, that.MCP)
+			deriveTeleportEqual_29(this.MCP, that.MCP)
 }
 
 // deriveTeleportEqual_ returns whether this and that are equal.
-func deriveTeleportEqual_(this, that *Redshift) bool {
+func deriveTeleportEqual_(this, that *AppServerSpecV3) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.Version == that.Version &&
+			this.Hostname == that.Hostname &&
+			this.HostID == that.HostID &&
+			deriveTeleportEqual_30(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqualAppV3(this.App, that.App) &&
+			deriveTeleportEqual_25(this.ProxyIDs, that.ProxyIDs) &&
+			this.RelayGroup == that.RelayGroup &&
+			deriveTeleportEqual_25(this.RelayIds, that.RelayIds) &&
+			deriveTeleportEqual_31(this.ComponentFeatures, that.ComponentFeatures)
+}
+
+// deriveTeleportEqual_1 returns whether this and that are equal.
+func deriveTeleportEqual_1(this, that *Redshift) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ClusterID == that.ClusterID
 }
 
-// deriveTeleportEqual_1 returns whether this and that are equal.
-func deriveTeleportEqual_1(this, that *RDS) bool {
+// deriveTeleportEqual_2 returns whether this and that are equal.
+func deriveTeleportEqual_2(this, that *RDS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.InstanceID == that.InstanceID &&
 			this.ClusterID == that.ClusterID &&
 			this.ResourceID == that.ResourceID &&
 			this.IAMAuth == that.IAMAuth &&
-			deriveTeleportEqual_24(this.Subnets, that.Subnets) &&
+			deriveTeleportEqual_25(this.Subnets, that.Subnets) &&
 			this.VPCID == that.VPCID &&
-			deriveTeleportEqual_24(this.SecurityGroups, that.SecurityGroups)
+			deriveTeleportEqual_25(this.SecurityGroups, that.SecurityGroups)
 }
 
-// deriveTeleportEqual_2 returns whether this and that are equal.
-func deriveTeleportEqual_2(this, that *ElastiCache) bool {
+// deriveTeleportEqual_3 returns whether this and that are equal.
+func deriveTeleportEqual_3(this, that *ElastiCache) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ReplicationGroupID == that.ReplicationGroupID &&
-			deriveTeleportEqual_24(this.UserGroupIDs, that.UserGroupIDs) &&
+			deriveTeleportEqual_25(this.UserGroupIDs, that.UserGroupIDs) &&
 			this.TransitEncryptionEnabled == that.TransitEncryptionEnabled &&
 			this.EndpointType == that.EndpointType
 }
 
-// deriveTeleportEqual_3 returns whether this and that are equal.
-func deriveTeleportEqual_3(this, that *SecretStore) bool {
+// deriveTeleportEqual_4 returns whether this and that are equal.
+func deriveTeleportEqual_4(this, that *SecretStore) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.KeyPrefix == that.KeyPrefix &&
 			this.KMSKeyID == that.KMSKeyID
 }
 
-// deriveTeleportEqual_4 returns whether this and that are equal.
-func deriveTeleportEqual_4(this, that *MemoryDB) bool {
+// deriveTeleportEqual_5 returns whether this and that are equal.
+func deriveTeleportEqual_5(this, that *MemoryDB) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ClusterName == that.ClusterName &&
@@ -275,8 +303,8 @@ func deriveTeleportEqual_4(this, that *MemoryDB) bool {
 			this.EndpointType == that.EndpointType
 }
 
-// deriveTeleportEqual_5 returns whether this and that are equal.
-func deriveTeleportEqual_5(this, that *RDSProxy) bool {
+// deriveTeleportEqual_6 returns whether this and that are equal.
+func deriveTeleportEqual_6(this, that *RDSProxy) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
@@ -284,8 +312,8 @@ func deriveTeleportEqual_5(this, that *RDSProxy) bool {
 			this.ResourceID == that.ResourceID
 }
 
-// deriveTeleportEqual_6 returns whether this and that are equal.
-func deriveTeleportEqual_6(this, that *RedshiftServerless) bool {
+// deriveTeleportEqual_7 returns whether this and that are equal.
+func deriveTeleportEqual_7(this, that *RedshiftServerless) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.WorkgroupName == that.WorkgroupName &&
@@ -293,8 +321,8 @@ func deriveTeleportEqual_6(this, that *RedshiftServerless) bool {
 			this.WorkgroupID == that.WorkgroupID
 }
 
-// deriveTeleportEqual_7 returns whether this and that are equal.
-func deriveTeleportEqual_7(this, that *OpenSearch) bool {
+// deriveTeleportEqual_8 returns whether this and that are equal.
+func deriveTeleportEqual_8(this, that *OpenSearch) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.DomainName == that.DomainName &&
@@ -302,8 +330,8 @@ func deriveTeleportEqual_7(this, that *OpenSearch) bool {
 			this.EndpointType == that.EndpointType
 }
 
-// deriveTeleportEqual_8 returns whether this and that are equal.
-func deriveTeleportEqual_8(this, that map[string]string) bool {
+// deriveTeleportEqual_9 returns whether this and that are equal.
+func deriveTeleportEqual_9(this, that map[string]string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -322,8 +350,8 @@ func deriveTeleportEqual_8(this, that map[string]string) bool {
 	return true
 }
 
-// deriveTeleportEqual_9 returns whether this and that are equal.
-func deriveTeleportEqual_9(this, that *DocumentDB) bool {
+// deriveTeleportEqual_10 returns whether this and that are equal.
+func deriveTeleportEqual_10(this, that *DocumentDB) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ClusterID == that.ClusterID &&
@@ -331,121 +359,121 @@ func deriveTeleportEqual_9(this, that *DocumentDB) bool {
 			this.EndpointType == that.EndpointType
 }
 
-// deriveTeleportEqual_10 returns whether this and that are equal.
-func deriveTeleportEqual_10(this, that *ElastiCacheServerless) bool {
+// deriveTeleportEqual_11 returns whether this and that are equal.
+func deriveTeleportEqual_11(this, that *ElastiCacheServerless) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.CacheName == that.CacheName
 }
 
-// deriveTeleportEqual_11 returns whether this and that are equal.
-func deriveTeleportEqual_11(this, that *AzureRedis) bool {
+// deriveTeleportEqual_12 returns whether this and that are equal.
+func deriveTeleportEqual_12(this, that *AzureRedis) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ClusteringPolicy == that.ClusteringPolicy
 }
 
-// deriveTeleportEqual_12 returns whether this and that are equal.
-func deriveTeleportEqual_12(this, that *DatabaseSpecV3) bool {
+// deriveTeleportEqual_13 returns whether this and that are equal.
+func deriveTeleportEqual_13(this, that *DatabaseSpecV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Protocol == that.Protocol &&
 			this.URI == that.URI &&
 			this.CACert == that.CACert &&
-			deriveTeleportEqual_21(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_22(this.DynamicLabels, that.DynamicLabels) &&
 			deriveTeleportEqualAWS(&this.AWS, &that.AWS) &&
 			deriveTeleportEqualGCPCloudSQL(&this.GCP, &that.GCP) &&
 			deriveTeleportEqualAzure(&this.Azure, &that.Azure) &&
-			deriveTeleportEqual_29(&this.TLS, &that.TLS) &&
-			deriveTeleportEqual_30(&this.AD, &that.AD) &&
-			deriveTeleportEqual_31(&this.MySQL, &that.MySQL) &&
-			deriveTeleportEqual_32(this.AdminUser, that.AdminUser) &&
-			deriveTeleportEqual_33(&this.MongoAtlas, &that.MongoAtlas) &&
-			deriveTeleportEqual_34(&this.Oracle, &that.Oracle)
+			deriveTeleportEqual_32(&this.TLS, &that.TLS) &&
+			deriveTeleportEqual_33(&this.AD, &that.AD) &&
+			deriveTeleportEqual_34(&this.MySQL, &that.MySQL) &&
+			deriveTeleportEqual_35(this.AdminUser, that.AdminUser) &&
+			deriveTeleportEqual_36(&this.MongoAtlas, &that.MongoAtlas) &&
+			deriveTeleportEqual_37(&this.Oracle, &that.Oracle)
 }
 
-// deriveTeleportEqual_13 returns whether this and that are equal.
-func deriveTeleportEqual_13(this, that *DynamicWindowsDesktopSpecV1) bool {
+// deriveTeleportEqual_14 returns whether this and that are equal.
+func deriveTeleportEqual_14(this, that *DynamicWindowsDesktopSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Addr == that.Addr &&
 			this.Domain == that.Domain &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_35(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_38(this.ScreenSize, that.ScreenSize)
 }
 
-// deriveTeleportEqual_14 returns whether this and that are equal.
-func deriveTeleportEqual_14(this, that *WindowsDesktopSpecV3) bool {
+// deriveTeleportEqual_15 returns whether this and that are equal.
+func deriveTeleportEqual_15(this, that *WindowsDesktopSpecV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Addr == that.Addr &&
 			this.Domain == that.Domain &&
 			this.HostID == that.HostID &&
 			this.NonAD == that.NonAD &&
-			deriveTeleportEqual_35(this.ScreenSize, that.ScreenSize)
+			deriveTeleportEqual_38(this.ScreenSize, that.ScreenSize)
 }
 
-// deriveTeleportEqual_15 returns whether this and that are equal.
-func deriveTeleportEqual_15(this, that *KubernetesClusterSpecV3) bool {
+// deriveTeleportEqual_16 returns whether this and that are equal.
+func deriveTeleportEqual_16(this, that *KubernetesClusterSpecV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_21(this.DynamicLabels, that.DynamicLabels) &&
+			deriveTeleportEqual_22(this.DynamicLabels, that.DynamicLabels) &&
 			bytes.Equal(this.Kubeconfig, that.Kubeconfig) &&
 			deriveTeleportEqualKubeAzure(&this.Azure, &that.Azure) &&
 			deriveTeleportEqualKubeAWS(&this.AWS, &that.AWS) &&
 			deriveTeleportEqualKubeGCP(&this.GCP, &that.GCP)
 }
 
-// deriveTeleportEqual_16 returns whether this and that are equal.
-func deriveTeleportEqual_16(this, that *KubernetesClusterDiscoveryStatus) bool {
+// deriveTeleportEqual_17 returns whether this and that are equal.
+func deriveTeleportEqual_17(this, that *KubernetesClusterDiscoveryStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_36(this.Aws, that.Aws)
+			deriveTeleportEqual_39(this.Aws, that.Aws)
 }
 
-// deriveTeleportEqual_17 returns whether this and that are equal.
-func deriveTeleportEqual_17(this, that *KubernetesServerSpecV3) bool {
+// deriveTeleportEqual_18 returns whether this and that are equal.
+func deriveTeleportEqual_18(this, that *KubernetesServerSpecV3) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Version == that.Version &&
 			this.Hostname == that.Hostname &&
 			this.HostID == that.HostID &&
-			deriveTeleportEqual_37(&this.Rotation, &that.Rotation) &&
+			deriveTeleportEqual_30(&this.Rotation, &that.Rotation) &&
 			deriveTeleportEqualKubernetesClusterV3(this.Cluster, that.Cluster) &&
-			deriveTeleportEqual_24(this.ProxyIDs, that.ProxyIDs) &&
+			deriveTeleportEqual_25(this.ProxyIDs, that.ProxyIDs) &&
 			this.RelayGroup == that.RelayGroup &&
-			deriveTeleportEqual_24(this.RelayIds, that.RelayIds)
-}
-
-// deriveTeleportEqual_18 returns whether this and that are equal.
-func deriveTeleportEqual_18(this, that *AWSOrganizationUnitsMatcher) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			deriveTeleportEqual_24(this.Include, that.Include) &&
-			deriveTeleportEqual_24(this.Exclude, that.Exclude)
+			deriveTeleportEqual_25(this.RelayIds, that.RelayIds)
 }
 
 // deriveTeleportEqual_19 returns whether this and that are equal.
-func deriveTeleportEqual_19(this, that *OktaAssignmentSpecV1) bool {
+func deriveTeleportEqual_19(this, that *AWSOrganizationUnitsMatcher) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_25(this.Include, that.Include) &&
+			deriveTeleportEqual_25(this.Exclude, that.Exclude)
+}
+
+// deriveTeleportEqual_20 returns whether this and that are equal.
+func deriveTeleportEqual_20(this, that *OktaAssignmentSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.User == that.User &&
-			deriveTeleportEqual_38(this.Targets, that.Targets) &&
+			deriveTeleportEqual_40(this.Targets, that.Targets) &&
 			this.CleanupTime.Equal(that.CleanupTime) &&
 			this.Status == that.Status &&
 			this.LastTransition.Equal(that.LastTransition) &&
 			this.Finalized == that.Finalized
 }
 
-// deriveTeleportEqual_20 returns whether this and that are equal.
-func deriveTeleportEqual_20(this, that *UserGroupSpecV1) bool {
+// deriveTeleportEqual_21 returns whether this and that are equal.
+func deriveTeleportEqual_21(this, that *UserGroupSpecV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_24(this.Applications, that.Applications)
+			deriveTeleportEqual_25(this.Applications, that.Applications)
 }
 
-// deriveTeleportEqual_21 returns whether this and that are equal.
-func deriveTeleportEqual_21(this, that map[string]CommandLabelV2) bool {
+// deriveTeleportEqual_22 returns whether this and that are equal.
+func deriveTeleportEqual_22(this, that map[string]CommandLabelV2) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -457,32 +485,32 @@ func deriveTeleportEqual_21(this, that map[string]CommandLabelV2) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_39(&v, &thatv)) {
+		if !(deriveTeleportEqual_41(&v, &thatv)) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_22 returns whether this and that are equal.
-func deriveTeleportEqual_22(this, that *Rewrite) bool {
+// deriveTeleportEqual_23 returns whether this and that are equal.
+func deriveTeleportEqual_23(this, that *Rewrite) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_24(this.Redirect, that.Redirect) &&
-			deriveTeleportEqual_40(this.Headers, that.Headers) &&
+			deriveTeleportEqual_25(this.Redirect, that.Redirect) &&
+			deriveTeleportEqual_42(this.Headers, that.Headers) &&
 			this.JWTClaims == that.JWTClaims
 }
 
-// deriveTeleportEqual_23 returns whether this and that are equal.
-func deriveTeleportEqual_23(this, that *AppAWS) bool {
+// deriveTeleportEqual_24 returns whether this and that are equal.
+func deriveTeleportEqual_24(this, that *AppAWS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ExternalID == that.ExternalID &&
-			deriveTeleportEqual_41(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
+			deriveTeleportEqual_43(this.RolesAnywhereProfile, that.RolesAnywhereProfile)
 }
 
-// deriveTeleportEqual_24 returns whether this and that are equal.
-func deriveTeleportEqual_24(this, that []string) bool {
+// deriveTeleportEqual_25 returns whether this and that are equal.
+func deriveTeleportEqual_25(this, that []string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -497,28 +525,28 @@ func deriveTeleportEqual_24(this, that []string) bool {
 	return true
 }
 
-// deriveTeleportEqual_25 returns whether this and that are equal.
-func deriveTeleportEqual_25(this, that *CORSPolicy) bool {
+// deriveTeleportEqual_26 returns whether this and that are equal.
+func deriveTeleportEqual_26(this, that *CORSPolicy) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_24(this.AllowedOrigins, that.AllowedOrigins) &&
-			deriveTeleportEqual_24(this.AllowedMethods, that.AllowedMethods) &&
-			deriveTeleportEqual_24(this.AllowedHeaders, that.AllowedHeaders) &&
+			deriveTeleportEqual_25(this.AllowedOrigins, that.AllowedOrigins) &&
+			deriveTeleportEqual_25(this.AllowedMethods, that.AllowedMethods) &&
+			deriveTeleportEqual_25(this.AllowedHeaders, that.AllowedHeaders) &&
 			this.AllowCredentials == that.AllowCredentials &&
 			this.MaxAge == that.MaxAge &&
-			deriveTeleportEqual_24(this.ExposedHeaders, that.ExposedHeaders)
-}
-
-// deriveTeleportEqual_26 returns whether this and that are equal.
-func deriveTeleportEqual_26(this, that *AppIdentityCenter) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.AccountID == that.AccountID &&
-			deriveTeleportEqual_42(this.PermissionSets, that.PermissionSets)
+			deriveTeleportEqual_25(this.ExposedHeaders, that.ExposedHeaders)
 }
 
 // deriveTeleportEqual_27 returns whether this and that are equal.
-func deriveTeleportEqual_27(this, that []*PortRange) bool {
+func deriveTeleportEqual_27(this, that *AppIdentityCenter) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.AccountID == that.AccountID &&
+			deriveTeleportEqual_44(this.PermissionSets, that.PermissionSets)
+}
+
+// deriveTeleportEqual_28 returns whether this and that are equal.
+func deriveTeleportEqual_28(this, that []*PortRange) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -526,24 +554,45 @@ func deriveTeleportEqual_27(this, that []*PortRange) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_43(this[i], that[i])) {
+		if !(deriveTeleportEqual_45(this[i], that[i])) {
 			return false
 		}
 	}
 	return true
 }
 
-// deriveTeleportEqual_28 returns whether this and that are equal.
-func deriveTeleportEqual_28(this, that *MCP) bool {
+// deriveTeleportEqual_29 returns whether this and that are equal.
+func deriveTeleportEqual_29(this, that *MCP) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Command == that.Command &&
-			deriveTeleportEqual_24(this.Args, that.Args) &&
+			deriveTeleportEqual_25(this.Args, that.Args) &&
 			this.RunAsHostUser == that.RunAsHostUser
 }
 
-// deriveTeleportEqual_29 returns whether this and that are equal.
-func deriveTeleportEqual_29(this, that *DatabaseTLS) bool {
+// deriveTeleportEqual_30 returns whether this and that are equal.
+func deriveTeleportEqual_30(this, that *Rotation) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.State == that.State &&
+			this.Phase == that.Phase &&
+			this.Mode == that.Mode &&
+			this.CurrentID == that.CurrentID &&
+			this.Started.Equal(that.Started) &&
+			this.GracePeriod == that.GracePeriod &&
+			this.LastRotated.Equal(that.LastRotated) &&
+			deriveTeleportEqual_46(&this.Schedule, &that.Schedule)
+}
+
+// deriveTeleportEqual_31 returns whether this and that are equal.
+func deriveTeleportEqual_31(this, that *componentfeaturesv1.ComponentFeatures) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual_47(this.Features, that.Features)
+}
+
+// deriveTeleportEqual_32 returns whether this and that are equal.
+func deriveTeleportEqual_32(this, that *DatabaseTLS) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Mode == that.Mode &&
@@ -552,8 +601,8 @@ func deriveTeleportEqual_29(this, that *DatabaseTLS) bool {
 			this.TrustSystemCertPool == that.TrustSystemCertPool
 }
 
-// deriveTeleportEqual_30 returns whether this and that are equal.
-func deriveTeleportEqual_30(this, that *AD) bool {
+// deriveTeleportEqual_33 returns whether this and that are equal.
+func deriveTeleportEqual_33(this, that *AD) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.KeytabFile == that.KeytabFile &&
@@ -566,30 +615,30 @@ func deriveTeleportEqual_30(this, that *AD) bool {
 			this.LDAPServiceAccountSID == that.LDAPServiceAccountSID
 }
 
-// deriveTeleportEqual_31 returns whether this and that are equal.
-func deriveTeleportEqual_31(this, that *MySQLOptions) bool {
+// deriveTeleportEqual_34 returns whether this and that are equal.
+func deriveTeleportEqual_34(this, that *MySQLOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ServerVersion == that.ServerVersion
 }
 
-// deriveTeleportEqual_32 returns whether this and that are equal.
-func deriveTeleportEqual_32(this, that *DatabaseAdminUser) bool {
+// deriveTeleportEqual_35 returns whether this and that are equal.
+func deriveTeleportEqual_35(this, that *DatabaseAdminUser) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.DefaultDatabase == that.DefaultDatabase
 }
 
-// deriveTeleportEqual_33 returns whether this and that are equal.
-func deriveTeleportEqual_33(this, that *MongoAtlas) bool {
+// deriveTeleportEqual_36 returns whether this and that are equal.
+func deriveTeleportEqual_36(this, that *MongoAtlas) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name
 }
 
-// deriveTeleportEqual_34 returns whether this and that are equal.
-func deriveTeleportEqual_34(this, that *OracleOptions) bool {
+// deriveTeleportEqual_37 returns whether this and that are equal.
+func deriveTeleportEqual_37(this, that *OracleOptions) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.AuditUser == that.AuditUser &&
@@ -597,64 +646,25 @@ func deriveTeleportEqual_34(this, that *OracleOptions) bool {
 			this.ShuffleHostnames == that.ShuffleHostnames
 }
 
-// deriveTeleportEqual_35 returns whether this and that are equal.
-func deriveTeleportEqual_35(this, that *Resolution) bool {
+// deriveTeleportEqual_38 returns whether this and that are equal.
+func deriveTeleportEqual_38(this, that *Resolution) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Width == that.Width &&
 			this.Height == that.Height
 }
 
-// deriveTeleportEqual_36 returns whether this and that are equal.
-func deriveTeleportEqual_36(this, that *KubernetesClusterAWSStatus) bool {
+// deriveTeleportEqual_39 returns whether this and that are equal.
+func deriveTeleportEqual_39(this, that *KubernetesClusterAWSStatus) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.SetupAccessForArn == that.SetupAccessForArn &&
 			this.Integration == that.Integration &&
-			deriveTeleportEqual_44(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
-}
-
-// deriveTeleportEqual_37 returns whether this and that are equal.
-func deriveTeleportEqual_37(this, that *Rotation) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.State == that.State &&
-			this.Phase == that.Phase &&
-			this.Mode == that.Mode &&
-			this.CurrentID == that.CurrentID &&
-			this.Started.Equal(that.Started) &&
-			this.GracePeriod == that.GracePeriod &&
-			this.LastRotated.Equal(that.LastRotated) &&
-			deriveTeleportEqual_45(&this.Schedule, &that.Schedule)
-}
-
-// deriveTeleportEqual_38 returns whether this and that are equal.
-func deriveTeleportEqual_38(this, that []*OktaAssignmentTargetV1) bool {
-	if this == nil || that == nil {
-		return this == nil && that == nil
-	}
-	if len(this) != len(that) {
-		return false
-	}
-	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_46(this[i], that[i])) {
-			return false
-		}
-	}
-	return true
-}
-
-// deriveTeleportEqual_39 returns whether this and that are equal.
-func deriveTeleportEqual_39(this, that *CommandLabelV2) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.Period == that.Period &&
-			deriveTeleportEqual_24(this.Command, that.Command) &&
-			this.Result == that.Result
+			deriveTeleportEqual_48(this.DiscoveryAssumedRole, that.DiscoveryAssumedRole)
 }
 
 // deriveTeleportEqual_40 returns whether this and that are equal.
-func deriveTeleportEqual_40(this, that []*Header) bool {
+func deriveTeleportEqual_40(this, that []*OktaAssignmentTargetV1) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -662,7 +672,7 @@ func deriveTeleportEqual_40(this, that []*Header) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_47(this[i], that[i])) {
+		if !(deriveTeleportEqual_49(this[i], that[i])) {
 			return false
 		}
 	}
@@ -670,15 +680,16 @@ func deriveTeleportEqual_40(this, that []*Header) bool {
 }
 
 // deriveTeleportEqual_41 returns whether this and that are equal.
-func deriveTeleportEqual_41(this, that *AppAWSRolesAnywhereProfile) bool {
+func deriveTeleportEqual_41(this, that *CommandLabelV2) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			this.ProfileARN == that.ProfileARN &&
-			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+			this.Period == that.Period &&
+			deriveTeleportEqual_25(this.Command, that.Command) &&
+			this.Result == that.Result
 }
 
 // deriveTeleportEqual_42 returns whether this and that are equal.
-func deriveTeleportEqual_42(this, that []*IdentityCenterPermissionSet) bool {
+func deriveTeleportEqual_42(this, that []*Header) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -686,7 +697,7 @@ func deriveTeleportEqual_42(this, that []*IdentityCenterPermissionSet) bool {
 		return false
 	}
 	for i := 0; i < len(this); i++ {
-		if !(deriveTeleportEqual_48(this[i], that[i])) {
+		if !(deriveTeleportEqual_50(this[i], that[i])) {
 			return false
 		}
 	}
@@ -694,24 +705,39 @@ func deriveTeleportEqual_42(this, that []*IdentityCenterPermissionSet) bool {
 }
 
 // deriveTeleportEqual_43 returns whether this and that are equal.
-func deriveTeleportEqual_43(this, that *PortRange) bool {
+func deriveTeleportEqual_43(this, that *AppAWSRolesAnywhereProfile) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.ProfileARN == that.ProfileARN &&
+			this.AcceptRoleSessionName == that.AcceptRoleSessionName
+}
+
+// deriveTeleportEqual_44 returns whether this and that are equal.
+func deriveTeleportEqual_44(this, that []*IdentityCenterPermissionSet) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(deriveTeleportEqual_51(this[i], that[i])) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_45 returns whether this and that are equal.
+func deriveTeleportEqual_45(this, that *PortRange) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Port == that.Port &&
 			this.EndPort == that.EndPort
 }
 
-// deriveTeleportEqual_44 returns whether this and that are equal.
-func deriveTeleportEqual_44(this, that *AssumeRole) bool {
-	return (this == nil && that == nil) ||
-		this != nil && that != nil &&
-			this.RoleARN == that.RoleARN &&
-			this.ExternalID == that.ExternalID &&
-			this.RoleName == that.RoleName
-}
-
-// deriveTeleportEqual_45 returns whether this and that are equal.
-func deriveTeleportEqual_45(this, that *RotationSchedule) bool {
+// deriveTeleportEqual_46 returns whether this and that are equal.
+func deriveTeleportEqual_46(this, that *RotationSchedule) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.UpdateClients.Equal(that.UpdateClients) &&
@@ -719,24 +745,49 @@ func deriveTeleportEqual_45(this, that *RotationSchedule) bool {
 			this.Standby.Equal(that.Standby)
 }
 
-// deriveTeleportEqual_46 returns whether this and that are equal.
-func deriveTeleportEqual_46(this, that *OktaAssignmentTargetV1) bool {
+// deriveTeleportEqual_47 returns whether this and that are equal.
+func deriveTeleportEqual_47(this, that []componentfeaturesv1.ComponentFeatureID) bool {
+	if this == nil || that == nil {
+		return this == nil && that == nil
+	}
+	if len(this) != len(that) {
+		return false
+	}
+	for i := 0; i < len(this); i++ {
+		if !(this[i] == that[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// deriveTeleportEqual_48 returns whether this and that are equal.
+func deriveTeleportEqual_48(this, that *AssumeRole) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.RoleARN == that.RoleARN &&
+			this.ExternalID == that.ExternalID &&
+			this.RoleName == that.RoleName
+}
+
+// deriveTeleportEqual_49 returns whether this and that are equal.
+func deriveTeleportEqual_49(this, that *OktaAssignmentTargetV1) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Type == that.Type &&
 			this.Id == that.Id
 }
 
-// deriveTeleportEqual_47 returns whether this and that are equal.
-func deriveTeleportEqual_47(this, that *Header) bool {
+// deriveTeleportEqual_50 returns whether this and that are equal.
+func deriveTeleportEqual_50(this, that *Header) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Value == that.Value
 }
 
-// deriveTeleportEqual_48 returns whether this and that are equal.
-func deriveTeleportEqual_48(this, that *IdentityCenterPermissionSet) bool {
+// deriveTeleportEqual_51 returns whether this and that are equal.
+func deriveTeleportEqual_51(this, that *IdentityCenterPermissionSet) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.ARN == that.ARN &&

--- a/api/types/internal/equaltesting/fill_value.go
+++ b/api/types/internal/equaltesting/fill_value.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package equaltesting
+
+package equaltesting
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+)
+
+type fillValueOptions struct {
+	ignoreUnexported   bool
+	skipProtoXXXFields bool
+	timeVal            time.Time
+}
+
+type FillValueOpt func(*fillValueOptions)
+
+func WithIgnoreUnexported(ignoreUnexported bool) FillValueOpt {
+	return func(o *fillValueOptions) {
+		o.ignoreUnexported = ignoreUnexported
+	}
+}
+
+func WithSkipProtoXXXFields(skipProtoXXXFields bool) FillValueOpt {
+	return func(o *fillValueOptions) {
+		o.skipProtoXXXFields = skipProtoXXXFields
+	}
+}
+
+func WithTimeVal(t time.Time) FillValueOpt {
+	return func(o *fillValueOptions) {
+		o.timeVal = t
+	}
+}
+
+// FillValue fills the given value with a simple non-zero value.
+func FillValue(i any, opts ...FillValueOpt) error {
+	v := reflect.ValueOf(i)
+	if v.Kind() != reflect.Pointer {
+		return fmt.Errorf("expected a pointer, got %q", v.Kind())
+	}
+
+	opt := fillValueOptions{
+		timeVal: time.Now(),
+	}
+	for _, o := range opts {
+		o(&opt)
+	}
+
+	return fillValue(v.Elem(), opt)
+}
+
+func fillValue(v reflect.Value, opt fillValueOptions) error {
+	if !v.CanSet() {
+		if opt.ignoreUnexported {
+			return nil
+		}
+		return errors.New("value is not addressable or is an unexported struct field")
+	}
+
+	// Handle pointers.
+	if v.Kind() == reflect.Pointer {
+		v.Set(reflect.New(v.Type().Elem()))
+		return fillValue(v.Elem(), opt)
+	}
+
+	// Special handling for time.Time.
+	if v.Type() == reflect.TypeOf(time.Time{}) {
+		v.Set(reflect.ValueOf(opt.timeVal))
+		return nil
+	}
+
+	switch kind := v.Kind(); kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		v.SetInt(1)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		v.SetUint(1)
+	case reflect.Float32, reflect.Float64:
+		v.SetFloat(1.0)
+	case reflect.Complex64, reflect.Complex128:
+		v.SetComplex(1.0 + 1i)
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.String:
+		v.SetString("SetA")
+
+	case reflect.Struct:
+		t := v.Type()
+		for i := range v.NumField() {
+			if opt.skipProtoXXXFields && strings.HasPrefix(t.Field(i).Name, "XXX_") {
+				continue
+			}
+			if err := fillValue(v.Field(i), opt); err != nil {
+				return fmt.Errorf("field %q: %w", v.Type().Field(i).Name, err)
+			}
+		}
+
+	case reflect.Slice:
+		slice := reflect.MakeSlice(v.Type(), 1, 1)
+		if err := fillValue(slice.Index(0), opt); err != nil {
+			return err
+		}
+		v.Set(slice)
+
+	case reflect.Map:
+		mapT := v.Type()
+		mapV := reflect.MakeMap(mapT)
+
+		key := reflect.New(mapT.Key()).Elem()
+		if err := fillValue(key, opt); err != nil {
+			return fmt.Errorf("map key: %w", err)
+		}
+		val := reflect.New(mapT.Elem()).Elem()
+		if err := fillValue(val, opt); err != nil {
+			return fmt.Errorf("map value: %w", err)
+		}
+
+		mapV.SetMapIndex(key, val)
+		v.Set(mapV)
+	default:
+		return fmt.Errorf("unsupported kind %q", kind)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Related issue https://github.com/gravitational/teleport.e/issues/7799

I was prototyping a solution and we'll need an equality func which allows ignoring HostID for the Okta apps reconciler. I don't want to extend the default [CompareResources](https://github.com/gravitational/teleport/blob/5cfd9b431fd2e9c119c07f671ea2e127bf5bd03c/lib/services/compare.go#L35) func based on go-cmp which we shouldn't use outside testing code.