### PR TITLE
Center search bar input in Connect

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { MutableRefObject } from 'react';
+import { RefObject } from 'react';
 import styled from 'styled-components';
 
 import { Flex } from 'design';
@@ -28,8 +28,8 @@ import { Connections } from './Connections';
 import { Identity } from './Identity';
 
 export function TopBar(props: {
-  connectMyComputerRef: MutableRefObject<HTMLDivElement>;
-  accessRequestRef: MutableRefObject<HTMLDivElement>;
+  connectMyComputerRef: RefObject<HTMLDivElement>;
+  accessRequestRef: RefObject<HTMLDivElement>;
 }) {
   return (
     <Grid>

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -72,15 +72,21 @@ const CentralContainer = styled(Flex).attrs({ gap: 3 })`
   max-width: calc(${props => props.theme.space[10]}px * 9);
 `;
 
+// Reserve space for dynamic icons (Connect My Computer and access requests)
+// to prevent layout shift. Side containers must be of equal width to keep the
+// search bar input centered, so that it is completely hidden when the search
+// is open.
+const SIDE_CONTAINER_WIDTH = '128px';
+
 const JustifyLeft = styled(Flex).attrs({ gap: 3 })`
+  width: ${SIDE_CONTAINER_WIDTH};
   align-items: center;
-  min-width: 80px; // reserves space for Connect My Computer icon to prevent layout shifting
   height: 100%;
 `;
 
 const JustifyRight = styled(Flex).attrs({ gap: 2 })`
+  width: ${SIDE_CONTAINER_WIDTH};
   justify-content: end;
   align-items: center;
-  min-width: 128px; // reserves space for access requests icon to prevent layout shifting
   height: 100%;
 `;


### PR DESCRIPTION
Since https://github.com/gravitational/teleport/pull/51960 the input is a little misaligned.

Before the fix:
<img width="950" height="213" alt="image" src="https://github.com/user-attachments/assets/f3b6c800-497c-4c72-9153-d4157f5c008d" />

After the fix:
<img width="950" height="213" alt="image" src="https://github.com/user-attachments/assets/1879d0bd-3dd5-4544-8961-d3d03657f812" />
