### PR TITLE
Fix logical error in TestStaticHostUserHandler

### DIFF
--- a/lib/srv/statichostuser_test.go
+++ b/lib/srv/statichostuser_test.go
@@ -133,7 +133,7 @@ func TestStaticHostUserHandler(t *testing.T) {
 			select {
 			case events.events <- event:
 			case <-ctx.Done():
-				break
+				return
 			}
 		}
 	}


### PR DESCRIPTION
If the context is canceled, the break statement would break out of the select, not the loop. This would cause us to continue to send events, effectively ignoring context cancelation.