### PR TITLE
[v18] docs: Remove surplus 'a' from Infrastructure as Code

### DIFF
--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -29,7 +29,7 @@ import mcpAndAiSvg from "@site/src/components/Icon/teleport-svg/mcp-and-ai.svg";
   linksColumnCount={2}
   links={[
     {
-      title: "Infrastructure as a Code",
+      title: "Infrastructure as Code",
       description: "Manage resources as code with Terraform, Kubernetes operator, and tctl",
       href: "../zero-trust-access/infrastructure-as-code/managing-resources/",
       icon: terminalWindowSvg,
@@ -55,7 +55,7 @@ href="./application-access/"
 tagLists={
   [
     {
-      tags: 
+      tags:
         [
           {
             name: "Cloud consoles",
@@ -77,7 +77,7 @@ tagLists={
             href: "./application-access/configuration/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }
@@ -91,7 +91,7 @@ href="./database-access/"
 tagLists={
   [
     {
-      tags: 
+      tags:
         [
           {
             name: "AWS",
@@ -113,7 +113,7 @@ tagLists={
             href: "./database-access/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }
@@ -128,7 +128,7 @@ tagLists={
   [
     {
       title: "Kubernetes Clusters Guides",
-      tags: 
+      tags:
         [
           {
             name: "Enroll Kubernetes clusters",
@@ -138,7 +138,7 @@ tagLists={
             name: "Access controls",
             href: "./kubernetes-access/controls/",
           },
-        ] 
+        ]
     },
   ]
 }
@@ -153,7 +153,7 @@ tagLists={
   [
     {
       title: "Windows Desktops Access Guides",
-      tags: 
+      tags:
         [
           {
             name: "Local Windows users",
@@ -163,7 +163,7 @@ tagLists={
             name: "Active Directory",
             href: "./desktop-access/active-directory/",
           },
-        ] 
+        ]
     },
   ]
 }
@@ -178,7 +178,7 @@ tagLists={
   [
     {
       title: "Server Access Guides",
-      tags: 
+      tags:
         [
           {
             name: "Get started guide",
@@ -193,7 +193,7 @@ tagLists={
             href: "./server-access/guides/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }
@@ -208,7 +208,7 @@ tagLists={
   [
     {
       title: "MCP Server Guides",
-      tags: 
+      tags:
         [
           {
             name: "Get Started Guide",
@@ -222,7 +222,7 @@ tagLists={
             name: "DB access for MCP",
             href: "../connect-your-client/model-context-protocol/database-access/",
           },
-        ] 
+        ]
     },
   ]
 }


### PR DESCRIPTION
Backport #62714 to branch/v18