### PR TITLE
[v17] docs: Remove surplus 'a' from Infrastructure as Code (#62714)

### DIFF
--- a/docs/pages/enroll-resources/enroll-resources.mdx
+++ b/docs/pages/enroll-resources/enroll-resources.mdx
@@ -28,7 +28,7 @@ import windowsDesktopsSvg from "@site/src/components/Icon/teleport-svg/windows-d
   linksColumnCount={2}
   links={[
     {
-      title: "Infrastructure as a Code",
+      title: "Infrastructure as Code",
       description: "Manage resources as code with Terraform, Kubernetes operator, and tctl",
       href: "../zero-trust-access/infrastructure-as-code/managing-resources/",
       icon: terminalWindowSvg,
@@ -54,7 +54,7 @@ href="./application-access/"
 tagLists={
   [
     {
-      tags: 
+      tags:
         [
           {
             name: "Cloud consoles",
@@ -76,7 +76,7 @@ tagLists={
             href: "./application-access/guides/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }
@@ -90,7 +90,7 @@ href="./database-access/"
 tagLists={
   [
     {
-      tags: 
+      tags:
         [
           {
             name: "AWS",
@@ -112,7 +112,7 @@ tagLists={
             href: "./database-access/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }
@@ -127,7 +127,7 @@ tagLists={
   [
     {
       title: "Kubernetes Clusters Guides",
-      tags: 
+      tags:
         [
           {
             name: "Enroll Kubernetes clusters",
@@ -137,7 +137,7 @@ tagLists={
             name: "Access controls",
             href: "./kubernetes-access/controls/",
           },
-        ] 
+        ]
     },
   ]
 }
@@ -152,7 +152,7 @@ tagLists={
   [
     {
       title: "Windows Desktops Access Guides",
-      tags: 
+      tags:
         [
           {
             name: "Local Windows users",
@@ -162,7 +162,7 @@ tagLists={
             name: "Active Directory",
             href: "./desktop-access/active-directory/",
           },
-        ] 
+        ]
     },
   ]
 }
@@ -177,7 +177,7 @@ tagLists={
   [
     {
       title: "Server Access Guides",
-      tags: 
+      tags:
         [
           {
             name: "Get started guide",
@@ -192,7 +192,7 @@ tagLists={
             href: "./server-access/guides/",
             arrow: true,
           }
-        ] 
+        ]
     },
   ]
 }


### PR DESCRIPTION
Manual backport of #62714 to branch/v17