### PR TITLE
[v18] postgres: add client certificate reloading for pg compatible backends/events

### DIFF
--- a/lib/events/pgevents/pgevents_test.go
+++ b/lib/events/pgevents/pgevents_test.go
@@ -202,6 +202,11 @@ func TestConfig(t *testing.T) {
 			RetentionPeriod: defaultRetentionPeriod,
 			CleanupInterval: defaultCleanupInterval,
 		},
+		"postgres://foo#cert_reload_interval=1h": {
+			RetentionPeriod:    defaultRetentionPeriod,
+			CleanupInterval:    defaultCleanupInterval,
+			CertReloadInterval: time.Hour,
+		},
 
 		"postgres://foo#auth_mode=invalid-auth-mode": nil,
 	}


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/62616

changelog: Added automatic client certificate reloading option for postgres backends