### PR TITLE
Update neutral alert to match design

### DIFF
--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -193,7 +193,7 @@ export const Alert = ({
   wrapContents = false,
   ...otherProps
 }: AlertProps) => {
-  const alertIconSize = kind === 'neutral' ? 'large' : 'small';
+  const alertIconSize = 'small';
   const [dismissed, setDismissed] = useState(false);
 
   const onDismissClick = () => {
@@ -324,7 +324,8 @@ const iconContainerStyles = ({
     case 'neutral':
       return {
         color: theme.colors.text.main,
-        background: 'none',
+        background: theme.colors.interactive.tonal.neutral[0],
+        padding: `${theme.space[2]}px`,
       };
   }
 };
@@ -387,7 +388,7 @@ const ActionButtons = ({
       )}
       {secondaryAction && (
         <ActionButton
-          fill="minimal"
+          fill={kind === 'neutral' ? 'filled' : 'minimal'}
           intent="neutral"
           action={secondaryAction}
         />


### PR DESCRIPTION
Make the info alert match the design system:
- Use the same size icon
- Fill in a background behind the icon
- Use a filled secondary button (for the neutral/info kind only)

See [Figma](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=8890-5502&p=f&t=j47wlR88Jagq20ft-0) for design. 

Before:

<img width="1024" height="409" alt="image" src="https://github.com/user-attachments/assets/f63c50f6-8859-4d18-93e8-f3bb10425b89" />

After:

<img width="1034" height="416" alt="image" src="https://github.com/user-attachments/assets/41de0c81-16eb-4287-b9b7-6ad22c34bde2" />


Closes #58509