### PR TITLE
[v18] Docs: remove reference to old versions of Teleport

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/vnet.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/vnet.mdx
@@ -61,7 +61,7 @@ following mitigations for DNS rebinding attacks:
 <Tabs>
 <TabItem label="macOS">
 - A client machine running macOS Ventura (13.0) or higher.
-- [Teleport Connect](teleport-connect.mdx), version 16.0.0 or higher.
+- [Teleport Connect](teleport-connect.mdx).
 </TabItem>
 <TabItem label="Windows">
 - A client machine running Windows 10 or higher.

--- a/docs/pages/enroll-resources/kubernetes-access/faq.mdx
+++ b/docs/pages/enroll-resources/kubernetes-access/faq.mdx
@@ -30,8 +30,7 @@ more information and examples.
 
 ## Can Teleport automatically discover my Kubernetes clusters on cloud providers (AWS, GCP, Azure)?
 
-Since version 11, Teleport can discover your Kubernetes clusters on AWS, GCP,
-and Azure.
+Teleport can discover your Kubernetes clusters on AWS, GCP, and Azure.
 
 Check out the [Kubernetes Service Discovery
 Guide](../auto-discovery/kubernetes/kubernetes.mdx) for more

--- a/docs/pages/includes/tls-multiplexing-warnings.mdx
+++ b/docs/pages/includes/tls-multiplexing-warnings.mdx
@@ -9,5 +9,4 @@ annotations:
 ```
 
 Deploying Teleport behind Cloudflare, whether using its proxy ("orange-clouding") or tunnels
-(`cloudflared`) should work with Teleport version 15.1 or higher. See the
-[TLS Routing FAQ](../reference/architecture/tls-routing.mdx) for more details.
+(`cloudflared`) should work. See the [TLS Routing FAQ](../reference/architecture/tls-routing.mdx) for more details.

--- a/docs/pages/installation/docker.mdx
+++ b/docs/pages/installation/docker.mdx
@@ -94,7 +94,7 @@ Teleport, which is currently `(=teleport.latest_oss_docker_image=)`.
 
 ### Interacting with distroless images
 
-Since version 15, Teleport images are based on Google's [Distroless](https://github.com/GoogleContainerTools/distroless) images.
+Teleport images are based on Google's [Distroless](https://github.com/GoogleContainerTools/distroless) images.
 Those images don't contain any shell.
 
 To execute Teleport commands on containers based on these images, run commands similar to the following:

--- a/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/aws-oidc-federation.mdx
@@ -63,11 +63,6 @@ This guide covers configuring OIDC federation. For Roles Anywhere, see
   information, see the [deployment
   guides](../deployment/deployment.mdx).
 
-<Admonition type="warning">
-Issuing JWT SVIDs with Teleport Workload Identity requires at least Teleport
-version 16.4.3.
-</Admonition>
-
 ### Deciding on a SPIFFE ID structure
 
 Within Teleport Workload Identity, all identities are represented using a

--- a/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/azure-federated-credentials.mdx
@@ -48,11 +48,6 @@ protect Azure APIs in a few ways:
 - An Azure resource group and subscription you wish to grant the workload access
   to.
 
-<Admonition type="warning">
-Issuing JWT SVIDs with Teleport Workload Identity requires at least Teleport
-version 16.4.3.
-</Admonition>
-
 ### Deciding on a SPIFFE ID structure
 
 Within Teleport Workload Identity, all identities are represented using a

--- a/docs/pages/machine-workload-identity/workload-identity/federation.mdx
+++ b/docs/pages/machine-workload-identity/workload-identity/federation.mdx
@@ -29,9 +29,6 @@ workloads in the other trust domain cannot validate the identities of workloads
 in the first trust domain. It is therefore typical to establish the federation
 relationship in both directions.
 
-SPIFFE Federation support was introduced in Teleport version 16.3.0. Both your
-Teleport Auth Service and tbot agent must be running at least this version.
-
 <Admonition type="warning" title="Teleport Enterprise Required">
 A valid Teleport Enterprise license is required to use the federation features
 of Teleport Workload Identity.

--- a/docs/pages/reference/access-controls/user-types.mdx
+++ b/docs/pages/reference/access-controls/user-types.mdx
@@ -75,8 +75,7 @@ authentication connector and allow user to log in via an IdP.
 
 ### Synced users
 
-Since version 15, Teleport supports fetching users from external identity
-providers like Okta.
+Teleport supports fetching users from external identity providers like Okta.
 
 Synchronizing users from the external IdP allows all users to be represented in
 Teleport, whether they logged in Teleport or not. The benefits of such

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -33,24 +33,6 @@ The `teleport-kube-agent` chart can run any or all of three Teleport services:
 | [`discovery_service`](../../enroll-resources/auto-discovery/auto-discovery.mdx)              | `discovery`                            | Uses Teleport to discover new resources<br/> and dynamically add them to the cluster         |
 | [`jamf_service`](../../identity-governance/device-trust/jamf-integration.mdx) | `jamf`                                 | Uses Teleport to integrate with Jamf Pro<br/> and sync devices with Device Trust inventory   |
 
-### Legacy releases
-
-Releases of this chart installed before version 11 are considered legacy
-releases, which launch the Teleport pod as a `Deployment` if no storage was
-configured.
-
-In version 11 and above, the chart launches the Teleport pod as a `StatefulSet`
-even when the chart is configured not to use external storage, and the Teleport pod
-reads its state from a Kubernetes `Secret`.
-
-While the Teleport pod does not require external storage, you can still use the
-[`storage.enabled`](#storageenabled) field to configure the way the Teleport pod
-reads data from a persistent volume.
-
-To learn how upgrading from a legacy release to version 11 will affect
-resources launched by this chart, see the [resource
-list](#kubernetes-resources).
-
 ### Kubernetes resources
 
 The `teleport-kube-agent` chart deploys the following Kubernetes resources:

--- a/docs/pages/usage-billing.mdx
+++ b/docs/pages/usage-billing.mdx
@@ -61,7 +61,7 @@ The code that aggregates and anonymizes this data can be found in our [GitHub
 repository](https://github.com/gravitational/teleport/tree/master/lib/usagereporter/teleport/aggregating).
 
 For a restricted network environment you can configure Teleport Auth Service instances
-to send usage data through a proxy for version 16.0.4/15.4.7 or later.
+to send usage data through a proxy .
 Set the `TELEPORT_REPORTING_HTTPS_PROXY` and `TELEPORT_REPORTING_HTTP_PROXY`
 environment variables to your proxy address. That will apply as the HTTP connect
 proxy setting overriding `HTTPS_PROXY` and `HTTP_PROXY` just for outbound usage reporting.

--- a/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/zero-trust-access/compliance-frameworks/fedramp.mdx
@@ -237,8 +237,7 @@ authentication:
 
 ```
 
-As of Teleport version 15, versionOverride and extraArgs no longer need to be set
-in the values file to enable FIPS mode.
+`versionOverride` and `extraArgs` no longer need to be set in the values file to enable FIPS mode.
 
 ## Default cryptographic algorithms
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator-standalone.mdx
@@ -36,7 +36,6 @@ You can then deploy the Operator by installing the `teleport-operator` chart.
   Deployment, Secret, Role, RoleBinding and CustomResourceDefinition resources.
 - [Helm](https://helm.sh/docs/intro/quickstart/)
 - [kubectl](https://kubernetes.io/docs/tasks/tools/)
-- a Teleport cluster running at least version 15.
 
 Validate Kubernetes connectivity by running the following command:
 

--- a/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/teleport-operator/teleport-operator.mdx
@@ -16,7 +16,7 @@ can use a Kubernetes client like `kubectl` or their existing CI/CD Kubernetes pi
 custom resources. The Teleport Kubernetes Operator watches for those resources and does API calls to Teleport to
 reach the desired state.  
 
-Since Teleport version 15, the operator can be deployed both:
+The operator can be deployed both:
 - Alongside self-hosted Teleport clusters deployed with the `teleport-cluster` Helm chart.
   An operator outage cannot affect Teleport's availability.
 - Against a remote Teleport instance (such as Teleport Cloud or deployed with Terraform)

--- a/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/terraform-provider/local.mdx
@@ -25,8 +25,8 @@ connect to Teleport as the temporary bot.
 
 ## Prerequisites
 
-- A running Teleport cluster, version 16.2 or higher
-- Local tsh/tctl clients with versions higher than 16.2
+- A running Teleport cluster
+- Local tsh/tctl clients
 - Being locally logged in Teleport with a role that allows creating Bot and Token resources.
   You can use the default `editor` role for this.
 

--- a/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
+++ b/docs/pages/zero-trust-access/management/security/idp-compromise.mdx
@@ -34,7 +34,7 @@ It's compatible with hardware keys (e.g., YubiKeys, SoloKeys) and biometric auth
 
 ### Prerequisites
 
-- A running Teleport cluster or Teleport Cloud, version 16 or later. If you want to get started with Teleport,
+- A running Teleport cluster or Teleport Cloud. If you want to get started with Teleport,
 [sign up](https://goteleport.com/signup) for a free trial.
 
 - The `tctl` admin tool and `tsh` client tool.


### PR DESCRIPTION
Backport #62760 to branch/v18