### PR TITLE
ui: Update application getting started link

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -3471,6 +3471,11 @@
       "source": "/zero-trust-access/deploy-a-cluster/proxy-peering/",
       "destination": "/zero-trust-access/deploy-a-cluster/reliability/proxy-peering/",
       "permanent": true
+    },
+    {
+      "source": "/enroll-resources/application-access/introduction/",
+      "destination": "/enroll-resources/application-access/getting-started/",
+      "permanent": true
     }
   ]
 }

--- a/web/packages/teleport/src/Apps/AddApp/Manually.tsx
+++ b/web/packages/teleport/src/Apps/AddApp/Manually.tsx
@@ -133,7 +133,7 @@ const StepsWithoutToken = ({ tshLoginCmd, host }: StepsWithoutTokenProps) => (
             Learn more about application access `}
       <Link
         href={
-          'https://goteleport.com/docs/enroll-resources/application-access/introduction/'
+          'https://goteleport.com/docs/enroll-resources/application-access/getting-started/'
         }
         target="_blank"
       >


### PR DESCRIPTION
The user will get 404 in the current UI on the https://goteleport.com/docs/enroll-resources/application-access/introduction/ link in the app ui flow. This updates to the current link and directs old links to the new one.