### PR TITLE
[v18] rdp-client: bump rsa from 0.9.8 to 0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1852,11 +1852,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -2493,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -30,7 +30,7 @@ iso7816 = "0.1.4"
 iso7816-tlv = "0.4.4"
 log = "0.4.27"
 rand = { version = "0.9.0", features = ["os_rng"] }
-rsa = "0.9.8"
+rsa = "0.9.10"
 sspi = { version = "0.15.0", features = ["network_client"] }
 tokio = { version = "1.44", features = ["full"] }
 tokio-boring = { git = "https://github.com/gravitational/boring", rev = "99897308abb5976ea05625b8314c24b16eebb01b", optional = true }


### PR DESCRIPTION
changelog: updated rustcrypto/rsa dependency to fix potential panic (CVE-2026-21895)