### PR TITLE
lib msgraph `IterateGroupOwners`

### DIFF
--- a/lib/msgraph/models.go
+++ b/lib/msgraph/models.go
@@ -45,6 +45,8 @@ type Group struct {
 	OnPremisesNetBiosName *string `json:"onPremisesNetBiosName,omitempty"`
 	// OnPremisesSamAccountName is the on-premises SAM account name of the group.
 	OnPremisesSamAccountName *string `json:"onPremisesSamAccountName,omitempty"`
+	// Owners is a list of users who are the owners of this group.
+	Owners []*User `json:"owners,omitempty"`
 }
 
 func (g *Group) IsOffice365Group() bool {

--- a/lib/msgraph/msgraphtest/storage.go
+++ b/lib/msgraph/msgraphtest/storage.go
@@ -28,6 +28,7 @@ type Storage struct {
 	Users        map[string]*msgraph.User
 	Groups       map[string]*msgraph.Group
 	GroupMembers map[string][]msgraph.GroupMember
+	GroupOwners  map[string][]*msgraph.User
 	Applications map[string]*msgraph.Application
 }
 
@@ -37,6 +38,7 @@ func NewStorage() *Storage {
 		Users:        make(map[string]*msgraph.User),
 		Groups:       make(map[string]*msgraph.Group),
 		GroupMembers: make(map[string][]msgraph.GroupMember),
+		GroupOwners:  make(map[string][]*msgraph.User),
 		Applications: make(map[string]*msgraph.Application),
 	}
 }
@@ -117,6 +119,9 @@ func NewDefaultStorage() *Storage {
 	storage.GroupMembers["group1"] = []msgraph.GroupMember{alice, group2}
 	storage.GroupMembers["group2"] = []msgraph.GroupMember{alice, bob, carol}
 	storage.GroupMembers["group3"] = []msgraph.GroupMember{alice, bob, carol}
+
+	storage.GroupOwners["group1"] = []*msgraph.User{alice, bob}
+	storage.GroupOwners["group3"] = []*msgraph.User{bob, carol}
 
 	storage.Applications[*app1.AppID] = app1
 

--- a/lib/msgraph/paginated.go
+++ b/lib/msgraph/paginated.go
@@ -257,6 +257,18 @@ func (c *Client) IterateGroupMembers(ctx context.Context, groupID string, f func
 	return trace.Wrap(itErr)
 }
 
+// IterateGroupOwners lists Microsoft Entra ID group owners.
+// Group owners are of User object type and can be either User
+// or Service Principals. Teleport only supports User as group owners.
+// `f` will be called for each object in the result set.
+// if `f` returns `false`, the iteration is stopped (equivalent to `break` in a normal loop).
+// Ref: [https://learn.microsoft.com/en-us/graph/api/group-list-owners?view=graph-rest-1.0].
+func (c *Client) IterateGroupOwners(ctx context.Context, groupID string, f func(*User) bool, opts ...IterateOpt) error {
+	// Group owners of user type is requested by
+	// using "microsoft.graph.user" OData cast.
+	return iterateSimple(c, ctx, path.Join("groups", groupID, "owners", "microsoft.graph.user"), f, opts...)
+}
+
 const (
 	graphNamespaceGroups         = "microsoft.graph.group"
 	graphNamespaceDirectoryRoles = "microsoft.graph.directoryRole"


### PR DESCRIPTION
Updates `lib/msgraph` with a new `IterateGroupOwners` method to list Entra ID group owners. 
See API doc https://learn.microsoft.com/en-us/graph/api/group-list-owners?view=graph-rest-1.0.

Alternatives considered:
- Instead of using a separate `group-list-owners` API, it's possible to list group owners from the list `group` API using `$expand` query. The `$expand` query however has a limit of 20 items max and owners in higher number will otherwise be excluded from the response without any error. See https://developer.microsoft.com/en-us/graph/known-issues/?search=13635

Part of https://github.com/gravitational/customer-sensitive-requests/issues/525