### PR TITLE
docs: add RBAC prerequisite for CA rotations

### DIFF
--- a/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
+++ b/docs/pages/zero-trust-access/management/security/ca-rotation.mdx
@@ -44,8 +44,8 @@ following order:
 
 Before the final `standby` phase, you can also put the rotation in the
 `rollback` phase to abort the rotation return to the original certificate
-authority.
-After the `rollback` phase you will then proceed to the `standby` phase.
+authority. After the `rollback` phase you will then proceed to the `standby`
+phase.
 
 CA rotations can be **manual** or **semi-automatic**. In manual mode, admins
 must instruct the Teleport Auth Service to advance from one phase to the next.
@@ -53,18 +53,32 @@ Between phases, admins can prepare their infrastructure to adjust to each
 change. In semi-automatic mode, the Teleport Auth Service cycles through each
 phase automatically, with a grace period between each phase.
 
-In 17.0.5+ `tctl auth rotate` (with no arguments) starts an interactive
-terminal UI for CA rotations.
-The interactive UI displays a live cluster status, allows you to choose a CA to
-rotate and guides you through each phase, automatically performs certain checks
-to make sure the cluster is ready for the next phase, and lists any manual steps
-that need to be completed.
+In 17.0.5+ `tctl auth rotate` (with no arguments) starts an interactive terminal
+UI for CA rotations. The interactive UI displays a live cluster status, allows
+you to choose a CA to rotate and guides you through each phase, automatically
+performs certain checks to make sure the cluster is ready for the next phase,
+and lists any manual steps that need to be completed.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
+
+- Your user must have a role with permission to `create` and `update` the
+  `certificate_authority` resource.
+
+  ```yaml
+  kind: role
+  version: v8
+  metadata:
+    name: rotate-cas
+  spec:
+    allow:
+      rules:
+      - resources: [ certificate_authority ]
+        verbs: [ create, update ]
+  ```
 
 ## Step 1/4. Choose a CA to rotate
 


### PR DESCRIPTION
CA rotations require create/update on certificate_authority. These permissions are available on the local RoleAdmin role when running tctl on the same host as the auth server, but they are not available in any of the preset roles.