### PR TITLE
Improve error message for terminal size unmarshalling

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -199,7 +199,10 @@ type TerminalParams struct {
 func UnmarshalTerminalParams(s string) (*TerminalParams, error) {
 	parts := strings.Split(s, ":")
 	if len(parts) != 2 {
-		return nil, trace.BadParameter("failed to unmarshal: too many parts")
+		return nil, trace.BadParameter(
+			"failed to unmarshal terminal parameters: expected W:H, got %q",
+			s,
+		)
 	}
 
 	w, err := strconv.Atoi(parts[0])


### PR DESCRIPTION
Updating the error message returned when an a terminal size string is formatted correctly.

I was torn on including the the un-parseable string itself in the error message, but leaned towards not. Would like to hear if anyone thinks otherwise.