### PR TITLE
Disable -buildmode=pie

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,9 +53,8 @@ BUILDFLAGS ?= $(ADDFLAGS) -gcflags=all="-N -l" -buildvcs=false
 BUILDFLAGS_TBOT ?= $(ADDFLAGS) -gcflags=all="-N -l" -buildvcs=false
 BUILDFLAGS_TELEPORT_UPDATE ?= $(ADDFLAGS) -gcflags=all="-N -l" -buildvcs=false
 else
-BUILDFLAGS ?= $(ADDFLAGS) -ldflags '$(GO_LDFLAGS)' -trimpath -buildmode=pie -buildvcs=false
+BUILDFLAGS ?= $(ADDFLAGS) -ldflags '$(GO_LDFLAGS)' -trimpath -buildvcs=false
 BUILDFLAGS_TBOT ?= $(ADDFLAGS) -ldflags '$(GO_LDFLAGS)' -trimpath -buildvcs=false
-# teleport-update builds with disabled cgo, buildmode=pie is not required.
 BUILDFLAGS_TELEPORT_UPDATE ?= $(ADDFLAGS) -ldflags '$(GO_LDFLAGS)' -trimpath -buildvcs=false
 endif
 
@@ -321,9 +320,8 @@ ifneq ("$(ARCH)","amd64")
 $(error "Building for windows requires ARCH=amd64")
 endif
 CGOFLAG = CGO_ENABLED=1 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++
-BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath -buildmode=pie -buildvcs=false
+BUILDFLAGS = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath -buildvcs=false
 BUILDFLAGS_TBOT = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath -buildvcs=false
-# teleport-update builds with disabled cgo, buildmode=pie is not required.
 BUILDFLAGS_TELEPORT_UPDATE = $(ADDFLAGS) -ldflags '-w -s $(KUBECTL_SETVERSION)' -trimpath -buildvcs=false
 endif
 
@@ -404,8 +402,6 @@ $(BUILDDIR)/tsh:
 # tbot is CGO-less by default except on Windows because lib/client/terminal/ wants CGO on this OS
 # We force cgo to be disabled, else the compiler might decide to enable it.
 $(BUILDDIR)/tbot: TBOT_CGO_FLAGS ?= $(if $(filter windows,$(OS)),$(CGOFLAG),CGO_ENABLED=0)
-# Build mode pie requires CGO
-$(BUILDDIR)/tbot: BUILDFLAGS_TBOT += $(if $(findstring CGO_ENABLED=1,$(TBOT_CGO_FLAGS)), -buildmode=pie)
 $(BUILDDIR)/tbot:
 	GOOS=$(OS) GOARCH=$(ARCH) $(TBOT_CGO_FLAGS) go build -tags "$(FIPS_TAG) $(KUSTOMIZE_NO_DYNAMIC_PLUGIN)" -o $(BUILDDIR)/tbot $(BUILDFLAGS_TBOT) $(TOOLS_LDFLAGS) ./tool/tbot
 


### PR DESCRIPTION
This PR removes the `-buildmode=pie` build option that we've been using for cgo-enabled builds of Teleport (all of them, except non-fips `tbot` and `teleport-update` for unix platforms). For the `teleport` binary, runtime relocations end up requiring about 40MB of private runtime memory and roughly the same amount of additional disk space compared to the same binary built with `-buildmode=exe` (i.e. `=default`), as well as some additional CPU cost at startup (20msec for an amd64 build on an EC2 m7a.xlarge instance), and the benefits provided by using a PIE binary are not worth the extra cost, especially when factoring in the need to reexecute the `teleport` binary over and over to run user sessions for the SSH service.

It might be possible to simplify the build system, especially with regards to using precompiled static dependencies that are not compiled with `-fPIE` or `-fPIC` (seeing as we don't need that anymore) but that's out of scope for this PR, and it's something that can be done at a later time. 

ent PR: gravitational/teleport.e#7816

Fixes #62366