### PR TITLE
Web listIntegrations optional summaries and IntegrationList Issues, Details updates

### DIFF
--- a/api/types/integration.go
+++ b/api/types/integration.go
@@ -81,6 +81,9 @@ type Integration interface {
 	// CanChangeStateTo checks if the current Integration can be updated for the provided integration.
 	CanChangeStateTo(Integration) error
 
+	// SupportsDiscoveryResources returns whether this integration can have associated DiscoverConfigs.
+	SupportsDiscoveryResources() bool
+
 	// GetAWSOIDCIntegrationSpec returns the `aws-oidc` spec fields.
 	GetAWSOIDCIntegrationSpec() *AWSOIDCIntegrationSpecV1
 	// SetAWSOIDCIntegrationSpec sets the `aws-oidc` spec fields.
@@ -206,6 +209,17 @@ func NewIntegrationAWSRA(md Metadata, spec *AWSRAIntegrationSpecV1) (*Integratio
 		return nil, trace.Wrap(err)
 	}
 	return ig, nil
+}
+
+// SupportsDiscoveryResources specifies if this integration subkind may have associated discovery configs.
+func (ig *IntegrationV1) SupportsDiscoveryResources() bool {
+	switch ig.GetSubKind() {
+	case IntegrationSubKindAWSOIDC,
+		IntegrationSubKindAzureOIDC:
+		return true
+	default:
+		return false
+	}
 }
 
 // String returns the integration string representation.

--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -20,6 +20,7 @@ package web
 
 import (
 	"context"
+	"iter"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -37,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/usertasks"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/integrations/access/msteams"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
@@ -344,70 +346,51 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 		}
 	}
 
-	var nextPage string
-	for {
-		filters := &usertasksv1.ListUserTasksFilters{
-			Integration: req.integration.GetName(),
-			TaskState:   usertasks.TaskStateOpen,
-		}
-		userTasks, nextToken, err := req.userTasksClient.ListUserTasks(ctx, 0, nextPage, filters)
-		if err != nil {
-			return nil, err
-		}
-
-		ret.UserTasks = append(ret.UserTasks, ui.MakeUserTasks(userTasks)...)
-
-		for _, userTask := range userTasks {
-			switch userTask.GetSpec().GetTaskType() {
-			case usertasks.TaskTypeDiscoverEC2:
-				ret.AWSEC2.UnresolvedUserTasks++
-			case usertasks.TaskTypeDiscoverEKS:
-				ret.AWSEKS.UnresolvedUserTasks++
-			case usertasks.TaskTypeDiscoverRDS:
-				ret.AWSRDS.UnresolvedUserTasks++
-			}
-		}
-
-		if nextToken == "" {
-			break
-		}
-		nextPage = nextToken
-	}
-
-	ret.UnresolvedUserTasks = len(ret.UserTasks)
-
-	nextPage = ""
-	for {
-		discoveryConfigs, nextToken, err := req.discoveryConfigLister.ListDiscoveryConfigs(ctx, 0, nextPage)
+	tasks := allUserTasks(ctx, req.userTasksClient, &usertasksv1.ListUserTasksFilters{
+		Integration: req.integration.GetName(),
+		TaskState:   usertasks.TaskStateOpen,
+	})
+	for task, err := range tasks {
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		for _, dc := range discoveryConfigs {
-			discoveredResources, ok := dc.Status.IntegrationDiscoveredResources[req.integration.GetName()]
-			if !ok {
-				continue
-			}
+		ret.UserTasks = append(ret.UserTasks, ui.MakeUserTask(task))
 
-			if matchers := rulesWithIntegration(dc, types.AWSMatcherEC2, req.integration.GetName()); matchers != 0 {
-				ret.AWSEC2.RulesCount += matchers
-				mergeResourceTypeSummary(&ret.AWSEC2, dc.Status.LastSyncTime, discoveredResources.AwsEc2)
-			}
+		switch task.GetSpec().GetTaskType() {
+		case usertasks.TaskTypeDiscoverEC2:
+			ret.AWSEC2.UnresolvedUserTasks++
+		case usertasks.TaskTypeDiscoverEKS:
+			ret.AWSEKS.UnresolvedUserTasks++
+		case usertasks.TaskTypeDiscoverRDS:
+			ret.AWSRDS.UnresolvedUserTasks++
+		}
+	}
+	ret.UnresolvedUserTasks = len(ret.UserTasks)
 
-			if matchers := rulesWithIntegration(dc, types.AWSMatcherRDS, req.integration.GetName()); matchers != 0 {
-				ret.AWSRDS.RulesCount += matchers
-				mergeResourceTypeSummary(&ret.AWSRDS, dc.Status.LastSyncTime, discoveredResources.AwsRds)
-			}
-
-			if matchers := rulesWithIntegration(dc, types.AWSMatcherEKS, req.integration.GetName()); matchers != 0 {
-				ret.AWSEKS.RulesCount += matchers
-				mergeResourceTypeSummary(&ret.AWSEKS, dc.Status.LastSyncTime, discoveredResources.AwsEks)
-			}
+	for cfg, err := range allDiscoveryConfigs(ctx, req.discoveryConfigLister) {
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 
-		if nextToken == "" {
-			break
+		discoveredResources, ok := cfg.Status.IntegrationDiscoveredResources[req.integration.GetName()]
+		if !ok {
+			continue
 		}
-		nextPage = nextToken
+
+		if matchers := rulesWithIntegration(cfg, types.AWSMatcherEC2, req.integration.GetName()); matchers != 0 {
+			ret.AWSEC2.RulesCount += matchers
+			mergeResourceTypeSummary(&ret.AWSEC2, cfg.Status.LastSyncTime, discoveredResources.AwsEc2)
+		}
+
+		if matchers := rulesWithIntegration(cfg, types.AWSMatcherRDS, req.integration.GetName()); matchers != 0 {
+			ret.AWSRDS.RulesCount += matchers
+			mergeResourceTypeSummary(&ret.AWSRDS, cfg.Status.LastSyncTime, discoveredResources.AwsRds)
+		}
+
+		if matchers := rulesWithIntegration(cfg, types.AWSMatcherEKS, req.integration.GetName()); matchers != 0 {
+			ret.AWSEKS.RulesCount += matchers
+			mergeResourceTypeSummary(&ret.AWSEKS, cfg.Status.LastSyncTime, discoveredResources.AwsEks)
+		}
 	}
 
 	switch req.integration.GetSubKind() {
@@ -440,6 +423,84 @@ func collectIntegrationStats(ctx context.Context, req collectIntegrationStatsReq
 	}
 
 	return ret, nil
+}
+
+func buildBriefSummaries(ctx context.Context, igs []types.Integration, uclt userTasksLister, dclt discoveryConfigLister) (map[string]*ui.BriefSummary, error) {
+	summaries := make(map[string]*ui.BriefSummary, len(igs))
+	for _, ig := range igs {
+		if !ig.SupportsDiscoveryResources() {
+			continue
+		}
+		summaries[ig.GetName()] = &ui.BriefSummary{}
+	}
+
+	if len(summaries) == 0 {
+		return summaries, nil
+	}
+
+	for name := range summaries {
+		tasks := allUserTasks(ctx, uclt, &usertasksv1.ListUserTasksFilters{
+			Integration: name,
+			TaskState:   usertasks.TaskStateOpen,
+		})
+		for task, err := range tasks {
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			summaries[name].UnresolvedUserTasks = append(summaries[name].UnresolvedUserTasks, ui.MakeUserTask(task))
+		}
+	}
+
+	for cfg, err := range allDiscoveryConfigs(ctx, dclt) {
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		for name, rscs := range cfg.Status.IntegrationDiscoveredResources {
+			if _, ok := summaries[name]; !ok {
+				continue
+			}
+
+			if summaries[name].ResourcesCount == nil {
+				summaries[name].ResourcesCount = &ui.ResourcesCount{}
+			}
+			addResourceCounts(summaries[name].ResourcesCount, rscs.AwsEc2)
+			addResourceCounts(summaries[name].ResourcesCount, rscs.AwsEks)
+			addResourceCounts(summaries[name].ResourcesCount, rscs.AwsRds)
+			addResourceCounts(summaries[name].ResourcesCount, rscs.AzureVms)
+		}
+	}
+
+	return summaries, nil
+}
+
+func addResourceCounts(rc *ui.ResourcesCount, dr *discoveryconfigv1.ResourcesDiscoveredSummary) {
+	if rc == nil || dr == nil {
+		return
+	}
+	rc.Found += int(dr.Found)
+	rc.Enrolled += int(dr.Enrolled)
+	rc.Failed += int(dr.Failed)
+}
+
+func allUserTasks(
+	ctx context.Context,
+	lister userTasksLister,
+	filters *usertasksv1.ListUserTasksFilters,
+) iter.Seq2[*usertasksv1.UserTask, error] {
+	return clientutils.Resources(ctx,
+		func(ctx context.Context, pageSize int, nextToken string) ([]*usertasksv1.UserTask, string, error) {
+			return lister.ListUserTasks(ctx, int64(pageSize), nextToken, filters)
+		})
+}
+
+func allDiscoveryConfigs(
+	ctx context.Context,
+	lister discoveryConfigLister,
+) iter.Seq2[*discoveryconfig.DiscoveryConfig, error] {
+	return clientutils.Resources(ctx,
+		func(ctx context.Context, pageSize int, nextToken string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+			return lister.ListDiscoveryConfigs(ctx, pageSize, nextToken)
+		})
 }
 
 func countAWSOIDCDeployedDatabaseServices(ctx context.Context, req collectIntegrationStatsRequest) (int, error) {
@@ -647,14 +708,27 @@ func (h *Handler) integrationsList(w http.ResponseWriter, r *http.Request, p htt
 		return nil, trace.Wrap(err)
 	}
 
+	var summaries map[string]*ui.BriefSummary
+	withSummaries, err := parseBoolWithDefault(values.Get("withSummaries"), false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if withSummaries {
+		summaries, err = buildBriefSummaries(r.Context(), igs, clt.UserTasksServiceClient(), clt.DiscoveryConfigClient())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	items, err := ui.MakeIntegrations(igs)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return ui.IntegrationsListResponse{
-		Items:   items,
-		NextKey: nextKey,
+		Items:     items,
+		NextKey:   nextKey,
+		Summaries: summaries,
 	}, nil
 }
 

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -209,10 +209,15 @@ func TestIntegrationsCRUDRolesAnywhere(t *testing.T) {
 
 type mockUserTasksLister struct {
 	defaultPageSize int64
+	err             error
 	userTasks       []*usertasksv1.UserTask
 }
 
 func (m *mockUserTasksLister) ListUserTasks(ctx context.Context, pageSize int64, nextToken string, filters *usertasksv1.ListUserTasksFilters) ([]*usertasksv1.UserTask, string, error) {
+	if m.err != nil {
+		return nil, "", m.err
+	}
+
 	var ret []*usertasksv1.UserTask
 	if pageSize == 0 {
 		pageSize = m.defaultPageSize
@@ -975,7 +980,6 @@ func TestGitHubIntegration(t *testing.T) {
 				Integration: uiIntegration,
 			})
 			require.Error(t, err)
-
 		})
 		t.Run("success", func(t *testing.T) {
 			createResp, err := authPack.clt.PostJSON(ctx, endpoint, ui.CreateIntegrationRequest{
@@ -1084,4 +1088,202 @@ func TestGitHubIntegration(t *testing.T) {
 			require.True(t, trace.IsNotFound(err))
 		})
 	})
+}
+
+func TestBuildBriefSummaries(t *testing.T) {
+	mockAwsInt := newMockAWSOIDCIntegration(t, "aws-oidc-1")
+	mockGithubInt := newMockGitHubIntegration(t, "gh")
+
+	mockUserTasks := []*usertasksv1.UserTask{
+		{
+			Spec: &usertasksv1.UserTaskSpec{
+				Integration: mockAwsInt.GetName(),
+				TaskType:    usertasks.TaskTypeDiscoverEC2,
+				State:       usertasks.TaskStateOpen,
+			},
+		},
+		{
+			Spec: &usertasksv1.UserTaskSpec{
+				Integration: mockAwsInt.GetName(),
+				TaskType:    usertasks.TaskTypeDiscoverEKS,
+				State:       usertasks.TaskStateOpen,
+			},
+		},
+	}
+
+	mockDC1 := &discoveryconfig.DiscoveryConfig{
+		Status: discoveryconfig.Status{
+			IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				mockAwsInt.GetName(): {
+					AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
+					AwsEks: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 3, Enrolled: 0, Failed: 1},
+					AwsRds: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 5, Enrolled: 2, Failed: 2},
+				},
+			},
+		},
+	}
+	mockDC2 := &discoveryconfig.DiscoveryConfig{
+		Status: discoveryconfig.Status{
+			IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+				mockAwsInt.GetName(): {
+					AzureVms: &discoveryconfigv1.ResourcesDiscoveredSummary{Found: 2, Enrolled: 1, Failed: 0},
+				},
+			},
+		},
+	}
+
+	mockErr := errors.New("test error")
+
+	tests := []struct {
+		name         string
+		utLister     *mockUserTasksLister
+		dcLister     *mockDiscoveryConfigLister
+		integrations []types.Integration
+		expected     map[string]*ui.BriefSummary
+		error        error
+	}{
+		{"Empty Input", &mockUserTasksLister{}, &mockDiscoveryConfigLister{}, nil, map[string]*ui.BriefSummary{}, nil},
+		{
+			"Skips Integrations With No Support",
+			&mockUserTasksLister{},
+			&mockDiscoveryConfigLister{},
+			[]types.Integration{
+				mockAwsInt,
+				mockGithubInt,
+			},
+			map[string]*ui.BriefSummary{
+				mockAwsInt.GetName(): {},
+			},
+			nil,
+		},
+		{
+			"Collects User Tasks",
+			&mockUserTasksLister{
+				userTasks:       mockUserTasks,
+				defaultPageSize: 100,
+			},
+			&mockDiscoveryConfigLister{},
+			[]types.Integration{
+				mockAwsInt,
+				mockGithubInt,
+			},
+			map[string]*ui.BriefSummary{
+				mockAwsInt.GetName(): {
+					UnresolvedUserTasks: ui.MakeUserTasks(mockUserTasks),
+				},
+			},
+			nil,
+		},
+		{
+			"Counts Discovered Resources",
+			&mockUserTasksLister{},
+			&mockDiscoveryConfigLister{
+				configs: [][]*discoveryconfig.DiscoveryConfig{{mockDC1}, {mockDC2}},
+			},
+			[]types.Integration{
+				mockAwsInt,
+				mockGithubInt,
+			},
+			map[string]*ui.BriefSummary{
+				mockAwsInt.GetName(): {
+					ResourcesCount: &ui.ResourcesCount{
+						Found:    12,
+						Enrolled: 4,
+						Failed:   3,
+					},
+				},
+			},
+			nil,
+		},
+		{
+			"Error From User Task Lister",
+			&mockUserTasksLister{err: mockErr},
+			&mockDiscoveryConfigLister{},
+			[]types.Integration{
+				mockAwsInt,
+			},
+			nil,
+			mockErr,
+		},
+		{
+			"Error From Discovery Config Lister",
+			&mockUserTasksLister{},
+			&mockDiscoveryConfigLister{err: mockErr},
+			[]types.Integration{
+				mockAwsInt,
+			},
+			nil,
+			mockErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := buildBriefSummaries(context.Background(), tt.integrations, tt.utLister, tt.dcLister)
+			require.Equal(t, tt.expected, actual)
+			require.Equal(t, tt.error, trace.Unwrap(err))
+		})
+	}
+}
+
+type mockDiscoveryConfigLister struct {
+	configs [][]*discoveryconfig.DiscoveryConfig
+	err     error
+
+	calls int
+}
+
+func (m *mockDiscoveryConfigLister) ListDiscoveryConfigs(ctx context.Context, pageSize int, nextToken string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+	m.calls++
+	if m.err != nil {
+		return nil, "", m.err
+	}
+	if len(m.configs) == 0 {
+		return nil, "", nil
+	}
+
+	var page int
+	if nextToken != "" {
+		switch nextToken {
+		case "1":
+			page = 1
+		case "2":
+			page = 2
+		default:
+			page = 0
+		}
+	}
+
+	if page >= len(m.configs) {
+		return nil, "", nil
+	}
+	next := ""
+	if page+1 < len(m.configs) {
+		next = string(rune('0' + (page + 1)))
+	}
+	return m.configs[page], next, nil
+}
+
+func newMockAWSOIDCIntegration(t *testing.T, name string) types.Integration {
+	t.Helper()
+	ig, err := types.NewIntegrationAWSOIDC(
+		types.Metadata{Name: name},
+		&types.AWSOIDCIntegrationSpecV1{
+			RoleARN:     "arn:aws:iam::123456789012:role/test",
+			IssuerS3URI: "s3://bucket/prefix",
+			Audience:    "aws-identity-center",
+		},
+	)
+	require.NoError(t, err)
+	return ig
+}
+
+func newMockGitHubIntegration(t *testing.T, name string) types.Integration {
+	t.Helper()
+	ig, err := types.NewIntegrationGitHub(
+		types.Metadata{Name: name},
+		&types.GitHubIntegrationSpecV1{Organization: "test"},
+	)
+	require.NoError(t, err)
+	return ig
 }

--- a/lib/web/parse.go
+++ b/lib/web/parse.go
@@ -1,0 +1,31 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package web
+
+import "strconv"
+
+// parseBoolWithDefault parses string for a boolean value,
+// returns the default if the value is empty and
+// returns error if the value is not recognized.
+func parseBoolWithDefault(val string, def bool) (bool, error) {
+	if val == "" {
+		return def, nil
+	}
+	return strconv.ParseBool(val)
+}

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -135,6 +135,24 @@ type IntegrationWithSummary struct {
 	IsManagedByTerraform bool `json:"isManagedByTerraform"`
 }
 
+// BriefSummary contains gathered information about an integration surfaced in the UI.
+type BriefSummary struct {
+	// UnresolvedUserTasks contains the list of open user tasks associated with this integration
+	UnresolvedUserTasks []UserTask `json:"unresolvedUserTasks"`
+	// ResourcesCount show the count of resources found, enrolled, and failed from this integration
+	ResourcesCount *ResourcesCount `json:"resourcesCount,omitempty"`
+}
+
+// ResourcesCount contains counts of resources by status.
+type ResourcesCount struct {
+	// Found is the count of resources discovered
+	Found int `json:"found"`
+	// Enrolled is the count of resources found and enrolled to the cluster
+	Enrolled int `json:"enrolled"`
+	// Failed is the count of resources that were found but failed to be enrolled
+	Failed int `json:"failed"`
+}
+
 // ResourceTypeSummary contains the summary of the enrollment rules and found resources by the integration.
 type ResourceTypeSummary struct {
 	// RulesCount is the number of enrollment rules that are using this integration.
@@ -340,6 +358,8 @@ type IntegrationsListResponse struct {
 	Items []*Integration `json:"items"`
 	// NextKey is the position to resume listing events.
 	NextKey string `json:"nextKey"`
+	// Summaries are abbreviated details about the integration.
+	Summaries map[string]*BriefSummary `json:"summaries,omitempty"`
 }
 
 // MakeIntegrations creates a UI list of Integrations.

--- a/web/packages/design/src/Label/Label.tsx
+++ b/web/packages/design/src/Label/Label.tsx
@@ -103,9 +103,9 @@ const kind = ({
 
   if (kind === 'outline-secondary') {
     return {
-      color: theme.colors.text.muted,
+      color: theme.colors.text.slightlyMuted,
       backgroundColor: theme.colors.interactive.tonal.neutral[0],
-      borderColor: theme.colors.text.muted,
+      borderColor: theme.colors.text.slightlyMuted,
       borderWidth: 1,
       borderStyle: 'solid',
       fontWeight: theme.fontWeights.regular,
@@ -137,9 +137,9 @@ const kind = ({
 
   if (kind === 'outline-warning') {
     return {
-      color: theme.colors.interactive.solid.alert.hover,
+      color: theme.colors.dataVisualisation.primary.sunflower,
       backgroundColor: theme.colors.interactive.tonal.alert[0],
-      borderColor: theme.colors.interactive.solid.alert.hover,
+      borderColor: theme.colors.dataVisualisation.primary.sunflower,
       borderWidth: 1,
       borderStyle: 'solid',
       fontWeight: theme.fontWeights.regular,
@@ -154,7 +154,7 @@ const kind = ({
 
   if (kind === 'outline-danger') {
     return {
-      color: theme.colors.interactive.solid.danger.default,
+      color: theme.colors.dataVisualisation.tertiary.abbey,
       backgroundColor: theme.colors.interactive.tonal.danger[0],
       borderColor: theme.colors.interactive.solid.danger.default,
       borderWidth: 1,

--- a/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
+++ b/web/packages/teleport/src/Discover/Overview/IaCIntegrationOverview.tsx
@@ -31,17 +31,16 @@ import {
   ArrowLeft,
   ArrowRight,
   ChevronRight,
-  CircleCheck,
   CircleCross,
   Warning,
 } from 'design/Icon';
-import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { TabBorder, useSlidingBottomBorderTabs } from 'design/Tabs';
 import { HoverTooltip } from 'design/Tooltip';
 import { pluralize } from 'shared/utils/text';
 
 import { FeatureBox } from 'teleport/components/Layout';
 import cfg from 'teleport/config';
+import { SummaryStatusLabel } from 'teleport/Integrations/shared/StatusLabel';
 import {
   IntegrationKind,
   integrationService,
@@ -186,12 +185,7 @@ function IntegrationHealthCard({
       <Flex flexDirection="column" gap={2}>
         <StatusRow label="Status:">
           <Flex alignItems="center" gap={2} flexWrap="wrap">
-            <LabelButtonWithIcon
-              IconLeft={hasIssues ? Warning : CircleCheck}
-              kind={hasIssues ? 'outline-warning' : 'outline-success'}
-            >
-              {hasIssues ? 'Issues' : 'Healthy'}
-            </LabelButtonWithIcon>
+            <SummaryStatusLabel summary={stats} />
             {hasIssues && (
               <>
                 <Text typography="body3">

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -21,10 +21,12 @@ import { useHistory } from 'react-router';
 import { Link as InternalRouteLink } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Box, Flex } from 'design';
+import { Box, Flex, Text } from 'design';
 import Table, { Cell, StyledPanel } from 'design/DataTable';
 import InputSearch from 'design/DataTable/InputSearch';
+import { CircleCheck, CircleCross, Warning } from 'design/Icon';
 import { ResourceIcon } from 'design/ResourceIcon';
+import { HoverTooltip } from 'design/Tooltip';
 import {
   applyFilters,
   FilterMap,
@@ -33,6 +35,7 @@ import {
 import { MenuButton, MenuItem } from 'shared/components/MenuAction';
 import { useAsync } from 'shared/hooks/useAsync';
 import { saveOnDisk } from 'shared/utils/saveOnDisk';
+import { pluralize } from 'shared/utils/text';
 
 import cfg from 'teleport/config';
 import {
@@ -170,8 +173,14 @@ export function IntegrationList(props: Props) {
             ),
           },
           {
+            key: 'summary',
+            headerText: 'Issues',
+            render: item => <IssuesCell integration={item} />,
+          },
+          {
             key: 'details',
             headerText: 'Details',
+            render: item => <DetailsCell integration={item} />,
           },
           {
             altKey: 'options-btn',
@@ -407,4 +416,132 @@ const NameCell = ({ item }: { item: IntegrationLike }) => {
 const IconContainer = styled(ResourceIcon)`
   width: 22px;
   margin-right: 10px;
+`;
+
+const IssuesCell = ({ integration }: { integration: IntegrationLike }) => {
+  const issueCount = integration.summary?.unresolvedUserTasks.length;
+  if (issueCount > 0) {
+    // In the list tooltip, we only want to show up to 3 tasks. If there are more,
+    // the user can go to the integration dashboard to see all of them.
+    const showTopX = 3;
+    return (
+      <Cell>
+        <HoverTooltip
+          tipContent={
+            <Box>
+              <Text fontWeight={600}>
+                {issueCount.toLocaleString()} {pluralize(issueCount, 'Issue')}
+              </Text>
+              <TaskUL>
+                {integration.summary.unresolvedUserTasks
+                  .slice(0, showTopX)
+                  .map(issue => (
+                    <TaskLI key={issue.name}>{issue.title}</TaskLI>
+                  ))}
+              </TaskUL>
+              {issueCount > showTopX && (
+                <Text>
+                  and {(issueCount - showTopX).toLocaleString()} more...
+                </Text>
+              )}
+            </Box>
+          }
+        >
+          <PointerFlex inline alignItems="center" gap={1}>
+            {issueCount.toLocaleString()}
+            <Warning size="small" />
+          </PointerFlex>
+        </HoverTooltip>
+      </Cell>
+    );
+  }
+  return <Cell>-</Cell>;
+};
+
+const TaskUL = styled.ul`
+  margin: 0;
+  padding-left: ${p => p.theme.space[2]}px;
+`;
+
+const TaskLI = styled.li`
+  list-style-position: inside;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+const percentFormatter = new Intl.NumberFormat(undefined, {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+  roundingMode: 'trunc',
+});
+
+export function percent(n: number, d: number): string {
+  if (!Number.isFinite(n) || !Number.isFinite(d) || d <= 0) {
+    return '-';
+  }
+
+  const ratio = n / d;
+
+  if (isNaN(ratio)) {
+    return '-';
+  }
+
+  return percentFormatter.format(ratio);
+}
+
+const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
+  let content = <Text>{integration.details}</Text>;
+  switch (integration.kind) {
+    case IntegrationKind.AwsOidc:
+    case IntegrationKind.AzureOidc:
+      if (integration.summary?.resourcesCount) {
+        const rc = integration.summary.resourcesCount;
+        const hasFailures = rc.failed > 0;
+        const enrolledPct = percent(rc.enrolled, rc.found);
+        const failedPct = percent(rc.failed, rc.found);
+        content = (
+          <HoverTooltip
+            tipContent={
+              <Box>
+                <Text fontWeight={600}>
+                  {rc.found.toLocaleString()} Resources Found
+                </Text>
+                <Flex alignItems="center" mt={1} gap={1}>
+                  <CircleCheck size="small" color="success.main" />
+                  <Text>
+                    {rc.enrolled.toLocaleString()} enrolled ({enrolledPct})
+                  </Text>
+                </Flex>
+                {hasFailures && (
+                  <>
+                    <Flex alignItems="center" gap={1}>
+                      <CircleCross size="small" color="error.main" />
+                      <Text>
+                        {rc.failed.toLocaleString()} failed ({failedPct})
+                      </Text>
+                    </Flex>
+                    <Text mt={1}>
+                      For more information on failures, please check the
+                      integration overview.
+                    </Text>
+                  </>
+                )}
+              </Box>
+            }
+          >
+            <PointerFlex inline gap={1}>
+              {rc.enrolled.toLocaleString()} Resources enrolled ({enrolledPct})
+            </PointerFlex>
+          </HoverTooltip>
+        );
+      }
+      break;
+  }
+  return <Cell>{content}</Cell>;
+};
+
+const PointerFlex = styled(Flex)`
+  cursor: pointer;
 `;

--- a/web/packages/teleport/src/Integrations/Integrations.tsx
+++ b/web/packages/teleport/src/Integrations/Integrations.tsx
@@ -56,9 +56,11 @@ export function Integrations() {
     // TODO(lisa): handle paginating as a follow up polish.
     // Default fetch is 1k of integrations, which is plenty for beginning.
     run(() =>
-      integrationService.fetchIntegrations().then(resp => setItems(resp.items))
+      integrationService
+        .fetchIntegrations(true)
+        .then(resp => setItems(resp.items))
     );
-  }, []);
+  }, [run]);
 
   function removeIntegration() {
     return integrationOps.remove().then(() => {

--- a/web/packages/teleport/src/Integrations/fixtures.ts
+++ b/web/packages/teleport/src/Integrations/fixtures.ts
@@ -186,12 +186,76 @@ export const integrations: Integration[] = [
     kind: IntegrationKind.AwsOidc,
     statusCode: IntegrationStatusCode.Running,
     spec: { roleArn: '', issuerS3Prefix: '', issuerS3Bucket: '' },
+    summary: {
+      resourcesCount: {
+        found: 1000,
+        enrolled: 999,
+        failed: 1,
+      },
+      unresolvedUserTasks: [
+        {
+          name: 'ut-ec2-enroll-0001',
+          taskType: 'discover-ec2',
+          state: 'OPEN',
+          issueType: 'ec2-enroll',
+          title: 'Enroll discovered EC2 instances',
+          integration: 'aws-prod',
+          lastStateChange: '2026-01-11T18:42:10Z',
+        },
+        {
+          name: 'ut-eks-enroll-0007',
+          taskType: 'discover-eks',
+          state: 'OPEN',
+          issueType: 'eks-enroll',
+          title: 'An extra long title to show text overflow styles',
+          integration: 'aws-prod',
+          lastStateChange: '2026-01-10T03:15:00Z',
+        },
+        {
+          name: 'ut-rds-failure-0042',
+          taskType: 'discover-rds',
+          state: 'OPEN',
+          issueType: 'rds-discovery-failed',
+          title: 'RDS discovery failed',
+          integration: 'aws-staging',
+          lastStateChange: '2026-01-09T22:01:33Z',
+        },
+        {
+          name: 'aws-oidc:discover-eks:eks-agent-not-connecting:123456789012:us-east-1:example-cluster',
+          taskType: 'discover-eks',
+          state: 'OPEN',
+          issueType: 'eks-agent-not-connecting',
+          title:
+            'Teleport Kubernetes agent is not connecting for EKS cluster example-cluster',
+          integration: 'aws-oidc',
+          lastStateChange: '2026-01-10T18:42:00Z',
+        },
+      ],
+    },
   },
   {
     resourceType: 'integration',
     name: 'azure',
     kind: IntegrationKind.AzureOidc,
     statusCode: IntegrationStatusCode.Running,
+    summary: {
+      unresolvedUserTasks: [
+        {
+          name: 'ut-rds-failure-0042',
+          taskType: 'discover-rds',
+          state: 'OPEN',
+          issueType: 'rds-discovery-failed',
+          title: 'RDS discovery failed',
+          integration: 'aws-staging',
+          lastStateChange: '2026-01-09T22:01:33Z',
+        },
+      ],
+      resourcesCount: {
+        found: 10,
+        enrolled: 10,
+        failed: 0,
+      },
+    },
   },
   {
     resourceType: 'integration',

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -1418,13 +1418,17 @@ const cfg = {
     });
   },
 
-  getIntegrationsUrl(integrationName?: string) {
+  getIntegrationsUrl(integrationName?: string, withSummaries: boolean = false) {
     // Currently you can only create integrations at the root cluster.
     const clusterId = cfg.proxyCluster;
-    return generatePath(cfg.api.integrationsPath, {
+    let url = generatePath(cfg.api.integrationsPath, {
       clusterId,
       name: integrationName,
     });
+    if (withSummaries) {
+      url += `?withSummaries=true`;
+    }
+    return url;
   },
 
   getDeleteIntegrationUrlV2(req: IntegrationDeleteRequest) {

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -89,14 +89,21 @@ export const integrationService = {
       .then(resp => makeIntegration(resp) as T);
   },
 
-  fetchIntegrations(): Promise<IntegrationListResponse> {
-    return api.get(cfg.getIntegrationsUrl()).then(resp => {
-      const integrations = resp?.items ?? [];
-      return {
-        items: integrations.map(makeIntegration),
-        nextKey: resp?.nextKey,
-      };
-    });
+  fetchIntegrations(
+    withSummaries: boolean = false
+  ): Promise<IntegrationListResponse> {
+    return api
+      .get(cfg.getIntegrationsUrl(undefined, withSummaries))
+      .then(resp => {
+        const integrations = resp?.items ?? [];
+        if (withSummaries) {
+          mapSummaries(integrations, resp?.summaries);
+        }
+        return {
+          items: integrations.map(makeIntegration),
+          nextKey: resp?.nextKey,
+        };
+      });
   },
 
   createIntegration<T extends IntegrationCreateRequest>(
@@ -629,9 +636,18 @@ export function makeIntegrations(json: any): Integration[] {
 
 function makeIntegration(json: any): Integration {
   json = json || {};
-  const { name, subKind, awsoidc, github, awsra, isManagedByTerraform } = json;
+  const {
+    name,
+    subKind,
+    awsoidc,
+    github,
+    awsra,
+    isManagedByTerraform,
+    summary,
+  } = json;
 
   const commonFields = {
+    resourceType: 'integration' as const,
     name,
     kind: subKind,
     // The integration resource does not have a "status" field, but is
@@ -641,12 +657,12 @@ function makeIntegration(json: any): Integration {
     // https://github.com/gravitational/teleport/pull/22556#discussion_r1158674300
     statusCode: IntegrationStatusCode.Running,
     isManagedByTerraform,
+    summary,
   };
 
   if (subKind === IntegrationKind.AwsOidc) {
     return {
       ...commonFields,
-      resourceType: 'integration',
       details:
         'Enroll EC2, RDS and EKS resources or enable Web/CLI access to your AWS Account.',
       spec: {
@@ -661,7 +677,6 @@ function makeIntegration(json: any): Integration {
   if (subKind === IntegrationKind.AwsRa) {
     return {
       ...commonFields,
-      resourceType: 'integration',
       details: 'Sync AWS IAM Roles Anywhere Profiles with Teleport',
       spec: {
         trustAnchorARN: awsra?.trustAnchorARN,
@@ -678,7 +693,6 @@ function makeIntegration(json: any): Integration {
   if (subKind === IntegrationKind.GitHub) {
     return {
       ...commonFields,
-      resourceType: 'integration',
       details: `GitHub repository access for organization "${github.organization}"`,
       spec: {
         organization: github.organization,
@@ -686,10 +700,18 @@ function makeIntegration(json: any): Integration {
     };
   }
 
-  return {
-    ...commonFields,
-    resourceType: 'integration',
-  };
+  return commonFields;
+}
+
+function mapSummaries(integrations, summaryMap) {
+  if (!integrations || !summaryMap) return;
+
+  for (const i of integrations) {
+    const s = summaryMap[i.name];
+    if (s !== undefined) {
+      i.summary = s;
+    }
+  }
 }
 
 export function makeAwsDatabase(json: any): AwsRdsDatabase {

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -72,7 +72,18 @@ export type IntegrationTemplate<
   statusCode: IntegrationStatusCode;
   status?: SD;
   credentials?: PluginCredentials;
+  summary?: BriefSummary;
 };
+
+type BriefSummary = {
+  unresolvedUserTasks: UserTask[];
+  resourcesCount?: {
+    found: number;
+    enrolled: number;
+    failed: number;
+  };
+};
+
 // IntegrationKind string values should be in sync
 // with the backend value for defining the integration
 // resource's subKind field.


### PR DESCRIPTION
This adds an option to request summaries with integrations when listing integrations. The summaries are the open user tasks and resource counts for the integration, which are being shown on the Integrations page. We only build summaries for integration types that support them: AWS OIDC and Azure OIDC.

<img width="1163" height="312" alt="Screenshot 2026-01-15 at 1 00 21 PM" src="https://github.com/user-attachments/assets/ba542475-797b-4497-a99e-e82fab3e0bd5" />
