### PR TITLE
[v18] Fix Lint (Proto) path filters

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -71,7 +71,9 @@ jobs:
               - 'docs/pages/enroll-resources/**'
               - 'docs/pages/reference/infrastructure-as-code/operator-resources/**'
               - 'docs/pages/reference/infrastructure-as-code/terraform-provider/**'
+              - 'docs/pages/reference/infrastructure-as-code/teleport-resources/**'
               - 'examples/chart/teleport-cluster/charts/teleport-operator/operator-crds'
+              - 'build.assets/tooling/cmd/resource-ref-generator/**'
             has_ui:
               - '.github/workflows/lint.yaml'
               - 'web/**'

--- a/build.assets/tooling/cmd/resource-ref-generator/config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/config.yaml
@@ -25,6 +25,11 @@ resources:
     yaml_version: v2
 
 camel_case_exceptions:
+  - AWS
+  - CORS
+  - EKS
+  - GCP
+  - HTTP
   - ID
   - MFA
   - OIDC


### PR DESCRIPTION
Backports #62707

Check whether the resource reference was generated correctly. Currently, we never execute the step called `Check if resource reference docs are up to date` if a PR updates the resource reference generator configuration or code.

Also edit the resource reference generator config so re-running the generator would not produce diffs.