### PR TITLE
[v18] MWI: Deflake `TestWait*` tests

### DIFF
--- a/tool/tbot/wait_test.go
+++ b/tool/tbot/wait_test.go
@@ -31,8 +31,26 @@ import (
 	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
+// requestNotification is minimal helper that is sent when a request starts, and
+// provides a done channel to notify when the request ends.
+type requestNotification struct {
+	done <-chan struct{}
+}
+
+// isComplete checks if the request is still in flight (false) or complete
+// (true).
+func (r *requestNotification) isComplete() bool {
+	select {
+	case <-r.done:
+		return true
+	default:
+		return false
+	}
+}
+
 type inMemoryTransport struct {
-	handler http.Handler
+	handler  http.Handler
+	requests chan<- requestNotification
 }
 
 func (c *inMemoryTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -44,8 +62,19 @@ func (c *inMemoryTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	// another goroutine and manually return an error if the context is
 	// canceled.
 	go func() {
+		// Notify test that the request is in flight.
+		reqDone := make(chan struct{})
+
+		// Attempt to notify the test about the request. Drop any notifications
+		// to a full channel - we never want to block, and the tests in practice
+		// only care about the first request and the existence of future
+		// requests.
+		c.requests <- requestNotification{done: reqDone}
+
 		c.handler.ServeHTTP(rr, r)
+
 		close(done)
+		close(reqDone)
 	}()
 
 	select {
@@ -57,22 +86,30 @@ func (c *inMemoryTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	}
 }
 
-func createInMemoryWaitClient(handler http.Handler) *http.Client {
+func createInMemoryWaitClient(handler http.Handler, requests chan<- requestNotification) *http.Client {
 	return &http.Client{
 		Transport: &inMemoryTransport{
-			handler: handler,
+			handler:  handler,
+			requests: requests,
 		},
 	}
 }
 
 func TestWaitTimeoutExceeded(t *testing.T) {
-	t.Parallel()
+	// TODO: Evaluate reenabling parallel execution if this branch is updated to
+	// go1.25. Otherwise, parallel execution triggers race conditions in go1.24
+	// synctest bubbles and causes spurious failures.
+	// (This test was for whatever reason not impacted, but has parallel exec
+	// disabled anyway for safety.)
+	// t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
 		reg := readyz.NewRegistry()
 		_ = reg.AddService("svc", "a")
 
 		handler := readyz.HTTPWaitHandler(reg)
+		requests := make(chan requestNotification, 20)
+		client := createInMemoryWaitClient(handler, requests)
 
 		ch := make(chan error)
 		go func() {
@@ -80,49 +117,64 @@ func TestWaitTimeoutExceeded(t *testing.T) {
 				DiagAddr: "http://fake",
 				Service:  "a",
 				Timeout:  time.Millisecond * 250,
-				Client:   createInMemoryWaitClient(handler),
+				Client:   client,
 			})
 		}()
 
-		synctest.Wait()
-
-		time.Sleep(time.Millisecond * 500)
-
-		synctest.Wait()
+		// Wait for an initial request. This request will delay as no status has
+		// been reported.
+		req := <-requests
+		require.False(t, req.isComplete())
 
 		select {
 		case res := <-ch:
 			require.ErrorContains(t, res, "context deadline exceeded")
-		case <-time.After(250 * time.Millisecond):
+		case <-time.After(500 * time.Millisecond):
 			require.Fail(t, "wait failed to honor timeout")
 		}
 	})
 }
 
 func TestWaitSuccess(t *testing.T) {
-	t.Parallel()
+	// TODO: Evaluate reenabling parallel execution if this branch is updated to
+	// go1.25. Otherwise, parallel execution triggers race conditions in go1.24
+	// synctest bubbles and causes spurious failures.
+	// Some extended discussion of issues in go1.24's impl can be found at
+	// https://github.com/golang/go/issues/67434. The issue in these tests
+	// appeared to be that when run in parallel - and only when run in
+	// parallel - tests would occasionally cause synthetic clock advancement in
+	// other, unrelated tests. This would result in timers completing too early
+	// leading to deadlocks, or time advancing impossibly quickly in otherwise
+	// "safe" timers.
+	//
+	// t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
 		reg := readyz.NewRegistry()
-		a := reg.AddService("svc", "a")
+		b := reg.AddService("svc", "b")
 
 		handler := readyz.HTTPWaitHandler(reg)
+		requests := make(chan requestNotification, 20)
+		client := createInMemoryWaitClient(handler, requests)
 
 		ch := make(chan error)
 		go func() {
 			ch <- onWaitCommand(t.Context(), &cli.WaitCommand{
 				DiagAddr: "http://fake",
-				Service:  "a",
+				Service:  "b",
 				Timeout:  time.Second * 2,
-				Client:   createInMemoryWaitClient(handler),
+				Client:   client,
 			})
 		}()
 
-		synctest.Wait()
+		// Wait for an initial request. This request will delay as no status has
+		// been reported.
+		req := <-requests
+		require.False(t, req.isComplete())
 
-		a.Report(readyz.Healthy)
-
-		synctest.Wait()
+		// Once the service reports healthy, the request should complete
+		b.Report(readyz.Healthy)
+		<-req.done
 
 		select {
 		case res := <-ch:
@@ -134,20 +186,32 @@ func TestWaitSuccess(t *testing.T) {
 }
 
 func TestWaitEventualSuccess(t *testing.T) {
-	t.Parallel()
+	// TODO: Evaluate reenabling parallel execution if this branch is updated to
+	// go1.25. Otherwise, parallel execution triggers race conditions in go1.24
+	// synctest bubbles and causes spurious failures.
+	// t.Parallel()
 
 	synctest.Test(t, func(t *testing.T) {
 		reg := readyz.NewRegistry()
-		a := reg.AddService("svc", "a")
+		c := reg.AddService("svc", "c")
 
 		handler := readyz.HTTPWaitHandler(reg)
+
+		// We don't want to strictly predict the precise number of requests
+		// `onWaitCommand` makes, so use an overly large buffer to ensure it can
+		// never plausibly block. The retry driver increases exponentially from
+		// 250ms so 5000ms/250ms=20 maximum possible retries - not that it
+		// should ever reach that in a synctest bubble, especially in go1.25+.
+		requests := make(chan requestNotification, 20)
+
+		client := createInMemoryWaitClient(handler, requests)
 
 		ch := make(chan error)
 		go func() {
 			ch <- onWaitCommand(t.Context(), &cli.WaitCommand{
 				DiagAddr: "http://fake",
-				Service:  "a",
-				Client:   createInMemoryWaitClient(handler),
+				Service:  "c",
+				Client:   client,
 
 				// More generous timeout since this will depend on exponential
 				// backoff (with configured worst case of 2 seconds)
@@ -155,24 +219,47 @@ func TestWaitEventualSuccess(t *testing.T) {
 			})
 		}()
 
+		// Wait for an initial request. This request will delay as no status has
+		// been reported.
+		req := <-requests
+		require.False(t, req.isComplete())
+
+		// Initially report unhealthy. This internally triggers a response and
+		// the HTTP endpoint will return the unhealthy status instead of
+		// waiting. The CLI should retry until the endpoint reports healthy.
+		c.ReportReason(readyz.Unhealthy, "oops")
+
+		// Allow that request to return with the unhealthy status.
+		select {
+		case <-req.done:
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "initial wait request did not return as expected")
+		}
+
+		// The nonblocking select below is probably safe, but yield here out of
+		// caution.
 		synctest.Wait()
 
-		// Initially report unhealthy. This internally triggers a response and the
-		// HTTP endpoint will return the unhealthy status instead of waiting. The
-		// CLI should retry until the endpoint reports healthy.
-		a.ReportReason(readyz.Unhealthy, "oops")
-		time.Sleep(time.Millisecond * 200)
+		// Make sure `onWaitCommand` still hasn't returned.
+		select {
+		case res := <-ch:
+			require.Fail(t, "received unexpected ready status: %+v", res)
+		default:
+			// Expected, should still be waiting due to unhealthy status.
+		}
 
-		synctest.Wait()
+		// Wait for at least one additional request to begin. synctest will
+		// advance the synthetic clock automatically to ensure the internal
+		// timers trigger.
+		<-requests
+		c.Report(readyz.Healthy)
 
-		a.Report(readyz.Healthy)
-
-		synctest.Wait()
-
+		// Wait for a final response.
 		select {
 		case res := <-ch:
 			require.NoError(t, res, "must report ready")
 		case <-time.After(6 * time.Second):
+			// Modest wait beyond the maximum timeout (still synthetic)
 			require.Fail(t, "test timed out and failed to honor configured timeout")
 		}
 	})


### PR DESCRIPTION
This improves and deflakes `TestWait*` tests, including eliminating synthetic `time.Sleep()` calls and adding explicit synchronization to the in-memory HTTP request handler.

The finding seems to be that synctest bubbles in go1.24 do not support `t.Parallel()`, or at least some stdlib feature exercised by these tests is not fully contained within the synctest bubble and is causing timer advancement in parallel bubbles.

The actual fix is disabling `t.Parallel()` for branch/v18. I've tested the fix as thoroughly as possible, but repeat executions with `go test ... -count 10000` don't trigger the bug, so I was unfortunately stuck repeatedly running `go test` which is a few orders of magnitude less efficient.

Fixes #62770