### PR TITLE
helm: add `jobResources` value to teleport-cluster

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2335,6 +2335,7 @@ Resource requests/limits which should be configured for pre-deploy jobs.
 
 Jobs currently include config validation and potentially migration hooks.
 The resource requirements are typically lower than for the main teleport deployment.
+In most cases, you should leave these limits unset.
 
 `values.yaml` example:
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2322,6 +2322,28 @@ See [the GitHub PR](https://github.com/gravitational/teleport/pull/36251) for te
       cpu: 1
       memory: 2Gi
   ```
+
+## `jobResources`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+
+Resource requests/limits which should be configured for pre-deploy jobs.
+
+Jobs currently include config validation and potentially migration hooks.
+The resource requirements are typically lower than for the main teleport deployment.
+
+`values.yaml` example:
+
+```yaml
+jobResources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+```
 ## `goMemLimitRatio`
 
 | Type    | Default |

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -39,6 +39,10 @@ spec:
       - name: "teleport-config-check"
         image: '{{ if $auth.enterprise }}{{ $auth.enterpriseImage }}{{ else }}{{ $auth.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $auth.imagePullPolicy }}
+{{- if $auth.jobResources }}
+        resources:
+  {{- toYaml $auth.jobResources | nindent 10 }}
+{{- end }}
 {{- if or $auth.extraEnv $auth.tls.existingCASecretName }}
         env:
   {{- if (gt (len $auth.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -39,6 +39,10 @@ spec:
       - name: "teleport"
         image: '{{ if $proxy.enterprise }}{{ $proxy.enterpriseImage }}{{ else }}{{ $proxy.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $proxy.imagePullPolicy }}
+{{- if $proxy.jobResources }}
+        resources:
+  {{- toYaml $proxy.jobResources | nindent 10 }}
+{{- end }}
 {{- if or $proxy.extraEnv $proxy.tls.existingCASecretName }}
         env:
   {{- if (gt (len $proxy.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -56,20 +56,65 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not set resources on auth predeploy job when set in values
+  - it: should not set resources on auth predeploy job when resources set in values
     template: auth/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].resources
-  - it: should not set resources on proxy predeploy job when set in values
+
+  - it: should not set resources on proxy predeploy job when resources set in values
     template: proxy/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].resources
+
+  - it: should set resources on auth predeploy job when jobResources set in values
+    template: auth/predeploy_job.yaml
+    values:
+      - ../.lint/resources.yaml
+    set:
+      jobResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+
+  - it: should set resources on proxy predeploy job when jobResources set in values
+    template: proxy/predeploy_job.yaml
+    values:
+      - ../.lint/resources.yaml
+    set:
+      jobResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
 
   - it: should set imagePullSecrets on proxy predeploy job when set in values
     template: proxy/predeploy_job.yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -826,6 +826,18 @@ resources: {}
 #  limits:
 #    memory: "2Gi"
 
+# Resources to request for the teleport pre-deploy jobs.
+# https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+#
+# Jobs currently include config validation and potentially migration hooks.
+# The resource requirements are typically lower than for the main teleport deployment.
+jobResources: {}
+#  requests:
+#    cpu: "20m"
+#    memory: "500Mi"
+#  limits:
+#    memory: "500Mi"
+
 # goMemLimitRatio configures the GOMEMLIMIT env var set by the chart.
 # GOMEMLIMIT instructs the go garbage collector to try to keep allocated memory
 # below a given threshold. This is a best-effort attempt, but this helps

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -831,6 +831,7 @@ resources: {}
 #
 # Jobs currently include config validation and potentially migration hooks.
 # The resource requirements are typically lower than for the main teleport deployment.
+# In most cases, you should leave these limits unset.
 jobResources: {}
 #  requests:
 #    cpu: "20m"


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/62597

This PR is backportable to v18 as-is, but not to v17. In v17, we should default `jobResources` to `resources` to replicate the previous v17 behaviour.

Related to: https://github.com/gravitational/teleport/pull/61856
Changelog: Made the `teleport-cluster` Helm chart job resources configurable again via the `jobResources` value.