### PR TITLE
Fix case where renewed X509 SVIDs would not be sent via SDS

### DIFF
--- a/lib/tbot/internal/sds/handler.go
+++ b/lib/tbot/internal/sds/handler.go
@@ -338,6 +338,7 @@ func (h *Handler) StreamSecrets(
 		case <-renewalTimer.C:
 			// Handle renewal time!
 			log.DebugContext(ctx, "Renewing SVIDs for StreamSecrets stream")
+			// Set svids to nil to fetching of fresh SVIDs
 			svids = nil
 		}
 

--- a/lib/tbot/internal/sds/handler.go
+++ b/lib/tbot/internal/sds/handler.go
@@ -338,6 +338,7 @@ func (h *Handler) StreamSecrets(
 		case <-renewalTimer.C:
 			// Handle renewal time!
 			log.DebugContext(ctx, "Renewing SVIDs for StreamSecrets stream")
+			svids = nil
 		}
 
 		// Fetch the SVIDs if necessary

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -198,8 +198,10 @@ func (s *WorkloadAPIService) Run(ctx context.Context) error {
 	)
 	workloadpb.RegisterSpiffeWorkloadAPIServer(srv, s)
 	sdsHandler, err := sds.NewHandler(sds.HandlerConfig{
-		Logger:           s.log,
-		RenewalInterval:  s.defaultCredentialLifetime.RenewalInterval,
+		Logger: s.log,
+		RenewalInterval: cmp.Or(
+			s.cfg.CredentialLifetime, s.defaultCredentialLifetime,
+		).RenewalInterval,
 		TrustBundleCache: s.trustBundleCache,
 		ClientAuthenticator: func(ctx context.Context) (*slog.Logger, sds.SVIDFetcher, error) {
 			log, attrs, err := s.authenticateClient(ctx)


### PR DESCRIPTION
`tbot` should send an renewed X509-SVID to Envoy on an interval. In some cases, the renewed X509-SVIDs would not be proactively sent to Envoy. It looks like this bug was introduced to our implementation of the Secret Discovery Service when I introduced support for federation.

changelog: Fixed renewed X509-SVIDs not being proactively sent to Envoy instances.