### PR TITLE
Run Bloat Check workflow if Makefile is modified

### DIFF
--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -9,6 +9,8 @@ on:
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'Makefile'
+      - '*.mk'
     branches:
       - master
       - branch/**


### PR DESCRIPTION
This PR updates the Bloat Check workflow so that it's triggered on commits that modify `Makefile` or `*.mk`, since those are modified pretty rarely and can result in changes to the size of the build.