### PR TITLE
[v17] Fix case where renewed X509 SVIDs would not be sent via SDS

### DIFF
--- a/lib/tbot/internal/sds/handler.go
+++ b/lib/tbot/internal/sds/handler.go
@@ -337,6 +337,7 @@ func (h *Handler) StreamSecrets(
 		case <-renewalTimer.C:
 			// Handle renewal time!
 			log.DebugContext(ctx, "Renewing SVIDs for StreamSecrets stream")
+			// Set svids to nil to fetching of fresh SVIDs
 			svids = nil
 		}
 

--- a/lib/tbot/internal/sds/handler.go
+++ b/lib/tbot/internal/sds/handler.go
@@ -337,6 +337,7 @@ func (h *Handler) StreamSecrets(
 		case <-renewalTimer.C:
 			// Handle renewal time!
 			log.DebugContext(ctx, "Renewing SVIDs for StreamSecrets stream")
+			svids = nil
 		}
 
 		// Fetch the SVIDs if necessary

--- a/lib/tbot/services/workloadidentity/workload_api.go
+++ b/lib/tbot/services/workloadidentity/workload_api.go
@@ -197,8 +197,10 @@ func (s *WorkloadAPIService) Run(ctx context.Context) error {
 	)
 	workloadpb.RegisterSpiffeWorkloadAPIServer(srv, s)
 	sdsHandler, err := sds.NewHandler(sds.HandlerConfig{
-		Logger:           s.log,
-		RenewalInterval:  s.defaultCredentialLifetime.RenewalInterval,
+		Logger: s.log,
+		RenewalInterval: cmp.Or(
+			s.cfg.CredentialLifetime, s.defaultCredentialLifetime,
+		).RenewalInterval,
 		TrustBundleCache: s.trustBundleCache,
 		ClientAuthenticator: func(ctx context.Context) (*slog.Logger, sds.SVIDFetcher, error) {
 			log, attrs, err := s.authenticateClient(ctx)


### PR DESCRIPTION
Backport #62813 to branch/v17

changelog: Fixed renewed X509-SVIDs not being proactively sent to Envoy instances.
