### PR TITLE
Guard against nil in notifications and access request caches

### DIFF
--- a/lib/services/access_request_cache.go
+++ b/lib/services/access_request_cache.go
@@ -376,9 +376,16 @@ func (c *AccessRequestCache) SetInitCallback(cb func()) {
 // processEventsAndUpdateCurrent is part of the resourceCollector interface and is used to update the
 // primary cache state when modification events occur.
 func (c *AccessRequestCache) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
+	if len(events) < 1 {
+		return
+	}
+
 	c.rw.RLock()
 	cache := c.primaryCache
 	c.rw.RUnlock()
+	if cache == nil {
+		return
+	}
 
 	for _, event := range events {
 		switch event.Type {


### PR DESCRIPTION
This PR fixes a data race as well as a rare crash that could be triggered in the notifications cache and access request cache if a reader tried to read from the cache or events were pushed by the resource watcher machinery right after the cache went stale.

The new logic in `StreamGlobalNotifications` and `StreamUserNotifications` loads a potentially different reference to the cache for every page, which is what we've been doing with other streaming-like abstractions on top of the regular cache.

changelog: fixed crash in the Auth Service when loading notifications