### PR TITLE
[v18] oidc: stop erroneously advertising pairwise subject support

### DIFF
--- a/lib/utils/oidc/openidconfig.go
+++ b/lib/utils/oidc/openidconfig.go
@@ -40,6 +40,6 @@ func OpenIDConfigurationForIssuer(issuer, jwksURI string) OpenIDConfiguration {
 		IdTokenSigningAlgValuesSupported: []string{"RS256"},
 		ResponseTypesSupported:           []string{"id_token"},
 		ScopesSupported:                  []string{"openid"},
-		SubjectTypesSupported:            []string{"public", "pair-wise"},
+		SubjectTypesSupported:            []string{"public"},
 	}
 }

--- a/lib/utils/oidc/openidconfig_test.go
+++ b/lib/utils/oidc/openidconfig_test.go
@@ -32,7 +32,7 @@ func TestOpenIDConfigurationForIssuer(t *testing.T) {
 		IdTokenSigningAlgValuesSupported: []string{"RS256"},
 		ResponseTypesSupported:           []string{"id_token"},
 		ScopesSupported:                  []string{"openid"},
-		SubjectTypesSupported:            []string{"public", "pair-wise"},
+		SubjectTypesSupported:            []string{"public"},
 	}
 
 	got := OpenIDConfigurationForIssuer("https://localhost:8080", "https://localhost:8080/.well-known/jwks")

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -67,7 +67,7 @@ func TestOIDCIdPPublicEndpoints(t *testing.T) {
 		Claims:                           []string{"iss", "sub", "obo", "aud", "jti", "iat", "exp", "nbf"},
 		ResponseTypesSupported:           []string{"id_token"},
 		ScopesSupported:                  []string{"openid"},
-		SubjectTypesSupported:            []string{"public", "pair-wise"},
+		SubjectTypesSupported:            []string{"public"},
 	}
 	require.Equal(t, expectedConfiguration, gotConfiguration)
 


### PR DESCRIPTION
Backport #62831 to branch/v18

changelog: Removed erroneous `pair-wise` subject type from Teleport's OpenID configuration
