### PR TITLE
Validate Bedrock model ID when using placeholders

### DIFF
--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -78,11 +78,13 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 			return trace.BadParameter("spec.openai.openai_model_id is required")
 		}
 	case *summarizerv1.InferenceModelSpec_Bedrock:
-		if p.Bedrock.GetBedrockModelId() == "" {
-			return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
-		}
-		if p.Bedrock.GetRegion() == "" {
-			return trace.BadParameter("spec.bedrock.region is required")
+		if m.GetMetadata().GetName() != CloudDefaultInferenceModelName {
+			if p.Bedrock.GetBedrockModelId() == "" {
+				return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
+			}
+			if p.Bedrock.GetRegion() == "" {
+				return trace.BadParameter("spec.bedrock.region is required")
+			}
 		}
 	}
 

--- a/api/types/summarizer/summarizer.go
+++ b/api/types/summarizer/summarizer.go
@@ -25,7 +25,19 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-const CloudDefaultInferenceModelName = "teleport-cloud-default"
+const (
+	// CloudDefaultInferenceModelName is the name of the built-in Bedrock inference
+	// model used by Teleport Cloud.
+	CloudDefaultInferenceModelName = "teleport-cloud-default"
+	// BedrockModelExpansionPlaceholder is a placeholder value for Bedrock model IDs
+	// that indicates the model ID should be expanded based on the TELEPORT_BEDROCK_MODEL
+	// environment variable.
+	BedrockModelExpansionPlaceholder = "{{env.bedrock_model_id}}"
+	// BedrockRegionExpansionPlaceholder is a placeholder value for Bedrock regions
+	// that indicates the region should be expanded based on the TELEPORT_BEDROCK_REGION
+	// environment variable.
+	BedrockRegionExpansionPlaceholder = "{{env.bedrock_region}}"
+)
 
 // NewInferenceModel creates a new InferenceModel resource with the given name
 // and spec.
@@ -78,17 +90,33 @@ func ValidateInferenceModel(m *summarizerv1.InferenceModel) error {
 			return trace.BadParameter("spec.openai.openai_model_id is required")
 		}
 	case *summarizerv1.InferenceModelSpec_Bedrock:
-		if m.GetMetadata().GetName() != CloudDefaultInferenceModelName {
-			if p.Bedrock.GetBedrockModelId() == "" {
-				return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
-			}
-			if p.Bedrock.GetRegion() == "" {
-				return trace.BadParameter("spec.bedrock.region is required")
-			}
+		if p.Bedrock.GetBedrockModelId() == "" {
+			return trace.BadParameter("spec.bedrock.bedrock_model_id is required")
+		}
+
+		if containsPlaceholderInstruction(p.Bedrock.GetBedrockModelId()) &&
+			strings.ReplaceAll(p.Bedrock.GetBedrockModelId(), " ", "") != BedrockModelExpansionPlaceholder {
+			return trace.BadParameter("spec.bedrock.bedrock_model_id contains invalid placeholder instructions. Valid placeholder: %s; got %s", BedrockModelExpansionPlaceholder, p.Bedrock.GetBedrockModelId())
+		}
+
+		if p.Bedrock.GetRegion() == "" {
+			return trace.BadParameter("spec.bedrock.region is required")
+		}
+
+		if containsPlaceholderInstruction(p.Bedrock.GetRegion()) &&
+			strings.ReplaceAll(p.Bedrock.GetRegion(), " ", "") != BedrockRegionExpansionPlaceholder {
+			return trace.BadParameter("spec.bedrock.region contains invalid placeholder instructions. Valid placeholder: %s; got %s", BedrockRegionExpansionPlaceholder, p.Bedrock.GetRegion())
 		}
 	}
 
 	return nil
+}
+
+// containsPlaceholderInstruction returns true if the given string contains
+// any placeholder instructions (e.g., "{placeholder}").
+func containsPlaceholderInstruction(s string) bool {
+	return strings.Contains(s, "{") ||
+		strings.Contains(s, "}")
 }
 
 // NewInferenceSecret creates a new InferenceSecret resource with the given name

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -46,7 +46,28 @@ func TestValidateInferenceModel(t *testing.T) {
 	validBedrockCloudDefault := NewInferenceModel(CloudDefaultInferenceModelName,
 		&summarizerv1.InferenceModelSpec{
 			Provider: &summarizerv1.InferenceModelSpec_Bedrock{
-				Bedrock: &summarizerv1.BedrockProvider{},
+				Bedrock: &summarizerv1.BedrockProvider{
+					BedrockModelId: BedrockModelExpansionPlaceholder,
+					Region:         BedrockRegionExpansionPlaceholder,
+				},
+			},
+		})
+	invalidBedrockModelIDPlaceholder := NewInferenceModel(CloudDefaultInferenceModelName,
+		&summarizerv1.InferenceModelSpec{
+			Provider: &summarizerv1.InferenceModelSpec_Bedrock{
+				Bedrock: &summarizerv1.BedrockProvider{
+					BedrockModelId: "{{ env.bedrock_model_i }}",
+					Region:         BedrockRegionExpansionPlaceholder,
+				},
+			},
+		})
+	invalidBedrockRegionPlaceholder := NewInferenceModel(CloudDefaultInferenceModelName,
+		&summarizerv1.InferenceModelSpec{
+			Provider: &summarizerv1.InferenceModelSpec_Bedrock{
+				Bedrock: &summarizerv1.BedrockProvider{
+					BedrockModelId: "{{ env.bedrock_model_id }}",
+					Region:         "{{ env.bedrock_regio}}",
+				},
 			},
 		})
 	require.NoError(t, ValidateInferenceModel(validOpenAI))
@@ -112,6 +133,16 @@ func TestValidateInferenceModel(t *testing.T) {
 			base: validBedrock,
 			fn:   func(m *summarizerv1.InferenceModel) { m.Spec.GetBedrock().Region = "" },
 			msg:  "spec.bedrock.region is required",
+		},
+		{
+			base: invalidBedrockModelIDPlaceholder,
+			fn:   func(m *summarizerv1.InferenceModel) {},
+			msg:  "spec.bedrock.bedrock_model_id contains invalid placeholder instructions. Valid placeholder: {{env.bedrock_model_id}}; got {{ env.bedrock_model_i }}",
+		},
+		{
+			base: invalidBedrockRegionPlaceholder,
+			fn:   func(m *summarizerv1.InferenceModel) {},
+			msg:  "spec.bedrock.region contains invalid placeholder instructions. Valid placeholder: {{env.bedrock_region}}; got {{ env.bedrock_regio}}",
 		},
 	}
 

--- a/api/types/summarizer/summarizer_test.go
+++ b/api/types/summarizer/summarizer_test.go
@@ -43,8 +43,15 @@ func TestValidateInferenceModel(t *testing.T) {
 			},
 		},
 	})
+	validBedrockCloudDefault := NewInferenceModel(CloudDefaultInferenceModelName,
+		&summarizerv1.InferenceModelSpec{
+			Provider: &summarizerv1.InferenceModelSpec_Bedrock{
+				Bedrock: &summarizerv1.BedrockProvider{},
+			},
+		})
 	require.NoError(t, ValidateInferenceModel(validOpenAI))
 	require.NoError(t, ValidateInferenceModel(validBedrock))
+	require.NoError(t, ValidateInferenceModel(validBedrockCloudDefault))
 
 	cases := []struct {
 		base *summarizerv1.InferenceModel


### PR DESCRIPTION
This will later be used in https://github.com/gravitational/teleport.e/pull/7835 to override Bedrock configuration from environment variables.

Updates https://github.com/gravitational/teleport.e/issues/7216