### PR TITLE
fix scope column in tsh ls

### DIFF
--- a/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/mixed_scoped_and_unscoped_verbose.golden
@@ -1,0 +1,7 @@
+Scope         Node Name            Node ID              Address    Labels              
+------------- -------------------- -------------------- ---------- ------------------- 
+              unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val             
+/staging/west scoped-direct-name   scoped-direct-uuid   1.2.3.4:44 key1=val1,key2=val2 
+              unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel                       
+/staging/west scoped-tunnel-name   scoped-tunnel-uuid   ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_scoped.golden
@@ -1,0 +1,5 @@
+Scope         Node Name          Address    Labels              
+------------- ------------------ ---------- ------------------- 
+/staging/west scoped-direct-name 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west scoped-tunnel-name ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/non-verbose_unscoped.golden
@@ -1,0 +1,5 @@
+Node Name            Address    Labels  
+-------------------- ---------- ------- 
+unscoped-direct-name 1.2.3.4:22 key=val 
+unscoped-tunnel-name ⟵ Tunnel           
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_scoped.golden
@@ -1,0 +1,5 @@
+Scope         Node Name          Node ID            Address    Labels              
+------------- ------------------ ------------------ ---------- ------------------- 
+/staging/west scoped-direct-name scoped-direct-uuid 1.2.3.4:44 key1=val1,key2=val2 
+/staging/west scoped-tunnel-name scoped-tunnel-uuid ⟵ Tunnel                       
+

--- a/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
+++ b/tool/tsh/common/testdata/TestPrintNodesAsText/verbose_unscoped.golden
@@ -1,0 +1,5 @@
+Node Name            Node ID              Address    Labels  
+-------------------- -------------------- ---------- ------- 
+unscoped-direct-name unscoped-direct-uuid 1.2.3.4:22 key=val 
+unscoped-tunnel-name unscoped-tunnel-uuid ⟵ Tunnel           
+

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3318,7 +3318,11 @@ func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool)
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
-		t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		if withScope {
+			t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		} else {
+			t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
+		}
 	// In normal mode chunk the labels and print two per line and allow multiple
 	// lines per node.
 	case false:

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -101,6 +101,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/testutils"
+	"github.com/gravitational/teleport/lib/utils/testutils/golden"
 	"github.com/gravitational/teleport/tool/common"
 	testserver "github.com/gravitational/teleport/tool/teleport/testenv"
 )
@@ -946,6 +947,113 @@ func TestSwitchingProxies(t *testing.T) {
 	require.Error(t, err)
 
 	cancel()
+}
+
+// TestPrintNodesAsText verifies the expected behavior of printNodesAsText.
+func TestPrintNodesAsText(t *testing.T) {
+	t.Parallel()
+
+	unscopedDirect := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name: "unscoped-direct-uuid",
+			Labels: map[string]string{
+				"key": "val",
+			},
+		},
+		Spec: types.ServerSpecV2{
+			Addr:     "1.2.3.4:22",
+			Hostname: "unscoped-direct-name",
+		},
+		Version: types.V2,
+	}
+
+	unscopedTunnel := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name: "unscoped-tunnel-uuid",
+		},
+		Spec: types.ServerSpecV2{
+			UseTunnel: true,
+			Hostname:  "unscoped-tunnel-name",
+		},
+		Version: types.V2,
+	}
+
+	scopedDirect := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name: "scoped-direct-uuid",
+			Labels: map[string]string{
+				"key1": "val1",
+				"key2": "val2",
+			},
+		},
+		Scope: "/staging/west",
+		Spec: types.ServerSpecV2{
+			Addr:     "1.2.3.4:44",
+			Hostname: "scoped-direct-name",
+		},
+		Version: types.V2,
+	}
+
+	scopedTunnel := &types.ServerV2{
+		Kind: types.KindNode,
+		Metadata: types.Metadata{
+			Name: "scoped-tunnel-uuid",
+		},
+		Scope: "/staging/west",
+		Spec: types.ServerSpecV2{
+			UseTunnel: true,
+			Hostname:  "scoped-tunnel-name",
+		},
+		Version: types.V2,
+	}
+
+	tts := []struct {
+		name    string
+		nodes   []types.Server
+		verbose bool
+	}{
+		{
+			name:    "non-verbose unscoped",
+			nodes:   []types.Server{unscopedDirect, unscopedTunnel},
+			verbose: false,
+		},
+		{
+			name:    "verbose unscoped",
+			nodes:   []types.Server{unscopedDirect, unscopedTunnel},
+			verbose: true,
+		},
+		{
+			name:    "non-verbose scoped",
+			nodes:   []types.Server{scopedDirect, scopedTunnel},
+			verbose: false,
+		},
+		{
+			name:    "verbose scoped",
+			nodes:   []types.Server{scopedDirect, scopedTunnel},
+			verbose: true,
+		},
+		{
+			name:    "mixed scoped and unscoped verbose",
+			nodes:   []types.Server{unscopedDirect, scopedDirect, unscopedTunnel, scopedTunnel},
+			verbose: true,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printNodesAsText(&buf, tt.nodes, tt.verbose)
+
+			if golden.ShouldSet() {
+				golden.Set(t, buf.Bytes())
+			}
+
+			require.Equal(t, string(golden.Get(t)), buf.String())
+		})
+	}
 }
 
 func TestMakeClient(t *testing.T) {


### PR DESCRIPTION
Fixes an issue introduced during recent scopes work that resulted in incorrect column headers in `tsh ls -v` when no scoped nodes were present in inventory.  Additionally, adds some basic test coverage for the table output.