### PR TITLE
docs: Fixes to break-glass guide

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -55,7 +55,7 @@ Certificate Authority (CA).
 On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
 
 ```bash
-export KEY=$(curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/cert-authority\ /g/")
+export KEY=$(curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/cert-authority\ //g")
 echo "$KEY" | sudo tee /etc/ssh/teleport_user_ca.pub
 ```
 
@@ -156,25 +156,7 @@ Create the role by applying with:
 tctl create -f breakglass-role.yaml
 ```
 
-
-## Step 4/5. Create a Teleport Machine ID bot to issue an SSH Key and Certificate for the `breakglass` user using Teleport's CA
-
-**This step is completed on the machine where you will make use of the certificates for break-glass access.**
-
-This step will configure and start a [Teleport Machine ID bot](../../../machine-workload-identity/deployment/deployment.mdx) as a background
-daemon (managed by `systemd`), which will continually generate and refresh a short-lived key and certificate for break-glass access on the machine
-where it runs.
-
-This guide will join the Teleport Machine ID bot to the cluster using a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/concepts.mdx)
-which is a secure, optionally single-use join method based on public key cryptography, providing a strong guarantee of security and protection against
-credential theft.
-
-The configuration below generates a certificate which is valid for 24 hours from the time of issuance, refreshed every 2 hours. This means that
-depending on the exact time of usage, the certificate will be usable for break-glass access for between 22 and 24 hours. This validity period was
-chosen as a sane default to strike a good balance between usability (shorter-lived certificates may be invalid by the time they are needed) and
-security (longer-lived certificates are less secure, as the period where they could be used if compromised is longer).
-
-1. Create a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
+3. Create a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
 
 Define the bot in a file named `breakglass-bot.yaml`:
 
@@ -189,13 +171,13 @@ spec:
   roles: ['breakglass-role']
 ```
 
-2. Create the bot using `tctl`:
+4. Create the bot using `tctl`:
 
 ```bash
 tctl create -f breakglass-bot.yaml
 ```
 
-3. Create a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx) to use as a join method for running instances of the bot:
+5. Create a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx) to use as a join method for running instances of the bot:
 
 Define the join method in a file named `breakglass-token.yaml`:
 
@@ -216,21 +198,39 @@ spec:
       limit: 1
 ```
 
-4. Create the token using `tctl`:
+6. Create the token using `tctl`:
 
 ```bash
 tctl create -f breakglass-token.yaml
 ```
 
-5. Get the `registration_secret` for the bot using `tctl` - this is needed to create the bot's config file in the next step.
+7. Get the `registration_secret` for the bot using `tctl` - this is needed to create the bot's config file in the next step.
 
 ```bash
 tctl get token/breakglass-bot-join-token --format=json | jq -r '.[0].status.bound_keypair.registration_secret'
 ```
 
+
+## Step 4/5. Create a Teleport Machine ID bot to issue an SSH Key and Certificate for the `breakglass` user using Teleport's CA
+
+**This step is completed on the machine where you will make use of the certificates for break-glass access.**
+
+This step will configure and start a [Teleport Machine ID bot](../../../machine-workload-identity/deployment/deployment.mdx) as a background
+daemon (managed by `systemd`), which will continually generate and refresh a short-lived key and certificate for break-glass access on the machine
+where it runs.
+
+This guide will join the Teleport Machine ID bot to the cluster using a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/concepts.mdx)
+which is a secure, optionally single-use join method based on public key cryptography, providing a strong guarantee of security and protection against
+credential theft.
+
+The configuration below generates a certificate which is valid for 24 hours from the time of issuance, refreshed every 2 hours. This means that
+depending on the exact time of usage, the certificate will be usable for break-glass access for between 22 and 24 hours. This validity period was
+chosen as a sane default to strike a good balance between usability (shorter-lived certificates may be invalid by the time they are needed) and
+security (longer-lived certificates are less secure, as the period where they could be used if compromised is longer).
+
 This assumes `jq` is installed. If not, run `tctl get token/breakglass-bot-join-token` and inspect the `.status.bound_keypair.registration_secret` field.
 
-6. Write a config file for the bot.
+1. Write a config file for the bot.
 
 Define the config in a file named `/etc/tbot-teleport-breakglass.yaml`:
 
@@ -249,16 +249,16 @@ onboarding:
 storage:
   type: directory
   # change to a directory to use to store the bot's own identity for communicating with the Teleport cluster
-  path: /var/lib/teleport/breakglass-bot
+  path: /var/lib/teleport-breakglass
 outputs:
 - type: identity
   destination:
     type: directory
     # change to the output directory you'd like to use to store the bot's outputted OpenSSH private key and certificate
-    path: /opt/teleport-breakglass-output
+    path: /opt/teleport-breakglass/output
 ```
 
-7. To configure the bot to run in the background, write out a systemd unit file for the bot:
+2. To configure the bot to run in the background, write out a systemd unit file for the bot:
 
 ```bash
 sudo tbot install systemd \
@@ -280,23 +280,30 @@ You must also create the bot's storage and output directories, and give the `tel
 
 ```bash
 sudo mkdir -p /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-sudo chown teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass /opt/teleport-breakglass/output
-sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass /opt/teleport-breakglass/output
+sudo chown -R teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass/output
 ```
 
-8. Reload the systemd configuration:
+You also need to modify the path to the PID file used, as non-root users do not have access to the default location (`/run`):
+
+```bash
+sudo sed -i "s_PIDFile=/run/_PIDFile=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
+sudo sed -i "s_--pid-file=/run/_--pid-file=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
+```
+
+3. Reload the systemd configuration:
 
 ```bash
 sudo systemctl daemon-reload
 ```
 
-9. Configure the bot to start when the machine boots, and start it immediately:
+4. Configure the bot to start when the machine boots, and start it immediately:
 
 ```bash
 sudo systemctl enable --now tbot-teleport-breakglass
 ```
 
-10. Check that the bot has started successfully:
+5. Check that the bot has started successfully:
 
 ```bash
 $ sudo systemctl status tbot-teleport-breakglass
@@ -311,10 +318,10 @@ $ sudo systemctl status tbot-teleport-breakglass
              └─2437534 /usr/local/bin/tbot start -c /etc/tbot-teleport-breakglass.yaml
 ```
 
-11. Check that the bot has correctly outputted a certificate:
+6. Check that the bot has correctly outputted a certificate (you must use `sudo`, as these certificates are only readable by the `teleport-breakglass` user):
 
 ```bash
-$ ls -l /opt/teleport-breakglass/output/
+$ sudo -u teleport-breakglass ls -l /opt/teleport-breakglass/output/
 total 60
 -rw------- 1 teleport-breakglass teleport-breakglass 5513 Nov 27 10:32 identity
 -rw------- 1 teleport-breakglass teleport-breakglass  241 Nov 27 10:32 key
@@ -328,7 +335,7 @@ total 60
 -rw------- 1 teleport-breakglass teleport-breakglass 1375 Nov 27 10:32 tlscert
 ```
 
-12. Check the validity of the certificate to see that it is valid for ~24 hours from now:
+7. Check the validity of the certificate to see that it is valid for ~24 hours from now:
 
 ```bash
 $ date

--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -55,7 +55,7 @@ Certificate Authority (CA).
 On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
 
 ```bash
-export KEY=$(curl -fsSL --proto '=https' --tlsv1.2 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/^cert-authority\ //g")
+export KEY=$(curl -fsSL --proto '=https' --tlsv1.2 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/^cert-authority\ //")
 echo "${KEY:?}" | sudo tee /etc/ssh/teleport_user_ca.pub
 ```
 

--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -55,7 +55,7 @@ Certificate Authority (CA).
 On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
 
 ```bash
-export KEY=$(curl -fsSL 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/cert-authority\ //g")
+export KEY=$(curl -fsSL --proto '=https' --tlsv1.2 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/^cert-authority\ //g")
 echo "${KEY:?}" | sudo tee /etc/ssh/teleport_user_ca.pub
 ```
 

--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -381,6 +381,8 @@ Host *
     IdentityFile /opt/teleport-breakglass/output/key
     CertificateFile /opt/teleport-breakglass/output/key-cert.pub
     StrictHostKeyChecking no
+    # Only use identities explicitly set here, not those from any running ssh-agent.
+    IdentitiesOnly yes
 ```
 
 Make sure the permissions are set correctly:

--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -55,14 +55,23 @@ Certificate Authority (CA).
 On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
 
 ```bash
-export KEY=$(curl 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/cert-authority\ //g")
-echo "$KEY" | sudo tee /etc/ssh/teleport_user_ca.pub
+export KEY=$(curl -fsSL 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/cert-authority\ //g")
+echo "${KEY:?}" | sudo tee /etc/ssh/teleport_user_ca.pub
 ```
 
 2. Ensure the following line is added and/or uncommented in your `/etc/ssh/sshd_config` file:
 
 ```
 Include /etc/ssh/sshd_config.d/*.conf
+```
+
+3. Add an `/etc/ssh/authorized_principals/breakglass` file to set the only authorized principal for login to `breakglass`, and limit its permissions:
+
+```bash
+sudo mkdir -p /etc/ssh/authorized_principals
+sudo chmod 755 /etc/ssh/authorized_principals
+echo "breakglass" | sudo tee /etc/ssh/authorized_principals/breakglass
+sudo chmod 644 /etc/ssh/authorized_principals/breakglass
 ```
 
 3. Create a `teleport-breakglass.conf` file under `/etc/ssh/sshd_config.d`:
@@ -73,8 +82,8 @@ sudo tee /etc/ssh/sshd_config.d/teleport-breakglass.conf > /dev/null <<'EOF'
 Match User breakglass
     # Trust the Teleport user CA for connections as this user
     TrustedUserCAKeys /etc/ssh/teleport_user_ca.pub
-    # Explicitly use sshd's default behaviour: the username being used to connect must match a principal on the certificate
-    AuthorizedPrincipalsFile none
+    # Only allow principals listed in the file to connect (i.e. breakglass)
+    AuthorizedPrincipalsFile /etc/ssh/authorized_principals/breakglass
     # Don't allow SSH key authentication as this user
     AuthorizedKeysFile /dev/null
 EOF
@@ -88,7 +97,7 @@ sudo sshd -t
 
 5. Restart the sshd service:
 
-```bash
+```shell
 # This unit may also be called ssh.service depending on your distribution
 # Check with 'systemctl list-unit-files | grep ssh | grep service'
 sudo systemctl restart sshd
@@ -111,12 +120,12 @@ sudo adduser --disabled-password breakglass
 
 <Admonition type="note">
 As a general security principle, it is highly recommended to limit `root` permissions through `sudo`. Because `breakglass` will need
-ability to gain elevated access to the system to troubleshoot and recover access, however, any use of break-glass access should always be audited
-via `sshd` access logs.
+ability to gain elevated access to the system to troubleshoot and recover access, however, any use of break-glass access should always
+be audited via `sshd` access logs.
 </Admonition>
 
 
-## Step 3/5. Create `breakglass` Role in Teleport
+## Step 3/5. Create `breakglass` Role, Bot and Join Method in Teleport
 
 **This step is completed on your local machine.**
 
@@ -156,7 +165,7 @@ Create the role by applying with:
 tctl create -f breakglass-role.yaml
 ```
 
-3. Create a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
+3. Define a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
 
 Define the bot in a file named `breakglass-bot.yaml`:
 
@@ -171,7 +180,9 @@ spec:
   roles: ['breakglass-role']
 ```
 
-4. Create the bot using `tctl`:
+We will set up the bot on the target machine in the next step.
+
+4. Register the bot using `tctl`:
 
 ```bash
 tctl create -f breakglass-bot.yaml
@@ -204,14 +215,14 @@ spec:
 tctl create -f breakglass-token.yaml
 ```
 
-7. Get the `registration_secret` for the bot using `tctl` - this is needed to create the bot's config file in the next step.
+7. Get the `registration_secret` for the bot using `tctl` - we will write this to a file in the next step to be read by the Machine ID bot.
 
 ```bash
 tctl get token/breakglass-bot-join-token --format=json | jq -r '.[0].status.bound_keypair.registration_secret'
 ```
 
 
-## Step 4/5. Create a Teleport Machine ID bot to issue an SSH Key and Certificate for the `breakglass` user using Teleport's CA
+## Step 4/5. Set up a Teleport Machine ID bot to issue an SSH Key and Certificate for the `breakglass` user using Teleport's CA
 
 **This step is completed on the machine where you will make use of the certificates for break-glass access.**
 
@@ -230,7 +241,32 @@ security (longer-lived certificates are less secure, as the period where they co
 
 This assumes `jq` is installed. If not, run `tctl get token/breakglass-bot-join-token` and inspect the `.status.bound_keypair.registration_secret` field.
 
-1. Write a config file for the bot.
+1. Create a `teleport-breakglass` user and needed storage paths on this machine:
+
+```bash
+sudo useradd -s /sbin/nologin teleport-breakglass
+```
+
+You must also create the bot's storage and output directories:
+
+```bash
+sudo mkdir -p /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+```
+
+2. Write the `registration_secret` you gathered during the previous step to a file on this machine:
+
+```bash
+echo "REGISTRATION-SECRET-FROM-PREVIOUS-STEP" | sudo tee /var/lib/teleport-breakglass/registration-secret
+```
+
+Now, we change ownership of these directories to the `teleport-breakglass` user and prevent access by other system users:
+
+```bash
+sudo chown -R teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+```
+
+3. Write a config file for the bot.
 
 Define the config in a file named `/etc/tbot-teleport-breakglass.yaml`:
 
@@ -245,7 +281,7 @@ onboarding:
   token: breakglass-bot-join-token
   bound_keypair:
     # replace this with the value of `registration_secret` from the previous step
-    registration_secret: REGISTRATION-SECRET-VALUE-FROM-PREVIOUS-STEP
+    registration_secret_path: /var/lib/teleport-breakglass/registration-secret
 storage:
   type: directory
   # change to a directory to use to store the bot's own identity for communicating with the Teleport cluster
@@ -269,22 +305,7 @@ sudo tbot install systemd \
   --group teleport-breakglass
 ```
 
-The user and group you specify here must already exist on the server running the `tbot` service. If you do not already have a `teleport-breakglass` user
-and group, create one:
-
-```bash
-sudo useradd -s /sbin/nologin teleport-breakglass
-```
-
-You must also create the bot's storage and output directories, and give the `teleport-breakglass` user permissions.
-
-```bash
-sudo mkdir -p /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-sudo chown -R teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-```
-
-You also need to modify the path to the PID file used, as non-root users do not have access to the default location (`/run`):
+You will also need to modify the path to the PID file used, as non-root users do not have access to the default location (`/run`):
 
 ```bash
 sudo sed -i "s_PIDFile=/run/_PIDFile=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service

--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/breakglass-access.mdx
@@ -43,192 +43,194 @@ than emergency break-glass access when the regular Teleport access path is unava
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-## Step 1/5. Configure an out-of-band OpenSSH server running on the Teleport Agent machine to trust the Teleport user CA
+## Step 1/5. Configure an out-of-band OpenSSH server
 
 **This step is completed on the Teleport Agent machine.**
 
-For break-glass access, an OpenSSH server must be running, and configured to trust client certificates issued by the Teleport `user`
-Certificate Authority (CA).
+This step configures an out-of-band OpenSSH server running on the Teleport Agent machine to trust the Teleport
+`user` CA. For break-glass access, an OpenSSH server must be running, and configured to trust client certificates
+issued by the Teleport `user` Certificate Authority (CA).
 
 1. Export the public key of the Teleport `user` CA:
 
-On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
+   On the Teleport Agent machine, run the following command. Replace `teleport.example.com` with the address of your Teleport Proxy Service:
+   ```code
+   $ export KEY=$(curl -fsSL --proto '=https' --tlsv1.2 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/^cert-authority\ //")
+   $ echo "${KEY:?}" | sudo tee /etc/ssh/teleport_user_ca.pub
+   ```
 
-```bash
-export KEY=$(curl -fsSL --proto '=https' --tlsv1.2 'https://<Var name="teleport.example.com" />/webapi/auth/export?type=user' | sed "s/^cert-authority\ //")
-echo "${KEY:?}" | sudo tee /etc/ssh/teleport_user_ca.pub
-```
+1. Ensure the following line is added and/or uncommented in your `/etc/ssh/sshd_config` file:
 
-2. Ensure the following line is added and/or uncommented in your `/etc/ssh/sshd_config` file:
+   ```
+   Include /etc/ssh/sshd_config.d/*.conf
+   ```
 
-```
-Include /etc/ssh/sshd_config.d/*.conf
-```
+1. Add an `/etc/ssh/authorized_principals/breakglass` file to set the only authorized principal for login to `breakglass`, and limit its permissions:
 
-3. Add an `/etc/ssh/authorized_principals/breakglass` file to set the only authorized principal for login to `breakglass`, and limit its permissions:
+   ```code
+   $ sudo mkdir -p /etc/ssh/authorized_principals
+   $ sudo chmod 755 /etc/ssh/authorized_principals
+   $ echo "breakglass" | sudo tee /etc/ssh/authorized_principals/breakglass
+   $ sudo chmod 644 /etc/ssh/authorized_principals/breakglass
+   ```
 
-```bash
-sudo mkdir -p /etc/ssh/authorized_principals
-sudo chmod 755 /etc/ssh/authorized_principals
-echo "breakglass" | sudo tee /etc/ssh/authorized_principals/breakglass
-sudo chmod 644 /etc/ssh/authorized_principals/breakglass
-```
+1. Create a `teleport-breakglass.conf` file under `/etc/ssh/sshd_config.d`:
 
-3. Create a `teleport-breakglass.conf` file under `/etc/ssh/sshd_config.d`:
+   ```bash
+   sudo tee /etc/ssh/sshd_config.d/teleport-breakglass.conf > /dev/null <<'EOF'
+   # Teleport breakglass config
+   Match User breakglass
+       # Trust the Teleport user CA for connections as this user
+       TrustedUserCAKeys /etc/ssh/teleport_user_ca.pub
+       # Only allow principals listed in the file to connect (i.e. breakglass)
+       AuthorizedPrincipalsFile /etc/ssh/authorized_principals/breakglass
+       # Don't allow SSH key authentication as this user
+       AuthorizedKeysFile /dev/null
+   EOF
+   ```
 
-```bash
-sudo tee /etc/ssh/sshd_config.d/teleport-breakglass.conf > /dev/null <<'EOF'
-# Teleport breakglass config
-Match User breakglass
-    # Trust the Teleport user CA for connections as this user
-    TrustedUserCAKeys /etc/ssh/teleport_user_ca.pub
-    # Only allow principals listed in the file to connect (i.e. breakglass)
-    AuthorizedPrincipalsFile /etc/ssh/authorized_principals/breakglass
-    # Don't allow SSH key authentication as this user
-    AuthorizedKeysFile /dev/null
-EOF
-```
+1. Check the syntax of the sshd config file (you should see no errors printed):
 
-4. Check the syntax of the sshd config file (you should see no errors printed):
+   ```code
+   $ sudo sshd -t
+   ```
 
-```bash
-sudo sshd -t
-```
+1. Restart the sshd service:
 
-5. Restart the sshd service:
-
-```shell
-# This unit may also be called ssh.service depending on your distribution
-# Check with 'systemctl list-unit-files | grep ssh | grep service'
-sudo systemctl restart sshd
-```
+   ```code
+   # This unit may also be called ssh.service depending on your distribution
+   # Check with 'systemctl list-unit-files | grep ssh | grep service'
+   $ sudo systemctl restart sshd
+   ```
 
 Now, `sshd` will trust users who present a Teleport-issued SSH certificate.
 
 
-## Step 2/5. Create a `breakglass` user on the Teleport Agent server
+## Step 2/5. Create a `breakglass` user
 
 **This step is completed on the Teleport Agent machine.**
+
+This step adds a `breakglass` user on the Teleport Agent server to be used when logging in for break-glass access.
 
 Log into the Teleport Agent server and run the following commands.
 
 1. Create the `breakglass` user:
 
-```bash
-sudo adduser --disabled-password breakglass
-```
+   ```code
+   $ sudo adduser --disabled-password breakglass
+   ```
 
-<Admonition type="note">
-As a general security principle, it is highly recommended to limit `root` permissions through `sudo`. Because `breakglass` will need
-ability to gain elevated access to the system to troubleshoot and recover access, however, any use of break-glass access should always
-be audited via `sshd` access logs.
-</Admonition>
+   <Admonition type="note">
+   As a general security principle, it is highly recommended to limit `root` permissions through `sudo`. Because `breakglass` will need
+   ability to gain elevated access to the system to troubleshoot and recover access, however, any use of break-glass access should always
+   be audited via `sshd` access logs.
+   </Admonition>
 
 
-## Step 3/5. Create `breakglass` Role, Bot and Join Method in Teleport
+## Step 3/5. Create `breakglass` role, bot and join method in Teleport
 
 **This step is completed on your local machine.**
 
 1. Log into your Teleport cluster with a user that has permission to create roles:
 
-```bash
-tsh login --proxy=<Var name="teleport.example.com" />
-```
+   ```code
+   $ tsh login --proxy=<Var name="teleport.example.com" />
+   ```
 
-2. Create a `breakglass` Teleport role:
+1. Create a `breakglass` Teleport role:
 
-Define the role in a file named `breakglass-role.yaml`:
+   Define the role in a file named `breakglass-role.yaml`:
 
-```yaml
-kind: role
-metadata:
-  name: breakglass-role
-spec:
-  allow:
-    logins:
-    - breakglass
-    node_labels:
-      '*': '*'
-  deny: {}
-  options:
-    cert_format: standard
-    forward_agent: false
-    max_session_ttl: 24h0m0s
-    port_forwarding: true
-    ssh_file_copy: true
-version: v7
-```
+   ```yaml
+   kind: role
+   metadata:
+     name: breakglass-role
+   spec:
+     allow:
+       logins:
+       - breakglass
+       node_labels:
+         '*': '*'
+     deny: {}
+     options:
+       cert_format: standard
+       forward_agent: false
+       max_session_ttl: 24h0m0s
+       port_forwarding: true
+      ssh_file_copy: true
+   version: v7
+   ```
 
-Create the role by applying with:
+   Create the role by applying with:
 
-```bash
-tctl create -f breakglass-role.yaml
-```
+   ```code
+   $ tctl create -f breakglass-role.yaml
+   ```
 
-3. Define a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
+1. Define a `breakglass` bot which will run in the background to continually refresh a certificate which is valid for break-glass usage:
 
-Define the bot in a file named `breakglass-bot.yaml`:
+   Define the bot in a file named `breakglass-bot.yaml`:
 
-```yaml
-kind: bot
-version: v1
-metadata:
-  # name is a unique identifier for the Bot in the cluster.
-  name: breakglass-bot
-spec:
-  # roles is a list of roles to grant to the Bot
-  roles: ['breakglass-role']
-```
+   ```yaml
+   kind: bot
+   version: v1
+   metadata:
+     # name is a unique identifier for the Bot in the cluster.
+     name: breakglass-bot
+   spec:
+     # roles is a list of roles to grant to the Bot
+     roles: ['breakglass-role']
+   ```
 
-We will set up the bot on the target machine in the next step.
+   We will set up the bot on the target machine in the next step.
 
-4. Register the bot using `tctl`:
+1. Register the bot using `tctl`:
 
-```bash
-tctl create -f breakglass-bot.yaml
-```
+   ```code
+   $ tctl create -f breakglass-bot.yaml
+   ```
 
-5. Create a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx) to use as a join method for running instances of the bot:
+1. Create a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx) to use as a join method for running instances of the bot:
 
-Define the join method in a file named `breakglass-token.yaml`:
+   Define the join method in a file named `breakglass-token.yaml`:
 
-```yaml
-kind: token
-version: v2
-metadata:
-  # This name will be used in tbot's `onboarding.token` field.
-  name: breakglass-bot-join-token
-spec:
-  roles: [Bot]
-  # bot_name must match the name of the bot created earlier.
-  bot_name: breakglass-bot
-  join_method: bound_keypair
-  bound_keypair:
-    recovery:
-      mode: standard
-      limit: 1
-```
+   ```yaml
+   kind: token
+   version: v2
+   metadata:
+     # This name will be used in tbot's `onboarding.token` field.
+     name: breakglass-bot-join-token
+   spec:
+     roles: [Bot]
+     # bot_name must match the name of the bot created earlier.
+     bot_name: breakglass-bot
+     join_method: bound_keypair
+     bound_keypair:
+       recovery:
+         mode: standard
+         limit: 1
+   ```
 
-6. Create the token using `tctl`:
+1. Create the token using `tctl`:
 
-```bash
-tctl create -f breakglass-token.yaml
-```
+   ```code
+   $ tctl create -f breakglass-token.yaml
+   ```
 
-7. Get the `registration_secret` for the bot using `tctl` - we will write this to a file in the next step to be read by the Machine ID bot.
+1. Get the `registration_secret` for the bot using `tctl` - we will write this to a file in the next step to be read by the Machine ID bot.
 
-```bash
-tctl get token/breakglass-bot-join-token --format=json | jq -r '.[0].status.bound_keypair.registration_secret'
-```
+   ```code
+   $ tctl get token/breakglass-bot-join-token --format=json | jq -r '.[0].status.bound_keypair.registration_secret'
+   ```
 
 
-## Step 4/5. Set up a Teleport Machine ID bot to issue an SSH Key and Certificate for the `breakglass` user using Teleport's CA
+## Step 4/5. Set up a Teleport Machine ID Bot
 
-**This step is completed on the machine where you will make use of the certificates for break-glass access.**
+**This step is completed on the machine where you will store and make use of the certificates for break-glass access.**
 
 This step will configure and start a [Teleport Machine ID bot](../../../machine-workload-identity/deployment/deployment.mdx) as a background
-daemon (managed by `systemd`), which will continually generate and refresh a short-lived key and certificate for break-glass access on the machine
-where it runs.
+daemon (managed by `systemd`), which will continually generate and refresh a short-lived key and certificate for break-glass access (using the
+`breakglass` user) and store it on the machine where it runs.
 
 This guide will join the Teleport Machine ID bot to the cluster using a [bound keypair](../../../reference/machine-workload-identity/bound-keypair/concepts.mdx)
 which is a secure, optionally single-use join method based on public key cryptography, providing a strong guarantee of security and protection against
@@ -243,182 +245,184 @@ This assumes `jq` is installed. If not, run `tctl get token/breakglass-bot-join-
 
 1. Create a `teleport-breakglass` user and needed storage paths on this machine:
 
-```bash
-sudo useradd -s /sbin/nologin teleport-breakglass
-```
+   ```code
+   $ sudo useradd -s /sbin/nologin teleport-breakglass
+   ```
 
-You must also create the bot's storage and output directories:
+   You must also create the bot's storage and output directories:
 
-```bash
-sudo mkdir -p /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-```
+   ```code
+   $ sudo mkdir -p /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+   ```
 
-2. Write the `registration_secret` you gathered during the previous step to a file on this machine:
+1. Write the `registration_secret` you gathered during the previous step to a file on this machine:
 
-```bash
-echo "REGISTRATION-SECRET-FROM-PREVIOUS-STEP" | sudo tee /var/lib/teleport-breakglass/registration-secret
-```
+   ```code
+   $ echo "REGISTRATION-SECRET-FROM-PREVIOUS-STEP" | sudo tee /var/lib/teleport-breakglass/registration-secret
+   ```
 
-Now, we change ownership of these directories to the `teleport-breakglass` user and prevent access by other system users:
+   Now, we change ownership of these directories to the `teleport-breakglass` user and prevent access by other system users:
 
-```bash
-sudo chown -R teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass/output
-```
+   ```code
+   $ sudo chown -R teleport-breakglass:teleport-breakglass /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+   $ sudo chmod 700 /var/lib/teleport-breakglass /opt/teleport-breakglass/output
+   ```
 
-3. Write a config file for the bot.
+1. Write a config file for the bot.
 
-Define the config in a file named `/etc/tbot-teleport-breakglass.yaml`:
+   Define the config in a file named `/etc/tbot-teleport-breakglass.yaml`:
 
-```yaml
-version: v2
-# replace teleport.example.com with the FQDN of your Teleport proxy server
-proxy_server: <Var name="teleport.example.com" />:443
-certificate_ttl: "24h"
-renewal_interval: "2h"
-onboarding:
-  join_method: bound_keypair
-  token: breakglass-bot-join-token
-  bound_keypair:
-    # replace this with the value of `registration_secret` from the previous step
-    registration_secret_path: /var/lib/teleport-breakglass/registration-secret
-storage:
-  type: directory
-  # change to a directory to use to store the bot's own identity for communicating with the Teleport cluster
-  path: /var/lib/teleport-breakglass
-outputs:
-- type: identity
-  destination:
-    type: directory
-    # change to the output directory you'd like to use to store the bot's outputted OpenSSH private key and certificate
-    path: /opt/teleport-breakglass/output
-```
+   ```yaml
+   version: v2
+   # replace teleport.example.com with the FQDN of your Teleport proxy server
+   proxy_server: <Var name="teleport.example.com" />:443
+   certificate_ttl: "24h"
+   renewal_interval: "2h"
+   onboarding:
+     join_method: bound_keypair
+     token: breakglass-bot-join-token
+     bound_keypair:
+       # replace this with the value of `registration_secret` from the previous step
+       registration_secret_path: /var/lib/teleport-breakglass/registration-secret
+   storage:
+     type: directory
+     # change to a directory to use to store the bot's own identity for communicating with the Teleport cluster
+     path: /var/lib/teleport-breakglass
+   outputs:
+   - type: identity
+     destination:
+       type: directory
+       # change to the output directory you'd like to use to store the bot's outputted OpenSSH private key and certificate
+       path: /opt/teleport-breakglass/output
+   ```
 
-2. To configure the bot to run in the background, write out a systemd unit file for the bot:
+1. To configure the bot to run in the background, write out a systemd unit file for the bot:
 
-```bash
-sudo tbot install systemd \
-  --write \
-  --name tbot-teleport-breakglass \
-  --config /etc/tbot-teleport-breakglass.yaml \
-  --user teleport-breakglass \
-  --group teleport-breakglass
-```
+   ```code
+   $ sudo tbot install systemd \
+     --write \
+     --name tbot-teleport-breakglass \
+     --config /etc/tbot-teleport-breakglass.yaml \
+     --user teleport-breakglass \
+     --group teleport-breakglass
+   ```
 
-You will also need to modify the path to the PID file used, as non-root users do not have access to the default location (`/run`):
+   You will also need to modify the path to the PID file used, as non-root users do not have access to the default location (`/run`):
 
-```bash
-sudo sed -i "s_PIDFile=/run/_PIDFile=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
-sudo sed -i "s_--pid-file=/run/_--pid-file=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
-```
+   ```code
+   $ sudo sed -i "s_PIDFile=/run/_PIDFile=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
+   $ sudo sed -i "s_--pid-file=/run/_--pid-file=/var/lib/teleport-breakglass/_g" /etc/systemd/system/tbot-teleport-breakglass.service
+   ```
 
-3. Reload the systemd configuration:
+1. Reload the systemd configuration:
 
-```bash
-sudo systemctl daemon-reload
-```
+   ```code
+   $ sudo systemctl daemon-reload
+   ```
 
-4. Configure the bot to start when the machine boots, and start it immediately:
+1. Configure the bot to start automatically when the machine boots, and then start it immediately:
 
-```bash
-sudo systemctl enable --now tbot-teleport-breakglass
-```
+   ```code
+   $ sudo systemctl enable --now tbot-teleport-breakglass
+   ```
 
-5. Check that the bot has started successfully:
+1. Check that the bot has started successfully:
 
-```bash
-$ sudo systemctl status tbot-teleport-breakglass
-● tbot-teleport-breakglass.service - tbot-teleport-breakglass - Teleport Machine & Workload Identity Service
-     Loaded: loaded (/etc/systemd/system/tbot-teleport-breakglass.service; enabled; preset: enabled)
-     Active: active (running) since Thu 2025-11-27 10:32:24 AST; 7s ago
-   Main PID: 2437534 (tbot)
-      Tasks: 9 (limit: 9065)
-     Memory: 22.8M (peak: 23.4M)
-        CPU: 239ms
-     CGroup: /system.slice/tbot-teleport-breakglass.service
-             └─2437534 /usr/local/bin/tbot start -c /etc/tbot-teleport-breakglass.yaml
-```
+   ```code
+   $ sudo systemctl status tbot-teleport-breakglass
+   ● tbot-teleport-breakglass.service - tbot-teleport-breakglass - Teleport Machine & Workload Identity Service
+        Loaded: loaded (/etc/systemd/system/tbot-teleport-breakglass.service; enabled; preset: enabled)
+        Active: active (running) since Thu 2025-11-27 10:32:24 AST; 7s ago
+      Main PID: 2437534 (tbot)
+         Tasks: 9 (limit: 9065)
+        Memory: 22.8M (peak: 23.4M)
+           CPU: 239ms
+        CGroup: /system.slice/tbot-teleport-breakglass.service
+                └─2437534 /usr/local/bin/tbot start -c /etc/tbot-teleport-breakglass.yaml
+   ```
 
-6. Check that the bot has correctly outputted a certificate (you must use `sudo`, as these certificates are only readable by the `teleport-breakglass` user):
+1. Check that the bot has correctly outputted a certificate (you must use `sudo`, as these certificates are only readable by the `teleport-breakglass` user):
 
-```bash
-$ sudo -u teleport-breakglass ls -l /opt/teleport-breakglass/output/
-total 60
--rw------- 1 teleport-breakglass teleport-breakglass 5513 Nov 27 10:32 identity
--rw------- 1 teleport-breakglass teleport-breakglass  241 Nov 27 10:32 key
--rw------- 1 teleport-breakglass teleport-breakglass 1274 Nov 27 10:32 key-cert.pub
--rw------- 1 teleport-breakglass teleport-breakglass  161 Nov 27 10:32 key.pub
--rw------- 1 teleport-breakglass teleport-breakglass  612 Nov 27 10:32 known_hosts
--rw------- 1 teleport-breakglass teleport-breakglass 1379 Nov 27 10:32 ssh_config
--rw------- 1 teleport-breakglass teleport-breakglass 1330 Nov 27 10:32 teleport-database-ca.crt
--rw------- 1 teleport-breakglass teleport-breakglass 2051 Nov 27 10:32 teleport-host-ca.crt
--rw------- 1 teleport-breakglass teleport-breakglass  794 Nov 27 10:32 teleport-user-ca.crt
--rw------- 1 teleport-breakglass teleport-breakglass 1375 Nov 27 10:32 tlscert
-```
+   ```code
+   $ sudo -u teleport-breakglass ls -l /opt/teleport-breakglass/output/
+   total 60
+   -rw------- 1 teleport-breakglass teleport-breakglass 5513 Nov 27 10:32 identity
+   -rw------- 1 teleport-breakglass teleport-breakglass  241 Nov 27 10:32 key
+   -rw------- 1 teleport-breakglass teleport-breakglass 1274 Nov 27 10:32 key-cert.pub
+   -rw------- 1 teleport-breakglass teleport-breakglass  161 Nov 27 10:32 key.pub
+   -rw------- 1 teleport-breakglass teleport-breakglass  612 Nov 27 10:32 known_hosts
+   -rw------- 1 teleport-breakglass teleport-breakglass 1379 Nov 27 10:32 ssh_config
+   -rw------- 1 teleport-breakglass teleport-breakglass 1330 Nov 27 10:32 teleport-database-ca.crt
+   -rw------- 1 teleport-breakglass teleport-breakglass 2051 Nov 27 10:32 teleport-host-ca.crt
+   -rw------- 1 teleport-breakglass teleport-breakglass  794 Nov 27 10:32 teleport-user-ca.crt
+   -rw------- 1 teleport-breakglass teleport-breakglass 1375 Nov 27 10:32 tlscert
+   ```
 
-7. Check the validity of the certificate to see that it is valid for ~24 hours from now:
+1. Check the validity of the certificate to see that it is valid for ~24 hours from now:
 
-```bash
-$ date
-Thu Nov 27 10:39:41 AST 2025
-$ sudo -u teleport-breakglass ssh-keygen -Lf /opt/teleport-breakglass/output/key-cert.pub | grep Valid
-        Valid: from 2025-11-27T10:31:24 to 2025-11-28T10:32:24
-```
+   ```code
+   $ date
+   Thu Nov 27 10:39:41 AST 2025
+   $ sudo -u teleport-breakglass ssh-keygen -Lf /opt/teleport-breakglass/output/key-cert.pub | grep Valid
+           Valid: from 2025-11-27T10:31:24 to 2025-11-28T10:32:24
+   ```
 
 
 ## Step 5/5. Access the Teleport Agent machine using OpenSSH
 
-**This step is completed on the machine where you will make use of the certificates for break-glass access.**
+**This step is completed on the machine where you will store and make use of the certificates for break-glass access.**
+
+This step describes the sequence of actions you will take in the event that you need to make use of break-glass access.
 
 1. Create a local SSH config which uses the Teleport-issued break-glass certificate to connect:
 
-Define the config in a file called `/opt/teleport-breakglass/breakglass_ssh_config`:
+   Define the config in a file called `/opt/teleport-breakglass/breakglass_ssh_config`:
 
-```bash
-Host *
-    User breakglass
-    UserKnownHostsFile /opt/teleport-breakglass/output/known_hosts
-    IdentityFile /opt/teleport-breakglass/output/key
-    CertificateFile /opt/teleport-breakglass/output/key-cert.pub
-    StrictHostKeyChecking no
-    # Only use identities explicitly set here, not those from any running ssh-agent.
-    IdentitiesOnly yes
-```
+   ```bash
+   Host *
+       User breakglass
+       UserKnownHostsFile /opt/teleport-breakglass/output/known_hosts
+       IdentityFile /opt/teleport-breakglass/output/key
+       CertificateFile /opt/teleport-breakglass/output/key-cert.pub
+       StrictHostKeyChecking no
+       # Only use identities explicitly set here, not those from any running ssh-agent.
+       IdentitiesOnly yes
+   ```
 
-Make sure the permissions are set correctly:
+   Make sure the permissions are set correctly:
 
-```bash
-sudo chown teleport-breakglass:teleport-breakglass /opt/teleport-breakglass/breakglass_ssh_config
-```
+   ```code
+   $ sudo chown teleport-breakglass:teleport-breakglass /opt/teleport-breakglass/breakglass_ssh_config
+   ```
 
-2. Now, use the break-glass SSH config to securely access the Teleport Agent using the `breakglass` user and Teleport-issued certificate:
+1. Now, use the break-glass SSH config to securely access the Teleport Agent using the `breakglass` user and Teleport-issued certificate:
 
-```bash
-sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config sshd-server
-```
+   ```code
+   $ sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config sshd-server
+   ```
 
-<Admonition type="note">
-We use `sudo -u teleport-breakglass ssh` here because the outputted certificates and files in the `/opt/teleport-breakglass-output` directory
-are only readable by the `teleport-breakglass` user and `root`, to improve security.
-</Admonition>
+   <Admonition type="note">
+   We use `sudo -u teleport-breakglass ssh` here because the outputted certificates and files in the `/opt/teleport-breakglass-output` directory
+   are only readable by the `teleport-breakglass` user and `root`, to improve security.
+   </Admonition>
 
-If you do not have DNS resolution available for the hostname you need to connect to, you can use the IP address:
+   If you do not have DNS resolution available for the hostname you need to connect to, you can use the IP address:
 
-```bash
-sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config 10.11.12.134
-```
+   ```code
+   $ sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config 10.11.12.134
+   ```
 
-Alternatively, you can provide the IP to use with the `HostName` option to `ssh`:
+   Alternatively, you can provide the IP to use with the `HostName` option to `ssh`:
 
-```bash
-sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config -o "HostName=10.11.12.134" sshd-server
-```
+   ```code
+   $ sudo -u teleport-breakglass ssh -F /opt/teleport-breakglass/breakglass_ssh_config -o "HostName=10.11.12.134" sshd-server
+   ```
 
-<Admonition type="important">
-If the connection from `tbot` to the Teleport control plane remains offline, the outputted certificate will only be valid for the following
-22 hours, then it will expire and break-glass access will no longer be available. If you cannot restore access to your Teleport control plane
-within this timeframe, you should use your break-glass access to set up alternative strategies for access while the certificate is still valid.
-</Admonition>
+   <Admonition type="important">
+   If the connection from `tbot` to the Teleport control plane remains offline, the outputted certificate will only be valid for the following
+   22 hours, then it will expire and break-glass access will no longer be available. If you cannot restore access to your Teleport control plane
+   within this timeframe, you should use your break-glass access to set up alternative strategies for access while the certificate is still valid.
+   </Admonition>
 
 ---
 


### PR DESCRIPTION
- Small typo in `cert-authority` sed line
- Moves bot/role/token creation steps to run on local machine rather than remote machine
- Fixes some typos in paths:
   - `/var/lib/teleport/breakglass-bot` -> `/var/lib/teleport-breakglass`
   - `/opt/teleport-breakglass-output` -> `/opt/teleport-breakglass/output`
- Rewrites PID file path root from `/run/` to `/var/lib/teleport-breakglass/` to allow access as a non-root user
- Use `sudo` to run `ls -l` as `teleport-breakglass` rather than the regular user
- Set `AuthorizedPrincipalsFile` to a known value (as explicitly setting `none` appears to have different behaviour to the "default" behaviour)
    - Also explicitly write `/etc/ssh/authorized_principals/breakglass` file
- Fail early if `curl` cannot connect (i.e. hostname typo) and error if `$KEY` is set to a blank value to prevent blank user CA values
- Make comments stating that sshd service name may be `ssh.service` more obvious
- Switch to using `registration_secret_path` so registration secret cannot be read from the `tbot` config file in plaintext