### PR TITLE
operator add synchronous test suite and convert SAML tests

### DIFF
--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -31,9 +31,11 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 )
 
+type ReconcilerFactory func(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error)
+
 type reconcilerFactory struct {
 	cr      string
-	factory func(kclient.Client, *client.Client) (controllers.Reconciler, error)
+	factory ReconcilerFactory
 }
 
 // SetupAllControllers sets up all controllers

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -24,6 +24,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
+	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
@@ -182,6 +185,9 @@ type TestSetup struct {
 	OperatorName             string
 	stepByStepReconciliation bool
 	log                      *slog.Logger
+	TeleportServer           *helpers.TeleInstance
+	ResourceName             string
+	Context                  context.Context
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -191,6 +197,9 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 		s.StopKubernetesOperator()
 	}
 
+	if s.K8sRestConfig == nil {
+		require.FailNow(t, "K8sRestConfig is required to start the operator, you cannot run a full test against a fake cluster.")
+	}
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
@@ -249,6 +258,7 @@ func setupTeleportClient(t *testing.T, setup *TestSetup) {
 	// Start a Teleport server for the test and set up a client connected to
 	// that server.
 	teleportServer, operatorName := defaultTeleportServiceConfig(t)
+	setup.TeleportServer = teleportServer
 	require.NoError(t, teleportServer.Start())
 	setup.TeleportClient = clientForTeleport(t, teleportServer, operatorName)
 	setup.OperatorName = operatorName
@@ -273,6 +283,56 @@ func WithTeleportClient(clt *client.Client) TestOption {
 
 func StepByStep(setup *TestSetup) {
 	setup.stepByStepReconciliation = true
+}
+
+// WithResourceName makes the test resource name static instead of letting the test generate a random one.
+// This is used if the resource name much match a specific pattern, or a fixture that was created beforehand
+// (e.g. trusted cluster).
+func WithResourceName(resourceName string) TestOption {
+	return func(setup *TestSetup) {
+		setup.ResourceName = resourceName
+	}
+}
+
+// SetupFakeKubeTestEnv is like SetupTestEnv but creates a fake Kubernetes
+// cluster by using controller-runtime's fake package.
+// This is way faster than using testEnv to spin up a full kube test cluster
+// on every test.
+// This does not support tests starting a full controller manager and can only be
+// used with Synchronous tests.
+func SetupFakeKubeTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
+	builder := fake.NewClientBuilder()
+	builder.WithScheme(scheme)
+	// Every CR kind must be registered as "WithStatusSubresource" so he fake client implements
+	// the status updates properly.
+	customScheme, err := apiresources.NewScheme()
+	require.NoError(t, err)
+	knownTypes := customScheme.AllKnownTypes()
+	for _, reflectType := range knownTypes {
+		reflectValue := reflect.New(reflectType).Interface()
+		obj, ok := reflectValue.(kclient.Object)
+		if !ok {
+			continue
+		}
+		builder.WithStatusSubresource(obj)
+	}
+	k8sClient := builder.Build()
+	ns := createNamespaceForTest(t, k8sClient)
+
+	setup := &TestSetup{
+		Context:      t.Context(),
+		K8sClient:    k8sClient,
+		Namespace:    ns,
+		ResourceName: ValidRandomResourceName("resource-"),
+	}
+
+	for _, opt := range opts {
+		opt(setup)
+	}
+
+	setupTeleportClient(t, setup)
+
+	return setup
 }
 
 // SetupTestEnv creates a Kubernetes server, a teleport server and starts the operator
@@ -303,9 +363,11 @@ func SetupTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 	})
 
 	setup := &TestSetup{
+		Context:       t.Context(),
 		K8sClient:     k8sClient,
 		Namespace:     ns,
 		K8sRestConfig: cfg,
+		ResourceName:  ValidRandomResourceName("resource-"),
 	}
 
 	for _, opt := range opts {

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -26,10 +26,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
 
 type ResourceTestingPrimitives[T reconcilers.Resource, K reconcilers.KubernetesCR[T]] interface {
@@ -187,5 +190,236 @@ func ResourceUpdateTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t
 
 	// Delete the resource to avoid leftover state.
 	err = test.DeleteTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+}
+
+func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test setup: Creating resource in Teleport with Kube origin
+	err = test.CreateTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the resource to be served by Teleport, fail early if Teleport is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err, "Teleport resource still not served by Teleport, Teleport might be stale/with a broken cache.")
+	})
+
+	// Test setup: Creating Kubernetes CR
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the CR to be served by Kubernetes, fail early if Kubernetes is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err, "Kubernetes resource still not served by Kubernetes, Kubernetes might be stale/with a broken cache.")
+	})
+
+	// Test setup: Kick off the reconciliation, make sure everything is in sync.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Test setup: Check if both Teleport and Kube resources are in-sync.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		// Kubernetes and Teleport resources are in-sync
+		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+	})
+
+	// Test execution: Induce a drift by updating the Kubernetes CR
+	require.NoError(t, test.ModifyKubernetesResource(ctx, resourceName))
+
+	// Test execution: Trigger reconciliation
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var testPassed bool
+	debugInfo := func() {
+		// If the test passed, disarm the debugging dump
+		if testPassed {
+			return
+		}
+		// Little type crime
+		var debug any = test
+		if debuggableTest, ok := debug.(interface{ DebugDrifts(*testing.T, string) }); ok {
+			t.Log("Test failed, dumping the state for troubleshooting purposes")
+			debuggableTest.DebugDrifts(t, resourceName)
+		}
+	}
+	t.Cleanup(debugInfo)
+
+	// Test validation: Check the drift was correct and resource updated in Teleport
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		// Kubernetes and Teleport resources are in-sync
+		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+	})
+	testPassed = true
+
+	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
+	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
+	require.NoError(t, test.DeleteTeleportResource(ctx, resourceName))
+	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+}
+
+func ResourceCreationSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test execution: create a Kubernetes resource
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test execution: Kick off the reconciliation.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var testPassed bool
+	debugInfo := func() {
+		// If the test passed, disarm the debugging dump
+		if testPassed {
+			return
+		}
+		// Little type crime
+		var debug any = test
+		if debuggableTest, ok := debug.(interface{ DebugDrifts(*testing.T, string) }); ok {
+			t.Log("Test failed, dumping the state for troubleshooting purposes")
+			debuggableTest.DebugDrifts(t, resourceName)
+		}
+	}
+	t.Cleanup(debugInfo)
+
+	// Test execution: wait for the cache to be refreshed.
+	var tResource T
+	FastEventually(t, func() bool {
+		tResource, err = test.GetTeleportResource(ctx, resourceName)
+		t.Log(err)
+		return !trace.IsNotFound(err)
+	})
+	require.NoError(t, err)
+	testPassed = true
+
+	// Test validation: we check that the Teleport resource has the right fields.
+
+	// We get the kube resource to get the resourceName as it might have been changed if this is a singleton resource
+	kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+	require.Equal(t, kubeResource.GetName(), test.GetResourceName(tResource))
+	require.Equal(t, types.OriginKubernetes, test.GetResourceOrigin(tResource))
+
+	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
+	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
+	require.NoError(t, test.DeleteTeleportResource(ctx, resourceName))
+	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+}
+
+func ResourceDeletionDriftSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test setup: create the Kube CR
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Reconcile and make sure the Teleport resource is created.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	FastEventually(t, func() bool {
+		_, err = test.GetTeleportResource(ctx, resourceName)
+		return !trace.IsNotFound(err)
+	})
+
+	// Test execution: Cause a drift by deleting the Teleport resource.
+	err = test.DeleteTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+	FastEventually(t, func() bool {
+		_, err = test.GetTeleportResource(ctx, resourceName)
+		return trace.IsNotFound(err)
+	})
+
+	// Test execution: Flag the resource for deletion in Kubernetes
+	// It won't be fully removed until the reconciler has processed it and removed the finalizer.
+	err = test.DeleteKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test execution: let the reonciler see that the Teleport resource was deleted and remove the finalizer on the kube resource.
+	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This is the second PR of my operator test refactoring. We always had issues with operator tests being slow and flaky (https://github.com/gravitational/teleport/issues/22698) because they start a whole kube cluster. This also makes them painful to run as you need to install the kube binaries and set a bunch of env vars.

This PR introduces a new test suite, synchronous, and using a fake kubernetes (based on the controller runtime fake client). For readability's sake and to make transition easier both tests suites will live until everything is converted.

This PR also adds an optional `DebugDrifts` function to the resource test primitives to get more debugging info if a test fails in the CI (this often happens for the SAML resource, I am not sure why, I don't plan to add the function to other controllers unless they start being flaky).

A third PR will follow, converting every test to the new synchronous test suite. In terms of performance, compilation is a bit slower (1 minute) but tests are way faster (10+min -> 2min). We might even run them in //. This also removes our testenv/kube dependency.