### PR TITLE
Add cache support for workload cluster

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -35,6 +35,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -178,6 +179,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	case types.Resource153UnwrapperT[*appauthconfigv1.AppAuthConfig]:
 		out.Resource = &proto.Event_AppAuthConfig{
 			AppAuthConfig: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]:
+		out.Resource = &proto.Event_WorkloadCluster{
+			WorkloadCluster: r.UnwrapT(),
 		}
 	case *types.ResourceHeader:
 		out.Resource = &proto.Event_ResourceHeader{
@@ -690,6 +695,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		return &out, nil
 	} else if r := in.GetAppAuthConfig(); r != nil {
 		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetWorkloadCluster(); r != nil {
+		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", in.Resource)

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -43,6 +43,7 @@ import (
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	v2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	v112 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	v122 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	v115 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -204,6 +205,7 @@ type Event struct {
 	//	*Event_AutoUpdateBotInstanceReport
 	//	*Event_AppAuthConfig
 	//	*Event_LinuxDesktop
+	//	*Event_WorkloadCluster
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -991,6 +993,15 @@ func (x *Event) GetLinuxDesktop() *v121.LinuxDesktop {
 	return nil
 }
 
+func (x *Event) GetWorkloadCluster() *v122.WorkloadCluster {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_WorkloadCluster); ok {
+			return x.WorkloadCluster
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1410,6 +1421,11 @@ type Event_LinuxDesktop struct {
 	LinuxDesktop *v121.LinuxDesktop `protobuf:"bytes,87,opt,name=LinuxDesktop,proto3,oneof"`
 }
 
+type Event_WorkloadCluster struct {
+	// WorkloadCluster is a resource for defining workload clusters.
+	WorkloadCluster *v122.WorkloadCluster `protobuf:"bytes,88,opt,name=WorkloadCluster,proto3,oneof"`
+}
+
 func (*Event_ResourceHeader) isEvent_Resource() {}
 
 func (*Event_CertAuthority) isEvent_Resource() {}
@@ -1574,11 +1590,13 @@ func (*Event_AppAuthConfig) isEvent_Resource() {}
 
 func (*Event_LinuxDesktop) isEvent_Resource() {}
 
+func (*Event_WorkloadCluster) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a-teleport/appauthconfig/v1/appauthconfig.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a,teleport/linuxdesktop/v1/linux_desktop.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\x832\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a-teleport/appauthconfig/v1/appauthconfig.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a,teleport/linuxdesktop/v1/linux_desktop.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a1teleport/workloadcluster/v1/workloadcluster.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xdd2\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1675,7 +1693,8 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\x06plugin\x18T \x01(\v2\x0f.types.PluginV1H\x00R\x06plugin\x12w\n" +
 	"\x1bAutoUpdateBotInstanceReport\x18U \x01(\v23.teleport.autoupdate.v1.AutoUpdateBotInstanceReportH\x00R\x1bAutoUpdateBotInstanceReport\x12P\n" +
 	"\rAppAuthConfig\x18V \x01(\v2(.teleport.appauthconfig.v1.AppAuthConfigH\x00R\rAppAuthConfig\x12L\n" +
-	"\fLinuxDesktop\x18W \x01(\v2&.teleport.linuxdesktop.v1.LinuxDesktopH\x00R\fLinuxDesktopB\n" +
+	"\fLinuxDesktop\x18W \x01(\v2&.teleport.linuxdesktop.v1.LinuxDesktopH\x00R\fLinuxDesktop\x12X\n" +
+	"\x0fWorkloadCluster\x18X \x01(\v2,.teleport.workloadcluster.v1.WorkloadClusterH\x00R\x0fWorkloadClusterB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1780,6 +1799,7 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v111.AutoUpdateBotInstanceReport)(nil),    // 78: teleport.autoupdate.v1.AutoUpdateBotInstanceReport
 	(*v120.AppAuthConfig)(nil),                  // 79: teleport.appauthconfig.v1.AppAuthConfig
 	(*v121.LinuxDesktop)(nil),                   // 80: teleport.linuxdesktop.v1.LinuxDesktop
+	(*v122.WorkloadCluster)(nil),                // 81: teleport.workloadcluster.v1.WorkloadCluster
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1865,11 +1885,12 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	78, // 80: proto.Event.AutoUpdateBotInstanceReport:type_name -> teleport.autoupdate.v1.AutoUpdateBotInstanceReport
 	79, // 81: proto.Event.AppAuthConfig:type_name -> teleport.appauthconfig.v1.AppAuthConfig
 	80, // 82: proto.Event.LinuxDesktop:type_name -> teleport.linuxdesktop.v1.LinuxDesktop
-	83, // [83:83] is the sub-list for method output_type
-	83, // [83:83] is the sub-list for method input_type
-	83, // [83:83] is the sub-list for extension type_name
-	83, // [83:83] is the sub-list for extension extendee
-	0,  // [0:83] is the sub-list for field type_name
+	81, // 83: proto.Event.WorkloadCluster:type_name -> teleport.workloadcluster.v1.WorkloadCluster
+	84, // [84:84] is the sub-list for method output_type
+	84, // [84:84] is the sub-list for method input_type
+	84, // [84:84] is the sub-list for extension type_name
+	84, // [84:84] is the sub-list for extension extendee
+	0,  // [0:84] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -1960,6 +1981,7 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_AutoUpdateBotInstanceReport)(nil),
 		(*Event_AppAuthConfig)(nil),
 		(*Event_LinuxDesktop)(nil),
+		(*Event_WorkloadCluster)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -41,6 +41,7 @@ import "teleport/secreports/v1/secreports.proto";
 import "teleport/userloginstate/v1/userloginstate.proto";
 import "teleport/userprovisioning/v2/statichostuser.proto";
 import "teleport/usertasks/v1/user_tasks.proto";
+import "teleport/workloadcluster/v1/workloadcluster.proto";
 import "teleport/workloadidentity/v1/resource.proto";
 import "teleport/workloadidentity/v1/revocation_resource.proto";
 
@@ -240,5 +241,7 @@ message Event {
     teleport.appauthconfig.v1.AppAuthConfig AppAuthConfig = 86;
     // LinuxDesktop is a resource for linux desktop.
     teleport.linuxdesktop.v1.LinuxDesktop LinuxDesktop = 87;
+    // WorkloadCluster is a resource for defining workload clusters.
+    teleport.workloadcluster.v1.WorkloadCluster WorkloadCluster = 88;
   }
 }

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -116,6 +116,7 @@ type Config struct {
 	RecordingEncryption     services.RecordingEncryption
 	Plugin                  services.Plugins
 	AppAuthConfig           services.AppAuthConfigReader
+	WorkloadClusterService  services.WorkloadClusterService
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -204,6 +205,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		RecordingEncryption:     cfg.RecordingEncryption,
 		Plugin:                  cfg.Plugin,
 		AppAuthConfig:           cfg.AppAuthConfig,
+		WorkloadClusterService:  cfg.WorkloadClusterService,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1496,6 +1496,9 @@ type Cache interface {
 
 	// AppAuthConfigGetter defines methods for fetching app auth configs.
 	services.AppAuthConfigReader
+
+	// WorkloadClusterServiceGetter defines methods for fetching workload clusters.
+	services.WorkloadClusterServiceGetter
 }
 
 type NodeWrapper struct {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1619,6 +1619,7 @@ type ClientI interface {
 	services.AppAuthConfigSessions
 	types.Events
 	services.ScopedAccessClientGetter
+	services.WorkloadClusterService
 
 	// ListUnifiedInstances returns a paginated list of unified instances (teleport instances and bot instances).
 	ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -613,6 +613,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		Plugin:                  p.AuthServer.Services.Plugins,
 		AppAuthConfig:           p.AuthServer.Services.AppAuthConfig,
 		StaticScopedToken:       p.AuthServer.Services.ClusterConfigurationInternal,
+		WorkloadClusterService:  p.AuthServer.Services.WorkloadClusterService,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -218,6 +218,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindBotInstance},
 		{Kind: types.KindRecordingEncryption},
 		{Kind: types.KindAppAuthConfig},
+		{Kind: types.KindWorkloadCluster},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	// We don't want to enable partial health for auth cache because auth uses an event stream

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -794,6 +794,8 @@ type Config struct {
 	Plugin services.Plugins
 	// AppAuthConfig is a app auth config service.
 	AppAuthConfig services.AppAuthConfigReader
+	// WorkloadClusterService is a workload cluster service
+	WorkloadClusterService services.WorkloadClusterService
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -61,6 +61,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -171,6 +172,7 @@ type testPack struct {
 	recordingEncryption     *local.RecordingEncryptionService
 	plugin                  *local.PluginsService
 	appAuthConfigs          *local.AppAuthConfigService
+	workloadClusters        *local.WorkloadClusterService
 }
 
 // resourceOps contains helpers to modify the state of either types.Resource or types.Resource153  which
@@ -530,6 +532,12 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	workloadClusterSvc, err := local.NewWorkloadClusterService(p.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	p.workloadClusters = workloadClusterSvc
 
 	return p, nil
 }
@@ -2649,6 +2657,18 @@ func newAutoUpdateBotInstanceReport(t *testing.T) *autoupdate.AutoUpdateBotInsta
 			},
 		},
 	}
+}
+
+func newWorkloadCluster(t *testing.T, name string) *workloadclusterv1.WorkloadCluster {
+	t.Helper()
+
+	workloadCluster := &workloadclusterv1.WorkloadCluster{
+		Metadata: &headerv1.Metadata{
+			Name: name,
+		},
+	}
+
+	return workloadCluster
 }
 
 func withKeepalive[T any](fn func(context.Context, T) (*types.KeepAlive, error)) func(context.Context, T) error {

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -603,6 +603,7 @@ func newPack(t testing.TB, setupConfig func(c Config) Config, opts ...packOption
 		EventsC:                 p.eventsC,
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
+		WorkloadClusterService:  p.workloadClusters,
 	}))
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -874,6 +875,7 @@ func TestCompletenessInit(t *testing.T) {
 			Plugin:                  p.plugin,
 			AppAuthConfig:           p.appAuthConfigs,
 			StaticScopedToken:       p.clusterConfigS,
+			WorkloadClusterService:  p.workloadClusters,
 		}))
 		require.NoError(t, err)
 
@@ -964,6 +966,7 @@ func TestCompletenessReset(t *testing.T) {
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
+		WorkloadClusterService:  p.workloadClusters,
 	}))
 	require.NoError(t, err)
 
@@ -1126,6 +1129,7 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
+		WorkloadClusterService:  p.workloadClusters,
 	}))
 	require.NoError(t, err)
 
@@ -1227,6 +1231,7 @@ func initStrategy(t *testing.T) {
 		Plugin:                  p.plugin,
 		AppAuthConfig:           p.appAuthConfigs,
 		StaticScopedToken:       p.clusterConfigS,
+		WorkloadClusterService:  p.workloadClusters,
 	}))
 	require.NoError(t, err)
 
@@ -1973,6 +1978,7 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 		types.KindRelayServer:                       types.ProtoResource153ToLegacy(new(presencev1.RelayServer)),
 		types.KindBotInstance:                       types.ProtoResource153ToLegacy(new(machineidv1.BotInstance)),
 		types.KindAppAuthConfig:                     types.Resource153ToLegacy(new(appauthconfigv1.AppAuthConfig)),
+		types.KindWorkloadCluster:                   types.Resource153ToLegacy(newWorkloadCluster(t, "test")),
 	}
 
 	for name, cfg := range cases {
@@ -2046,6 +2052,8 @@ func TestCacheWatchKindExistsInEvents(t *testing.T) {
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*machineidv1.BotInstance]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				case types.Resource153UnwrapperT[*appauthconfigv1.AppAuthConfig]:
 					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*appauthconfigv1.AppAuthConfig]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
+				case types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]:
+					require.Empty(t, cmp.Diff(resource.(types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]).UnwrapT(), uw.UnwrapT(), protocmp.Transform()))
 				default:
 					require.Empty(t, cmp.Diff(resource, event.Resource))
 				}

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -789,6 +789,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.appAuthConfig = collect
 			out.byKind[resourceKind] = out.appAuthConfig
+		case types.KindWorkloadCluster:
+			collect, err := newWorkloadClusterCollection(c.WorkloadClusterService, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.workloadClusters = collect
+			out.byKind[resourceKind] = out.workloadClusters
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -39,6 +39,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -148,6 +149,7 @@ type collections struct {
 	recordingEncryption                *collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]
 	plugins                            *collection[types.Plugin, pluginIndex]
 	appAuthConfig                      *collection[*appauthconfigv1.AppAuthConfig, appAuthConfigIndex]
+	workloadClusters                   *collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -213,6 +213,9 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 	appAuthConfig, err := local.NewAppAuthConfigService(bkWrapper)
 	require.NoError(t, err)
 
+	workloadClusters, err := local.NewWorkloadClusterService(bkWrapper)
+	require.NoError(t, err)
+
 	c, err := cache.New(setupConfig(cache.Config{
 		Context:                 ctx,
 		Events:                  eventsS,
@@ -264,6 +267,7 @@ func setupTestCache(t *testing.T, setupConfig cache.SetupConfigFn) (*testCache, 
 		StaticScopedToken:       clusterConfig,
 		MaxRetryPeriod:          200 * time.Millisecond,
 		EventsC:                 eventsC,
+		WorkloadClusterService:  workloadClusters,
 	}))
 	require.NoError(t, err)
 

--- a/lib/cache/workload_cluster.go
+++ b/lib/cache/workload_cluster.go
@@ -1,0 +1,104 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type workloadClusterIndex string
+
+const workloadClusterNameIndex workloadClusterIndex = "name"
+
+func newWorkloadClusterCollection(upstream services.WorkloadClusterService, w types.WatchKind) (*collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter WorkloadClusters")
+	}
+
+	return &collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		store: newStore(
+			types.KindWorkloadCluster,
+			proto.CloneOf[*workloadclusterv1.WorkloadCluster],
+			map[workloadClusterIndex]func(*workloadclusterv1.WorkloadCluster) string{
+				workloadClusterNameIndex: func(r *workloadclusterv1.WorkloadCluster) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*workloadclusterv1.WorkloadCluster, error) {
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, i int, nextToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+				return upstream.ListWorkloadClusters(ctx, i, nextToken)
+			}))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *workloadclusterv1.WorkloadCluster {
+			return &workloadclusterv1.WorkloadCluster{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListWorkloadClusters returns a list of WorkloadCluster resources.
+func (c *Cache) ListWorkloadClusters(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListWorkloadClusters")
+	defer span.End()
+
+	lister := genericLister[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		cache:      c,
+		collection: c.collections.workloadClusters,
+		index:      workloadClusterNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			out, next, err := c.Config.WorkloadClusterService.ListWorkloadClusters(ctx, pageSize, pageToken)
+			return out, next, trace.Wrap(err)
+		},
+		nextToken: func(t *workloadclusterv1.WorkloadCluster) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetWorkloadCluster returns the specified WorkloadCluster resource.
+func (c *Cache) GetWorkloadCluster(ctx context.Context, name string) (*workloadclusterv1.WorkloadCluster, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetWorkloadCluster")
+	defer span.End()
+
+	getter := genericGetter[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		cache:       c,
+		collection:  c.collections.workloadClusters,
+		index:       workloadClusterNameIndex,
+		upstreamGet: c.Config.WorkloadClusterService.GetWorkloadCluster,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/workload_cluster_test.go
+++ b/lib/cache/workload_cluster_test.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+)
+
+// TestWorkloadClusters tests that CRUD operations on workload clusters resources are
+// replicated from the backend to the cache.
+func TestWorkloadClusters(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*workloadclusterv1.WorkloadCluster]{
+		newResource: func(name string) (*workloadclusterv1.WorkloadCluster, error) {
+			return newWorkloadCluster(t, name), nil
+		},
+		create: func(ctx context.Context, item *workloadclusterv1.WorkloadCluster) error {
+			_, err := p.workloadClusters.CreateWorkloadCluster(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			return p.workloadClusters.ListWorkloadClusters(ctx, pageSize, pageToken)
+		},
+		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			return p.workloadClusters.ListWorkloadClusters(ctx, pageSize, pageToken)
+		},
+		deleteAll: p.workloadClusters.DeleteAllWorkloadClusters,
+	})
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3074,6 +3074,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.RecordingEncryption = services.RecordingEncryptionManager
 	cfg.Plugin = services.Plugins
 	cfg.AppAuthConfig = services.AppAuthConfig
+	cfg.WorkloadClusterService = services.WorkloadClusterService
 
 	return accesspoint.NewCache(cfg)
 }


### PR DESCRIPTION
This adds cache support for workload clusters.

Teleport users will create `workload_cluster` resources to instruct Teleport Cloud to provision a child Teleport Cloud cluster with the provided configuration. Users are able to configure the region to use for auth and supply configuration for starting the Teleport cluster with a Teleport Bot and Token using IAM joining.

This pull request is part of a chain:

- #62863
- #62864
- #62865
- #62866 (this pull request)
- #62867
- #62868

RFD: https://github.com/gravitational/cloud/blob/master/rfd/0203-child-clusters.md
Goal:  https://github.com/gravitational/cloud/issues/15315 https://github.com/gravitational/cloud/issues/15870