### PR TITLE
Support WorkloadClusters entitlement

### DIFF
--- a/entitlements/entitlements.go
+++ b/entitlements/entitlements.go
@@ -54,6 +54,7 @@ const (
 	LicenseAutoUpdate          EntitlementKind = "LicenseAutoUpdate"
 	AccessGraphDemoMode        EntitlementKind = "AccessGraphDemoMode"
 	ClientIPRestrictions       EntitlementKind = "ClientIPRestrictions"
+	WorkloadClusters           EntitlementKind = "WorkloadClusters"
 )
 
 // AllEntitlements returns all Entitlements; should be 1:1 with the const declared above.
@@ -61,7 +62,7 @@ var AllEntitlements = []EntitlementKind{
 	AccessLists, AccessMonitoring, AccessRequests, App, CloudAuditLogRetention, DB, Desktop, DeviceTrust,
 	ExternalAuditStorage, FeatureHiding, HSM, Identity, JoinActiveSessions, K8s, MobileDeviceManagement, OIDC, OktaSCIM,
 	OktaUserSync, Policy, SAML, SessionLocks, UnrestrictedManagedUpdates, UpsellAlert, UsageReporting, LicenseAutoUpdate, AccessGraphDemoMode,
-	ClientIPRestrictions,
+	ClientIPRestrictions, WorkloadClusters,
 }
 
 // BackfillFeatures ensures entitlements are backwards compatible.

--- a/entitlements/entitlements_test.go
+++ b/entitlements/entitlements_test.go
@@ -96,6 +96,7 @@ func TestBackfillFeatures(t *testing.T) {
 					string(AccessGraphDemoMode):        {Enabled: true},
 					string(UnrestrictedManagedUpdates): {Enabled: true},
 					string(ClientIPRestrictions):       {Enabled: true},
+					string(WorkloadClusters):           {Enabled: true},
 				},
 			},
 			expected: map[string]*proto.EntitlementInfo{
@@ -126,6 +127,7 @@ func TestBackfillFeatures(t *testing.T) {
 				string(AccessGraphDemoMode):        {Enabled: true},
 				string(UnrestrictedManagedUpdates): {Enabled: true},
 				string(ClientIPRestrictions):       {Enabled: true},
+				string(WorkloadClusters):           {Enabled: true},
 			},
 		},
 		{
@@ -205,6 +207,7 @@ func TestBackfillFeatures(t *testing.T) {
 				string(AccessGraphDemoMode):        {Enabled: false},
 				string(UnrestrictedManagedUpdates): {Enabled: false},
 				string(ClientIPRestrictions):       {Enabled: false},
+				string(WorkloadClusters):           {Enabled: false},
 			},
 		},
 		{
@@ -281,6 +284,7 @@ func TestBackfillFeatures(t *testing.T) {
 				string(AccessGraphDemoMode):        {Enabled: false},
 				string(UnrestrictedManagedUpdates): {Enabled: false},
 				string(ClientIPRestrictions):       {Enabled: false},
+				string(WorkloadClusters):           {Enabled: false},
 				// Identity off, fields false
 				string(Identity):     {Enabled: false},
 				string(SessionLocks): {Enabled: false},

--- a/lib/modules/modules_test.go
+++ b/lib/modules/modules_test.go
@@ -165,6 +165,7 @@ func TestFeatures_ToProto(t *testing.T) {
 			string(entitlements.AccessGraphDemoMode):        {Enabled: true},
 			string(entitlements.UnrestrictedManagedUpdates): {Enabled: true},
 			string(entitlements.ClientIPRestrictions):       {Enabled: true},
+			string(entitlements.WorkloadClusters):           {Enabled: true},
 		},
 		//	 Legacy Fields; remove in v18
 		Kubernetes:             true,
@@ -243,6 +244,7 @@ func TestFeatures_ToProto(t *testing.T) {
 			entitlements.AccessGraphDemoMode:        {Enabled: true, Limit: 0},
 			entitlements.UnrestrictedManagedUpdates: {Enabled: true, Limit: 0},
 			entitlements.ClientIPRestrictions:       {Enabled: true, Limit: 0},
+			entitlements.WorkloadClusters:           {Enabled: true, Limit: 0},
 		},
 	}
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -4917,6 +4917,7 @@ func TestGetWebConfig_WithEntitlements(t *testing.T) {
 			string(entitlements.AccessGraphDemoMode):        {Enabled: false},
 			string(entitlements.UnrestrictedManagedUpdates): {Enabled: false},
 			string(entitlements.ClientIPRestrictions):       {Enabled: false},
+			string(entitlements.WorkloadClusters):           {Enabled: false},
 		},
 		TunnelPublicAddress:            "",
 		RecoveryCodesEnabled:           false,
@@ -5102,6 +5103,7 @@ func TestGetWebConfig_LegacyFeatureLimits(t *testing.T) {
 			string(entitlements.AccessGraphDemoMode):        {Enabled: false},
 			string(entitlements.UnrestrictedManagedUpdates): {Enabled: false},
 			string(entitlements.ClientIPRestrictions):       {Enabled: false},
+			string(entitlements.WorkloadClusters):           {Enabled: false},
 		},
 		PlayableDatabaseProtocols:     player.SupportedDatabaseProtocols,
 		IsPolicyRoleVisualizerEnabled: true,
@@ -11407,6 +11409,7 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 					string(entitlements.AccessGraphDemoMode):        {Enabled: true, Limit: 99},
 					string(entitlements.UnrestrictedManagedUpdates): {Enabled: true, Limit: 99},
 					string(entitlements.ClientIPRestrictions):       {Enabled: true, Limit: 99},
+					string(entitlements.WorkloadClusters):           {Enabled: true, Limit: 99},
 				},
 			},
 			expected: &webclient.WebConfig{
@@ -11472,6 +11475,7 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 					string(entitlements.AccessGraphDemoMode):        {Enabled: true, Limit: 99},
 					string(entitlements.UnrestrictedManagedUpdates): {Enabled: true, Limit: 99},
 					string(entitlements.ClientIPRestrictions):       {Enabled: true, Limit: 99},
+					string(entitlements.WorkloadClusters):           {Enabled: true, Limit: 99},
 				},
 			},
 		},
@@ -11576,6 +11580,7 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 					string(entitlements.AccessGraphDemoMode):        {Enabled: false},
 					string(entitlements.UnrestrictedManagedUpdates): {Enabled: false},
 					string(entitlements.ClientIPRestrictions):       {Enabled: false},
+					string(entitlements.WorkloadClusters):           {Enabled: false},
 
 					// set to equivalent legacy feature
 					string(entitlements.ExternalAuditStorage):   {Enabled: true},
@@ -11707,6 +11712,7 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 					string(entitlements.AccessGraphDemoMode):        {Enabled: false},
 					string(entitlements.UnrestrictedManagedUpdates): {Enabled: false},
 					string(entitlements.ClientIPRestrictions):       {Enabled: false},
+					string(entitlements.WorkloadClusters):           {Enabled: false},
 
 					// set to legacy feature "IsIGSEnabled"; false so set value and keep limits
 					string(entitlements.AccessLists):       {Enabled: true, Limit: 88},
@@ -11820,6 +11826,7 @@ func Test_setEntitlementsWithLegacyLogic(t *testing.T) {
 					string(entitlements.AccessGraphDemoMode):        {Enabled: false},
 					string(entitlements.UnrestrictedManagedUpdates): {Enabled: false},
 					string(entitlements.ClientIPRestrictions):       {Enabled: false},
+					string(entitlements.WorkloadClusters):           {Enabled: false},
 				},
 			},
 		},


### PR DESCRIPTION
This pull request adds support for the WorkloadClusters entitlement. This entitlement controls access to using the `workload_cluster` resource in enterprise builds for Teleport Cloud users.

Teleport users will create `workload_cluster` resources to instruct Teleport Cloud to provision a child Teleport Cloud cluster with the provided configuration. Users are able to configure the region to use for auth and supply configuration for starting the Teleport cluster with a Teleport Bot and Token using IAM joining.

This pull request is part of a chain:

- #62863
- #62864
- #62865
- #62866
- #62867
- #62868 (this pull request)

---

Before merging and backporting:

- [x] Merge https://github.com/gravitational/teleport.e/pull/7907
- [x] Backport https://github.com/gravitational/teleport.e/pull/7926
- [x] Update e reference in master
- [x] Update e reference in branch/v18

RFD: https://github.com/gravitational/cloud/blob/master/rfd/0203-child-clusters.md
Goal:  https://github.com/gravitational/cloud/issues/15315 https://github.com/gravitational/cloud/issues/15870