### PR TITLE
[v18] Remove superfluous lib/winpki.GenerateCredentialsRequest.CAType field

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -174,7 +174,6 @@ func (d *dbCertGetter) getCertificate(ctx context.Context, username string) (*ge
 	}
 
 	req := &winpki.GenerateCredentialsRequest{
-		CAType:             types.DatabaseClientCA,
 		TTL:                time.Minute * 10,
 		Domain:             d.domain,
 		ClusterName:        clusterName.GetClusterName(),

--- a/lib/srv/db/common/kerberos/kinit/ldap.go
+++ b/lib/srv/db/common/kerberos/kinit/ldap.go
@@ -138,7 +138,6 @@ func (s *ldapConnector) tlsConfigForLDAP(ctx context.Context, clusterName string
 
 	req := &winpki.GenerateCredentialsRequest{
 		Username:           user,
-		CAType:             types.DatabaseClientCA,
 		TTL:                time.Hour,
 		ClusterName:        clusterName,
 		Domain:             s.ldapConfig.domain,

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1285,7 +1285,6 @@ type generateCredentialsRequest struct {
 // https://docs.microsoft.com/en-us/windows/security/identity-protection/smart-cards/smart-card-certificate-requirements-and-enumeration
 func (s *WindowsService) generateCredentials(ctx context.Context, request generateCredentialsRequest) (certDER, keyDER []byte, err error) {
 	return winpki.GenerateWindowsDesktopCredentials(ctx, s.cfg.AuthClient, &winpki.GenerateCredentialsRequest{
-		CAType:             types.UserCA,
 		Username:           request.username,
 		Domain:             request.domain,
 		PKIDomain:          s.cfg.PKIDomain,

--- a/lib/winpki/windows.go
+++ b/lib/winpki/windows.go
@@ -171,9 +171,6 @@ type GenerateCredentialsRequest struct {
 	// specified by Username. If specified (!= ""), it is
 	// encoded in the certificate per https://go.microsoft.com/fwlink/?linkid=2189925.
 	ActiveDirectorySID string
-	// CAType is the certificate authority type used to generate the certificate.
-	// This is used to proper generate the CRL LDAP path.
-	CAType types.CertAuthType
 	// CreateUser specifies if Windows user should be created if missing
 	CreateUser bool
 	// Groups are groups that user should be member of

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -412,7 +412,6 @@ func (a *AuthCommand) generateWindowsCert(ctx context.Context, clusterAPI certif
 	}
 
 	certDER, _, err := winpki.GenerateWindowsDesktopCredentials(ctx, clusterAPI, &winpki.GenerateCredentialsRequest{
-		CAType:             types.UserCA,
 		Username:           a.windowsUser,
 		Domain:             a.windowsDomain,
 		PKIDomain:          a.windowsPKIDomain,


### PR DESCRIPTION
Backport #62370 to branch/v18.

#10111