### PR TITLE
helm: deploy/destroy teleport-kube-agents in parallel

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -55,6 +55,11 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
       podManagementPolicy: Parallel
+      {{- if (gt (int $replicaCount) 1) }}
+      updateStrategy:
+        rollingUpdate:
+          maxUnavailable: 50%
+      {{- end }}
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:
         {{- if .Values.affinity }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -54,6 +54,7 @@ spec:
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}
+      podManagementPolicy: Parallel
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:
         {{- if .Values.affinity }}


### PR DESCRIPTION
The first commit sets the [`podManagementPolicy`](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#parallel-pod-management) to parallel, enabling kubernetes to deploy / destroy all pods at once.

The second lets kubernetes update 50% of the pods at once (rounded up, so with 3 replicas it will recreate two pods and once those are ready recreate the last pod).