### PR TITLE
Create the WindowsCA on cluster startup

### DIFF
--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -85,6 +85,7 @@ const (
 // CertAuthTypes lists all certificate authority types.
 var CertAuthTypes = []CertAuthType{
 	HostCA,
+	// TODO(codingllama): Add WindowsCA to the list.
 	UserCA,
 	DatabaseCA,
 	DatabaseClientCA,
@@ -96,13 +97,24 @@ var CertAuthTypes = []CertAuthType{
 	OktaCA,
 	AWSRACA,
 	BoundKeypairCA,
-	// TODO(codingllama): Add WindowsCA to the list.
 }
 
-// CertAuthTypesExtended is `append(CertAuthTypes, WindowsCA)`.
+// CertAuthTypesExtended is the union of `CertAuthTypes` and `{WindowsCA}`.
+// WindowsCA is always placed before UserCA.
 //
 // TODO(codingllama): Remove once WindowsCA is listed on CertAuthTypes.
-var CertAuthTypesExtended = append(CertAuthTypes, WindowsCA)
+var CertAuthTypesExtended = makeCertAuthTypesExtended()
+
+func makeCertAuthTypesExtended() []CertAuthType {
+	dst := make([]CertAuthType, 0, len(CertAuthTypes)+1)
+	for _, caType := range CertAuthTypes {
+		if caType == UserCA {
+			dst = append(dst, WindowsCA)
+		}
+		dst = append(dst, caType)
+	}
+	return dst
+}
 
 // NewlyAdded should return true for CA types that were added in the current
 // major version, so that we can avoid erroring out when a potentially older

--- a/api/types/trust_test.go
+++ b/api/types/trust_test.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Gravitational, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+)
+
+// TODO(codingllama): DELETE IN 20. This won't matter once the migration doesn't exist.
+func TestCertAuthTypes_WindowsBeforeUser(t *testing.T) {
+	var foundUser bool
+	for _, caType := range CertAuthTypesExtended {
+		switch caType {
+		case UserCA:
+			foundUser = true
+		case WindowsCA:
+			if !foundUser {
+				return // OK, Windows before User.
+			}
+			t.Errorf("" +
+				"CertAuthTypes: UserCA appears before WindowsCA. " +
+				"It's important for WindowsCA to be created before UserCA in new clusters, so it's not incorrectly cloned from UserCA if initial CA creation is only partly successful.")
+		}
+	}
+}

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -8338,7 +8338,7 @@ func (a *Server) addAdditionalTrustedKeysAtomic(ctx context.Context, ca types.Ce
 }
 
 // newKeySet generates a new sets of keys for a given CA type.
-// Keep this function in sync with lib/auth/authcatest.NewTestCAWithConfig().
+// Keep this function in sync with lib/auth/authcatest.NewCAWithConfig().
 func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertAuthID) (types.CAKeySet, error) {
 	switch caID.Type {
 	case
@@ -8353,7 +8353,8 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 		types.SPIFFECA,
 		types.OktaCA,
 		types.AWSRACA,
-		types.BoundKeypairCA:
+		types.BoundKeypairCA,
+		types.WindowsCA:
 		// OK, known CA type.
 	default:
 		return types.CAKeySet{}, trace.BadParameter(
@@ -8374,7 +8375,14 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 
 	// Add TLS keys if necessary.
 	switch caID.Type {
-	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
+	case types.UserCA,
+		types.HostCA,
+		types.DatabaseCA,
+		types.DatabaseClientCA,
+		types.SAMLIDPCA,
+		types.SPIFFECA,
+		types.AWSRACA,
+		types.WindowsCA:
 		tlsKeyPair, err := keyStore.NewTLSKeyPair(ctx, caID.DomainName, tlsCAKeyPurpose(caID.Type))
 		if err != nil {
 			return keySet, trace.Wrap(err)
@@ -8393,7 +8401,7 @@ func newKeySet(ctx context.Context, keyStore *keystore.Manager, caID types.CertA
 	}
 
 	// Sanity check that the key set has at least one key.
-	if len(keySet.SSH) == 0 && len(keySet.TLS) == 0 && len(keySet.JWT) == 0 {
+	if keySet.Empty() {
 		return types.CAKeySet{}, trace.BadParameter("no keys generated for CA type %q", caID.Type)
 	}
 
@@ -8428,6 +8436,8 @@ func tlsCAKeyPurpose(caType types.CertAuthType) cryptosuites.KeyPurpose {
 		return cryptosuites.SPIFFECATLS
 	case types.AWSRACA:
 		return cryptosuites.AWSRACATLS
+	case types.WindowsCA:
+		return cryptosuites.WindowsCARDP
 	}
 	return cryptosuites.KeyPurposeUnspecified
 }

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4055,7 +4055,7 @@ func TestCAGeneration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for _, caType := range types.CertAuthTypes {
+	for _, caType := range types.CertAuthTypesExtended {
 		t.Run(string(caType), func(t *testing.T) {
 			ca, err := authcatest.NewCA(caType, clusterName, privKey)
 			require.NoError(t, err)

--- a/lib/auth/authcatest/ca.go
+++ b/lib/auth/authcatest/ca.go
@@ -76,7 +76,8 @@ func NewCAWithConfig(config CAConfig) (*types.CertAuthorityV2, error) {
 		types.SPIFFECA,
 		types.OktaCA,
 		types.AWSRACA,
-		types.BoundKeypairCA:
+		types.BoundKeypairCA,
+		types.WindowsCA:
 		// OK, known CA type.
 	default:
 		return nil, trace.BadParameter("cannot generate new key set for unknown CA type %q", config.Type)
@@ -153,7 +154,14 @@ func NewCAWithConfig(config CAConfig) (*types.CertAuthorityV2, error) {
 
 	// Add TLS keys if necessary.
 	switch config.Type {
-	case types.UserCA, types.HostCA, types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
+	case types.UserCA,
+		types.HostCA,
+		types.DatabaseCA,
+		types.DatabaseClientCA,
+		types.SAMLIDPCA,
+		types.SPIFFECA,
+		types.AWSRACA,
+		types.WindowsCA:
 		cert, err := tlsca.GenerateSelfSignedCAWithConfig(tlsca.GenerateCAConfig{
 			Signer: key.Signer,
 			Entity: pkix.Name{
@@ -187,7 +195,7 @@ func NewCAWithConfig(config CAConfig) (*types.CertAuthorityV2, error) {
 
 	// Sanity check that the CA has at least one active key.
 	aks := ca.Spec.ActiveKeys
-	if len(aks.SSH) == 0 && len(aks.TLS) == 0 && len(aks.JWT) == 0 {
+	if aks.Empty() {
 		return nil, trace.BadParameter("no keys generated for CA type %q", config.Type)
 	}
 

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -334,3 +334,9 @@ type GitHubManager = githubManager
 func (s *TLSServer) GRPCServer() *GRPCServer {
 	return s.grpcServer
 }
+
+type MigrateWindowsCAParams = migrateWindowsCAParams
+
+func MigrateWindowsCA(ctx context.Context, params MigrateWindowsCAParams) error {
+	return migrateWindowsCA(ctx, params)
+}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -735,7 +735,7 @@ func initializeAuthorities(ctx context.Context, asrv *Server, cfg *InitConfig) e
 	)
 	usableKeysResults := make(map[types.CertAuthType]*keystore.UsableKeysResult)
 	g, gctx := errgroup.WithContext(ctx)
-	for _, caType := range types.CertAuthTypes {
+	for _, caType := range types.CertAuthTypesExtended {
 		g.Go(func() error {
 			tctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthority", oteltrace.WithAttributes(attribute.String("type", string(caType))))
 			defer span.End()

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -654,6 +654,21 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 		return trace.Wrap(err, "applying migrations")
 	}
 
+	// Clone UserCA into WindowsCA. Must happen before initializeAuthorities() so
+	// it only affects upgraded clusters.
+	// Added on Teleport 18.x and 19.
+	clusterConfiguration, err := local.NewClusterConfigurationService(cfg.Backend)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := migrateWindowsCA(ctx, migrateWindowsCAParams{
+		Logger:               asrv.logger,
+		ClusterConfiguration: clusterConfiguration,
+		Trust:                local.NewCAService(cfg.Backend),
+	}); err != nil {
+		return trace.Wrap(err, "migrate WindowsCA")
+	}
+
 	// generate certificate authorities if they don't exist
 	if err := initializeAuthorities(ctx, asrv, &cfg); err != nil {
 		return trace.Wrap(err)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -2328,7 +2328,7 @@ func TestInitCreatesCertsIfMissing(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	for _, caType := range types.CertAuthTypes {
+	for _, caType := range types.CertAuthTypesExtended {
 		cert, err := auth.GetCertAuthorities(ctx, caType, false)
 		require.NoError(t, err)
 		require.Len(t, cert, 1)

--- a/lib/auth/init_windows_ca.go
+++ b/lib/auth/init_windows_ca.go
@@ -79,10 +79,10 @@ func migrateWindowsCAOnCluster(
 	// Query dst CA.
 	switch _, err := trust.GetCertAuthority(ctx, dst, false /* loadSigningKeys */); {
 	case err == nil:
-		logger.DebugContext(ctx, "dst CA already exists, nothing to do")
+		logger.DebugContext(ctx, "Windows CA already exists, nothing to do")
 		return nil // dst already exists.
 	case !trace.IsNotFound(err):
-		logger.DebugContext(ctx, "src CA not found (new cluster)")
+		logger.DebugContext(ctx, "User CA not found (new cluster)")
 		return trace.Wrap(err, "read %q CA", dst.Type)
 	}
 

--- a/lib/auth/init_windows_ca.go
+++ b/lib/auth/init_windows_ca.go
@@ -1,0 +1,142 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type migrateWindowsCAParams struct {
+	Logger               *slog.Logger
+	ClusterConfiguration services.ClusterNameGetter
+	Trust                services.Trust
+}
+
+// migrateWindowsCA performs the WindowsCA migration, which clones an existing
+// UserCA into the new WindowsCA.
+//
+// TODO(codingllama): DELETE IN 20.
+func migrateWindowsCA(ctx context.Context, p migrateWindowsCAParams) error {
+	switch {
+	case p.Logger == nil:
+		return errors.New("param Logger required")
+	case p.ClusterConfiguration == nil:
+		return errors.New("param ClusterConfiguration required")
+	case p.Trust == nil:
+		return errors.New("param Trust required")
+	}
+
+	cn, err := p.ClusterConfiguration.GetClusterName(ctx)
+	if err != nil {
+		return trace.Wrap(err, "read cluster name")
+	}
+	cluster := cn.GetClusterName()
+
+	return trace.Wrap(
+		migrateWindowsCAOnCluster(ctx, p.Logger, p.Trust, cluster),
+		"migrate cluster %q", cluster,
+	)
+}
+
+func migrateWindowsCAOnCluster(
+	ctx context.Context,
+	logger *slog.Logger,
+	trust services.Trust,
+	clusterName string,
+) error {
+	dst := types.CertAuthID{Type: types.WindowsCA, DomainName: clusterName}
+	src := types.CertAuthID{Type: types.UserCA, DomainName: clusterName}
+
+	logger = logger.With(
+		teleport.ComponentKey, "WindowsCA",
+		"cluster", clusterName,
+		"src", src.Type,
+		"dst", dst.Type,
+	)
+
+	// Query dst CA.
+	switch _, err := trust.GetCertAuthority(ctx, dst, false /* loadSigningKeys */); {
+	case err == nil:
+		logger.DebugContext(ctx, "dst CA already exists, nothing to do")
+		return nil // dst already exists.
+	case !trace.IsNotFound(err):
+		logger.DebugContext(ctx, "src CA not found (new cluster)")
+		return trace.Wrap(err, "read %q CA", dst.Type)
+	}
+
+	// Query src CA.
+	srcCA, err := trust.GetCertAuthority(ctx, src, true /* loadSigningKeys */)
+	switch {
+	case trace.IsNotFound(err):
+		return nil // src does not exist, fresh cluster.
+	case err != nil:
+		return trace.Wrap(err, "read %q CA", src.Type)
+	}
+
+	logger.InfoContext(ctx, "Started migration")
+
+	// Verify that the CA holds a private key.
+	//
+	// If src is undergoing rotation then only the currently active keys are
+	// copied. This is by design: the active keys must be trusted by definition
+	// and we don't want to create a copied CA that is in a transitional state
+	// (ie, mid-rotation).
+	activeKeys := srcCA.GetActiveKeys()
+	foundViableKey := false
+	for _, kp := range activeKeys.TLS {
+		if len(kp.Key) > 0 {
+			foundViableKey = true
+			break
+		}
+	}
+	if !foundViableKey {
+		logger.WarnContext(ctx, "ActiveKeys set lacks a viable key, skipping migration")
+		return nil
+	}
+
+	// Clone!
+	dstCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        dst.Type,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			TLS: activeKeys.TLS,
+		},
+	})
+	if err != nil {
+		return trace.Wrap(err, "new cert authority")
+	}
+
+	// Create dst CA.
+	switch err := trust.CreateCertAuthority(ctx, dstCA); {
+	case err == nil:
+		logger.InfoContext(ctx, "Migration successful")
+		return nil
+	case trace.IsAlreadyExists(err):
+		logger.InfoContext(ctx, "Migration performed by another Auth instance", "error", err)
+		return nil
+	default:
+		return trace.Wrap(err, "create cert authority")
+	}
+}

--- a/lib/auth/init_windows_ca.go
+++ b/lib/auth/init_windows_ca.go
@@ -82,7 +82,6 @@ func migrateWindowsCAOnCluster(
 		logger.DebugContext(ctx, "Windows CA already exists, nothing to do")
 		return nil // dst already exists.
 	case !trace.IsNotFound(err):
-		logger.DebugContext(ctx, "User CA not found (new cluster)")
 		return trace.Wrap(err, "read %q CA", dst.Type)
 	}
 
@@ -90,6 +89,7 @@ func migrateWindowsCAOnCluster(
 	srcCA, err := trust.GetCertAuthority(ctx, src, true /* loadSigningKeys */)
 	switch {
 	case trace.IsNotFound(err):
+		logger.DebugContext(ctx, "User CA not found (new cluster)")
 		return nil // src does not exist, fresh cluster.
 	case err != nil:
 		return trace.Wrap(err, "read %q CA", src.Type)

--- a/lib/auth/init_windows_ca_test.go
+++ b/lib/auth/init_windows_ca_test.go
@@ -1,0 +1,185 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package auth_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+)
+
+// Acquired from a local install, cluster name "zarquon2".
+const exampleActiveKeys = `
+{
+  "ssh": [
+    {
+      "private_key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1DNENBUUF3QlFZREsyVndCQ0lFSUxwY0dFM3UwZlA1TkZWMGliVlZCdXpDMjlVVDVUd0ViMGRoYWErVnlPcloKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=",
+      "public_key": "c3NoLWVkMjU1MTkgQUFBQUMzTnphQzFsWkRJMU5URTVBQUFBSUIzZzN2dHFMbHRPSDdyV3lQdDU3Sjc2VURCWnZNYVBiYWk1UlJmZHp2MjgK"
+    }
+  ],
+  "tls": [
+    {
+      "cert": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUI4VENDQVplZ0F3SUJBZ0lSQU1sU2IrdjVGeE1iODU0Q3VaU0w1N0l3Q2dZSUtvWkl6ajBFQXdJd1dERVIKTUE4R0ExVUVDaE1JZW1GeWNYVnZiakl4RVRBUEJnTlZCQU1UQ0hwaGNuRjFiMjR5TVRBd0xnWURWUVFGRXljeQpOamMyTURJNE5qVTFNemd6TkRFNE1EVTBPRFkyT0RZNU1EWTVNek0xT1RNeU16YzBNall3SGhjTk1qVXhNVEEwCk1qQTFNREUxV2hjTk16VXhNVEF5TWpBMU1ERTFXakJZTVJFd0R3WURWUVFLRXdoNllYSnhkVzl1TWpFUk1BOEcKQTFVRUF4TUllbUZ5Y1hWdmJqSXhNREF1QmdOVkJBVVRKekkyTnpZd01qZzJOVFV6T0RNME1UZ3dOVFE0TmpZNApOamt3Tmprek16VTVNekl6TnpReU5qQlpNQk1HQnlxR1NNNDlBZ0VHQ0NxR1NNNDlBd0VIQTBJQUJBSWlWYk4wCnF5QXcrM0xKUEZOYldISnJvTmNPOFlMMUloaHdYRHc1TEN4MGl1MDFNTGs0dkZuUjlIS0FvblNnU2NGT1BiZisKM2VMZEhxcmkvaUc2QUFXalFqQkFNQTRHQTFVZER3RUIvd1FFQXdJQmhqQVBCZ05WSFJNQkFmOEVCVEFEQVFILwpNQjBHQTFVZERnUVdCQlRSZWhGMThPa2daamI5Yk55cGh1b1ZXQlM2N2pBS0JnZ3Foa2pPUFFRREFnTklBREJGCkFpQjFiaGwzTS9VdkdJaTg0Qk83dWt1OUZDZkswbCt6VVJYOWdHNUlsQjRsQ3dJaEFMaEFyVmZ1bTlKR2ZLcFgKUGw2R1gycXoyUjVLaHdvRjBwZ0RCUysxeFk1SQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==",
+      "crl": "MIIBEjCBuAIBATAKBggqhkjOPQQDAjBYMREwDwYDVQQKEwh6YXJxdW9uMjERMA8GA1UEAxMIemFycXVvbjIxMDAuBgNVBAUTJzI2NzYwMjg2NTUzODM0MTgwNTQ4NjY4NjkwNjkzMzU5MzIzNzQyNhcNMjUxMTA0MjA0OTE1WhcNMzUxMTAyMjA1MDE1WqAvMC0wHwYDVR0jBBgwFoAU0XoRdfDpIGY2/WzcqYbqFVgUuu4wCgYDVR0UBAMCAQEwCgYIKoZIzj0EAwIDSQAwRgIhAKE3zRCSPblEKBtTdHpuqLTjeatZ4eKIbqZDpYh/+6mcAiEAimOkxNa4RdBSeSTIvvFOHWCpKKDSskuQWs8pNmnVS5U=",
+      "key": "LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1JR0hBZ0VBTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5QXdFSEJHMHdhd0lCQVFRZ3BkK1NYWEdxNjRyU2RPd3YKL2pjMWdlVWJPUERuajNUZFh1ZlpLMGU1SFB1aFJBTkNBQVFDSWxXemRLc2dNUHR5eVR4VFcxaHlhNkRYRHZHQwo5U0lZY0Z3OE9Td3NkSXJ0TlRDNU9MeFowZlJ5Z0tKMG9FbkJUajIzL3QzaTNSNnE0djRodWdBRgotLS0tLUVORCBQUklWQVRFIEtFWS0tLS0tCg=="
+    }
+  ]
+}`
+
+func TestMigrateWindowsCA(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new cluster", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		env := newMigrateCAEnv(t)
+
+		require.NoError(t,
+			auth.MigrateWindowsCA(ctx, env.Params),
+			"migrateWindowsCA",
+		)
+
+		// Verify no new CAs created.
+		trust := env.Params.Trust
+		winCAs, err := trust.GetCertAuthorities(ctx, types.WindowsCA, false /* loadSigningKeys */)
+		require.NoError(t, err)
+		assert.Empty(t, winCAs, "Found unexpected WindowsCA entities")
+		userCAs, err := trust.GetCertAuthorities(ctx, types.UserCA, false /* loadSigningKeys */)
+		require.NoError(t, err)
+		assert.Empty(t, userCAs, "Found unexpected UserCA entities")
+	})
+
+	t.Run("existing cluster", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		env := newMigrateCAEnv(t)
+		trust := env.Params.Trust
+
+		userID := types.CertAuthID{
+			Type:       types.UserCA,
+			DomainName: env.ClusterName,
+		}
+		winID := types.CertAuthID{
+			Type:       types.WindowsCA,
+			DomainName: env.ClusterName,
+		}
+
+		activeKeys := &types.CAKeySet{}
+		require.NoError(t, json.Unmarshal([]byte(exampleActiveKeys), activeKeys))
+
+		// Create the UserCA to migrate from.
+		userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+			Type:        types.UserCA,
+			ClusterName: env.ClusterName,
+			ActiveKeys:  *activeKeys,
+		})
+		require.NoError(t, err)
+		require.NoError(t, trust.CreateCertAuthority(ctx, userCA))
+		// Read back so we get the latest revision.
+		userCA, err = trust.GetCertAuthority(ctx, userID, true /* loadSigningKeys */)
+		require.NoError(t, err)
+
+		// Run migration.
+		require.NoError(t,
+			auth.MigrateWindowsCA(ctx, env.Params),
+			"migrateWindowsCA",
+		)
+
+		// Verify the new WindowsCA.
+		winCA, err := trust.GetCertAuthority(ctx, winID, true /* loadSigningKeys */)
+		require.NoError(t, err)
+
+		wantCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+			Type:        types.WindowsCA,
+			ClusterName: env.ClusterName,
+			ActiveKeys: types.CAKeySet{
+				TLS: activeKeys.TLS,
+			},
+		})
+		require.NoError(t, err)
+		wantCA.SetRevision(winCA.GetRevision())
+
+		if diff := cmp.Diff(wantCA, winCA); diff != "" {
+			t.Errorf("WindowsCA mismatch (-want +got)\n%s", diff)
+		}
+
+		t.Run("migration idempotent", func(t *testing.T) {
+			// Migration runs without error.
+			require.NoError(t, auth.MigrateWindowsCA(ctx, env.Params))
+
+			// UserCA not modified.
+			gotUser, err := trust.GetCertAuthority(ctx, userID, true /* loadSigningKeys */)
+			require.NoError(t, err)
+			if diff := cmp.Diff(userCA, gotUser); diff != "" {
+				t.Errorf("UserCA mismatch (-want +got)\n%s", diff)
+			}
+
+			// WindowsCA not modified.
+			gotWin, err := trust.GetCertAuthority(ctx, winID, true /* loadSigningKeys */)
+			require.NoError(t, err)
+			if diff := cmp.Diff(winCA, gotWin); diff != "" {
+				t.Errorf("WindowsCA mismatch (-want +got)\n%s", diff)
+			}
+		})
+	})
+}
+
+type migrateCAEnv struct {
+	ClusterName string
+	Params      auth.MigrateWindowsCAParams
+}
+
+func newMigrateCAEnv(t *testing.T) *migrateCAEnv {
+	backend, err := memory.New(memory.Config{
+		Context: t.Context(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, backend.Close())
+	})
+
+	clusterConfiguration, err := local.NewClusterConfigurationService(backend)
+	require.NoError(t, err)
+
+	// Assign a cluster name.
+	cn, err := types.NewClusterName(types.ClusterNameSpecV2{
+		ClusterName: "zarquon2", // must match exampleActiveKeys
+		ClusterID:   "607e6238-3bcc-4169-b129-2a5b04e8c338",
+	})
+	require.NoError(t, err)
+	require.NoError(t, clusterConfiguration.SetClusterName(cn))
+
+	return &migrateCAEnv{
+		ClusterName: cn.GetClusterName(),
+		Params: auth.MigrateWindowsCAParams{
+			Logger:               logtest.NewLogger(),
+			ClusterConfiguration: clusterConfiguration,
+			Trust:                local.NewCAService(backend),
+		},
+	}
+}

--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -64,7 +64,7 @@ func newCertAuthorityCollection(t services.Trust, w types.WatchKind) (*collectio
 		},
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.CertAuthority, error) {
 			var authorities []types.CertAuthority
-			for _, caType := range types.CertAuthTypes {
+			for _, caType := range types.CertAuthTypesExtended {
 				cas, err := t.GetCertAuthorities(ctx, caType, loadSecrets)
 				// if caType was added in this major version we might get a BadParameter
 				// error if we're connecting to an older upstream that doesn't know about it

--- a/lib/cryptosuites/suites.go
+++ b/lib/cryptosuites/suites.go
@@ -131,6 +131,10 @@ const (
 	// RecordingKeyWrapping is a key used for wrapping session recording decryption keys.
 	RecordingKeyWrapping
 
+	// WindowsCARDP represents a key used by the Windows CA to generate RDP
+	// (Remote Desktop Protocol) certificates.
+	WindowsCARDP
+
 	// keyPurposeMax is 1 greater than the last valid key purpose, used to test that all values less than this
 	// are valid for each suite.
 	keyPurposeMax
@@ -217,6 +221,7 @@ var (
 		BoundKeypairJoining:  Ed25519,
 		BoundKeypairCAJWT:    ECDSAP256,
 		RecordingKeyWrapping: RSA4096,
+		WindowsCARDP:         RSA2048, // same as UserCATLS
 	}
 
 	// balancedV1 strikes a balance between security, compatibility, and
@@ -252,6 +257,7 @@ var (
 		BoundKeypairJoining:     Ed25519,
 		BoundKeypairCAJWT:       Ed25519,
 		RecordingKeyWrapping:    RSA4096,
+		WindowsCARDP:            ECDSAP256, // same as UserCATLS
 	}
 
 	// fipsv1 is an algorithm suite tailored for FIPS compliance. It is based on
@@ -288,6 +294,7 @@ var (
 		BoundKeypairJoining:     ECDSAP256,
 		BoundKeypairCAJWT:       ECDSAP256,
 		RecordingKeyWrapping:    RSA4096,
+		WindowsCARDP:            ECDSAP256, // same as UserCATLS
 	}
 
 	// hsmv1 in an algorithm suite tailored for clusters using an HSM or KMS
@@ -326,6 +333,7 @@ var (
 		BoundKeypairJoining:     Ed25519,
 		BoundKeypairCAJWT:       ECDSAP256,
 		RecordingKeyWrapping:    RSA4096,
+		WindowsCARDP:            ECDSAP256, // same as UserCATLS
 	}
 
 	allSuites = map[types.SignatureAlgorithmSuite]suite{

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -141,30 +141,7 @@ func checkDatabaseCA(cai types.CertAuthority) error {
 		return trace.BadParameter("unknown CA type %T", cai)
 	}
 
-	if len(ca.Spec.ActiveKeys.TLS) == 0 {
-		return trace.BadParameter("%s certificate authority missing TLS key pairs", ca.GetType())
-	}
-
-	for _, pair := range ca.GetTrustedTLSKeyPairs() {
-		if len(pair.Key) > 0 && pair.KeyType == types.PrivateKeyType_RAW {
-			var err error
-			if len(pair.Cert) > 0 {
-				_, err = tls.X509KeyPair(pair.Cert, pair.Key)
-			} else {
-				_, err = keys.ParsePrivateKey(pair.Key)
-			}
-			if err != nil {
-				return trace.Wrap(err)
-			}
-		} else {
-			_, err := tlsca.ParseCertificatePEM(pair.Cert)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-		}
-	}
-
-	return nil
+	return trace.Wrap(checkTLSKeys(ca))
 }
 
 // checkOpenSSHCA checks if provided certificate authority contains a valid SSH key pair.
@@ -237,26 +214,29 @@ func checkSAMLIDPCA(cai types.CertAuthority) error {
 		return trace.BadParameter("unknown CA type %T", cai)
 	}
 
+	return trace.Wrap(checkTLSKeys(ca))
+}
+
+func checkTLSKeys(ca *types.CertAuthorityV2) error {
 	if len(ca.Spec.ActiveKeys.TLS) == 0 {
-		return trace.BadParameter("missing SAML IdP CA")
+		return trace.BadParameter("%s certificate authority missing TLS key pairs", ca.GetType())
 	}
 
 	for _, pair := range ca.GetTrustedTLSKeyPairs() {
-		if len(pair.Key) != 0 && pair.KeyType == types.PrivateKeyType_RAW {
-			var err error
-			if len(pair.Cert) > 0 {
-				_, err = tls.X509KeyPair(pair.Cert, pair.Key)
-			} else {
-				_, err = keys.ParsePrivateKey(pair.Key)
+		// Note: A non-empty pair.Cert is required by pair.CheckAndSetDefaults().
+
+		if len(pair.Key) > 0 && pair.KeyType == types.PrivateKeyType_RAW {
+			if _, err := tls.X509KeyPair(pair.Cert, pair.Key); err != nil {
+				return trace.Wrap(err, "private key and certificate")
 			}
-			if err != nil {
-				return trace.Wrap(err)
-			}
+			continue
 		}
+
 		if _, err := tlsca.ParseCertificatePEM(pair.Cert); err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "certificate")
 		}
 	}
+
 	return nil
 }
 

--- a/lib/services/authority.go
+++ b/lib/services/authority.go
@@ -77,6 +77,8 @@ func ValidateCertAuthority(ca types.CertAuthority) (err error) {
 		err = checkSPIFFECA(ca)
 	case types.AWSRACA:
 		err = checkAWSRACA(ca)
+	case types.WindowsCA:
+		err = checkWindowsCA(ca)
 	default:
 		return trace.BadParameter("invalid CA type %q", ca.GetType())
 	}
@@ -209,6 +211,15 @@ func checkJWTKeys(cai types.CertAuthority) error {
 // checkSAMLIDPCA checks if provided certificate authority contains a valid TLS key pair.
 // This function is used to verify the SAML IDP CA.
 func checkSAMLIDPCA(cai types.CertAuthority) error {
+	ca, ok := cai.(*types.CertAuthorityV2)
+	if !ok {
+		return trace.BadParameter("unknown CA type %T", cai)
+	}
+
+	return trace.Wrap(checkTLSKeys(ca))
+}
+
+func checkWindowsCA(cai types.CertAuthority) error {
 	ca, ok := cai.(*types.CertAuthorityV2)
 	if !ok {
 		return trace.BadParameter("unknown CA type %T", cai)

--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -84,7 +84,7 @@ func getCertAuthority(ctx context.Context, client *authclient.Client, ref servic
 	getAll := ref.SubKind == "" && ref.Name == ""
 	if getAll {
 		var allAuthorities []types.CertAuthority
-		for _, caType := range types.CertAuthTypes {
+		for _, caType := range types.CertAuthTypesExtended {
 			authorities, err := client.GetCertAuthorities(ctx, caType, opts.WithSecrets)
 			if err != nil {
 				if trace.IsBadParameter(err) {


### PR DESCRIPTION
Creates the WindowsCA on cluster startup:

* On existing clusters the UserCA is "cloned" to the WindowsCA
* On new clusters the WindowsCA is created "fresh"

A cluster is considered "new" if the UserCA cannot be found. This is similar to how we [detect new clusters in other places][1] (except that this uses the UserCA instead of the HostCA).

The PR temporarily adds `CertAuthTypesExtended` and uses it in hand-picked places instead of adding the new CA directly to `CertAuthTypes`. Adding it to CertAuthTypes has a large knock-on effect that is handled by subsequent PRs. I'll remove CertAuthTypesExtended once it's not needed anymore.

Any clusters that runs this code will have a WindowsCA ready to be used.

#10111

[1]: https://github.com/gravitational/teleport/blob/534806aeae0d3ea8781945eaaa05bab8a54b39f6/lib/auth/init.go#L1516
