### PR TITLE
Consistency of `tbot` CLI flags

### DIFF
--- a/lib/tbot/cli/copy_binaries.go
+++ b/lib/tbot/cli/copy_binaries.go
@@ -34,14 +34,14 @@ type CopyBinariesCommand struct {
 // NewCopyBinariesCommand initializes the `tbot copy-binaries` subcommand and
 // its fields.
 func NewCopyBinariesCommand(app KingpinClause, action func(*CopyBinariesCommand) error) *CopyBinariesCommand {
-	cmd := app.Command("copy-binaries", "Copies this tbot binary to a given destination")
+	cmd := app.Command("copy-binaries", "Copies this tbot binary to a given destination.")
 	cmd.Interspersed(true)
 
 	c := &CopyBinariesCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
 	cmd.Flag("include-fdpass", "If set, also copy `fdpass-teleport`. It must be available in the same path as `tbot`.").BoolVar(&c.IncludeFDPass)
-	cmd.Arg("destination-dir", "The destination path to write the copy of the tbot binary").Required().StringVar(&c.DestinationDir)
+	cmd.Arg("destination-dir", "The destination path to write the copy of the tbot binary.").Required().StringVar(&c.DestinationDir)
 
 	return c
 }

--- a/lib/tbot/cli/db.go
+++ b/lib/tbot/cli/db.go
@@ -36,7 +36,7 @@ func NewDBCommand(app KingpinClause, action func(*DBCommand) error) *DBCommand {
 	c := &DBCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("proxy-server", "The address of Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
+	cmd.Flag("proxy-server", "The address of the Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
 	cmd.Flag("destination-dir", "The destination directory to provide tsh for authentication.").StringVar(&c.DestinationDir)
 	cmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&c.Cluster)
 	c.RemainingArgs = RemainingArgs(cmd.Arg(

--- a/lib/tbot/cli/db.go
+++ b/lib/tbot/cli/db.go
@@ -31,13 +31,13 @@ type DBCommand struct {
 
 // NewDBCommand initializes flags for `tbot db`
 func NewDBCommand(app KingpinClause, action func(*DBCommand) error) *DBCommand {
-	cmd := app.Command("db", "Execute database commands through tsh.")
+	cmd := app.Command("db", "Executes database commands through tsh.")
 
 	c := &DBCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
-	cmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&c.DestinationDir)
+	cmd.Flag("proxy-server", "The address of Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
+	cmd.Flag("destination-dir", "The destination directory to provide tsh for authentication.").StringVar(&c.DestinationDir)
 	cmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&c.Cluster)
 	c.RemainingArgs = RemainingArgs(cmd.Arg(
 		"args",

--- a/lib/tbot/cli/globals.go
+++ b/lib/tbot/cli/globals.go
@@ -74,10 +74,10 @@ type GlobalArgs struct {
 func NewGlobalArgs(app *kingpin.Application) *GlobalArgs {
 	g := &GlobalArgs{}
 
-	app.Flag("debug", "Verbose logging to stdout.").Short('d').Envar(TBotDebugEnvVar).IsSetByUser(&g.debugSetByUser).BoolVar(&g.Debug)
+	app.Flag("debug", "Enables verbose logging to stdout.").Short('d').Envar(TBotDebugEnvVar).IsSetByUser(&g.debugSetByUser).BoolVar(&g.Debug)
 	app.Flag("config", "Path to a configuration file.").Short('c').Envar(TBotConfigPathEnvVar).StringVar(&g.ConfigPath)
 	app.Flag("config-string", "Base64 encoded configuration string.").Hidden().Envar(TBotConfigEnvVar).StringVar(&g.ConfigString)
-	app.Flag("fips", "Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.").IsSetByUser(&g.fipsSetByUser).BoolVar(&g.FIPS)
+	app.Flag("fips", "Enables FIPS compliance mode. This requires the FIPS binary is in use.").IsSetByUser(&g.fipsSetByUser).BoolVar(&g.FIPS)
 	app.Flag("trace", "Capture and export distributed traces.").Hidden().BoolVar(&g.Trace)
 	app.Flag("trace-exporter", "An OTLP exporter URL to send spans to.").Hidden().StringVar(&g.TraceExporter)
 	app.Flag(

--- a/lib/tbot/cli/init.go
+++ b/lib/tbot/cli/init.go
@@ -42,7 +42,7 @@ type InitCommand struct {
 // NewInitCommand constructs an InitCommand at the top level of the given
 // application. It will execute `action` when selected by the user.
 func NewInitCommand(app KingpinClause, action func(*InitCommand) error) *InitCommand {
-	cmd := app.Command("init", "Initialize a certificate destination directory for writes from a separate bot user.")
+	cmd := app.Command("init", "Initializes a destination directory for writes from a separate bot user.")
 
 	c := &InitCommand{}
 	c.AuthProxyArgs = newAuthProxyArgs(cmd)
@@ -53,7 +53,7 @@ func NewInitCommand(app KingpinClause, action func(*InitCommand) error) *InitCom
 	cmd.Flag("bot-user", "Enables POSIX ACLs and defines Linux user that can read/write short-lived certificates to \"--destination-dir\".").StringVar(&c.BotUser)
 	cmd.Flag("reader-user", "Enables POSIX ACLs and defines Linux user that will read short-lived certificates from \"--destination-dir\".").StringVar(&c.ReaderUser)
 	cmd.Flag("init-dir", "If using a config file and multiple destinations are configured, controls which destination dir to configure.").StringVar(&c.InitDir)
-	cmd.Flag("clean", "If set, remove unexpected files and directories from the destination.").BoolVar(&c.Clean)
+	cmd.Flag("clean", "If set, removes unexpected files and directories from the destination.").BoolVar(&c.Clean)
 
 	return c
 }

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -48,16 +48,16 @@ type KeypairCreateCommand struct {
 // NewKeypairCreateCommand initializes the `keypair create` command and returns
 // a struct to contain the parse result.
 func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreateCommand) error) *KeypairCreateCommand {
-	cmd := parentCmd.Command("create", "Create a keypair to preregister for bound-keypair joining").Hidden()
+	cmd := parentCmd.Command("create", "Creates a keypair to preregister for bound-keypair joining.").Hidden()
 
 	c := &KeypairCreateCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("storage", "An internal storage URI to write the keypair, such as file:///var/lib/teleport/bot").StringVar(&c.Storage)
-	cmd.Flag("proxy-server", "The proxy server, which will be pinged to determine the current cryptographic suite in use").Required().StringVar(&c.ProxyServer)
+	cmd.Flag("storage", "The internal storage URI to write the keypair to, such as `file:///var/lib/teleport/bot`.").StringVar(&c.Storage)
+	cmd.Flag("proxy-server", "The proxy server, which will be pinged to determine the current cryptographic suite in use.").Required().StringVar(&c.ProxyServer)
 	cmd.Flag("overwrite", "If set, overwrite any existing keypair. If unset and a keypair already exists, its key will be printed for use.").BoolVar(&c.Overwrite)
 	cmd.Flag("format", "Output format, one of: text, json").Default(teleport.Text).EnumVar(&c.Format, teleport.Text, teleport.JSON)
-	cmd.Flag("static", "If set, create a static private key instead of writing a mutable key into bot storage. If --static-key-path is unset, the key will be printed to the terminal.").BoolVar(&c.Static)
+	cmd.Flag("static", "If set, creates a static private key instead of writing a mutable key into bot storage. If --static-key-path is unset, the key will be printed to the terminal.").BoolVar(&c.Static)
 	cmd.Flag("static-key-path", "If set, writes the static private key to a file.").StringVar(&c.StaticKeyPath)
 
 	return c

--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -48,7 +48,7 @@ type KeypairCreateCommand struct {
 // NewKeypairCreateCommand initializes the `keypair create` command and returns
 // a struct to contain the parse result.
 func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreateCommand) error) *KeypairCreateCommand {
-	cmd := parentCmd.Command("create", "Creates a keypair to preregister for bound-keypair joining.").Hidden()
+	cmd := parentCmd.Command("create", "Creates a keypair to preregister for bound-keypair joining.")
 
 	c := &KeypairCreateCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)

--- a/lib/tbot/cli/kube_credentials.go
+++ b/lib/tbot/cli/kube_credentials.go
@@ -27,12 +27,12 @@ type KubeCredentialsCommand struct {
 // NewKubeCredentialsCommand initializes a kubernetes `credentials` command
 // and returns a struct that will contain the parse result.
 func NewKubeCredentialsCommand(parentCmd KingpinClause, action func(*KubeCredentialsCommand) error) *KubeCredentialsCommand {
-	cmd := parentCmd.Command("credentials", "Get credentials for kubectl access").Hidden()
+	cmd := parentCmd.Command("credentials", "Get credentials for kubectl access.").Hidden()
 
 	c := &KubeCredentialsCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("destination-dir", "The destination directory with which to generate Kubernetes credentials").Required().StringVar(&c.DestinationDir)
+	cmd.Flag("destination-dir", "The destination directory with which to generate Kubernetes credentials.").Required().StringVar(&c.DestinationDir)
 
 	return c
 }

--- a/lib/tbot/cli/migrate.go
+++ b/lib/tbot/cli/migrate.go
@@ -29,12 +29,12 @@ type MigrateCommand struct {
 
 // NewMigrateCommand initializes the `tbot migrate` command and its flags.
 func NewMigrateCommand(app KingpinClause, action func(*MigrateCommand) error) *MigrateCommand {
-	cmd := app.Command("migrate", "Migrates a config file from an older version to the newest version. Outputs to stdout by default.")
+	cmd := app.Command("migrate", "Migrates a configuration file from an older version to the newest version. Outputs to stdout by default.")
 
 	c := &MigrateCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&c.ConfigureOutput)
+	cmd.Flag("output", "The path to write the generated configuration file to. If unset, it will be written to stdout.").Short('o').StringVar(&c.ConfigureOutput)
 
 	return c
 }

--- a/lib/tbot/cli/proxy.go
+++ b/lib/tbot/cli/proxy.go
@@ -36,7 +36,7 @@ func NewProxyCommand(app KingpinClause, action func(*ProxyCommand) error) *Proxy
 	c := &ProxyCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("proxy-server", "The address of Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
+	cmd.Flag("proxy-server", "The address of the Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
 	cmd.Flag("destination-dir", "The destination directory to provide tsh for authentication.").StringVar(&c.DestinationDir)
 	cmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&c.Cluster)
 	c.ProxyRemaining = RemainingArgs(cmd.Arg(

--- a/lib/tbot/cli/proxy.go
+++ b/lib/tbot/cli/proxy.go
@@ -31,13 +31,13 @@ type ProxyCommand struct {
 
 // NewProxyCommand initializes the subcommand for `tbot proxy`
 func NewProxyCommand(app KingpinClause, action func(*ProxyCommand) error) *ProxyCommand {
-	cmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
+	cmd := app.Command("proxy", "Starts a local TLS proxy via tsh to connect to Teleport in single-port mode.")
 
 	c := &ProxyCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)
 
-	cmd.Flag("proxy-server", "The Teleport proxy server to use, in host:port form.").Envar(ProxyServerEnvVar).StringVar(&c.ProxyServer)
-	cmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&c.DestinationDir)
+	cmd.Flag("proxy-server", "The address of Teleport proxy server to use, in host:port form.").StringVar(&c.ProxyServer)
+	cmd.Flag("destination-dir", "The destination directory to provide tsh for authentication.").StringVar(&c.DestinationDir)
 	cmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&c.Cluster)
 	c.ProxyRemaining = RemainingArgs(cmd.Arg(
 		"args",

--- a/lib/tbot/cli/start_application.go
+++ b/lib/tbot/cli/start_application.go
@@ -51,7 +51,7 @@ func NewApplicationCommand(parentCmd *kingpin.CmdClause, action MutatorAction, m
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
 	cmd.Flag("app", "The name of the app in Teleport").Required().StringVar(&c.AppName)
-	cmd.Flag("specific-tls-extensions", "If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions").BoolVar(&c.SpecificTLSExtensions)
+	cmd.Flag("specific-tls-extensions", "If set, includes additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions").BoolVar(&c.SpecificTLSExtensions)
 
 	// Note: CLI will not support roles; all will be requested.
 

--- a/lib/tbot/cli/start_application_proxy.go
+++ b/lib/tbot/cli/start_application_proxy.go
@@ -41,13 +41,13 @@ type ApplicationProxyCommand struct {
 // NewApplicationProxyCommand initializes flags for an app proxy command and
 // returns a struct to contain the parse result.
 func NewApplicationProxyCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *ApplicationProxyCommand {
-	cmd := parentCmd.Command("application-proxy", fmt.Sprintf("%s tbot with an application proxy.", mode)).Alias("app-proxy")
+	cmd := parentCmd.Command("application-proxy", fmt.Sprintf("%s tbot with a HTTP application proxy.", mode)).Alias("app-proxy")
 
 	c := &ApplicationProxyCommand{}
 	c.sharedStartArgs = newSharedStartArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("listen", "A socket URI, such as tcp://0.0.0.0:8080").Required().StringVar(&c.Listen)
+	cmd.Flag("listen", "The socket URI on which the local proxy should listen, such as `tcp://0.0.0.0:8080`.").Required().StringVar(&c.Listen)
 
 	return c
 }

--- a/lib/tbot/cli/start_application_tunnel.go
+++ b/lib/tbot/cli/start_application_tunnel.go
@@ -48,7 +48,7 @@ func NewApplicationTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAct
 	c.sharedStartArgs = newSharedStartArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("listen", "A socket URI, such as tcp://0.0.0.0:8080").Required().StringVar(&c.Listen)
+	cmd.Flag("listen", "The socket URI on which the tunnel should listen, such as `tcp://0.0.0.0:8080`.").Required().StringVar(&c.Listen)
 	cmd.Flag("app", "The name of the app in Teleport").Required().StringVar(&c.AppName)
 
 	// Note: CLI will not support roles; all will be requested.

--- a/lib/tbot/cli/start_database.go
+++ b/lib/tbot/cli/start_database.go
@@ -52,10 +52,10 @@ func NewDatabaseCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode
 	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("format", "The database output format if necessary").Default("").EnumVar(&c.Format, database.SupportedDatabaseFormatStrings()...)
-	cmd.Flag("service", "The database service name").Required().StringVar(&c.Service)
-	cmd.Flag("username", "The database user name").Required().StringVar(&c.Username)
-	cmd.Flag("database", "The name of the database available in the requested database service").Required().StringVar(&c.Database)
+	cmd.Flag("format", "The format of the credentials to generate. If specified, must be `tls`, `mongo` or `cockroach`.").Default("").EnumVar(&c.Format, database.SupportedDatabaseFormatStrings()...)
+	cmd.Flag("service", "The database service name.").Required().StringVar(&c.Service)
+	cmd.Flag("username", "The database user name.").Required().StringVar(&c.Username)
+	cmd.Flag("database", "The name of the database available in the requested database service.").Required().StringVar(&c.Database)
 
 	return c
 }

--- a/lib/tbot/cli/start_database_tunnel.go
+++ b/lib/tbot/cli/start_database_tunnel.go
@@ -49,10 +49,10 @@ func NewDatabaseTunnelCommand(parentCmd *kingpin.CmdClause, action MutatorAction
 	c.sharedStartArgs = newSharedStartArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("listen", "A socket URI to listen on, such as tcp://0.0.0.0:3306").Required().StringVar(&c.Listen)
-	cmd.Flag("service", "The database service name").Required().StringVar(&c.Service)
-	cmd.Flag("username", "The database user name").Required().StringVar(&c.Username)
-	cmd.Flag("database", "The name of the database available in the requested database service").Required().StringVar(&c.Database)
+	cmd.Flag("listen", "A socket URI to listen on, such as `tcp://0.0.0.0:3306`.").Required().StringVar(&c.Listen)
+	cmd.Flag("service", "The database service name.").Required().StringVar(&c.Service)
+	cmd.Flag("username", "The database user name.").Required().StringVar(&c.Username)
+	cmd.Flag("database", "The name of the database available in the requested database service.").Required().StringVar(&c.Database)
 
 	// Note: excluding roles from the CLI; will default to all available.
 

--- a/lib/tbot/cli/start_identity.go
+++ b/lib/tbot/cli/start_identity.go
@@ -51,7 +51,7 @@ func NewIdentityCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode
 
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("cluster", "The name of a specific cluster for which to issue an identity if using a leaf cluster").StringVar(&c.Cluster)
+	cmd.Flag("cluster", "The name of a specific cluster for which to issue an identity if using a leaf cluster.").StringVar(&c.Cluster)
 	cmd.Flag("allow-reissue", "Allow the credentials output by this command to be reissued.").BoolVar(&c.AllowReissue)
 	// Note: roles and ssh_config mode are excluded for now.
 

--- a/lib/tbot/cli/start_kubernetes.go
+++ b/lib/tbot/cli/start_kubernetes.go
@@ -50,7 +50,7 @@ func NewKubernetesCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mo
 	c.sharedDestinationArgs = newSharedDestinationArgs(cmd)
 	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
 
-	cmd.Flag("kubernetes-cluster", "The name of the Kubernetes cluster in Teleport for which to fetch credentials").Required().StringVar(&c.KubernetesCluster)
+	cmd.Flag("kubernetes-cluster", "The name of the Kubernetes cluster in Teleport for which to fetch credentials.").Required().StringVar(&c.KubernetesCluster)
 	cmd.Flag("disable-exec-plugin", "If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.").BoolVar(&c.DisableExecPlugin)
 
 	// Note: excluding roles; the bot will fetch all available in CLI mode.

--- a/lib/tbot/cli/start_kubernetes_v2.go
+++ b/lib/tbot/cli/start_kubernetes_v2.go
@@ -46,7 +46,7 @@ type KubernetesV2Command struct {
 	KubernetesClusterLabels []string
 }
 
-// NewKubernetesCommand initializes the command and flags for kubernetes outputs
+// NewKubernetesV2Command initializes the command and flags for kubernetes outputs
 // and returns a struct to contain the parse result.
 func NewKubernetesV2Command(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *KubernetesV2Command {
 	cmd := parentCmd.Command("kubernetes/v2", fmt.Sprintf("%s tbot with a Kubernetes V2 output.", mode)).Alias("k8s/v2")

--- a/lib/tbot/cli/start_workload_identity_api.go
+++ b/lib/tbot/cli/start_workload_identity_api.go
@@ -60,11 +60,11 @@ func NewWorkloadIdentityAPICommand(parentCmd *kingpin.CmdClause, action MutatorA
 
 	cmd.Flag(
 		"name-selector",
-		"The name of the workload identity to issue",
+		"The name of the workload identity to issue. Mutually exclusive with --label-selector.",
 	).StringVar(&c.NameSelector)
 	cmd.Flag(
 		"label-selector",
-		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.",
+		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.",
 	).StringVar(&c.LabelSelector)
 	cmd.Flag(
 		"listen",

--- a/lib/tbot/cli/start_workload_identity_aws_ra.go
+++ b/lib/tbot/cli/start_workload_identity_aws_ra.go
@@ -93,11 +93,11 @@ func NewWorkloadIdentityAWSRACommand(
 
 	cmd.Flag(
 		"name-selector",
-		"The name of the workload identity to issue",
+		"The name of the workload identity to issue. Mutually exclusive with --label-selector.",
 	).StringVar(&c.NameSelector)
 	cmd.Flag(
 		"label-selector",
-		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.",
+		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.",
 	).StringVar(&c.LabelSelector)
 	cmd.Flag(
 		"role-arn",

--- a/lib/tbot/cli/start_workload_identity_jwt.go
+++ b/lib/tbot/cli/start_workload_identity_jwt.go
@@ -59,11 +59,11 @@ func NewWorkloadIdentityJWTCommand(parentCmd *kingpin.CmdClause, action MutatorA
 
 	cmd.Flag(
 		"name-selector",
-		"The name of the workload identity to issue",
+		"The name of the workload identity to issue. Mutually exclusive with --label-selector.",
 	).StringVar(&c.NameSelector)
 	cmd.Flag(
 		"label-selector",
-		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.",
+		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.",
 	).StringVar(&c.LabelSelector)
 	cmd.Flag(
 		"audience",

--- a/lib/tbot/cli/start_workload_identity_x509.go
+++ b/lib/tbot/cli/start_workload_identity_x509.go
@@ -57,15 +57,15 @@ func NewWorkloadIdentityX509Command(parentCmd *kingpin.CmdClause, action Mutator
 
 	cmd.Flag(
 		"include-federated-trust-bundles",
-		"If set, include federated trust bundles in the output",
+		"If set, include federated trust bundles in the output.",
 	).BoolVar(&c.IncludeFederatedTrustBundles)
 	cmd.Flag(
 		"name-selector",
-		"The name of the workload identity to issue",
+		"The name of the workload identity to issue. Mutually exclusive with --label-selector.",
 	).StringVar(&c.NameSelector)
 	cmd.Flag(
 		"label-selector",
-		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.",
+		"A label-based selector for which workload identities to issue. Multiple labels can be provided using ','. Mutually exclusive with --name-selector.",
 	).StringVar(&c.LabelSelector)
 
 	return c

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -69,20 +69,20 @@ func Run(args []string, stdout io.Writer) error {
 	globalCfg := cli.NewGlobalArgs(app)
 
 	// Miscellaneous args exposed globally but handled here.
-	app.Flag("mem-profile", "Write memory profile to file").Hidden().StringVar(&memProfile)
-	app.Flag("cpu-profile", "Write CPU profile to file").Hidden().StringVar(&cpuProfile)
-	app.Flag("trace-profile", "Write trace profile to file").Hidden().StringVar(&traceProfile)
+	app.Flag("mem-profile", "Writes a memory profile to the given path.").Hidden().StringVar(&memProfile)
+	app.Flag("cpu-profile", "Writes a CPU profile to the given path.").Hidden().StringVar(&cpuProfile)
+	app.Flag("trace-profile", "Writes a trace profile to the given path.").Hidden().StringVar(&traceProfile)
 	app.HelpFlag.Short('h')
 
 	// Construct the top-level subcommands.
-	versionCmd := app.Command("version", "Print the version of your tbot binary.")
+	versionCmd := app.Command("version", "Prints the version of this tbot binary.")
 
-	kubeCmd := app.Command("kube", "Kubernetes helpers").Hidden()
+	kubeCmd := app.Command("kube", "Kubernetes helpers.").Hidden()
 
-	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
+	startCmd := app.Command("start", "Starts an instance of tbot.")
 
 	configureCmd := app.Command("configure", "Creates a config file based on flags provided, and writes it to stdout or a file (-c <path>).")
-	configureCmd.Flag("output", "Path to write the generated configuration file to rather than write to stdout.").Short('o').StringVar(&configureOutPath)
+	configureCmd.Flag("output", "Path to write the generated configuration file to rather. If unspecified, the generated configuration is written to stdout.").Short('o').StringVar(&configureOutPath)
 
 	keypairCmd := app.Command("keypair", "Manage keypairs for bound-keypair joining")
 
@@ -182,7 +182,7 @@ func Run(args []string, stdout io.Writer) error {
 	spiffeInspectCmd.Flag("path", "The path to the SPIFFE Workload API endpoint to test.").Required().StringVar(&spiffeInspectPath)
 
 	tpmCommand := app.Command("tpm", "Commands related to managing TPM joining functionality.")
-	tpmIdentifyCommand := tpmCommand.Command("identify", "Output identifying information related to the TPM detected on the system.")
+	tpmIdentifyCommand := tpmCommand.Command("identify", "Outputs identifying information related to the TPM detected on the system.")
 
 	installSystemdCmdStr, installSystemdCmdFn := setupInstallSystemdCmd(app)
 


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/62732 generates the `tbot` CLI ref from code-base. I noticed that a lot of our help strings were quite inconsistent with formatting/grammar and this makes it look a little sloppy when presented side-by-side on the reference page. This PR goes through and tries to make the style more consistent and adds further explanation where specific CLI flags were not super clear.