### PR TITLE
Adds AWS Bedrock IAM integration for session summaries

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -27,8 +27,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-var wildcard = "*"
-var allResources = []string{wildcard}
+var (
+	wildcard     = "*"
+	allResources = []string{wildcard}
+)
 
 // StatementForECSManageService returns the statement that allows managing the ECS Service deployed
 // by DeployService (AWS OIDC Integration).
@@ -600,5 +602,31 @@ func StatementForAWSRolesAnywhereSyncRolePolicy() *Statement {
 			"iam:GetRole",
 		},
 		Resources: allResources,
+	}
+}
+
+// StatementForBedrockSessionSummaries returns the statement that allows invoking AWS Bedrock models
+// for the Session Summaries feature. The resource parameter can be either:
+// - A full ARN (e.g., "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-v2" or app inference profile)
+// - A model ID (e.g., "anthropic.claude-v2" or "*"), which will be converted to an ARN with wildcard region
+func StatementForBedrockSessionSummaries(accountID, resource string) *Statement {
+	var resourceARN string
+
+	// Check if the resource is already an ARN
+	if parsedARN, err := arn.Parse(resource); err == nil && parsedARN.Service == "bedrock" {
+		resourceARN = resource
+	} else {
+		// If it's a model ID, create an ARN with wildcard region
+		resourceARN = fmt.Sprintf("arn:aws:bedrock:*:%s:foundation-model/%s", accountID, resource)
+	}
+
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: SliceOrString{
+			"bedrock:InvokeModel",
+			// we don't use it yet, but we might in the future
+			"bedrock:InvokeModelWithResponseStream",
+		},
+		Resources: SliceOrString{resourceARN},
 	}
 }

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -613,7 +613,7 @@ func StatementForBedrockSessionSummaries(accountID, resource string) *Statement 
 	var resourceARN string
 
 	// Check if the resource is already an ARN
-	if parsedARN, err := arn.Parse(resource); err == nil && parsedARN.Service == "bedrock" {
+	if parsedARN, err := arn.Parse(resource); err == nil && parsedARN.Service == "bedrock" || resource == types.Wildcard {
 		resourceARN = resource
 	} else {
 		// If it's a model ID, create an ARN with wildcard region

--- a/lib/cloud/aws/policy_statements_test.go
+++ b/lib/cloud/aws/policy_statements_test.go
@@ -1,0 +1,71 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatementForBedrockSessionSummaries(t *testing.T) {
+	tests := []struct {
+		name             string
+		accountID        string
+		resource         string
+		expectedResource string
+	}{
+		{
+			name:             "bedrock ARN is preserved",
+			accountID:        "123456789012",
+			resource:         "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-v2",
+			expectedResource: "arn:aws:bedrock:us-east-1:123456789012:foundation-model/anthropic.claude-v2",
+		},
+		{
+			name:             "inference profile ARN is preserved",
+			accountID:        "123456789012",
+			resource:         "arn:aws:bedrock:us-east-1:123456789012:inference-profile/my-profile",
+			expectedResource: "arn:aws:bedrock:us-east-1:123456789012:inference-profile/my-profile",
+		},
+		{
+			name:             "model ID converted to ARN with wildcard region",
+			accountID:        "123456789012",
+			resource:         "anthropic.claude-v2",
+			expectedResource: "arn:aws:bedrock:*:123456789012:foundation-model/anthropic.claude-v2",
+		},
+		{
+			name:             "wildcard model ID",
+			accountID:        "123456789012",
+			resource:         "*",
+			expectedResource: "*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statement := StatementForBedrockSessionSummaries(tt.accountID, tt.resource)
+
+			require.Equal(t, &Statement{
+				Effect:    EffectAllow,
+				Actions:   SliceOrString{"bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"},
+				Resources: SliceOrString{tt.expectedResource},
+			}, statement)
+		})
+	}
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -267,6 +267,10 @@ type CommandLineFlags struct {
 	// `teleport integration configure awsra-trust-anchor` command
 	IntegrationConfAWSRATrustAnchorArguments IntegrationConfAWSRATrustAnchor
 
+	// IntegrationConfSessionSummariesBedrockArguments contains the arguments of
+	// `teleport integration configure session-summaries bedrock` command
+	IntegrationConfSessionSummariesBedrockArguments IntegrationConfSessionSummariesBedrock
+
 	// LogLevel is the new application's log level.
 	LogLevel string
 
@@ -460,6 +464,20 @@ type IntegrationConfListDatabasesIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+	// AccountID is the AWS account ID.
+	AccountID string
+	// AutoConfirm skips user confirmation of the operation plan if true.
+	AutoConfirm bool
+}
+
+// IntegrationConfSessionSummariesBedrock contains the arguments of
+// `teleport integration configure session-summaries bedrock` command
+type IntegrationConfSessionSummariesBedrock struct {
+	// Role is the AWS Role associated with the Integration
+	Role string
+	// Resource is the AWS Bedrock resource to grant access to.
+	// Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).
+	Resource string
 	// AccountID is the AWS account ID.
 	AccountID string
 	// AutoConfirm skips user confirmation of the operation plan if true.

--- a/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
+++ b/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
@@ -1,0 +1,134 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package awsoidc
+
+import (
+	"context"
+	"io"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+	"github.com/gravitational/teleport/lib/cloud/provisioning"
+	"github.com/gravitational/teleport/lib/cloud/provisioning/awsactions"
+	"github.com/gravitational/teleport/lib/utils/aws/iamutils"
+)
+
+const (
+	// defaultPolicyNameForBedrockSessionSummaries is the default name for the Inline Policy added to the IntegrationRole.
+	defaultPolicyNameForBedrockSessionSummaries = "TeleportBedrockSessionSummariesAccess"
+)
+
+// BedrockSessionSummariesIAMConfigureRequest is a request to configure the required Policies to use Bedrock for Session Summaries.
+type BedrockSessionSummariesIAMConfigureRequest struct {
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+
+	// IntegrationRoleBedrockPolicy is the Policy Name that is created to allow access to call Bedrock APIs.
+	// Defaults to "BedrockSessionSummariesAccess"
+	IntegrationRoleBedrockPolicy string
+
+	// Resource is the AWS Bedrock resource to grant access to.
+	// Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).
+	Resource string
+
+	// AccountID is the AWS account ID.
+	AccountID string
+
+	// AutoConfirm skips user confirmation of the operation plan if true.
+	AutoConfirm bool
+
+	// stdout is used to override stdout output in tests.
+	stdout io.Writer
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *BedrockSessionSummariesIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.Resource == "" {
+		return trace.BadParameter("resource is required")
+	}
+
+	if r.AccountID == "" {
+		return trace.BadParameter("account ID is required")
+	}
+
+	if r.IntegrationRoleBedrockPolicy == "" {
+		r.IntegrationRoleBedrockPolicy = defaultPolicyNameForBedrockSessionSummaries
+	}
+
+	return nil
+}
+
+// BedrockSessionSummariesIAMConfigureClient describes the required methods to create the IAM Policies
+// required for enabling Bedrock Session Summaries in Teleport.
+type BedrockSessionSummariesIAMConfigureClient interface {
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultBedrockSessionSummariesIAMConfigureClient struct {
+	*iam.Client
+}
+
+// NewBedrockSessionSummariesIAMConfigureClient creates a new BedrockSessionSummariesIAMConfigureClient.
+func NewBedrockSessionSummariesIAMConfigureClient(ctx context.Context) (BedrockSessionSummariesIAMConfigureClient, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("" /* region */))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultBedrockSessionSummariesIAMConfigureClient{
+		Client: iamutils.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureBedrockSessionSummariesIAM sets up the IAM policy required for Teleport to invoke Bedrock models
+// for the Session Summaries feature.
+// The following actions must be allowed by the IAM Role assigned in the Client:
+//   - iam:PutRolePolicy
+func ConfigureBedrockSessionSummariesIAM(ctx context.Context, clt BedrockSessionSummariesIAMConfigureClient, req BedrockSessionSummariesIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	accountID := req.AccountID
+
+	statement := awslib.StatementForBedrockSessionSummaries(accountID, req.Resource)
+	policy := awslib.NewPolicyDocument(statement)
+
+	putRolePolicy, err := awsactions.PutRolePolicy(clt, req.IntegrationRoleBedrockPolicy, req.IntegrationRole, policy)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return trace.Wrap(provisioning.Run(ctx, provisioning.OperationConfig{
+		Name: "bedrock-session-summaries",
+		Actions: []provisioning.Action{
+			*putRolePolicy,
+		},
+		AutoConfirm: req.AutoConfirm,
+		Output:      req.stdout,
+	}))
+}

--- a/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
+++ b/lib/integrations/awsoidc/bedrock_session_summaries_iam_config.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2024  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1097,6 +1097,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/requireddatabasesvpcs", h.WithClusterAuth(h.awsOIDCRequiredDatabasesVPCS))
 	h.GET("/webapi/scripts/integrations/configure/eks-iam.sh", h.WithLimiter(h.awsOIDCConfigureEKSIAM))
 	h.GET("/webapi/scripts/integrations/configure/access-graph-cloud-sync-iam.sh", h.WithLimiter(h.accessGraphCloudSyncOIDC))
+	h.GET("/webapi/scripts/integrations/configure/aws-oidc-bedrock.sh", h.WithLimiter(h.awsBedrockSummarizerOIDC))
 	h.GET("/webapi/scripts/integrations/configure/aws-app-access-iam.sh", h.WithLimiter(h.awsOIDCConfigureAWSAppAccessIAM))
 	// TODO(kimlisa): DELETE IN 19.0 - Replaced by /v2 equivalent endpoint
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/aws-app-access", h.WithClusterAuth(h.awsOIDCCreateAWSAppAccess))
@@ -2074,7 +2075,8 @@ func globMatch(pattern, str string) (bool, error) {
 // userMatchesConnector is a helper function to check if a user matches any of a connector's user matchers.
 func userMatchesConnector(username string, connector interface {
 	GetUserMatchers() []string
-}) (isMatch bool, isFallback bool, err error) {
+},
+) (isMatch bool, isFallback bool, err error) {
 	matchers := connector.GetUserMatchers()
 	for _, pattern := range matchers {
 		matched, err := globMatch(pattern, username)
@@ -3794,7 +3796,6 @@ func (h *Handler) getClusterLocks(
 			return clt.GetLocks(ctx, inForceOnlyFalse)
 		},
 	)
-
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2075,8 +2075,7 @@ func globMatch(pattern, str string) (bool, error) {
 // userMatchesConnector is a helper function to check if a user matches any of a connector's user matchers.
 func userMatchesConnector(username string, connector interface {
 	GetUserMatchers() []string
-},
-) (isMatch bool, isFallback bool, err error) {
+}) (isMatch bool, isFallback bool, err error) {
 	matchers := connector.GetUserMatchers()
 	for _, pattern := range matchers {
 		matched, err := globMatch(pattern, username)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1344,17 +1344,17 @@ func (h *Handler) awsBedrockSummarizerOIDC(w http.ResponseWriter, r *http.Reques
 		return nil, trace.BadParameter("invalid role %q", role)
 	}
 	awsAccountID := queryParams.Get("awsAccountID")
-	if err := aws.IsValidAccountID(awsAccountID); err != nil {
-		return nil, trace.Wrap(err, "invalid awsAccountID")
-	}
 	// The script must execute the following command:
 	// "teleport integration configure session-summaries bedrock"
 	argsList := []string{
 		"integration", "configure", "session-summaries", "bedrock",
 		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
 		fmt.Sprintf("--resource=%s", shsprintf.EscapeDefaultContext(queryParams.Get("resource"))),
-		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
 	}
+	if awsAccountID != "" {
+		argsList = append(argsList, fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)))
+	}
+
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		EntrypointArgs: strings.Join(argsList, " "),
 		SuccessMessage: "Success! You can now go back to the Teleport Web UI to complete the Access Graph AWS Sync enrollment.",

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -1337,6 +1337,38 @@ func (h *Handler) accessGraphCloudSyncOIDC(w http.ResponseWriter, r *http.Reques
 	}
 }
 
+func (h *Handler) awsBedrockSummarizerOIDC(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (any, error) {
+	queryParams := r.URL.Query()
+	role := queryParams.Get("role")
+	if err := aws.IsValidIAMRoleName(role); err != nil {
+		return nil, trace.BadParameter("invalid role %q", role)
+	}
+	awsAccountID := queryParams.Get("awsAccountID")
+	if err := aws.IsValidAccountID(awsAccountID); err != nil {
+		return nil, trace.Wrap(err, "invalid awsAccountID")
+	}
+	// The script must execute the following command:
+	// "teleport integration configure session-summaries bedrock"
+	argsList := []string{
+		"integration", "configure", "session-summaries", "bedrock",
+		fmt.Sprintf("--role=%s", shsprintf.EscapeDefaultContext(role)),
+		fmt.Sprintf("--resource=%s", shsprintf.EscapeDefaultContext(queryParams.Get("resource"))),
+		fmt.Sprintf("--aws-account-id=%s", shsprintf.EscapeDefaultContext(awsAccountID)),
+	}
+	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
+		EntrypointArgs: strings.Join(argsList, " "),
+		SuccessMessage: "Success! You can now go back to the Teleport Web UI to complete the Access Graph AWS Sync enrollment.",
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	httplib.SetScriptHeaders(w.Header())
+	_, err = w.Write([]byte(script))
+
+	return nil, trace.Wrap(err)
+}
+
 func (h *Handler) awsAccessGraphOIDCSync(w http.ResponseWriter, r *http.Request, _ httprouter.Params) (any, error) {
 	queryParams := r.URL.Query()
 	role := queryParams.Get("role")

--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -313,3 +313,21 @@ func onIntegrationConfAWSRATrustAnchor(ctx context.Context, clf config.CommandLi
 	}
 	return trace.Wrap(awsra.ConfigureRolesAnywhereIAM(ctx, rolesAnywhereConfigClient, confReq))
 }
+
+func onIntegrationConfSessionSummariesBedrock(ctx context.Context, params config.IntegrationConfSessionSummariesBedrock) error {
+	// Ensure we print output to the user. LogLevel at this point was set to Error.
+	utils.InitLogger(utils.LoggingForDaemon, slog.LevelInfo)
+
+	iamClient, err := awsoidc.NewBedrockSessionSummariesIAMConfigureClient(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	confReq := awsoidc.BedrockSessionSummariesIAMConfigureRequest{
+		IntegrationRole: params.Role,
+		Resource:        params.Resource,
+		AccountID:       params.AccountID,
+		AutoConfirm:     params.AutoConfirm,
+	}
+	return trace.Wrap(awsoidc.ConfigureBedrockSessionSummariesIAM(ctx, iamClient, confReq))
+}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -535,7 +535,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 
 	integrationConfSessionSummariesCmd := integrationConfigureCmd.Command("session-summaries", "Adds required IAM permissions for Session Summaries feature.")
 	integrationBedrockSessionSummariesCmd := integrationConfSessionSummariesCmd.Command("bedrock", "Adds required IAM permissions for Session Summaries feature using AWS Bedrock.")
-	integrationBedrockSessionSummariesCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Role)
+	integrationBedrockSessionSummariesCmd.Flag("role", "The AWS Role name used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Role)
 	integrationBedrockSessionSummariesCmd.Flag("resource", "The AWS Bedrock resource to grant access to. Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).").Default("*").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Resource)
 	integrationBedrockSessionSummariesCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AccountID)
 	integrationBedrockSessionSummariesCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AutoConfirm)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -533,6 +533,13 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEKSCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfEKSIAMArguments.AccountID)
 	integrationConfEKSCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfEKSIAMArguments.AutoConfirm)
 
+	integrationConfSessionSummariesCmd := integrationConfigureCmd.Command("session-summaries", "Adds required IAM permissions for Session Summaries feature.")
+	integrationBedrockSessionSummariesCmd := integrationConfSessionSummariesCmd.Command("bedrock", "Adds required IAM permissions for Session Summaries feature using AWS Bedrock.")
+	integrationBedrockSessionSummariesCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Role)
+	integrationBedrockSessionSummariesCmd.Flag("resource", "The AWS Bedrock resource to grant access to. Can be a full ARN or a model ID (e.g., 'anthropic.claude-v2' or '*' for all models).").Default("*").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.Resource)
+	integrationBedrockSessionSummariesCmd.Flag("aws-account-id", "The AWS account ID.").StringVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AccountID)
+	integrationBedrockSessionSummariesCmd.Flag("confirm", "Apply changes without confirmation prompt.").BoolVar(&ccf.IntegrationConfSessionSummariesBedrockArguments.AutoConfirm)
+
 	integrationConfAccessGraphCmd := integrationConfigureCmd.Command("access-graph", "Manages Access Graph configuration.")
 	integrationConfAccessGraphAWSSyncCmd := integrationConfAccessGraphCmd.Command("aws-iam", "Adds required AWS IAM permissions for syncing AWS resources into Access Graph service.")
 	integrationConfAccessGraphAWSSyncCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfAccessGraphAWSSyncArguments.Role)
@@ -795,6 +802,8 @@ Examples:
 		err = onIntegrationConfAccessGraphAWSSync(ctx, ccf.IntegrationConfAccessGraphAWSSyncArguments)
 	case integrationConfAccessGraphAzureSyncCmd.FullCommand():
 		err = onIntegrationConfAccessGraphAzureSync(ctx, ccf.IntegrationConfAccessGraphAzureSyncArguments)
+	case integrationBedrockSessionSummariesCmd.FullCommand():
+		err = onIntegrationConfSessionSummariesBedrock(ctx, ccf.IntegrationConfSessionSummariesBedrockArguments)
 	case integrationConfAzureOIDCCmd.FullCommand():
 		err = onIntegrationConfAzureOIDCCmd(ctx, ccf.IntegrationConfAzureOIDCArguments)
 	case integrationSAMLIdPGCPWorkforce.FullCommand():


### PR DESCRIPTION
Introduces support for configuring IAM permissions to allow Teleport's session summaries feature to invoke AWS Bedrock models.