### PR TITLE
[v18] Refactor dynamoDB event queries to use proper pagination solution

### DIFF
--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1711,14 +1711,14 @@ dateLoop:
 				"iterator", l.checkpoint.Iterator,
 			)
 
-			result, stopped, err := l.processQueryOutput(out)
+			result, limitReached, err := l.processQueryOutput(out)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			values = append(values, result...)
 
 			// Return all currently processed events.
-			if stopped {
+			if limitReached {
 				return values, nil
 			}
 			// An empty iterator indicates that there are no more events to fetch from the current date.

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -20,8 +20,6 @@ package dynamoevents
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -264,6 +262,15 @@ type event struct {
 	Expires        *int64 `json:"Expires,omitempty" dynamodbav:",omitempty"`
 	FieldsMap      events.EventFields
 	EventNamespace string
+}
+
+// toIterator marshals an event's EventKey, to be used in checkpointKey.
+func (e *event) toIterator() (string, error) {
+	b, err := json.Marshal(e.EventKey)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	return string(b), nil
 }
 
 const (
@@ -739,11 +746,6 @@ type checkpointKey struct {
 
 	// A DynamoDB query iterator. Allows us to resume a partial query.
 	Iterator string `json:"iterator,omitempty"`
-
-	// EventKey is a derived identifier for an event used for resuming
-	// sub-page breaks due to size constraints.
-	// TODO(hugoShaka): Deprecate and remove this field.
-	EventKey string `json:"event_key,omitempty"`
 }
 
 // legacyCheckpointKey is the old checkpoint key returned by older auth versions. Used to decode
@@ -926,8 +928,6 @@ func (l *Log) searchEventsRaw(ctx context.Context, fromUTC, toUTC time.Time, nam
 		}
 	}
 
-	foundStart := checkpoint.EventKey == ""
-
 	var forward bool
 	switch order {
 	case types.EventOrderAscending:
@@ -952,7 +952,6 @@ func (l *Log) searchEventsRaw(ctx context.Context, fromUTC, toUTC time.Time, nam
 		log:        logger,
 		totalSize:  totalSize,
 		checkpoint: &checkpoint,
-		foundStart: foundStart,
 		dates:      dates,
 		left:       left,
 		fromUTC:    fromUTC,
@@ -1066,7 +1065,6 @@ func getCheckpointFromLegacyStartKey(startKey string) (checkpointKey, error) {
 	return checkpointKey{
 		Date:     checkpoint.Date,
 		Iterator: string(iterator),
-		EventKey: checkpoint.EventKey,
 	}, nil
 }
 
@@ -1084,16 +1082,6 @@ func getExprFilter(filter searchEventsFilter) *string {
 		filterExpr = aws.String(strings.Join(filterConds, " AND "))
 	}
 	return filterExpr
-}
-
-func getSubPageCheckpoint(e *event) (string, error) {
-	data, err := utils.FastMarshal(e)
-	if err != nil {
-		return "", trace.Wrap(err)
-	}
-
-	hash := sha256.Sum256(data)
-	return hex.EncodeToString(hash[:]), nil
 }
 
 // SearchSessionEvents returns session related events only. This is used to
@@ -1586,7 +1574,6 @@ type eventsFetcher struct {
 	totalSize  int
 	hasLeft    bool
 	checkpoint *checkpointKey
-	foundStart bool
 	dates      []string
 	left       int32
 
@@ -1598,8 +1585,11 @@ type eventsFetcher struct {
 	filter    searchEventsFilter
 }
 
+// processQueryOutput returns events from the DynamoDB query output.
+// It stops if events.MaxEventBytesInResponse is reached, the query limit is reached, or there are no more events.
+// If events.MaxEventBytesInResponse is reached or the query limit is reached,
+// we create a new nonempty checkpoint iterator, indicating there are more events to fetch.
 func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeftFun func() bool) ([]event, bool, error) {
-	oldIterator := l.checkpoint.Iterator
 	l.checkpoint.Iterator = ""
 
 	if output.LastEvaluatedKey != nil {
@@ -1630,53 +1620,53 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 			return nil, false, trace.Wrap(err)
 		}
 
-		// TODO(hugoShaka): Fix this. This code path has terrible performance
-		// and should be replaced by proper pagination.
-		if !l.foundStart {
-			key, err := getSubPageCheckpoint(&e)
-			if err != nil {
-				return nil, false, trace.Wrap(err)
-			}
-
-			if key != l.checkpoint.EventKey {
-				continue
-			}
-			l.foundStart = true
-		}
-		// Because this may break on non page boundaries an additional
-		// checkpoint is needed for sub-page breaks.
+		// When the fetcher's total size exceeds the response size limit,
+		// create a checkpoint from the last processed event.
+		// This overrides LastEvaluatedKey to resume processing from this checkpoint.
 		if l.totalSize+len(data) >= events.MaxEventBytesInResponse {
-			key, err := getSubPageCheckpoint(&e)
-			if err != nil {
-				return nil, false, trace.Wrap(err)
+			if len(out) > 0 {
+				lastEvent := out[len(out)-1]
+				iterator, err := lastEvent.toIterator()
+				if err != nil {
+					return nil, false, trace.Wrap(err)
+				}
+
+				// If we stopped because of the size limit, we know that at least one event has to be fetched from the
+				// current date, so we must set it to true independently of the hasLeftFun.
+				l.checkpoint.Iterator = iterator
+				l.hasLeft = true
+
+				l.log.DebugContext(context.Background(), "fetcher's total size exceeds response size limit (sub-page break), creating new checkpoint", "iterator", iterator)
+				return out, true, nil
 			}
-			l.log.DebugContext(context.Background(), "breaking up sub-page due to event size", "key", key)
-			l.checkpoint.EventKey = key
-
-			// We need to reset the iterator so we get the previous page again.
-			l.checkpoint.Iterator = oldIterator
-
-			// If we stopped because of the size limit, we know that at least one event has to be fetched from the
-			// current date and old iterator, so we must set it to true independently of the hasLeftFun or
-			// the new iterator being empty.
-			l.hasLeft = true
-
-			return out, true, nil
 		}
 		l.totalSize += len(data)
 		out = append(out, e)
 		l.left--
+		// Stop early if the query limit is reached.
 		if l.left == 0 {
-			hf := false
-			if hasLeftFun != nil {
-				hf = hasLeftFun()
+			lastEvent := out[len(out)-1]
+			iterator, err := lastEvent.toIterator()
+			if err != nil {
+				return nil, false, trace.Wrap(err)
 			}
-			l.hasLeft = hf || l.checkpoint.Iterator != ""
-			l.checkpoint.EventKey = ""
-			l.log.DebugContext(context.Background(), "resetting checkpoint event-key due to full page", "has_left", l.hasLeft, "checkpoint", l.checkpoint)
+
+			// Since we stopped because of the query limit, we assume there are more events to fetch.
+			// If there are no more, the next fetch returns no events and an empty iterator.
+			l.checkpoint.Iterator = iterator
+			l.hasLeft = true
+
+			l.log.DebugContext(context.Background(), "query limit reached (sub-page break), creating new checkpoint", "iterator", iterator)
 			return out, true, nil
 		}
 	}
+
+	// If all items in current page are processed (no sub-page breaks), check if there are more items.
+	hf := false
+	if hasLeftFun != nil {
+		hf = hasLeftFun()
+	}
+	l.hasLeft = hf || l.checkpoint.Iterator != ""
 	return out, false, nil
 }
 
@@ -1741,26 +1731,23 @@ dateLoop:
 			hasLeft := func() bool {
 				return i+1 != len(l.dates)
 			}
-			result, limitReached, err := l.processQueryOutput(out, hasLeft)
+			result, stopped, err := l.processQueryOutput(out, hasLeft)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			values = append(values, result...)
-			if limitReached {
-				// If we've reached the limit, we need to determine whether there are more events to fetch from the current date
+			if stopped {
+				// If we stopped, we need to determine whether there are more events to fetch from the current date
 				// or if we need to move the cursor to the next date.
-				// To do this, we check if the iterator is empty and if the EventKey is empty.
-				// DynamoDB returns an empty iterator if all events from the current date have been consumed.
-				// We need to check if the EventKey is empty because it indicates that we left the page midway
-				// due to reaching the maximum response size. In this case, we need to resume the query
-				// from the same date and the request's iterator to fetch the remainder of the page.
-				// If the input iterator is empty but the EventKey is not, we need to resume the query from the same date
-				// and we shouldn't move to the next date.
-				if i < len(l.dates)-1 && l.checkpoint.Iterator == "" && l.checkpoint.EventKey == "" {
+				// To do this, we check if the iterator is empty.
+				// DynamoDB returns an empty iterator (LastEvaluatedKey) if all events from the current date have been consumed.
+				// However, in the case that we stopped early and the iterator is nonempty, we should not move to the next date.
+				if i < len(l.dates)-1 && l.checkpoint.Iterator == "" {
 					l.checkpoint.Date = l.dates[i+1]
 				}
 				return values, nil
 			}
+			// An empty iterator indicates that there are no more events to fetch from the current date.
 			if l.checkpoint.Iterator == "" {
 				continue dateLoop
 			}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -979,7 +979,7 @@ func (l *Log) searchEventsRaw(ctx context.Context, fromUTC, toUTC time.Time, nam
 	}
 
 	var lastKey []byte
-	if ef.hasLeft {
+	if checkpoint.Iterator != "" {
 		lastKey, err = json.Marshal(&checkpoint)
 		if err != nil {
 			return nil, "", trace.Wrap(err)
@@ -1572,7 +1572,6 @@ type eventsFetcher struct {
 	api query
 
 	totalSize  int
-	hasLeft    bool
 	checkpoint *checkpointKey
 	dates      []string
 	left       int32
@@ -1589,7 +1588,7 @@ type eventsFetcher struct {
 // It stops if events.MaxEventBytesInResponse is reached, the query limit is reached, or there are no more events.
 // If events.MaxEventBytesInResponse is reached or the query limit is reached,
 // we create a new nonempty checkpoint iterator, indicating there are more events to fetch.
-func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeftFun func() bool) ([]event, bool, error) {
+func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput) ([]event, bool, error) {
 	l.checkpoint.Iterator = ""
 
 	if output.LastEvaluatedKey != nil {
@@ -1638,13 +1637,6 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 			return out, true, nil
 		}
 	}
-
-	// If all items in current page are processed (no sub-page breaks), check if there are more items.
-	hf := false
-	if hasLeftFun != nil {
-		hf = hasLeftFun()
-	}
-	l.hasLeft = hf || l.checkpoint.Iterator != ""
 	return out, false, nil
 }
 
@@ -1656,11 +1648,7 @@ func (l *eventsFetcher) saveCheckpointAtEvent(e event) error {
 		return trace.Wrap(err)
 	}
 
-	// Since the iterator is manually reset, we should always assume there are more
-	// events to fetch.
 	l.checkpoint.Iterator = iterator
-	l.hasLeft = true
-
 	l.log.DebugContext(context.Background(), "sub-page break, saving new checkpoint", "iterator", iterator)
 	return nil
 }
@@ -1669,7 +1657,7 @@ func (l *eventsFetcher) QueryByDateIndex(ctx context.Context, filterExpr *string
 	query := "CreatedAtDate = :date AND CreatedAt BETWEEN :start and :end"
 
 dateLoop:
-	for i, date := range l.dates {
+	for _, date := range l.dates {
 		l.checkpoint.Date = date
 
 		attributes := map[string]interface{}{
@@ -1723,23 +1711,14 @@ dateLoop:
 				"iterator", l.checkpoint.Iterator,
 			)
 
-			hasLeft := func() bool {
-				return i+1 != len(l.dates)
-			}
-			result, stopped, err := l.processQueryOutput(out, hasLeft)
+			result, stopped, err := l.processQueryOutput(out)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			values = append(values, result...)
+
+			// Return all currently processed events.
 			if stopped {
-				// If we stopped, we need to determine whether there are more events to fetch from the current date
-				// or if we need to move the cursor to the next date.
-				// To do this, we check if the iterator is empty.
-				// DynamoDB returns an empty iterator (LastEvaluatedKey) if all events from the current date have been consumed.
-				// However, in the case that we stopped early and the iterator is nonempty, we should not move to the next date.
-				if i < len(l.dates)-1 && l.checkpoint.Iterator == "" {
-					l.checkpoint.Date = l.dates[i+1]
-				}
 				return values, nil
 			}
 			// An empty iterator indicates that there are no more events to fetch from the current date.
@@ -1801,13 +1780,10 @@ func (l *eventsFetcher) QueryBySessionIDIndex(ctx context.Context, sessionID str
 		"iterator", l.checkpoint.Iterator,
 	)
 
-	result, limitReached, err := l.processQueryOutput(out, nil)
+	result, _, err := l.processQueryOutput(out)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	values = append(values, result...)
-	if limitReached {
-		return values, nil
-	}
 	return values, nil
 }

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1624,21 +1624,19 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput, hasLeft
 		// create a checkpoint from the last processed event.
 		// This overrides LastEvaluatedKey to resume processing from this checkpoint.
 		if l.totalSize+len(data) >= events.MaxEventBytesInResponse {
-			if len(out) > 0 {
-				lastEvent := out[len(out)-1]
-				iterator, err := lastEvent.toIterator()
-				if err != nil {
-					return nil, false, trace.Wrap(err)
-				}
-
-				// If we stopped because of the size limit, we know that at least one event has to be fetched from the
-				// current date, so we must set it to true independently of the hasLeftFun.
-				l.checkpoint.Iterator = iterator
-				l.hasLeft = true
-
-				l.log.DebugContext(context.Background(), "fetcher's total size exceeds response size limit (sub-page break), creating new checkpoint", "iterator", iterator)
-				return out, true, nil
+			lastEvent := out[len(out)-1]
+			iterator, err := lastEvent.toIterator()
+			if err != nil {
+				return nil, false, trace.Wrap(err)
 			}
+
+			// If we stopped because of the size limit, we know that at least one event has to be fetched from the
+			// current date, so we must set it to true independently of the hasLeftFun.
+			l.checkpoint.Iterator = iterator
+			l.hasLeft = true
+
+			l.log.DebugContext(context.Background(), "fetcher's total size exceeds response size limit (sub-page break), creating new checkpoint", "iterator", iterator)
+			return out, true, nil
 		}
 		l.totalSize += len(data)
 		out = append(out, e)

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -34,6 +34,11 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -41,6 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -155,7 +161,7 @@ func TestCheckpointOutsideOfWindow(t *testing.T) {
 func TestSizeBreak(t *testing.T) {
 	tt := setupDynamoContext(t)
 
-	const eventSize = 50 * 1024
+	const eventSize = 200 * 1024
 	blob := randStringAlpha(eventSize)
 
 	const eventCount int = 10
@@ -192,7 +198,7 @@ func TestSizeBreak(t *testing.T) {
 			break
 		}
 	}
-
+	require.Len(t, gotEvents, eventCount)
 	lastTime := tt.suite.Clock.Now().UTC().Add(time.Hour)
 
 	for _, event := range gotEvents {
@@ -826,7 +832,6 @@ func TestStartKeyBackCompat(t *testing.T) {
 
 	// we must check the iterator field equality separately because it's a string
 	// containing a JSON-encoded event and field ordering might not be consistent.
-	require.Equal(t, oldCP.EventKey, newCP.EventKey)
 	require.Equal(t, oldCP.Date, newCP.Date)
 
 	var oldIterator, newIterator event
@@ -911,4 +916,247 @@ func TestCursorIteratorPrecision(t *testing.T) {
 		require.Contains(t, eventsSeen, id, "eventsSeen should contain %q", id)
 	}
 
+}
+
+func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
+	event1 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-1",
+		},
+	}
+	event2 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-2",
+		},
+	}
+	event3 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-3",
+		},
+	}
+	event4 := &apievents.AppCreate{
+		Metadata: apievents.Metadata{
+			ID:   uuid.NewString(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+			Type: events.AppCreateEvent,
+		},
+		AppMetadata: apievents.AppMetadata{
+			AppName: "app-4",
+		},
+	}
+
+	// have a deterministic session ID (UID) when used in test cases
+	key1 := eventToKey(event1)
+	key3 := eventToKey(event3)
+	key4 := eventToKey(event4)
+
+	tests := []struct {
+		name          string
+		limit         int32
+		mockResponses map[EventKey]mockResponse
+		wantEvents    []apievents.AuditEvent
+		wantKey       *EventKey
+	}{
+		{
+			name:  "no data returned from query, return empty results",
+			limit: 10,
+		},
+		{
+			name:  "paginated events less than limit",
+			limit: 10,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3},
+					returnKey: &key3,
+				},
+				key3: {
+					events:    []apievents.AuditEvent{event4},
+					returnKey: nil,
+				},
+			},
+			wantEvents: []apievents.AuditEvent{event1, event2, event3, event4},
+		},
+		{
+			name:  "number of events equals limit, should return last key",
+			limit: 4,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3, event4},
+					returnKey: nil,
+				},
+			},
+			wantEvents: []apievents.AuditEvent{event1, event2, event3, event4},
+			wantKey:    &key4,
+		},
+		{
+			name:  "number of events exceeds limit",
+			limit: 3,
+			mockResponses: map[EventKey]mockResponse{
+				{}: {
+					events:    []apievents.AuditEvent{event1},
+					returnKey: &key1,
+				},
+				key1: {
+					events:    []apievents.AuditEvent{event2, event3, event4},
+					returnKey: nil,
+				},
+			},
+			// we don't expect event4 because it should go to next batch
+			wantEvents: []apievents.AuditEvent{event1, event2, event3},
+			wantKey:    &key3,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mock := &mockQuery{
+				responses: test.mockResponses,
+			}
+
+			ef := eventsFetcher{
+				log:        slog.Default(),
+				api:        mock,
+				dates:      []string{"2025-02-05"},
+				fromUTC:    time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
+				toUTC:      time.Date(2025, 2, 6, 0, 0, 0, 0, time.UTC),
+				checkpoint: &checkpointKey{},
+				left:       test.limit,
+				filter:     searchEventsFilter{},
+			}
+
+			gotRawEvents, err := ef.QueryByDateIndex(t.Context(), getExprFilter(ef.filter))
+			require.NoError(t, err)
+
+			if test.wantKey != nil {
+				var gotKey EventKey
+				require.NotEmpty(t, ef.checkpoint.Iterator)
+				require.NoError(t, json.Unmarshal([]byte(ef.checkpoint.Iterator), &gotKey))
+				require.Equal(t, *test.wantKey, gotKey)
+			}
+
+			got := make([]events.EventFields, 0, len(gotRawEvents))
+			for _, rawEvent := range gotRawEvents {
+				got = append(got, rawEvent.FieldsMap)
+			}
+
+			want := make([]events.EventFields, 0, len(test.wantEvents))
+			for _, event := range test.wantEvents {
+				fields, err := events.ToEventFields(event)
+				require.NoError(t, err)
+				want = append(want, fields)
+			}
+
+			require.Empty(t, cmp.Diff(want, got, cmpopts.EquateEmpty()))
+		})
+	}
+}
+
+type mockQuery struct {
+	query
+	responses map[EventKey]mockResponse
+}
+
+type mockResponse struct {
+	events    []apievents.AuditEvent
+	returnKey *EventKey
+}
+
+// Query is a simple mock implementation that does not distinguish queries by date.
+func (m *mockQuery) Query(ctx context.Context, params *dynamodb.QueryInput, optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error) {
+	if m.responses == nil {
+		return &dynamodb.QueryOutput{}, nil
+	}
+
+	var currentKey EventKey
+	if params.ExclusiveStartKey != nil {
+		if err := attributevalue.UnmarshalMap(params.ExclusiveStartKey, &currentKey); err != nil {
+			return nil, err
+		}
+	}
+
+	response, ok := m.responses[currentKey]
+	if !ok {
+		return nil, trace.Errorf("return parameter not defined in mockQuery")
+	}
+
+	items, err := eventsToItems(response.events)
+	if err != nil {
+		return nil, err
+	}
+
+	var lastKey map[string]dynamodbtypes.AttributeValue
+	if response.returnKey != nil {
+		e := *response.returnKey
+		lastKey, err = attributevalue.MarshalMap(&e)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &dynamodb.QueryOutput{
+		Items:            items,
+		LastEvaluatedKey: lastKey,
+	}, nil
+}
+
+func eventsToItems(in []apievents.AuditEvent) ([]map[string]dynamodbtypes.AttributeValue, error) {
+	items := make([]map[string]dynamodbtypes.AttributeValue, 0, len(in))
+	for _, e := range in {
+		fieldsMap, err := events.ToEventFields(e)
+		if err != nil {
+			return nil, err
+		}
+
+		event := event{
+			EventKey: EventKey{
+				SessionID:     e.GetID(), // to make testing deterministic, use ID
+				EventIndex:    e.GetIndex(),
+				CreatedAt:     e.GetTime().Unix(),
+				CreatedAtDate: e.GetTime().Format(iso8601DateFormat),
+			},
+			EventType:      e.GetType(),
+			EventNamespace: apidefaults.Namespace,
+			FieldsMap:      fieldsMap,
+		}
+		item, err := attributevalue.MarshalMap(event)
+		if err != nil {
+			return nil, err
+		}
+
+		items = append(items, item)
+	}
+
+	return items, nil
+}
+
+func eventToKey(e apievents.AuditEvent) EventKey {
+	return EventKey{
+		SessionID:     e.GetID(), // to make testing deterministic, use ID
+		EventIndex:    e.GetIndex(),
+		CreatedAt:     e.GetTime().Unix(),
+		CreatedAtDate: e.GetTime().Format(iso8601DateFormat),
+	}
 }

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -1075,7 +1075,6 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 }
 
 type mockQuery struct {
-	query
 	responses map[EventKey]mockResponse
 }
 

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -900,6 +900,7 @@ func TestStartKeyBackCompat(t *testing.T) {
 
 	// we must check the iterator field equality separately because it's a string
 	// containing a JSON-encoded event and field ordering might not be consistent.
+	require.Equal(t, oldCP.EventKey, newCP.EventKey)
 	require.Equal(t, oldCP.Date, newCP.Date)
 
 	var oldIterator, newIterator event


### PR DESCRIPTION
Backport #62659 to branch/v18

This backport includes manual changes to re-add the old pagination solution, in order to read old checkpoints using `checkpointKey.EventKey` field. While we support reading in `EventKey`, new checkpoints will not use this field and set checkpoints using `checkpointKey.Iterator` instead.

changelog: Improved performance of large search queries for DynamoDB event backend
