### PR TITLE
Fix large event handling for DynamoDB backend

### DIFF
--- a/lib/events/athena/querier.go
+++ b/lib/events/athena/querier.go
@@ -1030,7 +1030,8 @@ func (rb *responseBuilder) appendUntilSizeLimit(resultResp *athena.GetQueryResul
 // to the maximum size, which may result in loss of data.
 // Trimming requires unmarshalling the event to audit.Event and then
 // calling TrimToMaxSize on it.
-// This is not an efficient operation, but it is executed once per page,
+// This is not an efficient operation, but it is executed at most once per page,
+// and only when a single event exceeds the limit,
 // so it should not be a problem in practice.
 func trimToMaxSize(fields events.EventFields) (events.EventFields, error) {
 	event, err := events.FromEventFields(fields)

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1641,18 +1641,18 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput) ([]even
 				return nil, false, trace.Wrap(err)
 			}
 
-			if l.totalSize+len(trimmedData) <= events.MaxEventBytesInResponse {
-				events.MetricQueriedTrimmedEvents.Inc()
-			} else {
+			if l.totalSize+len(trimmedData) > events.MaxEventBytesInResponse {
 				// Failed to trim the event to size.
 				// Even if we fail to trim the event, we still try to return the oversized event.
-				l.log.ErrorContext(context.Background(), "Failed to trim event exceeding maximum response size.",
+				l.log.WarnContext(context.Background(), "Failed to trim event exceeding maximum response size.",
 					"event_type", e.FieldsMap.GetType(),
 					"event_id", e.FieldsMap.GetID(),
 					"event_size", len(data),
 					"event_size_after_trim", len(trimmedData),
 				)
 			}
+			events.MetricQueriedTrimmedEvents.Inc()
+
 			l.totalSize += len(trimmedData)
 			out = append(out, e)
 			l.left--

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1689,7 +1689,8 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput) ([]even
 // to the maximum size, which may result in loss of data.
 // Trimming requires unmarshalling the event to apievents.AuditEvent and then
 // calling TrimToMaxSize on it.
-// This is not an efficient operation, but it is executed once per page,
+// This is not an efficient operation, but it is executed at most once per page,
+// and only when a single event exceeds the limit,
 // so it should not be a problem in practice.
 func trimToMaxSize(fields events.EventFields) (events.EventFields, error) {
 	event, err := events.FromEventFields(fields)

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1621,7 +1621,7 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput) ([]even
 		}
 
 		// Stop early when the fetcher's total size exceeds the response size limit.
-		if l.totalSize+len(data) >= events.MaxEventBytesInResponse {
+		if l.totalSize+len(data) > events.MaxEventBytesInResponse {
 			// Encountered an event that would push the total page over the size limit.
 			// Return all processed events, and the next event will be picked up on the next page.
 			if len(out) > 0 {

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -1650,7 +1650,7 @@ func (l *eventsFetcher) processQueryOutput(output *dynamodb.QueryOutput) ([]even
 					"event_type", e.FieldsMap.GetType(),
 					"event_id", e.FieldsMap.GetID(),
 					"event_size", len(data),
-					"event_size after trim", len(trimmedData),
+					"event_size_after_trim", len(trimmedData),
 				)
 			}
 			l.totalSize += len(trimmedData)

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -1031,7 +1031,7 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 	bigUntrimmableEvent := &apievents.AppCreate{
 		Metadata: apievents.Metadata{
 			ID:   uuid.NewString(),
-			Time: time.Now().UTC(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
 			Type: events.AppCreateEvent,
 		},
 		AppMetadata: apievents.AppMetadata{
@@ -1041,7 +1041,7 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 	bigTrimmableEvent := &apievents.DatabaseSessionQuery{
 		Metadata: apievents.Metadata{
 			ID:   uuid.NewString(),
-			Time: time.Now().UTC(),
+			Time: time.Date(2025, 2, 5, 0, 0, 0, 0, time.UTC),
 			Type: events.DatabaseSessionQueryEvent,
 		},
 		DatabaseQuery: strings.Repeat("aaaaa", events.MaxEventBytesInResponse),
@@ -1157,7 +1157,7 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 					returnKey: &key1,
 				},
 				key1: {
-					events:    []apievents.AuditEvent{event2, event3, bigUntrimmableEvent},
+					events:    []apievents.AuditEvent{event2, event3, bigTrimmableEvent},
 					returnKey: nil,
 				},
 			},

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -1160,7 +1160,7 @@ func Test_eventsFetcher_QueryByDateIndex(t *testing.T) {
 					returnKey: nil,
 				},
 			},
-			// we don't expect bigTrimmedEvent because it should go to next batch
+			// we don't expect bigTrimmableEvent because it should go to next batch
 			wantEvents: []apievents.AuditEvent{event1, event2, event3},
 			wantKey:    &key3,
 		},


### PR DESCRIPTION
Fixes #61645

This PR fixes a bug where the event handler would get stuck when querying large events (>1 MiB) from DynamoDB.

We attempt to trim the single large event first using `AuditEvent.TrimToMaxSize` before sending it over.

changelog: Fixed bug where event handler would get stuck on DynamoDB backend when handling large events