### PR TITLE
MWI: Unhide `tbot keypair create` from help

### DIFF
--- a/lib/tbot/cli/keypair_create.go
+++ b/lib/tbot/cli/keypair_create.go
@@ -48,7 +48,7 @@ type KeypairCreateCommand struct {
 // NewKeypairCreateCommand initializes the `keypair create` command and returns
 // a struct to contain the parse result.
 func NewKeypairCreateCommand(parentCmd KingpinClause, action func(*KeypairCreateCommand) error) *KeypairCreateCommand {
-	cmd := parentCmd.Command("create", "Creates a keypair to preregister for bound-keypair joining.").Hidden()
+	cmd := parentCmd.Command("create", "Creates a keypair to preregister for bound-keypair joining.")
 
 	c := &KeypairCreateCommand{}
 	c.genericExecutorHandler = newGenericExecutorHandler(cmd, c, action)


### PR DESCRIPTION
This unhides the `tbot keypair create` utility, which was previously hidden. It's directly referenced in guides and documented on the web reference page, so it shouldn't remain hidden.