### PR TITLE
Collect user tasks for Azure VM discovery

### DIFF
--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
@@ -156,9 +156,12 @@ type UserTaskSpec struct {
 	DiscoverEks *DiscoverEKS `protobuf:"bytes,6,opt,name=discover_eks,json=discoverEks,proto3" json:"discover_eks,omitempty"`
 	// DiscoverRDS contains the AWS RDS databases that failed to auto enroll into the cluster.
 	// Present when TaskType is discover-rds.
-	DiscoverRds   *DiscoverRDS `protobuf:"bytes,7,opt,name=discover_rds,json=discoverRds,proto3" json:"discover_rds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	DiscoverRds *DiscoverRDS `protobuf:"bytes,7,opt,name=discover_rds,json=discoverRds,proto3" json:"discover_rds,omitempty"`
+	// DiscoverAzureVM contains the Azure VMs that failed to auto enroll into the cluster.
+	// Present when TaskType is discover-azure-vm.
+	DiscoverAzureVm *DiscoverAzureVM `protobuf:"bytes,8,opt,name=discover_azure_vm,json=discoverAzureVm,proto3" json:"discover_azure_vm,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *UserTaskSpec) Reset() {
@@ -236,6 +239,13 @@ func (x *UserTaskSpec) GetDiscoverEks() *DiscoverEKS {
 func (x *UserTaskSpec) GetDiscoverRds() *DiscoverRDS {
 	if x != nil {
 		return x.DiscoverRds
+	}
+	return nil
+}
+
+func (x *UserTaskSpec) GetDiscoverAzureVm() *DiscoverAzureVM {
+	if x != nil {
+		return x.DiscoverAzureVm
 	}
 	return nil
 }
@@ -769,6 +779,170 @@ func (x *DiscoverRDSDatabase) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
+// DiscoverAzureVM contains the VMs that failed to auto-enroll into the cluster.
+type DiscoverAzureVM struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Instances maps a VM ID to the result of enrolling that VM into teleport.
+	Instances map[string]*DiscoverAzureVMInstance `protobuf:"bytes,1,rep,name=instances,proto3" json:"instances,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// SubscriptionID is the Azure Subscription ID for the VMs.
+	SubscriptionId string `protobuf:"bytes,2,opt,name=subscription_id,json=subscriptionId,proto3" json:"subscription_id,omitempty"`
+	// ResourceGroup is the Azure Resource Group where VMs are located.
+	ResourceGroup string `protobuf:"bytes,3,opt,name=resource_group,json=resourceGroup,proto3" json:"resource_group,omitempty"`
+	// Region is the Azure Region where Teleport failed to enroll VMs.
+	Region        string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverAzureVM) Reset() {
+	*x = DiscoverAzureVM{}
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverAzureVM) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverAzureVM) ProtoMessage() {}
+
+func (x *DiscoverAzureVM) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverAzureVM.ProtoReflect.Descriptor instead.
+func (*DiscoverAzureVM) Descriptor() ([]byte, []int) {
+	return file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *DiscoverAzureVM) GetInstances() map[string]*DiscoverAzureVMInstance {
+	if x != nil {
+		return x.Instances
+	}
+	return nil
+}
+
+func (x *DiscoverAzureVM) GetSubscriptionId() string {
+	if x != nil {
+		return x.SubscriptionId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetResourceGroup() string {
+	if x != nil {
+		return x.ResourceGroup
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+// DiscoverAzureVMInstance contains the result of enrolling an Azure VM.
+type DiscoverAzureVMInstance struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// VM ID is the Azure VM ID that uniquely identifies the virtual machine.
+	VmId string `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	// Resource ID allows locating the VM in resource hierarchy.
+	ResourceId string `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	// Name is the VM name.
+	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// DiscoveryConfig is the discovery config name that originated this VM enrollment.
+	DiscoveryConfig string `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
+	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
+	DiscoveryGroup string `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
+	// SyncTime is the timestamp when the error was produced.
+	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverAzureVMInstance) Reset() {
+	*x = DiscoverAzureVMInstance{}
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverAzureVMInstance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverAzureVMInstance) ProtoMessage() {}
+
+func (x *DiscoverAzureVMInstance) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverAzureVMInstance.ProtoReflect.Descriptor instead.
+func (*DiscoverAzureVMInstance) Descriptor() ([]byte, []int) {
+	return file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DiscoverAzureVMInstance) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetDiscoveryConfig() string {
+	if x != nil {
+		return x.DiscoveryConfig
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetDiscoveryGroup() string {
+	if x != nil {
+		return x.DiscoveryGroup
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SyncTime
+	}
+	return nil
+}
+
 var File_teleport_usertasks_v1_user_tasks_proto protoreflect.FileDescriptor
 
 const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
@@ -780,7 +954,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x127\n" +
 	"\x04spec\x18\x05 \x01(\v2#.teleport.usertasks.v1.UserTaskSpecR\x04spec\x12=\n" +
-	"\x06status\x18\x06 \x01(\v2%.teleport.usertasks.v1.UserTaskStatusR\x06status\"\xd7\x02\n" +
+	"\x06status\x18\x06 \x01(\v2%.teleport.usertasks.v1.UserTaskStatusR\x06status\"\xab\x03\n" +
 	"\fUserTaskSpec\x12 \n" +
 	"\vintegration\x18\x01 \x01(\tR\vintegration\x12\x1b\n" +
 	"\ttask_type\x18\x02 \x01(\tR\btaskType\x12\x1d\n" +
@@ -789,7 +963,8 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x05state\x18\x04 \x01(\tR\x05state\x12E\n" +
 	"\fdiscover_ec2\x18\x05 \x01(\v2\".teleport.usertasks.v1.DiscoverEC2R\vdiscoverEc2\x12E\n" +
 	"\fdiscover_eks\x18\x06 \x01(\v2\".teleport.usertasks.v1.DiscoverEKSR\vdiscoverEks\x12E\n" +
-	"\fdiscover_rds\x18\a \x01(\v2\".teleport.usertasks.v1.DiscoverRDSR\vdiscoverRds\"X\n" +
+	"\fdiscover_rds\x18\a \x01(\v2\".teleport.usertasks.v1.DiscoverRDSR\vdiscoverRds\x12R\n" +
+	"\x11discover_azure_vm\x18\b \x01(\v2&.teleport.usertasks.v1.DiscoverAzureVMR\x0fdiscoverAzureVm\"X\n" +
 	"\x0eUserTaskStatus\x12F\n" +
 	"\x11last_state_change\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastStateChange\"\xcd\x02\n" +
 	"\vDiscoverEC2\x12O\n" +
@@ -840,6 +1015,22 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06engine\x18\x03 \x01(\tR\x06engine\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xbc\x02\n" +
+	"\x0fDiscoverAzureVM\x12S\n" +
+	"\tinstances\x18\x01 \x03(\v25.teleport.usertasks.v1.DiscoverAzureVM.InstancesEntryR\tinstances\x12'\n" +
+	"\x0fsubscription_id\x18\x02 \x01(\tR\x0esubscriptionId\x12%\n" +
+	"\x0eresource_group\x18\x03 \x01(\tR\rresourceGroup\x12\x16\n" +
+	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
+	"\x0eInstancesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x17DiscoverAzureVMInstance\x12\x13\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
+	"\vresource_id\x18\x02 \x01(\tR\n" +
+	"resourceId\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
+	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
+	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
 	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTimeBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var (
@@ -854,45 +1045,52 @@ func file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP() []byte {
 	return file_teleport_usertasks_v1_user_tasks_proto_rawDescData
 }
 
-var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
-	(*UserTask)(nil),              // 0: teleport.usertasks.v1.UserTask
-	(*UserTaskSpec)(nil),          // 1: teleport.usertasks.v1.UserTaskSpec
-	(*UserTaskStatus)(nil),        // 2: teleport.usertasks.v1.UserTaskStatus
-	(*DiscoverEC2)(nil),           // 3: teleport.usertasks.v1.DiscoverEC2
-	(*DiscoverEC2Instance)(nil),   // 4: teleport.usertasks.v1.DiscoverEC2Instance
-	(*DiscoverEKS)(nil),           // 5: teleport.usertasks.v1.DiscoverEKS
-	(*DiscoverEKSCluster)(nil),    // 6: teleport.usertasks.v1.DiscoverEKSCluster
-	(*DiscoverRDS)(nil),           // 7: teleport.usertasks.v1.DiscoverRDS
-	(*DiscoverRDSDatabase)(nil),   // 8: teleport.usertasks.v1.DiscoverRDSDatabase
-	nil,                           // 9: teleport.usertasks.v1.DiscoverEC2.InstancesEntry
-	nil,                           // 10: teleport.usertasks.v1.DiscoverEKS.ClustersEntry
-	nil,                           // 11: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
-	(*v1.Metadata)(nil),           // 12: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
+	(*UserTask)(nil),                // 0: teleport.usertasks.v1.UserTask
+	(*UserTaskSpec)(nil),            // 1: teleport.usertasks.v1.UserTaskSpec
+	(*UserTaskStatus)(nil),          // 2: teleport.usertasks.v1.UserTaskStatus
+	(*DiscoverEC2)(nil),             // 3: teleport.usertasks.v1.DiscoverEC2
+	(*DiscoverEC2Instance)(nil),     // 4: teleport.usertasks.v1.DiscoverEC2Instance
+	(*DiscoverEKS)(nil),             // 5: teleport.usertasks.v1.DiscoverEKS
+	(*DiscoverEKSCluster)(nil),      // 6: teleport.usertasks.v1.DiscoverEKSCluster
+	(*DiscoverRDS)(nil),             // 7: teleport.usertasks.v1.DiscoverRDS
+	(*DiscoverRDSDatabase)(nil),     // 8: teleport.usertasks.v1.DiscoverRDSDatabase
+	(*DiscoverAzureVM)(nil),         // 9: teleport.usertasks.v1.DiscoverAzureVM
+	(*DiscoverAzureVMInstance)(nil), // 10: teleport.usertasks.v1.DiscoverAzureVMInstance
+	nil,                             // 11: teleport.usertasks.v1.DiscoverEC2.InstancesEntry
+	nil,                             // 12: teleport.usertasks.v1.DiscoverEKS.ClustersEntry
+	nil,                             // 13: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
+	nil,                             // 14: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
+	(*v1.Metadata)(nil),             // 15: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),   // 16: google.protobuf.Timestamp
 }
 var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
-	12, // 0: teleport.usertasks.v1.UserTask.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 0: teleport.usertasks.v1.UserTask.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.usertasks.v1.UserTask.spec:type_name -> teleport.usertasks.v1.UserTaskSpec
 	2,  // 2: teleport.usertasks.v1.UserTask.status:type_name -> teleport.usertasks.v1.UserTaskStatus
 	3,  // 3: teleport.usertasks.v1.UserTaskSpec.discover_ec2:type_name -> teleport.usertasks.v1.DiscoverEC2
 	5,  // 4: teleport.usertasks.v1.UserTaskSpec.discover_eks:type_name -> teleport.usertasks.v1.DiscoverEKS
 	7,  // 5: teleport.usertasks.v1.UserTaskSpec.discover_rds:type_name -> teleport.usertasks.v1.DiscoverRDS
-	13, // 6: teleport.usertasks.v1.UserTaskStatus.last_state_change:type_name -> google.protobuf.Timestamp
-	9,  // 7: teleport.usertasks.v1.DiscoverEC2.instances:type_name -> teleport.usertasks.v1.DiscoverEC2.InstancesEntry
-	13, // 8: teleport.usertasks.v1.DiscoverEC2Instance.sync_time:type_name -> google.protobuf.Timestamp
-	10, // 9: teleport.usertasks.v1.DiscoverEKS.clusters:type_name -> teleport.usertasks.v1.DiscoverEKS.ClustersEntry
-	13, // 10: teleport.usertasks.v1.DiscoverEKSCluster.sync_time:type_name -> google.protobuf.Timestamp
-	11, // 11: teleport.usertasks.v1.DiscoverRDS.databases:type_name -> teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
-	13, // 12: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
-	4,  // 13: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 14: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 15: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	9,  // 6: teleport.usertasks.v1.UserTaskSpec.discover_azure_vm:type_name -> teleport.usertasks.v1.DiscoverAzureVM
+	16, // 7: teleport.usertasks.v1.UserTaskStatus.last_state_change:type_name -> google.protobuf.Timestamp
+	11, // 8: teleport.usertasks.v1.DiscoverEC2.instances:type_name -> teleport.usertasks.v1.DiscoverEC2.InstancesEntry
+	16, // 9: teleport.usertasks.v1.DiscoverEC2Instance.sync_time:type_name -> google.protobuf.Timestamp
+	12, // 10: teleport.usertasks.v1.DiscoverEKS.clusters:type_name -> teleport.usertasks.v1.DiscoverEKS.ClustersEntry
+	16, // 11: teleport.usertasks.v1.DiscoverEKSCluster.sync_time:type_name -> google.protobuf.Timestamp
+	13, // 12: teleport.usertasks.v1.DiscoverRDS.databases:type_name -> teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
+	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
+	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
+	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
+	4,  // 16: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 17: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 18: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 19: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }
@@ -906,7 +1104,7 @@ func file_teleport_usertasks_v1_user_tasks_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_usertasks_v1_user_tasks_proto_rawDesc), len(file_teleport_usertasks_v1_user_tasks_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/usertasks/v1/user_tasks.proto
+++ b/api/proto/teleport/usertasks/v1/user_tasks.proto
@@ -65,6 +65,9 @@ message UserTaskSpec {
   // DiscoverRDS contains the AWS RDS databases that failed to auto enroll into the cluster.
   // Present when TaskType is discover-rds.
   DiscoverRDS discover_rds = 7;
+  // DiscoverAzureVM contains the Azure VMs that failed to auto enroll into the cluster.
+  // Present when TaskType is discover-azure-vm.
+  DiscoverAzureVM discover_azure_vm = 8;
 }
 
 // UserTaskStatus contains the current status for the UserTask.
@@ -159,6 +162,34 @@ message DiscoverRDSDatabase {
   // Eg, aurora-postgresql, postgresql
   string engine = 3;
   // DiscoveryConfig is the discovery config name that originated this database enrollment.
+  string discovery_config = 4;
+  // DiscoveryGroup is the DiscoveryGroup name that originated this task.
+  string discovery_group = 5;
+  // SyncTime is the timestamp when the error was produced.
+  google.protobuf.Timestamp sync_time = 6;
+}
+
+// DiscoverAzureVM contains the VMs that failed to auto-enroll into the cluster.
+message DiscoverAzureVM {
+  // Instances maps a VM ID to the result of enrolling that VM into teleport.
+  map<string, DiscoverAzureVMInstance> instances = 1;
+  // SubscriptionID is the Azure Subscription ID for the VMs.
+  string subscription_id = 2;
+  // ResourceGroup is the Azure Resource Group where VMs are located.
+  string resource_group = 3;
+  // Region is the Azure Region where Teleport failed to enroll VMs.
+  string region = 4;
+}
+
+// DiscoverAzureVMInstance contains the result of enrolling an Azure VM.
+message DiscoverAzureVMInstance {
+  // VM ID is the Azure VM ID that uniquely identifies the virtual machine.
+  string vm_id = 1;
+  // Resource ID allows locating the VM in resource hierarchy.
+  string resource_id = 2;
+  // Name is the VM name.
+  string name = 3;
+  // DiscoveryConfig is the discovery config name that originated this VM enrollment.
   string discovery_config = 4;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 5;

--- a/api/types/usertasks/object_test.go
+++ b/api/types/usertasks/object_test.go
@@ -16,18 +16,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package usertasks_test
+package usertasks
 
 import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
-	"github.com/gravitational/teleport/api/types/usertasks"
 )
 
 func TestValidateUserTask(t *testing.T) {
@@ -36,7 +36,7 @@ func TestValidateUserTask(t *testing.T) {
 	exampleInstanceID := "i-123"
 
 	baseEC2DiscoverTask := func(t *testing.T) *usertasksv1.UserTask {
-		userTask, err := usertasks.NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
+		userTask, err := NewDiscoverEC2UserTask(&usertasksv1.UserTaskSpec{
 			Integration: "my-integration",
 			TaskType:    "discover-ec2",
 			IssueType:   "ec2-ssm-invocation-failure",
@@ -60,7 +60,7 @@ func TestValidateUserTask(t *testing.T) {
 
 	exampleClusterName := "MyCluster"
 	baseEKSDiscoverTask := func(t *testing.T) *usertasksv1.UserTask {
-		userTask, err := usertasks.NewDiscoverEKSUserTask(&usertasksv1.UserTaskSpec{
+		userTask, err := NewDiscoverEKSUserTask(&usertasksv1.UserTaskSpec{
 			Integration: "my-integration",
 			TaskType:    "discover-eks",
 			IssueType:   "eks-agent-not-connecting",
@@ -84,7 +84,7 @@ func TestValidateUserTask(t *testing.T) {
 
 	exampleDatabaseName := "my-db"
 	baseRDSDiscoverTask := func(t *testing.T) *usertasksv1.UserTask {
-		userTask, err := usertasks.NewDiscoverRDSUserTask(&usertasksv1.UserTaskSpec{
+		userTask, err := NewDiscoverRDSUserTask(&usertasksv1.UserTaskSpec{
 			Integration: "my-integration",
 			TaskType:    "discover-rds",
 			IssueType:   "rds-iam-auth-disabled",
@@ -110,10 +110,10 @@ func TestValidateUserTask(t *testing.T) {
 
 	exampleVMID := "/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm"
 	baseAzureVMDiscoverTask := func(t *testing.T) *usertasksv1.UserTask {
-		userTask, err := usertasks.NewDiscoverAzureVMUserTask(
-			usertasks.TaskGroup{
+		userTask, err := NewDiscoverAzureVMUserTask(
+			TaskGroup{
 				Integration: "my-integration",
-				IssueType:   usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+				IssueType:   AutoDiscoverAzureVMIssueEnrollmentError,
 			},
 			time.Now().Add(24*time.Hour),
 			&usertasksv1.DiscoverAzureVM{
@@ -634,7 +634,7 @@ func TestValidateUserTask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := usertasks.ValidateUserTask(tt.task(t))
+			err := ValidateUserTask(tt.task(t))
 			if tt.wantErr == noError {
 				require.NoError(t, err)
 			} else {
@@ -673,7 +673,7 @@ func TestNewDiscoverEC2UserTask(t *testing.T) {
 	tests := []struct {
 		name         string
 		taskSpec     *usertasksv1.UserTaskSpec
-		taskOption   []usertasks.UserTaskOption
+		taskOption   []UserTaskOption
 		expectedTask *usertasksv1.UserTask
 	}{
 		{
@@ -688,15 +688,15 @@ func TestNewDiscoverEC2UserTask(t *testing.T) {
 				},
 				Spec: baseEC2DiscoverTaskSpec,
 			},
-			taskOption: []usertasks.UserTaskOption{
-				usertasks.WithExpiration(userTaskExpirationTime),
+			taskOption: []UserTaskOption{
+				WithExpiration(userTaskExpirationTime),
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTask, err := usertasks.NewDiscoverEC2UserTask(tt.taskSpec, tt.taskOption...)
+			gotTask, err := NewDiscoverEC2UserTask(tt.taskSpec, tt.taskOption...)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedTask, gotTask)
 		})
@@ -732,7 +732,7 @@ func TestNewDiscoverEKSUserTask(t *testing.T) {
 	tests := []struct {
 		name         string
 		taskSpec     *usertasksv1.UserTaskSpec
-		taskOption   []usertasks.UserTaskOption
+		taskOption   []UserTaskOption
 		expectedTask *usertasksv1.UserTask
 	}{
 		{
@@ -747,15 +747,15 @@ func TestNewDiscoverEKSUserTask(t *testing.T) {
 				},
 				Spec: baseEKSDiscoverTaskSpec,
 			},
-			taskOption: []usertasks.UserTaskOption{
-				usertasks.WithExpiration(userTaskExpirationTime),
+			taskOption: []UserTaskOption{
+				WithExpiration(userTaskExpirationTime),
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTask, err := usertasks.NewDiscoverEKSUserTask(tt.taskSpec, tt.taskOption...)
+			gotTask, err := NewDiscoverEKSUserTask(tt.taskSpec, tt.taskOption...)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedTask, gotTask)
 		})
@@ -793,7 +793,7 @@ func TestNewDiscoverRDSUserTask(t *testing.T) {
 	tests := []struct {
 		name         string
 		taskSpec     *usertasksv1.UserTaskSpec
-		taskOption   []usertasks.UserTaskOption
+		taskOption   []UserTaskOption
 		expectedTask *usertasksv1.UserTask
 	}{
 		{
@@ -808,15 +808,15 @@ func TestNewDiscoverRDSUserTask(t *testing.T) {
 				},
 				Spec: baseRDSDiscoverTaskSpec,
 			},
-			taskOption: []usertasks.UserTaskOption{
-				usertasks.WithExpiration(userTaskExpirationTime),
+			taskOption: []UserTaskOption{
+				WithExpiration(userTaskExpirationTime),
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTask, err := usertasks.NewDiscoverRDSUserTask(tt.taskSpec, tt.taskOption...)
+			gotTask, err := NewDiscoverRDSUserTask(tt.taskSpec, tt.taskOption...)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedTask, gotTask)
 		})
@@ -848,16 +848,16 @@ func TestNewDiscoverAzureVMUserTask(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		taskGroup    usertasks.TaskGroup
+		taskGroup    TaskGroup
 		expiryTime   time.Time
 		data         *usertasksv1.DiscoverAzureVM
 		expectedTask *usertasksv1.UserTask
 	}{
 		{
 			name: "valid task created",
-			taskGroup: usertasks.TaskGroup{
+			taskGroup: TaskGroup{
 				Integration: "my-integration",
-				IssueType:   usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+				IssueType:   AutoDiscoverAzureVMIssueEnrollmentError,
 			},
 			expiryTime: userTaskExpirationTime,
 			data:       baseAzureVMDiscoverData,
@@ -873,7 +873,7 @@ func TestNewDiscoverAzureVMUserTask(t *testing.T) {
 					TaskType: "discover-azure-vm",
 
 					Integration: "my-integration",
-					IssueType:   usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+					IssueType:   AutoDiscoverAzureVMIssueEnrollmentError,
 
 					DiscoverAzureVm: baseAzureVMDiscoverData,
 				},
@@ -883,9 +883,32 @@ func TestNewDiscoverAzureVMUserTask(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotTask, err := usertasks.NewDiscoverAzureVMUserTask(tt.taskGroup, tt.expiryTime, tt.data)
+			gotTask, err := NewDiscoverAzureVMUserTask(tt.taskGroup, tt.expiryTime, tt.data)
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedTask, gotTask)
+		})
+	}
+}
+
+func TestTaskNameFromParts(t *testing.T) {
+	ns := uuid.MustParse("9d074a38-c369-4cc6-87c7-3eef3156ee23")
+
+	tests := []struct {
+		name  string
+		parts []string
+		want  string
+	}{
+		{"empty", []string{}, "9995b172-4843-5e9f-ae05-f6ad85e3f509"},
+		{"single", []string{"task1"}, "66dab5c1-6995-5773-9e03-7daba7e83635"},
+		{"multiple", []string{"a", "b", "c"}, "1c6393ee-bf43-5db8-aeef-0ddd92a591aa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := taskNameFromParts(ns, tt.parts...)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/api/types/usertasks/object_test.go
+++ b/api/types/usertasks/object_test.go
@@ -134,17 +134,19 @@ func TestValidateUserTask(t *testing.T) {
 		return userTask
 	}
 
+	const noError = ""
+
 	tests := []struct {
 		name    string
 		task    func(t *testing.T) *usertasksv1.UserTask
-		wantErr require.ErrorAssertionFunc
+		wantErr string
 	}{
 		{
 			name: "nil user task",
 			task: func(t *testing.T) *usertasksv1.UserTask {
 				return nil
 			},
-			wantErr: require.Error,
+			wantErr: "invalid kind",
 		},
 		{
 			name: "invalid task type",
@@ -153,12 +155,12 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.TaskType = "invalid"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "is not valid",
 		},
 		{
 			name:    "DiscoverEC2: valid",
 			task:    baseEC2DiscoverTask,
-			wantErr: require.NoError,
+			wantErr: noError,
 		},
 		{
 			name: "DiscoverEC2: invalid state",
@@ -167,16 +169,17 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.State = "invalid"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "invalid task state",
 		},
 		{
 			name: "DiscoverEC2: invalid issue type",
 			task: func(t *testing.T) *usertasksv1.UserTask {
 				ut := baseEC2DiscoverTask(t)
 				ut.Spec.IssueType = "unknown error"
+				ut.Metadata.Name = "1b8320d7-0cc0-53f8-81a5-14a8661a9846"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "invalid issue type state, allowed values",
 		},
 		{
 			name: "DiscoverEC2: missing integration",
@@ -185,7 +188,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.Integration = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "integration is required",
 		},
 		{
 			name: "DiscoverEC2: missing discover ec2 field",
@@ -194,7 +197,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2 = nil
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-ec2 requires the discover_ec2 field",
 		},
 		{
 			name: "DiscoverEC2: wrong task name",
@@ -203,7 +206,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Metadata.Name = "another-name"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "task name is pre-defined for discover-ec2 types",
 		},
 		{
 			name: "DiscoverEC2: missing account id",
@@ -212,7 +215,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.AccountId = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-ec2 requires the discover_ec2.account_id field",
 		},
 		{
 			name: "DiscoverEC2: missing region",
@@ -221,7 +224,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Region = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-ec2 requires the discover_ec2.region field",
 		},
 		{
 			name: "DiscoverEC2: instances - missing instance id in map key",
@@ -231,7 +234,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Instances[""] = origInstanceMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "instance id in discover_ec2.instances map is required",
 		},
 		{
 			name: "DiscoverEC2: instances - missing instance id in instance metadata",
@@ -242,7 +245,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Instances[exampleInstanceID] = origInstanceMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "instance id in discover_ec2.instances field is required",
 		},
 		{
 			name: "DiscoverEC2: instances - different instance id",
@@ -253,7 +256,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Instances[exampleInstanceID] = origInstanceMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "instance id in discover_ec2.instances map and field are different",
 		},
 		{
 			name: "DiscoverEC2: instances - missing discovery config",
@@ -264,7 +267,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Instances[exampleInstanceID] = origInstanceMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery config in discover_ec2.instances field is required",
 		},
 		{
 			name: "DiscoverEC2: instances - missing discovery group",
@@ -275,21 +278,22 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEc2.Instances[exampleInstanceID] = origInstanceMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery group in discover_ec2.instances field is required",
 		},
 		{
 			name:    "DiscoverEKS: valid",
 			task:    baseEKSDiscoverTask,
-			wantErr: require.NoError,
+			wantErr: noError,
 		},
 		{
 			name: "DiscoverEKS: invalid issue type",
 			task: func(t *testing.T) *usertasksv1.UserTask {
 				ut := baseEKSDiscoverTask(t)
 				ut.Spec.IssueType = "unknown error"
+				ut.Metadata.Name = "ebb43107-ea5f-5e6c-a53f-230aa683c4a7"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "invalid issue type state, allowed values:",
 		},
 		{
 			name: "DiscoverEKS: missing integration",
@@ -298,7 +302,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.Integration = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "integration is required",
 		},
 		{
 			name: "DiscoverEKS: missing discover eks field",
@@ -307,7 +311,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks = nil
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-eks requires the discover_eks field",
 		},
 		{
 			name: "DiscoverEKS: wrong task name",
@@ -316,7 +320,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Metadata.Name = "another-name"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "task name is pre-defined for discover-eks types",
 		},
 		{
 			name: "DiscoverEKS: missing account id",
@@ -325,7 +329,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.AccountId = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-eks requires the discover_eks.account_id field",
 		},
 		{
 			name: "DiscoverEKS: missing region",
@@ -334,7 +338,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Region = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-eks requires the discover_eks.region field",
 		},
 		{
 			name: "DiscoverEKS: clusters - missing cluster name in map key",
@@ -344,7 +348,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Clusters[""] = origClusterMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "cluster name in discover_eks.clusters map is required",
 		},
 		{
 			name: "DiscoverEKS: clusters - missing cluster name in cluster metadata",
@@ -355,7 +359,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Clusters[exampleClusterName] = origClusterMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "cluster name in discover_eks.clusters field is required",
 		},
 		{
 			name: "DiscoverEKS: clusters - different cluster name",
@@ -366,7 +370,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Clusters[exampleClusterName] = origClusterMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "cluster name in discover_eks.clusters map and field are different",
 		},
 		{
 			name: "DiscoverEKS: clusters - missing discovery config",
@@ -377,7 +381,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Clusters[exampleClusterName] = origClusterMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery config in discover_eks.clusters field is required",
 		},
 		{
 			name: "DiscoverEKS: clusters - missing discovery group",
@@ -388,21 +392,22 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverEks.Clusters[exampleClusterName] = origClusterMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery group in discover_eks.clusters field is required",
 		},
 		{
 			name:    "DiscoverRDS: valid",
 			task:    baseRDSDiscoverTask,
-			wantErr: require.NoError,
+			wantErr: noError,
 		},
 		{
 			name: "DiscoverRDS: invalid issue type",
 			task: func(t *testing.T) *usertasksv1.UserTask {
 				ut := baseRDSDiscoverTask(t)
 				ut.Spec.IssueType = "unknown error"
+				ut.Metadata.Name = "8f7bd657-fd2a-507d-bc7b-c42593ec78f6"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "invalid issue type state, allowed values:",
 		},
 		{
 			name: "DiscoverRDS: missing integration",
@@ -411,7 +416,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.Integration = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "integration is required",
 		},
 		{
 			name: "DiscoverRDS: missing discover rds field",
@@ -420,7 +425,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds = nil
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-rds requires the discover_rds field",
 		},
 		{
 			name: "DiscoverRDS: wrong task name",
@@ -429,7 +434,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Metadata.Name = "another-name"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "task name is pre-defined for discover-rds types",
 		},
 		{
 			name: "DiscoverRDS: missing account id",
@@ -438,7 +443,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.AccountId = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-rds requires the discover_rds.account_id field",
 		},
 		{
 			name: "DiscoverRDS: missing region",
@@ -447,7 +452,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Region = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover-rds requires the discover_rds.region field",
 		},
 		{
 			name: "DiscoverRDS: databases - missing database name in map key",
@@ -457,7 +462,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Databases[""] = origDatabasdeMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "database identifier in discover_rds.databases map is required",
 		},
 		{
 			name: "DiscoverRDS: databases - missing database name in metadata",
@@ -468,7 +473,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Databases[exampleDatabaseName] = origDatabasdeMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "database identifier in discover_rds.databases field is required",
 		},
 		{
 			name: "DiscoverRDS: databases - different database name",
@@ -479,7 +484,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Databases[exampleDatabaseName] = origDatabasdeMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "database identifier in discover_rds.databases map and field are different",
 		},
 		{
 			name: "DiscoverRDS: databases - missing discovery config",
@@ -490,7 +495,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Databases[exampleDatabaseName] = origDatabasdeMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery config in discover_rds.databases field is required",
 		},
 		{
 			name: "DiscoverRDS: databases - missing discovery group",
@@ -501,12 +506,12 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverRds.Databases[exampleDatabaseName] = origDatabasdeMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discovery group in discover_rds.databases field is required",
 		},
 		{
 			name:    "DiscoverAzureVM: valid",
 			task:    baseAzureVMDiscoverTask,
-			wantErr: require.NoError,
+			wantErr: noError,
 		},
 		{
 			name: "DiscoverAzureVM: invalid issue type",
@@ -515,7 +520,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.IssueType = "unknown error"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "issue_type must be one of",
 		},
 		{
 			name: "DiscoverAzureVM: missing integration",
@@ -524,7 +529,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.Integration = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "integration cannot be empty",
 		},
 		{
 			name: "DiscoverAzureVM: missing discover azure vm field",
@@ -533,7 +538,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm = nil
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm field is required",
 		},
 		{
 			name: "DiscoverAzureVM: wrong task name",
@@ -542,7 +547,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Metadata.Name = "another-name"
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "task name must be d3672afc-63f5-5d8a-bf63-2a2f81d6fa61, got another-name",
 		},
 		{
 			name: "DiscoverAzureVM: missing subscription id",
@@ -551,7 +556,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.SubscriptionId = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.subscription_id field is required",
 		},
 		{
 			name: "DiscoverAzureVM: missing resource group",
@@ -560,7 +565,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.ResourceGroup = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.resource_group field is required",
 		},
 		{
 			name: "DiscoverAzureVM: missing region",
@@ -569,7 +574,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Region = ""
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.region field is required",
 		},
 		{
 			name: "DiscoverAzureVM: instances - missing vm id in map key",
@@ -579,7 +584,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Instances[""] = origVMMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.instances map key is empty",
 		},
 		{
 			name: "DiscoverAzureVM: instances - missing vm id in instance metadata",
@@ -590,7 +595,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Instances[exampleVMID] = origVMMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.instances[/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm].vm_id field is required",
 		},
 		{
 			name: "DiscoverAzureVM: instances - different vm id",
@@ -601,7 +606,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Instances[exampleVMID] = origVMMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.instances map key /subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm does not match vm_id /subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/other-vm",
 		},
 		{
 			name: "DiscoverAzureVM: instances - missing discovery config",
@@ -612,7 +617,7 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Instances[exampleVMID] = origVMMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.instances[/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm].discovery_config field is required",
 		},
 		{
 			name: "DiscoverAzureVM: instances - missing discovery group",
@@ -623,14 +628,18 @@ func TestValidateUserTask(t *testing.T) {
 				ut.Spec.DiscoverAzureVm.Instances[exampleVMID] = origVMMetadata
 				return ut
 			},
-			wantErr: require.Error,
+			wantErr: "discover_azure_vm.instances[/subscriptions/sub-123/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm].discovery_group field is required",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := usertasks.ValidateUserTask(tt.task(t))
-			tt.wantErr(t, err)
+			if tt.wantErr == noError {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -25,6 +25,12 @@ import (
 	"github.com/gravitational/teleport/api/types/usertasks"
 )
 
+// classifyAzureVMEnrollmentError classifies Azure API errors into user-facing
+// messages for VM auto-discovery. This is best-effort based on error strings
+// which may change without notice. The matching logic may require future
+// adjustments to track upstream changes, as well as expansion to handle new
+// error patterns. Unrecognized errors will return a generic message; the user
+// should check server logs for the underlying error details.
 func classifyAzureVMEnrollmentError(err error) string {
 	if err == nil {
 		return ""

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/gravitational/teleport/api/types/usertasks"
+)
+
+func classifyAzureVMEnrollmentError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	errMsg := err.Error()
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		switch {
+		case respErr.StatusCode == 403 && respErr.ErrorCode == "AuthorizationFailed":
+			if strings.Contains(errMsg, "runCommands") {
+				return usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission
+			}
+		case respErr.StatusCode == 409 && respErr.ErrorCode == "OperationNotAllowed":
+			if strings.Contains(errMsg, "VM is not running") {
+				return usertasks.AutoDiscoverAzureVMIssueVMNotRunning
+			}
+			if strings.Contains(errMsg, "extension operations are disallowed") {
+				return usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable
+			}
+		}
+	}
+
+	// generic error
+	return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
+}

--- a/lib/srv/discovery/azure_vm_error_parser_test.go
+++ b/lib/srv/discovery/azure_vm_error_parser_test.go
@@ -1,0 +1,101 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/usertasks"
+)
+
+func TestClassifyAzureVMEnrollmentError(t *testing.T) {
+	azureError := func(statusCode int, errorCode, errorMessage string) error {
+		resp := &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(errorMessage)),
+			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
+		}
+		return runtime.NewResponseErrorWithErrorCode(resp, errorCode)
+	}
+
+	tests := []struct {
+		name              string
+		err               error
+		expectedIssueType string
+	}{
+		{
+			name:              "nil error",
+			err:               nil,
+			expectedIssueType: "",
+		},
+		{
+			name:              "unrecognized error",
+			err:               errors.New("something went wrong"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "403 AuthorizationFailed with runCommands/write",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+		},
+		{
+			name:              "403 AuthorizationFailed with runCommands/read",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/read'"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+		},
+		{
+			name:              "403 AuthorizationFailed without runCommands",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform some other action"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "409 OperationNotAllowed VM not running",
+			err:               azureError(409, "OperationNotAllowed", "Cannot modify extensions in the VM when the VM is not running"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueVMNotRunning,
+		},
+		{
+			name:              "409 OperationNotAllowed extension operations disallowed",
+			err:               azureError(409, "OperationNotAllowed", "This operation cannot be performed when extension operations are disallowed. To allow, please ensure VM Agent is installed on the VM and the osProfile.allowExtensionOperations property is true."),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable,
+		},
+		{
+			name:              "409 OperationNotAllowed other message",
+			err:               azureError(409, "OperationNotAllowed", "some other operation not allowed error"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "500 InternalServerError",
+			err:               azureError(500, "InternalServerError", "An internal error occurred"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyAzureVMEnrollmentError(tt.err)
+			require.Equal(t, tt.expectedIssueType, result, "issue type mismatch")
+		})
+	}
+}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -3057,7 +3057,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 	}
 
 	vmMatcher := vmMatcherFn()
-	defaultDiscoveryConfig, err := discoveryconfig.NewDiscoveryConfig(
+
+	cfg, err := discoveryconfig.NewDiscoveryConfig(
 		header.Metadata{Name: uuid.NewString()},
 		discoveryconfig.Spec{
 			DiscoveryGroup: defaultDiscoveryGroup,
@@ -3068,6 +3069,10 @@ func TestAzureVMDiscovery(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	defaultDiscoveryConfig := func() *discoveryconfig.DiscoveryConfig {
+		return cfg.Clone()
+	}
 
 	foundAzureVMs := func() []*armcompute.VirtualMachine {
 		return []*armcompute.VirtualMachine{
@@ -3159,14 +3164,14 @@ func TestAzureVMDiscovery(t *testing.T) {
 		{
 			name:                   "no nodes present, 1 found using dynamic matchers",
 			presentVMs:             []types.Server{},
-			discoveryConfig:        defaultDiscoveryConfig,
+			discoveryConfig:        defaultDiscoveryConfig(),
 			staticMatchers:         Matchers{},
 			wantInstalledInstances: []string{"testvm", "testvm-integration"},
 		},
 		{
 			name:                   "installation failure creates user task",
 			presentVMs:             []types.Server{},
-			discoveryConfig:        defaultDiscoveryConfig,
+			discoveryConfig:        defaultDiscoveryConfig(),
 			staticMatchers:         Matchers{},
 			wantInstalledInstances: []string{},
 			runError:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
@@ -3195,7 +3200,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 								"test-vmid-integration": {
 									VmId:            "test-vmid-integration",
 									Name:            "testvm-integration",
-									DiscoveryConfig: defaultDiscoveryConfig.GetName(),
+									DiscoveryConfig: defaultDiscoveryConfig().GetName(),
 									DiscoveryGroup:  defaultDiscoveryGroup,
 								},
 							},

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -37,6 +38,7 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
@@ -63,6 +65,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -72,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
@@ -80,6 +84,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -2978,15 +2983,20 @@ func mustNewDatabase(t *testing.T, meta types.Metadata, spec types.DatabaseSpecV
 type mockAzureRunCommandClient struct {
 	mu                 sync.Mutex
 	installedInstances map[string]struct{}
+	runErr             error
 }
 
 func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.runErr != nil {
+		return m.runErr
+	}
 	if m.installedInstances == nil {
 		m.installedInstances = make(map[string]struct{})
 	}
 	m.installedInstances[req.VMName] = struct{}{}
-	m.mu.Unlock()
 	return nil
 }
 
@@ -3109,6 +3119,15 @@ func TestAzureVMDiscovery(t *testing.T) {
 	presentNodeAlt := presentNode.DeepCopy().(*types.ServerV2)
 	presentNodeAlt.Metadata.Labels["teleport.internal/vm-id"] = "alternate-vmid"
 
+	azureError := func(statusCode int, errorCode, message string) error {
+		resp := &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(message)),
+			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
+		}
+		return azruntime.NewResponseErrorWithErrorCode(resp, errorCode)
+	}
+
 	tests := []struct {
 		name                     string
 		presentVMs               []types.Server
@@ -3116,6 +3135,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 		staticMatchers           Matchers
 		wantInstalledInstances   []string
 		expectedIntegrationNames []string
+		runError                 error
+		userTasksCheck           func(*testing.T, UserTaskLister)
 	}{
 		{
 			name:                   "no nodes present, 1 found",
@@ -3142,13 +3163,80 @@ func TestAzureVMDiscovery(t *testing.T) {
 			staticMatchers:         Matchers{},
 			wantInstalledInstances: []string{"testvm", "testvm-integration"},
 		},
+		{
+			name:                   "installation failure creates user task",
+			presentVMs:             []types.Server{},
+			discoveryConfig:        defaultDiscoveryConfig,
+			staticMatchers:         Matchers{},
+			wantInstalledInstances: []string{},
+			runError:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+				var tasks []*usertasksv1.UserTask
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					var err error
+					tasks, _, err = lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+					require.NoError(c, err)
+					require.Len(c, tasks, 1)
+				}, 3*time.Second, 100*time.Millisecond)
+
+				expectedTask := &usertasksv1.UserTask{
+					Kind:    types.KindUserTask,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "d09fef6d-2454-5bdd-80c7-db7edddf2a2e", // stable hash
+					},
+					Spec: &usertasksv1.UserTaskSpec{
+						Integration: dummyIntegration,
+						TaskType:    usertasks.TaskTypeDiscoverAzureVM,
+						IssueType:   usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+						State:       usertasks.TaskStateOpen,
+						DiscoverAzureVm: &usertasksv1.DiscoverAzureVM{
+							Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
+								"test-vmid-integration": {
+									VmId:            "test-vmid-integration",
+									Name:            "testvm-integration",
+									DiscoveryConfig: defaultDiscoveryConfig.GetName(),
+									DiscoveryGroup:  defaultDiscoveryGroup,
+								},
+							},
+							SubscriptionId: "testsub",
+							ResourceGroup:  "testrg",
+							Region:         "westcentralus",
+						},
+					},
+					Status: nil,
+				}
+
+				require.Empty(t, cmp.Diff(expectedTask, tasks[0],
+					protocmp.Transform(),
+					protocmp.IgnoreFields(&headerv1.Metadata{}, "expires", "revision"),
+					protocmp.IgnoreFields(&usertasksv1.DiscoverAzureVMInstance{}, "sync_time"),
+				))
+			},
+		},
+		{
+			name:                   "static matcher failure does not create user task",
+			presentVMs:             []types.Server{},
+			staticMatchers:         vmMatcherFn(),
+			wantInstalledInstances: []string{},
+			runError:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					tasks, _, err := lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+					require.NoError(c, err)
+					require.Len(c, tasks, 0)
+				}, 3*time.Second, 100*time.Millisecond)
+			},
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			runClient := &mockAzureRunCommandClient{}
+			runClient := &mockAzureRunCommandClient{
+				runErr: tc.runError,
+			}
 
 			initAzureClients := func(opts ...azure.ClientsOption) (azure.Clients, error) {
 				return &azuretest.Clients{
@@ -3237,11 +3325,16 @@ func TestAzureVMDiscovery(t *testing.T) {
 				} else {
 					require.Equal(c, tc.wantInstalledInstances, runClient.getInstalled())
 				}
-				// all current tests install at least one VM, so this cannot be zero.
-				// multiple installations will trigger just one event.
-				const expectedEventCount = 1
-				require.Equal(c, expectedEventCount, reporter.ResourceCreateEventCount())
+				expectedEvents := 1
+				if tc.runError != nil {
+					expectedEvents = 0
+				}
+				require.Equal(c, expectedEvents, reporter.ResourceCreateEventCount())
 			}, 500*time.Millisecond, 50*time.Millisecond)
+
+			if tc.userTasksCheck != nil {
+				tc.userTasksCheck(t, tlsServer.Auth())
+			}
 
 			// make sure azure client cache has expected entries
 			for _, integrationName := range tc.expectedIntegrationNames {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -3229,7 +3229,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.EventuallyWithT(t, func(c *assert.CollectT) {
 					tasks, _, err := lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
 					require.NoError(c, err)
-					require.Len(c, tasks, 0)
+					require.Empty(c, tasks)
 				}, 3*time.Second, 100*time.Millisecond)
 			},
 		},

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -19,16 +19,26 @@
 package discovery
 
 import (
+	"context"
 	"maps"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestTruncateErrorMessage(t *testing.T) {
@@ -74,15 +84,9 @@ func (m *mockInstance) GetDiscoveryGroup() string {
 }
 
 func TestMergeExistingInstances(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	pollInterval := 10 * time.Minute
-	s := &Server{
-		Config: &Config{
-			clock:          clock,
-			PollInterval:   pollInterval,
-			DiscoveryGroup: "group-1",
-		},
-	}
+	s, _ := newTaskUpdater(t)
+	clock := s.clock
+	pollInterval := s.PollInterval
 
 	now := clock.Now()
 	tooOld := now.Add(-3 * pollInterval)
@@ -160,6 +164,342 @@ func TestMergeExistingInstances(t *testing.T) {
 			workingCopy := maps.Clone(tt.freshInstances)
 			mergeExistingInstances(s, tt.oldInstances, workingCopy)
 			require.Equal(t, tt.expected, workingCopy)
+		})
+	}
+}
+
+func TestMergeUpsertUserTask(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	syncTime := timestamppb.New(clock.Now())
+
+	newTask := func(t *testing.T, tag string) *usertasksv1.UserTask {
+		ut, err := usertasks.NewDiscoverAzureVMUserTask(
+			usertasks.TaskGroup{
+				Integration: "my-int",
+				IssueType:   usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+			},
+			clock.Now().Add(20*time.Minute),
+			&usertasksv1.DiscoverAzureVM{
+				Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
+					tag: {
+						VmId:            tag,
+						DiscoveryConfig: tag,
+						DiscoveryGroup:  tag,
+						SyncTime:        syncTime,
+					},
+				},
+				// these feed into task name, in addition to the task group above.
+				SubscriptionId: "sub-123",
+				ResourceGroup:  "rg-123",
+				Region:         "westus",
+			},
+		)
+		require.NoError(t, err)
+		return ut
+	}
+
+	tests := []struct {
+		name         string
+		existingTask *usertasksv1.UserTask
+		newTask      *usertasksv1.UserTask
+		mergeCalled  bool
+	}{
+		{
+			name:         "no existing task - merge not called",
+			existingTask: nil,
+			newTask:      newTask(t, "foo"),
+			mergeCalled:  false,
+		},
+		{
+			name:         "existing task with spec - merge is called",
+			existingTask: newTask(t, "bar"),
+			newTask:      newTask(t, "foo"),
+			mergeCalled:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ap := newTaskUpdater(t, tt.existingTask)
+
+			mergeCalled := false
+			mergeFunc := func(oldSpec *usertasksv1.UserTaskSpec, newSpec *usertasksv1.UserTaskSpec) {
+				mergeCalled = true
+			}
+
+			require.NoError(t, s.mergeUpsertUserTask(tt.newTask, mergeFunc))
+			require.Equal(t, tt.mergeCalled, mergeCalled, "mergeCalled mismatch")
+
+			// Verify the task was upserted
+			upsertedTask, err := ap.GetUserTask(s.ctx, tt.newTask.GetMetadata().GetName())
+			require.NoError(t, err)
+			require.NotNil(t, upsertedTask)
+			require.Empty(t, cmp.Diff(tt.newTask.Spec, upsertedTask.Spec, protocmp.Transform()))
+		})
+	}
+}
+
+type mocktaskUpdaterAccessPoint struct {
+	types.Semaphores
+
+	mu sync.Mutex
+
+	tasks map[string]*usertasksv1.UserTask
+}
+
+func (m *mocktaskUpdaterAccessPoint) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return &types.SemaphoreLease{}, nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	return nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.tasks[req.GetMetadata().GetName()] = req
+
+	return req, nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	task, ok := m.tasks[name]
+	if !ok {
+		return nil, trace.NotFound("task %q not found", name)
+	}
+	return task, nil
+}
+
+func newTaskUpdater(t *testing.T, existingTasks ...*usertasksv1.UserTask) (*taskUpdater, *mocktaskUpdaterAccessPoint) {
+	t.Helper()
+
+	clock := clockwork.NewFakeClock()
+
+	ap := &mocktaskUpdaterAccessPoint{
+		tasks: make(map[string]*usertasksv1.UserTask),
+	}
+
+	manager := &taskUpdater{
+		ctx:   t.Context(),
+		clock: clock,
+
+		DiscoveryGroup: "group-1",
+		ServerID:       "discover-server-id",
+		PollInterval:   10 * time.Minute,
+		Log:            logtest.NewLogger(),
+		AccessPoint:    ap,
+	}
+
+	for _, task := range existingTasks {
+		if task == nil {
+			continue
+		}
+		_, err := manager.AccessPoint.UpsertUserTask(manager.ctx, task)
+		require.NoError(t, err)
+	}
+
+	return manager, ap
+}
+
+func TestAzureVMTasks_AddFailedEnrollment(t *testing.T) {
+	t.Parallel()
+
+	var testTaskGroup = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError}
+	var testTaskGroupAlt = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueVMNotRunning}
+	var testAzureKey = azureVMTaskKey{subscriptionID: "sub-1", resourceGroup: "rg-1", region: "westus"}
+	var testAzureKeyAlt = azureVMTaskKey{subscriptionID: "sub-2", resourceGroup: "rg-2", region: "eastus"}
+
+	syncTime := timestamppb.New(time.Now())
+
+	vm := func(tag string) *usertasksv1.DiscoverAzureVMInstance {
+		return &usertasksv1.DiscoverAzureVMInstance{
+			VmId:            tag,
+			DiscoveryConfig: "dc-01",
+			DiscoveryGroup:  "group-1",
+			SyncTime:        syncTime,
+		}
+	}
+
+	azureData := func(key azureVMTaskKey, instances ...string) *usertasksv1.DiscoverAzureVM {
+		data := &usertasksv1.DiscoverAzureVM{
+			SubscriptionId: key.subscriptionID,
+			ResourceGroup:  key.resourceGroup,
+			Region:         key.region,
+			Instances:      make(map[string]*usertasksv1.DiscoverAzureVMInstance),
+		}
+		for _, instance := range instances {
+			data.Instances[instance] = vm(instance)
+		}
+		return data
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(tasks *azureVMTasks)
+		expected map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM
+	}{
+		{
+			name: "empty integration is ignored",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(usertasks.TaskGroup{Integration: "", IssueType: "x"}, testAzureKey, vm("foo"))
+			},
+		},
+		{
+			name: "empty issue type is ignored",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(usertasks.TaskGroup{Integration: "x", IssueType: ""}, testAzureKey, vm("foo"))
+			},
+		},
+		{
+			name: "creates task group and adds VM",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo"),
+				},
+			},
+		},
+		{
+			name: "adds multiple VMs to same key",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo", "bar"),
+				},
+			},
+		},
+		{
+			name: "different issue types create separate groups",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroupAlt, testAzureKey, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo"),
+				},
+				testTaskGroupAlt: {
+					testAzureKey: azureData(testAzureKey, "bar"),
+				},
+			},
+		},
+		{
+			name: "different azure keys create separate entries",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKeyAlt, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey:    azureData(testAzureKey, "foo"),
+					testAzureKeyAlt: azureData(testAzureKeyAlt, "bar"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := &azureVMTasks{}
+			tt.mutate(tasks)
+			require.Empty(t, cmp.Diff(tt.expected, tasks.taskGroups, protocmp.Transform()))
+		})
+	}
+}
+
+func TestAzureVMTasks_UpsertAll(t *testing.T) {
+	t.Parallel()
+
+	var testTaskGroup = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError}
+	var testAzureKey = azureVMTaskKey{subscriptionID: "sub-1", resourceGroup: "rg-1", region: "westus"}
+	var testAzureKeyAlt = azureVMTaskKey{subscriptionID: "sub-2", resourceGroup: "rg-2", region: "eastus"}
+
+	azureData := func(key azureVMTaskKey, instances ...string) *usertasksv1.DiscoverAzureVM {
+		data := &usertasksv1.DiscoverAzureVM{
+			SubscriptionId: key.subscriptionID,
+			ResourceGroup:  key.resourceGroup,
+			Region:         key.region,
+			Instances:      make(map[string]*usertasksv1.DiscoverAzureVMInstance),
+		}
+		for _, instance := range instances {
+			data.Instances[instance] = &usertasksv1.DiscoverAzureVMInstance{
+				VmId:            instance,
+				DiscoveryConfig: "dc-01",
+				DiscoveryGroup:  "group-1",
+				SyncTime:        timestamppb.New(time.Now()),
+			}
+		}
+		return data
+	}
+
+	tests := []struct {
+		name          string
+		tasks         *azureVMTasks
+		existingTasks []*usertasksv1.UserTask
+		expectedTasks int
+	}{
+		{
+			name:          "nil taskGroups does not panic",
+			tasks:         &azureVMTasks{},
+			expectedTasks: 0,
+		},
+		{
+			name: "empty instances are skipped",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {testAzureKey: azureData(testAzureKey)},
+				},
+			},
+			expectedTasks: 0,
+		},
+		{
+			name: "upserts single task",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {
+						testAzureKey: azureData(testAzureKey, "foo"),
+					},
+				},
+			},
+			expectedTasks: 1,
+		},
+		{
+			name: "upserts multiple tasks for different keys",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {
+						testAzureKey:    azureData(testAzureKey, "foo"),
+						testAzureKeyAlt: azureData(testAzureKeyAlt, "bar"),
+					},
+				},
+			},
+			expectedTasks: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ap := newTaskUpdater(t, tt.existingTasks...)
+
+			tt.tasks.upsertAll(s)
+
+			tasks := slices.Collect(maps.Values(ap.tasks))
+			require.Len(t, tasks, tt.expectedTasks)
 		})
 	}
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -230,7 +230,8 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 			if err != nil {
 				f.Logger.WarnContext(ctx, "Skipping Teleport installation on Azure VM - failed to infer resource group from vm id",
 					"subscription_id", f.Subscription,
-					"vm_id", azure.StringVal(vm.ID),
+					"vm_id", azure.StringVal(vm.Properties.VMID),
+					"resource_id", azure.StringVal(vm.ID),
 					"error", err,
 				)
 				continue

--- a/lib/usertasks/descriptions/azure-vm-agent-not-available.md
+++ b/lib/usertasks/descriptions/azure-vm-agent-not-available.md
@@ -1,0 +1,28 @@
+# VM agent not available
+
+Teleport could not reach the Azure VM agent to run the enrollment command on this VM.
+Azure reported that extension operations are disallowed.
+
+This usually means one of the following:
+
+**VM agent not installed or unhealthy**
+
+Ensure the Azure VM agent is installed and running.
+
+See Azure documentation for details: [Azure Linux VM agent](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-linux).
+
+**Extensions disabled**
+
+Confirm that `osProfile.allowExtensionOperations` is set to `true` on the VM.
+
+You can check this setting using the Azure CLI:
+
+```bash
+az vm show \
+  --resource-group <resource-group> \
+  --name <vm-name> \
+  --query "osProfile.allowExtensionOperations"
+
+```
+
+If a policy disables extension operations, Run Command will not work.

--- a/lib/usertasks/descriptions/azure-vm-enrollment-error.md
+++ b/lib/usertasks/descriptions/azure-vm-enrollment-error.md
@@ -1,14 +1,3 @@
 # Enrollment failed
 Teleport could not auto enroll the Azure VM due to an unexpected error.
 
-To troubleshoot, check the following:
-
-**Teleport Discovery Service logs**
-
-Look for Azure API errors or Run Command failures around the enrollment time.
-The logs usually include the underlying Azure error message.
-
-**Azure Activity Log**
-
-Check the VM activity log for failed Run Command or extension operations.
-This helps identify permission or policy problems at the Azure layer.

--- a/lib/usertasks/descriptions/azure-vm-enrollment-error.md
+++ b/lib/usertasks/descriptions/azure-vm-enrollment-error.md
@@ -1,0 +1,15 @@
+# Enrollment failed
+Teleport could not auto enroll the Azure VM due to an unexpected error.
+This issue is used when the failure does not match a known Azure error pattern.
+
+To troubleshoot, check the following:
+
+**Teleport Discovery Service logs**
+
+Look for Azure API errors or Run Command failures around the enrollment time.
+The logs usually include the underlying Azure error message.
+
+**Azure Activity Log**
+
+Check the VM activity log for failed Run Command or extension operations.
+This helps identify permission or policy problems at the Azure layer.

--- a/lib/usertasks/descriptions/azure-vm-enrollment-error.md
+++ b/lib/usertasks/descriptions/azure-vm-enrollment-error.md
@@ -1,6 +1,5 @@
 # Enrollment failed
 Teleport could not auto enroll the Azure VM due to an unexpected error.
-This issue is used when the failure does not match a known Azure error pattern.
 
 To troubleshoot, check the following:
 

--- a/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
+++ b/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
@@ -1,0 +1,11 @@
+# Missing Run Command permissions
+Teleport uses Azure VM Run Command to install the Teleport agent during auto enrollment.
+The Azure identity used by this integration does not have the permissions required to execute commands on this VM.
+
+To fix this, grant the identity a role that includes the following permissions:
+- `Microsoft.Compute/virtualMachines/runCommand/action`
+- `Microsoft.Compute/virtualMachines/runCommands/read`
+- `Microsoft.Compute/virtualMachines/runCommands/write`
+- `Microsoft.Compute/virtualMachines/runCommands/delete`
+
+You can assign these permissions at the Subscription level for broad access, or limit the scope to the Resource Group.

--- a/lib/usertasks/descriptions/azure-vm-not-running.md
+++ b/lib/usertasks/descriptions/azure-vm-not-running.md
@@ -1,0 +1,5 @@
+# VMs not running
+
+Teleport uses Azure Run Command to install the agent, which requires VMs to be in a running state.
+
+The enrollment will be retried automatically once the machines reach the Running state.

--- a/lib/usertasks/descriptions_test.go
+++ b/lib/usertasks/descriptions_test.go
@@ -31,6 +31,7 @@ func TestAllDescriptions(t *testing.T) {
 		usertasksapi.DiscoverEC2IssueTypes,
 		usertasksapi.DiscoverEKSIssueTypes,
 		usertasksapi.DiscoverRDSIssueTypes,
+		usertasksapi.DiscoverAzureVMIssueTypes,
 	} {
 		for _, issueType := range issueGroup {
 			title, description := DescriptionForDiscoverEC2Issue(issueType)


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/60817

Changelog: VM installation errors will be captured as user tasks for Azure Discovery flows.