### PR TITLE
[v18] Manage TLS session tickets manually in QUIC peering

### DIFF
--- a/lib/proxy/peer/quic/server.go
+++ b/lib/proxy/peer/quic/server.go
@@ -145,6 +145,14 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		c := tlsConfig.Clone()
 		c.GetConfigForClient = nil
 		c.ClientCAs = clientCAs
+
+		// we are sharing session ticket keys and using VerifyPeerCertificate
+		// (as opposed to VerifyCertificate, which does get called on resumed
+		// connections) because we use TLS session resumption as if we were
+		// keeping a persistent connection between peer proxies; we might want
+		// to revisit this if proxy peering grew more capabilities, but since
+		// all it currently does is open bytestreams through tunnels, this is no
+		// worse than gRPC proxy peering with a single persistent TCP connection
 		c.SetSessionTicketKeys(str.getSessionTicketKeys())
 		return c, nil
 	}

--- a/lib/proxy/peer/quic/server.go
+++ b/lib/proxy/peer/quic/server.go
@@ -500,8 +500,6 @@ type sessionTicketRefresher struct {
 	mu sync.Mutex
 }
 
-func _() { new(tls.Config).SetSessionTicketKeys(new(sessionTicketRefresher).getSessionTicketKeys()) }
-
 // getSessionTicketKeys returns a slice of session tickets, potentially adding a
 // new one and rotating out expired old ones. A new ticket is created when the
 // most recent is a day old, and tickets are rotated away after a week or so.

--- a/lib/proxy/peer/quic/server.go
+++ b/lib/proxy/peer/quic/server.go
@@ -18,6 +18,7 @@ package quic
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
@@ -25,6 +26,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -133,15 +135,17 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	}
 
 	getClientCAs := cfg.GetClientCAs
+	str := new(sessionTicketRefresher)
 	tlsConfig.GetConfigForClient = func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
 		clientCAs, err := getClientCAs(chi)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
-		utils.RefreshTLSConfigTickets(tlsConfig)
 		c := tlsConfig.Clone()
+		c.GetConfigForClient = nil
 		c.ClientCAs = clientCAs
+		c.SetSessionTicketKeys(str.getSessionTicketKeys())
 		return c, nil
 	}
 
@@ -476,4 +480,69 @@ func (r *replayStore) add(nonce uint64, now time.Time) (added bool) {
 	}
 	r.currentSet[nonce] = struct{}{}
 	return true
+}
+
+// sessionTicketRefresherState contains a non-empty slice of randomly generated
+// session tickets together with a slice of creation times that has the same
+// length and is in descending order.
+type sessionTicketRefresherState struct {
+	tickets [][32]byte
+	created []time.Time
+}
+
+// sessionTicketRefresher generates and rotates TLS session tickets suitable for
+// use with [tls.Config.SetSessionTicketKeys].
+type sessionTicketRefresher struct {
+	// state is either nil or a pointer to a valid (i.e. non-zero) state struct.
+	state atomic.Pointer[sessionTicketRefresherState]
+	// mu should be held before calculating and storing a new state, to avoid
+	// extra work.
+	mu sync.Mutex
+}
+
+func _() { new(tls.Config).SetSessionTicketKeys(new(sessionTicketRefresher).getSessionTicketKeys()) }
+
+// getSessionTicketKeys returns a slice of session tickets, potentially adding a
+// new one and rotating out expired old ones. A new ticket is created when the
+// most recent is a day old, and tickets are rotated away after a week or so.
+func (s *sessionTicketRefresher) getSessionTicketKeys() [][32]byte {
+	// same logic for the fast path as in crypto/tls, including the fact that
+	// the oldest ticket can actually be up to 8 days old since we don't check
+	// for expiry in the fast path
+	if state := s.state.Load(); state != nil && time.Since(state.created[0]) < 24*time.Hour {
+		return state.tickets
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state := s.state.Load()
+	now := time.Now()
+	if state != nil && now.Sub(state.created[0]) < 24*time.Hour {
+		return state.tickets
+	}
+
+	if state == nil {
+		state = new(sessionTicketRefresherState)
+	}
+	newState := &sessionTicketRefresherState{
+		tickets: make([][32]byte, 0, 1+len(state.tickets)),
+		created: make([]time.Time, 0, 1+len(state.tickets)),
+	}
+
+	var newTicket [32]byte
+	rand.Read(newTicket[:])
+	newState.tickets = append(newState.tickets, newTicket)
+	newState.created = append(newState.created, now)
+
+	for i := range state.tickets {
+		if now.Sub(state.created[i]) >= 7*24*time.Hour {
+			break
+		}
+		newState.tickets = append(newState.tickets, state.tickets[i])
+		newState.created = append(newState.created, state.created[i])
+	}
+	s.state.Store(newState)
+
+	return newState.tickets
 }

--- a/lib/proxy/peer/quic/server_test.go
+++ b/lib/proxy/peer/quic/server_test.go
@@ -19,7 +19,6 @@ package quic
 import (
 	"encoding/binary"
 	"testing"
-	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	quicpeeringv1a "github.com/gravitational/teleport/gen/proto/go/teleport/quicpeering/v1alpha"
+	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 func TestDialResponseOKEncoding(t *testing.T) {


### PR DESCRIPTION
Backport #62896 to branch/v18