### PR TITLE
[v17] helm: add `jobResources` value to teleport-cluster

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -2316,6 +2316,29 @@ See [the GitHub PR](https://github.com/gravitational/teleport/pull/36251) for te
       memory: 2Gi
   ```
 
+## `jobResources`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+
+Resource requests/limits which should be configured for pre-deploy jobs.
+
+Jobs currently include config validation and potentially migration hooks.
+The resource requirements are typically lower than for the main teleport deployment.
+In most cases, you should leave these limits unset.
+
+`values.yaml` example:
+
+```yaml
+jobResources:
+  requests:
+    cpu: 1
+    memory: 2Gi
+```
+
 ## `podSecurityContext`
 
 | Type     | Default value |

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -39,6 +39,10 @@ spec:
       - name: "teleport-config-check"
         image: '{{ if $auth.enterprise }}{{ $auth.enterpriseImage }}{{ else }}{{ $auth.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $auth.imagePullPolicy }}
+{{- if $auth.jobResources }}
+        resources:
+  {{- toYaml $auth.jobResources | nindent 10 }}
+{{- end }}
 {{- if or $auth.extraEnv $auth.tls.existingCASecretName }}
         env:
   {{- if (gt (len $auth.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/predeploy_job.yaml
@@ -1,5 +1,7 @@
 {{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.validateConfigOnDeploy }}
+{{/* Replicating a v17 bug for stability: we were granting the Teleport resources to the job. */}}
+{{- $resources := coalesce $auth.jobResources $auth.resources }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,9 +41,8 @@ spec:
       - name: "teleport-config-check"
         image: '{{ if $auth.enterprise }}{{ $auth.enterpriseImage }}{{ else }}{{ $auth.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $auth.imagePullPolicy }}
-{{- if $auth.jobResources }}
-        resources:
-  {{- toYaml $auth.jobResources | nindent 10 }}
+{{- if $resources }}
+        resources: {{- toYaml $resources | nindent 10 }}
 {{- end }}
 {{- if or $auth.extraEnv $auth.tls.existingCASecretName }}
         env:

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -39,6 +39,10 @@ spec:
       - name: "teleport"
         image: '{{ if $proxy.enterprise }}{{ $proxy.enterpriseImage }}{{ else }}{{ $proxy.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $proxy.imagePullPolicy }}
+{{- if $proxy.jobResources }}
+        resources:
+  {{- toYaml $proxy.jobResources | nindent 10 }}
+{{- end }}
 {{- if or $proxy.extraEnv $proxy.tls.existingCASecretName }}
         env:
   {{- if (gt (len $proxy.extraEnv) 0) }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -1,5 +1,7 @@
 {{- $proxy := mustMergeOverwrite (mustDeepCopy .Values) .Values.proxy -}}
 {{- if $proxy.validateConfigOnDeploy }}
+{{/* Replicating a v17 bug for stability: we were granting the Teleport resources to the job. */}}
+{{- $resources := coalesce $proxy.jobResources $proxy.resources }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -39,9 +41,8 @@ spec:
       - name: "teleport"
         image: '{{ if $proxy.enterprise }}{{ $proxy.enterpriseImage }}{{ else }}{{ $proxy.image }}{{ end }}:{{ include "teleport-cluster.version" . }}'
         imagePullPolicy: {{ $proxy.imagePullPolicy }}
-{{- if $proxy.jobResources }}
-        resources:
-  {{- toYaml $proxy.jobResources | nindent 10 }}
+{{- if $resources }}
+        resources: {{- toYaml $resources | nindent 10 }}
 {{- end }}
 {{- if or $proxy.extraEnv $proxy.tls.existingCASecretName }}
         env:

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -56,20 +56,65 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not set resources on auth predeploy job when set in values
+  - it: should not set resources on auth predeploy job when resources set in values
     template: auth/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].resources
-  - it: should not set resources on proxy predeploy job when set in values
+
+  - it: should not set resources on proxy predeploy job when resources set in values
     template: proxy/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].resources
+
+  - it: should set resources on auth predeploy job when jobResources set in values
+    template: auth/predeploy_job.yaml
+    values:
+      - ../.lint/resources.yaml
+    set:
+      jobResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+
+  - it: should set resources on proxy predeploy job when jobResources set in values
+    template: proxy/predeploy_job.yaml
+    values:
+      - ../.lint/resources.yaml
+    set:
+      jobResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 512Mi
+          cpu: 1
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
 
   - it: should set imagePullSecrets on proxy predeploy job when set in values
     template: proxy/predeploy_job.yaml

--- a/examples/chart/teleport-cluster/tests/predeploy_test.yaml
+++ b/examples/chart/teleport-cluster/tests/predeploy_test.yaml
@@ -56,21 +56,59 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not set resources on auth predeploy job when resources set in values
+  - it: should not set resources on auth predeploy job when no resources are specified
     template: auth/predeploy_job.yaml
-    values:
-      - ../.lint/resources.yaml
+    set:
+      clusterName: helm-lint
     asserts:
       - isEmpty:
           path: spec.template.spec.containers[0].resources
 
+  - it: should not set resources on proxy predeploy job when no resources are specified
+    template: proxy/predeploy_job.yaml
+    set:
+      clusterName: helm-lint
+    asserts:
+      - isEmpty:
+          path: spec.template.spec.containers[0].resources
+
+  # changes in v18, is here to ensure v17 stability
+  - it: should set resources on auth predeploy job when resources set in values
+    template: auth/predeploy_job.yaml
+    values:
+      - ../.lint/resources.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+
+  # changes in v18, is here to ensure v17 stability
   - it: should not set resources on proxy predeploy job when resources set in values
     template: proxy/predeploy_job.yaml
     values:
       - ../.lint/resources.yaml
     asserts:
-      - isEmpty:
-          path: spec.template.spec.containers[0].resources
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
 
   - it: should set resources on auth predeploy job when jobResources set in values
     template: auth/predeploy_job.yaml

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -827,6 +827,19 @@ resources: {}
 #  limits:
 #    memory: "2Gi"
 
+# Resources to request for the teleport pre-deploy jobs.
+# https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+#
+# Jobs currently include config validation and potentially migration hooks.
+# The resource requirements are typically lower than for the main teleport deployment.
+# In most cases, you should leave these limits unset.
+jobResources: {}
+#  requests:
+#    cpu: "20m"
+#    memory: "500Mi"
+#  limits:
+#    memory: "500Mi"
+
 # Pod security context for any pods created by the chart
 podSecurityContext: {}
   # fsGroup: 65532


### PR DESCRIPTION
Manual backport of #62809 to `branch/v17`.

The backport has 1 additional commit: a5695c34ede3f899d86a263aee5dbfc07cf3a3a7

This commit restores the previous v17 behaviour of using the `resources` by default for the hooks.

Changelog: Made the teleport-cluster Helm chart job resources configurable again via the `jobResources` value.
Changelog: Reverted a disruptive change from v17.7.11: `teleport-cluster` Helm chart uses `resources` for Jobs again. If set `jobResources` takes precedence. This will change in v18, only `jobResources` will be used.