### PR TITLE
Implement `tctl get cert_authority/catype`

### DIFF
--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -81,8 +81,9 @@ func certAuthorityHandler() Handler {
 	}
 }
 func getCertAuthority(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
-	getAll := ref.SubKind == "" && ref.Name == ""
-	if getAll {
+	switch {
+	// `tctl get cert_authority`.
+	case ref.SubKind == "" && ref.Name == "":
 		var allAuthorities []types.CertAuthority
 		for _, caType := range types.CertAuthTypes {
 			authorities, err := client.GetCertAuthorities(ctx, caType, opts.WithSecrets)
@@ -96,14 +97,30 @@ func getCertAuthority(ctx context.Context, client *authclient.Client, ref servic
 			allAuthorities = append(allAuthorities, authorities...)
 		}
 		return &certAuthorityCollection{cas: allAuthorities}, nil
-	}
 
-	id := types.CertAuthID{Type: types.CertAuthType(ref.SubKind), DomainName: ref.Name}
-	authority, err := client.GetCertAuthority(ctx, id, opts.WithSecrets)
-	if err != nil {
-		return nil, trace.Wrap(err)
+	// Eg: `tctl get cert_authority/user`.
+	case ref.SubKind == "":
+		caType := ref.Name // ref.Name is set first.
+		authorities, err := client.GetCertAuthorities(ctx, types.CertAuthType(caType), opts.WithSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &certAuthorityCollection{cas: authorities}, nil
+
+	// Eg: `tctl get cert_authority/user/example.com`.
+	default:
+		caType := ref.SubKind // ref.SubKind is set first.
+		name := ref.Name
+		id := types.CertAuthID{
+			Type:       types.CertAuthType(caType),
+			DomainName: name,
+		}
+		authority, err := client.GetCertAuthority(ctx, id, opts.WithSecrets)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &certAuthorityCollection{cas: []types.CertAuthority{authority}}, nil
 	}
-	return &certAuthorityCollection{cas: []types.CertAuthority{authority}}, nil
 }
 
 func createCertAuthority(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {


### PR DESCRIPTION
Currently there are 2 different functioning incantations of "tctl get cert_authority":

1. `tctl get cert_authority`: gets all authorities
1. `tctl get cert_authority/catype/domain`: gets a specific authority

Attempting to do `tctl get cert_authority/catype` returns an cryptical error message:

```shell
$ tctl get cert_authority/user
> ERROR: getting resource "user" of type "cert_authority"
>         "" authority type is not supported
```

This PR adds the 3rd form - `tctl get cert_authority/catype` - so that all possible "tctl get" incantations are handled.

Changelog: Implemented "tctl get cert_authority/catype", in addition to the already existing "tctl get cert_authority" and "tctl get cert_authority/catype/domain"

#10111