### PR TITLE
Adding immutable labels to scoped tokens

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -230,7 +230,7 @@ func (a *AppV3) GetLabel(key string) (value string, ok bool) {
 
 // GetAllLabels returns the app combined static and dynamic labels.
 func (a *AppV3) GetAllLabels() map[string]string {
-	return CombineLabels(a.Metadata.Labels, a.Spec.DynamicLabels)
+	return CombineLabels(nil, a.Metadata.Labels, a.Spec.DynamicLabels)
 }
 
 // GetDescription returns the app description.

--- a/api/types/appserver.go
+++ b/api/types/appserver.go
@@ -349,7 +349,7 @@ func (s *AppServerV3) GetAllLabels() map[string]string {
 		dynamicLabels = s.Spec.App.Spec.DynamicLabels
 	}
 
-	return CombineLabels(staticLabels, dynamicLabels)
+	return CombineLabels(nil, staticLabels, dynamicLabels)
 }
 
 // GetStaticLabels returns the app server static labels.

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -276,7 +276,7 @@ func (d *DatabaseV3) GetLabel(key string) (value string, ok bool) {
 
 // GetAllLabels returns the database combined static and dynamic labels.
 func (d *DatabaseV3) GetAllLabels() map[string]string {
-	return CombineLabels(d.Metadata.Labels, d.Spec.DynamicLabels)
+	return CombineLabels(nil, d.Metadata.Labels, d.Spec.DynamicLabels)
 }
 
 // GetDescription returns the database description.

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -264,7 +264,7 @@ func (k *KubernetesClusterV3) SetDynamicLabels(dl map[string]CommandLabel) {
 
 // GetAllLabels returns the combined static and dynamic labels.
 func (k *KubernetesClusterV3) GetAllLabels() map[string]string {
-	return CombineLabels(k.Metadata.Labels, k.Spec.DynamicLabels)
+	return CombineLabels(nil, k.Metadata.Labels, k.Spec.DynamicLabels)
 }
 
 // GetDescription returns the description.

--- a/api/types/kubernetes_server.go
+++ b/api/types/kubernetes_server.go
@@ -304,7 +304,7 @@ func (s *KubernetesServerV3) GetAllLabels() map[string]string {
 		dynamicLabels = s.Spec.Cluster.Spec.DynamicLabels
 	}
 
-	return CombineLabels(staticLabels, dynamicLabels)
+	return CombineLabels(nil, staticLabels, dynamicLabels)
 }
 
 // GetStaticLabels returns the kube server static labels.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/utils"
 )
 
@@ -189,6 +190,10 @@ type ProvisionToken interface {
 	// GetSecret returns the token's secret value and a bool representing whether
 	// or not the token had a secret..
 	GetSecret() (string, bool)
+
+	// GetImmutableLabels returns labels that must be applied to resources
+	// provisioned with this token.
+	GetImmutableLabels() *joiningv1.ImmutableLabels
 
 	// Clone creates a copy of the token.
 	Clone() ProvisionToken
@@ -683,6 +688,12 @@ func (p *ProvisionTokenV2) GetAssignedScope() string {
 // dedicated secret value. The name itself is the secret for the "token" join method.
 func (p *ProvisionTokenV2) GetSecret() (string, bool) {
 	return "", false
+}
+
+// GetImmutableLabels always returns nil labels because a [ProvisionTokenV2] can not assign
+// immutable labels
+func (p *ProvisionTokenV2) GetImmutableLabels() *joiningv1.ImmutableLabels {
+	return nil
 }
 
 // String returns the human readable representation of a provisioning token.

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -120,6 +120,8 @@ type Server interface {
 	GetComponentFeatures() *componentfeaturesv1.ComponentFeatures
 	// SetComponentFeatures sets the supported features for the server.
 	SetComponentFeatures(*componentfeaturesv1.ComponentFeatures)
+	// GetImmutableLabels returns the immutable labels for the server.
+	GetImmutableLabels() map[string]string
 }
 
 // NewServer creates an instance of Server.
@@ -338,6 +340,10 @@ func (s *ServerV2) GetHostname() string {
 // GetLabel retrieves the label with the provided key. If not found
 // value will be empty and ok will be false.
 func (s *ServerV2) GetLabel(key string) (value string, ok bool) {
+	if v, ok := s.Spec.ImmutableLabels[key]; ok {
+		return v, ok
+	}
+
 	if cmd, ok := s.Spec.CmdLabels[key]; ok {
 		return cmd.Result, ok
 	}
@@ -351,7 +357,7 @@ func (s *ServerV2) GetLabel(key string) (value string, ok bool) {
 // exists to preserve backwards compatibility, while GetStaticLabels exists to
 // implement ResourcesWithLabels.
 func (s *ServerV2) GetLabels() map[string]string {
-	return s.Metadata.Labels
+	return s.GetStaticLabels()
 }
 
 // GetStaticLabels returns the server static labels.
@@ -359,7 +365,7 @@ func (s *ServerV2) GetLabels() map[string]string {
 // exists to preserve backwards compatibility, while GetStaticLabels exists to
 // implement ResourcesWithLabels.
 func (s *ServerV2) GetStaticLabels() map[string]string {
-	return s.Metadata.Labels
+	return CombineLabels(s.Spec.ImmutableLabels, s.Metadata.Labels, nil)
 }
 
 // SetStaticLabels sets the server static labels.
@@ -429,22 +435,25 @@ func (s *ServerV2) GetRelayIDs() []string {
 // "command labels"
 func (s *ServerV2) GetAllLabels() map[string]string {
 	// server labels (static and dynamic)
-	labels := CombineLabels(s.Metadata.Labels, s.Spec.CmdLabels)
+	labels := CombineLabels(s.Spec.ImmutableLabels, s.Metadata.Labels, s.Spec.CmdLabels)
 	return labels
 }
 
 // CombineLabels combines the passed in static and dynamic labels.
-func CombineLabels(static map[string]string, dynamic map[string]CommandLabelV2) map[string]string {
-	if len(dynamic) == 0 {
+func CombineLabels(immutable, static map[string]string, dynamic map[string]CommandLabelV2) map[string]string {
+	if len(dynamic) == 0 && len(immutable) == 0 {
 		return static
 	}
-
-	lmap := make(map[string]string, len(static)+len(dynamic))
+	lmap := make(map[string]string, len(static)+len(dynamic)+len(immutable))
 	for key, value := range static {
 		lmap[key] = value
 	}
 	for key, cmd := range dynamic {
 		lmap[key] = cmd.Result
+	}
+	// immutable labels must always override static and dynamic labels
+	for key, value := range immutable {
+		lmap[key] = value
 	}
 	return lmap
 }
@@ -770,6 +779,11 @@ func (s *ServerV2) SetCloudMetadata(meta *CloudMetadata) {
 // GetScope returns the scope this server belongs to.
 func (s *ServerV2) GetScope() string {
 	return s.Scope
+}
+
+// GetImmutableLabels returns the immutable labels for the server.
+func (s *ServerV2) GetImmutableLabels() map[string]string {
+	return s.Spec.ImmutableLabels
 }
 
 // CommandLabel is a label that has a value as a result of the

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -858,3 +858,43 @@ func TestServerLabels(t *testing.T) {
 	require.True(t, MatchLabels(server, map[string]string{"time": "now"}))
 	require.True(t, MatchLabels(server, map[string]string{"time": "now", "role": "database"}))
 }
+
+func TestServerGetLabel(t *testing.T) {
+	server := ServerV2{
+		Metadata: Metadata{
+			Labels: map[string]string{
+				"static": "static",
+				// immutable and cmd included to ensure they're overridden
+				"immutable": "static",
+				"cmd":       "static",
+			},
+		},
+		Spec: ServerSpecV2{
+			CmdLabels: map[string]CommandLabelV2{
+				"cmd": {
+					Result: "cmd",
+				},
+				// immutable included to ensure it's overridden
+				"immutable": {
+					Result: "cmd",
+				},
+			},
+			ImmutableLabels: map[string]string{
+				"immutable": "immutable",
+			},
+		},
+	}
+
+	// if priority is respected, all label values should match their keys
+	val, ok := server.GetLabel("immutable")
+	require.True(t, ok)
+	require.Equal(t, "immutable", val)
+
+	val, ok = server.GetLabel("cmd")
+	require.True(t, ok)
+	require.Equal(t, "cmd", val)
+
+	val, ok = server.GetLabel("static")
+	require.True(t, ok)
+	require.Equal(t, "static", val)
+}

--- a/constants.go
+++ b/constants.go
@@ -558,6 +558,9 @@ const (
 	// CertExtensionGitHubUsername indicates the GitHub username identified by
 	// the GitHub connector.
 	CertExtensionGitHubUsername = "github-login@goteleport.com"
+	// CertExtensionImmutableLabelHash is the hash used to verify immutable
+	// labels against a certificate.
+	CertExtensionImmutableLabelHash = "immutable-label-hash@goteleport.com"
 )
 
 // Note: when adding new providers to this list, consider updating the help message for --provider flag

--- a/integration/utmp_integration_test.go
+++ b/integration/utmp_integration_test.go
@@ -40,6 +40,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -258,13 +259,15 @@ func newSrvCtx(ctx context.Context, t *testing.T) *SrvCtx {
 	sshPublicKey := ssh.MarshalAuthorizedKey(sshPub)
 
 	certs, err := s.server.Auth().GenerateHostCerts(ctx,
-		&proto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     s.server.ClusterName(),
-			Role:         types.RoleNode,
-			PublicSSHKey: sshPublicKey,
-			PublicTLSKey: tlsPublicKey,
-		}, "")
+		auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:       hostID,
+				NodeName:     s.server.ClusterName(),
+				Role:         types.RoleNode,
+				PublicSSHKey: sshPublicKey,
+				PublicTLSKey: tlsPublicKey,
+			},
+		})
 	require.NoError(t, err)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5277,9 +5277,21 @@ func ExtractHostID(hostName string, clusterName string) (string, error) {
 	return strings.TrimSuffix(hostName, suffix), nil
 }
 
+// HostCertsParams attaches additional parameters to a [proto.HostCertsRequest] that should not be
+// exposed by the request itself.
+type HostCertsParams struct {
+	// Req is the original request to generate host certificates.
+	Req *proto.HostCertsRequest
+	// The AgentScope that should be encoded into the resulting certificates.
+	AgentScope string
+	// The ImmutableLabelHash that should be encoded into the resulting certificates.
+	ImmutableLabelHash string
+}
+
 // GenerateHostCerts generates new host certificates (signed
 // by the host certificate authority) for a node.
-func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequest, scope string) (*proto.Certs, error) {
+func (a *Server) GenerateHostCerts(ctx context.Context, params HostCertsParams) (*proto.Certs, error) {
+	req := params.Req
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -5410,10 +5422,11 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 		HostID:        req.HostID,
 		NodeName:      req.NodeName,
 		Identity: sshca.Identity{
-			ClusterName: clusterName.GetClusterName(),
-			SystemRole:  req.Role,
-			Principals:  req.AdditionalPrincipals,
-			AgentScope:  scope,
+			ClusterName:        clusterName.GetClusterName(),
+			SystemRole:         req.Role,
+			Principals:         req.AdditionalPrincipals,
+			AgentScope:         params.AgentScope,
+			ImmutableLabelHash: params.ImmutableLabelHash,
 		},
 	})
 	if err != nil {
@@ -5431,11 +5444,12 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 
 	// generate host TLS certificate
 	identity := tlsca.Identity{
-		Username:        utils.HostFQDN(req.HostID, clusterName.GetClusterName()),
-		Groups:          []string{req.Role.String()},
-		TeleportCluster: clusterName.GetClusterName(),
-		SystemRoles:     systemRoles,
-		AgentScope:      scope,
+		Username:           utils.HostFQDN(req.HostID, clusterName.GetClusterName()),
+		Groups:             []string{req.Role.String()},
+		TeleportCluster:    clusterName.GetClusterName(),
+		SystemRoles:        systemRoles,
+		AgentScope:         params.AgentScope,
+		ImmutableLabelHash: params.ImmutableLabelHash,
 	}
 	subject, err := identity.Subject()
 	if err != nil {

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -68,6 +68,7 @@ import (
 	iterstream "github.com/gravitational/teleport/lib/itertools/stream"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/local/generic"
@@ -662,7 +663,11 @@ func (a *ServerWithRoles) GenerateHostCerts(ctx context.Context, req *proto.Host
 		return nil, trace.AccessDenied("roles do not match: %v and %v", existingRoles, req.Role)
 	}
 	identity := a.context.Identity.GetIdentity()
-	return a.authServer.GenerateHostCerts(ctx, req, identity.AgentScope)
+	return a.authServer.GenerateHostCerts(ctx, HostCertsParams{
+		Req:                req,
+		AgentScope:         identity.AgentScope,
+		ImmutableLabelHash: identity.ImmutableLabelHash,
+	})
 }
 
 // checkAdditionalSystemRoles verifies additional system roles in host cert request.
@@ -802,7 +807,12 @@ func (a *ServerWithRoles) RegisterInventoryControlStream(ics client.UpstreamInve
 		return nil, trace.AccessDenied("provided scope %q does not match agent identity %q", hello.Scope, agentScope)
 	}
 	hello.Scope = agentScope
-
+	labelHash := a.context.Identity.GetIdentity().ImmutableLabelHash
+	if labels := hello.GetImmutableLabels(); labels != nil || labelHash != "" {
+		if !joining.VerifyImmutableLabelsHash(labels, labelHash) {
+			return nil, trace.AccessDenied("immutable labels do not match their agent identity")
+		}
+	}
 	return hello, a.authServer.RegisterInventoryControlStream(ics, hello)
 }
 

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -727,28 +727,30 @@ func generateCertificate(authServer *auth.Server, identity TestIdentity) ([]byte
 
 		return tlsCert, privateKeyPEM, nil
 	case authz.BuiltinRole:
-		certs, err := authServer.GenerateHostCerts(ctx,
-			&proto.HostCertsRequest{
+		certs, err := authServer.GenerateHostCerts(ctx, auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
 				HostID:       id.Username,
 				NodeName:     id.Username,
 				Role:         id.Role,
 				PublicTLSKey: tlsPublicKeyPEM,
 				PublicSSHKey: sshPublicKeyPEM,
 				SystemRoles:  id.AdditionalSystemRoles,
-			}, "")
+			},
+		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
 		return certs.TLS, privateKeyPEM, nil
 	case authz.RemoteBuiltinRole:
-		certs, err := authServer.GenerateHostCerts(ctx,
-			&proto.HostCertsRequest{
+		certs, err := authServer.GenerateHostCerts(ctx, auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
 				HostID:       id.Username,
 				NodeName:     id.Username,
 				Role:         id.Role,
 				PublicTLSKey: tlsPublicKeyPEM,
 				PublicSSHKey: sshPublicKeyPEM,
-			}, "")
+			},
+		})
 		if err != nil {
 			return nil, nil, trace.Wrap(err)
 		}
@@ -1369,14 +1371,15 @@ func NewServerIdentity(clt *auth.Server, hostID string, role types.SystemRole) (
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := clt.GenerateHostCerts(context.Background(),
-		&proto.HostCertsRequest{
+	certs, err := clt.GenerateHostCerts(context.Background(), auth.HostCertsParams{
+		Req: &proto.HostCertsRequest{
 			HostID:       hostID,
 			NodeName:     hostID,
 			Role:         role,
 			PublicSSHKey: ssh.MarshalAuthorizedKey(sshPubKey),
 			PublicTLSKey: tlsPubKey,
-		}, "")
+		},
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1617,8 +1617,8 @@ func GenerateIdentity(a *Server, id state.IdentityID, additionalPrincipals, dnsN
 		return nil, trace.Wrap(err)
 	}
 
-	certs, err := a.GenerateHostCerts(context.Background(),
-		&proto.HostCertsRequest{
+	certs, err := a.GenerateHostCerts(context.Background(), HostCertsParams{
+		Req: &proto.HostCertsRequest{
 			HostID:               id.HostUUID,
 			NodeName:             id.NodeName,
 			Role:                 id.Role,
@@ -1626,7 +1626,8 @@ func GenerateIdentity(a *Server, id state.IdentityID, additionalPrincipals, dnsN
 			DNSNames:             dnsNames,
 			PublicSSHKey:         ssh.MarshalAuthorizedKey(sshPub),
 			PublicTLSKey:         tlsPub,
-		}, "")
+		},
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/legacyjoin"
 	"github.com/gravitational/teleport/lib/join/provision"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 // checkTokenJoinRequestCommon checks all token join rules that are common to
@@ -509,17 +510,21 @@ func (a *Server) GenerateHostCertsForJoin(
 
 	// generate and return host certificate and keys
 	certs, err := a.GenerateHostCerts(ctx,
-		&proto.HostCertsRequest{
-			HostID:               params.HostID,
-			NodeName:             params.HostName,
-			Role:                 params.SystemRole,
-			AdditionalPrincipals: params.AdditionalPrincipals,
-			PublicTLSKey:         params.PublicTLSKey,
-			PublicSSHKey:         params.PublicSSHKey,
-			RemoteAddr:           params.RemoteAddr,
-			DNSNames:             params.DNSNames,
-			SystemRoles:          systemRoles,
-		}, token.GetAssignedScope())
+		HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:               params.HostID,
+				NodeName:             params.HostName,
+				Role:                 params.SystemRole,
+				AdditionalPrincipals: params.AdditionalPrincipals,
+				PublicTLSKey:         params.PublicTLSKey,
+				PublicSSHKey:         params.PublicSSHKey,
+				RemoteAddr:           params.RemoteAddr,
+				DNSNames:             params.DNSNames,
+				SystemRoles:          systemRoles,
+			},
+			AgentScope:         token.GetAssignedScope(),
+			ImmutableLabelHash: joining.HashImmutableLabels(token.GetImmutableLabels()),
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/webclient"
 	joinv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/join/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/aws"
@@ -308,6 +309,9 @@ type RegisterResult struct {
 	// BoundKeypair contains additional results from bound keypair registration
 	// attempts. This is only set when bound keypair joining is used.
 	BoundKeypair *BoundKeypairRegisterResult
+	// ImmutableLabels are the immutable labels that have been assigned to
+	// the host by their join token.
+	ImmutableLabels *joiningv1.ImmutableLabels
 }
 
 // Register is used to get signed certificates when a node, proxy, or bot is

--- a/lib/auth/register.go
+++ b/lib/auth/register.go
@@ -59,18 +59,20 @@ func LocalRegister(id state.IdentityID, authServer *Server, additionalPrincipals
 		remoteAddr = defaults.Localhost
 	}
 	certs, err := authServer.GenerateHostCerts(context.Background(),
-		&proto.HostCertsRequest{
-			HostID:               id.HostUUID,
-			NodeName:             id.NodeName,
-			Role:                 id.Role,
-			AdditionalPrincipals: additionalPrincipals,
-			RemoteAddr:           remoteAddr,
-			DNSNames:             dnsNames,
-			NoCache:              true,
-			PublicSSHKey:         ssh.MarshalAuthorizedKey(sshPub),
-			PublicTLSKey:         tlsPub,
-			SystemRoles:          systemRoles,
-		}, "")
+		HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:               id.HostUUID,
+				NodeName:             id.NodeName,
+				Role:                 id.Role,
+				AdditionalPrincipals: additionalPrincipals,
+				RemoteAddr:           remoteAddr,
+				DNSNames:             dnsNames,
+				NoCache:              true,
+				PublicSSHKey:         ssh.MarshalAuthorizedKey(sshPub),
+				PublicTLSKey:         tlsPub,
+				SystemRoles:          systemRoles,
+			},
+		})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/state/identity.go
+++ b/lib/auth/state/identity.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -88,6 +89,11 @@ type Identity struct {
 	SystemRoles []string
 	// AgentScope is the scope an identity is constrained to.
 	AgentScope string
+	// ImmutableLabelHash is the hash used to verify immutable labels against
+	// the identity.
+	ImmutableLabelHash string
+	// ImmutableLabels are the immutable labels assigned to this identity at join time.
+	ImmutableLabels *joiningv1.ImmutableLabels
 }
 
 // HasSystemRole checks if this identity encompasses the supplied system role.
@@ -334,13 +340,16 @@ func ReadSSHIdentityFromKeyPair(keyBytes, certBytes []byte) (*Identity, error) {
 	}
 
 	agentScope := cert.Permissions.Extensions[teleport.CertExtensionAgentScope]
+	labelHash := cert.Permissions.Extensions[teleport.CertExtensionImmutableLabelHash]
+
 	return &Identity{
-		ID:          IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
-		ClusterName: clusterName,
-		KeyBytes:    keyBytes,
-		CertBytes:   certBytes,
-		KeySigner:   certSigner,
-		Cert:        cert,
-		AgentScope:  agentScope,
+		ID:                 IdentityID{HostUUID: cert.ValidPrincipals[0], Role: role},
+		ClusterName:        clusterName,
+		KeyBytes:           keyBytes,
+		CertBytes:          certBytes,
+		KeySigner:          certSigner,
+		Cert:               cert,
+		AgentScope:         agentScope,
+		ImmutableLabelHash: labelHash,
 	}, nil
 }

--- a/lib/auth/state/state.go
+++ b/lib/auth/state/state.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/trace"
 
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -137,4 +138,6 @@ type IdentitySpecV2 struct {
 	// SSHCACerts is a list of SSH certificate authorities encoded in the
 	// authorized_keys format.
 	SSHCACerts [][]byte `json:"ssh_ca_certs,omitempty"`
+	// ImmutableLabels are the immutable labels assigned to this identity at join time.
+	ImmutableLabels *joiningv1.ImmutableLabels `json:"immutable_labels"`
 }

--- a/lib/auth/storage/storage.go
+++ b/lib/auth/storage/storage.go
@@ -174,12 +174,17 @@ func (p *ProcessStorage) ReadIdentity(name string, role types.SystemRole) (*stat
 	if err := res.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return state.ReadIdentityFromKeyPair(res.Spec.Key, &proto.Certs{
+	identity, err := state.ReadIdentityFromKeyPair(res.Spec.Key, &proto.Certs{
 		SSH:        res.Spec.SSHCert,
 		TLS:        res.Spec.TLSCert,
 		TLSCACerts: res.Spec.TLSCACerts,
 		SSHCACerts: res.Spec.SSHCACerts,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	identity.ImmutableLabels = res.Spec.ImmutableLabels
+	return identity, nil
 }
 
 // WriteIdentity writes identity to the backend.
@@ -193,11 +198,12 @@ func (p *ProcessStorage) WriteIdentity(name string, id state.Identity) error {
 			},
 		},
 		Spec: state.IdentitySpecV2{
-			Key:        id.KeyBytes,
-			SSHCert:    id.CertBytes,
-			TLSCert:    id.TLSCertBytes,
-			TLSCACerts: id.TLSCACertsBytes,
-			SSHCACerts: id.SSHCACertBytes,
+			Key:             id.KeyBytes,
+			SSHCert:         id.CertBytes,
+			TLSCert:         id.TLSCertBytes,
+			TLSCACerts:      id.TLSCACertsBytes,
+			SSHCACerts:      id.SSHCACertBytes,
+			ImmutableLabels: id.ImmutableLabels,
 		},
 	}
 	if err := res.CheckAndSetDefaults(); err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1146,14 +1146,20 @@ func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 	}, nil
 }
 
+// ImmutableLabels capture yaml configuration used to generate [joiningv1.ImmutableLabels].
+type ImmutableLabels struct {
+	SSH map[string]string `yaml:"ssh"`
+}
+
 // StaticScopedToken is a statically defined scoped token. It is meant to capture
 // yaml configuration that can be used to generate a [joiningv1.ScopedToken].
 type StaticScopedToken struct {
-	Name   string   `yaml:"name"`
-	Secret string   `yaml:"secret"`
-	Roles  []string `yaml:"roles"`
-	Scope  string   `yaml:"scope"`
-	Path   string   `yaml:"path"`
+	Name            string           `yaml:"name"`
+	Secret          string           `yaml:"secret"`
+	Roles           []string         `yaml:"roles"`
+	Scope           string           `yaml:"scope"`
+	Path            string           `yaml:"path"`
+	ImmutableLabels *ImmutableLabels `yaml:"immutable_labels"`
 }
 
 // Validate whether or not a [StaticScopedToken] is well formed.

--- a/lib/decision/ssh_identity.go
+++ b/lib/decision/ssh_identity.go
@@ -70,6 +70,7 @@ func SSHIdentityToSSHCA(id *decisionpb.SSHIdentity) *sshca.Identity {
 		GitHubUserID:             id.GithubUserId,
 		GitHubUsername:           id.GithubUsername,
 		AgentScope:               id.AgentScope,
+		ImmutableLabelHash:       id.ImmutableLabelHash,
 	}
 }
 
@@ -117,6 +118,7 @@ func SSHIdentityFromSSHCA(id *sshca.Identity) *decisionpb.SSHIdentity {
 		GithubUsername:           id.GitHubUsername,
 		JoinToken:                id.JoinToken,
 		AgentScope:               id.AgentScope,
+		ImmutableLabelHash:       id.ImmutableLabelHash,
 	}
 }
 

--- a/lib/decision/ssh_identity_test.go
+++ b/lib/decision/ssh_identity_test.go
@@ -26,10 +26,12 @@ import (
 	"golang.org/x/crypto/ssh"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/sshca"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
@@ -106,6 +108,12 @@ func TestSSHIdentityConversion(t *testing.T) {
 		GitHubUserID:           "github",
 		GitHubUsername:         "ghuser",
 		AgentScope:             "/foo",
+		ImmutableLabelHash: joining.HashImmutableLabels(&joiningv1.ImmutableLabels{
+			Ssh: map[string]string{
+				"one": "1",
+				"two": "2",
+			},
+		}),
 	}
 
 	ignores := []string{

--- a/lib/inventory/controller.go
+++ b/lib/inventory/controller.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"iter"
 	"log/slog"
+	"maps"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -921,6 +922,10 @@ func (c *Controller) handleSSHServerHB(handle *upstreamHandle, sshServer *types.
 	// When an agent includes a scope in its heartbeat, we enforce that it matches what was found in the hello.
 	if sshServer.Scope != handle.Hello().GetScope() {
 		return trace.AccessDenied("incorrect ssh server scope (expected %q, got %q)", handle.Hello().GetScope(), sshServer.Scope)
+	}
+
+	if !maps.Equal(sshServer.GetImmutableLabels(), handle.Hello().GetImmutableLabels().GetSsh()) {
+		return trace.AccessDenied("immutable labels changed after registration")
 	}
 
 	// if a peer address is available in the context, use it to override zero-value addresses from

--- a/lib/inventory/controller_test.go
+++ b/lib/inventory/controller_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	presencev1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/presence/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/inventory/metadata"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
@@ -218,6 +219,7 @@ func TestSSHServerBasics(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, testSSHServerBasics)
 	synctest.Test(t, testSSHServerScope)
+	synctest.Test(t, testSSHServerImmutableLabels)
 }
 
 func testSSHServerScope(t *testing.T) {
@@ -313,6 +315,130 @@ func testSSHServerScope(t *testing.T) {
 				Addr: zeroAddr,
 			},
 			Scope: "/aa/bb/cc",
+		},
+	})
+	require.NoError(t, err)
+
+	// verify that the handler closes
+	awaitEvents(t, events,
+		expect(handlerClose),
+		deny(sshUpsertOk, sshKeepAliveOk),
+	)
+
+	// verify that closure propagates to server and client side interfaces
+	closeTimeout := time.After(time.Second * 10)
+	select {
+	case <-handle.Done():
+	case <-closeTimeout:
+		t.Fatal("timeout waiting for handle closure")
+	}
+	select {
+	case <-downstream.Done():
+	case <-closeTimeout:
+		t.Fatal("timeout waiting for handle closure")
+	}
+}
+
+func testSSHServerImmutableLabels(t *testing.T) {
+	const serverID = "test-server"
+	const zeroAddr = "0.0.0.0:123"
+	const peerAddr = "1.2.3.4:456"
+	const wantAddr = "1.2.3.4:123"
+
+	ctx := t.Context()
+
+	events := make(chan testEvent, 1024)
+
+	auth := &fakeAuth{
+		expectAddr: wantAddr,
+	}
+
+	rc := &resourceCounter{}
+	controller := NewController(
+		auth,
+		usagereporter.DiscardUsageReporter{},
+		withServerKeepAlive(time.Millisecond*200),
+		withTestEventsChannel(events),
+		WithOnConnect(rc.onConnect),
+		WithOnDisconnect(rc.onDisconnect),
+	)
+	defer controller.Close()
+
+	// set up fake in-memory control stream
+	upstream, downstream := client.InventoryControlStreamPipe(client.ICSPipePeerAddr(peerAddr))
+	t.Cleanup(func() {
+		controller.Close()
+		downstream.Close()
+		upstream.Close()
+	})
+
+	// launch goroutine to respond to ping requests
+	go func() {
+		for {
+			select {
+			case msg := <-downstream.Recv():
+				downstream.Send(ctx, &proto.UpstreamInventoryPong{
+					ID: msg.(*proto.DownstreamInventoryPing).GetID(),
+				})
+			case <-downstream.Done():
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	immutableLabels := &joiningv1.ImmutableLabels{
+		Ssh: map[string]string{
+			"foo": "bar",
+		},
+	}
+	controller.RegisterControlStream(upstream, &proto.UpstreamInventoryHello{
+		ServerID:        serverID,
+		Version:         teleport.Version,
+		Services:        types.SystemRoles{types.RoleNode}.StringSlice(),
+		ImmutableLabels: immutableLabels,
+	})
+
+	// verify that control stream handle is now accessible
+	handle, ok := controller.GetControlStream(serverID)
+	require.True(t, ok)
+
+	// verify that hb counter has been incremented
+	require.Equal(t, int64(1), controller.instanceHBVariableDuration.Count())
+
+	// send a fake ssh server heartbeat with a scope matching registration
+	err := downstream.Send(ctx, &proto.InventoryHeartbeat{
+		SSHServer: &types.ServerV2{
+			Metadata: types.Metadata{
+				Name: serverID,
+			},
+			Spec: types.ServerSpecV2{
+				Addr:            zeroAddr,
+				ImmutableLabels: immutableLabels.GetSsh(),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// verify that heartbeat creates both an upsert and a keepalive
+	awaitEvents(t, events,
+		expect(sshUpsertOk, sshKeepAliveOk),
+		deny(sshUpsertErr, sshKeepAliveErr, handlerClose),
+	)
+
+	// send an ssh server heartbeat with immutable labels different from registration
+	err = downstream.Send(ctx, &proto.InventoryHeartbeat{
+		SSHServer: &types.ServerV2{
+			Metadata: types.Metadata{
+				Name: serverID,
+			},
+			Spec: types.ServerSpecV2{
+				Addr: zeroAddr,
+				ImmutableLabels: map[string]string{
+					"foo": "baz",
+				},
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/lib/join/internal/messages/messages.go
+++ b/lib/join/internal/messages/messages.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/internal/diagnostic"
 	"github.com/gravitational/teleport/lib/join/joinutils"
@@ -547,6 +548,9 @@ type HostResult struct {
 	Certificates Certificates
 	// HostId is the unique ID assigned to the host.
 	HostID string
+	// ImmutableLabels are the immutable labels that have been assigned to
+	// the host.
+	ImmutableLabels *joiningv1.ImmutableLabels
 }
 
 // BotResult holds results for bot joining.

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	authjoin "github.com/gravitational/teleport/lib/auth/join"
 	proxyinsecureclient "github.com/gravitational/teleport/lib/client/proxy/insecure"
@@ -260,9 +261,9 @@ func joinWithClient(ctx context.Context, params JoinParams, client *joinv1.Clien
 	// Convert the result message into a JoinResult.
 	switch typedResult := resultMsg.(type) {
 	case *messages.HostResult:
-		return makeJoinResult(signer, typedResult.Certificates)
+		return makeJoinResult(signer, typedResult.Certificates, typedResult.ImmutableLabels)
 	case *messages.BotResult:
-		joinResult, err := makeJoinResult(signer, typedResult.Certificates)
+		joinResult, err := makeJoinResult(signer, typedResult.Certificates, nil)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -443,7 +444,7 @@ func makeClientParams(params JoinParams, publicKeys *messages.PublicKeys) messag
 	}
 }
 
-func makeJoinResult(signer crypto.Signer, certs messages.Certificates) (*JoinResult, error) {
+func makeJoinResult(signer crypto.Signer, certs messages.Certificates, immutableLabels *joiningv1.ImmutableLabels) (*JoinResult, error) {
 	// Callers expect proto.Certs with PEM-formatted TLS certs and
 	// authorized_keys formated SSH certs/keys.
 	sshCert, err := toAuthorizedKey(certs.SSHCert)
@@ -461,7 +462,8 @@ func makeJoinResult(signer crypto.Signer, certs messages.Certificates) (*JoinRes
 			SSH:        sshCert,
 			SSHCACerts: sshCAKeys, // SSHCACerts is a misnomer, SSH CAs are just public keys.
 		},
-		PrivateKey: signer,
+		PrivateKey:      signer,
+		ImmutableLabels: immutableLabels,
 	}, nil
 }
 

--- a/lib/join/joinv1/messages.go
+++ b/lib/join/joinv1/messages.go
@@ -529,15 +529,17 @@ func resultToMessage(resp *joinv1.Result) (messages.Response, error) {
 
 func hostResultToMessage(resp *joinv1.HostResult) *messages.HostResult {
 	return &messages.HostResult{
-		Certificates: certificatesToMessage(resp.GetCertificates()),
-		HostID:       resp.GetHostId(),
+		Certificates:    certificatesToMessage(resp.GetCertificates()),
+		HostID:          resp.GetHostId(),
+		ImmutableLabels: resp.GetImmutableLabels(),
 	}
 }
 
 func hostResultFromMessage(msg *messages.HostResult) *joinv1.HostResult {
 	return &joinv1.HostResult{
-		Certificates: certificatesFromMessage(&msg.Certificates),
-		HostId:       msg.HostID,
+		Certificates:    certificatesFromMessage(&msg.Certificates),
+		HostId:          msg.HostID,
+		ImmutableLabels: msg.ImmutableLabels,
 	}
 }
 

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -19,6 +19,7 @@ package provision
 import (
 	"time"
 
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -54,4 +55,7 @@ type Token interface {
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
+	// GetImmutableLabels returns labels that must be applied to resources
+	// provisioned with this token.
+	GetImmutableLabels() *joiningv1.ImmutableLabels
 }

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -523,8 +523,9 @@ func (s *Server) makeHostResult(
 		return nil, trace.Wrap(err)
 	}
 	return &messages.HostResult{
-		Certificates: *certificates,
-		HostID:       certsParams.HostID,
+		Certificates:    *certificates,
+		HostID:          certsParams.HostID,
+		ImmutableLabels: token.GetImmutableLabels(),
 	}, nil
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -1004,7 +1004,7 @@ func (f *Forwarder) getKubeAccessDetails(
 		}
 
 		// Get list of allowed kube user/groups based on kubernetes service labels.
-		labels := types.CombineLabels(c.GetStaticLabels(), types.LabelsToV2(c.GetDynamicLabels()))
+		labels := types.CombineLabels(nil, c.GetStaticLabels(), types.LabelsToV2(c.GetDynamicLabels()))
 
 		matchers := make([]services.RoleMatcher, 0, 2)
 		// Creates a matcher that matches the cluster labels against `kubernetes_labels`

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -17,6 +17,10 @@
 package joining
 
 import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"slices"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -106,6 +110,10 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 	roles, err := types.NewTeleportRoles(spec.Roles)
 	if err != nil {
 		return trace.Wrap(err, "validating scoped token roles")
+	}
+
+	if err := validateImmutableLabels(spec); err != nil {
+		return trace.Wrap(err)
 	}
 
 	for _, role := range roles {
@@ -290,4 +298,63 @@ func GetScopedToken(token provision.Token) (*joiningv1.ScopedToken, bool) {
 	}
 
 	return wrapper.scoped, true
+}
+
+// GetImmutableLabels returns labels that must be applied to resources
+// provisioned with this token.
+func (t *Token) GetImmutableLabels() *joiningv1.ImmutableLabels {
+	return t.scoped.GetSpec().GetImmutableLabels()
+}
+
+func validateImmutableLabels(spec *joiningv1.ScopedTokenSpec) error {
+	if spec == nil {
+		return nil
+	}
+
+	sshLabels := spec.GetImmutableLabels().GetSsh()
+	if len(sshLabels) > 0 {
+		if !slices.Contains(spec.GetRoles(), string(types.RoleNode)) {
+			return trace.BadParameter("immutable ssh labels are only supported for tokens that allow the node role")
+		}
+	}
+
+	for k := range sshLabels {
+		if !types.IsValidLabelKey(k) {
+			return trace.BadParameter("invalid immutable label key %q", k)
+		}
+	}
+
+	return nil
+}
+
+// HashImmutableLabels returns a deterministic hash of the given [*joiningv1.ImmutableLabels].
+func HashImmutableLabels(labels *joiningv1.ImmutableLabels) string {
+	if labels == nil {
+		return ""
+	}
+
+	hash := sha256.New()
+	if sshLabels := labels.GetSsh(); sshLabels != nil {
+		sorted := make([]struct{ key, value string }, 0, len(sshLabels))
+		for k, v := range sshLabels {
+			sorted = append(sorted, struct{ key, value string }{k, v})
+		}
+		slices.SortFunc(sorted, func(a, b struct{ key, value string }) int {
+			return cmp.Compare(a.key, b.key)
+		})
+
+		for _, v := range sorted {
+			_, _ = hash.Write([]byte(v.key))
+			_, _ = hash.Write([]byte(v.value))
+		}
+	}
+
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+// VerifyImmutableLabelsHash returns whether or not the given [*joiningv1.ImmutableLabels]
+// matches the given hash.
+func VerifyImmutableLabelsHash(labels *joiningv1.ImmutableLabels, hash string) bool {
+	newHash := HashImmutableLabels(labels)
+	return newHash == hash
 }

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -376,7 +377,7 @@ func TestValidateScopedToken(t *testing.T) {
 				},
 				Spec: &joiningv1.ScopedTokenSpec{
 					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
+					Roles:         []string{types.RoleNode.String()},
 					JoinMethod:    string(types.JoinMethodToken),
 					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
@@ -407,6 +408,61 @@ func TestValidateScopedToken(t *testing.T) {
 		// TODO (eriktate): add a test case for a missing secret with non-token join method once scoped
 		// tokens support other join methods
 		{
+			name: "invalid labels key",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+					ImmutableLabels: &joiningv1.ImmutableLabels{
+						Ssh: map[string]string{
+							"one":  "1",
+							"two;": "2",
+						},
+					},
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
+			},
+			expectedStrongErr: "invalid immutable label key \"two;\"",
+		},
+		{
+			name: "setting ssh labels for role other than node",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleBot.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodToken),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+					ImmutableLabels: &joiningv1.ImmutableLabels{
+						Ssh: map[string]string{
+							"one":   "1",
+							"two":   "2",
+							"three": "3",
+						},
+					},
+				},
+				Status: &joiningv1.ScopedTokenStatus{
+					Secret: "secret",
+				},
+			},
+			expectedStrongErr: "immutable ssh labels are only supported for tokens that allow the node role",
+		},
+		{
 			name: "valid scoped token",
 			token: &joiningv1.ScopedToken{
 				Kind:    types.KindScopedToken,
@@ -420,6 +476,13 @@ func TestValidateScopedToken(t *testing.T) {
 					AssignedScope: "/aa/bb",
 					JoinMethod:    string(types.JoinMethodToken),
 					UsageMode:     string(joining.TokenUsageModeUnlimited),
+					ImmutableLabels: &joiningv1.ImmutableLabels{
+						Ssh: map[string]string{
+							"one":   "1",
+							"two":   "2",
+							"three": "3",
+						},
+					},
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
@@ -445,4 +508,26 @@ func TestValidateScopedToken(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestImmutableLabelHashing(t *testing.T) {
+	labels := &joiningv1.ImmutableLabels{
+		Ssh: map[string]string{
+			"one":   "1",
+			"two":   "2",
+			"hello": "world",
+		},
+	}
+
+	// assert that the same labels match with their hash
+	initialHash := joining.HashImmutableLabels(labels)
+	require.True(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
+
+	// assert that changing a label value fails the hash check
+	labels.Ssh["hello"] = "other"
+	require.False(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
+
+	// assert that adding a label fails the hash check
+	labels.Ssh["three"] = "3"
+	require.False(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -239,6 +239,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		} else {
 			identity = newIdentity
 		}
+		process.SetImmutableLabels(identity.ImmutableLabels)
 	}
 
 	rotation := processState.Spec.Rotation
@@ -385,6 +386,7 @@ func (process *TeleportProcess) healInstanceIdentity(currentIdentity *state.Iden
 		if err != nil {
 			return nil, trace.Wrap(err, "failed to parse new identity")
 		}
+		newIdentity.ImmutableLabels = rejoinResult.ImmutableLabels
 	}
 
 	newSystemRoles := set.New(newIdentity.SystemRoles...)
@@ -454,7 +456,7 @@ type localReRegister struct {
 
 // GenerateHostCerts allows for generating host certs without providing a scope.
 func (l localReRegister) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequest) (*proto.Certs, error) {
-	return l.Server.GenerateHostCerts(ctx, req, "")
+	return l.Server.GenerateHostCerts(ctx, auth.HostCertsParams{Req: req})
 }
 
 // reRegister receives new identity credentials for proxy, node and auth.
@@ -558,6 +560,8 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 		if err := process.storage.PersistAssignedHostID(process.GracefulExitContext(), process.Config, identity.ID.HostID()); err != nil {
 			return nil, trace.Wrap(err, "persisting host ID to storage")
 		}
+
+		process.SetImmutableLabels(identity.ImmutableLabels)
 	}
 	process.logger.InfoContext(process.ExitContext(), "The process successfully wrote the credentials and state to the disk.", "identity", role)
 	return connector, nil
@@ -565,7 +569,12 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 
 func (process *TeleportProcess) firstTimeConnectIdentity(role types.SystemRole) (*state.Identity, error) {
 	if localAuth := process.getLocalAuth(); localAuth != nil {
-		return process.firstTimeConnectIdentityLocal(role, localAuth)
+		identity, err := process.firstTimeConnectIdentityLocal(role, localAuth)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return identity, nil
 	}
 	return process.firstTimeConnectIdentityRemote(role)
 }
@@ -623,7 +632,11 @@ func (process *TeleportProcess) firstTimeConnectIdentityRemote(role types.System
 		//
 		// TODO(nklaassen): DELETE IN 20
 		process.Config.Logger.InfoContext(process.GracefulExitContext(), "Instance identity does not include required system role, must re-join with a provision token", "role", role)
-		return process.legacyJoinWithHostUUID(role, instanceIdentity.ID.HostID())
+		identity, err := process.legacyJoinWithHostUUID(role, instanceIdentity.ID.HostID())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return identity, nil
 	}
 	// The instance connector does have the role requested, we can reregister
 	// without going through the join process.
@@ -657,20 +670,24 @@ func (process *TeleportProcess) instanceJoin() (*state.Identity, error) {
 		return nil, trace.Wrap(err)
 	}
 	process.logger.InfoContext(process.ExitContext(), "Joining the cluster with a secure token.")
-	joinResult, err := joinclient.Join(process.GracefulExitContext(), *joinParams)
+	result, err := joinclient.Join(process.GracefulExitContext(), *joinParams)
 	if err != nil {
 		if utils.IsUntrustedCertErr(err) {
 			return nil, trace.WrapWithMessage(err, utils.SelfSignedCertsMsg)
 		}
 		return nil, trace.Wrap(err)
 	}
-	privateKeyPEM, err := keys.MarshalPrivateKey(joinResult.PrivateKey)
+	privateKeyPEM, err := keys.MarshalPrivateKey(result.PrivateKey)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	identity, err := state.ReadIdentityFromKeyPair(privateKeyPEM, joinResult.Certs)
-	return identity, trace.Wrap(err)
+	identity, err := state.ReadIdentityFromKeyPair(privateKeyPEM, result.Certs)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	identity.ImmutableLabels = result.ImmutableLabels
+	return identity, nil
 }
 
 func (process *TeleportProcess) legacyJoinWithHostUUID(role types.SystemRole, hostUUID string) (*state.Identity, error) {
@@ -700,6 +717,10 @@ func (process *TeleportProcess) legacyJoinWithHostUUID(role types.SystemRole, ho
 		return nil, trace.Wrap(err)
 	}
 	identity, err := state.ReadIdentityFromKeyPair(privateKeyPEM, joinResult.Certs)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	identity.ImmutableLabels = joinResult.ImmutableLabels
 	return identity, trace.Wrap(err)
 }
 

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -62,6 +62,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
+	libproto "google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/gravitational/teleport"
@@ -73,6 +74,7 @@ import (
 	accessgraphsecretsv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/accessgraph/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	transportpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/transport/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
@@ -737,7 +739,8 @@ type TeleportProcess struct {
 	// need to add and remove metrics seevral times (e.g. hosted plugin metrics).
 	*metrics.SyncGatherers
 
-	tsrv reversetunnelclient.Server
+	tsrv            reversetunnelclient.Server
+	immutableLabels *joiningv1.ImmutableLabels
 }
 
 // processIndex is an internal process index
@@ -833,6 +836,23 @@ func (process *TeleportProcess) getInstanceRoles() []types.SystemRole {
 		out = append(out, role)
 	}
 	return out
+}
+
+// SetImmutableLabels sets the [*joiningv1.ImmutableLabels] for the process.
+func (process *TeleportProcess) SetImmutableLabels(labels *joiningv1.ImmutableLabels) {
+	process.Lock()
+	defer process.Unlock()
+
+	process.immutableLabels = libproto.CloneOf(labels)
+}
+
+// getImmutableLabels returns the [*joiningv1.ImmutableLabels] assigned to
+// the process.
+func (process *TeleportProcess) getImmutableLabels() *joiningv1.ImmutableLabels {
+	process.Lock()
+	defer process.Unlock()
+
+	return libproto.CloneOf(process.immutableLabels)
 }
 
 // getInstanceRoleEventMapping returns the same instance roles as getInstanceRoles, but as a mapping
@@ -1371,6 +1391,7 @@ func NewTeleport(cfg *servicecfg.Config) (_ *TeleportProcess, err error) {
 			Services:         services,
 			Hostname:         cfg.Hostname,
 			ExternalUpgrader: externalUpgrader,
+			ImmutableLabels:  process.getImmutableLabels(),
 		}
 
 		if upgraderVersion != nil {
@@ -3536,6 +3557,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetChildLogConfig(cfg),
 			regular.SetUUID(conn.HostUUID()),
 			regular.SetScope(conn.Scope()),
+			regular.SetImmutableLabels(process.getImmutableLabels().GetSsh()),
 			regular.SetLimiter(limiter),
 			regular.SetEmitter(&events.StreamerAndEmitter{Emitter: asyncEmitter, Streamer: conn.Client}),
 			regular.SetLabels(cfg.SSH.Labels, cfg.SSH.CmdLabels, process.cloudLabels),

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -109,6 +109,7 @@ func compareServers(a, b types.Server) int {
 	if a.GetUseTunnel() != b.GetUseTunnel() {
 		return Different
 	}
+
 	if !maps.Equal(a.GetStaticLabels(), b.GetStaticLabels()) {
 		return Different
 	}
@@ -120,6 +121,11 @@ func compareServers(a, b types.Server) int {
 	}) {
 		return Different
 	}
+
+	if !maps.Equal(a.GetImmutableLabels(), b.GetImmutableLabels()) {
+		return Different
+	}
+
 	if a.GetTeleportVersion() != b.GetTeleportVersion() {
 		return Different
 	}

--- a/lib/services/servers_test.go
+++ b/lib/services/servers_test.go
@@ -45,9 +45,10 @@ func TestServersCompare(t *testing.T) {
 				Labels:    map[string]string{"a": "b"},
 			},
 			Spec: types.ServerSpecV2{
-				Addr:      "localhost:3022",
-				CmdLabels: map[string]types.CommandLabelV2{"a": {Period: types.Duration(time.Minute), Command: []string{"ls", "-l"}}},
-				Version:   "4.0.0",
+				Addr:            "localhost:3022",
+				CmdLabels:       map[string]types.CommandLabelV2{"a": {Period: types.Duration(time.Minute), Command: []string{"ls", "-l"}}},
+				ImmutableLabels: map[string]string{"c": "d"},
+				Version:         "4.0.0",
 			},
 		}
 		node.SetExpiry(time.Date(2018, 1, 2, 3, 4, 5, 6, time.UTC))
@@ -67,6 +68,11 @@ func TestServersCompare(t *testing.T) {
 		// Command labels are different
 		node2 = *node
 		node2.Spec.CmdLabels = map[string]types.CommandLabelV2{"a": {Period: types.Duration(time.Minute), Command: []string{"ls", "-lR"}}}
+		require.Equal(t, Different, CompareServers(node, &node2))
+
+		// Immutable labels are different
+		node2 = *node
+		node2.Spec.ImmutableLabels = map[string]string{"c": "f"}
 		require.Equal(t, Different, CompareServers(node, &node2))
 
 		// Address has changed

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -260,6 +260,9 @@ type Server struct {
 
 	// childLogConfig is the log config for child processes.
 	childLogConfig *srv.ChildLogConfig
+
+	// immutableLabels are the immutable labels assigned to the server's host certificate
+	immutableLabels map[string]string
 }
 
 // EventMetadata returns metadata about the server.
@@ -803,6 +806,14 @@ func SetScope(scope string) ServerOption {
 	}
 }
 
+// SetImmutableLabels sets the server's immutable labels.
+func SetImmutableLabels(labels map[string]string) ServerOption {
+	return func(s *Server) error {
+		s.immutableLabels = labels
+		return nil
+	}
+}
+
 // SetChildLogConfig sets the config that will be used to handle logs
 // from child processes.
 func SetChildLogConfig(cfg *servicecfg.Config) ServerOption {
@@ -1183,14 +1194,15 @@ func (s *Server) getBasicInfo() *types.ServerV2 {
 			Labels:    s.getStaticLabels(),
 		},
 		Spec: types.ServerSpecV2{
-			CmdLabels:  s.getDynamicLabels(),
-			Addr:       addr,
-			Hostname:   s.hostname,
-			UseTunnel:  s.useTunnel,
-			Version:    teleport.Version,
-			ProxyIDs:   s.connectedProxyGetter.GetProxyIDs(),
-			RelayGroup: relayGroup,
-			RelayIds:   relayIDs,
+			CmdLabels:       s.getDynamicLabels(),
+			Addr:            addr,
+			Hostname:        s.hostname,
+			UseTunnel:       s.useTunnel,
+			Version:         teleport.Version,
+			ProxyIDs:        s.connectedProxyGetter.GetProxyIDs(),
+			RelayGroup:      relayGroup,
+			RelayIds:        relayIDs,
+			ImmutableLabels: s.immutableLabels,
 		},
 	}
 	srv.SetPublicAddrs(utils.NetAddrsToStrings(s.publicAddrs))

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -2391,15 +2391,17 @@ func newRawNode(t *testing.T, authSrv *auth.Server) *rawNode {
 
 	// Create host key and certificate for node.
 	certs, err := authSrv.GenerateHostCerts(t.Context(),
-		&proto.HostCertsRequest{
-			HostID:               "raw-node",
-			NodeName:             "raw-node",
-			Role:                 types.RoleNode,
-			AdditionalPrincipals: []string{hostname},
-			DNSNames:             []string{hostname},
-			PublicSSHKey:         pub,
-			PublicTLSKey:         tlsPub,
-		}, "")
+		auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:               "raw-node",
+				NodeName:             "raw-node",
+				Role:                 types.RoleNode,
+				AdditionalPrincipals: []string{hostname},
+				DNSNames:             []string{hostname},
+				PublicSSHKey:         pub,
+				PublicTLSKey:         tlsPub,
+			},
+		})
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -3273,13 +3275,15 @@ func newSigner(t testing.TB, ctx context.Context, testServer *authtest.Server) s
 	require.NoError(t, err)
 
 	certs, err := testServer.Auth().GenerateHostCerts(ctx,
-		&proto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     testServer.ClusterName(),
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		}, "")
+		auth.HostCertsParams{
+			Req: &proto.HostCertsRequest{
+				HostID:       hostID,
+				NodeName:     testServer.ClusterName(),
+				Role:         types.RoleNode,
+				PublicSSHKey: pub,
+				PublicTLSKey: tlsPub,
+			},
+		})
 	require.NoError(t, err)
 
 	// set up user CA and set up a user that has access to the server

--- a/lib/sshca/identity.go
+++ b/lib/sshca/identity.go
@@ -151,6 +151,9 @@ type Identity struct {
 	GitHubUsername string
 	// AgentScope is the scope this identity belongs to.
 	AgentScope string
+	// ImmutableLabelHash is the immutable label hash used to verify
+	// immutable labels against the identity.
+	ImmutableLabelHash string
 }
 
 // Encode encodes the identity into an ssh certificate. Note that the returned certificate is incomplete
@@ -196,6 +199,10 @@ func (i *Identity) Encode(certFormat string) (*ssh.Certificate, error) {
 
 	if i.AgentScope != "" {
 		cert.Permissions.Extensions[teleport.CertExtensionAgentScope] = i.AgentScope
+	}
+
+	if i.ImmutableLabelHash != "" {
+		cert.Permissions.Extensions[teleport.CertExtensionImmutableLabelHash] = i.ImmutableLabelHash
 	}
 
 	// --- user extensions ---
@@ -550,6 +557,8 @@ func DecodeIdentity(cert *ssh.Certificate) (*Identity, error) {
 		}
 		ident.ActiveRequests = reqs.AccessRequests
 	}
+
+	ident.ImmutableLabelHash = takeValue(teleport.CertExtensionImmutableLabelHash)
 
 	// aggregate all remaining extensions into the CertificateExtensions field
 	for name, value := range extensions {

--- a/lib/sshca/identity_test.go
+++ b/lib/sshca/identity_test.go
@@ -29,10 +29,12 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 
 	"github.com/gravitational/teleport/api/constants"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
 	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/utils/testutils"
 )
 
@@ -101,6 +103,12 @@ func TestIdentityConversion(t *testing.T) {
 		GitHubUserID:           "github",
 		GitHubUsername:         "ghuser",
 		AgentScope:             "/foo",
+		ImmutableLabelHash: joining.HashImmutableLabels(&joiningv1.ImmutableLabels{
+			Ssh: map[string]string{
+				"one": "1",
+				"two": "2",
+			},
+		}),
 	}
 
 	ignores := []string{

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -329,13 +329,15 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 
 	// start node
 	certs, err := s.server.Auth().GenerateHostCerts(s.ctx,
-		&authproto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     nodeID,
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		}, "")
+		auth.HostCertsParams{
+			Req: &authproto.HostCertsRequest{
+				HostID:       hostID,
+				NodeName:     nodeID,
+				Role:         types.RoleNode,
+				PublicSSHKey: pub,
+				PublicTLSKey: tlsPub,
+			},
+		})
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -651,13 +653,15 @@ func (s *WebSuite) addNode(t *testing.T, uuid string, hostname string, address s
 
 	// start node
 	certs, err := s.server.Auth().GenerateHostCerts(s.ctx,
-		&authproto.HostCertsRequest{
-			HostID:       uuid,
-			NodeName:     hostname,
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		}, "")
+		auth.HostCertsParams{
+			Req: &authproto.HostCertsRequest{
+				HostID:       uuid,
+				NodeName:     hostname,
+				Role:         types.RoleNode,
+				PublicSSHKey: pub,
+				PublicTLSKey: tlsPub,
+			},
+		})
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)
@@ -8457,13 +8461,15 @@ func newWebPack(t *testing.T, numProxies int, opts ...webPackOptions) *webPack {
 	const nodeID = "node"
 	// start auth server
 	certs, err := server.Auth().GenerateHostCerts(ctx,
-		&authproto.HostCertsRequest{
-			HostID:       hostID,
-			NodeName:     nodeID,
-			Role:         types.RoleNode,
-			PublicSSHKey: pub,
-			PublicTLSKey: tlsPub,
-		}, "")
+		auth.HostCertsParams{
+			Req: &authproto.HostCertsRequest{
+				HostID:       hostID,
+				NodeName:     nodeID,
+				Role:         types.RoleNode,
+				PublicSSHKey: pub,
+				PublicTLSKey: tlsPub,
+			},
+		})
 	require.NoError(t, err)
 
 	signer, err := sshutils.NewSigner(priv, certs.SSH)


### PR DESCRIPTION
This PR adds the ability for scoped tokens to assign immutable labels to provisioned resources. For now this is limited to SSH nodes.

It works by configuring a set of per-role labels on the scoped token resource. The deterministic hash of these labels is included in host certs and the labels themselves are included in the join result to be saved locally. The full set of labels is included with the hello message when registering the inventory control stream and their hash is verified against the hash found in the identity. This is ultimately what makes them "immutable" for a given identity. Heartbeat validation after the fact only ensures that the labels reported by the node are the same as the ones initially provided in the hello message, which means only the subset of relevant labels (e.g. SSH labels) need to be reported

# Manual Testing
- [x] Provision a scoped token with immutable labels `tctl scoped tokens add --type node --scope /local --assign-scope /local --ssh-labels my_label=immutable`
- [x] Provision a scoped SSH node using the scoped token
- [x] Confirm the immutable labels appear for the node in both `tsh ls` and the web UI
- [x] Confirm immutable label hash appears in host certs