### PR TITLE
Add support for tbot Managed Updates on Kubernetes

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -605,3 +605,188 @@ See [the Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-po
 for more details.
 
 By default, this is unset.
+
+## `updater`
+
+`updater` controls whether the Kube Agent Updater should be deployed alongside
+tbot. The updater fetches the target Teleport version, validates the
+image signature, and updates the tbot deployment.
+
+The updater can fetch the update information using two protocols:
+- the webapi update protocol (in this case the Teleport Proxy Service is the one driving the version rollout)
+- the version server protocol (this is an HTTP server serving static files specifying the version and if the update is critical).
+
+The webapi protocol takes precedence over the version server one if the Teleport Proxy Service supports it.
+The version server protocol failover can be disabled by unsetting `updater.versionServer`.
+The webapi protocol can be disabled by setting `updater.proxyAddr` to `""`.
+For backward compatibility reasons, the webapi protocol is not enabled if a custom `updater.versionServer` is set.
+
+All Kubernetes-specific fields such as `tolerations`, `affinity`, `nodeSelector`,
+... default to the tbot values. However, they can be overridden from the
+`updater` object. For example:
+
+```yaml
+# the tbot pod requests 1cpu and 2 GiB of memory. It also has a memory limit.
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    memory: "2Gi"
+
+# the updater pod requests 0.5 cpu and 512MiB of memory. The memory limit has also been unset.
+updater:
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: "512Mi"
+    limits: ~
+```
+
+Other updater-specific values that can be defined in `updater` are described
+below.
+
+### `updater.enabled`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`updater.enabled` Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
+You can enable this when:
+
+- using Teleport Cloud and your tenant is enrolled into automatic updates.
+  (You can check this through the web UI, choose `Add Kubernetes` and
+  `Enroll New Resource of type Kubernetes`, and check if the value is turned
+  on.)
+- using self-hosted Teleport and you maintain your own version server.
+
+You must not enable this when:
+
+- you are a Teleport Cloud customer not enrolled in automatic updates.
+- you are a self-hosted Teleport user and have not set up your Teleport cluster to
+  support automatic updates.
+
+### `updater.versionServer`
+
+| Type | Default |
+|------|---------|
+| `string` | `"https://{{ .Values.teleportProxyAddress }}/v1/webapi/automaticupgrades/channel"` |
+
+`updater.versionServer` is the URL of the version server the agent
+fetches the target version from. The complete version endpoint is built by
+concatenating [`versionServer`](#updaterversionserver) and [`releaseChannel`
+](#updaterreleasechannel).
+This field supports gotemplate.
+
+Setting this field makes the updater fetch the version using the version server protocol.
+Setting this field to a custom value disables the webapi update protocol to ensure backward compatibility.
+
+### `updater.releaseChannel`
+
+| Type | Default |
+|------|---------|
+| `string` | `"stable/cloud"` |
+
+`updater.releaseChannel` is the release channel the updater
+subscribes to.
+
+The complete version endpoint is built by concatenating
+[`versionServer`](#updaterversionserver) and [`releaseChannel`](#updaterreleasechannel).
+You must not change the default value if you are a Teleport Cloud user unless
+instructed by Teleport support.
+
+This value is used when the updater is fetching the version using the version server protocol.
+It is also used as a failover when fetching the version using the webapi protocol if `updater.group` is unset.
+
+### `updater.group`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.group` is the update group used when fetching the version using the webapi protocol.
+When unset, the group defaults to `default`.
+
+### `updater.image`
+
+| Type | Default |
+|------|---------|
+| `string` | `"public.ecr.aws/gravitational/teleport-kube-agent-updater"` |
+
+`updater.image` sets the container image used for Teleport updater
+pods run when `updater.enabled` is true.
+
+You can override this to use your own Teleport Kube Agent Updater image rather
+than a Teleport-published image.
+
+### `updater.serviceAccount`
+
+#### `updater.serviceAccount.name`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.serviceAccount.name` is the updater Kubernetes Service
+Account name. When unset, it defaults to `<tbot sa name>-updater`
+
+### `updater.pullCredentials`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.pullCredentials` configures how the updater attempts to
+get the image pull credentials used to validate the image signature.
+
+This is not required when pulling images from official public Teleport
+registries (chart's default).
+
+Supported values are `amazon`, `google`, `docker` and `none`.
+
+### `updater.extraArgs`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraArgs` contains additional arguments to pass to the updater
+binary.
+
+### `updater.extraVolumes`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumes` contains extra volumes to mount into the Updater pods.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumes:
+  - name: myvolume
+    secret:
+      secretName: testSecret
+```
+
+### `updater.extraVolumeMounts`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`updater.extraVolumeMounts` contains extra volumes mounts for the updater.
+See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+for more details.
+
+For example:
+```yaml
+updater:
+  extraVolumesMounts:
+  - name: myvolume
+    mountPath: /path/on/host
+```

--- a/examples/chart/tbot/.lint/affinity.yaml
+++ b/examples/chart/tbot/.lint/affinity.yaml
@@ -1,0 +1,20 @@
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: gravitational.io/dedicated
+          operator: In
+          values:
+          - teleport
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - teleport
+        topologyKey: kubernetes.io/hostname
+      weight: 1

--- a/examples/chart/tbot/.lint/annotations.yaml
+++ b/examples/chart/tbot/.lint/annotations.yaml
@@ -1,0 +1,16 @@
+annotations:
+  config:
+    kubernetes.io/config: "test-annotation"
+    kubernetes.io/config-different: 2
+  deployment:
+    kubernetes.io/deployment: "test-annotation"
+    kubernetes.io/deployment-different: 3
+  pod:
+    kubernetes.io/pod: "test-annotation"
+    kubernetes.io/pod-different: 4
+  secret:
+    kubernetes.io/secret: "test-annotation"
+    kubernetes.io/secret-different: 6
+  serviceAccount:
+    kubernetes.io/serviceaccount: "test-annotation"
+    kubernetes.io/serviceaccount-different: 5

--- a/examples/chart/tbot/.lint/extra-env.yaml
+++ b/examples/chart/tbot/.lint/extra-env.yaml
@@ -1,0 +1,6 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster
+extraEnv:
+- name: HTTPS_PROXY
+  value: "http://username:password@my.proxy.host:3128"

--- a/examples/chart/tbot/.lint/image-pull-policy.yaml
+++ b/examples/chart/tbot/.lint/image-pull-policy.yaml
@@ -1,0 +1,1 @@
+imagePullPolicy: Always

--- a/examples/chart/tbot/.lint/imagepullsecrets.yaml
+++ b/examples/chart/tbot/.lint/imagepullsecrets.yaml
@@ -1,0 +1,3 @@
+image: public.ecr.aws/gravitational/teleport
+imagePullSecrets:
+- name: myRegistryKeySecretName

--- a/examples/chart/tbot/.lint/node-selector.yaml
+++ b/examples/chart/tbot/.lint/node-selector.yaml
@@ -1,0 +1,2 @@
+nodeSelector:
+  gravitational.io/k8s-role: node

--- a/examples/chart/tbot/.lint/resources.yaml
+++ b/examples/chart/tbot/.lint/resources.yaml
@@ -1,0 +1,9 @@
+# These are just sample values to test the chart.
+# They are not intended to be guidelines or suggestions for running teleport.
+resources:
+  limits:
+    cpu: 2
+    memory: 4Gi
+  requests:
+    cpu: 1
+    memory: 2Gi

--- a/examples/chart/tbot/.lint/service-account-name.yaml
+++ b/examples/chart/tbot/.lint/service-account-name.yaml
@@ -1,0 +1,2 @@
+serviceAccount:
+  name: tbot-sa

--- a/examples/chart/tbot/.lint/tolerations.yaml
+++ b/examples/chart/tbot/.lint/tolerations.yaml
@@ -1,0 +1,9 @@
+tolerations:
+- key: "dedicated"
+  operator: "Equal"
+  value: "teleport"
+  effect: "NoExecute"
+- key: "dedicated"
+  operator: "Equal"
+  value: "teleport"
+  effect: "NoSchedule"

--- a/examples/chart/tbot/.lint/updater-secret-docker.yaml
+++ b/examples/chart/tbot/.lint/updater-secret-docker.yaml
@@ -1,0 +1,21 @@
+updater:
+  enabled: true
+  versionServer: https://my-custom-version-server/v1
+  releaseChannel: custom/preview
+  pullCredentials: docker
+  extraEnv:
+    - name: DOCKER_CONFIG
+      value: /mnt/docker/
+  extraVolumes:
+    - name: docker-config
+      projected:
+        sources:
+          - secret:
+              name: my-pull-secret
+              items:
+                - key: .dockerconfigjson
+                  path: config.json
+  extraVolumeMounts:
+    - name: docker-config
+      mountPath: "/mnt/docker"
+      readOnly: true

--- a/examples/chart/tbot/.lint/updater.yaml
+++ b/examples/chart/tbot/.lint/updater.yaml
@@ -1,0 +1,5 @@
+teleportProxyAddress: proxy.example.com:3080
+updater:
+  enabled: true
+  versionServer: https://my-custom-version-server/v1
+  releaseChannel: custom/preview

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -6,3 +6,7 @@ description: This chart deploys an instance of the Machine ID agent, TBot, into 
 icon: https://goteleport.com/static/teleport-symbol-bimi.svg
 keywords:
   - Teleport
+
+dependencies:
+  - name: teleport-kube-updater
+    version: *version

--- a/examples/chart/tbot/charts/teleport-kube-updater
+++ b/examples/chart/tbot/charts/teleport-kube-updater
@@ -1,0 +1,1 @@
+../../teleport-kube-updater

--- a/examples/chart/tbot/templates/updater.yaml
+++ b/examples/chart/tbot/templates/updater.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater }}
+{{/* Pass additional value from outside of updater. */}}
+{{- $_ := set $updater "releaseName" .Release.Name }}
+{{- $_ = set $updater "releaseNamespace" .Release.Namespace }}
+
+{{/* Unset updater-specific values so we don't accidentally pick up tbot-specific things. */}}
+{{- if not .Values.updater.extraArgs }}
+  {{- $_ = unset $updater "extraArgs" }}
+{{- end }}
+{{- if not .Values.updater.extraVolumes }}
+  {{- $_ = unset $updater "extraVolumes" }}
+{{- end }}
+{{- if not .Values.updater.extraVolumeMounts }}
+  {{- $_ = unset $updater "extraVolumeMounts" }}
+{{- end }}
+{{/* Compute dynamic values (depending on other teleport-kube agent values). */}}
+{{- $_ = set $updater.serviceAccount "name" (coalesce .Values.updater.serviceAccount.name (include "tbot.serviceAccountName" . | printf "%s-updater")) }}
+{{/* This is a backward compatibility trick to detect and honour MUv1 deployments that might have been replying on a custom version server. */}}
+{{- $_ = set $updater "versionServerOverride" (and $updater.versionServer (ne $updater.versionServer "https://{{ .Values.teleportProxyAddress }}/v1/webapi/automaticupgrades/channel")) }}
+{{/* Template the version server on the parent chart side as this is depends on its values. */}}
+{{- $_ = set $updater "versionServer" (tpl $updater.versionServer .) }}
+{{- $_ = set $updater "version" (include "tbot.version" .)}}
+{{- $_ = set $updater "proxyAddr" .Values.teleportProxyAddress }}
+{{- $_ = set $updater "baseImage" .Values.image }}
+{{ include "teleport-kube-updater.all" $updater }}
+{{- end -}}

--- a/examples/chart/tbot/templates/updater.yaml
+++ b/examples/chart/tbot/templates/updater.yaml
@@ -23,5 +23,6 @@
 {{- $_ = set $updater "version" (include "tbot.version" .)}}
 {{- $_ = set $updater "proxyAddr" .Values.teleportProxyAddress }}
 {{- $_ = set $updater "baseImage" .Values.image }}
+{{- $_ = set $updater "container" "tbot"}}
 {{ include "teleport-kube-updater.all" $updater }}
 {{- end -}}

--- a/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,6 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/tbot-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      env: null
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -64,7 +63,6 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/tbot-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      env: null
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -1,0 +1,103 @@
+sets the affinity:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gravitational.io/dedicated
+              operator: In
+              values:
+              - teleport
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - teleport
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/tbot-distroless
+      - --version-server=https://my-custom-version-server/v1
+      - --version-channel=custom/preview
+      env: null
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+    serviceAccountName: RELEASE-NAME-tbot-updater
+sets the tolerations:
+  1: |
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/tbot-distroless
+      - --version-server=https://my-custom-version-server/v1
+      - --version-channel=custom/preview
+      env: null
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+    serviceAccountName: RELEASE-NAME-tbot-updater
+    tolerations:
+    - effect: NoExecute
+      key: dedicated
+      operator: Equal
+      value: teleport
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
+      value: teleport

--- a/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -25,6 +25,7 @@ sets the affinity:
       - --agent-name=RELEASE-NAME
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/tbot-distroless
+      - --container=tbot
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
@@ -61,6 +62,7 @@ sets the tolerations:
       - --agent-name=RELEASE-NAME
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/tbot-distroless
+      - --container=tbot
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev

--- a/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -4,100 +4,100 @@ sets the affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
           nodeSelectorTerms:
-          - matchExpressions:
-            - key: gravitational.io/dedicated
-              operator: In
-              values:
-              - teleport
+            - matchExpressions:
+                - key: gravitational.io/dedicated
+                  operator: In
+                  values:
+                    - teleport
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
-        - podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - teleport
-            topologyKey: kubernetes.io/hostname
-          weight: 1
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - teleport
+              topologyKey: kubernetes.io/hostname
+            weight: 1
     containers:
-    - args:
-      - --agent-name=RELEASE-NAME
-      - --agent-namespace=NAMESPACE
-      - --base-image=public.ecr.aws/gravitational/tbot-distroless
-      - --container=tbot
-      - --version-server=https://my-custom-version-server/v1
-      - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /healthz
-          port: healthz
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 5
-      name: kube-agent-updater
-      ports:
-      - containerPort: 8080
-        name: metrics
-        protocol: TCP
-      - containerPort: 8081
-        name: healthz
-        protocol: TCP
-      readinessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /readyz
-          port: healthz
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 5
+      - args:
+          - --agent-name=RELEASE-NAME
+          - --agent-namespace=NAMESPACE
+          - --base-image=public.ecr.aws/gravitational/tbot-distroless
+          - --container=tbot
+          - --version-server=https://my-custom-version-server/v1
+          - --version-channel=custom/preview
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+        name: kube-agent-updater
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
+          - containerPort: 8081
+            name: healthz
+            protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
     serviceAccountName: RELEASE-NAME-tbot-updater
 sets the tolerations:
   1: |
     containers:
-    - args:
-      - --agent-name=RELEASE-NAME
-      - --agent-namespace=NAMESPACE
-      - --base-image=public.ecr.aws/gravitational/tbot-distroless
-      - --container=tbot
-      - --version-server=https://my-custom-version-server/v1
-      - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-dev
-      imagePullPolicy: IfNotPresent
-      livenessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /healthz
-          port: healthz
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 5
-      name: kube-agent-updater
-      ports:
-      - containerPort: 8080
-        name: metrics
-        protocol: TCP
-      - containerPort: 8081
-        name: healthz
-        protocol: TCP
-      readinessProbe:
-        failureThreshold: 6
-        httpGet:
-          path: /readyz
-          port: healthz
-        initialDelaySeconds: 5
-        periodSeconds: 5
-        timeoutSeconds: 5
+      - args:
+          - --agent-name=RELEASE-NAME
+          - --agent-namespace=NAMESPACE
+          - --base-image=public.ecr.aws/gravitational/tbot-distroless
+          - --container=tbot
+          - --version-server=https://my-custom-version-server/v1
+          - --version-channel=custom/preview
+        image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
+        name: kube-agent-updater
+        ports:
+          - containerPort: 8080
+            name: metrics
+            protocol: TCP
+          - containerPort: 8081
+            name: healthz
+            protocol: TCP
+        readinessProbe:
+          failureThreshold: 6
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 5
     serviceAccountName: RELEASE-NAME-tbot-updater
     tolerations:
-    - effect: NoExecute
-      key: dedicated
-      operator: Equal
-      value: teleport
-    - effect: NoSchedule
-      key: dedicated
-      operator: Equal
-      value: teleport
+      - effect: NoExecute
+        key: dedicated
+        operator: Equal
+        value: teleport
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: teleport

--- a/examples/chart/tbot/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_role_test.yaml.snap
@@ -1,0 +1,93 @@
+sets the correct role rules:
+  1: |
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - secrets
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-shared-state
+      resources:
+      - secrets
+      verbs:
+      - get
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
+    - apiGroups:
+      - ""
+      resources:
+      - configmaps
+      verbs:
+      - create
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-updater
+      resources:
+      - configmaps
+      verbs:
+      - get
+      - update
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      - deployments/status
+      - statefulsets/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - apps
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - update
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - leases
+      verbs:
+      - get
+      - update

--- a/examples/chart/tbot/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/updater_role_test.yaml.snap
@@ -1,93 +1,93 @@
 sets the correct role rules:
   1: |
     - apiGroups:
-      - ""
+        - ""
       resources:
-      - pods
+        - pods
       verbs:
-      - get
-      - watch
-      - list
-      - delete
+        - get
+        - watch
+        - list
+        - delete
     - apiGroups:
-      - ""
+        - ""
       resources:
-      - pods/status
+        - pods/status
       verbs:
-      - get
-      - watch
-      - list
+        - get
+        - watch
+        - list
     - apiGroups:
-      - ""
+        - ""
       resources:
-      - secrets
+        - secrets
       verbs:
-      - watch
-      - list
+        - watch
+        - list
     - apiGroups:
-      - ""
+        - ""
       resourceNames:
-      - RELEASE-NAME-shared-state
+        - RELEASE-NAME-shared-state
       resources:
-      - secrets
+        - secrets
       verbs:
-      - get
+        - get
     - apiGroups:
-      - ""
+        - ""
       resources:
-      - events
+        - events
       verbs:
-      - create
-      - patch
+        - create
+        - patch
     - apiGroups:
-      - ""
+        - ""
       resources:
-      - configmaps
+        - configmaps
       verbs:
-      - create
-      - watch
-      - list
+        - create
+        - watch
+        - list
     - apiGroups:
-      - ""
+        - ""
       resourceNames:
-      - RELEASE-NAME-updater
+        - RELEASE-NAME-updater
       resources:
-      - configmaps
+        - configmaps
       verbs:
-      - get
-      - update
+        - get
+        - update
     - apiGroups:
-      - apps
+        - apps
       resources:
-      - deployments
-      - statefulsets
-      - deployments/status
-      - statefulsets/status
+        - deployments
+        - statefulsets
+        - deployments/status
+        - statefulsets/status
       verbs:
-      - get
-      - watch
-      - list
+        - get
+        - watch
+        - list
     - apiGroups:
-      - apps
+        - apps
       resourceNames:
-      - RELEASE-NAME
+        - RELEASE-NAME
       resources:
-      - deployments
-      - statefulsets
+        - deployments
+        - statefulsets
       verbs:
-      - update
+        - update
     - apiGroups:
-      - coordination.k8s.io
+        - coordination.k8s.io
       resources:
-      - leases
+        - leases
       verbs:
-      - create
+        - create
     - apiGroups:
-      - coordination.k8s.io
+        - coordination.k8s.io
       resourceNames:
-      - RELEASE-NAME
+        - RELEASE-NAME
       resources:
-      - leases
+        - leases
       verbs:
-      - get
-      - update
+        - get
+        - update

--- a/examples/chart/tbot/tests/updater_deployment_test.yaml
+++ b/examples/chart/tbot/tests/updater_deployment_test.yaml
@@ -14,6 +14,7 @@ tests:
       - ../.lint/updater.yaml
     asserts:
       - containsDocument:
+          any: true
           kind: Deployment
           apiVersion: apps/v1
           name: RELEASE-NAME-updater
@@ -150,10 +151,10 @@ tests:
       - ../.lint/annotations.yaml
     asserts:
       - equal:
-          path: metadata.annotations.kubernetes\.io/deployment
+          path: metadata.annotations["kubernetes.io/deployment"]
           value: test-annotation
       - equal:
-          path: metadata.annotations.kubernetes\.io/deployment-different
+          path: metadata.annotations["kubernetes.io/deployment-different"]
           value: 3
   - it: sets the pod annotations
     documentIndex: 0
@@ -162,10 +163,10 @@ tests:
       - ../.lint/annotations.yaml
     asserts:
       - equal:
-          path: spec.template.metadata.annotations.kubernetes\.io/pod
+          path: spec.template.metadata.annotations["kubernetes.io/pod"]
           value: test-annotation
       - equal:
-          path: spec.template.metadata.annotations.kubernetes\.io/pod-different
+          path: spec.template.metadata.annotations["kubernetes.io/pod-different"]
           value: 4
   - it: sets the affinity
     documentIndex: 0

--- a/examples/chart/tbot/tests/updater_deployment_test.yaml
+++ b/examples/chart/tbot/tests/updater_deployment_test.yaml
@@ -14,7 +14,6 @@ tests:
       - ../.lint/updater.yaml
     asserts:
       - containsDocument:
-          any: true
           kind: Deployment
           apiVersion: apps/v1
           name: RELEASE-NAME-updater
@@ -22,26 +21,16 @@ tests:
   #
   # Testing the agent configuration
   #
-  - it: sets the base image used to update the agent
+  - it: sets the base image used to update tbot
     documentIndex: 0
     values:
       - ../.lint/updater.yaml
     set:
-      image: repo.example.com/gravitational/teleport-distroless
+      image: repo.example.com/gravitational/tbot-distroless
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--base-image=repo.example.com/gravitational/teleport-distroless"
-  - it: sets the updater base entreprise image
-    documentIndex: 0
-    values:
-      - ../.lint/updater.yaml
-    set:
-      enterprise: true
-    asserts:
-      - contains:
-          path: spec.template.spec.containers[0].args
-          content: "--base-image=public.ecr.aws/gravitational/teleport-ent-distroless"
+          content: "--base-image=repo.example.com/gravitational/tbot-distroless"
   - it: sets the updater agent name
     documentIndex: 0
     values:
@@ -65,8 +54,7 @@ tests:
   - it: defaults the updater version server to the proxy address
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
     asserts:
@@ -76,8 +64,7 @@ tests:
   - it: defaults the updater proxy server to the proxy address
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
         versionServer: ""
@@ -88,8 +75,7 @@ tests:
   - it: doesn't enable the RFD-184 proxy protocol if the versionServer is custom
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
         versionServer: "version-server.example.com"
@@ -104,8 +90,7 @@ tests:
   - it: defaults the update group to default when group is unset
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
         versionServer: ""
@@ -116,8 +101,7 @@ tests:
   - it: uses the update group when set
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
         versionServer: ""
@@ -129,8 +113,7 @@ tests:
   - it: unsets the version server when empty
     documentIndex: 0
     set:
-      proxyAddr: proxy.teleport.example.com:443
-      roles: "custom"
+      teleportProxyAddress: proxy.teleport.example.com:443
       updater:
         enabled: true
         versionServer: ""
@@ -167,10 +150,10 @@ tests:
       - ../.lint/annotations.yaml
     asserts:
       - equal:
-          path: metadata.annotations["kubernetes.io/deployment"]
+          path: metadata.annotations.kubernetes\.io/deployment
           value: test-annotation
       - equal:
-          path: metadata.annotations["kubernetes.io/deployment-different"]
+          path: metadata.annotations.kubernetes\.io/deployment-different
           value: 3
   - it: sets the pod annotations
     documentIndex: 0
@@ -179,10 +162,10 @@ tests:
       - ../.lint/annotations.yaml
     asserts:
       - equal:
-          path: spec.template.metadata.annotations["kubernetes.io/pod"]
+          path: spec.template.metadata.annotations.kubernetes\.io/pod
           value: test-annotation
       - equal:
-          path: spec.template.metadata.annotations["kubernetes.io/pod-different"]
+          path: spec.template.metadata.annotations.kubernetes\.io/pod-different
           value: 4
   - it: sets the affinity
     documentIndex: 0
@@ -242,29 +225,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].imagePullPolicy
           value: Always
-  - it: mounts the tls CA if provided and set the env var
-    documentIndex: 0
-    values:
-      - ../.lint/updater.yaml
-      - ../.lint/existing-tls-secret-with-ca.yaml
-    asserts:
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: teleport-tls-ca
-            secret:
-              secretName: helm-lint-existing-tls-secret-ca
-      - contains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            mountPath: /etc/teleport-tls-ca
-            name: teleport-tls-ca
-            readOnly: true
-      - contains:
-          path: spec.template.spec.containers[0].env
-          content:
-            name: SSL_CERT_FILE
-            value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
   - it: sets the updater container extraEnv
     documentIndex: 0
     values:
@@ -294,15 +254,6 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.memory
           value: 2Gi
-  - it: sets the pod priorityClass
-    documentIndex: 0
-    values:
-      - ../.lint/updater.yaml
-      - ../.lint/priority-class-name.yaml
-    asserts:
-      - equal:
-          path: spec.template.spec.priorityClassName
-          value: teleport-kube-agent
   - it: sets the pod service-account
     documentIndex: 0
     values:
@@ -311,7 +262,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
-          value: teleport-kube-agent-sa-updater
+          value: tbot-sa-updater
   - it: sets the pod service-account (override)
     documentIndex: 0
     values:
@@ -345,17 +296,16 @@ tests:
       - ../.lint/updater.yaml
     set:
       updater:
-        pullCredentials: "aws"
+        pullCredentials: "amazon"
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--pull-credentials=aws"
+          content: "--pull-credentials=amazon"
 
   - it: sets extraVolumes when specified
     documentIndex: 0
     values:
       - ../.lint/updater-secret-docker.yaml
-      - ../.lint/existing-tls-secret-with-ca.yaml
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -373,7 +323,6 @@ tests:
     documentIndex: 0
     values:
       - ../.lint/updater-secret-docker.yaml
-      - ../.lint/existing-tls-secret-with-ca.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
@@ -381,26 +330,3 @@ tests:
             name: docker-config
             mountPath: "/mnt/docker"
             readOnly: true
-
-  - it: sets the pod security context
-    documentIndex: 0
-    values:
-      - ../.lint/updater.yaml
-    set:
-      podSecurityContext:
-        seccompProfile:
-          type: RuntimeDefault
-        runAsUser: 65532
-        runAsGroup: 65532
-        fsGroup: 65532
-        runAsNonRoot: true
-    asserts:
-      - equal:
-          path: spec.template.spec.securityContext
-          value:
-            seccompProfile:
-              type: RuntimeDefault
-            runAsUser: 65532
-            runAsGroup: 65532
-            fsGroup: 65532
-            runAsNonRoot: true

--- a/examples/chart/tbot/tests/updater_role_test.yaml
+++ b/examples/chart/tbot/tests/updater_role_test.yaml
@@ -1,0 +1,30 @@
+suite: Updater Role
+templates:
+  - updater.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a Role when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a Role when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct role rules
+    documentIndex: 1
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - matchSnapshot:
+          path: rules

--- a/examples/chart/tbot/tests/updater_role_test.yaml
+++ b/examples/chart/tbot/tests/updater_role_test.yaml
@@ -14,6 +14,7 @@ tests:
       - ../.lint/updater.yaml
     asserts:
       - containsDocument:
+          any: true
           kind: Role
           apiVersion: rbac.authorization.k8s.io/v1
           name: RELEASE-NAME-updater

--- a/examples/chart/tbot/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/tbot/tests/updater_rolebinding_test.yaml
@@ -1,0 +1,41 @@
+suite: Updater RoleBinding
+templates:
+  - updater.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a RoleBinding when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a RoleBinding when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct rolebinding content
+    documentIndex: 2
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: RELEASE-NAME-updater
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: RELEASE-NAME-tbot-updater
+              namespace: NAMESPACE

--- a/examples/chart/tbot/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/tbot/tests/updater_rolebinding_test.yaml
@@ -14,6 +14,7 @@ tests:
       - ../.lint/updater.yaml
     asserts:
       - containsDocument:
+          any: true
           kind: RoleBinding
           apiVersion: rbac.authorization.k8s.io/v1
           name: RELEASE-NAME-updater

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -319,3 +319,136 @@ securityContext: null
 #
 # By default, this is unset.
 podSecurityContext: null
+
+# updater -- controls whether the Kube Agent Updater should be deployed alongside
+# tbot. The updater fetches the target Teleport version, validates the
+# image signature, and updates the tbot deployment.
+#
+# The updater can fetch the update information using two protocols:
+# - the webapi update protocol (in this case the Teleport Proxy Service is the one driving the version rollout)
+# - the version server protocol (this is an HTTP server serving static files specifying the version and if the update is critical).
+#
+# The webapi protocol takes precedence over the version server one if the Teleport Proxy Service supports it.
+# The version server protocol failover can be disabled by unsetting `updater.versionServer`.
+# The webapi protocol can be disabled by setting `updater.proxyAddr` to `""`.
+# For backward compatibility reasons, the webapi protocol is not enabled if a custom `updater.versionServer` is set.
+#
+# All Kubernetes-specific fields such as `tolerations`, `affinity`, `nodeSelector`,
+# ... default to the tbot values. However, they can be overridden from the
+# `updater` object. For example:
+#
+# ```yaml
+# # the tbot pod requests 1cpu and 2 GiB of memory. It also has a memory limit.
+# resources:
+#   requests:
+#     cpu: "1"
+#     memory: "2Gi"
+#   limits:
+#     memory: "2Gi"
+#
+# # the updater pod requests 0.5 cpu and 512MiB of memory. The memory limit has also been unset.
+# updater:
+#   resources:
+#     requests:
+#       cpu: "0.5"
+#       memory: "512Mi"
+#     limits: ~
+# ```
+#
+# Other updater-specific values that can be defined in `updater` are described
+# below.
+updater:
+  # updater.enabled(bool) -- Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
+  # You can enable this when:
+  #
+  # - using Teleport Cloud and your tenant is enrolled into automatic updates.
+  #   (You can check this through the web UI, choose `Add Kubernetes` and
+  #   `Enroll New Resource of type Kubernetes`, and check if the value is turned
+  #   on.)
+  # - using self-hosted Teleport and you maintain your own version server.
+  #
+  # You must not enable this when:
+  #
+  # - you are a Teleport Cloud customer not enrolled in automatic updates.
+  # - you are a self-hosted Teleport user and have not set up your Teleport cluster to
+  #   support automatic updates.
+  enabled: false
+
+  # updater.versionServer(string) -- is the URL of the version server the agent
+  # fetches the target version from. The complete version endpoint is built by
+  # concatenating [`versionServer`](#updaterversionserver) and [`releaseChannel`
+  # ](#updaterreleasechannel).
+  # This field supports gotemplate.
+  #
+  # Setting this field makes the updater fetch the version using the version server protocol.
+  # Setting this field to a custom value disables the webapi update protocol to ensure backward compatibility.
+  versionServer: "https://{{ .Values.teleportProxyAddress }}/v1/webapi/automaticupgrades/channel"
+
+  # updater.releaseChannel(string) -- is the release channel the updater
+  # subscribes to.
+  #
+  # The complete version endpoint is built by concatenating
+  # [`versionServer`](#updaterversionserver) and [`releaseChannel`](#updaterreleasechannel).
+  # You must not change the default value if you are a Teleport Cloud user unless
+  # instructed by Teleport support.
+  #
+  # This value is used when the updater is fetching the version using the version server protocol.
+  # It is also used as a failover when fetching the version using the webapi protocol if `updater.group` is unset.
+  releaseChannel: "stable/cloud"
+
+  # updater.group(string) -- is the update group used when fetching the version using the webapi protocol.
+  # When unset, the group defaults to `default`.
+  group: ""
+
+  # updater.image(string) -- sets the container image used for Teleport updater
+  # pods run when `updater.enabled` is true.
+  #
+  # You can override this to use your own Teleport Kube Agent Updater image rather
+  # than a Teleport-published image.
+  image: public.ecr.aws/gravitational/teleport-kube-agent-updater
+
+  # updater.serviceAccount --
+  serviceAccount:
+    # updater.serviceAccount.name(string) -- is the updater Kubernetes Service
+    # Account name. When unset, it defaults to `<tbot sa name>-updater`
+    name: ""
+
+  # updater.pullCredentials(string) -- configures how the updater attempts to
+  # get the image pull credentials used to validate the image signature.
+  #
+  # This is not required when pulling images from official public Teleport
+  # registries (chart's default).
+  #
+  # Supported values are `amazon`, `google`, `docker` and `none`.
+  pullCredentials: ""
+
+  # updater.extraArgs(list) -- contains additional arguments to pass to the updater
+  # binary.
+  extraArgs: []
+
+  # updater.extraVolumes(list) -- contains extra volumes to mount into the Updater pods.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumes:
+  #   - name: myvolume
+  #     secret:
+  #       secretName: testSecret
+  # ```
+  extraVolumes: []
+
+  # updater.extraVolumeMounts(list) -- contains extra volumes mounts for the updater.
+  # See [the Kubernetes volume documentation](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # for more details.
+  #
+  # For example:
+  # ```yaml
+  # updater:
+  #   extraVolumesMounts:
+  #   - name: myvolume
+  #     mountPath: /path/on/host
+  # ```
+  extraVolumeMounts: []

--- a/examples/chart/teleport-kube-agent/templates/updater.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater.yaml
@@ -24,5 +24,6 @@
 {{/* Not strictly needed for teleport-kube-agent but will be needed for other charts whose proxy addr is stored in a different value.*/}}
 {{- $_ = set $updater "proxyAddr" .Values.proxyAddr }}
 {{- $_ = set $updater "baseImage" (include "teleport-kube-agent.baseImage" .)}}
+{{- $_ = set $updater "container" "teleport"}}
 {{ include "teleport-kube-updater.all" $updater }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -25,6 +25,7 @@ sets the affinity:
           - --agent-name=RELEASE-NAME
           - --agent-namespace=NAMESPACE
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
+          - --container=teleport
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
         image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2
@@ -73,6 +74,7 @@ sets the tolerations:
           - --agent-name=RELEASE-NAME
           - --agent-namespace=NAMESPACE
           - --base-image=public.ecr.aws/gravitational/teleport-distroless
+          - --container=teleport
           - --version-server=https://my-custom-version-server/v1
           - --version-channel=custom/preview
         image: public.ecr.aws/gravitational/teleport-kube-agent-updater:19.0.0-prealpha.2

--- a/examples/chart/teleport-kube-updater/templates/_deployment.tpl
+++ b/examples/chart/teleport-kube-updater/templates/_deployment.tpl
@@ -47,12 +47,12 @@ spec:
 {{- if .imagePullPolicy }}
         imagePullPolicy: {{ toYaml .imagePullPolicy }}
 {{- end }}
-{{- if or .extraEnv .tls.existingCASecretName }}
+{{- if or .extraEnv (dig "tls" "existingCASecretName" .) }}
         env:
   {{- if (gt (len .extraEnv) 0) }}
     {{- toYaml .extraEnv | nindent 8 }}
   {{- end }}
-  {{- if .tls.existingCASecretName }}
+  {{- if (and .tls .tls.existingCASecretName) }}
         - name: SSL_CERT_FILE
           value: "/etc/teleport-tls-ca/{{ required "tls.existingCASecretKeyName must be set if tls.existingCASecretName is set in chart values" .tls.existingCASecretKeyName }}"
   {{- end }}
@@ -106,9 +106,9 @@ spec:
 {{- if .resources }}
         resources: {{- toYaml .resources | nindent 10 }}
 {{- end }}
-{{- if or .tls.existingCASecretName .extraVolumeMounts }}
+{{- if or (and .tls .tls.existingCASecretName) .extraVolumeMounts }}
         volumeMounts:
-  {{- if .tls.existingCASecretName }}
+  {{- if (and .tls .tls.existingCASecretName) }}
           - mountPath: /etc/teleport-tls-ca
             name: "teleport-tls-ca"
             readOnly: true
@@ -117,12 +117,12 @@ spec:
           {{- toYaml .extraVolumeMounts | nindent 10 }}
   {{- end }}
 {{- end }}
-{{- if or .tls.existingCASecretName .extraVolumes }}
+{{- if or (and .tls .tls.existingCASecretName) .extraVolumes }}
       volumes:
   {{- if .extraVolumes }}
         {{- toYaml .extraVolumes | nindent 8 }}
   {{- end }}
-  {{- if .tls.existingCASecretName }}
+  {{- if (and .tls .tls.existingCASecretName) }}
         - name: "teleport-tls-ca"
           secret:
             secretName: {{ .tls.existingCASecretName }}

--- a/examples/chart/teleport-kube-updater/templates/_deployment.tpl
+++ b/examples/chart/teleport-kube-updater/templates/_deployment.tpl
@@ -47,7 +47,7 @@ spec:
 {{- if .imagePullPolicy }}
         imagePullPolicy: {{ toYaml .imagePullPolicy }}
 {{- end }}
-{{- if or .extraEnv (dig "tls" "existingCASecretName" .) }}
+{{- if or .extraEnv (and .tls .tls.existingCASecretName) }}
         env:
   {{- if (gt (len .extraEnv) 0) }}
     {{- toYaml .extraEnv | nindent 8 }}

--- a/examples/chart/teleport-kube-updater/templates/_deployment.tpl
+++ b/examples/chart/teleport-kube-updater/templates/_deployment.tpl
@@ -61,6 +61,7 @@ spec:
           - "--agent-name={{ .releaseName }}"
           - "--agent-namespace={{ .releaseNamespace }}"
           - "--base-image={{ .baseImage }}"
+          - "--container={{ .container }}"
   {{- if .versionServer}}
           - "--version-server={{ .versionServer }}"
           - "--version-channel={{ .releaseChannel }}"

--- a/examples/chart/teleport-kube-updater/values.yaml
+++ b/examples/chart/teleport-kube-updater/values.yaml
@@ -1,9 +1,10 @@
-# These 5 vars are not exposed to the user.
+# These 6 vars are not exposed to the user.
 releaseName: ""
 releaseNamespace: ""
 versionServerOverride: false
 version: ""
 baseImage: ""
+containerName: "teleport"
 
 versionServer: "https://{{ .Values.proxyAddr }}/v1/webapi/automaticupgrades/channel"
 releaseChannel: "stable/cloud"

--- a/examples/chart/teleport-kube-updater/values.yaml
+++ b/examples/chart/teleport-kube-updater/values.yaml
@@ -1,4 +1,4 @@
-# Those 4 vars are not exposed to the user.
+# These 5 vars are not exposed to the user.
 releaseName: ""
 releaseNamespace: ""
 versionServerOverride: false

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -89,6 +89,7 @@ func main() {
 	var probeAddr string
 	var syncPeriod time.Duration
 	var baseImageName string
+	var containerName string
 	var versionServer string
 	var versionChannel string
 	var insecureNoVerify bool
@@ -112,6 +113,8 @@ func main() {
 	flag.StringVar(&versionServer, "version-server", "https://updates.releases.teleport.dev/v1/", "URL of the HTTP server advertising target version and critical maintenances. Trailing slash is optional.")
 	flag.StringVar(&versionChannel, "version-channel", "stable/cloud", "Version channel to get updates from.")
 	flag.StringVar(&baseImageName, "base-image", "public.ecr.aws/gravitational/teleport", "Image reference containing registry and repository.")
+	flag.StringVar(&containerName, "container", "teleport", "Name of the container in the pod to update.")
+
 	flag.StringVar(&credSource, "pull-credentials", img.NoCredentialSource,
 		fmt.Sprintf("Where to get registry pull credentials, values are '%s', '%s', '%s', '%s'.",
 			img.DockerCredentialSource, img.GoogleCredentialSource, img.AmazonCredentialSource, img.NoCredentialSource,
@@ -315,6 +318,7 @@ func main() {
 		StatusWriter:   statusWriter,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
+		ContainerName:  containerName,
 	}
 
 	if err := deploymentController.SetupWithManager(mgr); err != nil {
@@ -327,6 +331,7 @@ func main() {
 		StatusWriter:   statusWriter,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
+		ContainerName:  containerName,
 	}
 
 	if err := statefulsetController.SetupWithManager(mgr); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/constants.go
+++ b/integrations/kube-agent-updater/pkg/controller/constants.go
@@ -25,8 +25,6 @@ import (
 )
 
 const (
-	// Teleport container name in the `teleport-kube-agent` Helm chart
-	teleportContainerName = "teleport"
 	defaultRequeue        = 30 * time.Minute
 	reconciliationTimeout = 2 * time.Minute
 	kubeClientTimeout     = 1 * time.Minute

--- a/integrations/kube-agent-updater/pkg/controller/statefulset.go
+++ b/integrations/kube-agent-updater/pkg/controller/statefulset.go
@@ -155,7 +155,7 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	log.Info("Updating podSpec with image", "image", image.String())
-	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, teleportContainerName, image.String())
+	err = setContainerImageFromPodSpec(&obj.Spec.Template.Spec, r.ContainerName, image.String())
 	if err != nil {
 		log.Error(err, "Unexpected error, not updating.")
 		if err := r.writeStatus(ctx, &obj, currentVersion.String(), true); err != nil {

--- a/integrations/kube-agent-updater/pkg/controller/statefulset.go
+++ b/integrations/kube-agent-updater/pkg/controller/statefulset.go
@@ -41,7 +41,8 @@ type StatefulSetVersionUpdater struct {
 	VersionUpdater
 	StatusWriter
 	kclient.Client
-	Scheme *runtime.Scheme
+	Scheme        *runtime.Scheme
+	ContainerName string
 }
 
 // Reconcile treats a reconciliation request for a StatefulSet object. It gets the
@@ -90,7 +91,7 @@ func (r *StatefulSetVersionUpdater) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Get the current and past version
-	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec)
+	currentVersion, err := getWorkloadVersion(obj.Spec.Template.Spec, r.ContainerName)
 	if err != nil {
 		switch {
 		case trace.IsBadParameter(err):

--- a/integrations/kube-agent-updater/pkg/controller/utils.go
+++ b/integrations/kube-agent-updater/pkg/controller/utils.go
@@ -30,8 +30,8 @@ import (
 	"github.com/gravitational/teleport/lib/automaticupgrades/version"
 )
 
-func getWorkloadVersion(podSpec v1.PodSpec) (*semver.Version, error) {
-	image, err := getContainerImageFromPodSpec(podSpec, teleportContainerName)
+func getWorkloadVersion(podSpec v1.PodSpec, container string) (*semver.Version, error) {
+	image, err := getContainerImageFromPodSpec(podSpec, container)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integrations/kube-agent-updater/pkg/controller/utils_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/utils_test.go
@@ -30,7 +30,8 @@ import (
 )
 
 const (
-	nonSemverTag = "my-custom-tag"
+	nonSemverTag          = "my-custom-tag"
+	teleportContainerName = "teleport"
 )
 
 func Test_getContainerImageFromPod(t *testing.T) {
@@ -347,7 +348,7 @@ func Test_getWorkloadVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getWorkloadVersion(tt.podSpec)
+			got, err := getWorkloadVersion(tt.podSpec, teleportContainerName)
 			tt.assertErr(t, err)
 			require.Equal(t, tt.expected, got)
 		})


### PR DESCRIPTION
This PR uses the newly extracted updater library chart (https://github.com/gravitational/teleport/pull/62846) to add support for tbot Managed Updates on Kubernetes.

Notably, this uses the Deployment controller from kube-agent-updater, which is not currently used to update the agent (which uses StatefulSets). However, it appears to be functional and maintained. (CC: @hugoShaka)

Completed test plan (against v18 backport & master):
- Deployed to an independent kubernetes cluster
- Verified all pods ready + no errors without the updater running
- Re-deployed with the updater enabled, re-verified all pods ready + no errors
- Tested image upgrade by changing Cloud-advertised agent version
- Tested image downgrade by changing Cloud-advertised agent version
- Tested multiple sequential upgrades / downgrades

changelog: Add support for tbot Managed Updates on Kubernetes

RFD: https://github.com/gravitational/teleport/pull/47126
Goal (internal): https://github.com/gravitational/cloud/issues/15288
