### PR TITLE
operator tests: Convert non-standard tests

### DIFF
--- a/integrations/operator/controllers/resources/suite_test.go
+++ b/integrations/operator/controllers/resources/suite_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
@@ -38,14 +37,8 @@ type testSetup = testlib.TestSetup
 
 // Temporary function "aliases" to slightly decrease the size of this commit,
 // they can be removed in a follow-up.
-func setupTestEnv(t *testing.T, opts ...testlib.TestOption) *testlib.TestSetup {
-	return testlib.SetupTestEnv(t, opts...)
-}
 func validRandomResourceName(prefix string) string       { return testlib.ValidRandomResourceName(prefix) }
 func fastEventually(t *testing.T, condition func() bool) { testlib.FastEventually(t, condition) }
-func fastEventuallyWithT(t *testing.T, condition func(*assert.CollectT)) {
-	testlib.FastEventuallyWithT(t, condition)
-}
 
 func teleportCreateDummyRole(ctx context.Context, roleName string, tClient *client.Client) error {
 	// The role is created in Teleport


### PR DESCRIPTION
I am currently converting all operator tests to the old test suite spinning up real kube clusters and waiting on the operator to run, to a new test suite using a fake kubernetes client and synchronously triggering operator reconciliation. The goal is to have faster and less flaky tests.

The new test suite was introduced in: https://github.com/gravitational/teleport/pull/62859

This PR converts all the hand-rolled tests.

There are 2 cases:
- The tests were non-standard and have been converted to standard tests:
  - trusted-cluster
  - user
  - rolev5
- The test was testing something from the standard test suite (e.g. mutation) and was modified to use the fake kube test + call the reconciler manually.

