### PR TITLE
chore: avoid reading kube responses into memory if no filter is needed

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -954,7 +954,7 @@ func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, stat
 	}
 
 	r.populateEvent(event)
-	if err := f.cfg.AuthClient.EmitAuditEvent(f.ctx, event); err != nil {
+	if err := f.cfg.Emitter.EmitAuditEvent(f.ctx, event); err != nil {
 		f.log.WarnContext(f.ctx, "Failed to emit event", "error", err)
 	}
 }


### PR DESCRIPTION
This PR avoids reading a full response into memory if no filter is needed.

Filters are not needed when a user has wildcard access.