### PR TITLE
Remove `baseUrl` from TS config, fix incorrect imports

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
-    "baseUrl": ".",
+    "paths": {
+      "*": ["./*"]
+    },
     "useDefineForClassFields": true,
     "esModuleInterop": true,
     "importHelpers": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,9 +2,6 @@
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "allowJs": true,
-    "paths": {
-      "*": ["./*"]
-    },
     "useDefineForClassFields": true,
     "esModuleInterop": true,
     "importHelpers": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,16 +21,16 @@
     "noEmit": true,
     "types": ["node", "@types/wicg-file-system-access"],
     "paths": {
-      "build/*": ["web/packages/build/src/*"],
-      "build": ["web/packages/build/src/"],
-      "shared/*": ["web/packages/shared/*"],
-      "design/*": ["web/packages/design/src/*"],
-      "design": ["web/packages/design/src/"],
-      "teleport/*": ["web/packages/teleport/src/*"],
-      "teleport": ["web/packages/teleport/src/"],
-      "teleterm/*": ["web/packages/teleterm/src/*"],
-      "e-teleport/*": ["e/web/teleport/src/*"],
-      "gen-proto-ts/*": ["gen/proto/ts/*"]
+      "build/*": ["./web/packages/build/src/*"],
+      "build": ["./web/packages/build/src/"],
+      "shared/*": ["./web/packages/shared/*"],
+      "design/*": ["./web/packages/design/src/*"],
+      "design": ["./web/packages/design/src/"],
+      "teleport/*": ["./web/packages/teleport/src/*"],
+      "teleport": ["./web/packages/teleport/src/"],
+      "teleterm/*": ["./web/packages/teleterm/src/*"],
+      "e-teleport/*": ["./e/web/teleport/src/*"],
+      "gen-proto-ts/*": ["./gen/proto/ts/*"]
     }
   },
   "exclude": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,8 +21,8 @@
     "noEmit": true,
     "types": ["node", "@types/wicg-file-system-access"],
     "paths": {
-      "build/*": ["./web/packages/build/src/*"],
-      "build": ["./web/packages/build/src/"],
+      "build/*": ["./web/packages/build/*"],
+      "build": ["./web/packages/build/"],
       "shared/*": ["./web/packages/shared/*"],
       "design/*": ["./web/packages/design/src/*"],
       "design": ["./web/packages/design/src/"],

--- a/web/packages/design/tsconfig.json
+++ b/web/packages/design/tsconfig.json
@@ -9,10 +9,9 @@
     "strict": true,
     "noImplicitReturns": true,
     "paths": {
-      "design/*": ["web/packages/design/src/*"],
-      "design": ["web/packages/design/src/"],
-      "gen-proto-ts/*": ["gen/proto/ts/*"],
+      "design/*": ["./src/*"],
+      "design": ["./src/"],
+      "gen-proto-ts/*": ["../../../gen/proto/ts/*"],
     }
-
   }
 }

--- a/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
+++ b/web/packages/teleport/src/Discover/ConnectMyComputer/SetupConnect/SetupConnect.story.tsx
@@ -18,8 +18,8 @@
 
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
-import { withoutQuery } from 'web/packages/build/storybook';
 
+import { withoutQuery } from 'build/storybook';
 import {
   OverrideUserAgent,
   UserAgent,

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
@@ -18,8 +18,8 @@
 
 import { delay, http, HttpResponse } from 'msw';
 import { useEffect } from 'react';
-import { withoutQuery } from 'web/packages/build/storybook';
 
+import { withoutQuery } from 'build/storybook';
 import { Info } from 'design/Alert';
 
 import cfg from 'teleport/config';

--- a/web/packages/teleport/src/Discover/Kubernetes/SelfHosted/HelmChart/HelmChart.story.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/SelfHosted/HelmChart/HelmChart.story.tsx
@@ -19,7 +19,8 @@
 import { StoryObj } from '@storybook/react-vite';
 import { delay, http, HttpResponse } from 'msw';
 import { PropsWithChildren } from 'react';
-import { withoutQuery } from 'web/packages/build/storybook';
+
+import { withoutQuery } from 'build/storybook';
 
 import cfg from 'teleport/config';
 import {

--- a/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
@@ -19,7 +19,8 @@
 import { StoryObj } from '@storybook/react-vite';
 import { delay, http, HttpResponse } from 'msw';
 import { PropsWithChildren } from 'react';
-import { withoutQuery } from 'web/packages/build/storybook';
+
+import { withoutQuery } from 'build/storybook';
 
 import cfg from 'teleport/config';
 import {

--- a/web/packages/teleport/src/GitServers/fixtures.ts
+++ b/web/packages/teleport/src/GitServers/fixtures.ts
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GitServer } from 'web/packages/teleport/src/services/gitServers';
+import { GitServer } from 'teleport/services/gitServers';
 
 export const gitServers: GitServer[] = [
   {

--- a/web/packages/teleport/src/Notifications/Notification.story.tsx
+++ b/web/packages/teleport/src/Notifications/Notification.story.tsx
@@ -19,8 +19,8 @@
 import { subDays, subHours, subMinutes, subSeconds } from 'date-fns';
 import { delay, http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
-import { withoutQuery } from 'web/packages/build/storybook';
 
+import { withoutQuery } from 'build/storybook';
 import { Flex, H2 } from 'design';
 
 import cfg from 'teleport/config';

--- a/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/player/RecordingPlayer.tsx
@@ -27,9 +27,9 @@ import {
 } from 'react';
 import styled, { keyframes } from 'styled-components';
 import { useEventListener } from 'usehooks-ts';
-import Box from 'web/packages/design/src/Box';
-import Flex from 'web/packages/design/src/Flex';
-import { Pause, Play } from 'web/packages/design/src/Icon';
+
+import { Box, Flex } from 'design';
+import { Pause, Play } from 'design/Icon';
 
 import type { SessionRecordingEvent } from 'teleport/services/recordings';
 import {

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -17,7 +17,6 @@
  */
 
 import React, { useState, type JSX } from 'react';
-import { GitServer } from 'web/packages/teleport/src/services/gitServers';
 
 import { ButtonBorder, ButtonWithMenu, MenuItem } from 'design';
 import { AwsLaunchButton } from 'shared/components/AwsLaunchButton';
@@ -44,6 +43,7 @@ import { UnifiedResource } from 'teleport/services/agents';
 import { App, SamlAppLaunchUrl } from 'teleport/services/apps';
 import { Database } from 'teleport/services/databases';
 import { Desktop } from 'teleport/services/desktops';
+import { GitServer } from 'teleport/services/gitServers';
 import { Kube } from 'teleport/services/kube';
 import { Node, sortNodeLogins } from 'teleport/services/nodes';
 import { SamlServiceProviderPreset } from 'teleport/services/samlidp/types';

--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { GitServer } from 'web/packages/teleport/src/services/gitServers';
-
 import type { Platform } from 'design/platform';
 import {
   IncludedResourceMode,
@@ -27,6 +25,7 @@ import {
 import { App } from 'teleport/services/apps';
 import { Database } from 'teleport/services/databases';
 import { Desktop } from 'teleport/services/desktops';
+import { GitServer } from 'teleport/services/gitServers';
 import { Kube } from 'teleport/services/kube';
 import { Node } from 'teleport/services/nodes';
 import { UserGroup } from 'teleport/services/userGroups';


### PR DESCRIPTION
* teleport.e counterpart: https://github.com/gravitational/teleport.e/pull/7861

[`baseUrl` is getting deprecated in TypeScript 6.0](https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/). Arguably, this is not a top priority for us to address at the moment. However, while [testing TS 7.0](https://github.com/gravitational/teleport/pull/62021), I found that the existence of `baseUrl` allowed imports such as `web/packages/packages/foo/src/Bar` to exist. By getting rid of `baseUrl`, we guarantee that no more such imports will be added to the project.

No `baseUrl` means that all paths in TS configs must be relative.

I also realized that the path for the `build` package in tsconfig.json is wrong. Just like the shared package, the build package has no `src` directory.