### PR TITLE
[v18] docs: Promote GitHub Web UI guides

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -76,14 +76,14 @@ and [Architecture](../../reference/architecture/machine-id-architecture.mdx) to 
       name: "CircleCI",
     },
     {
+      icon: <Icon name="github" size="xl" />,
+      to: "./github-actions",
+      name: "GitHub Actions",
+    },
+    {
       icon: <Icon name="gitlab" size="xl" />,
       to: "./gitlab",
       name: "GitLab CI",
-    },
-    {
-      icon: <Icon name="githubActions" size="xl" />,
-      to: "./github-actions",
-      name: "GitHub Actions",
     },
     {
       icon: <Icon name="googleCloud" size="xl" />,
@@ -146,7 +146,7 @@ and continuous deployment platform.
       name: "GitLab CI",
     },
     {
-      icon: <Icon name="githubActions" size="xl" />,
+      icon: <Icon name="github" size="xl" />,
       to: "./github-actions",
       name: "GitHub Actions",
     },

--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -106,7 +106,7 @@ and [Architecture](../../reference/architecture/machine-id-architecture.mdx) to 
       name: "Linux",
     },
     {
-      icon: <Icon name="linux-servers" size="xl" />,
+      icon: <Icon name="linux" size="xl" />,
       to: "./linux-tpm",
       name: "Linux TPM",
     },

--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -173,6 +173,8 @@ and continuous deployment platform.
   ]}
 />
 
+<br />
+
 <Admonition type="tip" title="Unsupported Provider?">
 If your CI/CD provider does not have a dedicated join method listed above,
 consider using [Bound Keypair static keys][bound-keypair-static] as a fallback.

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -19,6 +19,18 @@ long-lived credentials.
 Teleport supports secure joining on both GitHub-hosted and self-hosted GitHub
 Actions runners as well as GitHub Enterprise Server.
 
+<Admonition type="info" title="Guided integration available">
+    Get up and running quickly using one of the guided integrations available
+    via the Teleport Web UI.
+
+    The guides walk you through connecting your GitHub Actions
+    workflow to Teleport and granting the permissions needed to access your
+    enrolled resources.
+
+    Find the guides in the Web UI;<br />
+    **Add New** > **Integration** > Search "**GitHub Actions**"
+</Admonition>
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -149,6 +161,18 @@ can be used for SSH and for administrative actions against a Teleport cluster.
 Environment variables are configured by this action and these automatically
 configure `tsh` and `tctl` to use this identity.
 
+<Admonition type="info" title="Guided integration available">
+    Why not use the GitHub Action + SSH integration guide via the
+    Teleport Web UI?
+    
+    The guide walks you through connecting your GitHub Actions
+    workflow to Teleport and giving it the permissions it needs to access your
+    enrolled SSH nodes.
+
+    Find the guide in the Web UI;<br />
+    **Add New** > **Integration** > **MWI: GitHub Actions + SSH**
+</Admonition>
+
 This example shows using the credentials to:
 
 - List the SSH nodes available using `tsh`
@@ -267,6 +291,18 @@ environment variable to automatically configure these clients.
 In this example, the `teleport-actions/auth-k8s` action will be used to list
 all the pods contained within the cluster, but this could just as easily be
 modified to deploy to a Kubernetes cluster with `kubectl` or `helm`.
+
+<Admonition type="info" title="Guided integration available">
+    Why not use the GitHub Action + Kubernetes integration guide via the
+    Teleport Web UI?
+    
+    The guide walks you through connecting your GitHub Actions
+    workflow to Teleport and giving it the permissions it needs to access your
+    enrolled Kubernetes clusters.
+
+    Find the guide in the Web UI;<br />
+    **Add New** > **Integration** > **MWI: GitHub Actions + Kubernetes**
+</Admonition>
 
 First, you'll need to adjust the role you assigned to the bot to grant it access
 to the Kubernetes cluster. This example will grant the bot access to all
@@ -459,4 +495,3 @@ interact with.
 - Find out more about GitHub Actions itself, read
   [their documentation](https://docs.github.com/en/actions).
 - [More information about `anonymous-telemetry`.](../../reference/machine-workload-identity/telemetry.mdx)
-

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -162,14 +162,14 @@ Environment variables are configured by this action and these automatically
 configure `tsh` and `tctl` to use this identity.
 
 <Admonition type="info" title="Guided integration available">
-    Why not use the GitHub Action + SSH integration guide via the
+    You can use the GitHub Action + SSH integration guide via the
     Teleport Web UI?
     
     The guide walks you through connecting your GitHub Actions
     workflow to Teleport and giving it the permissions it needs to access your
     enrolled SSH nodes.
 
-    Find the guide in the Web UI;<br />
+    Find the guide in the Web UI:<br />
     **Add New** > **Integration** > **MWI: GitHub Actions + SSH**
 </Admonition>
 
@@ -293,14 +293,14 @@ all the pods contained within the cluster, but this could just as easily be
 modified to deploy to a Kubernetes cluster with `kubectl` or `helm`.
 
 <Admonition type="info" title="Guided integration available">
-    Why not use the GitHub Action + Kubernetes integration guide via the
+    You can use the GitHub Action + Kubernetes integration guide via the
     Teleport Web UI?
     
     The guide walks you through connecting your GitHub Actions
     workflow to Teleport and giving it the permissions it needs to access your
     enrolled Kubernetes clusters.
 
-    Find the guide in the Web UI;<br />
+    Find the guide in the Web UI:<br />
     **Add New** > **Integration** > **MWI: GitHub Actions + Kubernetes**
 </Admonition>
 

--- a/docs/pages/machine-workload-identity/machine-workload-identity.mdx
+++ b/docs/pages/machine-workload-identity/machine-workload-identity.mdx
@@ -34,6 +34,7 @@ import appWindowSvg from "@site/src/components/Icon/teleport-svg/app-window.svg"
 import certificateSvg from "@site/src/components/Icon/teleport-svg/certificate.svg";
 import cloudSvg from "@site/src/components/Icon/teleport-svg/cloud.svg";
 import teleportSvg from "@site/src/components/Icon/teleport-svg/teleport.svg";
+import githubSvg from "@site/src/components/Icon/svg/github.svg";
 
 <LandingHero
   title="Machine & Workload Identity"
@@ -128,6 +129,12 @@ The following steps will help you get started with Machine and Workload Identity
       iconComponent: gcpSvg,
     },
     {
+      title: 'GitHub Actions',
+      href: './deployment/github-actions/',
+      iconColor: '#0000001A',
+      iconComponent: githubSvg,
+    },
+    {
       title: 'Gitlab CI',
       href: './deployment/gitlab/',
       iconColor: '#FF99001A',
@@ -148,12 +155,6 @@ The following steps will help you get started with Machine and Workload Identity
     {
       title: 'Linux',
       href: './deployment/linux/',
-      iconColor: '#FF99001A',
-      iconComponent: linuxSvg,
-    },
-    {
-      title: 'Linux (TPM)',
-      href: './deployment/linux-tpm/',
       iconColor: '#FF99001A',
       iconComponent: linuxSvg,
     }, 


### PR DESCRIPTION
Backport #62911 to branch/v18