### PR TITLE
Improve access requests checkout styling

### DIFF
--- a/web/packages/design/src/TextArea/TextArea.tsx
+++ b/web/packages/design/src/TextArea/TextArea.tsx
@@ -104,7 +104,7 @@ const StyledTextArea = styled.textarea<StyledTextAreaProps>`
   border-radius: 4px;
   box-sizing: border-box;
   display: block;
-  min-height: 50px;
+  min-height: ${props => textAreaGeometry[props.taSize].height}px;
   height: ${props => textAreaGeometry[props.taSize].height}px;
   padding: 8px 16px;
   outline: none;

--- a/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationRequest.tsx
+++ b/web/packages/shared/components/AccessRequests/AccessDuration/AccessDurationRequest.tsx
@@ -31,7 +31,7 @@ export function AccessDurationRequest({
 }) {
   return (
     <LabelInput color="text.slightlyMuted">
-      <Flex alignItems="center">
+      <Flex alignItems="center" mb={1}>
         <Text mr={1}>Access Duration</Text>
         <IconTooltip>
           How long you would be given elevated privileges. Note that the time it

--- a/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.tsx
+++ b/web/packages/shared/components/AccessRequests/AssumeStartTime/AssumeStartTime.tsx
@@ -29,7 +29,7 @@ import { ButtonSecondary } from 'design/Button';
 import { StyledDateRange } from 'design/DatePicker';
 import { displayShortDate } from 'design/datetime';
 import { Calendar as CalendarIcon, Refresh as RefreshIcon } from 'design/Icon';
-import FieldSelect from 'shared/components/FieldSelect';
+import { FieldSelect } from 'shared/components/FieldSelect';
 import Validation from 'shared/components/Validation';
 import { useRefClickOutside } from 'shared/hooks/useRefClickOutside';
 import { AccessRequest } from 'shared/services/accessRequests';
@@ -135,15 +135,14 @@ export function AssumeStartTime({
 
   return (
     <Validation>
-      <Flex gap={2} alignItems="end" mb={2}>
+      <Container threeColumns={!!showResetDateTime}>
         <Box css={{ position: 'relative' }} ref={dayPickerRef}>
           <LabelInput>Start Date</LabelInput>
           <CalendarPicker
+            $open={showDayPicker}
             onClick={() => {
               setShowDayPicker(s => !s);
             }}
-            maxWidth="270px"
-            minWidth="200px"
           >
             {startDateText}
             <CalendarIcon ml={3} />
@@ -198,7 +197,6 @@ export function AssumeStartTime({
             <LabelInput>Start Time</LabelInput>
             <FieldSelect
               mb={0}
-              width="190px"
               isSearchable={true}
               options={startTimeOptions}
               value={startTime}
@@ -216,21 +214,31 @@ export function AssumeStartTime({
             <RefreshIcon size="medium" />
           </ButtonIcon>
         )}
-      </Flex>
+      </Container>
     </Validation>
   );
 }
 
-const CalendarPicker = styled(Flex)`
+const Container = styled(Flex).attrs({ gap: 2, mb: 2, alignItems: 'end' })<{
+  threeColumns: boolean;
+}>`
+  display: grid;
+  grid-template-columns: ${props => (props.threeColumns ? '1fr 1fr auto' : '1fr 1fr')};
+}`;
+
+const CalendarPicker = styled(Flex)<{ $open: boolean }>`
   height: 40px;
-  border: 1px solid ${p => p.theme.colors.text.muted};
+  border: 1px solid ${p => p.theme.colors.interactive.tonal.neutral[2]};
   border-radius: ${p => p.theme.radii[2]}px;
-  padding: 0 ${p => p.theme.space[2]}px;
+  padding-right: ${p => p.theme.space[2]}px;
+  padding-left: ${p => p.theme.space[3]}px;
   align-items: center;
   justify-content: space-between;
   cursor: pointer;
   &:hover {
-    background-color: ${p => p.theme.colors.spotBackground[0]};
-    border: 1px solid ${p => p.theme.colors.text.slightlyMuted};
+    border: 1px solid ${p => p.theme.colors.text.muted};
   }
+  ${p =>
+    p.$open &&
+    `border-color: ${p.theme.colors.interactive.solid.primary.default};`}
 `;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
@@ -44,13 +44,7 @@ export function AdditionalOptions({
 
   return (
     <>
-      <Flex
-        justifyContent="space-between"
-        alignItems="center"
-        css={`
-          border-color: ${props => props.theme.colors.spotBackground[1]};
-        `}
-      >
+      <Flex justifyContent="space-between" alignItems="center">
         <Text mr={2} typography="body3">
           Additional Options
         </Text>

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
@@ -45,7 +45,6 @@ export function AdditionalOptions({
   return (
     <>
       <Flex
-        mb={1}
         justifyContent="space-between"
         alignItems="center"
         css={`

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/AdditionalOptions.tsx
@@ -45,12 +45,9 @@ export function AdditionalOptions({
   return (
     <>
       <Flex
-        mt={1}
-        mb={2}
-        pb={2}
+        mb={1}
         justifyContent="space-between"
         alignItems="center"
-        height="34px"
         css={`
           border-color: ${props => props.theme.colors.spotBackground[1]};
         `}
@@ -69,7 +66,7 @@ export function AdditionalOptions({
         <Box data-testid="reviewers">
           {pendingRequestTtlOptions.length > 0 && (
             <LabelInput color="text.slightlyMuted" mb={3}>
-              <Flex alignItems="center">
+              <Flex alignItems="center" mb={1}>
                 <Text mr={1}>Request expires if not reviewed in</Text>
                 <IconTooltip>
                   The request TTL which is the amount of time this request will

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -632,6 +632,7 @@ export function RequestCheckout<T extends PendingListItem>({
                     )}
                     <Flex
                       py={4}
+                      mt={1}
                       gap={2}
                       css={`
                         position: sticky;

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -44,6 +44,7 @@ import {
   P3,
   Subtitle2,
   Text,
+  TextArea,
 } from 'design';
 import { Danger } from 'design/Alert';
 import Table, { Cell } from 'design/DataTable';
@@ -924,38 +925,17 @@ function TextBox({
   const placeholderText =
     reasonPrompts && reasonPrompts.length && numPendingAccessRequests > 0
       ? reasonPrompts.filter(s => s.length > 0).join('\n')
-      : 'Describe your request...';
+      : 'Describe your request…';
 
   return (
     <LabelInput hasError={hasError}>
       <Text mb={1}>{labelText}</Text>
-      <Box
-        as="textarea"
-        height="80px"
-        width="100%"
-        borderRadius={2}
-        p={2}
-        color="text.main"
-        border={hasError ? '2px solid' : '1px solid'}
-        borderColor={hasError ? 'error.main' : 'text.muted'}
+      <TextArea
+        resizable
+        hasError={hasError}
         placeholder={placeholderText.replaceAll(/\\n/g, '\n')}
         value={reason}
         onChange={e => updateReason(e.target.value)}
-        css={`
-          outline: none;
-          background: transparent;
-          font-size: ${props => props.theme.fontSizes[2]}px;
-
-          &::placeholder {
-            color: ${({ theme }) => theme.colors.text.muted};
-          }
-
-          &:hover,
-          &:focus,
-          &:active {
-            border: 1px solid ${props => props.theme.colors.text.slightlyMuted};
-          }
-        `}
       />
     </LabelInput>
   );


### PR DESCRIPTION
e-counterpart: https://github.com/gravitational/teleport.e/pull/7864

Changes:
* Unified borders of the inputs.
* Unified spacing between inputs and labels.
* Replaced custom text area implementation with the standard one. Prevents the field from being resized below the minimum allowed size.

| Before | After |
|--------|----- |
| <img width="434" height="751" alt="image" src="https://github.com/user-attachments/assets/a127db9c-28a2-412f-994b-85367a9ef032" /> | <img width="434" height="751" alt="image" src="https://github.com/user-attachments/assets/f46c84bd-16aa-41e4-906a-3993f0bb7c4c" /> |