### PR TITLE
[v18] Allow editor preset to read autoupdate agent reports

### DIFF
--- a/gen/preset-roles.json
+++ b/gen/preset-roles.json
@@ -1053,6 +1053,15 @@
           },
           {
             "resources": [
+              "autoupdate_agent_report"
+            ],
+            "verbs": [
+              "list",
+              "read"
+            ]
+          },
+          {
+            "resources": [
               "autoupdate_bot_instance_report"
             ],
             "verbs": [

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -213,6 +213,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindAutoUpdateVersion, RW()),
 					types.NewRule(types.KindAutoUpdateConfig, RW()),
 					types.NewRule(types.KindAutoUpdateAgentRollout, RO()),
+					types.NewRule(types.KindAutoUpdateAgentReport, RO()),
 					types.NewRule(types.KindAutoUpdateBotInstanceReport, RO()),
 					types.NewRule(types.KindGitServer, RW()),
 					types.NewRule(types.KindWorkloadIdentityX509Revocation, RW()),


### PR DESCRIPTION
Backport #62947 to branch/v18

changelog: Added permissions to the `editor` role allowing users to view autoupdate agent reports.