### PR TITLE
Add streamable HTTP MCP handler with app auth config

### DIFF
--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -510,7 +510,7 @@ func (j *jwksIssuer) createJwt(t *testing.T, audience, email string, issuedAt ti
 }
 
 func newJwksIssuer(t *testing.T) *jwksIssuer {
-	kid := "kid-example"
+	const kid = "kid-example"
 	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
 

--- a/integration/appaccess/fixtures.go
+++ b/integration/appaccess/fixtures.go
@@ -19,6 +19,7 @@
 package appaccess
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -28,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
@@ -36,9 +39,11 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
+	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
@@ -51,6 +56,8 @@ type AppTestOptions struct {
 	LeafClusterListeners helpers.InstanceListenerSetupFunc
 	Clock                clockwork.Clock
 	MonitorCloseChannel  chan struct{}
+	RootAppAuthConfigs   []*appauthconfigv1.AppAuthConfig
+	JWKS                 *jwksIssuer
 
 	RootConfig func(config *servicecfg.Config)
 	LeafConfig func(config *servicecfg.Config)
@@ -136,6 +143,8 @@ func SetupWithOptions(t *testing.T, opts AppTestOptions) *Pack {
 		flushAppName:        "app-05",
 		flushAppPublicAddr:  "app-05.example.com",
 		flushAppClusterName: "example.com",
+
+		jwks: opts.JWKS,
 	}
 
 	createHandler := func(handler func(conn *websocket.Conn)) http.HandlerFunc {
@@ -476,4 +485,50 @@ func splitHostPort(hostport string) (string, int, error) {
 	}
 
 	return host, int(port), nil
+}
+
+type jwksIssuer struct {
+	signer      jose.Signer
+	signatures  []jose.SignatureAlgorithm
+	encodedJwks string
+	issuer      string
+}
+
+func (j *jwksIssuer) createJwt(t *testing.T, audience, email string, issuedAt time.Time, expiredAt time.Time) string {
+	token, err := jwt.Signed(j.signer).Claims(jwt.Claims{
+		Issuer:   j.issuer,
+		Audience: jwt.Audience{audience},
+		IssuedAt: jwt.NewNumericDate(issuedAt),
+		Expiry:   jwt.NewNumericDate(expiredAt),
+	}).Claims(
+		struct {
+			Email string `json:"email"`
+		}{Email: email},
+	).Serialize()
+	require.NoError(t, err)
+	return token
+}
+
+func newJwksIssuer(t *testing.T) *jwksIssuer {
+	kid := "kid-example"
+	privateKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
+	require.NoError(t, err)
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: privateKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	require.NoError(t, err)
+
+	encodedJwks, err := json.Marshal(&jose.JSONWebKeySet{Keys: []jose.JSONWebKey{
+		{Algorithm: string(jose.ES256), KeyID: kid, Key: privateKey.Public()},
+	}})
+	require.NoError(t, err)
+
+	return &jwksIssuer{
+		signer:      signer,
+		signatures:  []jose.SignatureAlgorithm{jose.ES256},
+		encodedJwks: string(encodedJwks),
+		issuer:      "https://issuer-url/",
+	}
 }

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -170,6 +170,8 @@ type Pack struct {
 	flushAppPublicAddr  string
 	flushAppClusterName string
 	flushAppURI         string
+
+	jwks *jwksIssuer
 }
 
 func (p *Pack) RootWebAddr() string {
@@ -904,6 +906,11 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 	servers, err := p.rootCluster.StartApps(configs)
 	require.NoError(t, err)
 	require.Len(t, configs, len(servers))
+
+	for _, config := range opts.RootAppAuthConfigs {
+		_, err := p.rootCluster.Process.GetAuthServer().CreateAppAuthConfig(t.Context(), config)
+		require.NoError(t, err, "failed to create app auth config")
+	}
 
 	for i, appServer := range servers {
 		srv := appServer

--- a/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
+++ b/lib/auth/appauthconfig/appauthconfigv1/sessions_service.go
@@ -159,7 +159,7 @@ func (s *SessionsService) CreateAppSessionWithJWT(ctx context.Context, req *appa
 		return nil, trace.AccessDenied("this request can be only executed by a proxy")
 	}
 
-	sid := services.GenerateAppSessionIDFromJWT(req.Jwt)
+	sid := services.GenerateAppSessionIDFromAuthHeader(req.Jwt)
 	if err := validateCreateAppSessionWithJWTRequest(req); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -178,6 +178,9 @@ type ReadProxyAccessPoint interface {
 	// resources.
 	services.HealthCheckConfigReader
 
+	// AppAuthConfigGetter defines methods for fetching app auth configs.
+	services.AppAuthConfigReader
+
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -949,6 +949,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindRelayServer, services.RO()),
 				types.NewRule(types.KindAccessList, services.RO()),
 				types.NewRule(types.KindHealthCheckConfig, services.RO()),
+				types.NewRule(types.KindAppAuthConfig, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{

--- a/lib/services/appauthconfig.go
+++ b/lib/services/appauthconfig.go
@@ -107,8 +107,9 @@ func validateJWTAppAuthConfig(s *appauthconfigv1.AppAuthConfigJWTSpec) error {
 	return nil
 }
 
-// GenerateAppSessionIDFromJWT generates a app session id based on JWT token.
-func GenerateAppSessionIDFromJWT(jwtToken string) string {
-	jwtHash := sha256.Sum256([]byte(jwtToken))
+// GenerateAppSessionIDFromAuthHeader generates a app session id based on auth
+// header contents.
+func GenerateAppSessionIDFromAuthHeader(authHeader string) string {
+	jwtHash := sha256.Sum256([]byte(authHeader))
 	return hex.EncodeToString(jwtHash[:])
 }

--- a/lib/utils/mcptest/test.go
+++ b/lib/utils/mcptest/test.go
@@ -133,9 +133,9 @@ func CallServerTool(ctx context.Context, client *mcpclient.Client) (*mcp.CallToo
 	return callToolResult, trace.Wrap(err)
 }
 
-// CallRequestHeaders calls the "request-headers" tool and returns the HTTP
+// CallRequestHeadersTool calls the "request-headers" tool and returns the HTTP
 // headers the server received.
-func CallRequestHeaders(ctx context.Context, client *mcpclient.Client) (http.Header, error) {
+func CallRequestHeadersTool(ctx context.Context, client *mcpclient.Client) (http.Header, error) {
 	req := mcp.CallToolRequest{}
 	req.Params.Name = "request-headers"
 	result, err := client.CallTool(ctx, req)
@@ -159,11 +159,11 @@ func CallRequestHeaders(ctx context.Context, client *mcpclient.Client) (http.Hea
 	return headers, nil
 }
 
-// MustCallRequestHeaders calls the "request-headers" tool and asserts it
+// MustCallRequestHeadersTool calls the "request-headers" tool and asserts it
 // succeeds, returning the HTTP headers the server received.
-func MustCallRequestHeaders(t *testing.T, client *mcpclient.Client) http.Header {
+func MustCallRequestHeadersTool(t *testing.T, client *mcpclient.Client) http.Header {
 	t.Helper()
-	headers, err := CallRequestHeaders(t.Context(), client)
+	headers, err := CallRequestHeadersTool(t.Context(), client)
 	require.NoError(t, err)
 	return headers
 }

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -757,9 +757,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			h.healthCheckAppServer = appHandler.HealthCheckAppServer
 		}
 
-		appHandler.BindMCPEndpoints(&h.Router, func(r *http.Request) error {
-			return rateLimitRequest(r, h.limiter)
-		})
+		appHandler.BindMCPEndpoints(&h.Router, h.WithUnauthenticatedLimiter)
 	}
 
 	go h.startFeatureWatcher()

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -756,6 +756,10 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		if h.healthCheckAppServer == nil {
 			h.healthCheckAppServer = appHandler.HealthCheckAppServer
 		}
+
+		appHandler.BindMCPEndpoints(&h.Router, func(r *http.Request) error {
+			return rateLimitRequest(r, h.limiter)
+		})
 	}
 
 	go h.startFeatureWatcher()

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -48,8 +48,8 @@ type fragmentRequest struct {
 // next in the chain of required app authentication redirects
 const TeleportNextAppRedirectUrlHeader = "X-Teleport-NextAppRedirectUrl"
 
-// appAuthConfigAuthorizationHeader is the default header name that contains
-// token used by app auth configs.
+// appAuthConfigAuthorizationHeader is the required header name that contains
+// authorization info used by app auth configs.
 const appAuthConfigAuthorizationHeader = "Authorization"
 
 // startAppAuthExchange will do two actions depending on the following:

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -284,7 +284,7 @@ func (h *Handler) BindMCPEndpoints(router *httprouter.Router, limiter func(httpl
 
 		},
 		func(app types.Application) bool {
-			return app.IsMCP()
+			return app.IsMCP() && types.GetMCPServerTransportType(app.GetURI()) == types.MCPTransportHTTP
 		},
 	))
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -420,7 +420,7 @@ func (h *Handler) authenticateWithAppAuth(ctx context.Context, r *http.Request, 
 	ws, appAuthConfig, err := h.getAppSessionUsingAuthConfig(r, reqAppServer)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to fetch application session", "error", err)
-		return nil, trace.Wrap(err)
+		return nil, trace.AccessDenied("invalid session")
 	}
 
 	session, err := h.getSessionWithAppAuth(ctx, ws, appAuthConfig)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -437,12 +437,15 @@ func (h *Handler) getAppSession(r *http.Request, reqAppServer *withAppServer) (w
 	// We have a client certificate with encoded session id in application
 	// access CLI flow i.e. when users log in using "tsh apps login" and
 	// then connect to the apps with the issued certs.
-	if HasClientCert(r) {
+	switch {
+	case HasClientCert(r):
 		ws, err = h.getAppSessionFromCert(r)
-	} else if HasSessionCookie(r) {
+	case HasSessionCookie(r):
 		ws, err = h.getAppSessionFromCookie(r)
-	} else {
+	case reqAppServer != nil:
 		ws, err = h.getAppSessionUsingAuthConfig(r, reqAppServer)
+	default:
+		return nil, trace.AccessDenied("no authentication method provided")
 	}
 	if err != nil {
 		h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -282,13 +282,13 @@ func (h *Handler) BindMCPEndpoints(router *httprouter.Router, limiter func(httpl
 		})
 	}
 
-	router.POST("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
-	router.DELETE("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
-	router.GET("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
+	router.POST("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
+	router.DELETE("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
+	router.GET("/mcp/sites/:site/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
 
-	router.POST("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
-	router.DELETE("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
-	router.GET("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleHttpResetPath, extractParams)))
+	router.POST("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
+	router.DELETE("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
+	router.GET("/mcp/apps/:app", wrapWithLimiter(h.withAuthAndAppResolver(h.handleStreamableMCP, extractParams)))
 }
 
 // handleHttp forwards the request to the application service or redirects
@@ -333,9 +333,9 @@ func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *se
 	return nil
 }
 
-// handleHttpResetPath handles app access requests using [handleHttp] function,
-// but before, it resets the request path.
-func (h *Handler) handleHttpResetPath(w http.ResponseWriter, r *http.Request, session *session) error {
+// handleStreamableMCP handles streamable HTTP MCP requests using [handleHttp]
+// function.
+func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, session *session) error {
 	r.URL.Path = "/"
 	return h.handleHttp(w, r, session)
 }

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -281,7 +281,6 @@ func (h *Handler) BindMCPEndpoints(router *httprouter.Router, limiter func(httpl
 				appName:     p.ByName("app"),
 				clusterName: p.ByName("site"),
 			}
-
 		},
 		func(app types.Application) bool {
 			return app.IsMCP() && types.GetMCPServerTransportType(app.GetURI()) == types.MCPTransportHTTP
@@ -356,45 +355,69 @@ func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, se
 	return h.handleHttp(w, r, session.session)
 }
 
-// handleForwardError when the forwarder has an error during the `ServeHTTP` it
-// will call this function. This handler will then renew the session in order
+// makeHandleForwardError when the forwarder has an error during the `ServeHTTP`
+// it will call this function. This handler will then renew the session in order
 // to get "fresh" app servers, and then will forwad the request to the newly
 // created session.
-func (h *Handler) handleForwardError(w http.ResponseWriter, req *http.Request, err error) {
-	// if it is not an agent connection problem, return without creating a new
-	// session.
-	if !trace.IsConnectionProblem(err) {
-		reverseproxy.DefaultHandler.ServeHTTP(w, req, err)
-		return
-	}
-
-	// If renewing the session fails, we should do the same for when the
-	// request authentication fails (defined in the "withAuth" middle). This is
-	// done to have a consistent UX to when launching an application.
-	session, err := h.renewSession(req)
-	if err != nil {
-		if redirectErr := h.redirectToLauncher(w, req, launcherURLParams{}); redirectErr == nil {
+func (h *Handler) makeHandleForwardError(sess *session) reverseproxy.ErrorHandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request, err error) {
+		// if it is not an agent connection problem, return without creating a new
+		// session.
+		if !trace.IsConnectionProblem(err) {
+			reverseproxy.DefaultHandler.ServeHTTP(w, req, err)
 			return
 		}
 
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
-		return
+		// If renewing the fwd fails, we should do the same for when the
+		// request authentication fails (defined in the "withAuth" middle). This is
+		// done to have a consistent UX to when launching an application.
+		fwd, err := sess.renewFunc(req)
+		if err != nil {
+			if redirectErr := h.redirectToLauncher(w, req, launcherURLParams{}); redirectErr == nil {
+				return
+			}
+
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(http.StatusText(http.StatusInternalServerError)))
+			return
+		}
+		// NOTE: This handler is called by the forwarder when it encounters an error
+		// during the `ServeHTTP` call. This means that the request forwarding was not successful.
+		// Since the request was not forwarded, and above we ignore all errors that are not
+		// connection problems, we can safely assume that the request body was not read.
+		// This happens because the connection problem is returned by the DialContext
+		// function, which is the HTTP transport requires before reading the request body.
+		// Although the request body is not read, the request body is closed by the
+		// HTTP Transport but we replace the request body in (*Handler).handleForward
+		// with a NopCloser so that the request body can be closed multiple times without
+		// impacting the request forwarding.
+		// If in the future we decide to retry requests that fail for other reasons,
+		// we need to support body rewinding with `req.GetBody` together with a
+		// `io.TeeReader` to read the request body and then rewind it.
+		fwd.ServeHTTP(w, req)
 	}
-	// NOTE: This handler is called by the forwarder when it encounters an error
-	// during the `ServeHTTP` call. This means that the request forwarding was not successful.
-	// Since the request was not forwarded, and above we ignore all errors that are not
-	// connection problems, we can safely assume that the request body was not read.
-	// This happens because the connection problem is returned by the DialContext
-	// function, which is the HTTP transport requires before reading the request body.
-	// Although the request body is not read, the request body is closed by the
-	// HTTP Transport but we replace the request body in (*Handler).handleForward
-	// with a NopCloser so that the request body can be closed multiple times without
-	// impacting the request forwarding.
-	// If in the future we decide to retry requests that fail for other reasons,
-	// we need to support body rewinding with `req.GetBody` together with a
-	// `io.TeeReader` to read the request body and then rewind it.
-	session.fwd.ServeHTTP(w, req)
+}
+
+// makeRenewAppAuthSession builds a renew function that attempts to renew app
+// auth session. The web session and app auth config are captured in the closure
+// so the renewer does not need to re-read them from the request (the request
+// headers may have been modified before forwarding, e.g. the JWT header is
+// stripped in handleStreamableMCP).
+func (h *Handler) makeRenewAppAuthSession(ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) sessionRenewFunc {
+	return func(r *http.Request) (*reverseproxy.Forwarder, error) {
+		// Remove the session from the cache, this will force a new session to be
+		// generated and cached.
+		h.cache.Remove(ws.GetName())
+
+		// Fetches a new session reusing the existing web session.
+		session, err := h.getSessionWithAppAuth(r.Context(), ws, reqAppServer, appAuthConfig)
+		if err != nil {
+			h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
+			return nil, trace.AccessDenied("invalid session")
+		}
+
+		return session.fwd, nil
+	}
 }
 
 // authenticate will check if request carries a session cookie matching a
@@ -426,7 +449,7 @@ func (h *Handler) authenticateWithAppAuth(ctx context.Context, r *http.Request, 
 		return nil, trace.AccessDenied("invalid session")
 	}
 
-	session, err := h.getSessionWithAppAuth(ctx, ws, appAuthConfig)
+	session, err := h.getSessionWithAppAuth(ctx, ws, reqAppServer, appAuthConfig)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to get session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
@@ -438,7 +461,7 @@ func (h *Handler) authenticateWithAppAuth(ctx context.Context, r *http.Request, 
 // renewSession based on the request removes the session from cache (if present)
 // and generates a new one using the `getSession` flow (same as in
 // `authenticate`).
-func (h *Handler) renewSession(r *http.Request) (*session, error) {
+func (h *Handler) renewSession(r *http.Request) (*reverseproxy.Forwarder, error) {
 	ws, err := h.getAppSession(r)
 	if err != nil {
 		h.logger.DebugContext(r.Context(), "Failed to fetch application session: not found")
@@ -456,7 +479,7 @@ func (h *Handler) renewSession(r *http.Request) (*session, error) {
 		return nil, trace.AccessDenied("invalid session")
 	}
 
-	return session, nil
+	return session.fwd, nil
 }
 
 // withAppServer holds information of the requested application.
@@ -653,7 +676,7 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 	// Put the session in the cache so the next request can use it.
 	ttl := ws.Expiry().Sub(h.c.Clock.Now())
 	sess, err := utils.FnCacheGetWithTTL(ctx, h.cache, ws.GetName(), ttl, func(ctx context.Context) (*session, error) {
-		sess, err := h.newSession(ctx, ws)
+		sess, err := h.newSession(ctx, ws, h.renewSession)
 		return sess, trace.Wrap(err)
 	})
 	return sess, trace.Wrap(err)
@@ -661,11 +684,11 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 
 // getSessionWithAppAuth returns a request session used to serve the request,
 // the session is authenticated with an app auth config.
-func (h *Handler) getSessionWithAppAuth(ctx context.Context, ws types.WebSession, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
+func (h *Handler) getSessionWithAppAuth(ctx context.Context, ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
 	// Put the session in the cache so the next request can use it.
 	ttl := ws.Expiry().Sub(h.c.Clock.Now())
 	sess, err := utils.FnCacheGetWithTTL(ctx, h.cache, ws.GetName(), ttl, func(ctx context.Context) (*sessionWithAppAuth, error) {
-		sess, err := h.newSessionWithAppAuth(ctx, ws, appAuthConfig)
+		sess, err := h.newSessionWithAppAuth(ctx, ws, reqAppServer, appAuthConfig)
 		return sess, trace.Wrap(err)
 	})
 	return sess, trace.Wrap(err)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -21,7 +21,6 @@
 package app
 
 import (
-	"cmp"
 	"context"
 	"crypto/tls"
 	"fmt"
@@ -339,20 +338,13 @@ func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *se
 
 // handleStreamableMCP handles streamable HTTP MCP requests using [handleHttp]
 // function.
-func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, session *sessionWithAppAuth) error {
-	switch spec := session.appAuthConfig.Spec.SubKindSpec.(type) {
-	case *appauthconfigv1.AppAuthConfigSpec_Jwt:
-		headerName := cmp.Or(spec.Jwt.AuthorizationHeader, appAuthConfigAuthorizationHeader)
-		r.Header.Del(headerName)
-	default:
-		return trace.BadParameter("unsupported app auth config")
-	}
-
+func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, session *session) error {
+	r.Header.Del(appAuthConfigAuthorizationHeader)
 	r.URL.Path = "/"
 	// We need to reset the `RequestURI` to indicate the reverse proxy to use
 	// the URL (which have the path reset).
 	r.RequestURI = ""
-	return h.handleHttp(w, r, session.session)
+	return h.handleHttp(w, r, session)
 }
 
 // makeHandleForwardError when the forwarder has an error during the `ServeHTTP`
@@ -403,14 +395,14 @@ func (h *Handler) makeHandleForwardError(sess *session) reverseproxy.ErrorHandle
 // so the renewer does not need to re-read them from the request (the request
 // headers may have been modified before forwarding, e.g. the JWT header is
 // stripped in handleStreamableMCP).
-func (h *Handler) makeRenewAppAuthSession(ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) sessionRenewFunc {
+func (h *Handler) makeRenewAppAuthSession(ws types.WebSession, reqAppServer *withAppServer) sessionRenewFunc {
 	return func(r *http.Request) (*reverseproxy.Forwarder, error) {
 		// Remove the session from the cache, this will force a new session to be
 		// generated and cached.
 		h.cache.Remove(ws.GetName())
 
 		// Fetches a new session reusing the existing web session.
-		session, err := h.getSessionWithAppAuth(r.Context(), ws, reqAppServer, appAuthConfig)
+		session, err := h.getSessionWithAppAuth(r.Context(), ws, reqAppServer)
 		if err != nil {
 			h.logger.WarnContext(r.Context(), "Failed to get session", "error", err)
 			return nil, trace.AccessDenied("invalid session")
@@ -442,14 +434,14 @@ func (h *Handler) authenticate(ctx context.Context, r *http.Request) (*session, 
 
 // authenticateWithAppAuth will check if the request carries matching app auth
 // config to authenticate the request.
-func (h *Handler) authenticateWithAppAuth(ctx context.Context, r *http.Request, reqAppServer *withAppServer) (*sessionWithAppAuth, error) {
-	ws, appAuthConfig, err := h.getAppSessionUsingAuthConfig(r, reqAppServer)
+func (h *Handler) authenticateWithAppAuth(ctx context.Context, r *http.Request, reqAppServer *withAppServer) (*session, error) {
+	ws, err := h.getAppSessionUsingAuthConfig(r, reqAppServer)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to fetch application session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
 	}
 
-	session, err := h.getSessionWithAppAuth(ctx, ws, reqAppServer, appAuthConfig)
+	session, err := h.getSessionWithAppAuth(ctx, ws, reqAppServer)
 	if err != nil {
 		h.logger.WarnContext(ctx, "Failed to get session", "error", err)
 		return nil, trace.AccessDenied("invalid session")
@@ -605,41 +597,40 @@ func (h *Handler) getAppSessionFromCookie(r *http.Request) (types.WebSession, er
 }
 
 // getAppSessionUsingAuthConfig retrieves the app session using app auth config.
-func (h *Handler) getAppSessionUsingAuthConfig(r *http.Request, reqAppServer *withAppServer) (types.WebSession, *appauthconfigv1.AppAuthConfig, error) {
+func (h *Handler) getAppSessionUsingAuthConfig(r *http.Request, reqAppServer *withAppServer) (types.WebSession, error) {
 	if reqAppServer == nil {
-		return nil, nil, trace.BadParameter("missing requested app")
+		return nil, trace.BadParameter("missing requested app")
+	}
+
+	authHeader, found := strings.CutPrefix(r.Header.Get(appAuthConfigAuthorizationHeader), "Bearer ")
+	if !found {
+		return nil, trace.BadParameter("expected request to include %q header", appAuthConfigAuthorizationHeader)
+	}
+
+	sid := services.GenerateAppSessionIDFromAuthHeader(authHeader)
+	if ws, err := h.getAppSessionFromAccessPoint(r.Context(), sid); err == nil {
+		h.logger.DebugContext(r.Context(), "session was present, returning...", "sid", ws.GetName())
+		return ws, nil
 	}
 
 	config, err := h.selectAppAuthConfig(r.Context(), reqAppServer.appServer.GetApp())
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	switch spec := config.Spec.SubKindSpec.(type) {
+	switch config.Spec.SubKindSpec.(type) {
 	case *appauthconfigv1.AppAuthConfigSpec_Jwt:
-		headerName := cmp.Or(spec.Jwt.AuthorizationHeader, appAuthConfigAuthorizationHeader)
-		jwtToken, found := strings.CutPrefix(r.Header.Get(headerName), "Bearer ")
-		if !found {
-			return nil, nil, trace.BadParameter("expected request to include %q header with JWT", headerName)
-		}
-
-		sid := services.GenerateAppSessionIDFromJWT(jwtToken)
-		if ws, err := h.getAppSessionFromAccessPoint(r.Context(), sid); err == nil {
-			h.logger.DebugContext(r.Context(), "session was present, returning...", "sid", ws.GetName())
-			return ws, config, nil
-		}
-
 		ws, err := h.startAppAuthConfigJWTSession(r.Context(), startAppAuthConfigSessionOptions{
 			sessionID:   sid,
-			token:       jwtToken,
+			token:       authHeader,
 			config:      config,
 			app:         reqAppServer.appServer.GetApp(),
 			clientAddr:  r.RemoteAddr,
 			clusterName: reqAppServer.clusterName,
 		})
-		return ws, config, trace.Wrap(err)
+		return ws, trace.Wrap(err)
 	default:
-		return nil, nil, trace.BadParameter("unsupported app auth config")
+		return nil, trace.BadParameter("unsupported app auth config")
 	}
 }
 
@@ -683,11 +674,11 @@ func (h *Handler) getSession(ctx context.Context, ws types.WebSession) (*session
 
 // getSessionWithAppAuth returns a request session used to serve the request,
 // the session is authenticated with an app auth config.
-func (h *Handler) getSessionWithAppAuth(ctx context.Context, ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
+func (h *Handler) getSessionWithAppAuth(ctx context.Context, ws types.WebSession, reqAppServer *withAppServer) (*session, error) {
 	// Put the session in the cache so the next request can use it.
 	ttl := ws.Expiry().Sub(h.c.Clock.Now())
-	sess, err := utils.FnCacheGetWithTTL(ctx, h.cache, ws.GetName(), ttl, func(ctx context.Context) (*sessionWithAppAuth, error) {
-		sess, err := h.newSessionWithAppAuth(ctx, ws, reqAppServer, appAuthConfig)
+	sess, err := utils.FnCacheGetWithTTL(ctx, h.cache, ws.GetName(), ttl, func(ctx context.Context) (*session, error) {
+		sess, err := h.newSession(ctx, ws, h.makeRenewAppAuthSession(ws, reqAppServer))
 		return sess, trace.Wrap(err)
 	})
 	return sess, trace.Wrap(err)

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -350,6 +350,9 @@ func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, se
 	}
 
 	r.URL.Path = "/"
+	// We need to reset the `RequestURI` to indicate the reverse proxy to use
+	// the URL (which have the path reset).
+	r.RequestURI = ""
 	return h.handleHttp(w, r, session.session)
 }
 

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -343,7 +343,7 @@ func (h *Handler) handleStreamableMCP(w http.ResponseWriter, r *http.Request, se
 	switch spec := session.appAuthConfig.Spec.SubKindSpec.(type) {
 	case *appauthconfigv1.AppAuthConfigSpec_Jwt:
 		headerName := cmp.Or(spec.Jwt.AuthorizationHeader, appAuthConfigAuthorizationHeader)
-		delete(r.Header, headerName)
+		r.Header.Del(headerName)
 	default:
 		return trace.BadParameter("unsupported app auth config")
 	}
@@ -655,12 +655,11 @@ func (h *Handler) selectAppAuthConfig(ctx context.Context, app types.Application
 		}
 
 		matched, message, err := services.MatchLabelGetter(convertedLabels, app)
-		if matched {
-			return config, nil
-		}
-
 		if err != nil {
 			return nil, trace.Wrap(err)
+		}
+		if matched {
+			return config, nil
 		}
 
 		h.logger.DebugContext(ctx, "unmatched app auth config", "reason", message)

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -908,7 +908,7 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		_, err = appHandler.authenticate(ctx, request, nil /* appServer */)
+		_, err = appHandler.authenticate(ctx, request)
 		require.NoError(t, err)
 	})
 
@@ -922,13 +922,13 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		request.TLS.PeerCertificates = []*x509.Certificate{x509Cert}
 
-		_, err = appHandler.authenticate(ctx, request, nil /* appServer */)
+		_, err = appHandler.authenticate(ctx, request)
 		require.NoError(t, err)
 	})
 
 	t.Run("without cookie or client cert", func(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
-		_, err := appHandler.authenticate(ctx, request, nil /* appServer */)
+		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
 	})
@@ -938,7 +938,7 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		_, err := appHandler.authenticate(ctx, request, nil /* appServer */)
+		_, err := appHandler.authenticate(ctx, request)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
 	})

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -41,9 +41,16 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/julienschmidt/httprouter"
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	mcpclienttransport "github.com/mark3labs/mcp-go/client/transport"
+	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/require"
 
+	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
+	labelv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/label/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/appauthconfig"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -54,6 +61,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/mcptest"
 )
 
 type eventCheckFn func(t *testing.T, events []apievents.AuditEvent)
@@ -440,11 +448,12 @@ func TestHealthCheckAppServer(t *testing.T) {
 }
 
 type testServer struct {
+	handler   *Handler
 	serverURL *url.URL
 }
 
 func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.ClientI, clusterGetter reversetunnelclient.ClusterGetter) *testServer {
-	appHandler, err := NewHandler(context.Background(), &HandlerConfig{
+	appHandler, err := NewHandler(t.Context(), &HandlerConfig{
 		Clock:                 clock,
 		AuthClient:            authClient,
 		AccessPoint:           authClient,
@@ -461,6 +470,7 @@ func setup(t *testing.T, clock *clockwork.FakeClock, authClient authclient.Clien
 	require.NoError(t, err)
 
 	return &testServer{
+		handler:   appHandler,
 		serverURL: url,
 	}
 }
@@ -502,16 +512,37 @@ func (p *testServer) makeRequest(t *testing.T, method, endpoint string, reqBody 
 	return resp.StatusCode, string(content)
 }
 
+func makeMCPClient(t *testing.T, testServer *httptest.Server, endpoint string, headers map[string]string) *mcpclient.Client {
+	ctx := t.Context()
+
+	mcpClientTransport, err := mcpclienttransport.NewStreamableHTTP(
+		testServer.URL+endpoint,
+		mcpclienttransport.WithContinuousListening(),
+		mcpclienttransport.WithHTTPBasicClient(testServer.Client()),
+		mcpclienttransport.WithHTTPHeaders(headers),
+	)
+	require.NoError(t, err)
+
+	client := mcpclient.NewClient(mcpClientTransport)
+	require.NoError(t, client.Start(ctx))
+
+	return client
+}
+
 type mockAuthClient struct {
 	authclient.ClientI
-	clusterName   string
-	appSession    types.WebSession
-	sessionError  error
-	appServers    []types.AppServer
-	caKey         []byte
-	caCert        []byte
-	emittedEvents []apievents.AuditEvent
-	mtx           sync.Mutex
+	clusterName         string
+	appSession          types.WebSession
+	sessionError        error
+	appServers          []types.AppServer
+	caKey               []byte
+	caCert              []byte
+	emittedEvents       []apievents.AuditEvent
+	mtx                 sync.Mutex
+	appAuthConfigs      []*appauthconfigv1.AppAuthConfig
+	appAuthConfigErr    error
+	createAppSession    types.WebSession
+	createAppSessionErr error
 }
 
 type mockClusterName struct {
@@ -546,6 +577,10 @@ func (c *mockAuthClient) GetAppSession(context.Context, types.GetAppSessionReque
 	return c.appSession, c.sessionError
 }
 
+func (c *mockAuthClient) CreateAppSessionWithJWT(context.Context, *appauthconfigv1.CreateAppSessionWithJWTRequest) (types.WebSession, error) {
+	return c.createAppSession, c.createAppSessionErr
+}
+
 func (c *mockAuthClient) GetApplicationServers(_ context.Context, _ string) ([]types.AppServer, error) {
 	return c.appServers, nil
 }
@@ -578,6 +613,10 @@ func (c *mockAuthClient) GetProxies() ([]types.Server, error) {
 
 func (c *mockAuthClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
 	return []types.Server{}, "", nil
+}
+
+func (c *mockAuthClient) ListAppAuthConfigs(ctx context.Context, limit int, startKey string) ([]*appauthconfigv1.AppAuthConfig, string, error) {
+	return c.appAuthConfigs, "", c.appAuthConfigErr
 }
 
 // fakeClusterListener Implements a `net.Listener` that return `net.Conn` from
@@ -847,7 +886,7 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		_, err = appHandler.authenticate(ctx, request)
+		_, err = appHandler.authenticate(ctx, request, nil /* appServer */)
 		require.NoError(t, err)
 	})
 
@@ -861,13 +900,13 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		request.TLS.PeerCertificates = []*x509.Certificate{x509Cert}
 
-		_, err = appHandler.authenticate(ctx, request)
+		_, err = appHandler.authenticate(ctx, request, nil /* appServer */)
 		require.NoError(t, err)
 	})
 
 	t.Run("without cookie or client cert", func(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
-		_, err := appHandler.authenticate(ctx, request)
+		_, err := appHandler.authenticate(ctx, request, nil /* appServer */)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
 	})
@@ -877,10 +916,282 @@ func TestHandlerAuthenticate(t *testing.T) {
 		request := httptest.NewRequest("GET", "https://"+publicAddr, nil)
 		addValidSessionCookiesToRequest(authClient.appSession, request)
 
-		_, err := appHandler.authenticate(ctx, request)
+		_, err := appHandler.authenticate(ctx, request, nil /* appServer */)
 		require.Error(t, err)
 		require.True(t, trace.IsAccessDenied(err))
 	})
+}
+
+// TestSelectAppAuthConfig given a list of app auth config and an app, ensures
+// that the function selects the correct config.
+func TestSelectAppAuthConfig(t *testing.T) {
+	expectAppConfigName := func(name string) require.ValueAssertionFunc {
+		return func(tt require.TestingT, i1 any, i2 ...any) {
+			require.NotNil(tt, i1, i2...)
+			require.IsType(tt, &appauthconfigv1.AppAuthConfig{}, i1, i2...)
+			config, _ := i1.(*appauthconfigv1.AppAuthConfig)
+			require.Equal(t, name, config.Metadata.GetName(), i2...)
+		}
+	}
+
+	for name, tc := range map[string]struct {
+		app          types.Application
+		configs      []*appauthconfigv1.AppAuthConfig
+		configsErr   error
+		assertError  require.ErrorAssertionFunc
+		assertConfig require.ValueAssertionFunc
+	}{
+		"single match": {
+			app: createMCPServer(t, "app", map[string]string{"env": "prod"}).GetApp(),
+			configs: []*appauthconfigv1.AppAuthConfig{
+				appauthconfig.NewAppAuthConfigJWT("config-1", []*labelv1.Label{{Name: "env", Values: []string{"prod"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
+			},
+			assertError:  require.NoError,
+			assertConfig: expectAppConfigName("config-1"),
+		},
+		"multiple matches, picks the first": {
+			app: createMCPServer(t, "app", map[string]string{"env": "prod"}).GetApp(),
+			configs: []*appauthconfigv1.AppAuthConfig{
+				appauthconfig.NewAppAuthConfigJWT("config-1", []*labelv1.Label{{Name: "env", Values: []string{"prod"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
+				appauthconfig.NewAppAuthConfigJWT("config-2", []*labelv1.Label{{Name: "env", Values: []string{"prod"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
+			},
+			assertError:  require.NoError,
+			assertConfig: expectAppConfigName("config-1"),
+		},
+		"no match": {
+			app: createMCPServer(t, "app", map[string]string{"env": "dev"}).GetApp(),
+			configs: []*appauthconfigv1.AppAuthConfig{
+				appauthconfig.NewAppAuthConfigJWT("config-1", []*labelv1.Label{{Name: "env", Values: []string{"prod"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
+				appauthconfig.NewAppAuthConfigJWT("config-2", []*labelv1.Label{{Name: "env", Values: []string{"prod"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
+			},
+			assertError:  require.Error,
+			assertConfig: require.Nil,
+		},
+		"list error": {
+			app:          createMCPServer(t, "app", map[string]string{"env": "dev"}).GetApp(),
+			configsErr:   trace.AccessDenied("failure"),
+			assertError:  require.Error,
+			assertConfig: require.Nil,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			authClient := &mockAuthClient{
+				appAuthConfigs:   tc.configs,
+				appAuthConfigErr: tc.configsErr,
+			}
+			appHandler, err := NewHandler(t.Context(), &HandlerConfig{
+				AuthClient:            authClient,
+				AccessPoint:           authClient,
+				CipherSuites:          utils.DefaultCipherSuites(),
+				IntegrationAppHandler: &mockIntegrationAppHandler{},
+			})
+			require.NoError(t, err)
+
+			selectedConfig, err := appHandler.selectAppAuthConfig(t.Context(), tc.app)
+			tc.assertError(t, err)
+			tc.assertConfig(t, selectedConfig)
+		})
+	}
+}
+
+// TestMCPEndpoints given a list of proxied MCP servers, initialize an MCP
+// client with the endpoints, and verify that the handle succeeds when
+// authentication succeeds and returns an error otherwise.
+func TestMCPEndpoints(t *testing.T) {
+	clusterName := "test-cluster"
+	mcpServerName := "mcp-test-server"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	header := "Authorization"
+	fakeClock := clockwork.NewFakeClock()
+	authClient := &mockAuthClient{
+		clusterName:      clusterName,
+		sessionError:     trace.BadParameter("not found"),
+		createAppSession: createAppSession(t, fakeClock, key, cert, clusterName, ""),
+		appServers:       []types.AppServer{createMCPServer(t, mcpServerName, nil /* labels */)},
+		caKey:            key,
+		caCert:           cert,
+		appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
+			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
+				AuthorizationHeader: header,
+			}),
+		},
+	}
+
+	fakeCluster := startFakeMCPServerOnCluster(t, clusterName, authClient, cert, key)
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{
+			fakeCluster,
+		},
+	}
+
+	p := setup(t, fakeClock, authClient, tunnel)
+	router := httprouter.New()
+	p.handler.BindMCPEndpoints(router, nil)
+	frontSrv := httptest.NewServer(router)
+	t.Cleanup(frontSrv.Close)
+
+	for _, endpoint := range []struct {
+		desc        string
+		unknownPath string
+		path        string
+	}{
+		{
+			desc:        "endpoint with site name and app name",
+			unknownPath: "/mcp/sites/random-site/apps/unknown-app",
+			path:        "/mcp/sites/" + clusterName + "/apps/" + mcpServerName,
+		},
+		{
+			desc:        "endpoint with only app name",
+			unknownPath: "/mcp/apps/unknown-app",
+			path:        "/mcp/apps/" + mcpServerName,
+		},
+	} {
+		t.Run(endpoint.desc, func(t *testing.T) {
+			t.Run("success", func(t *testing.T) {
+				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{header: "Bearer fake-token"})
+				mcptest.MustInitializeClient(t, clt)
+				mcptest.MustCallServerTool(t, clt)
+			})
+
+			t.Run("fails to resolve app", func(t *testing.T) {
+				clt := makeMCPClient(t, frontSrv, endpoint.unknownPath, nil)
+				_, err := mcptest.InitializeClient(t.Context(), clt)
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+func TestGetAppSessionAuthConfig(t *testing.T) {
+	t.Run("JWT", func(t *testing.T) {
+		clusterName := "test-cluster"
+		header := "Authorization"
+
+		fakeClock := clockwork.NewFakeClock()
+		key, cert, err := tlsca.GenerateSelfSignedCA(
+			pkix.Name{CommonName: clusterName},
+			[]string{apiutils.EncodeClusterName(clusterName)},
+			defaults.CATTL,
+		)
+		require.NoError(t, err)
+		appServer := createMCPServer(t, "mcp-server", nil /* labels */)
+
+		for name, tc := range map[string]struct {
+			appServer           *withAppServer
+			appSession          types.WebSession
+			createdAppSession   types.WebSession
+			createAppSessionErr error
+			appSessionError     error
+			headers             map[string]string
+			assertError         require.ErrorAssertionFunc
+		}{
+			"start new session": {
+				appServer:         &withAppServer{appServer: appServer},
+				appSessionError:   trace.NotFound("session not found"),
+				createdAppSession: createAppSession(t, fakeClock, key, cert, clusterName, ""),
+				headers:           map[string]string{header: "Bearer fake-token"},
+				assertError:       require.NoError,
+			},
+			"use existent session": {
+				appServer:   &withAppServer{appServer: appServer},
+				appSession:  createAppSession(t, fakeClock, key, cert, clusterName, ""),
+				headers:     map[string]string{header: "Bearer fake-token"},
+				assertError: require.NoError,
+			},
+			"error creating session": {
+				appServer:           &withAppServer{appServer: appServer},
+				appSessionError:     trace.NotFound("session not found"),
+				createAppSessionErr: trace.AccessDenied("error"),
+				headers:             map[string]string{header: "Bearer fake-token"},
+				assertError:         require.Error,
+			},
+			"empty app server returns error": {
+				appServer:   nil,
+				assertError: require.Error,
+			},
+		} {
+			t.Run(name, func(t *testing.T) {
+				req, err := http.NewRequest(http.MethodGet, "", nil)
+				require.NoError(t, err)
+				for headerName, headerVal := range tc.headers {
+					req.Header.Add(headerName, headerVal)
+				}
+
+				authClient := &mockAuthClient{
+					clusterName:         clusterName,
+					sessionError:        tc.appSessionError,
+					appSession:          tc.appSession,
+					createAppSession:    tc.createdAppSession,
+					createAppSessionErr: tc.createAppSessionErr,
+					appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
+						appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
+							AuthorizationHeader: header,
+						}),
+					},
+				}
+
+				handler, err := NewHandler(t.Context(), &HandlerConfig{
+					AuthClient:            authClient,
+					AccessPoint:           authClient,
+					CipherSuites:          utils.DefaultCipherSuites(),
+					IntegrationAppHandler: &mockIntegrationAppHandler{},
+				})
+				require.NoError(t, err)
+
+				_, err = handler.getAppSessionUsingAuthConfig(req, tc.appServer)
+				tc.assertError(t, err)
+			})
+		}
+	})
+}
+
+func startFakeMCPServerOnCluster(t *testing.T, clusterName string, accessPoint authclient.RemoteProxyAccessPoint, cert, key []byte) *reversetunnelclient.FakeCluster {
+	t.Helper()
+
+	tlsCert, err := tls.X509KeyPair(cert, key)
+	require.NoError(t, err)
+
+	sseServer := mcpserver.NewStreamableHTTPServer(mcptest.NewServer())
+	fakeCluster := reversetunnelclient.NewFakeCluster(clusterName, accessPoint)
+	streamableHTTPServer := &httptest.Server{
+		TLS: &tls.Config{
+			Certificates: []tls.Certificate{tlsCert},
+		},
+		Listener: &fakeClusterListener{
+			fakeCluster: fakeCluster,
+		},
+		Config: &http.Server{Handler: sseServer},
+	}
+	streamableHTTPServer.StartTLS()
+	t.Cleanup(func() {
+		fakeCluster.Close()
+		streamableHTTPServer.Close()
+	})
+	return fakeCluster
+}
+
+func createMCPServer(t *testing.T, name string, labels map[string]string) types.AppServer {
+	appServer, err := types.NewAppServerV3(
+		types.Metadata{Name: name, Labels: labels},
+		types.AppServerSpecV3{
+			HostID: uuid.New().String(),
+			App: &types.AppV3{
+				Metadata: types.Metadata{Name: name, Labels: labels},
+				Spec: types.AppSpecV3{
+					URI: "mcp+http://localhost",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	return appServer
 }
 
 func addValidSessionCookiesToRequest(appSession types.WebSession, r *http.Request) {

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1178,20 +1178,41 @@ func startFakeMCPServerOnCluster(t *testing.T, clusterName string, accessPoint a
 }
 
 func createMCPServer(t *testing.T, name string, labels map[string]string) types.AppServer {
+	t.Helper()
 	appServer, err := types.NewAppServerV3(
 		types.Metadata{Name: name, Labels: labels},
 		types.AppServerSpecV3{
 			HostID: uuid.New().String(),
-			App: &types.AppV3{
-				Metadata: types.Metadata{Name: name, Labels: labels},
-				Spec: types.AppSpecV3{
-					URI: "mcp+http://localhost",
-				},
-			},
+			App:    createMCPApp(t, name, labels),
 		},
 	)
 	require.NoError(t, err)
 	return appServer
+}
+
+func createAppServerWithApp(t *testing.T, app *types.AppV3) types.AppServer {
+	t.Helper()
+	appServer, err := types.NewAppServerV3(
+		types.Metadata{Name: uuid.New().String()},
+		types.AppServerSpecV3{
+			HostID: uuid.New().String(),
+			App:    app,
+		},
+	)
+	require.NoError(t, err)
+	return appServer
+}
+
+func createMCPApp(t *testing.T, name string, labels map[string]string) *types.AppV3 {
+	t.Helper()
+	app, err := types.NewAppV3(
+		types.Metadata{Name: name, Labels: labels},
+		types.AppSpecV3{
+			URI: "mcp+http://localhost",
+		},
+	)
+	require.NoError(t, err)
+	return app
 }
 
 func addValidSessionCookiesToRequest(appSession types.WebSession, r *http.Request) {

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1190,7 +1190,7 @@ func TestGetAppSessionAuthConfig(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				_, err = handler.getAppSessionUsingAuthConfig(req, tc.appServer)
+				_, _, err = handler.getAppSessionUsingAuthConfig(req, tc.appServer)
 				tc.assertError(t, err)
 			})
 		}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1127,6 +1127,128 @@ func TestMCPEndpoints(t *testing.T) {
 	})
 }
 
+func TestMCPSessionRenewOnConnectionProblem(t *testing.T) {
+	const (
+		clusterName   = "test-cluster"
+		mcpServerName = "mcp-test-server"
+		header        = "Authorization"
+	)
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	serverA := createMCPServer(t, mcpServerName, nil)
+	serverB := createMCPServer(t, mcpServerName, nil)
+
+	authClient := &mockAuthClient{
+		clusterName:      clusterName,
+		sessionError:     trace.BadParameter("not found"),
+		createAppSession: createAppSession(t, fakeClock, key, cert, clusterName, ""),
+		appServers:       []types.AppServer{serverA, serverB},
+		caKey:            key,
+		caCert:           cert,
+		appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
+			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
+				AuthorizationHeader: header,
+			}),
+		},
+	}
+
+	fakeCluster := startFakeMCPServerOnCluster(t, clusterName, authClient, cert, key)
+	// Initially, server B is offline so only server A is included in the session.
+	fakeCluster.OfflineTunnels = map[string]struct{}{
+		fmt.Sprintf("%s.%s", serverB.GetHostID(), clusterName): {},
+	}
+
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	p := setup(t, fakeClock, authClient, tunnel)
+	router := httprouter.New()
+	p.handler.BindMCPEndpoints(router, nil)
+	frontSrv := httptest.NewServer(router)
+	t.Cleanup(frontSrv.Close)
+
+	clt := makeMCPClient(t, frontSrv, "/mcp/apps/"+mcpServerName, map[string]string{
+		header: "Bearer fake-token",
+	})
+
+	// First requests succeed normally. The session is created with server A
+	// (server B is filtered during health check).
+	mcptest.MustInitializeClient(t, clt)
+	mcptest.MustCallServerTool(t, clt)
+
+	// Swap availability: server A goes offline, server B comes online.
+	fakeCluster.OfflineTunnels = map[string]struct{}{
+		fmt.Sprintf("%s.%s", serverA.GetHostID(), clusterName): {},
+	}
+
+	// Next tool call triggers the renewal flow and must succeed.
+	mcptest.MustCallServerTool(t, clt)
+}
+
+func TestSessionRenewOnConnectionProblem(t *testing.T) {
+	clusterName := "test-cluster"
+	publicAddr := "app.example.com"
+
+	key, cert, err := tlsca.GenerateSelfSignedCA(
+		pkix.Name{CommonName: clusterName},
+		[]string{publicAddr, apiutils.EncodeClusterName(clusterName)},
+		defaults.CATTL,
+	)
+	require.NoError(t, err)
+
+	fakeClock := clockwork.NewFakeClock()
+	serverA := createAppServer(t, publicAddr)
+	serverB := createAppServer(t, publicAddr)
+
+	authClient := &mockAuthClient{
+		clusterName: clusterName,
+		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr),
+		appServers:  []types.AppServer{serverA, serverB},
+		caKey:       key,
+		caCert:      cert,
+	}
+
+	fakeCluster := startFakeAppServerOnCluster(t, clusterName, authClient, cert, key)
+	// Initially, server B is offline so only server A is included in the session.
+	fakeCluster.OfflineTunnels = map[string]struct{}{
+		fmt.Sprintf("%s.%s", serverB.GetHostID(), clusterName): {},
+	}
+
+	tunnel := &reversetunnelclient.FakeServer{
+		FakeClusters: []reversetunnelclient.Cluster{fakeCluster},
+	}
+
+	p := setup(t, fakeClock, authClient, tunnel)
+	cookies := []http.Cookie{
+		{Name: CookieName, Value: "abc"},
+		{Name: SubjectCookieName, Value: authClient.appSession.GetBearerToken()},
+	}
+
+	// First request succeeds normally. The session is created with server A
+	// (server B is filtered during health check).
+	status, content := p.makeRequest(t, "GET", "/", []byte{}, cookies)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "Hello application", content)
+
+	// Swap availability: server A goes offline, server B comes online.
+	fakeCluster.OfflineTunnels = map[string]struct{}{
+		fmt.Sprintf("%s.%s", serverA.GetHostID(), clusterName): {},
+	}
+
+	// Second request triggers the renewal flow and must succeed.
+	status, content = p.makeRequest(t, "GET", "/", []byte{}, cookies)
+	require.Equal(t, http.StatusOK, status)
+	require.Equal(t, "Hello application", content)
+}
+
 func TestGetAppSessionAuthConfig(t *testing.T) {
 	t.Run("JWT", func(t *testing.T) {
 		clusterName := "test-cluster"
@@ -1238,7 +1360,8 @@ func startFakeMCPServerOnCluster(t *testing.T, clusterName string, accessPoint a
 func createMCPServer(t *testing.T, name string, labels map[string]string) types.AppServer {
 	t.Helper()
 	appServer, err := types.NewAppServerV3(
-		types.Metadata{Name: name, Labels: labels},
+		// App server names must be unique so we don't deduplicate them.
+		types.Metadata{Name: uuid.New().String(), Labels: labels},
 		types.AppServerSpecV3{
 			HostID: uuid.New().String(),
 			App:    createMCPApp(t, name, labels),

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -32,6 +32,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1024,7 +1025,7 @@ func TestMCPEndpoints(t *testing.T) {
 		clusterName       = "test-cluster"
 		mcpServerName     = "mcp-test-server"
 		appName           = "regular-app"
-		header            = "Authorization"
+		authHeader        = "Authorization"
 		customHader       = "X-Custom-Test-Header"
 		customHeaderValue = "random-value"
 	)
@@ -1049,7 +1050,7 @@ func TestMCPEndpoints(t *testing.T) {
 		caCert: cert,
 		appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
 			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
-				AuthorizationHeader: header,
+				AuthorizationHeader: authHeader,
 			}),
 		},
 	}
@@ -1085,15 +1086,24 @@ func TestMCPEndpoints(t *testing.T) {
 	} {
 		t.Run(endpoint.desc, func(t *testing.T) {
 			t.Run("success", func(t *testing.T) {
-				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{
-					header:      "Bearer fake-token",
-					customHader: customHeaderValue,
-				})
-				mcptest.MustInitializeClient(t, clt)
-				mcptest.MustCallServerTool(t, clt)
-				headers := mcptest.MustCallRequestHeaders(t, clt)
-				require.Empty(t, headers.Get(header))
-				require.Equal(t, customHeaderValue, headers.Get(customHader))
+				// Ensure the authorization header is case insensitive.
+				for _, header := range []string{
+					authHeader,
+					strings.ToLower(authHeader),
+					strings.ToUpper(authHeader),
+				} {
+					t.Run(header, func(t *testing.T) {
+						clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{
+							header:      "Bearer fake-token",
+							customHader: customHeaderValue,
+						})
+						mcptest.MustInitializeClient(t, clt)
+						mcptest.MustCallServerTool(t, clt)
+						headers := mcptest.MustCallRequestHeaders(t, clt)
+						require.Empty(t, headers.Get(header))
+						require.Equal(t, customHeaderValue, headers.Get(customHader))
+					})
+				}
 			})
 
 			t.Run("fails to resolve app", func(t *testing.T) {
@@ -1119,7 +1129,7 @@ func TestMCPEndpoints(t *testing.T) {
 			},
 		} {
 			t.Run(endpoint.desc, func(t *testing.T) {
-				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{header: "Bearer fake-token"})
+				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{authHeader: "Bearer fake-token"})
 				_, err := mcptest.InitializeClient(t.Context(), clt)
 				require.Error(t, err)
 			})

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1096,7 +1096,7 @@ func TestMCPEndpoints(t *testing.T) {
 						})
 						mcptest.MustInitializeClient(t, clt)
 						mcptest.MustCallServerTool(t, clt)
-						headers := mcptest.MustCallRequestHeaders(t, clt)
+						headers := mcptest.MustCallRequestHeadersTool(t, clt)
 						require.Empty(t, headers.Get(header))
 						require.Equal(t, customHeaderValue, headers.Get(customHader))
 					})

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -1025,7 +1025,6 @@ func TestMCPEndpoints(t *testing.T) {
 		clusterName       = "test-cluster"
 		mcpServerName     = "mcp-test-server"
 		appName           = "regular-app"
-		authHeader        = "Authorization"
 		customHader       = "X-Custom-Test-Header"
 		customHeaderValue = "random-value"
 	)
@@ -1049,9 +1048,7 @@ func TestMCPEndpoints(t *testing.T) {
 		caKey:  key,
 		caCert: cert,
 		appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
-			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
-				AuthorizationHeader: authHeader,
-			}),
+			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
 		},
 	}
 
@@ -1088,9 +1085,9 @@ func TestMCPEndpoints(t *testing.T) {
 			t.Run("success", func(t *testing.T) {
 				// Ensure the authorization header is case insensitive.
 				for _, header := range []string{
-					authHeader,
-					strings.ToLower(authHeader),
-					strings.ToUpper(authHeader),
+					appAuthConfigAuthorizationHeader,
+					strings.ToLower(appAuthConfigAuthorizationHeader),
+					strings.ToUpper(appAuthConfigAuthorizationHeader),
 				} {
 					t.Run(header, func(t *testing.T) {
 						clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{
@@ -1129,7 +1126,7 @@ func TestMCPEndpoints(t *testing.T) {
 			},
 		} {
 			t.Run(endpoint.desc, func(t *testing.T) {
-				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{authHeader: "Bearer fake-token"})
+				clt := makeMCPClient(t, frontSrv, endpoint.path, map[string]string{appAuthConfigAuthorizationHeader: "Bearer fake-token"})
 				_, err := mcptest.InitializeClient(t.Context(), clt)
 				require.Error(t, err)
 			})
@@ -1141,7 +1138,6 @@ func TestMCPSessionRenewOnConnectionProblem(t *testing.T) {
 	const (
 		clusterName   = "test-cluster"
 		mcpServerName = "mcp-test-server"
-		header        = "Authorization"
 	)
 
 	key, cert, err := tlsca.GenerateSelfSignedCA(
@@ -1163,9 +1159,7 @@ func TestMCPSessionRenewOnConnectionProblem(t *testing.T) {
 		caKey:            key,
 		caCert:           cert,
 		appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
-			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
-				AuthorizationHeader: header,
-			}),
+			appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
 		},
 	}
 
@@ -1186,7 +1180,7 @@ func TestMCPSessionRenewOnConnectionProblem(t *testing.T) {
 	t.Cleanup(frontSrv.Close)
 
 	clt := makeMCPClient(t, frontSrv, "/mcp/apps/"+mcpServerName, map[string]string{
-		header: "Bearer fake-token",
+		appAuthConfigAuthorizationHeader: "Bearer fake-token",
 	})
 
 	// First requests succeed normally. The session is created with server A
@@ -1262,7 +1256,6 @@ func TestSessionRenewOnConnectionProblem(t *testing.T) {
 func TestGetAppSessionAuthConfig(t *testing.T) {
 	t.Run("JWT", func(t *testing.T) {
 		clusterName := "test-cluster"
-		header := "Authorization"
 
 		fakeClock := clockwork.NewFakeClock()
 		key, cert, err := tlsca.GenerateSelfSignedCA(
@@ -1286,21 +1279,28 @@ func TestGetAppSessionAuthConfig(t *testing.T) {
 				appServer:         &withAppServer{appServer: appServer},
 				appSessionError:   trace.NotFound("session not found"),
 				createdAppSession: createAppSession(t, fakeClock, key, cert, clusterName, ""),
-				headers:           map[string]string{header: "Bearer fake-token"},
+				headers:           map[string]string{appAuthConfigAuthorizationHeader: "Bearer fake-token"},
 				assertError:       require.NoError,
 			},
 			"use existent session": {
 				appServer:   &withAppServer{appServer: appServer},
 				appSession:  createAppSession(t, fakeClock, key, cert, clusterName, ""),
-				headers:     map[string]string{header: "Bearer fake-token"},
+				headers:     map[string]string{appAuthConfigAuthorizationHeader: "Bearer fake-token"},
 				assertError: require.NoError,
 			},
 			"error creating session": {
 				appServer:           &withAppServer{appServer: appServer},
 				appSessionError:     trace.NotFound("session not found"),
 				createAppSessionErr: trace.AccessDenied("error"),
-				headers:             map[string]string{header: "Bearer fake-token"},
+				headers:             map[string]string{appAuthConfigAuthorizationHeader: "Bearer fake-token"},
 				assertError:         require.Error,
+			},
+			"wrong header": {
+				appServer:         &withAppServer{appServer: appServer},
+				appSessionError:   trace.NotFound("session not found"),
+				createdAppSession: createAppSession(t, fakeClock, key, cert, clusterName, ""),
+				headers:           map[string]string{"Random-Authorization": "Bearer fake-token"},
+				assertError:       require.Error,
 			},
 			"empty app server returns error": {
 				appServer:   nil,
@@ -1321,9 +1321,7 @@ func TestGetAppSessionAuthConfig(t *testing.T) {
 					createAppSession:    tc.createdAppSession,
 					createAppSessionErr: tc.createAppSessionErr,
 					appAuthConfigs: []*appauthconfigv1.AppAuthConfig{
-						appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{
-							AuthorizationHeader: header,
-						}),
+						appauthconfig.NewAppAuthConfigJWT("test-config", []*labelv1.Label{{Name: "*", Values: []string{"*"}}}, &appauthconfigv1.AppAuthConfigJWTSpec{}),
 					},
 				}
 
@@ -1335,7 +1333,7 @@ func TestGetAppSessionAuthConfig(t *testing.T) {
 				})
 				require.NoError(t, err)
 
-				_, _, err = handler.getAppSessionUsingAuthConfig(req, tc.appServer)
+				_, err = handler.getAppSessionUsingAuthConfig(req, tc.appServer)
 				tc.assertError(t, err)
 			})
 		}

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -104,8 +104,7 @@ func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterG
 	return nil, "", trace.NotFound("failed to resolve %v to any application within any cluster", fqdn)
 }
 
-// ResolveByName resolves app name into an application running on a
-// specific site (cluster).
+// ResolveByName resolves an application in a specific Teleport cluster by name.
 func ResolveByName(ctx context.Context, cluster reversetunnelclient.Cluster, appName string) (types.AppServer, error) {
 	servers, err := MatchUnshuffled(ctx, cluster, MatchName(appName))
 	if err != nil {

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -112,7 +112,7 @@ func ResolveByName(ctx context.Context, cluster reversetunnelclient.Cluster, app
 	}
 
 	if len(servers) == 0 {
-		return nil, trace.BadParameter("unable to solve requested app by name")
+		return nil, trace.BadParameter("unable to resolve requested app by name")
 	}
 
 	return servers[0], nil

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -62,12 +62,6 @@ func MatchName(name string) Matcher {
 	}
 }
 
-// ClusterGetter provides a means to retrieve all connected
-// Teleport clusters - either local or remote.
-type ClusterGetter interface {
-	Clusters(context.Context) ([]reversetunnelclient.Cluster, error)
-}
-
 // ResolveFQDN makes a best effort attempt to resolve FQDN to an application
 // running a root or leaf cluster.
 //
@@ -112,13 +106,13 @@ func ResolveFQDN(ctx context.Context, clusterGetter reversetunnelclient.ClusterG
 
 // ResolveByName resolves app name into an application running on a
 // specific site (cluster).
-func ResolveByName(ctx context.Context, cluster reversetunnelclient.Cluster, site string, appName string) (types.AppServer, error) {
+func ResolveByName(ctx context.Context, cluster reversetunnelclient.Cluster, appName string) (types.AppServer, error) {
 	servers, err := MatchUnshuffled(ctx, cluster, MatchName(appName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if len(servers) != 1 {
+	if len(servers) == 0 {
 		return nil, trace.BadParameter("unable to solve requested app by name")
 	}
 

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -67,14 +67,6 @@ func TestResolveByName(t *testing.T) {
 		createMCPApp(t, "example-2", nil /* labels */),
 		createMCPApp(t, "example-3", nil /* labels */),
 	}
-	// appServer, err := types.NewAppServerV3(
-	// 	types.Metadata{Name: name, Labels: labels},
-	// 	types.AppServerSpecV3{
-	// 		HostID: uuid.New().String(),
-	// 		App:    createMCPApp(t, name, labels),
-	// 	},
-	// )
-	// require.NoError(t, err)
 
 	for name, tc := range map[string]struct {
 		appName         string

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -170,7 +170,6 @@ func (m *mockAppServersGetter) GetApplicationServers(ctx context.Context, namesp
 
 type mockClusterGetter struct {
 	reversetunnelclient.ClusterGetter
-	ctx     context.Context
 	cluster *mockCluster
 }
 

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -115,7 +115,7 @@ func TestResolveByName(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			clock := clockwork.NewFakeClock()
 
 			bk, err := memory.New(memory.Config{
@@ -130,7 +130,7 @@ func TestResolveByName(t *testing.T) {
 
 			appService := local.NewAppService(bk)
 			for _, app := range apps {
-				require.NoError(t, appService.CreateApp(t.Context(), app))
+				require.NoError(t, appService.CreateApp(ctx, app))
 			}
 
 			w, err := services.NewAppServersWatcher(ctx, services.AppServersWatcherConfig{
@@ -145,7 +145,7 @@ func TestResolveByName(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			res, err := ResolveByName(t.Context(), &mockCluster{watcher: w}, tc.appName)
+			res, err := ResolveByName(ctx, &mockCluster{watcher: w}, tc.appName)
 			tc.assertError(t, err)
 			tc.assertAppServer(t, res)
 		})

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -70,9 +70,9 @@ type requestedAppParams struct {
 	clusterName string
 }
 
-// extracAppParamsFunc function used to extract the requested app params from
+// extractAppParamsFunc function used to extract the requested app params from
 // a request.
-type extracAppParamsFunc func(p httprouter.Params) requestedAppParams
+type extractAppParamsFunc func(p httprouter.Params) requestedAppParams
 
 // appQualifierFunc function used to check if the resolved app qualifies for
 // receiving the request.
@@ -80,7 +80,7 @@ type appQualifierFunc func(app types.Application) bool
 
 // withAppAuthConfig resolves app based on request then authenticate the
 // request before handling to a http.HandlerFunc.
-func (h *Handler) withAppAuthConfig(handler handlerWithAppAuthFunc, extractFunc extracAppParamsFunc, appFunc appQualifierFunc) httprouter.Handle {
+func (h *Handler) withAppAuthConfig(handler handlerWithAppAuthFunc, extractFunc extractAppParamsFunc, appFunc appQualifierFunc) httprouter.Handle {
 	return makeRouterHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 		params := extractFunc(p)
 		appName := params.appName

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -94,7 +94,7 @@ func (h *Handler) withAuthAndAppResolver(handler handlerAuthFunc, extractFunc ex
 			return trace.Wrap(err)
 		}
 
-		appServer, err := ResolveByName(r.Context(), clusterClient, site, appName)
+		appServer, err := ResolveByName(r.Context(), clusterClient, appName)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -80,7 +80,7 @@ type appQualifierFunc func(app types.Application) bool
 
 // withAppAuthConfig resolves app based on request then authenticate the
 // request before handling to a http.HandlerFunc.
-func (h *Handler) withAppAuthConfig(handler handlerWithAppAuthFunc, extractFunc extractAppParamsFunc, appFunc appQualifierFunc) httprouter.Handle {
+func (h *Handler) withAppAuthConfig(handler handlerWithSessionFunc, extractFunc extractAppParamsFunc, appFunc appQualifierFunc) httprouter.Handle {
 	return makeRouterHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) error {
 		params := extractFunc(p)
 		appName := params.appName
@@ -209,7 +209,7 @@ type routerAuthFunc func(http.ResponseWriter, *http.Request, httprouter.Params, 
 
 type handlerAuthFunc func(http.ResponseWriter, *http.Request, *session) error
 
-type handlerWithAppAuthFunc func(http.ResponseWriter, *http.Request, *sessionWithAppAuth) error
+type handlerWithSessionFunc func(http.ResponseWriter, *http.Request, *session) error
 
 type handlerFunc func(http.ResponseWriter, *http.Request) error
 

--- a/lib/web/app/middleware.go
+++ b/lib/web/app/middleware.go
@@ -105,7 +105,7 @@ func (h *Handler) withAppAuthConfig(handler handlerWithSessionFunc, extractFunc 
 		}
 
 		if !appFunc(appServer.GetApp()) {
-			return trace.NotFound("app not found")
+			return trace.BadParameter("unable to resolve requested app by name")
 		}
 
 		session, err := h.authenticateWithAppAuth(r.Context(), r, &withAppServer{

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/srv/app/common"
@@ -40,10 +41,12 @@ type session struct {
 	ws types.WebSession
 	// transport allows to dial an application server.
 	tr *transport
+	// appAuthConfig represents the app auth config to serve the session.
+	appAuthConfig *appauthconfigv1.AppAuthConfig
 }
 
 // newSession creates a new session.
-func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session, error) {
+func (h *Handler) newSession(ctx context.Context, ws types.WebSession, appAuthConfig *appauthconfigv1.AppAuthConfig) (*session, error) {
 	// Extract the identity of the user.
 	certificate, err := tlsca.ParseCertificatePEM(ws.GetTLSCert())
 	if err != nil {
@@ -124,8 +127,9 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 		return nil, trace.Wrap(err)
 	}
 	return &session{
-		fwd: fwd,
-		ws:  ws,
-		tr:  transport,
+		fwd:           fwd,
+		ws:            ws,
+		tr:            transport,
+		appAuthConfig: appAuthConfig,
 	}, nil
 }

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -21,6 +21,7 @@ package app
 import (
 	"context"
 	"math/rand/v2"
+	"net/http"
 	"slices"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+// sessionRenewFunc is a function used to renew sessions.
+type sessionRenewFunc func(r *http.Request) (*reverseproxy.Forwarder, error)
+
 // session holds a request forwarder and web session for this request.
 type session struct {
 	// fwd can rewrite and forward requests to the target application.
@@ -41,10 +45,13 @@ type session struct {
 	ws types.WebSession
 	// transport allows to dial an application server.
 	tr *transport
+	// renewer is the function used to renewFunc the session in case of connectivity
+	// issues.
+	renewFunc sessionRenewFunc
 }
 
 // newSession creates a new session.
-func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session, error) {
+func (h *Handler) newSession(ctx context.Context, ws types.WebSession, renewFunc sessionRenewFunc) (*session, error) {
 	// Extract the identity of the user.
 	certificate, err := tlsca.ParseCertificatePEM(ws.GetTLSCert())
 	if err != nil {
@@ -111,24 +118,25 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession) (*session
 	delegate := reverseproxy.NewHeaderRewriter()
 	delegate.TrustForwardHeader = false
 	hr := common.NewHeaderRewriter(delegate)
+	sess := &session{
+		ws:        ws,
+		tr:        transport,
+		renewFunc: renewFunc,
+	}
 
 	// Create a forwarder that will be used to forward requests.
-	fwd, err := reverseproxy.New(
+	sess.fwd, err = reverseproxy.New(
 		reverseproxy.WithPassHostHeader(),
 		reverseproxy.WithFlushInterval(100*time.Millisecond),
 		reverseproxy.WithRoundTripper(transport),
 		reverseproxy.WithLogger(h.logger),
-		reverseproxy.WithErrorHandler(h.handleForwardError),
+		reverseproxy.WithErrorHandler(h.makeHandleForwardError(sess)),
 		reverseproxy.WithRewriter(hr),
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	return &session{
-		fwd: fwd,
-		ws:  ws,
-		tr:  transport,
-	}, nil
+	return sess, nil
 }
 
 // sessionWithAppAuth holds a session that was authenticated with app auth
@@ -141,8 +149,8 @@ type sessionWithAppAuth struct {
 }
 
 // newSessionWithAppAuth creates a new session with app auth config.
-func (h *Handler) newSessionWithAppAuth(ctx context.Context, ws types.WebSession, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
-	sess, err := h.newSession(ctx, ws)
+func (h *Handler) newSessionWithAppAuth(ctx context.Context, ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
+	sess, err := h.newSession(ctx, ws, h.makeRenewAppAuthSession(ws, reqAppServer, appAuthConfig))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/app/session.go
+++ b/lib/web/app/session.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	appauthconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/appauthconfig/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/srv/app/common"
@@ -137,23 +136,4 @@ func (h *Handler) newSession(ctx context.Context, ws types.WebSession, renewFunc
 		return nil, trace.Wrap(err)
 	}
 	return sess, nil
-}
-
-// sessionWithAppAuth holds a session that was authenticated with app auth
-// config.
-type sessionWithAppAuth struct {
-	*session
-
-	// appAuthConfig represents the app auth config to serve the session.
-	appAuthConfig *appauthconfigv1.AppAuthConfig
-}
-
-// newSessionWithAppAuth creates a new session with app auth config.
-func (h *Handler) newSessionWithAppAuth(ctx context.Context, ws types.WebSession, reqAppServer *withAppServer, appAuthConfig *appauthconfigv1.AppAuthConfig) (*sessionWithAppAuth, error) {
-	sess, err := h.newSession(ctx, ws, h.makeRenewAppAuthSession(ws, reqAppServer, appAuthConfig))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &sessionWithAppAuth{session: sess, appAuthConfig: appAuthConfig}, nil
 }


### PR DESCRIPTION
Related to [RFD 0030e](https://github.com/gravitational/teleport.e/blob/c6fb7c51e3e8860253391c0a5b039e2c66bb27e5/rfd/0030e-remote-mcp.md).

Adds the web API endpoints that will accept/handle streamable HTTP MCP connections with app authentication (managed/done by appauthconfig service, introduced at #62324).

<hr>

### Manual testing

- [x] App access
  - [x] Cookie credentials (launch through WebUI)
  - [x] Certificates session (`tsh app login`)
  - [x] HA scenario (the app servers go down and the session is renewed).
- [x] MCP access
  - [x] Streamable with local proxy (`tsh mcp connect`).
  - [x] STDIO (`tsh mcp connect`).
  - [x] Streamable with app auth config JWT (more details on setup below)
  - [x] HA scenario (the app servers go down and the session is renewed).

<details>
<summary>Setup</summary>

To test the app auth config JWT, we need a JWT token issuer with JSON Web Key Set (JWKS). For this, I used Teleport itself.

First, start your Streamble MCP server. We're using `mcp-everything`:

```
$ bunx @modelcontextprotocol/server-everything streamableHttp
Starting Streamable HTTP server...
MCP Streamable HTTP Server listening on port 3001
```

Second, configure the `app_service`:
```yaml
app_service:
  enabled: true
  debug_app: true  # Important, as this is how we'll grab the user's JWT token.
  apps:
  - name: mcp-everything
    uri: mcp+http://localhost:3001/mcp
```

With this running, we can grab the dumper address and JWT that we'll use for accessing the MCP:

```
$ tsh app login dumper
...
$ curl \
  --cert ".tsh-home/keys/proxy.teleport.dev/alice-app/root.teleport.dev/dumper.crt" \
  --key ".tsh-home/keys/proxy.teleport.dev/alice-app/root.teleport.dev/dumper.key" \
  https://dumper.proxy.teleport.dev:443 -k

GET / HTTP/1.1
Host: 127.0.0.1:64703
Accept: */*
Accept-Encoding: gzip
Teleport-Jwt-Assertion: xxxxxxx
User-Agent: curl/8.7.1
X-Forwarded-For: 127.0.0.1
X-Forwarded-Host: dumper.proxy.teleport.dev:4443
X-Forwarded-Port: 443
X-Forwarded-Proto: https
X-Forwarded-Ssl: on
X-Real-Ip: 127.0.0.1
```

Now, set up the app auth config:

```yaml
version: v1
kind: app_auth_config
metadata:
  name: example
spec:
  app_labels:
  - name: teleport.internal/app-sub-kind
    values: [mcp]
  jwt:
    issuer: cluster-name
    audience: 127.0.0.1:64703 # This is the dumper Host.
    jwks_url: https://issuer/.well-known/jwks.json
```

With everything setup you can now use the MCP inspector to connect to the server.
- Use `https://your-proxy-addr/mcp/apps/mcp-everything` address.
- Set `Authorization` header with `Bearer xxx` value using the JWT response from the dumper request.

</details>