### PR TITLE
test: Extend `TextEditor` coverage

### DIFF
--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -64,11 +64,12 @@ class TextEditor extends Component {
 
     // If the data changes, reset the value in each session so changes are
     // rendered.
-    // Only update the content if the editor is read-only to prevent
-    // interrupting the editing experience.
-    if (this.props.readOnly && prevProps.data !== this.props.data) {
+    if (prevProps.data !== this.props.data) {
       this.props.data.forEach((doc, i) => {
-        this.sessions[i].setValue(doc.content);
+        const session = this.sessions[i];
+        if (session.getValue() !== doc.content) {
+          session.setValue(doc.content); // Note: resets the cursor to 0:0
+        }
       });
     }
 

--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -35,6 +35,8 @@ import StyledTextEditor from './StyledTextEditor';
 
 const { UndoManager } = ace.require('ace/undomanager');
 
+export const EDITOR_ID = 'text-editor';
+
 class TextEditor extends Component {
   onChange = () => {
     const isClean = this.editor.session.getUndoManager().isClean();
@@ -105,7 +107,7 @@ class TextEditor extends Component {
 
   componentDidMount() {
     const { data, readOnly } = this.props;
-    this.editor = ace.edit(this.ace_viewer);
+    this.editor = ace.edit(EDITOR_ID);
     this.editor.setFadeFoldWidgets(true);
     this.editor.setWrapBehavioursEnabled(true);
     this.editor.setHighlightActiveLine(false);
@@ -145,7 +147,7 @@ class TextEditor extends Component {
 
     return (
       <StyledTextEditor bg={bg}>
-        <div ref={e => (this.ace_viewer = e)} />
+        <div id={EDITOR_ID} />
         {hasButton && (
           <ButtonSection>
             {this.props.copyButton && (

--- a/web/packages/shared/components/TextEditor/TextEditor.jsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.jsx
@@ -35,8 +35,6 @@ import StyledTextEditor from './StyledTextEditor';
 
 const { UndoManager } = ace.require('ace/undomanager');
 
-export const EDITOR_ID = 'text-editor';
-
 class TextEditor extends Component {
   onChange = () => {
     const isClean = this.editor.session.getUndoManager().isClean();
@@ -108,7 +106,7 @@ class TextEditor extends Component {
 
   componentDidMount() {
     const { data, readOnly } = this.props;
-    this.editor = ace.edit(EDITOR_ID);
+    this.editor = ace.edit(this.ace_viewer);
     this.editor.setFadeFoldWidgets(true);
     this.editor.setWrapBehavioursEnabled(true);
     this.editor.setHighlightActiveLine(false);
@@ -148,7 +146,10 @@ class TextEditor extends Component {
 
     return (
       <StyledTextEditor bg={bg}>
-        <div id={EDITOR_ID} />
+        <div
+          ref={e => (this.ace_viewer = e)}
+          data-testid={this.props.testId ?? 'text-editor'}
+        />
         {hasButton && (
           <ButtonSection>
             {this.props.copyButton && (

--- a/web/packages/shared/components/TextEditor/TextEditor.story.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.story.tsx
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useState } from 'react';
+
 import Flex from 'design/Flex';
 
 import TextEditor from './TextEditor';
@@ -25,6 +27,7 @@ export default {
 };
 
 export const Editor = () => {
+  const [content, setContent] = useState(EXAMPLE);
   return (
     <Flex height="600px" width="600px" py={3} pr={3} bg="levels.deep">
       <TextEditor
@@ -35,12 +38,14 @@ export const Editor = () => {
             type: 'yaml',
           },
         ]}
+        onChange={(value: string) => setContent(value)}
       />
     </Flex>
   );
 };
 
 export const ReadOnly = () => {
+  const [content, setContent] = useState(EXAMPLE);
   return (
     <Flex height="600px" width="600px" py={3} pr={3} bg="levels.deep">
       <TextEditor
@@ -52,12 +57,14 @@ export const ReadOnly = () => {
             type: 'yaml',
           },
         ]}
+        onChange={(value: string) => setContent(value)}
       />
     </Flex>
   );
 };
 
 export const WithButtons = () => {
+  const [content, setContent] = useState(EXAMPLE);
   return (
     <Flex height="600px" width="600px" py={3} pr={3} bg="levels.deep">
       <TextEditor
@@ -68,6 +75,7 @@ export const WithButtons = () => {
             type: 'yaml',
           },
         ]}
+        onChange={(value: string) => setContent(value)}
         copyButton
         downloadButton
         downloadFileName="content.yaml"
@@ -76,7 +84,7 @@ export const WithButtons = () => {
   );
 };
 
-const content = `# example
+const EXAMPLE = `# example
 kind: github
 version: v3
 metadata:
@@ -87,7 +95,7 @@ spec:
   display: GitHub
   redirect_url: https://tele.example.com:443/v1/webapi/github/callback
   teams_to_roles:
-    - organization: octocats 
-      team: admin            
+    - organization: octocats
+      team: admin
       roles: ["access"]
 `;

--- a/web/packages/shared/components/TextEditor/TextEditor.test.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.test.tsx
@@ -16,13 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import ace from 'ace-builds';
+import { useEffect, useMemo, useState } from 'react';
+
 import * as copyModule from 'design/utils/copyToClipboard';
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 import * as downloadsModule from 'shared/utils/download';
 
-import TextEditor from '.';
+import TextEditor, { EDITOR_ID } from './TextEditor';
 
-describe('textEditor tests', () => {
+describe('TextEditor', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -63,4 +66,248 @@ describe('textEditor tests', () => {
     await userEvent.click(screen.getByTitle('Download'));
     expect(mockedDownload).toHaveBeenCalledWith('test.yaml', 'my-content');
   });
+
+  describe('with a stateful wrapper', () => {
+    test('editing', async () => {
+      const onChange = jest.fn();
+
+      render(
+        <StatefulWrapper initialValue={EXAMPLE_DOC} onChange={onChange} />
+      );
+
+      const editor = getEditorRef();
+      expect(editor.session.getMode()['$id']).toBe('ace/mode/yaml');
+
+      // Check that the initial document is rendered
+      await waitForMockToBeCalled(onChange, 1);
+      expect(onChange).toHaveBeenLastCalledWith(EXAMPLE_DOC);
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 0, column: 0 });
+
+      // Insert some text
+      editor.moveCursorTo(5, 13); // After "cranberry", zero-indexed
+      editor.insert('\n');
+      editor.insert('- durian');
+      await waitForMockToBeCalled(onChange, 2);
+      expect(onChange).toHaveBeenLastCalledWith(
+        EXAMPLE_DOC.replace('cranberry', 'cranberry\n  - durian')
+      );
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 6, column: 10 });
+
+      // Comment a line
+      editor.selection.setRange({
+        start: { row: 6, column: 0 },
+        end: { row: 6, column: 10 },
+      });
+      editor.toggleCommentLines();
+      await waitForMockToBeCalled(onChange, 3);
+      expect(onChange).toHaveBeenLastCalledWith(
+        EXAMPLE_DOC.replace('cranberry', 'cranberry\n  # - durian')
+      );
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 6, column: 12 });
+
+      // Undo the previous change
+      editor.undo();
+      await waitForMockToBeCalled(onChange, 4);
+      expect(onChange).toHaveBeenLastCalledWith(
+        EXAMPLE_DOC.replace('cranberry', 'cranberry\n  - durian')
+      );
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 6, column: 2 });
+
+      // Select the whole document and clear all text
+      editor.selectAll();
+      editor.remove();
+      await waitForMockToBeCalled(onChange, 5);
+      expect(onChange).toHaveBeenLastCalledWith('');
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 0, column: 0 });
+
+      // Paste the original example doc
+      editor.insert(EXAMPLE_DOC, true);
+      await waitForMockToBeCalled(onChange, 6);
+      expect(onChange).toHaveBeenLastCalledWith(EXAMPLE_DOC);
+      expect(editor.getCursorPosition()).toStrictEqual({ row: 6, column: 0 });
+    });
+  });
+
+  test('new content', async () => {
+    const onChange = jest.fn();
+
+    const { rerender } = render(
+      <TextEditor
+        data={[
+          {
+            content: '',
+            type: 'yaml',
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+
+    const editor = getEditorRef();
+
+    editor.insert('# hello');
+    await waitForMockToBeCalled(onChange, 1);
+    expect(onChange).toHaveBeenLastCalledWith('# hello');
+
+    editor.undo();
+    await waitForMockToBeCalled(onChange, 2);
+    expect(onChange).toHaveBeenLastCalledWith('');
+
+    rerender(
+      <TextEditor
+        data={[
+          {
+            content: '# world',
+            type: 'yaml',
+          },
+        ]}
+        onChange={onChange}
+      />
+    );
+    await waitForMockToBeCalled(onChange, 3);
+    expect(onChange).toHaveBeenLastCalledWith('# world');
+
+    // Ensure an undo doesn't revert the new content change
+    editor.undo();
+    await waitForMockToBeCalled(onChange, 3);
+    expect(onChange).toHaveBeenLastCalledWith('# world');
+  });
+
+  test('readonly', async () => {
+    const onChange = jest.fn();
+
+    const { rerender } = render(
+      <TextEditor
+        data={[
+          {
+            content: EXAMPLE_DOC,
+            type: 'yaml',
+          },
+        ]}
+        onChange={onChange}
+        readOnly
+      />
+    );
+
+    const editor = getEditorRef();
+    expect(editor.getReadOnly()).toBeTruthy();
+    expect(editor.getValue()).toBe(EXAMPLE_DOC);
+
+    // Re-render the component with new content
+    rerender(
+      <TextEditor
+        data={[
+          {
+            content: '# empty',
+            type: 'yaml',
+          },
+        ]}
+        onChange={onChange}
+        readOnly
+      />
+    );
+    await waitForMockToBeCalled(onChange, 1);
+    expect(onChange).toHaveBeenLastCalledWith('# empty');
+    expect(editor.getValue()).toBe('# empty');
+  });
+
+  test('sessions', async () => {
+    const user = userEvent.setup();
+
+    render(<SessionWrapper />);
+
+    const editor = getEditorRef();
+    expect(editor.getValue()).toBe('session-1');
+
+    await user.click(screen.getByRole('button', { name: 'session-2' }));
+    expect(editor.getValue()).toBe('session-2');
+
+    editor.moveCursorTo(0, 999);
+    editor.insert('-edited');
+    expect(editor.getValue()).toBe('session-2-edited');
+
+    await user.click(screen.getByRole('button', { name: 'session-3' }));
+    expect(editor.getValue()).toBe('session-3');
+
+    // Check the edit is retained
+    await user.click(screen.getByRole('button', { name: 'session-2' }));
+    expect(editor.getValue()).toBe('session-2-edited');
+  });
 });
+
+function getEditorRef() {
+  return window['ace'].edit(EDITOR_ID) as ace.Editor;
+}
+
+function waitForMockToBeCalled(fn: jest.Mock, times: number) {
+  return waitFor(() => expect(fn).toHaveBeenCalledTimes(times));
+}
+
+function StatefulWrapper(props: {
+  initialValue: string;
+  onChange?: (content: string) => void;
+}) {
+  const [value, setValue] = useState(props.initialValue);
+
+  // Calls the onChange callback when the state value changes
+  useEffect(() => {
+    props.onChange?.(value);
+  }, [props, value]);
+
+  return (
+    <TextEditor
+      data={[
+        {
+          content: value,
+          type: 'yaml',
+        },
+      ]}
+      onChange={(content: string) => setValue(content)}
+      readOnly={false}
+    />
+  );
+}
+
+function SessionWrapper() {
+  const [activeSession, setActiveSession] = useState(0);
+
+  const goToSession = (index: number) => {
+    setActiveSession(index);
+  };
+
+  // Keep this stable to avoid resetting the content of each session on re-render
+  const data = useMemo(
+    () => [
+      {
+        content: 'session-1',
+        type: 'yaml',
+      },
+      {
+        content: 'session-2',
+        type: 'yaml',
+      },
+      {
+        content: 'session-3',
+        type: 'yaml',
+      },
+    ],
+    []
+  );
+
+  return (
+    <>
+      <button onClick={() => goToSession(0)}>session-1</button>
+      <button onClick={() => goToSession(1)}>session-2</button>
+      <button onClick={() => goToSession(2)}>session-3</button>
+      <TextEditor data={data} activeIndex={activeSession} />
+    </>
+  );
+}
+
+const EXAMPLE_DOC = `# this is a comment
+title: "List of fruit"
+items:
+  - apple
+  - banana
+  - cranberry
+`;

--- a/web/packages/shared/components/TextEditor/TextEditor.test.tsx
+++ b/web/packages/shared/components/TextEditor/TextEditor.test.tsx
@@ -23,7 +23,7 @@ import * as copyModule from 'design/utils/copyToClipboard';
 import { render, screen, userEvent, waitFor } from 'design/utils/testing';
 import * as downloadsModule from 'shared/utils/download';
 
-import TextEditor, { EDITOR_ID } from './TextEditor';
+import TextEditor from './TextEditor';
 
 describe('TextEditor', () => {
   afterEach(() => {
@@ -236,7 +236,8 @@ describe('TextEditor', () => {
 });
 
 function getEditorRef() {
-  return window['ace'].edit(EDITOR_ID) as ace.Editor;
+  const element = screen.getByTestId('text-editor');
+  return window['ace'].edit(element) as ace.Editor;
 }
 
 function waitForMockToBeCalled(fn: jest.Mock, times: number) {

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -20,7 +20,6 @@ import { UserEvent } from '@testing-library/user-event';
 import ace from 'ace-builds';
 
 import { render, screen, userEvent, waitFor } from 'design/utils/testing';
-import { EDITOR_ID } from 'shared/components/TextEditor/TextEditor';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -668,8 +667,8 @@ const getYamlEditorTab = () =>
   screen.getByRole('tab', { name: 'Switch to YAML editor' });
 
 const findTextEditor = async () => {
-  await screen.findByTestId('text-editor-container');
-  return window['ace'].edit(EDITOR_ID) as ace.Editor;
+  const element = screen.getByTestId('text-editor');
+  return window['ace'].edit(element) as ace.Editor;
 };
 
 async function forwardToTab(name: string) {

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -16,10 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { fireEvent, waitFor, within } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
+import ace from 'ace-builds';
 
-import { render, screen, userEvent } from 'design/utils/testing';
+import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+import { EDITOR_ID } from 'shared/components/TextEditor/TextEditor';
 
 import cfg from 'teleport/config';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -49,20 +50,6 @@ import * as StandardModelModule from './StandardEditor/standardmodel';
 import { defaultOptions, withDefaults } from './StandardEditor/withDefaults';
 
 const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
-
-// The Ace editor is very difficult to deal with in tests, especially that for
-// handling its state, we are using input event, which is asynchronous. Thus,
-// for testing, we just mock it out with a simple text area.
-jest.mock('shared/components/TextEditor', () => ({
-  __esModule: true,
-  default: ({
-    data: [{ content }],
-    onChange,
-  }: {
-    data: { content: string }[];
-    onChange(s: string): void;
-  }) => <textarea value={content} onChange={e => onChange(e.target.value)} />,
-}));
 
 let user: UserEvent;
 
@@ -116,7 +103,10 @@ test('rendering and switching tabs for new role', async () => {
   expect(screen.getByRole('button', { name: 'Create Role' })).toBeEnabled();
 
   await user.click(getYamlEditorTab());
-  expect(fromFauxYaml(await getTextEditorContents())).toEqual(
+
+  const editor = await findTextEditor();
+
+  expect(fromFauxYaml(editor.getValue())).toEqual(
     withDefaults({
       kind: 'role',
       metadata: {
@@ -158,8 +148,13 @@ test('rendering and switching tabs for a non-standard role', async () => {
     />
   );
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
-  expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
-  expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+
+  {
+    const editor = await findTextEditor();
+
+    expect(fromFauxYaml(editor.getValue())).toEqual(originalRole);
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+  }
 
   await user.click(getStandardEditorTab());
   expect(screen.getByText(/This role is too complex/)).toBeVisible();
@@ -168,13 +163,21 @@ test('rendering and switching tabs for a non-standard role', async () => {
   expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
 
   await user.click(getYamlEditorTab());
-  expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
-  expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
 
-  await user.clear(await findTextEditor());
-  await user.click(await findTextEditor());
-  await user.paste('{"asdf":"qwer"}');
-  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+  {
+    const editor = await findTextEditor();
+
+    expect(fromFauxYaml(editor.getValue())).toEqual(originalRole);
+    expect(screen.getByRole('button', { name: 'Save Changes' })).toBeDisabled();
+
+    editor.selectAll();
+    editor.remove();
+    editor.insert('{"asdf":"qwer"}', true);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save Changes' })).toBeEnabled()
+    );
+    await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+  }
 
   expect(onSave).toHaveBeenCalledWith({
     yaml: '{"asdf":"qwer"}',
@@ -274,11 +277,13 @@ test('no double conversions when clicking already active tabs', async () => {
   expect(screen.getByLabelText('Role Name *')).toHaveValue('new_role_name_2');
 
   await user.click(getYamlEditorTab());
-  await user.clear(await findTextEditor());
-  await user.click(await findTextEditor());
-  await user.paste('{"kind":"role", metadata:{"name":"new_role_name_3"}}');
+  const editor = await findTextEditor();
+
+  editor.selectAll();
+  editor.remove();
+  editor.insert('{"kind":"role", metadata:{"name":"new_role_name_3"}}', true);
   await user.click(getYamlEditorTab());
-  expect(await getTextEditorContents()).toBe(
+  expect(editor.getValue()).toBe(
     '{"kind":"role", metadata:{"name":"new_role_name_3"}}'
   );
 });
@@ -358,20 +363,22 @@ describe('closing the editor', () => {
     // original back into the text editor, in case if the order of keys is
     // different.
     const editor = await findTextEditor();
-    expect(JSON.parse(editor.textContent)).toEqual(
+    expect(JSON.parse(editor.getValue())).toEqual(
       JSON.parse(originalRole.yaml)
     );
-    fireEvent.change(await findTextEditor(), {
-      target: { value: originalRole.yaml },
-    });
+    editor.selectAll();
+    editor.remove();
+    editor.insert(originalRole.yaml);
+    const saveButton = screen.getByRole('button', { name: 'Save Changes' });
+    await waitFor(() => expect(saveButton).toBeDisabled());
     await closeImmediately(onCancel);
   });
 
   test('YAML editor, modified existing resource', async () => {
     const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await user.click(getYamlEditorTab());
-    await user.click(await findTextEditor());
-    await user.paste('{"foo":"bar"}');
+    const editor = await findTextEditor();
+    editor.insert('{"foo":"bar"}', true);
     await closeWithConfirmation(onCancel);
   });
 });
@@ -422,14 +429,23 @@ describe('saving a new role after editing as YAML', () => {
     render(<TestRoleEditor onSave={onSave} />);
 
     await user.click(getYamlEditorTab());
-    await user.clear(await findTextEditor());
-    await user.click(await findTextEditor());
-    await user.paste('{"foo":"bar"}');
-    await user.click(screen.getByRole('button', { name: 'Create Role' }));
+    const saveButton = screen.getByRole('button', { name: 'Create Role' });
+    expect(saveButton).toBeEnabled();
 
+    const editor = await findTextEditor();
+
+    editor.selectAll();
+    editor.remove();
+    await waitFor(() => expect(saveButton).toBeDisabled());
+
+    editor.insert('{"foo":"bar"}', true);
+    await waitFor(() => expect(saveButton).toBeEnabled());
+
+    await user.click(saveButton);
     expect(onSave).toHaveBeenCalledWith({
       yaml: '{"foo":"bar"}',
     });
+
     expect(
       userEventService.captureCreateNewRoleSaveClickEvent
     ).toHaveBeenCalledWith({
@@ -451,22 +467,32 @@ describe('saving a new role after editing as YAML', () => {
     render(<TestRoleEditor onRoleUpdate={onRoleUpdate} onSave={onSave} />);
 
     await user.click(getYamlEditorTab());
-    await user.clear(await findTextEditor());
+    const previewButton = screen.getByRole('button', { name: 'Preview' });
+    expect(previewButton).toBeEnabled();
+
+    const editor = await findTextEditor();
+
+    editor.selectAll();
+    editor.remove();
+    await waitFor(() => expect(previewButton).toBeDisabled());
 
     onRoleUpdate.mockReset();
-    await user.click(await findTextEditor());
-    await user.paste('{"metadata":{"description":"foo"}}');
+
+    editor.insert('{"metadata":{"description":"foo"}}', true);
+    await waitFor(() => expect(previewButton).toBeEnabled());
+
     expect(onRoleUpdate).not.toHaveBeenCalled();
-    await user.click(screen.getByRole('button', { name: 'Preview' }));
+    await user.click(previewButton);
     expect(onRoleUpdate).toHaveBeenCalledTimes(1);
     expect(onRoleUpdate).toHaveBeenCalledWith(
       withDefaults({ metadata: { description: 'foo' } })
     );
-    await user.click(screen.getByRole('button', { name: 'Create Role' }));
 
+    await user.click(screen.getByRole('button', { name: 'Create Role' }));
     expect(onSave).toHaveBeenCalledWith({
       yaml: '{"metadata":{"description":"foo"}}',
     });
+
     expect(
       userEventService.captureCreateNewRoleSaveClickEvent
     ).toHaveBeenCalledWith({
@@ -525,7 +551,10 @@ test('YAML editor is usable even if the standard one throws', async () => {
 
   // Expect to still be able to use to the YAML editor.
   await user.click(getYamlEditorTab());
-  expect(fromFauxYaml(await getTextEditorContents())).toEqual(
+
+  const editor = await findTextEditor();
+
+  expect(fromFauxYaml(editor.getValue())).toEqual(
     withDefaults({
       kind: 'role',
       metadata: {
@@ -539,11 +568,16 @@ test('YAML editor is usable even if the standard one throws', async () => {
       version: defaultRoleVersion,
     })
   );
-  await user.clear(await findTextEditor());
-  await user.click(await findTextEditor());
-  await user.paste('{"modified":1}');
-  await user.click(screen.getByRole('button', { name: 'Create Role' }));
 
+  editor.selectAll();
+  editor.remove();
+  const createButton = screen.getByRole('button', { name: 'Create Role' });
+  await waitFor(() => expect(createButton).toBeDisabled());
+
+  editor.insert('{"modified":1}', true);
+  await waitFor(() => expect(createButton).toBeEnabled());
+
+  await user.click(createButton);
   expect(onSave).toHaveBeenCalledWith({
     yaml: '{"modified":1}',
   });
@@ -578,11 +612,15 @@ it('YAML editor usable even if the initial conversion throws', async () => {
   );
   expect(getYamlEditorTab()).toHaveAttribute('aria-selected', 'true');
 
-  expect(fromFauxYaml(await getTextEditorContents())).toEqual(originalRole);
-  await user.clear(await findTextEditor());
-  await user.click(await findTextEditor());
-  await user.paste('{"modified":1}');
-  await user.click(screen.getByRole('button', { name: 'Save Changes' }));
+  const editor = await findTextEditor();
+
+  expect(fromFauxYaml(editor.getValue())).toEqual(originalRole);
+  editor.selectAll();
+  editor.remove();
+  editor.insert('{"modified":1}', true);
+  const saveButton = screen.getByRole('button', { name: 'Save Changes' });
+  await waitFor(() => expect(saveButton).toBeEnabled());
+  await user.click(saveButton);
 
   expect(onSave).toHaveBeenCalledWith({
     yaml: '{"modified":1}',
@@ -629,16 +667,10 @@ const getStandardEditorTab = () =>
 const getYamlEditorTab = () =>
   screen.getByRole('tab', { name: 'Switch to YAML editor' });
 
-const findTextEditor = async () =>
-  within(await screen.findByTestId('text-editor-container')).getByRole(
-    'textbox'
-  );
-
-/**
- * Retrieves Ace text editor contents. We can't just trust the textarea
- * contents, this is unreliable. We really have to use Ace editor API to do it.
- */
-const getTextEditorContents = async () => (await findTextEditor()).textContent;
+const findTextEditor = async () => {
+  await screen.findByTestId('text-editor-container');
+  return window['ace'].edit(EDITOR_ID) as ace.Editor;
+};
 
 async function forwardToTab(name: string) {
   await user.click(screen.getByRole('button', { name: `Next: ${name}` }));

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -172,7 +172,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
 
     editor.selectAll();
     editor.remove();
-    editor.insert('{"asdf":"qwer"}', true);
+    editor.insert('{"asdf":"qwer"}');
     await waitFor(() =>
       expect(screen.getByRole('button', { name: 'Save Changes' })).toBeEnabled()
     );
@@ -281,7 +281,7 @@ test('no double conversions when clicking already active tabs', async () => {
 
   editor.selectAll();
   editor.remove();
-  editor.insert('{"kind":"role", metadata:{"name":"new_role_name_3"}}', true);
+  editor.insert('{"kind":"role", metadata:{"name":"new_role_name_3"}}');
   await user.click(getYamlEditorTab());
   expect(editor.getValue()).toBe(
     '{"kind":"role", metadata:{"name":"new_role_name_3"}}'
@@ -378,7 +378,7 @@ describe('closing the editor', () => {
     const onCancel = setup({ originalRole: newRoleWithYaml(newRole()) });
     await user.click(getYamlEditorTab());
     const editor = await findTextEditor();
-    editor.insert('{"foo":"bar"}', true);
+    editor.insert('{"foo":"bar"}');
     await closeWithConfirmation(onCancel);
   });
 });
@@ -438,7 +438,7 @@ describe('saving a new role after editing as YAML', () => {
     editor.remove();
     await waitFor(() => expect(saveButton).toBeDisabled());
 
-    editor.insert('{"foo":"bar"}', true);
+    editor.insert('{"foo":"bar"}');
     await waitFor(() => expect(saveButton).toBeEnabled());
 
     await user.click(saveButton);
@@ -478,7 +478,7 @@ describe('saving a new role after editing as YAML', () => {
 
     onRoleUpdate.mockReset();
 
-    editor.insert('{"metadata":{"description":"foo"}}', true);
+    editor.insert('{"metadata":{"description":"foo"}}');
     await waitFor(() => expect(previewButton).toBeEnabled());
 
     expect(onRoleUpdate).not.toHaveBeenCalled();
@@ -574,7 +574,7 @@ test('YAML editor is usable even if the standard one throws', async () => {
   const createButton = screen.getByRole('button', { name: 'Create Role' });
   await waitFor(() => expect(createButton).toBeDisabled());
 
-  editor.insert('{"modified":1}', true);
+  editor.insert('{"modified":1}');
   await waitFor(() => expect(createButton).toBeEnabled());
 
   await user.click(createButton);
@@ -617,7 +617,7 @@ it('YAML editor usable even if the initial conversion throws', async () => {
   expect(fromFauxYaml(editor.getValue())).toEqual(originalRole);
   editor.selectAll();
   editor.remove();
-  editor.insert('{"modified":1}', true);
+  editor.insert('{"modified":1}');
   const saveButton = screen.getByRole('button', { name: 'Save Changes' });
   await waitFor(() => expect(saveButton).toBeEnabled());
   await user.click(saveButton);

--- a/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/YamlEditor.tsx
@@ -78,12 +78,22 @@ export const YamlEditor = ({
       <ActionButtonsContainer>
         <SaveButton
           isEditing={isEditing}
-          disabled={isProcessing || !yamlEditorModel.isDirty || !wasPreviewed}
+          disabled={
+            isProcessing ||
+            !yamlEditorModel.isDirty ||
+            !wasPreviewed ||
+            yamlEditorModel.content === ''
+          }
           onClick={handleSave}
         />
         {onPreview && (
           <PreviewButton
-            disabled={isProcessing || wasPreviewed || !yamlEditorModel.isDirty}
+            disabled={
+              isProcessing ||
+              wasPreviewed ||
+              !yamlEditorModel.isDirty ||
+              yamlEditorModel.content === ''
+            }
             onClick={handlePreview}
           />
         )}


### PR DESCRIPTION
## Summary
This change primarily adds editing tests for `TextEditor`. It also improves the `RoleEditor` tests, as this is an important use of `TextEditor`. The goal is to provide safety for future changes to the component, and hopefully help [avoid introducing bugs](https://github.com/gravitational/teleport/issues/62481).

The testing approach makes use of the [Ace API](https://ajaxorg.github.io/ace-api-docs/classes/ace.Editor-1.html) instead of trying to mock user input in the normal way using `userEvent`. Equally, interrogating the content of the editor is also done using the Ace API.

Additionally, given the safety provided by the tests, the [previous quick fix](https://github.com/gravitational/teleport/pull/62484) to the content sync logic is replaced by a solution that allows usages in non-readonly mode to benefit.

A small change to the UX of the `RoleEditor` component was required to allow reliable testing of some scenarios. Namely, when creating a new role using the YAML editor mode, there is no visual indication of when the YAML content is _ready_ to submit. To a regular user, this has no negative effect, but to a test, there is a delay before the input changes are processed and clicking the save button too early submits the previous content instead.
To mitigate this, a new disabled condition is added to both "save" and "preview" buttons - when the content is empty, disable the buttons. This allows the test to wait for the button state changes as a reliable indication that a content change has been processed. The UX change should not affect regular users.

## Changes
- ~Use an element id instead of a `ref` reference - this allows easily finding a reference to the editor from tests.~ Reverted in favour of refs and test ids.
- Replace non-readonly quick fix - the new solution supports both readonly and non-readonly modes.
- Add test coverage for common editing operations when using different approaches to managing state
- Disable RoleEditor "save" and "preview" buttons when YAML content is empty
- Use Ace API in RoleEditor tests

## Manual Testing
The `TextEditor` component is used all over. I did not take the time to manually test and verify all usages, as many are behind complicated integration journeys. Instead, I've tried to represent each usage approach in a test (some manage state and some don't, some are readonly while others allow edits).

The plan is to get these changes merged, then hold-off backporting for some time to allow any issues to emerge naturally in dev only and be addressed, effectively crowd-sourcing regression testing. I'll send out a message to the engineering community to look out for niggles and possible regression issues related to the TextEditor.