### PR TITLE
[v18] Generate a tbot reference page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2001,11 +2001,19 @@ test-e2e: ensure-webassets
 
 .PHONY: cli-docs-tsh
 cli-docs-tsh:
-	# Not executing go run since we don't want to redirect linker warnings
-	# along with the docs page content.
+# Executing go build instead of go run since we don't want to redirect
+# irrelevant output along with the docs page content.
 	go build -o $(BUILDDIR)/tshdocs -tags docs ./tool/tsh && \
 	$(BUILDDIR)/tshdocs help 2>docs/pages/reference/cli/tsh.mdx && \
 	rm $(BUILDDIR)/tshdocs
+
+.PHONY: cli-docs-tbot
+cli-docs-tbot:
+# Executing go build instead of go run since we don't want to redirect
+# irrelevant output along with the docs page content.
+	go build -o $(BUILDDIR)/tbotdocs -tags docs ./tool/tbot && \
+	$(BUILDDIR)/tbotdocs help 2>docs/pages/reference/cli/tbot.mdx && \
+	rm $(BUILDDIR)/tbotdocs
 
 # audit-event-reference generates audit event reference docs using the Web UI
 # source.

--- a/docs/pages/machine-workload-identity/deployment/bitbucket.mdx
+++ b/docs/pages/machine-workload-identity/deployment/bitbucket.mdx
@@ -136,9 +136,8 @@ pipelines:
 Replace <Var name="example.teleport.sh"/> with the address of your Teleport Proxy Service.
 
 This example will start `tbot` in identity mode to generate SSH credentials.
-Refer to the [`tbot start` documentation](../../reference/cli/tbot.mdx#tbot-start)
-for details on using other modes such as database, application, and Kubernetes
-access.
+Refer to the [`tbot` documentation](../../reference/cli/tbot.mdx) for details on
+using other modes such as database, application, and Kubernetes access.
 
 If you're adapting an existing workflow, note these steps:
 1. Set `oidc: true` on the step properties so that step will be issued a token

--- a/docs/pages/reference/cli/tbot.mdx
+++ b/docs/pages/reference/cli/tbot.mdx
@@ -1,841 +1,1451 @@
 ---
-title: tbot CLI Reference
+title: tbot Reference
+description: Provides a comprehensive list of commands, arguments, and flags for tbot.
 sidebar_label: tbot
-description: Comprehensive reference of subcommands, flags, and arguments for the tbot CLI tool.
 tags:
- - reference
- - mwi
+  - reference
+  - mwi
 ---
+{/*vale messaging = NO*/}
+
+This guide provides a comprehensive list of commands, arguments, and flags for
+tbot.
 
 `tbot` is a CLI tool used with **Machine & Workload Identity** that
 programatically issues and renews short-lived certificates to any service
 account (e.g, a CI/CD server).
 
-The primary commands for `tbot` are as follows:
+```code
+$ tbot [<flags>] <command> [<args> ...]
+```
 
-| Command | Description |
-| - | - |
-| `tbot help` | Outputs guidance for using commands with `tbot`. |
-| `tbot version` | Outputs the current version of the `tbot` binary. |
-| `tbot configure` | Outputs a basic `tbot` client configuration file to be adjusted as needed. |
-| `tbot start` | Starts `tbot`, fetching and writing certificates to disk at a set interval. |
-| `tbot init` | Initialize a certificate destination directory for writes from a separate bot user, configuring either file or POSIX ACL permissions. |
-| `tbot db` | Connects to databases using native clients and queries database information. Functions as a wrapper for `tsh`, and requires `tsh` installation. |
-| `tbot proxy` | Allows for access to Teleport resources on a cluster using TLS Routing. Functions as a wrapper for `tsh`, and requires `tsh` installation. |
-| `tbot copy-binaries` | Copies the `tbot` binary (and optionally `fdpass-teleport`) to a destination directory. |
-| `tbot keypair create` | Generates a keypair for `bound_keypair` joining. |
-| `tbot wait` | Waits for a running `tbot` instance to become ready, using its diagnostics endpoint. |
-| `tbot tpm identify` | Output identifying information related to the TPM (Trusted Platform Module) detected on the system. |
+Global flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-c`, `--config`|none|Path to a configuration file.|
+|`-d`, `--[no-]debug`|`false`|Verbose logging to stdout.|
+|`--log-format`|`text`|Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.|
+|`--[no-]fips`|`false`|Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.|
+|`--[no-]insecure`|`false`|Insecure configures the bot to trust the certificates from the Auth Server or Proxy on first connect without verification. Do not use in production.|
+
+Global environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TBOT_CONFIG_PATH`|none|Path to a configuration file.|
+|`TBOT_DEBUG`|`false`|Verbose logging to stdout.|
+
+## tbot configure application
+
+Configures tbot with an application output.
+
+Usage:
+
+```code
+$ tbot configure application --destination=DESTINATION --app=APP [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--app`|none|The name of the app in Teleport|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]specific-tls-extensions`|`false`|If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure application-proxy
+
+Configures tbot with an application proxy.
+
+Usage:
+
+```code
+$ tbot configure application-proxy --listen=LISTEN [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure application-tunnel
+
+Configures tbot with an application tunnel.
+
+Usage:
+
+```code
+$ tbot configure application-tunnel --listen=LISTEN --app=APP [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--app`|none|The name of the app in Teleport|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure database
+
+Configures tbot with a database output.
+
+Usage:
+
+```code
+$ tbot configure database --destination=DESTINATION --service=SERVICE --username=USERNAME --database=DATABASE [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--database`|none|The name of the database available in the requested database service|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--format`|``|The database output format if necessary|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--service`|none|The database service name|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--username`|none|The database user name|
+
+## tbot configure database-tunnel
+
+Configures tbot with a database tunnel listener.
+
+Usage:
+
+```code
+$ tbot configure database-tunnel --listen=LISTEN --service=SERVICE --username=USERNAME --database=DATABASE [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--database`|none|The name of the database available in the requested database service|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI to listen on, such as tcp://0.0.0.0:3306|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--service`|none|The database service name|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--username`|none|The database user name|
+
+## tbot configure identity
+
+Configures tbot with an identity output for SSH and Teleport API access.
+
+Usage:
+
+```code
+$ tbot configure identity --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure kubernetes
+
+Configures tbot with a Kubernetes output.
+
+Usage:
+
+```code
+$ tbot configure kubernetes --destination=DESTINATION --kubernetes-cluster=KUBERNETES-CLUSTER [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials|
+|`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure kubernetes/v2
+
+Configures tbot with a Kubernetes V2 output.
+
+Usage:
+
+```code
+$ tbot configure kubernetes/v2 --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A set of Kubernetes labels to match in k1=v1,k2=v2 form. Repeatable.|
+|`--name-selector`|none|An explicit Kubernetes cluster name to include. Repeatable.|
+|`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure legacy
+
+Configures tbot with either a config file or a legacy output.
+
+Usage:
+
+```code
+$ tbot configure legacy [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--data-dir`|none|Directory to store internal bot data. Access to this directory should be limited.|
+|`--destination-dir`|none|Directory to write short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure ssh-multiplexer
+
+Configures tbot with an SSH Multiplexer service.
+
+Usage:
+
+```code
+$ tbot configure ssh-multiplexer --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-command`|none|The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--proxy-templates-path`|none|A path to a proxy template config file. Optional.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure workload-identity-api
+
+Configures tbot with a workload identity API listener. Compatible with the
+SPIFFE Workload API and Envoy SDS.
+
+Usage:
+
+```code
+$ tbot configure workload-identity-api --listen=LISTEN [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure workload-identity-aws-roles-anywhere
+
+Configures tbot with an output containing AWS credentials generated via AWS
+Roles Anywhere.
+
+Usage:
+
+```code
+$ tbot configure workload-identity-aws-roles-anywhere --destination=DESTINATION --role-arn=ROLE-ARN --profile-arn=PROFILE-ARN --trust-anchor-arn=TRUST-ANCHOR-ARN [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--region`|none|The AWS region to use. If unset, value will be used from the AWS config or the AWS_REGION environment variable.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--role-arn`|none|The ARN of the role to assume.|
+|`--session-duration`|none|The duration of the resulting AWS session and credentials. This may be up to 12 hours. When unset, this defaults to 6 hours.|
+|`--session-renewal-interval`|none|How often the session should be renewed. This should be less than the session duration. When unset, this defaults to 1 hour.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--trust-anchor-arn`|none|The ARN of the Roles Anywhere trust anchor to use.|
+
+## tbot configure workload-identity-jwt
+
+Configures tbot with a SPIFFE-compatible JWT SVID output.
+
+Usage:
+
+```code
+$ tbot configure workload-identity-jwt --destination=DESTINATION --audience=AUDIENCE [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--audience`|none|Specify the audiences to include in the JWT. At least one audience must be specified.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot configure workload-identity-x509
+
+Configures tbot with a SPIFFE-compatible SVID output.
+
+Usage:
+
+```code
+$ tbot configure workload-identity-x509 --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot copy-binaries
+
+Copies this tbot binary to a given destination
+
+Usage:
+
+```code
+$ tbot copy-binaries [<flags>] <destination-dir>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]include-fdpass`|`false`|If set, also copy `fdpass-teleport`. It must be available in the same path as `tbot`.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|destination-dir|none (required)|The destination path to write the copy of the tbot binary|
 
 ## tbot db
 
-Connects to databases using native clients and queries database information. This is best used for testing and validation purposes;
-most users will likely prefer to connect their own databases to a local proxy using `tbot proxy db`.
+Execute database commands through tsh.
 
-Note that `tsh` must be installed to make use of this command.
+Usage:
 
-### Flags
+```code
+$ tbot db [<flags>] [<args>...]
+```
 
-| Flag                | Description                                                                                              |
-|---------------------|----------------------------------------------------------------------------------------------------------|
-| `-d/--debug`        | Enable verbose logging to stderr.                                                                        |
-| `-c/--config`       | Path to a `tbot` configuration file. Required if not using other required configuration flags.                  |
-| `--destination-dir` | Path to the destination dir that should be used for authentication. Required.                 |
-| `--proxy-server`    | The `host:port` of the Teleport Proxy Service to use to access resources. Required.                      |
-| `--cluster`         | The name of the cluster on which resources should be accessed. Extracted from the bot identity if unset. |
+Flags:
 
-All other flags and arguments are passed directly to `tsh db ...`, along
-with authentication parameters to use the Machine & Workload identity to skip
-`tsh`'s login steps.
+|Flag|Default|Description|
+|---|---|---|
+|`--cluster`|none|The cluster name. Extracted from the certificate if unset.|
+|`--destination-dir`|none|The destination directory with which to authenticate tsh|
+|`--proxy-server`|none|The Teleport proxy server to use, in host:port form.|
 
-Note that certain CLI parameters, for example `--help`, may be captured by
-`tbot` even if intended to be passed to the wrapped `tsh`. A `--` argument can
-be used to ensure all following arguments are passed to `tsh` and ignored by
-`tbot`.
+Arguments:
 
-Additionally, be aware of the following limitations of `tbot db`:
- - `tbot db connect` requires a `tbot db login` for certain database types,
-   like MySQL, so that additional connection parameters can be written to a
-   local configuration file.
- - `tbot db env` is not fully supported.
+|Argument|Default|Description|
+|---|---|---|
+|args|none (optional)|Arguments to `tsh db ...`; prefix with `-- ` to ensure flags are passed correctly.|
+
+## tbot help
+
+Show help.
+
+Usage:
+
+```code
+$ tbot help [<command>...]
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (optional)|Show help on command.|
 
 ## tbot init
 
-Initializes a certificate destination directory for access from a separate bot
-user. Allows for certificates to be written to disks other than a Machine &
-Workload Identity client, configuring either file or POSIX ACL permissions.
+Initialize a certificate destination directory for writes from a separate bot
+user.
 
-Note that most use cases should instead use tbot's runtime ACL management by
-specifying allowed reader users and groups in the
-[destination configuration](../machine-workload-identity/configuration.mdx#directory).
-
-### Flags
-
-| Flag                | Description                                                                                                        |
-|---------------------|--------------------------------------------------------------------------------------------------------------------|
-| `-d/--debug`        | Enable verbose logging to stderr.                                                                                  |
-| `-c/--config`       | Path to a tbot configuration file.                                                                                 |
-| `--destination-dir` | Directory to write short-lived machine certificates to.                                                            |
-| `--owner`           | Defines the Linux `user:group` owner of `--destination-dir`. Defaults to the Linux user running `tbot` if unspecified. |
-| `--bot-user`        | Enables POSIX ACLs and defines the Linux user that can read/write short-lived certificates to `--destination-dir`. |
-| `--reader-user`     | Enables POSIX ACLs and defines the Linux user that will read short-lived certificates from `--destination-dir`.    |
-| `--init-dir`        | If using a config file and multiple destinations are configured, controls which destination dir to configure.      |
-| `--clean`           | If set, remove unexpected files and directories from the destination.                                              |
-| `--log-format`      | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.                                   |
-
-### Examples
-
-**Example using file permissions.**
-
-The following command highlights how to set permissions with `tbot` through Linux groups, using the user and group `jenkins:jenkins`.
-If running `tbot` as the Linux user `root`, use the following invocation of
-`tbot init` to initialize the short-lived certificate directory
-`/opt/machine-id` with owner `jenkins:jenkins`.
+Usage:
 
 ```code
-$ tbot init \
-    --destination-dir=/opt/machine-id \
-    --owner=jenkins:jenkins
+$ tbot init [<flags>]
 ```
 
-**Example using POSIX ACLs.**
+Environment variables:
 
-If running `tbot` as the Linux user `teleport`, use the following invocation of
-`tbot init` to initialize the short-lived certificate directory
-`/opt/machine-id` with owner `teleport:teleport` but allow `jenkins` to read
-from `/opt/machine-id`.
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--bot-user`|none|Enables POSIX ACLs and defines Linux user that can read/write short-lived certificates to "--destination-dir".|
+|`--destination-dir`|none|Directory to write short-lived machine certificates.|
+|`--init-dir`|none|If using a config file and multiple destinations are configured, controls which destination dir to configure.|
+|`--[no-]clean`|`false`|If set, remove unexpected files and directories from the destination.|
+|`--owner`|none|Defines Linux "user:group" owner of "--destination-dir". Defaults to the Linux user running tbot if unspecified.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-user`|none|Enables POSIX ACLs and defines Linux user that will read short-lived certificates from "--destination-dir".|
+
+## tbot install systemd
+
+Generates and installs a systemd unit file for a specified tbot configuration
+file.
+
+Usage:
 
 ```code
-$ tbot init \
-    --destination-dir=/opt/machine-id \
-    --bot-user=teleport \
-    --reader-user=jenkins
+$ tbot install systemd [<flags>]
 ```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--group`|`teleport`|The group that the service should run as. Defaults to 'teleport'.|
+|`--name`|`tbot`|Name for the systemd unit. Defaults to 'tbot'.|
+|`--[no-]anonymous-telemetry`|`false`|Enable anonymous telemetry.|
+|`--[no-]force`|`false`|Overwrite existing systemd unit file if present.|
+|`--[no-]write`|`false`|Write the systemd unit file. If not specified, this command runs in a dry-run mode that outputs the generated content to stdout.|
+|`--systemd-directory`|`/etc/systemd/system`|Path to the directory that the systemd unit file should be written. Defaults to '/etc/systemd/system'.|
+|`--user`|`teleport`|The user that the service should run as. Defaults to 'teleport'.|
+
+## tbot migrate
+
+Migrates a config file from an older version to the newest version. Outputs to
+stdout by default.
+
+Usage:
+
+```code
+$ tbot migrate [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-o`, `--output`|none|Path to write the generated configuration file to rather than write to stdout.|
 
 ## tbot proxy
 
-Allows for access to Teleport resources via a local TLS proxy in TLS Routing mode.
-The `tbot proxy` command acts as a wrapper for `tsh proxy` to provide local proxy functionality for various protocols.
+Start a local TLS proxy via tsh to connect to Teleport in single-port mode.
 
-Note that `tsh` must be installed to make use of this command.
-
-Consider using one of the following dedicated tunnel modes where possible:
-- [`tbot start application-tunnel`](#tbot-start-application-tunnel)
-- [`tbot start database-tunnel`](#tbot-start-database-tunnel)
-
-### Flags
-
-| Flag                | Description                                                                                              |
-|---------------------|----------------------------------------------------------------------------------------------------------|
-| `-d/--debug`        | Enable verbose logging to stderr.                                                                        |
-| `-c/--config`       | Path to the tbot configuration file. Required if not using other required configuration flags.           |
-| `--destination-dir` | Path to the tbot destination dir that should be used for authentication. Required.                       |
-| `--proxy-server`    | The `host:port` of the Teleport Proxy Service through which resources will be accessed. Required.        |
-| `--cluster`         | The name of the cluster on which resources should be accessed. Extracted from the bot identity if unset. |
-
-All other flags and arguments are passed directly to `tsh proxy ...`, along
-with authentication parameters to use Machine & Workload Identity to skip `tsh`'s
-login step.
-
-Additionally, the following should be noted:
-
-- Certain CLI parameters, for example `--help`, may be captured by
-  `tbot` even if intended to be passed to the wrapped `tsh`. A `--` argument can
-  be used to ensure all following arguments are passed to `tsh` and ignored by
-  `tbot`
-- If no configuration file is provided, `tbot` will apply a sample configuration based on provided CLI flags.
-  For this reason, it is recommended that settings are explicitly applied to a configuration file in production.
-
-### Examples
-
-**Example using OpenSSH**
-
-The following command forwards standard input and output over a proxy suitable for use as an OpenSSH `ProxyCommand` for SSH access:
+Usage:
 
 ```code
-$ tbot proxy --destination-dir=./tbot-user --proxy-server=proxy.example.com:3080 ssh alice@node:3022
+$ tbot proxy [<flags>] [<args>...]
 ```
 
-  In this case:
-   - `alice` is the remote username
-   - `node` is the Teleport Node name
-   - `3022` is the remote SSH port, which is `3022` for Nodes running the Teleport
-     SSH service.
+Environment variables:
 
-**Example using a Teleport-protected database**
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_PROXY`|none|The Teleport proxy server to use, in host:port form.|
 
-The following example opens a local proxy server to the given database. Your database client
-must still be configured with client TLS certificates:
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--cluster`|none|The cluster name. Extracted from the certificate if unset.|
+|`--destination-dir`|none|The destination directory with which to authenticate tsh|
+|`--proxy-server`|none|The Teleport proxy server to use, in host:port form.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|args|none (optional)|Arguments to `tsh proxy ...`; prefix with `-- ` to ensure flags are passed correctly.|
+
+## tbot spiffe-inspect
+
+Inspects a SPIFFE Workload API endpoint to ensure it is working correctly.
+
+Usage:
 
 ```code
-$ tbot proxy --destination-dir=./tbot-user --proxy-server=proxy.example.com:3080 db --port=1234 example
+$ tbot spiffe-inspect --path=PATH
 ```
 
-In this case:
- - `example` is the name of the database server as it exists in Teleport
- - `1234` is an arbitrary port on which to run the proxy
-
-Though not recommended, to avoid the need for additional client authentication,
-the `--tunnel` flag may be used to perform authentication at the local proxy
-rather than within your client:
-
-```code
-$ tbot proxy --destination-dir=./tbot-user --proxy-server=proxy.example.com:3080 db --tunnel --port=1234 example
-```
-
-Note that this decreases security:
- - It allows any user on the system to access the database via `localhost`.
- - Your connection to the database will be unencrypted until it reaches the
-   `tbot` proxy running on `localhost`.
-
-Refer to the [database guide](../../machine-workload-identity/access-guides/databases.mdx) for more information on
-using database proxies.
-
-### Flags
-
-| Flag                 | Description                                                                                    |
-|----------------------|------------------------------------------------------------------------------------------------|
-| `-d/--debug`         | Enable verbose logging to stderr.                                                              |
-| `-c/--config`        | Path to a configuration file.                                                                  |
-| `-a/--auth-server`   | Address of the Teleport Auth Service. Prefer using --proxy-server where possible                |
-| `--proxy-server`     | Address of the Teleport Proxy Server.                                                          |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token. |
-| `--ca-pin`           | CA pin to validate the Teleport Auth Service; used on first connect.                            |
-| `--data-dir`         | Directory to store internal bot data. In production environments access to this directory should be limited only to an isolated linux user as an owner with `0600` permissions. |
-| `--destination-dir`  | Directory to write short-lived machine certificates.                                           |
-| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                       |
-| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
-| `--join-method`      | Method to use to join the cluster. Can be `token` or `iam`.                                    |
-| `--oneshot`          | If set, quit after the first renewal.                                                          |
-
-## tbot configure
-
-The `tbot configure` command is used to convert a `tbot start` CLI call into a
-YAML configuration file. It supports all the same subcommands and flags as
-[`tbot start`](#tbot-start), but prints an equivalent configuration instead of
-starting a bot.
-
-For example, consider this `tbot start identity` CLI call:
-```code
-$ tbot start identity \
-   --destination=./example \
-   --join-method=token \
-   --token=foo \
-   --proxy-server=teleport.example.com:443
-```
-
-To convert this CLI command into a configuration file, replace `tbot start` with
-`tbot configure`:
-```code
-$ tbot configure identity \
-   --destination=./example \
-   --join-method=token \
-   --token=foo \
-   --proxy-server=teleport.example.com:443
-```
-
-An equivalent YAML configuration will be printed, which can be written to a
-file. The client can then be started using this configuration file:
-
-```code
-$ tbot configure identity \
-   --destination=./example \
-   --join-method=token \
-   --token=foo \
-   --proxy-server=teleport.example.com:443 > tbot.yaml
-$ tbot start -c tbot.yaml
-```
-
-### Flags
-
-This subcommand supports one additional flag beyond its `tbot start` equivalent:
-
-| Flag          | Description |
-|---------------|-------------|
-| `-o/--output` | If set, writes the generated configuration to the given file path instead of stdout. |
-
-## tbot start
-
-The `tbot start` family of commands starts the Machine & Workload Identity
-client in various modes, depending on the type of resources to be accessed:
-
-- [`tbot start legacy`](#tbot-start-legacy): Starts with a YAML configuration file or in legacy output mode
-- [`tbot start identity`](#tbot-start-identity): Starts with an identity output for SSH and Teleport API access
-- [`tbot start database`](#tbot-start-database): Starts with a database credential output
-- [`tbot start kubernetes`](#tbot-start-kubernetes): Starts with a Kubernetes output
-- [`tbot start application`](#tbot-start-application): Starts with an application TLS credential output
-- [`tbot start application-tunnel`](#tbot-start-application-tunnel): Starts a local application tunnel
-- [`tbot start database-tunnel`](#tbot-start-database-tunnel): Starts a local database tunnel
-- [`tbot start spiffe-svid`](#tbot-start-spiffe-svid): Starts a Workload ID SPIFFE SVID output
-
-If only `tbot start` is specified, `tbot start legacy` will be inferred by
-default; this is the correct mode for use with a YAML configuration file.
-
-### Common Start Flags
-
-These flags are available to all `tbot start` commands. Note that
-`tbot start legacy` supports slightly different options, so refer to its
-specific section for details when using a YAML config file or legacy output.
-
-| Flag                    | Description |
-|-------------------------|-------------|
-| `-d/--debug`            | Enable verbose logging to stderr. |
-| `--[no-]fips`           | Whether to run tbot in FIPS compliance mode. This requires the FIPS `tbot` binary. |
-| `--log-format`          | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`. |
-| `-a/--auth-server`      | Address of the Teleport Auth Service. Prefer using `--proxy-server` where possible. |
-| `--proxy-server`        | Address of the Teleport Proxy Service. |
-| `--token`               | A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect. |
-| `--ca-pin`              | CA pin to validate the Teleport Auth Service; used on first connect. |
-| `--certificate-ttl`     | TTL of short-lived machine certificates. |
-| `--renewal-interval`    | Interval at which short-lived certificates are renewed; must be less than the certificate TTL. |
-| `--join-method`         | Method to use to join the cluster. One of: `azure`, `circleci`, `gcp`, `github`, `gitlab`, `iam`, `kubernetes`, `spacelift`, `token`, `tpm`, `terraform_cloud` |
-| `--[no-]oneshot`        | If set, quit after the first renewal. |
-| `--diag-addr`           | If set and the bot is in debug mode, a diagnostics service will listen on specified address. |
-| `--storage`             | A destination URI for tbot's internal storage, e.g. `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. |
-| `--registration-secret` | An optional joining secret to use on first join with the `bound_keypair` join method. This can also be provided via the `TBOT_REGISTRATION_SECRET` environment variable. |
-| `--registration-secret-path` | An optional path to a file containing a joining secret to use on first join with the `bound_keypair` join method. |
-| `--static-key-path`     | An optional path to a file containing a static private key for use with the `bound_keypair` join method. A base64-encoded key can also be provided via the `TBOT_BOUND_KEYPAIR_STATIC_KEY` environment variable. |
-| `--pid-file`            | Full path to the PID file. By default no PID file will be created. |
-
-## tbot start legacy
-
-Starts `tbot`, fetching and writing certificates to disk at a set interval. This
-command either starts from a configuration file if `-c` is specified, or starts
-with a default, legacy-compatible identity output.
-
-This is the default `tbot start` subcommand if no other command is specified.
-Unless using a configuration file, consider using `tbot start identity` or
-another dedicated mode instead.
-
-### Flags
-
-| Flag                 | Description                                                                                                                                                                     |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `-d/--debug`         | Enable verbose logging to stderr. Can also be configured using the `TBOT_DEBUG` environment variable.                                                                           |
-| `-c/--config`        | Path to a tbot configuration file. Mutually exclusive with `--config-string`. Can also be configured with the `TBOT_CONFIG_PATH` environment variable.                          |
-| `--config-string`    | Allows the tbot configuration to be provided as a base 64 string directly via this flag or the `TBOT_CONFIG` environment variable. Mutually exclusive with `--config`           |
-| `--[no-]fips`        | Whether to run tbot in FIPS compliance mode. This requires the FIPS `tbot` binary.                                                                                              |
-| `-a/--auth-server`   | Address of the Teleport Auth Service. Prefer using --proxy-server where possible                                                                                                |
-| `--proxy-server`     | Address of the Teleport Proxy Server.                                                                                                                                           |
-| `--token`            | A bot join token, if attempting to onboard a new bot; used on first connect. Can also be an absolute path to a file containing the token.                                       |
-| `--ca-pin`           | CA pin to validate the Teleport Auth Service; used on first connect.                                                                                                            |
-| `--data-dir`         | Directory to store internal bot data. In production environments access to this directory should be limited only to an isolated linux user as an owner with `0600` permissions. |
-| `--destination-dir`  | Directory to write short-lived machine certificates.                                                                                                                            |
-| `--certificate-ttl`  | TTL of short-lived machine certificates.                                                                                                                                        |
-| `--renewal-interval` | Interval at which short-lived certificates are renewed; must be less than the certificate TTL.                                                                                  |
-| `--join-method`      | Method to use to join the cluster. Can be `token`, `azure`, `circleci`, `gcp`, `github`, `gitlab` or `iam`.                                                                     |
-| `--oneshot`          | If set, quit after the first renewal.                                                                                                                                           |
-| `--log-format`       | Controls the format of output logs. Can be `json` or `text`. Defaults to `text`.                                                                                                |
-| `--pid-file`         | Full path to the PID file. By default no PID file will be created.                                                                                                              |
-
-### Examples
-<Tabs>
-  <TabItem scope={["cloud", "team"]} label="Cloud-Hosted">
-
-```code
-$ tbot start \
-   --data-dir=/var/lib/teleport/bot \
-   --destination-dir=/opt/machine-id \
-   --token=00000000000000000000000000000000 \
-   --join-method=token \
-   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
-   --proxy-server=example.teleport.sh:443
-```
-
-  </TabItem>
-  <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
-
-```code
-$ tbot start \
-   --data-dir=/var/lib/teleport/bot \
-   --destination-dir=/opt/machine-id \
-   --token=00000000000000000000000000000000 \
-   --join-method=token \
-   --ca-pin=sha256:1111111111111111111111111111111111111111111111111111111111111111 \
-   --proxy-server=teleport.example.com:443
-```
-
-  </TabItem>
-</Tabs>
-
-## tbot start identity
-
-Starts `tbot` with an identity output, fetching and writing certificates at a
-regular interval to the output specified with
-`--destination`.
-
-```code
-$ tbot start identity --destination=DESTINATION [<flags>]
-```
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag                 | Description |
-|----------------------|-------------|
-| `--destination`  | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`  | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group` | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--cluster`      | The name of a specific cluster for which to issue an identity if using a leaf cluster |
-
-### Examples
-
-To start a bot with a one-time-use join token:
-
-```code
-$ tbot start identity \
-  --proxy-server=example.teleport.sh:443 \
-  --join-type=token \
-  --token=TOKEN \
-  --destination=./tbot-user \
-  --storage=./tbot-data
-```
-
-## tbot start database
-
-Starts `tbot` with a database output, fetching and writing database certificates
-at a regular interval to the output specified with
-`--destination`.
-
-```code
-$ tbot start database --destination=DESTINATION --service=SERVICE --username=USERNAME --database=DATABASE [<flags>]
-```
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag                 | Description |
-|----------------------|-------------|
-| `--destination`  | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`  | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group` | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--format`       | The database output format if necessary |
-| `--service`      | The service name of the database as it appears in Teleport and `tsh db ls`. Required. |
-| `--username`     | The database user name. The bot user must have permission to connect as this user. Required. |
-| `--database`     | The name of the database available in the requested service. Required. |
-
-## tbot start kubernetes
-
-Starts `tbot` with a Kubernetes output, fetching and writing Kubernetes
-credentials and a `kubeconfig.yaml` at a regular interval to the output
-specified with `--destination`.
-
-```code
-$ tbot start kubernetes --destination=DESTINATION --kubernetes-cluster=KUBERNETES-CLUSTER [<flags>]
-```
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag                   | Description |
-|------------------------|-------------|
-| `--destination`        | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`        | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group`       | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--kubernetes-cluster` | The name of the Kubernetes cluster in Teleport for which to fetch credentials |
-
-## tbot start kubernetes/v2
-
-Starts `tbot` with a Kubernetes V2 output, fetching and writing Kubernetes
-credentials to a `kubeconfig.yaml` at a regular interval to the output specified
-with `--destination`.
-
-Unlike the `kubernetes` output, `kubernetes/v2` allows fetching many Kubernetes
-clusters at once, as multiple contexts within the generated `kubeconfig.yaml`.
-If label selectors are used and clusters are added or removed, the list of
-clusters will be updated on the bot's next renewal. At least one selector -
-either name or label - is required.
-
-Note that as with human users using `tsh kube ls`, only clusters the bot user
-has permission to access will be matched. Additionally, note that label
-selectors do not currently support wildcards.
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag                    | Description |
-|-------------------------|-------------|
-| `--destination`         | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`         | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group`        | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--name-selector`       | Selects a Kubernetes cluster by exact name match. Repeatable. |
-| `--label-selector`      | Selects many Kubernetes clusters by label match, e.g. `env=dev,role=ci`. Repeatable. |
-| `--disable-exec-plugin` | If set, disables the exec plugin. Allows credentials to be used without the `tbot` binary. |
-
-### Examples
-
-First, run `tbot` to generate credentials:
-
-```code
-$ tbot start kubernetes/v2 --proxy-server=example.teleport.sh:443 --destination=./example --label-selector env=dev --name-selector example --oneshot
-```
-
-This will fetch credentials for all clusters with the label `env: dev`, plus the
-cluster named `example`. You can then access the clusters using `kubectl`:
-
-```code
-$ kubectl --kubeconfig ./example/kubeconfig.yaml --context example.teleport.sh-example get pods
-```
-
-You can inspect the generated `kubeconfig.yaml` to see which clusters were
-matched by the label selector.
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--path`|none|The path to the SPIFFE Workload API endpoint to test.|
 
 ## tbot start application
 
-Starts `tbot` with an application output, fetching and writing application TLS
-credentials at a regular interval to the output specified with `--destination`.
+Starts tbot with an application output.
+
+Usage:
 
 ```code
 $ tbot start application --destination=DESTINATION --app=APP [<flags>]
 ```
 
-### Flags
+Environment variables:
 
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-| Flag                 | Description |
-|----------------------|-------------|
-| `--destination`      | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`      | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group`     | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--app`              | The name of the app in Teleport |
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--app`|none|The name of the app in Teleport|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--[no-]specific-tls-extensions`|`false`|If set, include additional `tls.crt`, `tls.key`, and `tls.cas` for apps that require these file extensions|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot start application-proxy
+
+Starts tbot with an application proxy.
+
+Usage:
+
+```code
+$ tbot start application-proxy --listen=LISTEN [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
 ## tbot start application-tunnel
 
-Starts `tbot` with a local tunnel to a particular application. This tunnel will
-run continuously and automatically refresh its certificates.
+Starts tbot with an application tunnel.
 
-Note that this tunnel will be unencrypted. Be wary of the selected listen
-address, and prefer to use `localhost` or an equivalent loopback interface
-address when possible. Additionally, note that all users on the local system
-will be able to access this socket.
-
-If you wish to tunnel multiple apps from one bot instance, use
-`tbot configure application-tunnel ...` to generate a configuration file and
-repeat the generated block under `services:` as desired.
-
-This tunneling method is preferred over the legacy [`tbot proxy app`](#tbot-proxy).
+Usage:
 
 ```code
 $ tbot start application-tunnel --listen=LISTEN --app=APP [<flags>]
 ```
 
-### Flags
+Environment variables:
 
-| Flag       | Description |
-|------------|-------------|
-| `--listen` | A socket URI to listen on, e.g. `tcp://localhost:1234`. Required. |
-| `--app`    | The name of the app in Teleport |
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--app`|none|The name of the app in Teleport|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI, such as tcp://0.0.0.0:8080|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot start database
+
+Starts tbot with a database output.
+
+Usage:
+
+```code
+$ tbot start database --destination=DESTINATION --service=SERVICE --username=USERNAME --database=DATABASE [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--database`|none|The name of the database available in the requested database service|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--format`|``|The database output format if necessary|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--service`|none|The database service name|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--username`|none|The database user name|
 
 ## tbot start database-tunnel
 
-Starts `tbot` with a local tunnel to a particular database. This tunnel will run
-continuously and automatically refresh its certificates.
+Starts tbot with a database tunnel listener.
 
-Note that this tunnel will be unencrypted. Be wary of the selected listen
-address, and prefer to use `localhost` or an equivalent loopback interface
-address when possible. Additionally, note that all users on the local system
-will be able to access this socket.
-
-If you wish to tunnel multiple databases from one bot instance, use
-`tbot configure database-tunnel ...` to generate a configuration file and repeat
-the generated block under `services:` as desired.
-
-This tunneling method is preferred over the legacy
-[`tbot proxy db`](#tbot-proxy), and is roughly equivalent to
-`tbot proxy db --tunnel`.
+Usage:
 
 ```code
 $ tbot start database-tunnel --listen=LISTEN --service=SERVICE --username=USERNAME --database=DATABASE [<flags>]
 ```
 
-### Flags
+Environment variables:
 
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-| Flag         | Description |
-|--------------|-------------|
-| `--listen`   | A socket URI to listen on, e.g. `tcp://localhost:1234`. Required. |
-| `--service`  | The service name of the database as it appears in Teleport and `tsh db ls`. Required. |
-| `--username` | The database user name. The bot user must have permission to connect as this user. Required. |
-| `--database` | The name of the database available in the requested service. Required. |
+Flags:
 
-## tbot start workload-identity-x509
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--database`|none|The name of the database available in the requested database service|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--listen`|none|A socket URI to listen on, such as tcp://0.0.0.0:3306|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--service`|none|The database service name|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--username`|none|The database user name|
 
-Issues an X509 workload identity credential using Teleport Workload Identity and
-writes this credential to a specified destination.
+## tbot start identity
 
-See the [configuration reference](../machine-workload-identity/configuration.mdx) for further
-information about the workload identity credential output and the YAML
-configuration file format.
+Starts tbot with an identity output for SSH and Teleport API access.
 
-### Flags
+Usage:
 
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
+```code
+$ tbot start identity --destination=DESTINATION [<flags>]
+```
 
-| Flag                                     | Description                                                                                                                                                        |
-|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--destination`                          | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
-| `--reader-user`                          | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
-| `--reader-group`                         | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
-| `--[no-]include-federated-trust-bundles` | If set, include federated trust bundles in the output                                                                                                              |
-| `--name-selector`                        | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
-| `--label-selector`                       | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
+Environment variables:
 
-## tbot start workload-identity-aws-roles-anywhere
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-Issues an X509 workload identity credential, exchanges this for short-lived AWS
-credentials using Roles Anywhere, and writes these to a configured destination.
+Flags:
 
-See the [configuration reference](../machine-workload-identity/configuration.mdx) for further
-information about the workload identity credential output and the YAML
-configuration file format.
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--cluster`|none|The name of a specific cluster for which to issue an identity if using a leaf cluster|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]allow-reissue`|`false`|Allow the credentials output by this command to be reissued.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
-### Flags
+## tbot start kubernetes
 
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
+Starts tbot with a Kubernetes output.
 
-| Flag                         | Description                                                                                                                                                        |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--destination`              | A destination URI, such as `file:///foo/bar`. See [Destination URIs](#destination-uris) for more info. Required.                                                   |
-| `--reader-user`              | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
-| `--reader-group`             | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
-| `--name-selector`            | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
-| `--label-selector`           | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
-| `--role-arn`                 | The ARN of the AWS role to assume. Required.                                                                                                                       |
-| `--profile-arn`              | The ARN of the AWS profile to use for the Roles Anywhere exchange. Required.                                                                                       |
-| `--trust-anchor-arn`         | The ARN of the trust anchor to use for the Roles Anywhere exchange. Required.                                                                                      |
-| `--region`                   | The AWS region to use for the Roles Anywhere exchange. Falls back to value in `AWS_REGION` or the AWS configuration file if unspecified.                           |
-| `--session-duration`         | The duration of the AWS session. Defaults to `6h`. This may be up to `12h`.                                                                                        |
-| `--session-renewal-interval` | The interval at which to renew the AWS session. Defaults to `1h`. This must be less than the session duration.                                                     |
+Usage:
 
-## tbot start workload-identity-jwt
+```code
+$ tbot start kubernetes --destination=DESTINATION --kubernetes-cluster=KUBERNETES-CLUSTER [<flags>]
+```
 
-Issues a JWT workload identity credential using Teleport Workload Identity and
-writes this credential to a specified destination.
+Environment variables:
 
-The JWT workload identity credential is compatible with the [SPIFFE JWT SVID
-specification](https://github.com/spiffe/spiffe/blob/main/standards/JWT-SVID.md).
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-See the [configuration reference](../machine-workload-identity/configuration.mdx) for further
-information about the workload identity credential output and the YAML
-configuration file format.
+Flags:
 
-### Flags
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--kubernetes-cluster`|none|The name of the Kubernetes cluster in Teleport for which to fetch credentials|
+|`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
+## tbot start kubernetes/v2
 
-| Flag               | Description                                                                                                                                                        |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--destination`    | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required.                                                     |
-| `--reader-user`    | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                 |
-| `--reader-group`   | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.                                |
-| `--name-selector`  | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
-| `--label-selector` | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
-| `--audience`       | The audience for the JWT. Can be provided multiple times to produce a JWT with multiple audiences. At least one audience must be provided.                         |
+Starts tbot with a Kubernetes V2 output.
+
+Usage:
+
+```code
+$ tbot start kubernetes/v2 --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A set of Kubernetes labels to match in k1=v1,k2=v2 form. Repeatable.|
+|`--name-selector`|none|An explicit Kubernetes cluster name to include. Repeatable.|
+|`--[no-]disable-exec-plugin`|`false`|If set, disables the exec plugin. This allows credentials to be used without the `tbot` binary.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot start legacy
+
+Starts tbot with either a config file or a legacy output.
+
+Usage:
+
+```code
+$ tbot start legacy [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--data-dir`|none|Directory to store internal bot data. Access to this directory should be limited.|
+|`--destination-dir`|none|Directory to write short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot start ssh-multiplexer
+
+Starts tbot with an SSH Multiplexer service.
+
+Usage:
+
+```code
+$ tbot start ssh-multiplexer --destination=DESTINATION [<flags>]
+```
+
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--[no-]enable-resumption`|`false`|If set, disables SSH session resumption.|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-command`|none|The command to run as the SSH ProxyCommand, such as `fdpass-teleport`. Defaults to this tbot binary. Repeatable to add additional args.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--proxy-templates-path`|none|A path to a proxy template config file. Optional.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
 ## tbot start workload-identity-api
 
-Starts the `tbot` agent and opens a listener for the local workload identity
-API.
+Starts tbot with a workload identity API listener. Compatible with the SPIFFE
+Workload API and Envoy SDS.
 
-The configuration for this service can be complex, and therefore, it is
-recommended that you leverage the YAML configuration.
-
-See [Workload Identity API & Workload Attestation](../machine-workload-identity/workload-identity/workload-identity-api-and-workload-attestation.mdx)
-for further information about the local workload identity API and the YAML
-configuration.
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag               | Description                                                                                                                                                        |
-|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `--listen`         | A socket URI to listen on, e.g. `tcp://localhost:1234` or `unix:///opt/workload-identity.sock`. Required.                                                          |
-| `--name-selector`  | Specifies a WorkloadIdentity resource by name to use when issuing the X509 for a workload. Mutually exclusive with `--label-selector`.                             |
-| `--label-selector` | Specifies a set of labels to use when selecting WorkloadIdentity resources to use when issuing the X509 for a workload. Mutually exclusive with `--name-selector`. |
-
-## tbot start spiffe-svid
-
-<Admonition type="warning" >
-The use of this command has been deprecated as part of the introduction of the
-new Workload Identity configuration experience. You can replace the use of this
-command with the new `tbot start workload-identity-x509` command.
-
-For further information, see [the new Workload Identity configuration experience
-and how to migrate](../machine-workload-identity/workload-identity/configuration-resource-migration.mdx).
-</Admonition>
-
-### Flags
-
-In addition to the [common `tbot start` flags](#common-start-flags), this
-command supports these additional flags:
-
-| Flag                 | Description |
-|----------------------|-------------|
-| `--destination`                          | A destination URI, such as file:///foo/bar. See [Destination URIs](#destination-uris) for more info. Required. |
-| `--reader-user`                          | An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--reader-group`                         | An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux. |
-| `--[no-]include-federated-trust-bundles` | If set, include federated trust bundles in the output |
-| `--svid-path`                            | A SPIFFE ID to request, prefixed with '/'. Required. |
-| `--svid-hint`                            | An optional hint for consumers of the SVID to aid in identification |
-| `--dns-san`                              | A DNS name that should be included in the SVID. Repeatable. |
-| `--ip-san`                               | An IP address that should be included in the SVID. Repeatable. |
-
-## tbot copy-binaries
-
-Copies the `tbot` binary to a destination directory, optionally including
-`fdpass-teleport`.
-
-This command may be useful for copying the `tbot` binaries from Teleport's
-distroless containers into another container, for example as part of a
-Kubernetes `initContainer`.
-
-If using the `ssh-multiplexer` service with the `fdpass-teleport` helper, the
-`--include-fdpass` flag should be used to ensure that helper binary is also
-copied. However, note that the binary must be available in the source
-environment to be copied.
+Usage:
 
 ```code
-$ tbot copy-binaries [--include-fdpass] DESTINATION-DIR
+$ tbot start workload-identity-api --listen=LISTEN [<flags>]
 ```
 
-### Flags
+Environment variables:
 
-| Flag              | Description |
-|-------------------|-------------|
-| `--include-fdpass` | If set, also copy `fdpass-teleport` from the same directory as the `tbot` binary. |
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-## tbot install systemd
+Flags:
 
-Generates and installs a systemd unit file for a specific tbot configuration.
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--listen`|none|The address on which the workload identity API should listen. This should either be prefixed with 'unix://' or 'tcp://'.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
 
-### Flags
+## tbot start workload-identity-aws-roles-anywhere
 
-| Flag                  | Description                                                                                                                      |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| `-d/--debug`          | Enable verbose logging to stderr.                                                                                                |
-| `-c/--config`         | Path to a configuration file.                                                                                                    |
-| `--write `            | Write the systemd unit file. If not specified, this command runs in a dry-run mode that outputs the generated content to stdout. |
-| `--systemd-directory` | Path to the directory that the systemd unit file should be written. Defaults to '/etc/systemd/system'.                           |
-| `--force`             | Overwrite existing systemd unit file if present.                                                                                 |
-| `--name`              | Name for the systemd unit. Defaults to 'tbot'.                                                                                   |
-| `--user`              | The user that the service should run as. Defaults to 'teleport'.                                                                 |
-| `--group`             | The group that the service should run as. Defaults to 'teleport'.                                                                |
+Starts tbot with an output containing AWS credentials generated via AWS Roles
+Anywhere.
 
-### Examples
+Usage:
 
 ```code
-$ tbot install systemd \
-   --config=/etc/tbot.yaml \
-   --write
+$ tbot start workload-identity-aws-roles-anywhere --destination=DESTINATION --role-arn=ROLE-ARN --profile-arn=PROFILE-ARN --trust-anchor-arn=TRUST-ANCHOR-ARN [<flags>]
 ```
 
-## tbot keypair create
+Environment variables:
 
-Generates a keypair for use with `bound_keypair` joining and stores it in the
-specified bot internal storage directory. If a key already exists in the storage
-directory, no new key will be generated and the existing public key will be
-printed to the console; use the `--overwrite` flag to force the generation of a
-new keypair.
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
 
-### Flags
+Flags:
 
-| Flag | Description |
-|------|-------------|
-| `--storage`         | A destination URI to be used for bot internal storage. Required. |
-| `--proxy-server`    | A Teleport Proxy Service address. Required. |
-| `--overwrite`       | If set, always generate a new key. If unset, the existing public key will be printed if one already exists in the destination specified by `--storage`. |
-| `--static`          | If set, generates a static keypair. For more information, see [the static key guide](../machine-workload-identity/bound-keypair/static-keys.mdx). |
-| `--static-key-path` | If set with `--static`, writes the static keypair to a file. |
-| `--format`          | Override the output format, supported values: `text`, `json`. |
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--profile-arn`|none|The ARN of the Roles Anywhere profile to use.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--region`|none|The AWS region to use. If unset, value will be used from the AWS config or the AWS_REGION environment variable.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--role-arn`|none|The ARN of the role to assume.|
+|`--session-duration`|none|The duration of the resulting AWS session and credentials. This may be up to 12 hours. When unset, this defaults to 6 hours.|
+|`--session-renewal-interval`|none|How often the session should be renewed. This should be less than the session duration. When unset, this defaults to 1 hour.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`--trust-anchor-arn`|none|The ARN of the Roles Anywhere trust anchor to use.|
 
-### Examples
+## tbot start workload-identity-jwt
 
-First, ensure the desired internal storage directory exists:
+Starts tbot with a SPIFFE-compatible JWT SVID output.
+
+Usage:
+
 ```code
-$ mkdir -p /var/lib/teleport/bot
+$ tbot start workload-identity-jwt --destination=DESTINATION --audience=AUDIENCE [<flags>]
 ```
 
-Next, generate a keypair:
+Environment variables:
+
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--audience`|none|Specify the audiences to include in the JWT. At least one audience must be specified.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot start workload-identity-x509
+
+Starts tbot with a SPIFFE-compatible SVID output.
+
+Usage:
+
 ```code
-$ tbot keypair create --proxy-server example.teleport.sh:443 --storage /var/lib/teleport/bot
-2025-07-09T00:00:00.000-00:00 INFO [TBOT]      keypair has been written to storage storage:directory: /var/lib/teleport/bot tbot/keypair.go:135
-
-To register the keypair with Teleport, include this public key in the token's
-`spec.bound_keypair.onboarding.initial_public_key`:
-
-	ssh-ed25519 <data>
+$ tbot start workload-identity-x509 --destination=DESTINATION [<flags>]
 ```
 
-This public key, including the algorithm identifier (`ssh-ed25519`, but may vary
-depending on your cluster configuration) can then be copied into a Bound Keypair
-join token to be used as a
-[preregistered key](../machine-workload-identity/bound-keypair/concepts.mdx#onboarding).
+Environment variables:
 
-Note that the Teleport Proxy Service address is required to fetch the currently
-enabled [signature suite](../deployment/signature-algorithms.mdx). No authentication takes
-place at this time.
+|Variable|Default|Description|
+|---|---|---|
+|`TELEPORT_AUTH_SERVER`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`TELEPORT_BOT_TOKEN`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+|`TELEPORT_PROXY`|none|Address of the Teleport Proxy Server.|
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`-a`, `--auth-server`|none|Address of the Teleport Auth Server. Prefer using --proxy-server where possible.|
+|`--ca-pin`|none|CA pin to validate the Teleport Auth Server; used on first connect.|
+|`--certificate-ttl`|none|TTL of short-lived machine certificates.|
+|`--destination`|none|A destination URI, such as file:///foo/bar|
+|`--diag-addr`|none|If set and the bot is in debug mode, a diagnostics service will listen on specified address.|
+|`--join-method`|none|Method to use to join the cluster. (azure, azure_devops, bitbucket, circleci, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0)|
+|`--join-uri`|none|An optional URI with joining and authentication parameters. Individual flags for proxy, join method, token, etc may be used instead.|
+|`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
+|`--name-selector`|none|The name of the workload identity to issue|
+|`--[no-]include-federated-trust-bundles`|`false`|If set, include federated trust bundles in the output|
+|`--[no-]oneshot`|`false`|If set, quit after the first renewal.|
+|`--pid-file`|none|Full path to the PID file. By default no PID file will be created.|
+|`--proxy-server`|none|Address of the Teleport Proxy Server.|
+|`--reader-group`|none|An additional group name or GID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--reader-user`|none|An additional user name or UID that should be allowed by ACLs to read this destination. Only valid for file destinations on Linux.|
+|`--registration-secret`|none|For bound keypair joining, specifies a registration secret for use at first join.|
+|`--registration-secret-path`|none|For bound keypair joining, specifies a file containing a registration secret for use at first join.|
+|`--renewal-interval`|none|Interval at which short-lived certificates are renewed; must be less than the certificate TTL.|
+|`--static-key-path`|none|For bound keypair joining, specifies a path to a static key.|
+|`--storage`|none|A destination URI for tbot's internal storage, e.g. file:///foo/bar|
+|`--token`|none|A bot join token or path to file with token value, if attempting to onboard a new bot; used on first connect.|
+
+## tbot tpm identify
+
+Output identifying information related to the TPM detected on the system.
+
+Usage:
+
+```code
+$ tbot tpm identify
+```
+
+## tbot version
+
+Print the version of your tbot binary.
+
+Usage:
+
+```code
+$ tbot version
+```
 
 ## tbot wait
 
-Waits for a running `tbot` to become ready by querying its diagnostics endpoint.
+Waits for a running tbot to become ready.
 
-A `tbot` process must have been started with the diagnostics service enabled via
-the `--diag-addr` CLI flag or `diag_addr` YAML field.
-
-The `wait` command waits indefinitely for the bot (or single service, if
-specified) to begin reporting its status, and for the bot to become healthy as
-reported by the diagnostics service's `/readyz` endpoint. It is safe to run
-before the main `tbot` process has started running and will only return when
-either the bot is ready for use, or the timeout (if specified) has elapsed.
-
-If the `--timeout` flag is specified and the bot or specific service has not
-become healthy within the time limit, the command exits with an error. If not
-specified, the command will only exit if and when the bot becomes healthy.
+Usage:
 
 ```code
-$ tbot wait --diag-addr=127.0.0.1:1234 [<flags>]
+$ tbot wait --diag-addr=DIAG-ADDR [<flags>]
 ```
 
-### Flags
+Flags:
 
-| Flag         | Description |
-|--------------|-------------|
-| `--diag-addr` | The configured `--diag-addr` of a running bot, in `host:port` form. Required. |
-| `--service`  | If set, waits for only the named service to become healthy. If unset, waits for all services. |
-| `--timeout`  | An optional timeout duration string, e.g. `30s`. The command exits with an error if services are not healthy before the timeout. |
+|Flag|Default|Description|
+|---|---|---|
+|`--diag-addr`|none|The configured --diag-addr of a running bot, in host:port form.|
+|`--service`|none|An optional name. If set, waits for only the named service to become healthy. If unset, waits for all services.|
+|`--timeout`|none|An optional timeout. If set, returns an error if all specified services have reported healthy by the timeout.|
 
-
-## Destination URIs
-
-Many `tbot start` subcommands accept destination URIs via the `--storage` and
-`--destination` flags.
-
-| Protocol               | Description |
-|------------------------|-------------|
-| `file://`              | A local directory destination, such as `file:///foo/bar/` |
-| `memory://`            | An in-memory destination. Useful for internal bot storage if no persistence is required. |
-| `kubernetes-secret://` | A Kubernetes secret destination, such as `kubernetes-secret:///my-secret` |
-
-Plain file paths are also be accepted with no `file://` prefix; these will be
-treated as directory outputs.
-
-Note that `tbot start legacy` only supports directory output destinations via
-the `--destination-dir` flag, though it does support URIs for `--storage`. All
-other `tbot start` subcommands accept these URIs where relevant.

--- a/lib/utils/docsconfigs/tbot.yaml
+++ b/lib/utils/docsconfigs/tbot.yaml
@@ -1,0 +1,5 @@
+introduction: |-
+  `tbot` is a CLI tool used with **Machine & Workload Identity** that
+  programatically issues and renews short-lived certificates to any service
+  account (e.g, a CI/CD server).
+

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -53,12 +53,9 @@ func main() {
 	}
 }
 
-const appHelp = `Teleport Machine & Workload Identity
-
-Machine & Workload Identity issues and renews short-lived certificates so your
-machines can access Teleport protected resources in the same way your engineers do!
-
-Find out more at https://goteleport.com/docs/machine-workload-identity/`
+const appHelp = `Teleport Machine & Workload Identity issues and renews
+short-lived certificates so your machines can access Teleport protected
+resources in the same way your engineers do.`
 
 func Run(args []string, stdout io.Writer) error {
 	ctx := context.Background()


### PR DESCRIPTION
Backports #62732

Add a `cli-docs-tbot` Make target and generate the page.

This change adds 19 `tbot` commands not present in the current reference.

Also make minor changes to the app description so it can apply to both in-app help text and generated docs.