### PR TITLE
Fix proxy cache missing app auth config due to lack of permissions

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -949,6 +949,7 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindRelayServer, services.RO()),
 				types.NewRule(types.KindAccessList, services.RO()),
 				types.NewRule(types.KindHealthCheckConfig, services.RO()),
+				types.NewRule(types.KindAppAuthConfig, services.RO()),
 				// this rule allows cloud proxies to read
 				// plugins of `openai` type, since Assist uses the OpenAI API and runs in Proxy.
 				{

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1315,6 +1315,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindLock, services.RW()),
 						types.NewRule(types.KindSAML, services.ReadNoSecrets()),
 						types.NewRule(types.KindAccessList, services.RO()),
+						types.NewRule(types.KindAccessListMember, services.RO()),
 						// Okta can read/write access lists and roles it creates.
 						{
 							Resources: []string{types.KindRole},


### PR DESCRIPTION
The proxy cache wasn't properly starting the watcher for app auth configs due to a missing permission. This PR fixes that and adds a test to prevent similar permission issues.

Thanks @marcoandredinis for pointing this out!