### PR TITLE
Draw attention to SSO index page "integrate" link

### DIFF
--- a/docs/pages/zero-trust-access/sso/sso.mdx
+++ b/docs/pages/zero-trust-access/sso/sso.mdx
@@ -15,9 +15,15 @@ provider. You can centralize the way your infrastructure authenticates,
 authorizes, and audits users who want to access it, while also keeping your
 organization's existing processes for managing users.
 
+This guide explains key concepts related to Teleport single sign-on
+integrations.
+
+<Admonition type="tip">
+
 To get started integrating your identity provider with Teleport, read [Integrate
-your Identity Provider](integrate-idp/integrate-idp.mdx). The rest of this guide
-explains key concepts related to Teleport single sign-on integrations.
+your Identity Provider](integrate-idp/integrate-idp.mdx).
+
+</Admonition>
 
 ## How Teleport uses SSO
 


### PR DESCRIPTION
The link on the "Configure Single Sign-On" index page to the "Integrate your Provider" page is one that most readers will want to follow, but the link is currently embedded in a paragraph and difficult to find. Make the link more prominent by placing it in an Admonition.