### PR TITLE
tsh: Don't show scopes header with -v flag unless scoping is enabled

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3318,7 +3318,11 @@ func printNodesAsText[T types.Server](output io.Writer, nodes []T, verbose bool)
 	// In verbose mode, print everything on a single line and include the Node
 	// ID (UUID). Useful for machines that need to parse the output of "tsh ls".
 	case true:
-		t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		if withScope {
+			t = asciitable.MakeTable([]string{"Scope", "Node Name", "Node ID", "Address", "Labels"}, rows...)
+		} else {
+			t = asciitable.MakeTable([]string{"Node Name", "Node ID", "Address", "Labels"}, rows...)
+		}
 	// In normal mode chunk the labels and print two per line and allow multiple
 	// lines per node.
 	case false:


### PR DESCRIPTION
Prior to this PR, `tsh ls -v` would always show a "Scope" header, leading to a format string error. Introduced in https://github.com/gravitational/teleport/pull/62171

Before PR:

```
$ tsh ls -v
Scope            Node Name                            Node ID      Address                                                                                                                  Labels
---------------- ------------------------------------ ------------ ------------------------------------------------------------------------------------------------------------------------ ------
ip-172-31-30-140 e81b83e5-f84e-40be-a06e-83580960ee03 ⟵ Tunnel     aws/Name=gus.teleportdemo.com,aws/Owner=gus,aws/Purpose=demo-server,aws/instance_metadata_tagging_req=gus@goteleport.com %!v(MISSING)
test-node        10b4d2c9-5e84-4686-b9c4-83bf11c7cf82 test-node:22 env=dev                                                                                                                  %!v(MISSING)
```

After PR:
```
$ build/tsh ls -v
Node Name        Node ID                              Address      Labels
---------------- ------------------------------------ ------------ ------------------------------------------------------------------------------------------------------------------------
ip-172-31-30-140 e81b83e5-f84e-40be-a06e-83580960ee03 ⟵ Tunnel     aws/Name=gus.teleportdemo.com,aws/Owner=gus,aws/Purpose=demo-server,aws/instance_metadata_tagging_req=gus@goteleport.com
test-node        10b4d2c9-5e84-4686-b9c4-83bf11c7cf82 test-node:22 env=dev
```