### PR TITLE
convert cluster maintenance configto new handler format

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -169,7 +169,6 @@ func (c *semaphoreCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-
 type netRestrictionsCollection struct {
 	netRestricts types.NetworkRestrictions
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -169,36 +169,6 @@ func (c *semaphoreCollection) WriteText(w io.Writer, verbose bool) error {
 	return trace.Wrap(err)
 }
 
-type maintenanceWindowCollection struct {
-	cmc types.ClusterMaintenanceConfig
-}
-
-func (c *maintenanceWindowCollection) Resources() (r []types.Resource) {
-	if c.cmc == nil {
-		return nil
-	}
-	return []types.Resource{c.cmc}
-}
-
-func (c *maintenanceWindowCollection) WriteText(w io.Writer, verbose bool) error {
-	t := asciitable.MakeTable([]string{"Type", "Params"})
-
-	agentUpgradeParams := "none"
-
-	if c.cmc != nil {
-		if win, ok := c.cmc.GetAgentUpgradeWindow(); ok {
-			agentUpgradeParams = fmt.Sprintf("utc_start_hour=%d", win.UTCStartHour)
-			if len(win.Weekdays) != 0 {
-				agentUpgradeParams = fmt.Sprintf("%s, weekdays=%s", agentUpgradeParams, strings.Join(win.Weekdays, ","))
-			}
-		}
-	}
-
-	t.AddRow([]string{"Agent Upgrades", agentUpgradeParams})
-
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
 
 type netRestrictionsCollection struct {
 	netRestricts types.NetworkRestrictions

--- a/tool/tctl/common/resources/cluster_maintenance_config.go
+++ b/tool/tctl/common/resources/cluster_maintenance_config.go
@@ -1,0 +1,136 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+type clusterMaintenanceConfigCollection struct {
+	cmc types.ClusterMaintenanceConfig
+}
+
+func (c *clusterMaintenanceConfigCollection) Resources() (r []types.Resource) {
+	if c.cmc == nil {
+		return nil
+	}
+	return []types.Resource{c.cmc}
+}
+
+func (c *clusterMaintenanceConfigCollection) WriteText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Type", "Params"})
+
+	agentUpgradeParams := "none"
+
+	if c.cmc != nil {
+		if win, ok := c.cmc.GetAgentUpgradeWindow(); ok {
+			agentUpgradeParams = fmt.Sprintf("utc_start_hour=%d", win.UTCStartHour)
+			if len(win.Weekdays) != 0 {
+				agentUpgradeParams = fmt.Sprintf("%s, weekdays=%s", agentUpgradeParams, strings.Join(win.Weekdays, ","))
+			}
+		}
+	}
+
+	t.AddRow([]string{"Agent Upgrades", agentUpgradeParams})
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func clusterMaintenanceConfigHandler() Handler {
+	return Handler{
+		getHandler:    getClusterMaintenanceConfig,
+		createHandler: createClusterMaintenanceConfig,
+		updateHandler: updateClusterMaintenanceConfig,
+		deleteHandler: deleteClusterMaintenanceConfig,
+		singleton:     true,
+		mfaRequired:   false,
+		description:   "Configures when agent managed updates v1 happen. Cannot be edited in Teleport Cloud.",
+	}
+}
+
+func getClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	cmc, err := client.GetClusterMaintenanceConfig(ctx)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	return &clusterMaintenanceConfigCollection{cmc}, nil
+}
+
+func createClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	var cmc types.ClusterMaintenanceConfigV1
+	if err := utils.FastUnmarshal(raw.Raw, &cmc); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := cmc.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if opts.Force {
+		// max nonce forces "upsert" behavior
+		cmc.Nonce = math.MaxUint64
+	}
+
+	if err := client.UpdateClusterMaintenanceConfig(ctx, &cmc); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Println("cluster maintenance config created")
+	return nil
+}
+
+func updateClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	var cmc types.ClusterMaintenanceConfigV1
+	if err := utils.FastUnmarshal(raw.Raw, &cmc); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := cmc.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := client.UpdateClusterMaintenanceConfig(ctx, &cmc); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Println("cluster maintenance config updated")
+	return nil
+}
+
+func deleteClusterMaintenanceConfig(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.DeleteClusterMaintenanceConfig(ctx); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Println("cluster maintenance config deleted")
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -50,6 +50,7 @@ func Handlers() map[string]Handler {
 		types.KindBotInstance:                        botInstanceHandler(),
 		types.KindCertAuthority:                      certAuthorityHandler(),
 		types.KindClusterAuthPreference:              authPreferenceHandler(),
+		types.KindClusterMaintenanceConfig:           clusterMaintenanceConfigHandler(),
 		types.KindClusterNetworkingConfig:            networkingConfigHandler(),
 		types.KindConnectors:                         connectorsHandler(),
 		types.KindDatabase:                           databaseHandler(),


### PR DESCRIPTION
Part of: https://github.com/gravitational/teleport/issues/60370

This PR converts the following resources to the new tctl resource handler format:
- `cluster_maintenance_config`

Note: the conversion was partially done with an LLM.