### PR TITLE
Flatten published TF modules tarball contents

### DIFF
--- a/integrations/terraform-modules/Makefile
+++ b/integrations/terraform-modules/Makefile
@@ -76,7 +76,7 @@ build: $(BUILD_TARGETS) ;
 # https://developer.hashicorp.com/terraform/internals/module-registry-protocol
 $(BUILD_DIR)/$(PLUGIN_TYPE)_%.tar.gz: clean
 	@mkdir -p $(dir $@)
-	tar -czf $@ $(subst _,/,$*)
+	tar -C $(subst _,/,$*) -czf $@ . # change dirs to make the tarball because Terraform expects the tarball to only contain module source files, i.e., not nested in subdirectories.
 
 .PHONY: clean
 clean: tfclean


### PR DESCRIPTION
Before this change the tarball would contain the module directory tree relative to `integrations/terraform-modules` like this:

```
$ tree
.
└── teleport
    └── discovery
        └── aws
            ├── aws_iam_policy.tf
...
```

After this change it just contains the module dir contents:
```
$ tree
.
├── aws_iam_policy.tf
├── aws_iam_role.tf
...
```

Necessary because terraform won't work with the nested dirs format.

Part of
- https://github.com/gravitational/teleport/issues/62631