### PR TITLE
[v18] Add a Terraform module for AWS EC2 discovery

### DIFF
--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -20,6 +20,9 @@ jobs:
       # TODO: Fix Terraform linting issues and stop using force to pass the job.
       tflint_force: true
       tflint_config_path: $GITHUB_WORKSPACE/.tflint.hcl
+      # TODO(gavin): update shared-workflow version to lint module docs 
+      # terraform_docs_config_path: $GITHUB_WORKSPACE/integrations/terraform-modules/.terraform-docs.yml
+      # terraform_docs_find_dir: $GITHUB_WORKSPACE/integrations/terraform-modules
     permissions:
       actions: read
       contents: read

--- a/integrations/terraform-modules/.gitignore
+++ b/integrations/terraform-modules/.gitignore
@@ -1,0 +1,13 @@
+# Build artifacts
+build/*
+docs/
+bin/
+
+# Terraform state
+.terraform
+*.tfstate*
+*.lock.hcl
+
+tmp
+*.swp
+*.log

--- a/integrations/terraform-modules/.pre-commit-config.yaml
+++ b/integrations/terraform-modules/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+default_install_hook_types:
+  - "pre-push"
+default_stages:
+  - "pre-push"
+  - "manual"
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.103.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_docs
+        args:
+          - '--args=--config=integrations/terraform-modules/.terraform-docs.yml'
+      - id: terraform_tflint
+      - id: terraform_validate

--- a/integrations/terraform-modules/.terraform-docs.yml
+++ b/integrations/terraform-modules/.terraform-docs.yml
@@ -1,0 +1,35 @@
+content: ''
+footer-from: ''
+formatter: markdown table
+header-from: main.tf
+output:
+  file: README.md
+  mode: inject
+output-values:
+  enabled: false
+  from: ''
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+sections:
+  hide: []
+  show: []
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: false # avoid pinning provider version in README
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true
+sort:
+  enabled: true
+  by: name
+version: ''

--- a/integrations/terraform-modules/Makefile
+++ b/integrations/terraform-modules/Makefile
@@ -1,0 +1,91 @@
+.PHONY: all
+all: ;
+
+# this is defined because Make does not support .PHONY pattern recipes, but we
+# can make a no-op .PHONY recipe that a pattern recipe depends on to achieve the
+# same effect
+.PHONY: force
+force: ;
+
+.PHONY: fmt
+fmt:
+	terraform fmt -recursive .
+
+MODULE_DIRS := $(shell find . -type f -name '*.tf' -exec dirname {} \; 2>/dev/null | sort -u)
+README_FILES := $(addsuffix /README.md,$(MODULE_DIRS))
+
+.PHONY: docs
+docs: $(README_FILES) ;
+
+%/README.md: force
+	terraform-docs markdown table --config .terraform-docs.yml $*
+
+.PHONY: check
+check:
+	git ls-files -- . \
+	| xargs pre-commit run --hook-stage=manual --verbose --files
+
+.PHONY: require-pre-commit
+require-pre-commit:
+	@which pre-commit 1>/dev/null 2>&1 || (echo 'pre-commit is not installed. For installation instructions see https://pre-commit.com/#install'; exit 1)
+
+.PHONY: enable-pre-commit
+enable-pre-commit: require-pre-commit
+	pre-commit install
+
+.PHONY: disable-pre-commit
+disable-pre-commit: require-pre-commit
+	pre-commit uninstall
+
+VERSION ?= $(shell go run ../hack/get-version/get-version.go)
+BUILD_DIR ?= build
+
+# release builds the published module tarballs and then renames each tarball to innclude a version tag suffix, e.g.,
+# from: build/terraform-module_<namespace>_<name>_<system>.tar.gz
+# to:   build/terraform-module_<namespace>_<name>_<system>_<version>.tar.gz
+.PHONY: release
+release: build
+	@find $(BUILD_DIR) -maxdepth 1 -name '*.tar.gz' -type f -exec bash -c '\
+		for f; do \
+			mv "$$f" "$${f%.tar.gz}_v$(VERSION).tar.gz"; \
+		done \
+	' bash {} \+
+
+PLUGIN_TYPE := terraform-module
+# This list controls which modules are actually published.
+PUBLISHED_TF_MODULES := $(subst /,_, \
+	teleport/discovery/aws \
+)
+MODULE_TARBALLS:=$(addsuffix .tar.gz, $(PUBLISHED_TF_MODULES))
+BUILD_TARGETS:=$(addprefix $(BUILD_DIR)/$(PLUGIN_TYPE)_, $(MODULE_TARBALLS))
+
+.PHONY: build
+build: $(BUILD_TARGETS) ;
+
+# Build each published module in build/terraform-module_<namespace>_<name>_<system>.tar.gz
+# Module names follow the naming scheme as described in Terraform Module Registry Protocol.
+# <namespace> is the org (should be "teleport")
+# <name> is the module name
+# <system> is the target remote system, typically a cloud provider e.g., "aws", "google", "azurerm"
+# The subdirectory tree for modules follows the same naming convention, with
+# a directory for each of namespace, name, and system:
+# <namespace>/<name>/<system>/*.tf
+# For example, if we have a module at ./teleport/discovery/aws and we are
+# releasing version 19.0.0, then this will make build/terraform-module_teleport_discovery_aws_v19.0.0.tar.gz
+#
+# https://developer.hashicorp.com/terraform/internals/module-registry-protocol
+$(BUILD_DIR)/$(PLUGIN_TYPE)_%.tar.gz: clean
+	@mkdir -p $(dir $@)
+	tar -czf $@ $(subst _,/,$*)
+
+.PHONY: clean
+clean: tfclean
+	rm -rf build/
+
+.PHONY: tfclean
+tfclean:
+	find . \( \
+		-name '.terraform' \
+		-or -name '.terraform.lock.hcl' \
+		-or -name 'terraform.tfstate*' \
+	\) -exec rm -rf {} \+

--- a/integrations/terraform-modules/README.md
+++ b/integrations/terraform-modules/README.md
@@ -1,0 +1,15 @@
+# Teleport Terraform modules
+
+This directory contains Terraform modules that Teleport publishes for production usage.
+
+These modules set up Teleport cluster resources and/or cloud provider (AWS, Azure, GCP) resources.
+
+## Usage
+
+Each module contains a README.md and an `examples/` directory with example usage.
+
+## How to get help
+
+If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
+
+For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).

--- a/integrations/terraform-modules/teleport/discovery/aws/LICENSE
+++ b/integrations/terraform-modules/teleport/discovery/aws/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -1,0 +1,106 @@
+# AWS Discovery Terraform module
+
+This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover resources in AWS:
+
+- AWS IAM role for Teleport Discovery Service to assume. 
+- AWS IAM policy attached to the IAM role that grants the AWS permissions necessary for Teleport to discover resources in AWS. 
+- AWS OIDC Provider for Teleport Discovery Service to assume an IAM role using OIDC. This resource is optional - creation can be disabled using `create_aws_iam_openid_connect_provider = false`. This resource is optional to support two scenarios:
+  - When there is already an AWS IAM OIDC provider in the AWS account configured to use your Teleport cluster's proxy URL. AWS restricts AWS IAM OIDC providers to one per unique URL, so if you are managing that provider already then this module cannot create another one for the same Teleport cluster.
+  - When AWS IAM OIDC federation is not possible because your Teleport cluster's proxy URL is not reachable. In this case you should configure AWS IAM role credentials for your Teleport Discovery Service instances and set `discovery_service_iam_credential_source` to trust that role.
+- Teleport `discovery_config` cluster resource that configures Teleport for AWS resource discovery.
+- Teleport `integration` cluster resource for AWS OIDC.
+- Teleport `token` cluster resource that allows Teleport nodes to use AWS IAM credentials to join the cluster.
+
+## Prerequisites
+
+- [Install Teleport Terraform Provider](https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/)
+
+## Examples
+
+- [Discover resources in a single AWS account](./examples/single-account)
+
+## How to get help
+
+If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
+
+For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0 |
+| <a name="requirement_teleport"></a> [teleport](#requirement\_teleport) | >= 18.5.1 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | >= 3.0 |
+| <a name="provider_teleport"></a> [teleport](#provider\_teleport) | >= 18.5.1 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_openid_connect_provider.teleport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_policy.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.teleport_discovery_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| teleport_discovery_config.aws | resource |
+| teleport_integration.aws_oidc | resource |
+| teleport_provision_token.aws_iam | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.teleport_discovery_service_iam_role_trust](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [http_http.teleport_ping](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [tls_certificate.teleport_proxy](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/data-sources/certificate) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_apply_aws_tags"></a> [apply\_aws\_tags](#input\_apply\_aws\_tags) | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
+| <a name="input_apply_teleport_resource_labels"></a> [apply\_teleport\_resource\_labels](#input\_apply\_teleport\_resource\_labels) | Additional Teleport resource labels to apply to all created Teleport. | `map(string)` | `{}` | no |
+| <a name="input_aws_iam_policy_document"></a> [aws\_iam\_policy\_document](#input\_aws\_iam\_policy\_document) | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
+| <a name="input_aws_iam_policy_name"></a> [aws\_iam\_policy\_name](#input\_aws\_iam\_policy\_name) | Name for the AWS IAM policy for discovery. | `string` | `"teleport-discovery"` | no |
+| <a name="input_aws_iam_policy_use_name_prefix"></a> [aws\_iam\_policy\_use\_name\_prefix](#input\_aws\_iam\_policy\_use\_name\_prefix) | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
+| <a name="input_aws_iam_role_name"></a> [aws\_iam\_role\_name](#input\_aws\_iam\_role\_name) | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
+| <a name="input_aws_iam_role_use_name_prefix"></a> [aws\_iam\_role\_use\_name\_prefix](#input\_aws\_iam\_role\_use\_name\_prefix) | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
+| <a name="input_create"></a> [create](#input\_create) | Toggle creation of all resources. | `bool` | `true` | no |
+| <a name="input_create_aws_iam_openid_connect_provider"></a> [create\_aws\_iam\_openid\_connect\_provider](#input\_create\_aws\_iam\_openid\_connect\_provider) | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
+| <a name="input_discovery_service_iam_credential_source"></a> [discovery\_service\_iam\_credential\_source](#input\_discovery\_service\_iam\_credential\_source) | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | <pre>object({<br/>    use_oidc_integration = optional(bool)<br/>    trust_role = optional(object({<br/>      role_arn    = string<br/>      external_id = optional(string, "")<br/>    }))<br/>  })</pre> | <pre>{<br/>  "trust_role": null,<br/>  "use_oidc_integration": true<br/>}</pre> | no |
+| <a name="input_match_aws_regions"></a> [match\_aws\_regions](#input\_match\_aws\_regions) | AWS regions to discover. The default matches all AWS regions. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
+| <a name="input_match_aws_resource_types"></a> [match\_aws\_resource\_types](#input\_match\_aws\_resource\_types) | AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`. | `list(string)` | n/a | yes |
+| <a name="input_match_aws_tags"></a> [match\_aws\_tags](#input\_match\_aws\_tags) | AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | <pre>{<br/>  "*": [<br/>    "*"<br/>  ]<br/>}</pre> | no |
+| <a name="input_teleport_discovery_config_name"></a> [teleport\_discovery\_config\_name](#input\_teleport\_discovery\_config\_name) | Name for the `teleport_discovery_config` resource. | `string` | `"discovery"` | no |
+| <a name="input_teleport_discovery_config_use_name_prefix"></a> [teleport\_discovery\_config\_use\_name\_prefix](#input\_teleport\_discovery\_config\_use\_name\_prefix) | Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix. | `bool` | `true` | no |
+| <a name="input_teleport_discovery_group_name"></a> [teleport\_discovery\_group\_name](#input\_teleport\_discovery\_group\_name) | Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use "cloud-discovery-group". | `string` | n/a | yes |
+| <a name="input_teleport_integration_name"></a> [teleport\_integration\_name](#input\_teleport\_integration\_name) | Name for the `teleport_integration` resource. | `string` | `"discovery"` | no |
+| <a name="input_teleport_integration_use_name_prefix"></a> [teleport\_integration\_use\_name\_prefix](#input\_teleport\_integration\_use\_name\_prefix) | Determines whether the name of the Teleport integration (`teleport_integration_name`) is used as a prefix. | `bool` | `true` | no |
+| <a name="input_teleport_provision_token_name"></a> [teleport\_provision\_token\_name](#input\_teleport\_provision\_token\_name) | Name for the `teleport_provision_token` resource. | `string` | `"discovery"` | no |
+| <a name="input_teleport_provision_token_use_name_prefix"></a> [teleport\_provision\_token\_use\_name\_prefix](#input\_teleport\_provision\_token\_use\_name\_prefix) | Determines whether the name of the Teleport provision token (`teleport_provision_token_name`) is used as a prefix. | `bool` | `true` | no |
+| <a name="input_teleport_proxy_public_addr"></a> [teleport\_proxy\_public\_addr](#input\_teleport\_proxy\_public\_addr) | Teleport cluster proxy public address. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_oidc_provider_arn"></a> [aws\_oidc\_provider\_arn](#output\_aws\_oidc\_provider\_arn) | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
+| <a name="output_teleport_discovery_config_name"></a> [teleport\_discovery\_config\_name](#output\_teleport\_discovery\_config\_name) | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
+| <a name="output_teleport_discovery_service_iam_policy_arn"></a> [teleport\_discovery\_service\_iam\_policy\_arn](#output\_teleport\_discovery\_service\_iam\_policy\_arn) | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |
+| <a name="output_teleport_discovery_service_iam_role_arn"></a> [teleport\_discovery\_service\_iam\_role\_arn](#output\_teleport\_discovery\_service\_iam\_role\_arn) | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
+| <a name="output_teleport_integration_name"></a> [teleport\_integration\_name](#output\_teleport\_integration\_name) | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
+| <a name="output_teleport_provision_token_name"></a> [teleport\_provision\_token\_name](#output\_teleport\_provision\_token\_name) | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_policy.tf
@@ -1,0 +1,62 @@
+################################################################################
+# AWS IAM policy and attachment for Teleport Discovery Service
+################################################################################
+
+locals {
+  aws_iam_policy_name_prefix = (
+    var.aws_iam_policy_use_name_prefix
+    ? "${var.aws_iam_policy_name}-"
+    : null
+  )
+  aws_iam_policy_name = (
+    var.aws_iam_policy_use_name_prefix
+    ? null
+    : var.aws_iam_policy_name
+  )
+}
+
+data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
+  count = local.create ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "account:ListRegions",
+      "ec2:DescribeInstances",
+      "ssm:DescribeInstanceInformation",
+      "ssm:GetCommandInvocation",
+      "ssm:ListCommandInvocations",
+      "ssm:SendCommand",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "teleport_discovery_service" {
+  count = local.create ? 1 : 0
+
+  description = "AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS."
+  name        = local.aws_iam_policy_name
+  name_prefix = local.aws_iam_policy_name_prefix
+  path        = "/"
+  tags        = local.apply_aws_tags
+  policy = coalesce(
+    var.aws_iam_policy_document,
+    data.aws_iam_policy_document.teleport_discovery_service_single_account[0].json,
+  )
+}
+
+################################################################################
+# AWS IAM policy attachment for Teleport Discovery Service
+################################################################################
+
+resource "aws_iam_role_policy_attachment" "teleport_discovery_service" {
+  count = local.create ? 1 : 0
+
+  policy_arn = one(aws_iam_policy.teleport_discovery_service[*].arn)
+  # we already know the role name, but use expression reference to establish
+  # dependency on the role's existence
+  role = one(aws_iam_role.teleport_discovery_service[*].name)
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_iam_role.tf
@@ -1,0 +1,76 @@
+################################################################################
+# AWS IAM role for Teleport Discovery Service
+################################################################################
+
+locals {
+  aws_iam_role_name_prefix = (
+    var.aws_iam_role_use_name_prefix
+    ? "${var.aws_iam_role_name}-"
+    : null
+  )
+  aws_iam_role_name = (
+    var.aws_iam_role_use_name_prefix
+    ? null
+    : var.aws_iam_role_name
+  )
+  trust_roles = try({
+    local.trust_role.role_arn = local.trust_role
+  }, {})
+}
+
+data "aws_iam_policy_document" "teleport_discovery_service_iam_role_trust" {
+  count = local.create ? 1 : 0
+
+  dynamic "statement" {
+    for_each = local.use_oidc_integration ? [1] : []
+    iterator = trust
+
+    content {
+      principals {
+        type        = "Federated"
+        identifiers = [local.aws_iam_oidc_provider_arn]
+      }
+
+      actions = [
+        "sts:AssumeRoleWithWebIdentity"
+      ]
+
+      condition {
+        test     = "StringEquals"
+        variable = "${local.teleport_cluster_name}:aud"
+        values   = [local.aws_iam_oidc_provider_aud]
+      }
+    }
+  }
+
+  dynamic "statement" {
+    for_each = local.trust_roles
+    iterator = trust
+
+    content {
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = trust.value.role_arn
+      }
+
+      condition {
+        test     = "StringEquals"
+        variable = "sts:ExternalId"
+        values   = [trust.value.external_id]
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "teleport_discovery_service" {
+  count = local.create ? 1 : 0
+
+  assume_role_policy   = data.aws_iam_policy_document.teleport_discovery_service_iam_role_trust[0].json
+  description          = "AWS IAM role that Teleport Discovery Service will assume."
+  max_session_duration = 3600
+  name                 = local.aws_iam_role_name
+  name_prefix          = local.aws_iam_role_name_prefix
+  tags                 = local.apply_aws_tags
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/aws_oidc_provider.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/aws_oidc_provider.tf
@@ -1,0 +1,37 @@
+################################################################################
+# AWS IAM OIDC Provider
+################################################################################
+
+locals {
+  aws_iam_oidc_provider_arn = try(
+    aws_iam_openid_connect_provider.teleport[0].arn,
+    "arn:${local.aws_partition}:iam::${local.aws_account_id}:oidc-provider/${local.aws_iam_oidc_provider_name}",
+  )
+  aws_iam_oidc_provider_aud  = "discover.teleport"
+  aws_iam_oidc_provider_name = trimprefix(local.aws_iam_oidc_provider_url, "https://")
+  # strip the port since AWS OIDC provider doesn't support port in the url
+  aws_iam_oidc_provider_url = replace(local.teleport_proxy_public_url, "/:[0-9]+.*/", "")
+  create_aws_iam_openid_connect_provider = (
+    local.create
+    && local.use_oidc_integration
+    && var.create_aws_iam_openid_connect_provider
+  )
+  use_oidc_integration = var.discovery_service_iam_credential_source.use_oidc_integration
+}
+
+data "tls_certificate" "teleport_proxy" {
+  count = local.create_aws_iam_openid_connect_provider ? 1 : 0
+
+  url = local.teleport_proxy_public_url
+}
+
+# Create an AWS OIDC Provider, so that the Teleport Discovery Service can use
+# OIDC to assume the discovery AWS IAM role.
+resource "aws_iam_openid_connect_provider" "teleport" {
+  count = local.create_aws_iam_openid_connect_provider ? 1 : 0
+
+  url             = local.aws_iam_oidc_provider_url
+  client_id_list  = [local.aws_iam_oidc_provider_aud]
+  thumbprint_list = [data.tls_certificate.teleport_proxy[0].certificates[0].sha1_fingerprint]
+  tags            = local.apply_aws_tags
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
@@ -1,0 +1,42 @@
+# Teleport AWS Account Discovery Example
+
+Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_teleport"></a> [teleport](#requirement\_teleport) | >= 18.5.1 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_aws_discovery"></a> [aws\_discovery](#module\_aws\_discovery) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_policy_document.teleport_discovery_service_single_account](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_discovery"></a> [aws\_discovery](#output\_aws\_discovery) | n/a |
+<!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/main.tf
@@ -1,0 +1,66 @@
+module "aws_discovery" {
+  source = "../.."
+
+  teleport_proxy_public_addr    = "example.teleport.sh:443"
+  teleport_discovery_group_name = "cloud-discovery-group"
+
+  # Discover EC2 AWS resources 
+  match_aws_resource_types = ["ec2"]
+  # Apply the additional AWS tag "origin=example" to all AWS resources created by this module
+  apply_aws_tags = { origin = "example" }
+  # Apply the additional Teleport label "origin=example" to all Teleport resources created by this module
+  apply_teleport_resource_labels = { origin = "example" }
+
+  # Examples of existing AWS resource reuse:
+  # AWS IAM OIDC provider for this Teleport cluster's public proxy address must already exist
+  create_aws_iam_openid_connect_provider = false
+
+  # Use a custom IAM policy with permission conditions
+  aws_iam_policy_document = data.aws_iam_policy_document.teleport_discovery_service_single_account.json
+}
+
+
+data "aws_iam_policy_document" "teleport_discovery_service_single_account" {
+  # read-only discovery
+  statement {
+    effect = "Allow"
+    actions = [
+      "account:ListRegions",
+      "ec2:DescribeInstances",
+      "ssm:DescribeInstanceInformation",
+      "ssm:GetCommandInvocation",
+      "ssm:ListCommandInvocations",
+    ]
+    resources = ["*"]
+  }
+
+  # SSM command execution document access
+  # (Allows using any document, or restrict to specific documents here)
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ssm:*:*:document/AWS-RunShellScript"
+    ]
+  }
+
+  # SSM command execution instance access
+  statement {
+    effect = "Allow"
+    actions = [
+      "ssm:SendCommand",
+    ]
+    resources = [
+      "arn:aws:ec2:*:*:instance/*"
+    ]
+
+    # restrict command execution on instances based on resource tags
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/TeleportManaged"
+      values   = ["true"]
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/outputs.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_discovery" {
+  value = module.aws_discovery
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = ">= 18.5.1"
+    }
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/main.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/main.tf
@@ -1,0 +1,38 @@
+locals {
+  create = var.create
+  default_tags = {
+    "teleport.dev/cluster"     = local.teleport_cluster_name
+    "teleport.dev/integration" = local.teleport_integration_name
+    # this is the origin we set for resources created by the AWS OIDC integration web UI wizard.
+    "teleport.dev/iac-tool" = "terraform"
+  }
+  apply_aws_tags                 = merge(local.default_tags, var.apply_aws_tags)
+  apply_teleport_resource_labels = merge(local.default_tags, var.apply_teleport_resource_labels)
+
+  aws_account_id = try(data.aws_caller_identity.this[0].account_id, "")
+  aws_partition  = try(data.aws_partition.this[0].partition, "")
+
+  teleport_cluster_name         = try(local.teleport_ping.cluster_name, "")
+  teleport_ping                 = try(jsondecode(data.http.teleport_ping[0].response_body), null)
+  teleport_proxy_public_addr    = var.teleport_proxy_public_addr
+  teleport_proxy_public_url     = "https://${local.teleport_proxy_public_addr}"
+  teleport_resource_name_suffix = "aws-account-${local.aws_account_id}"
+}
+
+data "aws_caller_identity" "this" {
+  count = local.create ? 1 : 0
+}
+
+data "aws_partition" "this" {
+  count = local.create ? 1 : 0
+}
+
+data "http" "teleport_ping" {
+  count = local.create ? 1 : 0
+
+  url = "${local.teleport_proxy_public_url}/webapi/find"
+
+  request_headers = {
+    Accept = "application/json"
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/outputs.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/outputs.tf
@@ -1,0 +1,29 @@
+output "aws_oidc_provider_arn" {
+  description = "AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC."
+  value       = local.aws_iam_oidc_provider_arn
+}
+
+output "teleport_discovery_service_iam_policy_arn" {
+  description = "AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS."
+  value       = one(aws_iam_policy.teleport_discovery_service[*].arn)
+}
+
+output "teleport_discovery_service_iam_role_arn" {
+  description = "AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume."
+  value       = one(aws_iam_role.teleport_discovery_service[*].arn)
+}
+
+output "teleport_discovery_config_name" {
+  description = "Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`."
+  value       = try(teleport_discovery_config.aws[0].header.metadata.name, null)
+}
+
+output "teleport_integration_name" {
+  description = "Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'."
+  value       = try(teleport_integration.aws_oidc[0].metadata.name, null)
+}
+
+output "teleport_provision_token_name" {
+  description = "Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`."
+  value       = nonsensitive(try(teleport_provision_token.aws_iam[0].metadata.name, null))
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_discovery_config.tf
@@ -1,0 +1,54 @@
+################################################################################
+# Teleport cluster discovery config
+################################################################################
+
+locals {
+  teleport_discovery_config_name = (
+    var.teleport_discovery_config_use_name_prefix
+    ? "${var.teleport_discovery_config_name}-${local.teleport_resource_name_suffix}"
+    : var.teleport_discovery_config_name
+  )
+  trust_role = try({
+    role_arn    = var.discovery_service_iam_credential_source.trust_role.role_arn,
+    external_id = var.discovery_service_iam_credential_source.trust_role.external_id,
+  }, null)
+}
+
+resource "teleport_discovery_config" "aws" {
+  count = local.create ? 1 : 0
+
+  header = {
+    version = "v1"
+    metadata = {
+      name        = local.teleport_discovery_config_name
+      description = "Configure Teleport to discover AWS resources."
+      labels      = local.apply_teleport_resource_labels
+    }
+  }
+
+  spec = {
+    discovery_group = var.teleport_discovery_group_name
+    aws = [{
+      assume_role = local.trust_role
+      install = {
+        enroll_mode      = 1 # INSTALL_PARAM_ENROLL_MODE_SCRIPT
+        install_teleport = true
+        join_method      = "iam"
+        join_token       = local.teleport_provision_token_name
+        script_name      = "default-installer"
+        sshd_config      = "/etc/ssh/sshd_config"
+      }
+      integration = (
+        local.use_oidc_integration
+        ? try(teleport_integration.aws_oidc[0].metadata.name, local.teleport_integration_name)
+        : ""
+      )
+      regions = var.match_aws_regions
+      ssm = {
+        document_name = "AWS-RunShellScript"
+      }
+      tags  = var.match_aws_tags
+      types = var.match_aws_resource_types
+    }]
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_integration.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_integration.tf
@@ -1,0 +1,28 @@
+################################################################################
+# Teleport cluster integration
+################################################################################
+
+locals {
+  teleport_integration_name = (
+    var.teleport_integration_use_name_prefix
+    ? "${var.teleport_integration_name}-${local.teleport_resource_name_suffix}"
+    : var.teleport_integration_name
+  )
+}
+
+resource "teleport_integration" "aws_oidc" {
+  count = local.create ? 1 : 0
+
+  metadata = {
+    name        = local.teleport_integration_name
+    description = "AWS OIDC integration for AWS discovery."
+    labels      = local.apply_teleport_resource_labels
+  }
+  spec = {
+    aws_oidc = {
+      role_arn = one(aws_iam_role.teleport_discovery_service[*].arn)
+    }
+  }
+  sub_kind = "aws-oidc"
+  version  = "v1"
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/teleport_provision_token.tf
@@ -1,0 +1,32 @@
+################################################################################
+# Teleport cluster provision token for AWS
+################################################################################
+
+locals {
+  teleport_provision_token_name = (
+    var.teleport_provision_token_use_name_prefix
+    ? "${var.teleport_provision_token_name}-${local.teleport_resource_name_suffix}"
+    : coalesce(
+      var.teleport_provision_token_name,
+      local.teleport_resource_name_suffix,
+    )
+  )
+}
+
+resource "teleport_provision_token" "aws_iam" {
+  count = local.create ? 1 : 0
+
+  metadata = {
+    name        = local.teleport_provision_token_name
+    description = "Allow Teleport nodes to join the cluster using AWS IAM credentials."
+    labels      = local.apply_teleport_resource_labels
+  }
+  spec = {
+    allow = [{
+      aws_account = local.aws_account_id
+    }]
+    join_method = "iam"
+    roles       = ["Node"]
+  }
+  version = "v2"
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/variables.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/variables.tf
@@ -1,0 +1,217 @@
+################################################################################
+# Required variables
+################################################################################
+
+variable "teleport_proxy_public_addr" {
+  description = "Teleport cluster proxy public address."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = var.teleport_proxy_public_addr != ""
+    error_message = "Must not be empty."
+  }
+
+  validation {
+    condition     = !strcontains(var.teleport_proxy_public_addr, "://")
+    error_message = "Must not contain a URL scheme"
+  }
+}
+
+variable "teleport_discovery_group_name" {
+  description = "Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use \"cloud-discovery-group\"."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = var.teleport_discovery_group_name != ""
+    error_message = "Must not be empty."
+  }
+}
+
+variable "match_aws_resource_types" {
+  description = "AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`."
+  type        = list(string)
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      for rt in var.match_aws_resource_types :
+      contains([
+        # TODO(gavin): add module support for all resource types
+        # "docdb",
+        "ec2",
+        # "eks",
+        # "elasticache-serverless",
+        # "elasticache",
+        # "memorydb",
+        # "opensearch",
+        # "rds",
+        # "rdsproxy",
+        # "redshift-serverless",
+        # "redshift"
+      ], rt)
+    ])
+    error_message = format(
+      "Allowed values for match_aws_resource_types are: %s.",
+      join(", ", [
+        "ec2",
+      ])
+    )
+  }
+}
+
+################################################################################
+# Optional variables
+################################################################################
+
+variable "apply_aws_tags" {
+  description = "Additional AWS tags to apply to all created AWS resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "apply_teleport_resource_labels" {
+  description = "Additional Teleport resource labels to apply to all created Teleport."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "create" {
+  description = "Toggle creation of all resources."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "create_aws_iam_openid_connect_provider" {
+  description = "Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "aws_iam_policy_document" {
+  description = "Override the AWS IAM policy document attached to the AWS IAM role for resource discovery."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "match_aws_regions" {
+  description = "AWS regions to discover. The default matches all AWS regions."
+  type        = list(string)
+  default     = ["*"]
+  nullable    = false
+}
+
+variable "match_aws_tags" {
+  description = "AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources."
+  type        = map(list(string))
+  default     = { "*" : ["*"] }
+  nullable    = false
+}
+
+variable "aws_iam_policy_name" {
+  description = "Name for the AWS IAM policy for discovery."
+  type        = string
+  default     = "teleport-discovery"
+  nullable    = false
+}
+
+variable "aws_iam_policy_use_name_prefix" {
+  description = "Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "aws_iam_role_name" {
+  description = "Name for the AWS IAM role for discovery."
+  type        = string
+  default     = "teleport-discovery"
+  nullable    = false
+}
+
+variable "aws_iam_role_use_name_prefix" {
+  description = "Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "teleport_discovery_config_name" {
+  description = "Name for the `teleport_discovery_config` resource."
+  type        = string
+  default     = "discovery"
+  nullable    = false
+}
+
+variable "teleport_discovery_config_use_name_prefix" {
+  description = "Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "teleport_integration_name" {
+  description = "Name for the `teleport_integration` resource."
+  type        = string
+  default     = "discovery"
+  nullable    = false
+}
+
+variable "teleport_integration_use_name_prefix" {
+  description = "Determines whether the name of the Teleport integration (`teleport_integration_name`) is used as a prefix."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "teleport_provision_token_name" {
+  description = "Name for the `teleport_provision_token` resource."
+  type        = string
+  default     = "discovery"
+  nullable    = false
+}
+
+variable "teleport_provision_token_use_name_prefix" {
+  description = "Determines whether the name of the Teleport provision token (`teleport_provision_token_name`) is used as a prefix."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "discovery_service_iam_credential_source" {
+  description = "Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration."
+  type = object({
+    use_oidc_integration = optional(bool)
+    trust_role = optional(object({
+      role_arn    = string
+      external_id = optional(string, "")
+    }))
+  })
+  default = {
+    use_oidc_integration = true
+    trust_role           = null
+  }
+  nullable = false
+
+  validation {
+    condition = !(
+      var.discovery_service_iam_credential_source.use_oidc_integration
+      && var.discovery_service_iam_credential_source.trust_role != null
+    )
+    error_message = "The discovery service AWS IAM credential source must be configured to assume the AWS IAM role for discovery either via OIDC integration or by assuming the role with an external ID. If the AWS IAM role for discovery will be attached directly to the discovery service instance outside of this module, then set `use_oidc_integration` to false and leave `trust_role` unset."
+  }
+
+  validation {
+    condition = !(
+      !var.discovery_service_iam_credential_source.use_oidc_integration
+      && try(var.discovery_service_iam_credential_source.trust_role.role_arn == "", false)
+    )
+    error_message = "If the discovery service is to assume the discovery IAM role without OIDC (`use_oidc_integration` is set to false), then `trust_role.role_arn` must be set to a non-empty value."
+  }
+}

--- a/integrations/terraform-modules/teleport/discovery/aws/versions.tf
+++ b/integrations/terraform-modules/teleport/discovery/aws/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+    teleport = {
+      source  = "terraform.releases.teleport.dev/gravitational/teleport"
+      version = ">= 18.5.1"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
+  }
+}


### PR DESCRIPTION
Backport #62106 to branch/v18

changelog: Added a Terraform module to configure Teleport and AWS for EC2 discovery in an AWS account.
