### PR TITLE
gha(docs-amplify): bump version and run on `ubuntu-slim`

### DIFF
--- a/.github/workflows/docs-amplify.yaml
+++ b/.github/workflows/docs-amplify.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   amplify-preview:
     name: Prepare Amplify preview URL
-    runs-on: ubuntu-22.04-2core-arm64
+    runs-on: ubuntu-slim
     environment: docs-amplify
     steps:    
     - name: Configure AWS credentials
@@ -23,7 +23,7 @@ jobs:
         role-to-assume: ${{ vars.IAM_ROLE }}
 
     - name: Create Amplify preview environment
-      uses: gravitational/shared-workflows/tools/amplify-preview@664e788d45a7f56935cf63094b4fb52a41b12015 # tools/amplify-preview/v0.0.2
+      uses: gravitational/shared-workflows/tools/amplify-preview@b90d744feb39522329fba9c7764a4fe07d039d29 # tools/amplify-preview/v0.0.3
       id: amplify_preview
       with:
         app_ids: ${{ vars.AMPLIFY_APP_IDS }}


### PR DESCRIPTION
### Summary

- Bump `amplify-preview` GHA to the [tools/amplify-preview/v0.0.3](https://github.com/gravitational/shared-workflows/releases/tag/tools%2Famplify-preview%2Fv0.0.3)
- Switch runner to `ubuntu-slim`[^1] to save couple 💵 on executions


[^1]: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/