### PR TITLE
Make use of the newly-introduced WindowsCA

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -5547,6 +5547,14 @@ func (c *Client) GetCertAuthorities(ctx context.Context, caType types.CertAuthTy
 	return cas, nil
 }
 
+// shouldFallbackEmptyListToUserCA is used by GetCertAuthorities to decide if a
+// fallback query with UserCA is necessary.
+//
+// Cached responses of GetCertAuthorities don't error on unknown CA types,
+// instead they swallow the errors and return empty. This method detects that.
+//
+// Don't use this fallback in other scenarios unless you really know what you
+// are doing.
 func (c *Client) shouldFallbackEmptyListToUserCA(ctx context.Context, caType types.CertAuthType) bool {
 	if caType != types.WindowsCA {
 		return false

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/coreos/go-semver/semver"
+	gogoproto "github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -4324,6 +4325,15 @@ func (c *Client) CreateRegisterChallenge(ctx context.Context, in *proto.CreateRe
 // GenerateCertAuthorityCRL generates an empty CRL for a CA.
 func (c *Client) GenerateCertAuthorityCRL(ctx context.Context, req *proto.CertAuthorityRequest) (*proto.CRL, error) {
 	resp, err := c.grpc.GenerateCertAuthorityCRL(ctx, req)
+
+	// TODO(codingllama): DELETE IN 20.
+	if shouldFallbackToUserCA(err, req.Type) {
+		slog.WarnContext(ctx, "WindowsCA not available, falling back to UserCA")
+		req2 := gogoproto.Clone(req).(*proto.CertAuthorityRequest)
+		req2.Type = types.UserCA
+		resp, err = c.grpc.GenerateCertAuthorityCRL(ctx, req2)
+	}
+
 	return resp, trace.Wrap(err)
 }
 
@@ -5485,31 +5495,83 @@ func (c *Client) StableUNIXUsersClient() stableunixusersv1.StableUNIXUsersServic
 
 // GetCertAuthority retrieves a CA by type and domain.
 func (c *Client) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
-	ca, err := c.TrustClient().GetCertAuthority(ctx, &trustpb.GetCertAuthorityRequest{
+	trust := c.TrustClient()
+	req := &trustpb.GetCertAuthorityRequest{
 		Type:       string(id.Type),
 		Domain:     id.DomainName,
 		IncludeKey: loadKeys,
-	})
+	}
+
+	ca, err := trust.GetCertAuthority(ctx, req)
+
+	// TODO(codingllama): DELETE IN 20.
+	if shouldFallbackToUserCA(err, id.Type) {
+		slog.WarnContext(ctx, "WindowsCA not available, falling back to UserCA")
+		req.Type = string(types.UserCA)
+		ca, err = trust.GetCertAuthority(ctx, req)
+	}
 
 	return ca, trace.Wrap(err)
 }
 
 // GetCertAuthorities retrieves CAs by type.
 func (c *Client) GetCertAuthorities(ctx context.Context, caType types.CertAuthType, loadKeys bool) ([]types.CertAuthority, error) {
-	resp, err := c.TrustClient().GetCertAuthorities(ctx, &trustpb.GetCertAuthoritiesRequest{
+	trust := c.TrustClient()
+	req := &trustpb.GetCertAuthoritiesRequest{
 		Type:       string(caType),
 		IncludeKey: loadKeys,
-	})
+	}
+
+	resp, err := trust.GetCertAuthorities(ctx, req)
+
+	// TODO(codingllama): DELETE IN 20.
+	if shouldFallbackToUserCA(err, caType) ||
+		// Reads through the cache don't error on unknown types, instead they return
+		// empty. For example, "tctl get cas/windows" against an older binary.
+		(err == nil &&
+			len(resp.CertAuthoritiesV2) == 0 &&
+			c.shouldFallbackEmptyListToUserCA(ctx, caType)) {
+		slog.WarnContext(ctx, "WindowsCA not available, falling back to UserCA")
+		req.Type = string(types.UserCA)
+		resp, err = trust.GetCertAuthorities(ctx, req)
+	}
+
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	cas := make([]types.CertAuthority, 0, len(resp.CertAuthoritiesV2))
-	for _, ca := range resp.CertAuthoritiesV2 {
-		cas = append(cas, ca)
+	cas := make([]types.CertAuthority, len(resp.CertAuthoritiesV2))
+	for i, ca := range resp.CertAuthoritiesV2 {
+		cas[i] = ca
+	}
+	return cas, nil
+}
+
+func (c *Client) shouldFallbackEmptyListToUserCA(ctx context.Context, caType types.CertAuthType) bool {
+	if caType != types.WindowsCA {
+		return false
 	}
 
-	return cas, nil
+	cn, err := c.GetClusterName(ctx)
+	if err != nil {
+		slog.WarnContext(ctx, "Failed to fetch cluster name", "error", err)
+		return false
+	}
+
+	// Attempt to fetch a windows CA. If it returns an "unsupported authority"
+	// error this means we should fallback.
+	_, err = c.TrustClient().GetCertAuthority(ctx, &trustpb.GetCertAuthorityRequest{
+		Type:       string(caType),
+		Domain:     cn.GetClusterName(),
+		IncludeKey: false,
+	})
+	return shouldFallbackToUserCA(err, caType)
+}
+
+func shouldFallbackToUserCA(err error, caType types.CertAuthType) bool {
+	return err != nil &&
+		caType == types.WindowsCA &&
+		types.IsUnsupportedAuthorityErr(err)
 }
 
 // DeleteCertAuthority removes a CA matching the type and domain.

--- a/api/client/mock_server_test.go
+++ b/api/client/mock_server_test.go
@@ -26,7 +26,9 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/gravitational/teleport/api/client/proto"
+	clusterconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/clusterconfig/v1"
 	recordingencryptionv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/recordingencryption/v1"
+	trustv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/testhelpers/mtls"
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 )
@@ -40,7 +42,9 @@ type mockServer struct {
 
 type mockServices struct {
 	auth                proto.AuthServiceServer
+	clusterConfig       clusterconfigv1.ClusterConfigServiceServer
 	recordingEncryption recordingencryptionv1.RecordingEncryptionServiceServer
+	trust               trustv1.TrustServiceServer
 }
 
 func newMockServer(t *testing.T, addr string, services mockServices) *mockServer {
@@ -59,10 +63,16 @@ func newMockServer(t *testing.T, addr string, services mockServices) *mockServer
 	if services.auth != nil {
 		proto.RegisterAuthServiceServer(m.grpc, services.auth)
 	}
-
+	if services.clusterConfig != nil {
+		clusterconfigv1.RegisterClusterConfigServiceServer(m.grpc, services.clusterConfig)
+	}
 	if services.recordingEncryption != nil {
 		recordingencryptionv1.RegisterRecordingEncryptionServiceServer(m.grpc, services.recordingEncryption)
 	}
+	if services.trust != nil {
+		trustv1.RegisterTrustServiceServer(m.grpc, services.trust)
+	}
+
 	return m
 }
 

--- a/api/types/trust.go
+++ b/api/types/trust.go
@@ -85,7 +85,7 @@ const (
 // CertAuthTypes lists all certificate authority types.
 var CertAuthTypes = []CertAuthType{
 	HostCA,
-	// TODO(codingllama): Add WindowsCA to the list.
+	WindowsCA, // before UserCA to avoid undue CA cloning
 	UserCA,
 	DatabaseCA,
 	DatabaseClientCA,
@@ -97,23 +97,6 @@ var CertAuthTypes = []CertAuthType{
 	OktaCA,
 	AWSRACA,
 	BoundKeypairCA,
-}
-
-// CertAuthTypesExtended is the union of `CertAuthTypes` and `{WindowsCA}`.
-// WindowsCA is always placed before UserCA.
-//
-// TODO(codingllama): Remove once WindowsCA is listed on CertAuthTypes.
-var CertAuthTypesExtended = makeCertAuthTypesExtended()
-
-func makeCertAuthTypesExtended() []CertAuthType {
-	dst := make([]CertAuthType, 0, len(CertAuthTypes)+1)
-	for _, caType := range CertAuthTypes {
-		if caType == UserCA {
-			dst = append(dst, WindowsCA)
-		}
-		dst = append(dst, caType)
-	}
-	return dst
 }
 
 // NewlyAdded should return true for CA types that were added in the current
@@ -165,7 +148,7 @@ const authTypeNotSupported string = "authority type is not supported"
 
 // Check checks if certificate authority type value is correct
 func (c CertAuthType) Check() error {
-	if slices.Contains(CertAuthTypesExtended, c) {
+	if slices.Contains(CertAuthTypes, c) {
 		return nil
 	}
 

--- a/api/types/trust_test.go
+++ b/api/types/trust_test.go
@@ -21,7 +21,7 @@ import (
 // TODO(codingllama): DELETE IN 20. This won't matter once the migration doesn't exist.
 func TestCertAuthTypes_WindowsBeforeUser(t *testing.T) {
 	var foundUser bool
-	for _, caType := range CertAuthTypesExtended {
+	for _, caType := range CertAuthTypes {
 		switch caType {
 		case UserCA:
 			foundUser = true

--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -4069,7 +4069,7 @@ func TestCAGeneration(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	for _, caType := range types.CertAuthTypesExtended {
+	for _, caType := range types.CertAuthTypes {
 		t.Run(string(caType), func(t *testing.T) {
 			ca, err := authcatest.NewCA(caType, clusterName, privKey)
 			require.NoError(t, err)

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -438,7 +438,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	}
 
 	// Setup certificate and signing authorities.
-	for _, caType := range types.CertAuthTypes {
+	for _, caType := range types.CertAuthTypesExtended {
 		ca, err := authcatest.NewCAWithConfig(authcatest.CAConfig{
 			Type:        caType,
 			ClusterName: srv.ClusterName,

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -438,7 +438,7 @@ func NewAuthServer(cfg AuthServerConfig) (*AuthServer, error) {
 	}
 
 	// Setup certificate and signing authorities.
-	for _, caType := range types.CertAuthTypesExtended {
+	for _, caType := range types.CertAuthTypes {
 		ca, err := authcatest.NewCAWithConfig(authcatest.CAConfig{
 			Type:        caType,
 			ClusterName: srv.ClusterName,

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -735,7 +735,7 @@ func initializeAuthorities(ctx context.Context, asrv *Server, cfg *InitConfig) e
 	)
 	usableKeysResults := make(map[types.CertAuthType]*keystore.UsableKeysResult)
 	g, gctx := errgroup.WithContext(ctx)
-	for _, caType := range types.CertAuthTypesExtended {
+	for _, caType := range types.CertAuthTypes {
 		g.Go(func() error {
 			tctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthority", oteltrace.WithAttributes(attribute.String("type", string(caType))))
 			defer span.End()
@@ -1559,11 +1559,21 @@ func checkResourceConsistency(ctx context.Context, keyStore *keystore.Manager, c
 			var hasKeys bool
 			var signerErr error
 			switch r.GetType() {
-			case types.HostCA, types.UserCA, types.OpenSSHCA:
+			case types.HostCA,
+				types.UserCA,
+				types.OpenSSHCA:
 				_, signerErr = keyStore.GetSSHSigner(ctx, r)
-			case types.DatabaseCA, types.DatabaseClientCA, types.SAMLIDPCA, types.SPIFFECA, types.AWSRACA:
+			case types.DatabaseCA,
+				types.DatabaseClientCA,
+				types.SAMLIDPCA,
+				types.SPIFFECA,
+				types.AWSRACA,
+				types.WindowsCA:
 				_, _, signerErr = keyStore.GetTLSCertAndSigner(ctx, r)
-			case types.JWTSigner, types.OIDCIdPCA, types.OktaCA, types.BoundKeypairCA:
+			case types.JWTSigner,
+				types.OIDCIdPCA,
+				types.OktaCA,
+				types.BoundKeypairCA:
 				_, signerErr = keyStore.GetJWTSigner(ctx, r)
 			default:
 				return trace.BadParameter("unexpected cert_authority type %s for cluster %v", r.GetType(), clusterName)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -2335,7 +2335,7 @@ func TestInitCreatesCertsIfMissing(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	for _, caType := range types.CertAuthTypesExtended {
+	for _, caType := range types.CertAuthTypes {
 		cert, err := auth.GetCertAuthorities(ctx, caType, false)
 		require.NoError(t, err)
 		require.Len(t, cert, 1)

--- a/lib/cache/cert_authority.go
+++ b/lib/cache/cert_authority.go
@@ -64,7 +64,7 @@ func newCertAuthorityCollection(t services.Trust, w types.WatchKind) (*collectio
 		},
 		fetcher: func(ctx context.Context, loadSecrets bool) ([]types.CertAuthority, error) {
 			var authorities []types.CertAuthority
-			for _, caType := range types.CertAuthTypesExtended {
+			for _, caType := range types.CertAuthTypes {
 				cas, err := t.GetCertAuthorities(ctx, caType, loadSecrets)
 				// if caType was added in this major version we might get a BadParameter
 				// error if we're connecting to an older upstream that doesn't know about it

--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -199,7 +199,7 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 			ExportPrivateKeys: exportSecrets,
 		}
 		return exportTLSAuthority(ctx, client, req)
-	case "tls-user-der", "windows":
+	case "tls-user-der":
 		req := exportTLSAuthorityRequest{
 			AuthType:          types.UserCA,
 			UnpackPEM:         true,
@@ -209,6 +209,13 @@ func exportAuth(ctx context.Context, client authclient.ClientI, req ExportAuthor
 	case "saml-idp":
 		req := exportTLSAuthorityRequest{
 			AuthType:          types.SAMLIDPCA,
+			UnpackPEM:         true,
+			ExportPrivateKeys: exportSecrets,
+		}
+		return exportTLSAuthority(ctx, client, req)
+	case "windows":
+		req := exportTLSAuthorityRequest{
+			AuthType:          types.WindowsCA,
 			UnpackPEM:         true,
 			ExportPrivateKeys: exportSecrets,
 		}

--- a/lib/winpki/ldap.go
+++ b/lib/winpki/ldap.go
@@ -348,10 +348,14 @@ func CRLDistributionPoint(activeDirectoryDomain string, caType types.CertAuthTyp
 
 // crlKeyName returns the appropriate LDAP key given the CA type.
 //
-// UserCA must use "Teleport" to keep backwards compatibility.
+// WindowsCA must use "Teleport" to keep backwards compatibility.
 func crlKeyName(caType types.CertAuthType) (string, error) {
 	switch caType {
 	case types.UserCA:
+		// TODO(codingllama): DELETE IN 20.
+		//  Once the fallback is removed this shouldn't be needed anymore.
+		fallthrough
+	case types.WindowsCA:
 		return "Teleport", nil
 	case types.DatabaseCA, types.DatabaseClientCA:
 		return "TeleportDB", nil

--- a/lib/winpki/windows.go
+++ b/lib/winpki/windows.go
@@ -183,6 +183,10 @@ type GenerateCredentialsRequest struct {
 
 	// AD is true if we're connecting to a domain-joined desktop.
 	AD bool
+
+	// DisableWindowsCASupportForTesting does what it says on the tin.
+	// Do not use unless testing.
+	DisableWindowsCASupportForTesting bool
 }
 
 // GenerateWindowsDesktopCredentials generates a private key / certificate pair for the given
@@ -196,9 +200,10 @@ func GenerateWindowsDesktopCredentials(ctx context.Context, auth AuthInterface, 
 		return nil, nil, trace.Wrap(err)
 	}
 	genResp, err := auth.GenerateWindowsDesktopCert(ctx, &proto.WindowsDesktopCertRequest{
-		CSR:       certReq.csrPEM,
-		CRLDomain: certReq.cdpDomain,
-		TTL:       proto.Duration(req.TTL),
+		CSR:               certReq.csrPEM,
+		CRLDomain:         certReq.cdpDomain,
+		TTL:               proto.Duration(req.TTL),
+		SupportsWindowsCA: !req.DisableWindowsCASupportForTesting,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/winpki/windows_test.go
+++ b/lib/winpki/windows_test.go
@@ -44,13 +44,19 @@ func TestCRLDN(t *testing.T) {
 		{
 			name:        "test cluster name",
 			clusterName: "test",
+			caType:      types.WindowsCA,
+			crlDN:       "CN=test,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
+		},
+		{
+			name:        "test cluster name (UserCA)",
+			clusterName: "test",
 			caType:      types.UserCA,
 			crlDN:       "CN=test,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
 			name:        "full cluster name",
 			clusterName: "cluster.goteleport.com",
-			caType:      types.UserCA,
+			caType:      types.WindowsCA,
 			crlDN:       "CN=cluster.goteleport.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
@@ -60,22 +66,22 @@ func TestCRLDN(t *testing.T) {
 			crlDN:       "CN=cluster.goteleport.com,CN=TeleportDB,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
-			name:        "user CA",
+			name:        "windows CA",
 			clusterName: "cluster.goteleport.com",
-			caType:      types.UserCA,
+			caType:      types.WindowsCA,
 			crlDN:       "CN=cluster.goteleport.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
-			name:        "user CA with SKID",
+			name:        "windows CA with SKID",
 			clusterName: "example.com",
-			caType:      types.UserCA,
+			caType:      types.WindowsCA,
 			issuerSKID:  []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f, 0xa1, 0xba},
 			crlDN:       "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPV8DQ_example.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},
 		{
-			name:        "user CA with SKID requiring padding",
+			name:        "windows CA with SKID requiring padding",
 			clusterName: "example.com",
-			caType:      types.UserCA,
+			caType:      types.WindowsCA,
 			// This test makes sure we don't corrupt the DN with base32 padding in the even the SKID is not exactly 20 bytes long.
 			issuerSKID: []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f},
 			crlDN:      "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPU_example.com,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
@@ -83,7 +89,7 @@ func TestCRLDN(t *testing.T) {
 		{
 			name:        "long CN truncated",
 			clusterName: "reallylongclustername.goteleport.com",
-			caType:      types.UserCA,
+			caType:      types.WindowsCA,
 			issuerSKID:  []byte{0x61, 0xbe, 0xe7, 0xf0, 0xb4, 0x88, 0x78, 0x33, 0x40, 0x7d, 0x7a, 0xc0, 0xa8, 0x2a, 0xeb, 0x3e, 0x9d, 0x9f, 0xa1, 0xba},
 			crlDN:       "CN=C6VEFS5KH1S36G3TFB0AGANB7QEPV8DQ_reallylongclustern,CN=Teleport,CN=CDP,CN=Public Key Services,CN=Services,CN=Configuration,DC=test,DC=goteleport,DC=com",
 		},

--- a/tool/tctl/common/resources/cert_authority.go
+++ b/tool/tctl/common/resources/cert_authority.go
@@ -85,7 +85,7 @@ func getCertAuthority(ctx context.Context, client *authclient.Client, ref servic
 	// `tctl get cert_authority`.
 	case ref.SubKind == "" && ref.Name == "":
 		var allAuthorities []types.CertAuthority
-		for _, caType := range types.CertAuthTypesExtended {
+		for _, caType := range types.CertAuthTypes {
 			authorities, err := client.GetCertAuthorities(ctx, caType, opts.WithSecrets)
 			if err != nil {
 				if trace.IsBadParameter(err) {


### PR DESCRIPTION
Directly use the new WindowsCA, instead of the UserCA, throughout the codebase.

This PR, following #62877, constitutes the bulk of the WindowsCA migration/split. Therefore it does a number of small changes:

1. api/client falls back to UserCA when talking to older clusters
2. lib/winpki actively uses WindowsCA and publishes CRLs from Windows and UserCAs (the latter is still used in certain fallbacks)
3. GenerateWindowsDesktopCert uses WindowsCA to mint certificates
4. Exports targeted at "windows" use the WindowsCA
5. Finally, WindowsCA is added to CertAuthTypes, which makes it an "official" Teleport CA in the eyes of much of the codebase (for example, "tctl auth rotate" now sees it)

All put together, new and upgraded installs fully use the new Windows CA, the compatibility story works, and even clean CA rotations are now possible.

#10111