### PR TITLE
[v18] MWI: Allow `tbot` to be configured explicitly to write secrets to an external Kubernetes cluster

### DIFF
--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -1559,22 +1559,38 @@ The `kubernetes_secret` destination type stores artifacts in a Kubernetes
 secret. This allows them to be mounted into other containers deployed in
 Kubernetes.
 
-Prerequisites:
+There is no requirement that the secret already exists, one will be created
+if it does not exist. If a secret already exists, `tbot` will overwrite any
+other keys within the secret.
 
-- `tbot` must be running in Kubernetes with at most one replica. If using a
+By default, the `kubernetes_secret` destination operates against the Kubernetes
+cluster that `tbot` itself is running against. In this mode, very little
+configuration is required. However, you must ensure that:
+
+- `tbot` is running in Kubernetes with at most one replica. If using a
   `deployment`, then the `Recreate` strategy must be used to ensure only one
   instance exists at any time. This is because multiple `tbot` agents configured
   with the same secret will compete to write to the secret and it may be left
   in an inconsistent state or the `tbot` agents may fail to write.
-- The `tbot` pod must be configured with a service account that allows it to
+- The `tbot` is must be configured with a service account that allows it to
   read and write from the configured secret.
-- The `POD_NAMESPACE` environment variable must be configured with the
-  name of the namespace that `tbot` is running in. This is best achieved with
+- The `POD_NAMESPACE` environment variable is configured with the name of the
+  namespace that `tbot` is running in. This is best achieved with
   the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
 
-There is no requirement that the secret already exists, one will be created
-if it does not exist. If a secret already exists, `tbot` will overwrite any
-other keys within the secret.
+Using the `tbot` helm chart is the easiest way to ensure that all of these
+requirements are fulfilled.
+
+It is also possible for `tbot` to write to a secret in a Kubernetes cluster it
+is not running in. It may be running in a different Kubernetes cluster or
+running completely external to a Kubernetes cluster. To configure this:
+
+- Set `kubeconfig_path` to the path of a kubeconfig file that contains the
+  configuration necessary for `tbot` to connect and authenticate to the
+  Kubernetes cluster.
+- If your kubeconfig file contains multiple contexts, use `kubeconfig_context`
+  to select the desired one. If this is unset, the default context will be used.
+- Set `namespace` to the namespace that the secret should be written into.
 
 Configuration:
 
@@ -1596,6 +1612,28 @@ namespace: default
 # optional.
 labels:
   example: "foo"
+# kubeconfig_path is the path to a kubeconfig to use for connecting to and
+# authenticating to the Kubernetes API server. When running tbot inside a
+# Kubernetes cluster, configuring this is unnecessary as the in-cluster
+# credentials can be used.
+#
+# This can be useful when running tbot outside a Kubernetes cluster or
+# when tbot needs to write secrets to a Kubernetes cluster that differs
+# from the one it is running in.
+#
+# This may also be set using the KUBECONFIG environment variable. The value
+# here within the configuration file will take precedence over the
+# environment variable.
+kubeconfig_path: /opt/kube.yaml
+# kubeconfig_context overrides which context to use from the kubeconfig.
+#
+# This has no effect when relying on the default in-cluster config and can
+# only be used when the KUBECONFIG environment variable or the
+# `kubeconfig_path` field has been set.
+#
+# When unspecified, the context currently set within the Kubernetes config
+# file will be used.
+kubeconfig_context: my-cluster
 ```
 
 ## Bot resource

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -1572,7 +1572,7 @@ configuration is required. However, you must ensure that:
   instance exists at any time. This is because multiple `tbot` agents configured
   with the same secret will compete to write to the secret and it may be left
   in an inconsistent state or the `tbot` agents may fail to write.
-- The `tbot` is must be configured with a service account that allows it to
+- The `tbot` pod is configured with a service account that allows it to
   read and write from the configured secret.
 - The `POD_NAMESPACE` environment variable is configured with the name of the
   namespace that `tbot` is running in. This is best achieved with

--- a/lib/tbot/services/k8s/argocd_output.go
+++ b/lib/tbot/services/k8s/argocd_output.go
@@ -77,7 +77,7 @@ func ArgoCDServiceBuilder(cfg *ArgoCDOutputConfig, opts ...ArgoCDServiceOption) 
 		// environment.
 		if svc.k8s == nil {
 			var err error
-			if svc.k8s, err = newKubernetesClient(); err != nil {
+			if svc.k8s, err = newKubernetesClient("", ""); err != nil {
 				return nil, trace.Wrap(err, "creating Kubernetes client")
 			}
 		}

--- a/lib/tbot/services/k8s/secret_destination.go
+++ b/lib/tbot/services/k8s/secret_destination.go
@@ -19,6 +19,7 @@
 package k8s
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"os"
@@ -32,6 +33,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	applyconfigv1 "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/gravitational/teleport/lib/tbot/internal/encoding"
@@ -54,6 +56,30 @@ type SecretDestination struct {
 	// When using the Helm chart, you'll need to additionally grant the tbot
 	// service account permissions to read/write to the other namespace.
 	Namespace string `yaml:"namespace,omitempty"`
+	// KubeconfigPath is the path to a Kubeconfig to use for reaching and
+	// authenticating to the Kubernetes API server. When running tbot inside a
+	// Kubernetes cluster, configuring this is unnecessary as the pod will be
+	// autoconfigured for access to the cluster with the service account
+	// credentials.
+	//
+	// This can be useful when running tbot outside a Kubernetes cluster or
+	// when tbot needs to write secrets to a Kubernetes cluster that differs
+	// from the one it is running in.
+	//
+	// This may also be set using the KUBECONFIG environment variable. The value
+	// here within the configuration file will take precedence over the
+	// environment variable.
+	KubeconfigPath string `yaml:"kubeconfig_path,omitempty"`
+	// Context overrides which context to use from the Kubernetes API client
+	// configuration.
+	//
+	// This has no effect when relying on the default in-cluster config and can
+	// only be used when the KUBECONFIG environment variable or the
+	// `kubeconfig_path` field has been set.
+	//
+	// When unspecified, the context currently set within the Kubernetes config
+	// file will be used.
+	KubeconfigContext string `yaml:"kubeconfig_context,omitempty"`
 
 	mu          sync.Mutex
 	k8s         kubernetes.Interface
@@ -156,7 +182,9 @@ func (dks *SecretDestination) Init(ctx context.Context, subdirs []string) error 
 	// environment.
 	if dks.k8s == nil {
 		var err error
-		if dks.k8s, err = newKubernetesClient(); err != nil {
+		if dks.k8s, err = newKubernetesClient(
+			dks.KubeconfigPath, dks.KubeconfigContext,
+		); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -302,14 +330,46 @@ func (dks *SecretDestination) IsPersistent() bool {
 	return true
 }
 
-func newKubernetesClient() (*kubernetes.Clientset, error) {
-	// BuildConfigFromFlags falls back to InClusterConfig if both params
-	// are empty. This means KUBECONFIG takes precedence.
-	clientCfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+func kubeConfig(
+	kubeconfigPathOverride string,
+	contextOverride string,
+) (*rest.Config, error) {
+	// Check if the user has given us an override for the kubeconfig, either
+	// explicitly in the config file or via the environment variable.
+	kubeconfigPathOverride = cmp.Or(
+		kubeconfigPathOverride,
+		os.Getenv("KUBECONFIG"),
+	)
+	// If not, we return early with the k8s in cluster config. We expect this
+	// to be used in most cases.
+	if kubeconfigPathOverride == "" {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			return cfg, trace.Wrap(err)
+		}
+	}
+
+	overrides := &clientcmd.ConfigOverrides{
+		CurrentContext: contextOverride,
+	}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigPathOverride},
+		overrides,
+	).ClientConfig()
+
+}
+
+func newKubernetesClient(
+	kubeconfigPathOverride string,
+	contextOverride string,
+) (*kubernetes.Clientset, error) {
+	cfg, err := kubeConfig(kubeconfigPathOverride, contextOverride)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	k8s, err := kubernetes.NewForConfig(clientCfg)
+
+	k8s, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/tbot/services/k8s/secret_destination.go
+++ b/lib/tbot/services/k8s/secret_destination.go
@@ -56,11 +56,10 @@ type SecretDestination struct {
 	// When using the Helm chart, you'll need to additionally grant the tbot
 	// service account permissions to read/write to the other namespace.
 	Namespace string `yaml:"namespace,omitempty"`
-	// KubeconfigPath is the path to a Kubeconfig to use for reaching and
+	// KubeconfigPath is the path to a kubeconfig to use for reaching and
 	// authenticating to the Kubernetes API server. When running tbot inside a
-	// Kubernetes cluster, configuring this is unnecessary as the pod will be
-	// autoconfigured for access to the cluster with the service account
-	// credentials.
+	// Kubernetes cluster, configuring this is unnecessary as the in-cluster
+	// credentials can be used.
 	//
 	// This can be useful when running tbot outside a Kubernetes cluster or
 	// when tbot needs to write secrets to a Kubernetes cluster that differs
@@ -70,8 +69,7 @@ type SecretDestination struct {
 	// here within the configuration file will take precedence over the
 	// environment variable.
 	KubeconfigPath string `yaml:"kubeconfig_path,omitempty"`
-	// Context overrides which context to use from the Kubernetes API client
-	// configuration.
+	// KubeconfigContext overrides which context to use from the kubeconfig.
 	//
 	// This has no effect when relying on the default in-cluster config and can
 	// only be used when the KUBECONFIG environment variable or the

--- a/lib/tbot/services/k8s/secret_destination_test.go
+++ b/lib/tbot/services/k8s/secret_destination_test.go
@@ -152,6 +152,8 @@ func TestDestinationKubernetesSecret_YAML(t *testing.T) {
 				Labels: map[string]string{
 					"key": "value",
 				},
+				KubeconfigContext: "my-context",
+				KubeconfigPath:    "./kubeconfig.yaml",
 			},
 		},
 	}

--- a/lib/tbot/services/k8s/testdata/TestDestinationKubernetesSecret_YAML/full.golden
+++ b/lib/tbot/services/k8s/testdata/TestDestinationKubernetesSecret_YAML/full.golden
@@ -3,3 +3,5 @@ name: my-secret
 labels:
   key: value
 namespace: my-namespace
+kubeconfig_path: ./kubeconfig.yaml
+kubeconfig_context: my-context


### PR DESCRIPTION
Backport #62908 to branch/v18

changelog: Allow kubeconfig and context to be explicitly configured for `tbot` `kubernetes_secret` destination.
