### PR TITLE
[v18] Improve agentless default restart command

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2881,10 +2881,15 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 	lib.SetInsecureDevMode(clf.InsecureMode)
 
 	// Apply command line --debug flag to override logger severity.
+	level := slog.LevelError
 	if clf.Debug {
 		cfg.SetLogLevel(slog.LevelDebug)
+		level = slog.LevelDebug
 		cfg.Debug = clf.Debug
 	}
+
+	// Ensure that the logging level is respected by the logger.
+	utils.InitLogger(utils.LoggingForDaemon, level)
 
 	if clf.AuthToken != "" {
 		// store the value of the --token flag:
@@ -2894,6 +2899,11 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 	if clf.TokenSecret != "" {
 		// store the value of the --token-secret flag:
 		cfg.SetTokenSecret(clf.TokenSecret)
+	}
+
+	// apply --skip-version-check flag.
+	if clf.SkipVersionCheck {
+		cfg.SkipVersionCheck = clf.SkipVersionCheck
 	}
 
 	slog.DebugContext(context.Background(), "Disabling all services, only the Teleport OpenSSH service can run during the `teleport join openssh` command")

--- a/lib/openssh/sshd.go
+++ b/lib/openssh/sshd.go
@@ -20,7 +20,9 @@ package openssh
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,8 +45,6 @@ var (
 func sshdConfigInclude(dataDir string) string {
 	return fmt.Sprintf("Include %s", filepath.Join(dataDir, sshdConfigFile))
 }
-
-const DefaultRestartCommand = "systemctl restart sshd"
 
 const (
 	// TeleportKey is the name the OpenSSH private key
@@ -202,10 +202,17 @@ func (b *sshdBackend) restart() error {
 		return trace.Wrap(err)
 	}
 
-	cmd := exec.Command("/bin/sh", "-c", b.restartCmd)
-	if err := cmd.Run(); err != nil {
-		return trace.Wrap(err, "failed to restart the sshd service")
+	if b.restartCmd == "" {
+		if err := defaultRestart(); err != nil {
+			return trace.Wrap(err, "failed to restart OpenSSH")
+		}
+	} else {
+		cmd := exec.Command("/bin/sh", "-c", b.restartCmd)
+		if err := cmd.Run(); err != nil {
+			return trace.Wrap(err, "failed to restart OpenSSH")
+		}
 	}
+
 	return nil
 }
 
@@ -262,4 +269,32 @@ func checkSSHDConfigAlreadyUpdated(sshdConfigPath, fileContains string) (bool, e
 		return false, trace.ConvertSystemError(err)
 	}
 	return !strings.Contains(string(contents), fileContains), nil
+}
+
+// defaultRestart invokes systemctl to restart the OpenSSH service. Due to varying names
+// of OpenSSH services on different distributions both ssh and the sshd service are attempted
+// to be restarted if they are active. An error is returned if any of the enabled services fail to be restarted.
+func defaultRestart() error {
+	var restartErrors []error
+	for _, service := range []string{"ssh", "sshd"} {
+		sshShowCommand := exec.Command("/bin/sh", "-c", "systemctl show --property=ActiveState "+service+".service")
+		out, err := sshShowCommand.CombinedOutput()
+		if err != nil {
+			return trace.Wrap(err, "listing OpenSSH services")
+		}
+
+		const activeService = "ActiveState=active"
+		if !bytes.Equal([]byte(activeService), bytes.TrimSpace(out)) {
+			slog.DebugContext(context.Background(), "skipping inactive OpenSSH service", "service", service)
+			continue
+		}
+
+		slog.DebugContext(context.Background(), "restarting active OpenSSH service", "service", service)
+		restartCommand := exec.Command("/bin/sh", "-c", "systemctl restart "+service)
+		if err := restartCommand.Run(); err != nil {
+			restartErrors = append(restartErrors, err)
+		}
+	}
+
+	return trace.NewAggregate(restartErrors...)
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -50,7 +50,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	dtconfig "github.com/gravitational/teleport/lib/devicetrust/config"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/teleport/lib/openssh"
 	"github.com/gravitational/teleport/lib/selinux"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -492,12 +491,15 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	joinOpenSSH.Flag("data-dir", fmt.Sprintf("Path to directory to store teleport data [%v].", defaults.DataDir)).Default(defaults.DataDir).StringVar(&ccf.DataDir)
 	joinOpenSSH.Flag("restart-sshd", "Restart OpenSSH.").Default("true").BoolVar(&ccf.RestartOpenSSH)
 	joinOpenSSH.Flag("sshd-check-command", "Command to use when checking OpenSSH config for validity. (sshd -t -f <sshd_config>)").Default("sshd -t -f").StringVar(&ccf.CheckCommand)
-	joinOpenSSH.Flag("sshd-restart-command", "Command to use when restarting openssh.").Default(openssh.DefaultRestartCommand).StringVar(&ccf.RestartCommand)
+	joinOpenSSH.Flag("sshd-restart-command", "Command to use when restarting openssh.").StringVar(&ccf.RestartCommand)
 	joinOpenSSH.Flag("labels", "Comma-separated list of labels for this OpenSSH node, for example env=dev,app=web.").StringVar(&ccf.Labels)
 	joinOpenSSH.Flag("address", "Hostname or IP address of this OpenSSH node.").StringVar(&ccf.Address)
 	joinOpenSSH.Flag("additional-principals", "Additional principal to include, can be specified multiple times.").StringVar(&ccf.AdditionalPrincipals)
 	joinOpenSSH.Flag("insecure", "Insecure mode disables certificate validation.").BoolVar(&ccf.InsecureMode)
-
+	joinOpenSSH.Flag("skip-version-check",
+		"Skip version checking between server and client.").
+		Default("false").
+		BoolVar(&ccf.SkipVersionCheck)
 	joinOpenSSH.Flag("debug", "Enable verbose logging to stderr.").Short('d').BoolVar(&ccf.Debug)
 
 	integrationCmd := app.Command("integration", "Integration commands")


### PR DESCRIPTION
Backport #63011 and https://github.com/gravitational/teleport/pull/63244 to branch/v18

changelog: Fixed `teleport join openssh` on recent versions of Ubuntu.
