### PR TITLE
Remove workaround for TypeScript compiler running out of memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "pnpm eslint && pnpm prettier-check",
     "lint-fix": "pnpm eslint --fix && pnpm prettier-write",
     "eslint": "eslint --quiet '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
-    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc --build",
+    "type-check": "tsc --build",
     "optimize-resource-icons": "svgo --multipass --quiet -rf web/packages/design/src/ResourceIcon/assets",
     "prettier-check": "prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "prettier-write": "prettier --write --log-level silent '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",


### PR DESCRIPTION
This was added originally in #21168 to address TS running out of memory when type-checking the project. It looks like with the current version of TypeScript it's no longer needed and it makes the type checking faster by 10 seconds on my machine. It seems it has no effect on CI. Here's [a run with the env var](https://github.com/gravitational/teleport/actions/runs/21243788443/job/61127834456?pr=62021#step:8:9) and [without the env var](https://github.com/gravitational/teleport/actions/runs/21244238541/job/61129352062?pr=63053#step:8:9). Both take around one minute.

Merging this to just master for now. We don't keep TS version in sync across release branches and I don't have time to test if it behaves correctly on other TS versions as well.