### PR TITLE
AWS OIDC set up script: handle LimitExceededError

### DIFF
--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -97,5 +97,10 @@ func ConvertIAMError(err error) error {
 		return trace.BadParameter("%s", *malformedPolicyDocument.Message)
 	}
 
+	var limitExceededErr *iamtypes.LimitExceededException
+	if errors.As(err, &limitExceededErr) {
+		return trace.LimitExceeded("%s", *limitExceededErr.Message)
+	}
+
 	return ConvertRequestFailureError(err)
 }

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -213,6 +213,15 @@ func TestConvertIAMv2Error(t *testing.T) {
 				require.True(tt, trace.IsAlreadyExists(err), "expected trace.AlreadyExists error, got %v", err)
 			},
 		},
+		{
+			name: "creation fails because limit was reached for a given resource",
+			inErr: &iamtypes.LimitExceededException{
+				Message: aws.String("Cannot exceed quota for OpenIdConnectProvidersPerAccount: 100"),
+			},
+			errCheck: func(tt require.TestingT, err error, i ...any) {
+				require.True(tt, trace.IsLimitExceeded(err), "expected trace.LimitExceeded error, got %v", err)
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.errCheck(t, ConvertIAMError(tt.inErr))


### PR DESCRIPTION
During AWS OIDC integration set up, the user receives a script that they must run in order to set up the integration in AWS side.

This script, among other things, creates the AWS IAM Identity Provider (OIDC type), which then teleport uses to access the AWS APIs.

During the IdP creation, some errors can occur.
One of them is when the IdP already exists, in this case the script ignores the step and continues to the next ones.

We were wrongly parsing the AWS errors into 'already exists' error type. When AWS returns code 409, we always assume it is an EntityAlreadyExists error type.
However, we might also get a 409 code with LimitExceeded. In this case, the script must stop and return the error to the user.

You can see the full list of errors here:
https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateOpenIDConnectProvider.html#API_CreateOpenIDConnectProvider_Errors

Fixes https://github.com/gravitational/teleport/issues/63010