### PR TITLE
Export TLS CA additional trusted keys

### DIFF
--- a/lib/client/ca_export.go
+++ b/lib/client/ca_export.go
@@ -337,14 +337,22 @@ func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req expo
 		return nil, trace.Wrap(err)
 	}
 
-	activeKeys := certAuthority.GetActiveKeys().TLS
-	// TODO(codingllama): Export AdditionalTrustedKeys as well?
+	keyPairs := append(
+		certAuthority.GetActiveKeys().TLS,
+		certAuthority.GetAdditionalTrustedKeys().TLS...,
+	)
 
-	authorities := make([]*ExportedAuthority, len(activeKeys))
-	for i, activeKey := range activeKeys {
+	authorities := make([]*ExportedAuthority, 0, len(keyPairs))
+	for _, activeKey := range keyPairs {
 		bytesToExport := activeKey.Cert
 		if req.ExportPrivateKeys {
 			bytesToExport = activeKey.Key
+		}
+
+		// Skip empty keys (may happen with keys, unexpected with certs but it's
+		// fine to skip either way).
+		if len(bytesToExport) == 0 {
+			continue
 		}
 
 		if req.UnpackPEM {
@@ -355,9 +363,9 @@ func exportTLSAuthority(ctx context.Context, client authclient.ClientI, req expo
 			bytesToExport = block.Bytes
 		}
 
-		authorities[i] = &ExportedAuthority{
+		authorities = append(authorities, &ExportedAuthority{
 			Data: bytesToExport,
-		}
+		})
 	}
 
 	return authorities, nil

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/sshutils"
+	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 type mockAuthClient struct {
@@ -321,6 +322,118 @@ func TestExportAllAuthorities(t *testing.T) {
 			t.Run("ExportAllAuthoritiesSecrets", func(t *testing.T) {
 				runTest(t, ExportAllAuthoritiesSecrets, tt.assertSecrets)
 			})
+		})
+	}
+}
+
+func TestExportAllAuthorities_additionalKeys(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "zarq"
+	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: clusterName,
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, testAuth.Close()) })
+
+	authServer := testAuth.AuthServer
+	ctx := t.Context()
+
+	const caType = types.UserCA
+	ca, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       caType,
+		DomainName: clusterName,
+	}, true /* */)
+	require.NoError(t, err)
+
+	makeNewTLSKey := func(t *testing.T) *types.TLSKeyPair {
+		const ttl = 1 * time.Hour // Arbitrary. Actual CA TTLs are much larger.
+
+		keyPEM, certPEM, err := tlsca.GenerateSelfSignedCA(
+			pkix.Name{
+				Organization: []string{clusterName},
+				CommonName:   clusterName,
+			},
+			nil /* dnsNames */, ttl)
+		require.NoError(t, err)
+
+		return &types.TLSKeyPair{
+			Cert:    certPEM,
+			Key:     keyPEM,
+			KeyType: types.PrivateKeyType_RAW,
+		}
+	}
+
+	kp1 := makeNewTLSKey(t)
+
+	// Make sure multiple keys exist in both active and additionalTrusted sets.
+	aks := ca.GetActiveKeys()
+	aks.TLS = append(aks.TLS,
+		makeNewTLSKey(t),
+		&types.TLSKeyPair{Cert: kp1.Cert}, // Cert without Key.
+		// 3 entries total (existing + new + cert only)
+	)
+	require.NoError(t, ca.SetActiveKeys(aks))
+	tks := ca.GetAdditionalTrustedKeys()
+	tks.TLS = append(tks.TLS,
+		makeNewTLSKey(t),
+		makeNewTLSKey(t),
+		// 2 entries total (both new)
+	)
+	require.NoError(t, ca.SetAdditionalTrustedKeys(tks))
+
+	// Update CA with new keys.
+	_, err = authServer.UpdateCertAuthority(ctx, ca)
+	require.NoError(t, err)
+
+	var wantCerts, wantKeys []*ExportedAuthority
+	for _, keySet := range [][]*types.TLSKeyPair{aks.TLS, tks.TLS} {
+		for _, kp := range keySet {
+			wantCerts = append(wantCerts, &ExportedAuthority{Data: kp.Cert})
+			if len(kp.Key) > 0 {
+				wantKeys = append(wantKeys, &ExportedAuthority{Data: kp.Key})
+			}
+		}
+	}
+	// Sanity check.
+	require.Len(t, wantCerts, 5, "Unexpected number of wanted certs")
+	require.Len(t, wantKeys, 4, "Unexpected number of wanted keys")
+
+	authClient := &mockAuthClient{
+		server: authServer,
+	}
+
+	exportReq := ExportAuthoritiesRequest{
+		AuthType: "tls-user", // UserCA TLS certificates in PEM form.
+	}
+
+	tests := []struct {
+		name       string
+		exportFunc func(context.Context, authclient.ClientI, ExportAuthoritiesRequest) ([]*ExportedAuthority, error)
+		want       []*ExportedAuthority
+	}{
+		{
+			name:       "certs",
+			exportFunc: ExportAllAuthorities,
+			want:       wantCerts,
+		},
+		{
+			name:       "secrets",
+			exportFunc: ExportAllAuthoritiesSecrets,
+			want:       wantKeys,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			got, err := test.exportFunc(ctx, authClient, exportReq)
+			require.NoError(t, err)
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("Export mismatch (-want +got)\n%s", diff)
+			}
 		})
 	}
 }

--- a/lib/client/ca_export_test.go
+++ b/lib/client/ca_export_test.go
@@ -344,12 +344,13 @@ func TestExportAllAuthorities_additionalKeys(t *testing.T) {
 	ca, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
 		Type:       caType,
 		DomainName: clusterName,
-	}, true /* */)
+	}, true /* loadKeys */)
 	require.NoError(t, err)
 
 	makeNewTLSKey := func(t *testing.T) *types.TLSKeyPair {
-		const ttl = 1 * time.Hour // Arbitrary. Actual CA TTLs are much larger.
+		t.Helper()
 
+		const ttl = 1 * time.Hour // Arbitrary. Actual CA TTLs are much larger.
 		keyPEM, certPEM, err := tlsca.GenerateSelfSignedCA(
 			pkix.Name{
 				Organization: []string{clusterName},


### PR DESCRIPTION
Update "TLS" CA export to include "additional_trusted_keys". This is relevant, for example, during the "init" phase of a rotation, where the new certificates are present in the "additional" set (and are often necessary to configure downstream trust).

Callers of "ExportAllAuthorities*" methods were already prepared to handle multiple results, which makes this a simple change.

Tested manually:

1. `tctl auth rotate --type=user --phase=init`: start a rotation so we have "additional" entries)
2. `tctl auth export --type=tls-user --out=user-ca`: writes 2 cert files
3. `curl 'https://example.com:3080/webapi/auth/export?type=tls-user&format=json' -s | jq`: prints 2 entries

#10111

Changelog: Export "additional_trusted_keys" when exporting TLS CAs, which includes new certificates generated in the "init" rotation phase. Reflected in "tctl auth export" and the "/webapi/auth/export" endpoint.