### PR TITLE
Restart DiscoveryConfig watcher in Discovery Service

### DIFF
--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -38,7 +38,7 @@ import (
 const databaseEventPrefix = "db/"
 
 func (s *Server) startDatabaseWatchers() error {
-	if len(s.databaseFetchers) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.databaseFetchers) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -979,6 +979,29 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 	return existingTasks
 }
 
+type fakeAccessPointWithWatcher struct {
+	authclient.DiscoveryAccessPoint
+
+	discoveryConfigWatcherMu sync.RWMutex
+	discoveryConfigWatcher   types.Watcher
+}
+
+func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	watcher, err := f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
+
+	f.discoveryConfigWatcherMu.Lock()
+	defer f.discoveryConfigWatcherMu.Unlock()
+	f.discoveryConfigWatcher = watcher
+
+	return watcher, err
+}
+
+func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
+	f.discoveryConfigWatcherMu.Lock()
+	defer f.discoveryConfigWatcherMu.Unlock()
+	return f.discoveryConfigWatcher.Close()
+}
+
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
 // it restarts and continues to pick up new Discovery Configs matchers.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
@@ -1002,10 +1025,14 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
 
+	accessPoint := &fakeAccessPointWithWatcher{
+		DiscoveryAccessPoint: getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+	}
+
 	// Start discovery server
-	server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
+	server, err := New(t.Context(), &Config{
 		ClusterFeatures: func() proto.Features { return proto.Features{} },
-		AccessPoint:     getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+		AccessPoint:     accessPoint,
 		Matchers:        Matchers{},
 		Emitter:         authClient,
 		Log:             logtest.NewLogger(),
@@ -1034,9 +1061,7 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	// 2. Break the watcher
-	server.dynamicDiscoveryConfigMu.Lock()
-	server.dynamicMatcherWatcher.Close()
-	server.dynamicDiscoveryConfigMu.Unlock()
+	accessPoint.closeDiscoveryConfigWatcher()
 
 	// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
 	discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -980,108 +980,139 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 }
 
 type fakeAccessPointWithWatcher struct {
-	authclient.DiscoveryAccessPoint
+	*mockAuthServer
 
-	discoveryConfigWatcherMu sync.RWMutex
-	discoveryConfigWatcher   types.Watcher
+	discoveryConfigMu      sync.RWMutex
+	discoveryConfigWatcher *mockWatcher
+	discoveryConfigStore   []*discoveryconfig.DiscoveryConfig
+}
+
+func (f *fakeAccessPointWithWatcher) createDiscoveryConfig(discoveryConfig *discoveryconfig.DiscoveryConfig) {
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
+
+	f.discoveryConfigStore = append(f.discoveryConfigStore, discoveryConfig)
+
+	f.discoveryConfigWatcher.events <- types.Event{
+		Type:     types.OpPut,
+		Resource: discoveryConfig,
+	}
+}
+func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
+	return f.discoveryConfigWatcher.Close()
+}
+
+func (f *fakeAccessPointWithWatcher) ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+	f.discoveryConfigMu.RLock()
+	defer f.discoveryConfigMu.RUnlock()
+
+	return f.discoveryConfigStore, "", nil
 }
 
 func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
-	watcher, err := f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
 
-	f.discoveryConfigWatcherMu.Lock()
-	defer f.discoveryConfigWatcherMu.Unlock()
-	f.discoveryConfigWatcher = watcher
+	for _, kind := range watch.Kinds {
+		switch kind.Kind {
+		case types.KindDiscoveryConfig:
+			eventsCh := make(chan types.Event, 1)
+			eventsCh <- types.Event{
+				Type: types.OpInit,
+			}
 
-	return watcher, err
-}
+			f.discoveryConfigWatcher = &mockWatcher{
+				events: eventsCh,
+				done:   make(chan struct{}),
+			}
+			return f.discoveryConfigWatcher, nil
 
-func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
-	f.discoveryConfigWatcherMu.Lock()
-	defer f.discoveryConfigWatcherMu.Unlock()
-	return f.discoveryConfigWatcher.Close()
+		default:
+			return &mockWatcher{
+				events: make(chan types.Event, 1),
+				done:   make(chan struct{}),
+			}, nil
+		}
+	}
+
+	return nil, trace.BadParameter("missing watch kinds in NewWatcher")
 }
 
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
 // it restarts and continues to pick up new Discovery Configs matchers.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
-	fakeClock := clockwork.NewFakeClock()
+	const discoveryGroup = "discovery-group"
 
-	// Create and start test auth server.
-	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: fakeClock,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+	synctest.Test(t, func(t *testing.T) {
+		bk, err := memory.New(memory.Config{})
+		require.NoError(t, err)
 
-	tlsServer, err := testAuthServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+		mockAuthServer := &mockAuthServer{
+			events: local.NewEventsService(bk),
+		}
 
-	// Auth client for discovery service.
-	identity := authtest.TestServerID(types.RoleDiscovery, "hostID")
-	authClient, err := tlsServer.NewClient(identity)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+		mockAccessPoint := &fakeAccessPointWithWatcher{
+			mockAuthServer: mockAuthServer,
+		}
 
-	accessPoint := &fakeAccessPointWithWatcher{
-		DiscoveryAccessPoint: getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
-	}
+		server, err := New(t.Context(), &Config{
+			ClusterFeatures: func() proto.Features { return proto.Features{} },
+			AccessPoint:     mockAccessPoint,
+			Matchers:        Matchers{},
+			Emitter:         &mockEmitter{},
+			Log:             logtest.NewLogger(),
+			DiscoveryGroup:  discoveryGroup,
+		})
+		require.NoError(t, err)
+		require.NoError(t, server.Start())
+		t.Cleanup(server.Stop)
 
-	// Start discovery server
-	server, err := New(t.Context(), &Config{
-		ClusterFeatures: func() proto.Features { return proto.Features{} },
-		AccessPoint:     accessPoint,
-		Matchers:        Matchers{},
-		Emitter:         authClient,
-		Log:             logtest.NewLogger(),
-		DiscoveryGroup:  "discovery-group",
-		clock:           fakeClock,
-	})
-	require.NoError(t, err)
+		// Wait for the server to start discovering resources.
+		synctest.Wait()
 
-	go server.Start()
-	t.Cleanup(server.Stop)
+		// 1. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers.
+		discoveryConfigA, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-a"},
+			discoveryconfig.Spec{
+				DiscoveryGroup: discoveryGroup,
+			},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(discoveryConfigA)
 
-	// 1. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers.
-	discoveryConfigA, err := discoveryconfig.NewDiscoveryConfig(
-		header.Metadata{Name: "dc-a"},
-		discoveryconfig.Spec{
-			DiscoveryGroup: "discovery-group",
-		},
-	)
-	require.NoError(t, err)
-	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigA)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
+		// Wait until the event is processed.
+		synctest.Wait()
+
 		server.dynamicDiscoveryConfigMu.RLock()
-		defer server.dynamicDiscoveryConfigMu.RUnlock()
-		return len(server.dynamicDiscoveryConfig) == 1
-	}, 5*time.Second, 50*time.Millisecond)
+		require.Len(t, server.dynamicDiscoveryConfig, 1)
+		server.dynamicDiscoveryConfigMu.RUnlock()
 
-	// 2. Break the watcher
-	accessPoint.closeDiscoveryConfigWatcher()
+		// 2. Break the watcher
+		mockAccessPoint.closeDiscoveryConfigWatcher()
 
-	// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
-	discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(
-		header.Metadata{Name: "dc-b"},
-		discoveryconfig.Spec{
-			DiscoveryGroup: "discovery-group",
-		},
-	)
-	require.NoError(t, err)
-	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigB)
-	require.NoError(t, err)
+		// When the watcher breaks, it will restart after 1 minute.
+		// Sleep a little longer to ensure the watcher had time to restart.
+		time.Sleep(2 * time.Minute)
 
-	// DynamicMatcher watcher waits 1 minute before restarting, but in tests we can speed this up by advancing the fake clock.
-	fakeClock.Advance(2 * time.Minute)
+		// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
+		discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-b"},
+			discoveryconfig.Spec{
+				DiscoveryGroup: discoveryGroup,
+			},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(discoveryConfigB)
 
-	require.Eventually(t, func() bool {
+		// Wait until the event is processed.
+		synctest.Wait()
+
 		server.dynamicDiscoveryConfigMu.RLock()
-		defer server.dynamicDiscoveryConfigMu.RUnlock()
-		return len(server.dynamicDiscoveryConfig) == 2
-	}, 5*time.Second, 50*time.Millisecond)
+		require.Len(t, server.dynamicDiscoveryConfig, 2)
+		server.dynamicDiscoveryConfigMu.RUnlock()
+	})
 }
 
 func TestDiscoveryServerConcurrency(t *testing.T) {

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -49,7 +49,7 @@ import (
 // EKS watchers can do that and they behave differently from non-integration ones - we install agent on the
 // discovered clusters, instead of just proxying them.
 func (s *Server) startKubeIntegrationWatchers() error {
-	if len(s.getKubeIntegrationFetchers()) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.getKubeIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -35,7 +35,7 @@ import (
 const kubeEventPrefix = "kube/"
 
 func (s *Server) startKubeWatchers() error {
-	if len(s.getKubeNonIntegrationFetchers()) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.getKubeNonIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Discovery Service calls cloud (aws, azure, gcp) APIs to enroll resources into the cluster.
Which resources should be enrolled are defined as matchers.

A matcher can be instantiated in the Discovery Service's `teleport.yaml/discovery_service.[aws|azure|gcp]`, or can came from a Discovery Config.

The DiscoveryService creates a watcher for the DiscoveryConfig, so that any change in those resources is also applied to the Discovery Service.

The issue here is that sometimes the watcher can fail with a transient error.
Currently, this failure means that the watcher stops but the service continues working with the current snapshot of matchers.
Creating new DiscoveryConfigs or changing them does nothing, because the watcher is not working at this point.

This PR changes the watcher code, so that it restarts when there's a failure.
It waits 1 minute before retrying to ensure it gives some time for the cluster to recover from whatever issue it encountered when it failed for the first time.

Changelog: Fixed an issue that caused Discovery Service to stop working for Discovery Configs, also affecting AWS OIDC resource enrollments created from the UI.

Fixes: https://github.com/gravitational/teleport/issues/63030