### PR TITLE
[v18] Add `--exec-cmd` and `--exec-arg` flags to `tsh proxy kube`

### DIFF
--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -63,6 +63,8 @@ type proxyKubeCommand struct {
 	labels              string
 	predicateExpression string
 	exec                bool
+	execCmd             string   // Command to execute when --exec is enabled
+	execArgs            []string // Arguments for the command
 }
 
 func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
@@ -87,6 +89,8 @@ func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
 		Default(kubeconfig.ContextName("{{.ClusterName}}", "{{.KubeName}}")).
 		StringVar(&c.overrideContextName)
 	c.Flag("exec", "Run the proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to our config file.").BoolVar(&c.exec)
+	c.Flag("exec-cmd", "Command to execute when --exec is enabled. If not specified, defaults to $SHELL or /bin/bash. Implicitly enables exec mode.").StringVar(&c.execCmd)
+	c.Flag("exec-arg", "Arguments to pass to the executed command (can be specified multiple times).").StringsVar(&c.execArgs)
 	return c
 }
 
@@ -94,6 +98,11 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	cf.Labels = c.labels
 	cf.PredicateExpression = c.predicateExpression
 	cf.SiteName = c.siteName
+
+	// Validate flag combinations
+	if len(c.execArgs) > 0 && c.execCmd == "" {
+		return trace.BadParameter("cannot use --exec-arg without --exec-cmd")
+	}
 
 	if len(c.kubeClusters) > 1 || cf.Labels != "" || cf.PredicateExpression != "" {
 		err := kubeconfig.CheckContextOverrideTemplate(c.overrideContextName)
@@ -123,8 +132,8 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	defer localProxy.Close()
 
 	// re-exec into a new shell with $KUBECONFIG already pointed to our config file
-	// if --exec flag is set or headless mode is enabled.
-	reexecIntoShell := cf.Headless || c.exec
+	// if --exec flag is set, --exec-cmd is provided, or headless mode is enabled.
+	reexecIntoShell := cf.Headless || c.exec || c.execCmd != ""
 	if err := c.printTemplate(cf.Stdout(), reexecIntoShell, localProxy); err != nil {
 		return trace.Wrap(err)
 	}
@@ -135,8 +144,11 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 			return trace.Wrap(err)
 		}
 		go localProxy.Start(cf.Context)
+
+		command := getExecCommand(c.execCmd)
 		cmd := &exec.Cmd{
 			Path: "test",
+			Args: append([]string{command}, c.execArgs...),
 			Env:  []string{"KUBECONFIG=" + localProxy.KubeConfigPath()},
 		}
 		return trace.Wrap(cf.RunCommand(cmd))
@@ -145,7 +157,7 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	if reexecIntoShell {
 		// If headless, run proxy in the background and reexec into a new shell with $KUBECONFIG already pointed to
 		// our config file
-		return trace.Wrap(runHeadlessKubeProxy(cf, localProxy))
+		return trace.Wrap(runHeadlessKubeProxy(cf, localProxy, c.execCmd, c.execArgs))
 	} else {
 		// Write kubeconfig to a file and start local proxy in regular mode
 		if err := localProxy.WriteKubeConfig(); err != nil {
@@ -155,7 +167,19 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	}
 }
 
-func runHeadlessKubeProxy(cf *CLIConf, localProxy *kubeLocalProxy) error {
+// getExecCommand returns the command to execute for the kube proxy shell.
+// Priority: 1) provided command, 2) SHELL env var, 3) /bin/bash
+func getExecCommand(command string) string {
+	if command == "" {
+		command = "/bin/bash"
+		if shell, ok := os.LookupEnv("SHELL"); ok {
+			command = shell
+		}
+	}
+	return command
+}
+
+func runHeadlessKubeProxy(cf *CLIConf, localProxy *kubeLocalProxy, command string, args []string) error {
 	// Getting context with cancel function, so we could stop shell process if localProxy stops.
 	ctx, cancel := context.WithCancel(cf.Context)
 
@@ -172,7 +196,7 @@ func runHeadlessKubeProxy(cf *CLIConf, localProxy *kubeLocalProxy) error {
 		lpErrChan <- localProxy.Start(ctx)
 	}()
 
-	err = reexecToShell(ctx, configBytes)
+	err = reexecToShell(ctx, configBytes, command, args)
 	err = trace.NewAggregate(err, localProxy.Close())
 	_, _ = fmt.Fprint(cf.Stdout(), "Local proxy for Kubernetes is closed.\n")
 	err = trace.NewAggregate(err, <-lpErrChan)

--- a/tool/tsh/common/kube_proxy_darwin.go
+++ b/tool/tsh/common/kube_proxy_darwin.go
@@ -32,13 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-func reexecToShell(ctx context.Context, kubeconfigData []byte) (err error) {
-	// Prepare to re-exec shell
-	command := "/bin/bash"
-	if shell, ok := os.LookupEnv("SHELL"); ok {
-		command = shell
-	}
-
+func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, args []string) (err error) {
 	f, err := os.CreateTemp("", "proxy-kubeconfig-*")
 	if err != nil {
 		return trace.Wrap(err, "failed to create temporary file")
@@ -51,7 +45,9 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte) (err error) {
 		return trace.Wrap(err, "failed to write kubeconfig into temporary file")
 	}
 
-	cmd := exec.CommandContext(ctx, command)
+	command = getExecCommand(command)
+
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin

--- a/tool/tsh/common/kube_proxy_linux.go
+++ b/tool/tsh/common/kube_proxy_linux.go
@@ -63,7 +63,7 @@ func memFile(name string, fileContent []byte) (int, error) {
 	return fd, nil
 }
 
-func reexecToShell(ctx context.Context, kubeconfigData []byte) (err error) {
+func reexecToShell(ctx context.Context, kubeconfigData []byte, command string, args []string) (err error) {
 	// Create in-memory file containing kubeconfig and return file descriptor.
 	fd, err := memFile("proxy-kubeconfig", kubeconfigData)
 	if err != nil {
@@ -77,13 +77,9 @@ func reexecToShell(ctx context.Context, kubeconfigData []byte) (err error) {
 	f := os.NewFile(uintptr(fd), fp)
 	defer func() { err = trace.NewAggregate(err, f.Close()) }()
 
-	// Prepare to re-exec shell
-	command := "/bin/bash"
-	if shell, ok := os.LookupEnv("SHELL"); ok {
-		command = shell
-	}
+	command = getExecCommand(command)
 
-	cmd := exec.CommandContext(ctx, command)
+	cmd := exec.CommandContext(ctx, command, args...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin

--- a/tool/tsh/common/kube_proxy_other.go
+++ b/tool/tsh/common/kube_proxy_other.go
@@ -27,6 +27,6 @@ import (
 	"github.com/gravitational/trace"
 )
 
-func reexecToShell(_ context.Context, _ []byte) error {
+func reexecToShell(_ context.Context, _ []byte, _ string, _ []string) error {
 	return trace.NotImplemented("headless mode for local Kubernetes proxy is not implemented for %s", runtime.GOOS)
 }

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -97,6 +97,65 @@ func (p *kubeTestPack) testProxyKube(t *testing.T) {
 	})
 }
 
+func (p *kubeTestPack) testProxyKubeWithExecCmd(t *testing.T) {
+	// Set KUBECONFIG to non-existent file
+	t.Setenv("KUBECONFIG", filepath.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
+
+	tests := []struct {
+		name          string
+		args          []string
+		expectedCmd   []string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "with exec-cmd",
+			args:        []string{"proxy", "kube", p.rootKubeCluster1, "--insecure", "--exec", "--exec-cmd", "whoami"},
+			expectedCmd: []string{"whoami"},
+		},
+		{
+			name:        "with exec-cmd and args",
+			args:        []string{"proxy", "kube", p.rootKubeCluster1, "--insecure", "--exec", "--exec-cmd", "echo", "--exec-arg", "hello", "--exec-arg", "world"},
+			expectedCmd: []string{"echo", "hello", "world"},
+		},
+		{
+			name:        "backward compatibility - no exec-cmd",
+			args:        []string{"proxy", "kube", p.rootKubeCluster1, "--insecure", "--exec"},
+			expectedCmd: []string{os.Getenv("SHELL")},
+		},
+		{
+			name:        "exec-cmd without exec flag",
+			args:        []string{"proxy", "kube", p.rootKubeCluster1, "--insecure", "--exec-cmd", "date"},
+			expectedCmd: []string{"date"},
+		},
+		{
+			name:          "exec-arg without exec-cmd should error",
+			args:          []string{"proxy", "kube", p.rootKubeCluster1, "--insecure", "--exec-arg", "test"},
+			expectError:   true,
+			errorContains: "cannot use --exec-arg without --exec-cmd",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.expectError {
+				err := Run(t.Context(), tt.args)
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errorContains)
+			} else {
+				validateCmd := func(cmd *exec.Cmd) error {
+					require.Equal(t, tt.expectedCmd, cmd.Args)
+					return nil
+				}
+				err := Run(t.Context(), tt.args, setCmdRunner(validateCmd))
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func kubeConfigFromCmdEnv(t *testing.T, cmd *exec.Cmd) *clientcmdapi.Config {
 	t.Helper()
 

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -67,6 +67,7 @@ func TestKube(t *testing.T) {
 	pack := setupKubeTestPack(t, true)
 	t.Run("list kube", pack.testListKube)
 	t.Run("proxy kube", pack.testProxyKube)
+	t.Run("proxy kube with exec-cmd", pack.testProxyKubeWithExecCmd)
 }
 
 func TestKubeLogin(t *testing.T) {


### PR DESCRIPTION
Backport #62996 to branch/v18

changelog: Added `--exec-cmd` and `--exec-arg` flags to `tsh proxy kube` to allow launching custom commands like k9s directly without requiring environment variable workarounds.
