### PR TITLE
Bump MinClientVersion to 19.0.0-aa

### DIFF
--- a/lib/auth/middleware_test.go
+++ b/lib/auth/middleware_test.go
@@ -94,6 +94,13 @@ func TestValidateClientVersion(t *testing.T) {
 			middleware:    &auth.Middleware{OldestSupportedVersion: teleport.MinClientSemVer()},
 			clientVersion: semver.Version{Major: api.VersionMajor - 1}.String(),
 			errAssertion: func(t *testing.T, err error) {
+				if api.VersionMajor <= 19 {
+					// TODO(codingllama): DELETE IN 20.
+					//  Min required version bumped to 19 due to the WindowsCA migration.
+					require.ErrorContains(t, err, "client version")
+					return
+				}
+
 				require.NoError(t, err)
 			},
 		},
@@ -114,10 +121,26 @@ func TestValidateClientVersion(t *testing.T) {
 			},
 		},
 		{
-			name:          "pre-release client allowed",
+			name:          "pre-release client v-1 allowed",
 			middleware:    &auth.Middleware{OldestSupportedVersion: teleport.MinClientSemVer()},
 			clientVersion: semver.Version{Major: api.VersionMajor - 1, PreRelease: "dev.abcd.123"}.String(),
 			errAssertion: func(t *testing.T, err error) {
+				if api.VersionMajor <= 19 {
+					// TODO(codingllama): DELETE IN 20.
+					//  Min required version bumped to 19 due to the WindowsCA migration.
+					require.ErrorContains(t, err, "client version")
+					return
+				}
+
+				require.NoError(t, err)
+			},
+		},
+		{
+			name:          "pre-release client v-0 allowed",
+			middleware:    &auth.Middleware{OldestSupportedVersion: teleport.MinClientSemVer()},
+			clientVersion: semver.Version{Major: api.VersionMajor, PreRelease: "dev.abcd.123"}.String(),
+			errAssertion: func(t *testing.T, err error) {
+				// TODO(codingllama): DELETE IN 20. "pre-release client v-0" is enough by then.
 				require.NoError(t, err)
 			},
 		},

--- a/version.go
+++ b/version.go
@@ -37,7 +37,12 @@ func SemVer() *semver.Version {
 // version comes before <version>-alpha so that alpha, beta, rc, and dev builds
 // are permitted.
 func MinClientSemVer() *semver.Version {
-	return &semver.Version{Major: api.VersionMajor - 1, PreRelease: "aa"}
+	// TODO(codingllama): DELETE IN 20. Obsolete by then.
+	const minWindowsCAMajor = 19
+	return &semver.Version{
+		Major:      max(minWindowsCAMajor, api.VersionMajor-1),
+		PreRelease: "aa",
+	}
 }
 
 // Gitref is set to the output of "git describe" during the build process.


### PR DESCRIPTION
Bumps MinClientVersion to 19.0.0-aa, instead of the usual N-1 (ie, 18.0.0-aa).

This is protective measure due to the recently-introduced WindowsCA.

#10111

Changelog: Increased min client version to 19.0.0 due to the recently-introduced Windows CA.