### PR TITLE
Add UserTasks for missing IAM permissions during EC2 auto-discovery

### DIFF
--- a/lib/usertasks/descriptions/ec2-perm-account-list-regions.md
+++ b/lib/usertasks/descriptions/ec2-perm-account-list-regions.md
@@ -1,0 +1,29 @@
+# Missing permission: account:ListRegions
+Teleport failed to discover EC2 instances because the integration's IAM role lacks permission to list AWS regions.
+
+This error occurs when using `regions: ["*"]` (wildcard) in the EC2 matcher configuration, which requires Teleport to call `account:ListRegions` to determine which regions to scan.
+
+**How to fix**
+
+Add the `account:ListRegions` permission to the IAM role used by the integration:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "account:ListRegions",
+  "Resource": "*"
+}
+```
+
+**Alternative fix**
+
+Instead of using `regions: ["*"]`, specify explicit region names in your matcher configuration:
+
+```yaml
+regions:
+  - us-east-1
+  - us-west-2
+  - eu-west-1
+```
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.

--- a/lib/usertasks/descriptions/ec2-perm-describe-instances.md
+++ b/lib/usertasks/descriptions/ec2-perm-describe-instances.md
@@ -1,0 +1,18 @@
+# Missing permission: ec2:DescribeInstances
+Teleport failed to discover EC2 instances because the integration's IAM role lacks permission to describe EC2 instances.
+
+The `ec2:DescribeInstances` permission is required for Teleport to find EC2 instances that match your auto-discovery configuration.
+
+**How to fix**
+
+Add the `ec2:DescribeInstances` permission to the IAM role used by the integration:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": "ec2:DescribeInstances",
+  "Resource": "*"
+}
+```
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.

--- a/lib/usertasks/descriptions/ec2-perm-organizations.md
+++ b/lib/usertasks/descriptions/ec2-perm-organizations.md
@@ -1,0 +1,27 @@
+# Missing permissions: AWS Organizations
+Teleport failed to discover EC2 instances because the integration's IAM role lacks permissions to query AWS Organizations.
+
+This error occurs when using organization-wide discovery, which requires Teleport to list accounts across your AWS Organization.
+
+**How to fix**
+
+Add the following permissions to the IAM role used by the integration:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "organizations:ListRoots",
+    "organizations:ListChildren",
+    "organizations:ListAccountsForParent"
+  ],
+  "Resource": "*"
+}
+```
+
+These permissions allow Teleport to:
+- `organizations:ListRoots` - Find the root of your organization
+- `organizations:ListChildren` - Navigate organizational units (OUs)
+- `organizations:ListAccountsForParent` - List accounts within each OU
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.

--- a/lib/usertasks/descriptions/ec2-ssm-invocation-failure.md
+++ b/lib/usertasks/descriptions/ec2-ssm-invocation-failure.md
@@ -8,8 +8,6 @@ Usually this happens when:
 
 The IAM Role used by the integration might be missing some required permissions.
 Ensure the following actions are allowed in the IAM Role used by the integration:
-- `account:ListRegions`
-- `ec2:DescribeInstances`
 - `ssm:DescribeInstanceInformation`
 - `ssm:GetCommandInvocation`
 - `ssm:ListCommandInvocations`

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Task.test.tsx
@@ -36,7 +36,7 @@ test('renders ec2 impacts', async () => {
     issueType: 'ec2-ssm-invocation-failure',
     title: 'ec2 ssm invocation failure',
     description:
-      'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `account:ListRegions`\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+      'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
     discoverEks: undefined,
     discoverRds: undefined,
     discoverEc2: {

--- a/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
+++ b/web/packages/teleport/src/Integrations/status/AwsOidc/Tasks/Tasks.story.tsx
@@ -138,8 +138,6 @@ Usually this happens when:
 
 The IAM Role used by the integration might be missing some required permissions.
 Ensure the following actions are allowed in the IAM Role used by the integration:
-- \`account:ListRegions\`
-- \`ec2:DescribeInstances\`
 - \`ssm:DescribeInstanceInformation\`
 - \`ssm:GetCommandInvocation\`
 - \`ssm:ListCommandInvocations\`
@@ -247,7 +245,7 @@ const ec2Detail = {
   issueType: 'ec2-ssm-invocation-failure',
   title: 'EC2 failure',
   description:
-    'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `account:ListRegions`\n- `ec2:DescribeInstances`\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
+    'Teleport failed to access the SSM Agent to auto enroll the instance.\nSome instances failed to communicate with the AWS Systems Manager service to execute the install script.\n\nUsually this happens when:\n\n**Missing policies**\n\nThe IAM Role used by the integration might be missing some required permissions.\nEnsure the following actions are allowed in the IAM Role used by the integration:\n- `ssm:DescribeInstanceInformation`\n- `ssm:GetCommandInvocation`\n- `ssm:ListCommandInvocations`\n- `ssm:SendCommand`\n\n**SSM Document is invalid**\n\nTeleport uses an SSM Document to run an installation script.\nIf the document is changed or removed, it might no longer work.',
   discoverEc2: {
     region: 'us-east-2',
     instances: {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/62828

Changelog: Added UserTasks to alert users when EC2 auto-discovery fails due to missing IAM permissions (`account:ListRegions` , `ec2:DescribeInstances` and AWS Organizations). Users can now see these errors in the Web UI instead of needing to access Discovery Service logs.

## Motivation

When EC2 auto-discovery fails due to missing IAM permissions, users have no visibility into the failure unless they can access Discovery Service logs. This is particularly problematic for Teleport Cloud users who cannot access service logs.

Stage B of EC2 auto-discovery (SSM installation) already has good UserTask coverage for failures, but Stage A (discovering EC2 instances) had no UserTask coverage for permission errors. This change adds UserTask creation for:

- `account:ListRegions` - Required when using `regions: ["*"]` in AWS matcher configuration
- `ec2:DescribeInstances` - Required to discover EC2 instances
- AWS Organizations:
  - `organizations:ListRoots`
  - `organizations:ListChildren`
  - `organizations:ListAccountsForParent`

## Backward Compatibility

Fully backward compatible. This change only adds new UserTask issue types and does not modify any existing behavior. Existing configurations will continue to work, and users will now receive more informative error notifications.

Except, potentially...
Old client → New server │ ✅ Compatible - old clients don't create perm-related issues
New client → Old server │ ⚠️ Validation fails - old server rejects empty account_id/region always; new servers only rejects them if it's not a permission issue. Why? Because permission errors happen BEFORE we can get that information (account_id/region  data).

---
NOTE:
I'm finding my way thru manually testing this, will add a note when it is done.