### PR TITLE
Convert KubeServer and KubernetesCluster to handler format

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -251,54 +251,6 @@ func (c *databaseServerCollection) writeYAML(w io.Writer) error {
 	return utils.WriteYAML(w, c.servers)
 }
 
-type kubeServerCollection struct {
-	servers []types.KubeServer
-}
-
-func (c *kubeServerCollection) Resources() (r []types.Resource) {
-	for _, resource := range c.servers {
-		r = append(r, resource)
-	}
-	return r
-}
-
-func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
-	var rows [][]string
-	for _, server := range c.servers {
-		kube := server.GetCluster()
-		if kube == nil {
-			continue
-		}
-		labels := common.FormatLabels(kube.GetAllLabels(), verbose)
-		rows = append(rows, []string{
-			common.FormatResourceName(kube, verbose),
-			labels,
-			server.GetTeleportVersion(),
-		})
-
-	}
-	headers := []string{"Cluster", "Labels", "Version"}
-	var t asciitable.Table
-	if verbose {
-		t = asciitable.MakeTable(headers, rows...)
-	} else {
-		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
-	}
-	// stable sort by cluster name.
-	t.SortRowsBy([]int{0}, true)
-
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-func (c *kubeServerCollection) writeYAML(w io.Writer) error {
-	return utils.WriteYAML(w, c.servers)
-}
-
-func (c *kubeServerCollection) writeJSON(w io.Writer) error {
-	return utils.WriteJSONArray(w, c.servers)
-}
-
 type crownJewelCollection struct {
 	items []*crownjewelv1.CrownJewel
 }
@@ -320,47 +272,6 @@ func (c *crownJewelCollection) WriteText(w io.Writer, verbose bool) error {
 		rows = append(rows, []string{item.Metadata.GetName(), item.GetSpec().String(), labels})
 	}
 	headers := []string{"Name", "Spec", "Labels"}
-	var t asciitable.Table
-	if verbose {
-		t = asciitable.MakeTable(headers, rows...)
-	} else {
-		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
-	}
-	// stable sort by name.
-	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type kubeClusterCollection struct {
-	clusters []types.KubeCluster
-}
-
-func (c *kubeClusterCollection) Resources() (r []types.Resource) {
-	for _, resource := range c.clusters {
-		r = append(r, resource)
-	}
-	return r
-}
-
-// writeText formats the dynamic kube clusters into a table and writes them into w.
-// Name          Labels
-// ------------- ----------------------------------------------------------------------------------------------------------
-// cluster1      region=eastus,resource-group=cluster1,subscription-id=subID
-// cluster2      region=westeurope,resource-group=cluster2,subscription-id=subID
-// cluster3      region=northcentralus,resource-group=cluster3,subscription-id=subID
-// cluster4      owner=cluster4,region=southcentralus,resource-group=cluster4,subscription-id=subID
-// If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
-	var rows [][]string
-	for _, cluster := range c.clusters {
-		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
-		rows = append(rows, []string{
-			common.FormatResourceName(cluster, verbose),
-			labels,
-		})
-	}
-	headers := []string{"Name", "Labels"}
 	var t asciitable.Table
 	if verbose {
 		t = asciitable.MakeTable(headers, rows...)

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -105,7 +105,7 @@ func testKubeClusterCollection_writeText(t *testing.T) {
 		mustCreateNewKubeCluster(t, "cluster3-eks-us-west-1-123456789012", "", eksDiscoveredNameLabel),
 	}
 	test := writeTextTest{
-		collection: &kubeClusterCollection{clusters: kubeClusters},
+		collection: resources.NewKubeClusterCollection(kubeClusters),
 		wantNonVerboseTable: func() string {
 			table := asciitable.MakeTableWithTruncatedColumn(
 				[]string{"Name", "Labels"},
@@ -143,7 +143,7 @@ func testKubeServerCollection_writeText(t *testing.T) {
 		mustCreateNewKubeServer(t, "cluster3-eks-us-west-1-123456789012", "_", "cluster3", nil),
 	}
 	test := writeTextTest{
-		collection: &kubeServerCollection{servers: kubeServers},
+		collection: resources.NewKubeServerCollection(kubeServers),
 		wantNonVerboseTable: func() string {
 			table := asciitable.MakeTableWithTruncatedColumn(
 				[]string{"Cluster", "Labels", "Version"},

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
+	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
 // KubeCommand implements "tctl kube" group of commands.
@@ -108,14 +109,14 @@ func (c *KubeCommand) ListKube(ctx context.Context, clt *authclient.Client) erro
 		return trace.Wrap(err)
 	}
 
-	coll := &kubeServerCollection{servers: kubes}
+	coll := resources.NewKubeServerCollection(kubes)
 	switch c.format {
 	case teleport.Text:
 		return trace.Wrap(coll.WriteText(os.Stdout, c.verbose))
 	case teleport.JSON:
-		return trace.Wrap(coll.writeJSON(os.Stdout))
+		return trace.Wrap(writeJSON(coll, os.Stdout))
 	case teleport.YAML:
-		return trace.Wrap(coll.writeYAML(os.Stdout))
+		return trace.Wrap(writeYAML(coll, os.Stdout))
 	default:
 		return trace.BadParameter("unknown format %q", c.format)
 	}

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -1,0 +1,142 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/tool/common"
+	"github.com/gravitational/trace"
+)
+
+type kubeClusterCollection struct {
+	clusters []types.KubeCluster
+}
+
+func NewKubeClusterCollection(clusters []types.KubeCluster) Collection {
+	return &kubeClusterCollection{clusters: clusters}
+}
+
+func (c *kubeClusterCollection) Resources() (r []types.Resource) {
+	for _, resource := range c.clusters {
+		r = append(r, resource)
+	}
+	return r
+}
+
+// writeText formats the dynamic kube clusters into a table and writes them into w.
+// Name          Labels
+// ------------- ----------------------------------------------------------------------------------------------------------
+// cluster1      region=eastus,resource-group=cluster1,subscription-id=subID
+// cluster2      region=westeurope,resource-group=cluster2,subscription-id=subID
+// cluster3      region=northcentralus,resource-group=cluster3,subscription-id=subID
+// cluster4      owner=cluster4,region=southcentralus,resource-group=cluster4,subscription-id=subID
+// If verbose is disabled, labels column can be truncated to fit into the console.
+func (c *kubeClusterCollection) WriteText(w io.Writer, verbose bool) error {
+	var rows [][]string
+	for _, cluster := range c.clusters {
+		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
+		rows = append(rows, []string{
+			common.FormatResourceName(cluster, verbose),
+			labels,
+		})
+	}
+	headers := []string{"Name", "Labels"}
+	var t asciitable.Table
+	if verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
+	}
+	// stable sort by name.
+	t.SortRowsBy([]int{0}, true)
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func kubeClusterHandler() Handler {
+	return Handler{
+		getHandler:    getKubeCluster,
+		createHandler: createKubeCluster,
+		deleteHandler: deleteKubeCluster,
+		description:   "Represents a Kubernetes cluster in the cluster.",
+	}
+}
+
+func getKubeCluster(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	// TODO(okraport) DELETE IN v21.0.0, replace with regular Collect
+	clusters, err := clientutils.CollectWithFallback(ctx, client.ListKubernetesClusters, client.GetKubernetesClusters)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if ref.Name == "" {
+		return &kubeClusterCollection{clusters: clusters}, nil
+	}
+	clusters = FilterByNameOrDiscoveredName(clusters, ref.Name)
+	if len(clusters) == 0 {
+		return nil, trace.NotFound("Kubernetes cluster %q not found", ref.Name)
+	}
+	return &kubeClusterCollection{clusters: clusters}, nil
+}
+
+func createKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	cluster, err := services.UnmarshalKubeCluster(raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := client.CreateKubernetesCluster(ctx, cluster); err != nil {
+		if trace.IsAlreadyExists(err) {
+			if !opts.Force {
+				return trace.AlreadyExists("Kubernetes cluster %q already exists", cluster.GetName())
+			}
+			if err := client.UpdateKubernetesCluster(ctx, cluster); err != nil {
+				return trace.Wrap(err)
+			}
+			fmt.Printf("Kubernetes cluster %q has been updated\n", cluster.GetName())
+			return nil
+		}
+		return trace.Wrap(err)
+	}
+	fmt.Printf("Kubernetes cluster %q has been created\n", cluster.GetName())
+	return nil
+}
+
+func deleteKubeCluster(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	// TODO(okraport) DELETE IN v21.0.0, replace with regular Collect
+	clusters, err := clientutils.CollectWithFallback(ctx, client.ListKubernetesClusters, client.GetKubernetesClusters)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	resDesc := "Kubernetes cluster"
+	clusters = FilterByNameOrDiscoveredName(clusters, ref.Name)
+	name, err := GetOneResourceNameToDelete(clusters, ref, resDesc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := client.DeleteKubernetesCluster(ctx, name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("%s %q has been deleted\n", resDesc, name)
+	return nil
+}

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -21,13 +21,14 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/common"
-	"github.com/gravitational/trace"
 )
 
 type kubeClusterCollection struct {

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -81,7 +81,7 @@ func kubeClusterHandler() Handler {
 		getHandler:    getKubeCluster,
 		createHandler: createKubeCluster,
 		deleteHandler: deleteKubeCluster,
-		description:   "Represents a Kubernetes cluster in the cluster.",
+		description:   "A dynamic resource representing a Kubernetes cluster that can be accessed via a Kubernetes service.",
 	}
 }
 

--- a/tool/tctl/common/resources/kube_cluster.go
+++ b/tool/tctl/common/resources/kube_cluster.go
@@ -91,13 +91,13 @@ func getKubeCluster(ctx context.Context, client *authclient.Client, ref services
 		return nil, trace.Wrap(err)
 	}
 	if ref.Name == "" {
-		return &kubeClusterCollection{clusters: clusters}, nil
+		return NewKubeClusterCollection(clusters), nil
 	}
 	clusters = FilterByNameOrDiscoveredName(clusters, ref.Name)
 	if len(clusters) == 0 {
 		return nil, trace.NotFound("Kubernetes cluster %q not found", ref.Name)
 	}
-	return &kubeClusterCollection{clusters: clusters}, nil
+	return NewKubeClusterCollection(clusters), nil
 }
 
 func createKubeCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -87,7 +87,7 @@ func getKubeServer(ctx context.Context, client *authclient.Client, ref services.
 		return nil, trace.Wrap(err)
 	}
 	if ref.Name == "" {
-		return &kubeServerCollection{servers: servers}, nil
+		return NewKubeServerCollection(servers), nil
 	}
 	altNameFn := func(r types.KubeServer) string {
 		return r.GetHostname()
@@ -96,7 +96,7 @@ func getKubeServer(ctx context.Context, client *authclient.Client, ref services.
 	if len(servers) == 0 {
 		return nil, trace.NotFound("Kubernetes server %q not found", ref.Name)
 	}
-	return &kubeServerCollection{servers: servers}, nil
+	return NewKubeServerCollection(servers), nil
 }
 
 func deleteKubeServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -78,7 +78,7 @@ func kubeServerHandler() Handler {
 	return Handler{
 		getHandler:    getKubeServer,
 		deleteHandler: deleteKubeServer,
-		description:   "Represents a Kubernetes service in the cluster.",
+		description:   "Represents a Kubernetes service instance that proxies access to Kubernetes clusters.",
 	}
 }
 

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -21,12 +21,13 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/tool/common"
-	"github.com/gravitational/trace"
 )
 
 type kubeServerCollection struct {

--- a/tool/tctl/common/resources/kube_server.go
+++ b/tool/tctl/common/resources/kube_server.go
@@ -1,0 +1,121 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/tool/common"
+	"github.com/gravitational/trace"
+)
+
+type kubeServerCollection struct {
+	servers []types.KubeServer
+}
+
+func NewKubeServerCollection(servers []types.KubeServer) Collection {
+	return &kubeServerCollection{servers: servers}
+}
+
+func (c *kubeServerCollection) Resources() (r []types.Resource) {
+	for _, resource := range c.servers {
+		r = append(r, resource)
+	}
+	return r
+}
+
+func (c *kubeServerCollection) WriteText(w io.Writer, verbose bool) error {
+	var rows [][]string
+	for _, server := range c.servers {
+		kube := server.GetCluster()
+		if kube == nil {
+			continue
+		}
+		labels := common.FormatLabels(kube.GetAllLabels(), verbose)
+		rows = append(rows, []string{
+			common.FormatResourceName(kube, verbose),
+			labels,
+			server.GetTeleportVersion(),
+		})
+
+	}
+	headers := []string{"Cluster", "Labels", "Version"}
+	var t asciitable.Table
+	if verbose {
+		t = asciitable.MakeTable(headers, rows...)
+	} else {
+		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
+	}
+	// stable sort by cluster name.
+	t.SortRowsBy([]int{0}, true)
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func kubeServerHandler() Handler {
+	return Handler{
+		getHandler:    getKubeServer,
+		deleteHandler: deleteKubeServer,
+		description:   "Represents a Kubernetes service in the cluster.",
+	}
+}
+
+func getKubeServer(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	servers, err := client.GetKubernetesServers(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if ref.Name == "" {
+		return &kubeServerCollection{servers: servers}, nil
+	}
+	altNameFn := func(r types.KubeServer) string {
+		return r.GetHostname()
+	}
+	servers = FilterByNameOrDiscoveredName(servers, ref.Name, altNameFn)
+	if len(servers) == 0 {
+		return nil, trace.NotFound("Kubernetes server %q not found", ref.Name)
+	}
+	return &kubeServerCollection{servers: servers}, nil
+}
+
+func deleteKubeServer(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	servers, err := client.GetKubernetesServers(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	resDesc := "Kubernetes server"
+	servers = FilterByNameOrDiscoveredName(servers, ref.Name)
+	name, err := GetOneResourceNameToDelete(servers, ref, resDesc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	for _, s := range servers {
+		err := client.DeleteKubernetesServer(ctx, s.GetHostID(), name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	fmt.Printf("%s %q has been deleted\n", resDesc, name)
+	return nil
+}

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -65,6 +65,7 @@ func Handlers() map[string]Handler {
 		types.KindInferenceSecret:                    inferenceSecretHandler(),
 		types.KindInstaller:                          installerHandler(),
 		types.KindKubeServer:                         kubeServerHandler(),
+		types.KindKubernetesCluster:                  kubeClusterHandler(),
 		types.KindLock:                               lockHandler(),
 		types.KindNode:                               serverHandler(),
 		types.KindOIDCConnector:                      oidcConnectorHandler(),

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -64,6 +64,7 @@ func Handlers() map[string]Handler {
 		types.KindInferenceModel:                     inferenceModelHandler(),
 		types.KindInferenceSecret:                    inferenceSecretHandler(),
 		types.KindInstaller:                          installerHandler(),
+		types.KindKubeServer:                         kubeServerHandler(),
 		types.KindLock:                               lockHandler(),
 		types.KindNode:                               serverHandler(),
 		types.KindOIDCConnector:                      oidcConnectorHandler(),


### PR DESCRIPTION


## What

Converts `types.KindKubeServer` and `types.KindKubernetesCluster` resources from the legacy handler format to the modern standardized handler system in `tctl`.

Part of #60370 .

## Changes

### New Handler Files

**`tool/tctl/common/resources/kube_server.go`**
- Implements `getHandler` and `deleteHandler` for Kubernetes servers
- KubeServers represent Teleport services that provide access to Kubernetes clusters
- No create/update handlers as these resources are typically created automatically by the Teleport Kubernetes service

**`tool/tctl/common/resources/kube_cluster.go`**
- Implements `getHandler`, `createHandler`, and `deleteHandler` for Kubernetes clusters
- KubernetesClusters represent the actual Kubernetes clusters registered with Teleport

## Notes

### Terminology Clarification

- **KubernetesCluster (`kube_cluster`)**: The logical Kubernetes cluster resource registered with Teleport that users can access
- **KubeServer (`kube_server`)**: The Teleport service instance that provides proxy access to one or more Kubernetes clusters

### Question

I noticed a discrepancy where `tctl get kube_cluster` returned no results, while `tctl get kube_server` returned the expected resouce that contains a `kube_cluster` inside:

```bash
➜ build/tctl --config=config.yaml get kube_cluster
[]

➜ build/tctl --config=config.yaml get kube_server
kind: kube_server
metadata:
  expires: "2026-01-22T22:33:57.120766857Z"
  name: kind-kind
  revision: e627e20d-1f07-4442-9d98-473755d5f92f
spec:
  cluster:
    kind: kube_cluster
    metadata:
      name: kind-kind
    spec:
      aws: {}
      azure: {}
      gcp: {}
    version: v3
  host_id: 67445ff4-d8fd-43f3-8536-cb852f2bdcb3
  hostname: '[::]:3026'
  rotation:
    current_id: ""
    last_rotated: "0001-01-01T00:00:00Z"
    schedule:
      standby: "0001-01-01T00:00:00Z"
      update_clients: "0001-01-01T00:00:00Z"
      update_servers: "0001-01-01T00:00:00Z"
    started: "0001-01-01T00:00:00Z"
  version: 19.0.0-dev
status:
  target_health:
    address: 127.0.0.1:55056
    message: 1 health check passed
    protocol: http
    status: healthy
    transition_reason: threshold_reached
    transition_timestamp: "2026-01-22T19:40:49.940806Z"
version: v3
```

Are only kubernetes clusters discovered dynamically get saved as `kube_cluster` resources,
while statically defined clusters are only represented as `kube_server` resources?
If so, it might be worth clarifying this in the documentation to avoid confusion.
