### PR TITLE
Clean up modules TODOs

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -1340,18 +1340,7 @@ type PresetRoleManager interface {
 
 // GetPresetRoles returns a list of all preset roles expected to be available on
 // this cluster.
-func GetPresetRoles(buildTypes ...string) []types.Role {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func GetPresetRoles(buildType string) []types.Role {
 	presets := []types.Role{
 		services.NewPresetGroupAccessRole(buildType),
 		services.NewPresetEditorRole(),

--- a/lib/auth/testauthority/testauthority.go
+++ b/lib/auth/testauthority/testauthority.go
@@ -45,19 +45,6 @@ func NewKeygen(buildType string, now func() time.Time) (*Keygen, error) {
 	return &Keygen{Keygen: inner}, nil
 }
 
-// New creates a new key generator with defaults
-// Deprecated: Use NewKeygen instead.
-//
-// TODO(tross): Remove when all callers are converted to NewKeyGen
-func New() *Keygen {
-	kg, err := NewKeygen(modules.GetModules().BuildType(), time.Now)
-	if err != nil {
-		panic(err)
-	}
-
-	return kg
-}
-
 // GenerateKeyPair returns a new private key in PEM format and an ssh
 // public key in authorized_key format.
 func GenerateKeyPair() (priv, pub []byte, err error) {

--- a/lib/devicetrust/config/config.go
+++ b/lib/devicetrust/config/config.go
@@ -28,14 +28,7 @@ import (
 
 // GetEffectiveMode returns the effective device trust mode, considering both
 // `dt` and the current modules.
-func GetEffectiveMode(dt *types.DeviceTrust, m ...modules.Modules) string {
-	// TODO(tross): Remove the variadics and use m directly when
-	// enterprise is updated to provide modules.
-	mod := modules.GetModules()
-	if len(m) == 1 {
-		mod = m[0]
-	}
-
+func GetEffectiveMode(dt *types.DeviceTrust, mod modules.Modules) string {
 	// OSS doesn't support device trust.
 	if mod.IsOSSBuild() {
 		return constants.DeviceTrustModeOff

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 
 	accesslistv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/accesslist/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -171,22 +170,6 @@ func NewAccessListServiceV2(cfg AccessListServiceConfig) (*AccessListService, er
 		memberService: memberService,
 		reviewService: reviewService,
 	}, nil
-}
-
-// NewAccessListService creates a new AccessListService.
-// Deprecated: Prefer using NewAccessListServiceV2
-// TODO(tross): Delete when everything is using V2.
-func NewAccessListService(b backend.Backend, clock clockwork.Clock, opts ...ServiceOption) (*AccessListService, error) {
-	var opt serviceOptions
-	for _, o := range opts {
-		o(&opt)
-	}
-
-	return NewAccessListServiceV2(AccessListServiceConfig{
-		Backend:                     b,
-		Modules:                     modules.GetModules(),
-		RunWhileLockedRetryInterval: opt.runWhileLockedRetryInterval,
-	})
 }
 
 // GetAccessLists returns a list of all access lists.

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -41,18 +41,7 @@ import (
 // NewSystemAutomaticAccessApproverRole creates a new Role that is allowed to
 // approve any Access Request. This is restricted to Teleport Enterprise, and
 // returns nil in non-Enterproise builds.
-func NewSystemAutomaticAccessApproverRole(buildTypes ...string) types.Role {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func NewSystemAutomaticAccessApproverRole(buildType string) types.Role {
 	if buildType != modules.BuildEnterprise {
 		return nil
 	}
@@ -90,18 +79,7 @@ func NewSystemAutomaticAccessApproverRole(buildTypes ...string) types.Role {
 //   - Show up in user lists in WebUI
 //
 // TODO(tcsc): Implement/enforce above restrictions on this user
-func NewSystemAutomaticAccessBotUser(buildTypes ...string) types.User {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func NewSystemAutomaticAccessBotUser(buildType string) types.User {
 	if buildType != modules.BuildEnterprise {
 		return nil
 	}
@@ -427,18 +405,7 @@ func NewPresetReviewerRole(buildType string) types.Role {
 
 // NewPresetRequesterRole returns a new pre-defined role for requester. The
 // requester will be able to request all resources.
-func NewPresetRequesterRole(buildTypes ...string) types.Role {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func NewPresetRequesterRole(buildType string) types.Role {
 	if buildType != modules.BuildEnterprise {
 		return nil
 	}
@@ -710,18 +677,7 @@ func NewPresetListAccessRequestResourcesRole() types.Role {
 // SystemOktaAccessRoleName is the name of the system role that allows
 // access to Okta resources. This will be used by the Okta requester role to
 // search for Okta resources.
-func NewSystemOktaAccessRole(buildTypes ...string) types.Role {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func NewSystemOktaAccessRole(buildType string) types.Role {
 	if buildType != modules.BuildEnterprise {
 		return nil
 	}
@@ -754,21 +710,10 @@ func NewSystemOktaAccessRole(buildTypes ...string) types.Role {
 	return role
 }
 
-// SystemOktaRequesterRoleName is a name of a system role that allows
+// NewSystemOktaRequesterRole is a system role that allows
 // for requesting access to Okta resources. This differs from the requester role
 // in that it allows for requesting longer lived access.
-func NewSystemOktaRequesterRole(buildTypes ...string) types.Role {
-	// TODO(tross): make this take a single buildType after all uses are updated.
-	var buildType string
-	switch len(buildTypes) {
-	case 0:
-		buildType = modules.GetModules().BuildType()
-	case 1:
-		buildType = buildTypes[0]
-	default:
-		return nil
-	}
-
+func NewSystemOktaRequesterRole(buildType string) types.Role {
 	if buildType != modules.BuildEnterprise {
 		return nil
 	}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1418,7 +1418,7 @@ func localSettings(ctx context.Context, cap types.AuthPreference, logger *slog.L
 		PrivateKeyPolicy:        cap.GetPrivateKeyPolicy(),
 		PIVSlot:                 cap.GetPIVSlot(),
 		PIVPINCacheTTL:          cap.GetPIVPINCacheTTL(),
-		DeviceTrust:             deviceTrustSettings(cap),
+		DeviceTrust:             deviceTrustSettings(cap, modules.GetModules()),
 		SignatureAlgorithmSuite: cap.GetSignatureAlgorithmSuite(),
 	}
 
@@ -1462,7 +1462,7 @@ func oidcSettings(connector types.OIDCConnector, cap types.AuthPreference) webcl
 		PrivateKeyPolicy:        cap.GetPrivateKeyPolicy(),
 		PIVSlot:                 cap.GetPIVSlot(),
 		PIVPINCacheTTL:          cap.GetPIVPINCacheTTL(),
-		DeviceTrust:             deviceTrustSettings(cap),
+		DeviceTrust:             deviceTrustSettings(cap, modules.GetModules()),
 		SignatureAlgorithmSuite: cap.GetSignatureAlgorithmSuite(),
 	}
 }
@@ -1485,7 +1485,7 @@ func samlSettings(connector types.SAMLConnector, cap types.AuthPreference) webcl
 		PrivateKeyPolicy:        cap.GetPrivateKeyPolicy(),
 		PIVSlot:                 cap.GetPIVSlot(),
 		PIVPINCacheTTL:          cap.GetPIVPINCacheTTL(),
-		DeviceTrust:             deviceTrustSettings(cap),
+		DeviceTrust:             deviceTrustSettings(cap, modules.GetModules()),
 		SignatureAlgorithmSuite: cap.GetSignatureAlgorithmSuite(),
 	}
 }
@@ -1504,23 +1504,23 @@ func githubSettings(connector types.GithubConnector, cap types.AuthPreference) w
 		PrivateKeyPolicy:        cap.GetPrivateKeyPolicy(),
 		PIVSlot:                 cap.GetPIVSlot(),
 		PIVPINCacheTTL:          cap.GetPIVPINCacheTTL(),
-		DeviceTrust:             deviceTrustSettings(cap),
+		DeviceTrust:             deviceTrustSettings(cap, modules.GetModules()),
 		SignatureAlgorithmSuite: cap.GetSignatureAlgorithmSuite(),
 	}
 }
 
-func deviceTrustSettings(cap types.AuthPreference) webclient.DeviceTrustSettings {
+func deviceTrustSettings(cap types.AuthPreference, m modules.Modules) webclient.DeviceTrustSettings {
 	dt := cap.GetDeviceTrust()
 	return webclient.DeviceTrustSettings{
-		Disabled:   deviceTrustDisabled(cap),
+		Disabled:   deviceTrustDisabled(cap, m),
 		AutoEnroll: dt != nil && dt.AutoEnroll,
 	}
 }
 
 // deviceTrustDisabled is used to set its namesake field in
 // [webclient.PingResponse.Auth].
-func deviceTrustDisabled(cap types.AuthPreference) bool {
-	return dtconfig.GetEffectiveMode(cap.GetDeviceTrust()) == constants.DeviceTrustModeOff
+func deviceTrustDisabled(cap types.AuthPreference, m modules.Modules) bool {
+	return dtconfig.GetEffectiveMode(cap.GetDeviceTrust(), m) == constants.DeviceTrustModeOff
 }
 
 func getAuthSettings(ctx context.Context, authClient authclient.ClientI, logger *slog.Logger) (webclient.AuthenticationSettings, error) {

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -182,7 +183,7 @@ func (h *Handler) updateRoleHandle(w http.ResponseWriter, r *http.Request, param
 // should have the same security implications as the Teleport version exposed
 // via the public ping endpoint.
 func (h *Handler) getPresetRoles(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
-	presets := auth.GetPresetRoles()
+	presets := auth.GetPresetRoles(modules.GetModules().BuildType())
 	return ui.NewRoles(presets, false /* without role object */)
 }
 


### PR DESCRIPTION
The enterprise update in https://github.com/gravitational/teleport/pull/63075 contained all the changes required to remove TODOs left around from injecting modules into keygen, presets, device trust config and access list storage.

Contributes to https://github.com/gravitational/teleport/issues/62799.