### PR TITLE
Handle null unresolvedUserTasks

### DIFF
--- a/lib/web/integrations.go
+++ b/lib/web/integrations.go
@@ -431,7 +431,9 @@ func buildBriefSummaries(ctx context.Context, igs []types.Integration, uclt user
 		if !ig.SupportsDiscoveryResources() {
 			continue
 		}
-		summaries[ig.GetName()] = &ui.BriefSummary{}
+		summaries[ig.GetName()] = &ui.BriefSummary{
+			UnresolvedUserTasks: []ui.UserTask{},
+		}
 	}
 
 	if len(summaries) == 0 {

--- a/lib/web/integrations_test.go
+++ b/lib/web/integrations_test.go
@@ -1152,7 +1152,9 @@ func TestBuildBriefSummaries(t *testing.T) {
 				mockGithubInt,
 			},
 			map[string]*ui.BriefSummary{
-				mockAwsInt.GetName(): {},
+				mockAwsInt.GetName(): {
+					UnresolvedUserTasks: []ui.UserTask{},
+				},
 			},
 			nil,
 		},
@@ -1186,6 +1188,7 @@ func TestBuildBriefSummaries(t *testing.T) {
 			},
 			map[string]*ui.BriefSummary{
 				mockAwsInt.GetName(): {
+					UnresolvedUserTasks: []ui.UserTask{},
 					ResourcesCount: &ui.ResourcesCount{
 						Found:    12,
 						Enrolled: 4,

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -419,7 +419,7 @@ const IconContainer = styled(ResourceIcon)`
 `;
 
 const IssuesCell = ({ integration }: { integration: IntegrationLike }) => {
-  const issueCount = integration.summary?.unresolvedUserTasks.length;
+  const issueCount = integration.summary?.unresolvedUserTasks?.length;
   if (issueCount > 0) {
     // In the list tooltip, we only want to show up to 3 tasks. If there are more,
     // the user can go to the integration dashboard to see all of them.

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -76,7 +76,7 @@ export type IntegrationTemplate<
 };
 
 type BriefSummary = {
-  unresolvedUserTasks: UserTask[];
+  unresolvedUserTasks?: UserTask[];
   resourcesCount?: {
     found: number;
     enrolled: number;


### PR DESCRIPTION
Web was expecting this to be a required field, but the api was returning null when there were no unresolved UserTasks to process. Adding initialization on the API side, and a guard on the frontend.