### PR TITLE
Revert "Remove workaround for TypeScript compiler running out of memory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "pnpm eslint && pnpm prettier-check",
     "lint-fix": "pnpm eslint --fix && pnpm prettier-write",
     "eslint": "eslint --quiet '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
-    "type-check": "tsc --build",
+    "type-check": "NODE_OPTIONS='--max-old-space-size=4096' tsc --build",
     "optimize-resource-icons": "svgo --multipass --quiet -rf web/packages/design/src/ResourceIcon/assets",
     "prettier-check": "prettier --check '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",
     "prettier-write": "prettier --write --log-level silent '+(e|web)/**/*.{ts,tsx,js,jsx,mts}'",


### PR DESCRIPTION

This reverts commit b97fb3a88d5a287b9739eceba2e8e61fc9b2295b.

`e` web type-check CI is failing without this option https://github.com/gravitational/teleport.e/actions/runs/21273071856/job/61268020812#step:8:26