### PR TITLE
Minor Inventory UI fixes

### DIFF
--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -661,7 +661,7 @@ func (ic *InventoryCache) parseFilter(filter *inventoryv1.ListUnifiedInstancesFi
 func (ic *InventoryCache) ListUnifiedInstances(ctx context.Context, req *inventoryv1.ListUnifiedInstancesRequest) (*inventoryv1.ListUnifiedInstancesResponse, error) {
 	if !ic.IsHealthy() {
 		// This returns HTTP error 503. Keep in sync with web/packages/teleport/src/Instances/Instances.tsx (isCacheInitializing)
-		return nil, trace.ConnectionProblem(nil, "inventory cache is not yet healthy")
+		return nil, trace.ConnectionProblem(nil, "inventory cache is not yet healthy, please try again in a few minutes'")
 	}
 
 	if req.PageSize <= 0 {

--- a/lib/web/ui/instance.go
+++ b/lib/web/ui/instance.go
@@ -19,6 +19,8 @@
 package ui
 
 import (
+	"strings"
+
 	inventoryv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/inventory/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
@@ -85,7 +87,7 @@ func makeInstanceUnifiedItem(instance *types.InstanceV1) UnifiedInstance {
 
 	instanceData := &InstanceData{
 		Name:     instance.Spec.Hostname,
-		Version:  instance.Spec.Version,
+		Version:  strings.TrimPrefix(instance.Spec.Version, "v"),
 		Services: services,
 	}
 
@@ -114,7 +116,7 @@ func makeBotInstanceUnifiedItem(botInstance *machineidv1.BotInstance) UnifiedIns
 
 	if botInstance.Status != nil && len(botInstance.Status.LatestHeartbeats) > 0 {
 		heartbeat := botInstance.Status.LatestHeartbeats[0]
-		botData.Version = heartbeat.Version
+		botData.Version = strings.TrimPrefix(heartbeat.Version, "v")
 	}
 
 	return UnifiedInstance{

--- a/web/packages/teleport/src/Instances/Instances.story.tsx
+++ b/web/packages/teleport/src/Instances/Instances.story.tsx
@@ -58,7 +58,12 @@ export const Loaded: Story = {
 export const CacheInitializing: Story = {
   parameters: {
     msw: {
-      handlers: [listInstancesError(503, 'inventory cache is not yet healthy')],
+      handlers: [
+        listInstancesError(
+          503,
+          'inventory cache is not yet healthy, please try again in a few minutes'
+        ),
+      ],
     },
   },
 };

--- a/web/packages/teleport/src/Instances/Instances.test.tsx
+++ b/web/packages/teleport/src/Instances/Instances.test.tsx
@@ -148,7 +148,12 @@ it('having only instances permissions should show warning banner', async () => {
 });
 
 it('cache still initializing error should show correct error', async () => {
-  server.use(listInstancesError(503, 'inventory cache is not yet healthy'));
+  server.use(
+    listInstancesError(
+      503,
+      'inventory cache is not yet healthy, please try again in a few minutes'
+    )
+  );
   renderComponent();
 
   await waitFor(() => {
@@ -239,11 +244,12 @@ it('selecting a version filter should append the version predicate expression to
   await user.type(searchInput, 'name == "teleport-auth-01"{Enter}');
 
   await waitFor(() => {
-    expect(lastRequestUrl).toBeDefined();
-    const url = new URL(lastRequestUrl);
-    const query = url.searchParams.get('query');
-    expect(query).toBe('name == "teleport-auth-01"');
+    expect(lastRequestUrl).toContain('query=');
   });
+  {
+    const url = new URL(lastRequestUrl);
+    expect(url.searchParams.get('query')).toBe('name == "teleport-auth-01"');
+  }
 
   // Select a version filter
   const versionButton = screen.getByRole('button', { name: /Version/i });
@@ -257,11 +263,14 @@ it('selecting a version filter should append the version predicate expression to
 
   // Verify that the request made combines both predicates
   await waitFor(() => {
-    expect(lastRequestUrl).toBeDefined();
-    const url = new URL(lastRequestUrl);
-    const query = url.searchParams.get('query');
-    expect(query).toBe('(name == "teleport-auth-01") && (version == "18.2.4")');
+    expect(lastRequestUrl).toContain('version');
   });
+  {
+    const url = new URL(lastRequestUrl);
+    expect(url.searchParams.get('query')).toBe(
+      '(name == "teleport-auth-01") && (version == "18.2.4")'
+    );
+  }
 }, 15000);
 
 function renderComponent(options?: {


### PR DESCRIPTION
## Purpose

Minor fixes related to the inventory UI

- The "v" prefix should be stripped from all versions displayed in the UI
- The error message when the cache is not yet healthy now instructs the user to wait a bit, the previous message could easily have been misconstrued as a bug and cause support load
- Fix linter complaining about `Avoid using multiple assertions within waitFor callback  testing-library/no-wait-for-multiple-assertions`

