### PR TITLE
speed up init in lib/join/oraclejoin

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -328,6 +328,8 @@ linters:
       forbid:
         - pattern: ^rsa\.GenerateKey$
           msg: generating RSA keys is slow, use lib/cryptosuites to generate an appropriate key type
+        - pattern: ^common\.StringToRegion$
+          msg: use oraclejoincommon.StringToRegion to avoid OCI SDK data races
         - pattern: ^iam\.NewFromConfig$
           msg: Use iamutils.NewFromConfig
         - pattern: ^sts\.NewFromConfig$

--- a/lib/join/joinclient/oracle/oracle.go
+++ b/lib/join/joinclient/oracle/oracle.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/oraclejoin/oraclejoincommon"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -105,7 +106,7 @@ func makeSignedRootCAReq(client utils.HTTPDoClient) ([]byte, error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "finding local OCI region")
 	}
-	regionalAuthEndpoint := common.StringToRegion(localRegion).Endpoint("auth")
+	regionalAuthEndpoint := oraclejoincommon.StringToRegion(localRegion).Endpoint("auth")
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL: &url.URL{

--- a/lib/join/oraclejoin/oracle.go
+++ b/lib/join/oraclejoin/oracle.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
+	"github.com/gravitational/teleport/lib/join/oraclejoin/oraclejoincommon"
 	"github.com/gravitational/teleport/lib/join/provision"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -275,7 +276,7 @@ func regionFromInstanceID(instanceID string) (common.Region, error) {
 		return "", trace.BadParameter("instance ID does not have expected format, got %s", instanceID)
 	}
 	regionShortName := chunks[3]
-	region := common.StringToRegion(regionShortName)
+	region := oraclejoincommon.StringToRegion(regionShortName)
 	if _, err := region.RealmID(); err != nil {
 		// StringToRegion always returns something, RealmID will return an
 		// error if it's not a real region.

--- a/lib/join/oraclejoin/oraclejoincommon/region.go
+++ b/lib/join/oraclejoin/oraclejoincommon/region.go
@@ -1,0 +1,36 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package oraclejoincommon
+
+import (
+	"sync"
+
+	"github.com/oracle/oci-go-sdk/v65/common"
+)
+
+var initOCIRegionsOnce sync.Once
+
+// StringToRegion wraps [common.StringToRegion] with a safe initialization.
+func StringToRegion(rawRegion string) common.Region {
+	initOCIRegionsOnce.Do(func() {
+		// Hack: StringToRegion will lazily load regions from a config file if its
+		// input isn't in its hard-coded list, in a non-threadsafe way. Call it once
+		// on the first call so future calls are threadsafe.
+		_ = common.StringToRegion("") //nolint:forbidigo // required to pre-init OCI SDK regions safely
+	})
+	return common.StringToRegion(rawRegion) //nolint:forbidigo // this is the wrapped callsite
+}

--- a/lib/join/oraclejoin/region.go
+++ b/lib/join/oraclejoin/region.go
@@ -21,21 +21,14 @@ import (
 	"sync"
 
 	"github.com/gravitational/trace"
-	"github.com/oracle/oci-go-sdk/v65/common"
-)
 
-var initOCIRegionsOnce sync.Once
+	"github.com/gravitational/teleport/lib/join/oraclejoin/oraclejoincommon"
+)
 
 // ParseRegion parses a string into a full (not abbreviated) Oracle Cloud
 // region. It returns the empty string if the input is not a valid region.
 func ParseRegion(rawRegion string) (region, realm string) {
-	initOCIRegionsOnce.Do(func() {
-		// Hack: StringToRegion will lazily load regions from a config file if its
-		// input isn't in its hard-coded list, in a non-threadsafe way. Call it once
-		// before we start parsing so future calls are threadsafe.
-		_ = common.StringToRegion("")
-	})
-	canonicalRegion := common.StringToRegion(rawRegion)
+	canonicalRegion := oraclejoincommon.StringToRegion(rawRegion)
 	realm, err := canonicalRegion.RealmID()
 	if err != nil {
 		return "", ""

--- a/lib/join/oraclejoin/region.go
+++ b/lib/join/oraclejoin/region.go
@@ -18,7 +18,6 @@ package oraclejoin
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/gravitational/trace"
 
@@ -36,13 +35,11 @@ func ParseRegion(rawRegion string) (region, realm string) {
 	return string(canonicalRegion), realm
 }
 
-var ociRealms = sync.OnceValue(func() map[string]struct{} {
-	return map[string]struct{}{
-		"oc1": {}, "oc2": {}, "oc3": {}, "oc4": {}, "oc8": {}, "oc9": {},
-		"oc10": {}, "oc14": {}, "oc15": {}, "oc19": {}, "oc20": {}, "oc21": {},
-		"oc23": {}, "oc24": {}, "oc26": {}, "oc29": {}, "oc35": {},
-	}
-})
+var ociRealms = map[string]struct{}{
+	"oc1": {}, "oc2": {}, "oc3": {}, "oc4": {}, "oc8": {}, "oc9": {},
+	"oc10": {}, "oc14": {}, "oc15": {}, "oc19": {}, "oc20": {}, "oc21": {},
+	"oc23": {}, "oc24": {}, "oc26": {}, "oc29": {}, "oc35": {},
+}
 
 // ParseRegionFromOCID parses an Oracle OCID and returns the embedded region.
 // It returns an error if the input is not a valid OCID.
@@ -60,7 +57,7 @@ func ParseRegionFromOCID(ocid string) (string, error) {
 		return "", trace.BadParameter("invalid ocid version: %v", ocidParts[0])
 	}
 	// Check realm.
-	if _, ok := ociRealms()[ocidParts[2]]; !ok {
+	if _, ok := ociRealms[ocidParts[2]]; !ok {
 		return "", trace.BadParameter("invalid realm: %v", ocidParts[2])
 	}
 	resourceType := ocidParts[1]


### PR DESCRIPTION
The call to common.StringToRegion reads env vars and files, this can be slow during init. I measure it as 0.075ms which put it at the 18th-worst teleport package, but @espadolini reported 1.7 ms and the top offender on his machine. Using a sync.Once instead, and putting the ociRealms map into a sync.OnceValue, got this down to 0.001 ms during init. This seems like a sane tradeoff since a huge majority of teleport binaries will never use oci join code.