### PR TITLE
Add values template for Event Handler helm chart

### DIFF
--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -64,6 +64,7 @@ Teleport event handler (=teleport.version=)
 [2] Generated sample teleport-event-handler role and user file teleport-event-handler-role.yaml
 [3] Generated sample fluentd configuration file fluent.conf
 [4] Generated plugin configuration file teleport-event-handler.toml
+[5] Generated plugin helm configuration file teleport-plugin-event-handler-values.yaml
 ```
 
 The plugin generates several setup files:
@@ -79,6 +80,7 @@ $ ls -l
 # -rw------- 1 bob bob     1766 Jul  1 11:14 server.key
 # -rw------- 1 bob bob      260 Jul  1 11:14 teleport-event-handler-role.yaml
 # -rw------- 1 bob bob      343 Jul  1 11:14 teleport-event-handler.toml
+# -rw------- 1 bob bob      343 Jul  1 11:14 teleport-plugin-event-handler-values.yaml
 ```
 
 | File(s)                            | Purpose                                                             |
@@ -87,6 +89,8 @@ $ ls -l
 | `server.crt` and `server.key`      | Fluentd server certificate and key                                  |
 | `client.crt` and `client.key`      | Fluentd client certificate and key, all signed by the generated CA  |
 | `teleport-event-handler-role.yaml` | `user` and `role` resource definitions for Teleport's event handler |
+| `teleport-event-handler.toml`      | Example event handler configuration                                 |
+| `teleport-plugin-event-handler-values.yaml` | Example event handler helm configuration                   |
 | `fluent.conf`                      | Fluentd plugin configuration                                        |
 
 <details>

--- a/integrations/event-handler/main.go
+++ b/integrations/event-handler/main.go
@@ -36,7 +36,7 @@ var cli CLI
 
 const (
 	// pluginName is the plugin name
-	pluginName = "Teleport event handler"
+	pluginName = "teleport-event-handler"
 
 	// pluginDescription is the plugin description
 	pluginDescription = "Forwards Teleport AuditLog to external sources"

--- a/integrations/event-handler/tpl/teleport-plugin-event-handler-values.yaml.tpl
+++ b/integrations/event-handler/tpl/teleport-plugin-event-handler-values.yaml.tpl
@@ -1,0 +1,21 @@
+eventHandler:
+  storagePath: "./storage"
+  timeout: "10s"
+  batch: 20
+
+teleport:
+  address: "{{.Addr}}"
+  identitySecretName: teleport-event-handler-identity
+  identitySecretPath: identity
+
+fluentd:
+  url: "https://fluentd.fluentd.svc.cluster.local/events.log"
+  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
+  certificate:
+    secretName: "teleport-event-handler-client-tls"
+    caPath: "ca.crt"
+    certPath: "client.crt"
+    keyPath: "client.key"
+
+persistentVolumeClaim:
+  enabled: true


### PR DESCRIPTION
This PR adds a values.yaml template for the `teleport-plugin-event-handler` helm chart, as `teleport-plugin-event-handler-values.yaml`. This aims to improve the event handler guide when using the helm chart.

It also fixes the plugin name so event handler CLI help commands show the correct usage.

<details><summary>Template output</summary>
<p>

```yaml
# teleport-plugin-event-handler-values.yaml

eventHandler:
  storagePath: "./storage"
  timeout: "10s"
  batch: 20

teleport:
  address: "localhost:3025"
  identitySecretName: teleport-event-handler-identity
  identitySecretPath: identity

fluentd:
  url: "https://fluentd.fluentd.svc.cluster.local/events.log"
  sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
  certificate:
    secretName: "teleport-event-handler-client-tls"
    caPath: "ca.crt"
    certPath: "client.crt"
    keyPath: "client.key"

persistentVolumeClaim:
  enabled: true
```

</p>
</details> 

changelog: Added Helm chart support to the `teleport-event-handler configure` command