### PR TITLE
docs: adding upsell components to docs pages

### DIFF
--- a/docs/pages/connect-your-client/teleport-clients/tsh.mdx
+++ b/docs/pages/connect-your-client/teleport-clients/tsh.mdx
@@ -8,6 +8,10 @@ tags:
  - zero-trust
 ---
 
+<EnterpriseFeatureWidget title="Did you know?">
+   You can try out Teleport Enterprise capabilities like SSO, session recording summaries, and just-in-time Access Requests for free. No payment information required.
+</EnterpriseFeatureWidget>
+
 This guide shows you how to use the Teleport client tool `tsh` to connect to
 infrastructure resources in your cluster.
 

--- a/docs/pages/feature-matrix.mdx
+++ b/docs/pages/feature-matrix.mdx
@@ -6,6 +6,9 @@ tags:
  - platform-wide
 ---
 
+import Button from '@site/src/components/Button';
+import Icon from '@site/src/components/Icon'; 
+
 The Teleport feature matrix lists capabilities of the Teleport Infrastructure
 Identity Platform, organized by product.
 
@@ -65,7 +68,7 @@ include:
 least-privileged access to applications, servers, databases, Kubernetes
 clusters, and other resources across distributed infrastructures.
 
-|  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
 |**User identity.** Authenticate users without passwords:||||
 | [Single Sign-On](zero-trust-access/sso/sso.mdx)| GitHub, Google Workspace, Microsoft Entra ID, Okta, SailPoint, OIDC, SAML, Teleport | GitHub, Google Workspace, Microsoft Entra ID, Okta, SailPoint, OIDC, SAML, Teleport | GitHub |
@@ -107,7 +110,7 @@ clusters, and other resources across distributed infrastructures.
 solution that secures machine-to-machine communication with short-lived
 certificates, access control, and auditability.
 
-|  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
 | **Service Discovery:** Live inventory of machine and workload identities for CI/CD jobs, microservices, and others | ✔ | ✔ | ✔ |
 |**Issuance:** Provisions cryptographic identities for [machines](machine-workload-identity/getting-started.mdx) and [workloads](machine-workload-identity/workload-identity/getting-started.mdx), eliminating anonymous computing and the need for static over-privileged users and automating certificate rotation | ✔ | ✔ | ✔ |
@@ -125,7 +128,7 @@ certificates, access control, and auditability.
 **Teleport Identity Governance** hardens and monitors identities for both human
 and non-human identities.
 
-|  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
 | [JIT Access Requests](identity-governance/access-requests/access-requests.mdx): Grant only those privileges necessary to complete the task at hand. Remove the need for super-privileged accounts. | ✔ | ✔ | Only can request roles through CLI  |
 | Automatic Access Requests & Approvals: Automate pre-defined workflows based on RBAC, ABAC, or context-based authorization. | ✔ | ✔ | ✖ |
@@ -140,7 +143,7 @@ and non-human identities.
 
 **Teleport Identity Security** identifies & mitigates risk in access paths.
 
-|  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
 | Access Graph: Import and analysis of AWS, Azure, Okta, Microsoft Entra, GitLab and AWS IAM roles | ✔ | ✔ | ✖ |
 | Discover secrets, SSH Key Scanning| ✔ | ✔ | ✖ |
@@ -153,7 +156,7 @@ and non-human identities.
 
 ## Platform integrations, management, licensing, and deployment
 
-|  | **Enterprise (Cloud)** | **Enterprise (Self-Hosted)** | **Community Edition** |
+|  | **Enterprise (Cloud)** <div style={{ marginTop: 'var(--m-0-5)' }}><Button style={{ padding: '0 var(--m-1-5)', height: '2rem' }} as="link" href="https://goteleport.com/signup" target="_blank">Try for free</Button></div> | **Enterprise (Self-Hosted)** | **Community Edition** |
 |---|:---:|:---:|:---:|
 | **Integrations:** ||||
 | Infrastructure as Code (IaC): Terraform, K8s Operator | ✔ | ✔ | ✔ |

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -8,6 +8,10 @@ tags:
 
 import Button from '@site/src/components/Button';
 
+<EnterpriseFeatureWidget title="Did you know?">
+   You can try out Teleport Enterprise capabilities like SSO, session recording summaries, and just-in-time Access Requests for free. No payment information required.
+</EnterpriseFeatureWidget>
+
 This guide will walk you through deploying Teleport Community Edition. 
 
 You'll spin up a single-instance Teleport cluster on a Linux server, ideal for small-scale demos or home lab environments. Once deployed, you can move ahead in the guide to connecting your infrastructure, setting up role-based access control (RBAC), and auditing your access.


### PR DESCRIPTION
This PR adds the EnterpriseFeatureWidget upsell component to the top of a few docs pages that have been chosen based on particular analytics metrics. It also adds a callout button(s) for the Enterprise Cloud headings in the feature matrics docs page.

This is to test whether these callouts lead to increased conversions for new users to the signup page. 

Pages affected
- https://travis-rodgers-adding-upsells-to-docs-pages.d3b94eevwi10ji.amplifyapp.com/docs/connect-your-client/teleport-clients/tsh/
- https://travis-rodgers-adding-upsells-to-docs-pages.d3b94eevwi10ji.amplifyapp.com/docs/installation/
- https://travis-rodgers-adding-upsells-to-docs-pages.d3b94eevwi10ji.amplifyapp.com/docs/get-started/deploy-community/
- https://travis-rodgers-adding-upsells-to-docs-pages.d3b94eevwi10ji.amplifyapp.com/docs/feature-matrix/