### PR TITLE
Sub Access Graph entitlement

### DIFF
--- a/entitlements/entitlements.go
+++ b/entitlements/entitlements.go
@@ -47,7 +47,7 @@ const (
 	OIDC                       EntitlementKind = "OIDC"
 	OktaSCIM                   EntitlementKind = "OktaSCIM"
 	OktaUserSync               EntitlementKind = "OktaUserSync"
-	Policy                     EntitlementKind = "Policy"
+	Policy                     EntitlementKind = "Policy" // TODO(emargetis) DELETE IN 21.0.0, replaced by AccessGraph
 	SAML                       EntitlementKind = "SAML"
 	SessionLocks               EntitlementKind = "SessionLocks"
 	UnrestrictedManagedUpdates EntitlementKind = "UnrestrictedManagedUpdates"

--- a/lib/auth/clusterconfig/clusterconfigv1/service.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service.go
@@ -930,8 +930,8 @@ func (s *Service) GetClusterAccessGraphConfig(ctx context.Context, _ *clustercon
 		return nil, trace.AccessDenied("this request can be only executed by a Teleport service")
 	}
 
-	// If the policy feature is disabled in the license, return a disabled response. if cloud, return the response to allow demo mode enabling
-	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph && !modules.GetModules().Features().Cloud {
+	// If the access graph feature is disabled in the license, return a disabled response. if cloud, return the response to allow demo mode enabling
+	if !modules.GetModules().Features().GetEntitlement(entitlements.AccessGraph).Enabled && !modules.GetModules().Features().AccessGraph && !modules.GetModules().Features().Cloud {
 		return &clusterconfigpb.GetClusterAccessGraphConfigResponse{
 			AccessGraph: &clusterconfigpb.AccessGraphConfig{
 				Enabled: false,
@@ -1032,7 +1032,7 @@ func (s *Service) UpdateAccessGraphSettings(ctx context.Context, req *clustercon
 		return nil, trace.Wrap(err)
 	}
 
-	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph && !modules.GetModules().Features().Cloud {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.AccessGraph).Enabled && !modules.GetModules().Features().AccessGraph && !modules.GetModules().Features().Cloud {
 		return nil, trace.AccessDenied("access graph is feature isn't enabled")
 	}
 
@@ -1076,7 +1076,7 @@ func (s *Service) UpsertAccessGraphSettings(ctx context.Context, req *clustercon
 		return nil, trace.Wrap(err)
 	}
 
-	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.AccessGraph).Enabled && !modules.GetModules().Features().AccessGraph {
 		return nil, trace.AccessDenied("access graph is feature isn't enabled")
 	}
 
@@ -1120,7 +1120,7 @@ func (s *Service) ResetAccessGraphSettings(ctx context.Context, _ *clusterconfig
 		return nil, trace.Wrap(err)
 	}
 
-	if !modules.GetModules().Features().GetEntitlement(entitlements.Policy).Enabled && !modules.GetModules().Features().AccessGraph {
+	if !modules.GetModules().Features().GetEntitlement(entitlements.AccessGraph).Enabled && !modules.GetModules().Features().AccessGraph {
 		return nil, trace.AccessDenied("access graph is feature isn't enabled")
 	}
 

--- a/lib/auth/clusterconfig/clusterconfigv1/service_test.go
+++ b/lib/auth/clusterconfig/clusterconfigv1/service_test.go
@@ -1873,7 +1873,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}
@@ -1898,7 +1898,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}
@@ -1923,7 +1923,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}
@@ -2081,7 +2081,7 @@ func TestUpdateAccessGraphSettings(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}
@@ -2206,7 +2206,7 @@ func TestUpsertAccessGraphSettings(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}
@@ -2300,7 +2300,7 @@ func TestResetAccessGraphSettings(t *testing.T) {
 				m := modulestest.Modules{
 					TestFeatures: modules.Features{
 						Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-							entitlements.Policy: {Enabled: true},
+							entitlements.AccessGraph: {Enabled: true},
 						},
 					},
 				}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -5608,7 +5608,7 @@ func TestGetAccessGraphConfig(t *testing.T) {
 	modulestest.SetTestModules(t, modulestest.Modules{
 		TestFeatures: modules.Features{
 			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
-				entitlements.Policy: {Enabled: true},
+				entitlements.AccessGraph: {Enabled: true},
 			},
 		},
 	})

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -79,7 +79,7 @@ type Features struct {
 	// AccessGraph enables the usage of access graph.
 	// NOTE: this is a legacy flag that is currently used to signal
 	// that Access Graph integration is *enabled* on a cluster.
-	// *Access* to the feature is gated on the `Policy` flag.
+	// *Access* to the feature is gated on the `AccessGraph` entitlement.
 	// TODO(justinas): remove this field once "TAG enabled" status is moved to a resource in the backend.
 	AccessGraph bool
 	// AccessMonitoringConfigured contributes to the enablement of access monitoring.
@@ -137,7 +137,7 @@ func (f Features) ToProto() *proto.Features {
 		// TODO(michellescripts) DELETE IN v21.0.0
 		// Deprecated, use entitlements
 		Policy: &proto.PolicyFeature{
-			Enabled: f.GetEntitlement(entitlements.Policy).Enabled,
+			Enabled: f.GetEntitlement(entitlements.AccessGraph).Enabled || f.GetEntitlement(entitlements.Policy).Enabled,
 		},
 		AccessGraphDemoMode:  f.GetEntitlement(entitlements.AccessGraphDemoMode).Enabled,
 		ClientIPRestrictions: f.GetEntitlement(entitlements.ClientIPRestrictions).Enabled,

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -185,14 +185,14 @@ func GetProtoEntitlement(f *proto.Features, e entitlements.EntitlementKind) *pro
 	fE := f.GetEntitlements()
 	al, ok := fE[string(e)]
 	if !ok {
-		// TODO(emargetis): Policy fallback DELETE IN 21.0.0
+		// TODO(emargetis): Policy fallback DELETE IN 20.0.0
 		if e == entitlements.AccessGraph && f.GetPolicy().GetEnabled() {
 			return &proto.EntitlementInfo{Enabled: true}
 		}
 		return &proto.EntitlementInfo{}
 	}
 
-	// TODO(emargetis): Policy fallback DELETE IN 21.0.0
+	// TODO(emargetis): Policy fallback DELETE IN 20.0.0
 	if e == entitlements.AccessGraph && !al.Enabled && f.GetPolicy().GetEnabled() {
 		return &proto.EntitlementInfo{Enabled: true, Limit: al.Limit}
 	}

--- a/lib/modules/modules.go
+++ b/lib/modules/modules.go
@@ -185,7 +185,16 @@ func GetProtoEntitlement(f *proto.Features, e entitlements.EntitlementKind) *pro
 	fE := f.GetEntitlements()
 	al, ok := fE[string(e)]
 	if !ok {
+		// TODO(emargetis): Policy fallback DELETE IN 21.0.0
+		if e == entitlements.AccessGraph && f.GetPolicy().GetEnabled() {
+			return &proto.EntitlementInfo{Enabled: true}
+		}
 		return &proto.EntitlementInfo{}
+	}
+
+	// TODO(emargetis): Policy fallback DELETE IN 21.0.0
+	if e == entitlements.AccessGraph && !al.Enabled && f.GetPolicy().GetEnabled() {
+		return &proto.EntitlementInfo{Enabled: true, Limit: al.Limit}
 	}
 
 	return &proto.EntitlementInfo{

--- a/lib/srv/discovery/access_graph_aws.go
+++ b/lib/srv/discovery/access_graph_aws.go
@@ -344,8 +344,8 @@ func (s *Server) initializeAndWatchAccessGraph(ctx context.Context, reloadCh <-c
 	)
 
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	accessGraph := modules.GetProtoEntitlement(&clusterFeatures, entitlements.AccessGraph)
+	if !clusterFeatures.AccessGraph && !accessGraph.Enabled {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 
@@ -646,8 +646,8 @@ func (s *Server) startCloudtrailPoller(ctx context.Context, reloadCh <-chan stru
 	const semaphoreName = "access_graph_aws_cloudtrail_sync"
 
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	accessGraph := modules.GetProtoEntitlement(&clusterFeatures, entitlements.AccessGraph)
+	if !clusterFeatures.AccessGraph && !accessGraph.Enabled {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 

--- a/lib/srv/discovery/access_graph_azure.go
+++ b/lib/srv/discovery/access_graph_azure.go
@@ -216,8 +216,8 @@ func (s *Server) getAllTAGSyncAzureFetchers() []*azuresync.Fetcher {
 func (s *Server) initializeAndWatchAzureAccessGraph(ctx context.Context, reloadCh chan struct{}) error {
 	// Check if the access graph is enabled
 	clusterFeatures := s.Config.ClusterFeatures()
-	policy := modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy)
-	if !clusterFeatures.AccessGraph && !policy.Enabled {
+	accessGraph := modules.GetProtoEntitlement(&clusterFeatures, entitlements.AccessGraph)
+	if !clusterFeatures.AccessGraph && !accessGraph.Enabled {
 		return trace.Wrap(errTAGFeatureNotEnabled)
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2061,7 +2061,7 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		// if Entitlements are present, GetWebCfgEntitlements will populate the fields appropriately
 		Entitlements: GetWebCfgEntitlements(clusterFeatures.GetEntitlements()),
 		IdentitySecurity: webclient.IdentitySecurity{
-			IsClusterLicensed:           modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
+			IsClusterLicensed:           modules.GetProtoEntitlement(&clusterFeatures, entitlements.AccessGraph).Enabled || modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
 			AccessGraphConfigSet:        rsp.GetEnabled() && rsp.GetAddress() != "",
 			SessionSummarizationEnabled: sessionSummarizerEnabled,
 		},

--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -72,7 +72,8 @@ export function PolicyPlaceholder({
 
   // roleDiffProps can be undefined if not cloud and not role tester
   // enabled.
-  const hideSalesButton = (cfg.isPolicyEnabled || cfg.isCloud) && roleDiffProps;
+  const hideSalesButton =
+    (cfg.entitlements.AccessGraph.enabled || cfg.isCloud) && roleDiffProps;
 
   return (
     <Box maxWidth={promoImageWidth + 2 * 2} minWidth={300}>
@@ -90,7 +91,7 @@ export function PolicyPlaceholder({
         </Box>
         <Flex flex="0 0 auto" alignItems="start">
           {canUpdateAccessGraphSettings &&
-            !cfg.isPolicyEnabled &&
+            !cfg.entitlements.AccessGraph.enabled &&
             cfg.isCloud &&
             enableDemoMode && ( // cloud can enable a demo mode so show that button
               <ButtonPrimary

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.story.tsx
@@ -43,7 +43,7 @@ import { RoleEditorDialog } from './RoleEditorDialog';
 import { unableToUpdatePreviewMessage } from './Shared';
 import { withDefaults } from './StandardEditor/withDefaults';
 
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultIsAccessGraphEnabled = cfg.entitlements.AccessGraph.enabled;
 const defaultGetAccessGraphRoleTesterEnabled =
   storageService.getAccessGraphRoleTesterEnabled;
 
@@ -56,13 +56,13 @@ export default {
         ctx.storeUser.getRoleAccess = () => parameters.acl;
       }
       if (args.roleDiffEnabled) {
-        cfg.isPolicyEnabled = true;
+        cfg.entitlements.AccessGraph.enabled = true;
         storageService.getAccessGraphRoleTesterEnabled = () => true;
       }
       useEffect(() => {
         // Clean up
         return () => {
-          cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+          cfg.entitlements.AccessGraph.enabled = defaultIsAccessGraphEnabled;
           storageService.getAccessGraphRoleTesterEnabled =
             defaultGetAccessGraphRoleTesterEnabled;
         };

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.test.tsx
@@ -48,7 +48,7 @@ import { defaultRoleVersion, newRole } from './StandardEditor/standardmodel';
 import * as StandardModelModule from './StandardEditor/standardmodel';
 import { defaultOptions, withDefaults } from './StandardEditor/withDefaults';
 
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultIsAccessGraphEnabled = cfg.entitlements.AccessGraph.enabled;
 
 let user: UserEvent;
 
@@ -85,7 +85,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
-  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+  cfg.entitlements.AccessGraph.enabled = defaultIsAccessGraphEnabled;
 });
 
 test('rendering and switching tabs for new role', async () => {
@@ -192,7 +192,7 @@ test('rendering and switching tabs for a non-standard role', async () => {
 });
 
 it('calls onRoleUpdate on each modification in the standard editor', async () => {
-  cfg.isPolicyEnabled = true;
+  cfg.entitlements.AccessGraph.enabled = true;
   const onRoleUpdate = jest.fn();
   render(<TestRoleEditor demoMode onRoleUpdate={onRoleUpdate} />);
   expect(onRoleUpdate).toHaveBeenLastCalledWith(
@@ -208,7 +208,7 @@ it('calls onRoleUpdate on each modification in the standard editor', async () =>
 });
 
 it('calls onRoleUpdate after the first rendering of a non-standard role', async () => {
-  cfg.isPolicyEnabled = true;
+  cfg.entitlements.AccessGraph.enabled = true;
   const onRoleUpdate = jest.fn();
   const nonStandardRole = withDefaults({
     unsupportedField: true,
@@ -456,7 +456,7 @@ describe('saving a new role after editing as YAML', () => {
   });
 
   test('with Policy enabled', async () => {
-    cfg.isPolicyEnabled = true;
+    cfg.entitlements.AccessGraph.enabled = true;
     jest
       .spyOn(storageService, 'getAccessGraphRoleTesterEnabled')
       .mockReturnValue(true);

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditor.tsx
@@ -90,7 +90,8 @@ export const RoleEditor = ({
   onMinimizedChange,
 }: RoleEditorProps) => {
   const roleTesterEnabled =
-    (cfg.isPolicyEnabled && storageService.getAccessGraphRoleTesterEnabled()) ||
+    (cfg.entitlements.AccessGraph.enabled &&
+      storageService.getAccessGraphRoleTesterEnabled()) ||
     demoMode;
   const idPrefix = useId();
   // These IDs are needed to connect accessibility attributes between the

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.test.tsx
@@ -31,11 +31,11 @@ import { RoleDiffProps, RoleDiffState } from '../Roles';
 import { RoleEditorVisualizer } from './RoleEditorVisualizer';
 
 const defaultDemoMode = cfg.entitlements.AccessGraphDemoMode;
-const defaultIsPolicyEnabled = cfg.isPolicyEnabled;
+const defaultIsAccessGraphEnabled = cfg.entitlements.AccessGraph.enabled;
 const defaultIsCloud = cfg.isCloud;
 afterEach(() => {
   cfg.entitlements.AccessGraphDemoMode = defaultDemoMode;
-  cfg.isPolicyEnabled = defaultIsPolicyEnabled;
+  cfg.entitlements.AccessGraph.enabled = defaultIsAccessGraphEnabled;
   cfg.isCloud = defaultIsCloud;
 });
 
@@ -47,10 +47,10 @@ test('no roleDiffProps shows policyPlaceHolder', async () => {
   ).toBeInTheDocument();
 });
 
-test('POLICY_ENABLED displays roll diff visualizer', async () => {
+test('ACCESS_GRAPH_ENABLED displays roll diff visualizer', async () => {
   render(
     getComponent(
-      makeRoleDiffProps({ roleDiffState: RoleDiffState.PolicyEnabled })
+      makeRoleDiffProps({ roleDiffState: RoleDiffState.AccessGraphEnabled })
     )
   );
   expect(screen.getByText('i am rendered')).toBeInTheDocument();

--- a/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/RoleEditorVisualizer.tsx
@@ -107,6 +107,6 @@ export function RoleEditorVisualizer({
 export function shouldShowRoleDiff(rdp: RoleDiffProps) {
   return (
     rdp.roleDiffState === RoleDiffState.DemoReady ||
-    rdp.roleDiffState === RoleDiffState.PolicyEnabled
+    rdp.roleDiffState === RoleDiffState.AccessGraphEnabled
   );
 }

--- a/web/packages/teleport/src/Roles/Roles.test.tsx
+++ b/web/packages/teleport/src/Roles/Roles.test.tsx
@@ -318,7 +318,7 @@ test('renders the role diff component', async () => {
               {...defaultState()}
               roleDiffProps={{
                 roleDiffElement,
-                roleDiffState: RoleDiffState.PolicyEnabled,
+                roleDiffState: RoleDiffState.AccessGraphEnabled,
                 updateRoleDiff: () => null,
                 roleDiffAttempt: {
                   status: 'error',

--- a/web/packages/teleport/src/Roles/Roles.tsx
+++ b/web/packages/teleport/src/Roles/Roles.tsx
@@ -52,7 +52,7 @@ import { State, useRoles } from './useRoles';
 export enum RoleDiffState {
   Disabled,
   Error,
-  PolicyEnabled,
+  AccessGraphEnabled,
   LoadingSettings,
   WaitingForSync,
   DemoReady,

--- a/web/packages/teleport/src/entitlement.ts
+++ b/web/packages/teleport/src/entitlement.ts
@@ -39,7 +39,7 @@ type entitlement =
   | 'OIDC'
   | 'OktaSCIM'
   | 'OktaUserSync'
-  | 'Policy'
+  | 'Policy' // TODO(emargetis) DELETE IN 21.0.0, use AccessGraph instead
   | 'SAML'
   | 'SessionLocks'
   | 'UnrestrictedManagedUpdates'


### PR DESCRIPTION
## Summary
This PR substitutes the now deprecated Policy entitlement for the new Access Graph entitlement. It also swaps out all usages in Teleport of Policy for Access Graph.

Note: The Access Graph entitlement has a structure of `{Enabled: bool, Limit: num}` while Policy only had `{Enabled: bool}`. While this PR is a 1:1 swap that only passes through the `Enabled` flag, the `Limit` value may want to be used in the future, 0 indicating a dedicated instance and 1 indicating a shared instance.

https://github.com/gravitational/teleport.e/pull/7898 will be similar to this PR

----
Merge order of PRs:
1. https://github.com/gravitational/teleport.e/pull/7929
2. https://github.com/gravitational/teleport/pull/64340
3. (current) https://github.com/gravitational/teleport/pull/63117
4. https://github.com/gravitational/teleport.e/pull/7898

Supports https://github.com/gravitational/cloud/issues/16130

----
## Manual Test Plan

### Test Environment

I deployed a dev build with https://github.com/gravitational/teleport/pull/63117 included to cloud staging `erik-ag-partial`

### Test Cases
- [x] Toggling on and [rolling pods](https://www.notion.so/goteleport/Known-Support-Issues-601400b6644b4afe94044ff45f3a3b0f?source=copy_link#268fdd3830be80ed9c6fcc1c0fc8876d) enables access graph
- [x] Toggling off and [rolling pods](https://www.notion.so/goteleport/Known-Support-Issues-601400b6644b4afe94044ff45f3a3b0f?source=copy_link#268fdd3830be80ed9c6fcc1c0fc8876d) disables access graph

### Local Entitlement Testing

#### Prep

1. Check out this branch and the [corresponding e branch](https://github.com/gravitational/teleport.e/pull/7898)
2. Create and run a local enterprise cloud tenant against a local salescenter instance
3. Add this print statement on the Teleport side in  [feature.go](https://github.com/gravitational/teleport.e/blob/bfb3c66dcc90bb8484492f619a401d89e782351c/lib/cloud/feature/feature.go#L26) to verify entitlements received by Teleport:
```go
fmt.Printf("DEBUG GetCloudFeatures: entitlements=%v\n", resp.Entitlements)
```
 
#### Test `AccessGraph` entitlement independently

##### Enabled

1. Add this code snippet just before the [response from the handler](https://github.com/gravitational/cloud/blob/43da9d3ea379b0869a9c9e6e4e961532fb76173b/salescenter/tenantsserver/handler/handler.go#L522) and rebuild SC
```go
// test AccessGraph entitlement works independently
e["Policy"] = &v1.EntitlementInfo{Enabled: false}
```

2. Toggle `on` the Access Graph feature for the tenant in the SC UI
4. Restart local tenant, visit the access graph page (`/web/accessgraph`), and verify you see the following error:
<img width="898" height="302" alt="image" src="https://github.com/user-attachments/assets/41863dd9-642e-4464-9df0-c92ae4837dae" />

5. Verify in the Teleport logs that `Policy` was not enabled and `AccessGraph` was set to `enabled:true` in the response

##### Disabled

1. Toggle `off` Access Graph in the SC UI
2. Restart the tenant to make sure it has the latest license updates, visit the access graph page, and verify you see a trial ad instead of the error above:
<img width="1874" height="968" alt="image" src="https://github.com/user-attachments/assets/3469967b-87ab-4352-9dab-ce38269f2694" />
    
3. Verify in the Teleport logs that `Policy` was not enabled and `AccessGraph` entitlement was not enabled in the response

#### Test `Policy` entitlement independently for backward compatibility (simulating old licenses)

##### Enabled

1. Replace the code snippet from the previous test in [the handler](https://github.com/gravitational/cloud/blob/43da9d3ea379b0869a9c9e6e4e961532fb76173b/salescenter/tenantsserver/handler/handler.go#L522)with the following and rebuild SC:
```go
// test Policy entitlement still works independently
e["AccessGraph"] = &v1.EntitlementInfo{Enabled: false}  
```
    
2. Toggle `on` Access Graph in the SC UI
3. Restart local tenant, visit the access graph page (`/web/accessgraph`), and verify you see the same connection error again
4. Verify in the Teleport logs that `AccessGraph` was not enabled and `Policy` was set to `enabled:true` in the response

##### Disabled

1. Toggle `off` Access Graph in the SC UI
2. Restart the tenant to make sure it has the latest license updates, visit the access graph page, and verify you see the trial ad instead of the error above
3. Verify in the Teleport logs that `AccessGraph` was not enabled and `Policy` was not enabled in the response