### PR TITLE
docs: fix backup clone dynamodb field name

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/reliability/backup-restore.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/reliability/backup-restore.mdx
@@ -122,7 +122,7 @@ Kubernetes pod that usually runs the Teleport Auth Service, you can expect the
      src: 
        type: dynamodb
        region: us-east-1
-       table: teleport_backend
+       table_name: teleport_backend
      # dst is the configuration for the backend where data is cloned to.
      dst:
        type: sqlite


### PR DESCRIPTION
`table_name` is the field name for the dynamodb table.