### PR TITLE
Add `cert-manager` certificates opt-in for Event Handler helm chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -45,8 +45,8 @@ data:
   auth_id: #...
 ```
 
-Check out the [Export Events with Fluentd]
-(../../zero-trust-access/export-audit-events/fluentd.mdx) guide
+Check out the [Export Events with Fluentd
+](../../zero-trust-access/export-audit-events/fluentd.mdx) guide
 for more information about how to acquire these credentials.
 
 ### `teleport.identitySecretPath`
@@ -151,7 +151,7 @@ for a list of default skipped events.
 |------|---------|
 | `bool` | `false` |
 
-`eventHandler.dryRun` enables dry run without sending events to fluentd.
+`eventHandler.dryRun` enables dry run without sending events to Fluentd.
 
 ### `eventHandler.concurrency`
 
@@ -197,7 +197,7 @@ will trigger locking. By default, this is set to 1 minute.
 
 ## `fluentd`
 
-`fluentd` contains the configuration for the fluentd forwarder.
+`fluentd` contains the configuration for the Fluentd forwarder.
 
 ### `fluentd.url`
 
@@ -214,6 +214,11 @@ will trigger locking. By default, this is set to 1 minute.
 | `string` | `""` |
 
 `fluentd.sessionUrl` is the Fluentd URL where the session logs will be sent.
+
+### `fluentd.certificate`
+
+`fluentd.certificate` contains the configuration for the plugin's Fluentd client certificates.
+When `certManager.enabled` is true, `cert-manager` will use its own secrets, so this section is unused.
 
 #### `fluentd.certificate.secretName`
 
@@ -410,6 +415,103 @@ tokenSpecOverride:
       issuer: https://oidc.eks.us-west-2.amazonaws.com/id/my-cluster
 ```
 
+## `certManager`
+
+`certManager` controls whether the chart uses `cert-manager` to provision TLS certificates
+for mTLS connection between the plugin and Fluentd.
+
+<Admonition type="note" title="Installing cert manager">
+You must install and configure `cert-manager` in your Kubernetes cluster yourself.
+
+See the [cert-manager Helm install instructions](https://cert-manager.io/docs/installation/helm/)
+and the relevant sections of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx)
+and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+</Admonition>
+
+### `certManager.enabled`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`certManager.enabled` controls if cert-manager should be used to provision TLS certificates for the event handler plugin.
+
+### `certManager.issuerName`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`certManager.issuerName` is the name of the `Issuer` or `ClusterIssuer` to use for issuing certificates.
+
+<Admonition type="note" title="Configuring an Issuer">
+You must install and configure an appropriate `Issuer` supporting a DNS01 challenge yourself.
+
+Please see the [cert-manager DNS01 docs](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers) and the relevant sections
+of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx) and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+</Admonition>
+
+### `certManager.issuerKind`
+
+| Type | Default |
+|------|---------|
+| `string` | `"Issuer"` |
+
+`certManager.issuerKind` is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+Defaults to 'Issuer' to keep permissions scoped to the plugin's namespace.
+
+### `certManager.issuerGroup`
+
+| Type | Default |
+|------|---------|
+| `string` | `"cert-manager.io"` |
+
+`certManager.issuerGroup` is the `Group` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+Defaults to 'cert-manager.io' to use built-in issuers.
+
+### `certManager.dnsNames`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`certManager.dnsNames` is the DNS names for the Fluentd forwarder, populating the SANs extension of the server certificate.
+
+### `certManager.ipAddresses`
+
+| Type | Default |
+|------|---------|
+| `list` | `[]` |
+
+`certManager.ipAddresses` is the IP addresses for the Fluentd forwarder, populating the SANs extension of the server certificate.
+
+### `certManager.ttl`
+
+| Type | Default |
+|------|---------|
+| `string` | `"87600h"` |
+
+`certManager.ttl` is the time-to-live duration for the TLS certificates. Defaults to 87600 hours (10 years).
+
+### `certManager.renewBefore`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`certManager.renewBefore` is the time before `certManager.ttl` to renew the TLS certificates.
+This must be less than `certManager.ttl`. When empty, defaults to 1/3 of the issued
+certificate's time-to-live duration. For example, if a certificate is valid for 60 minutes,
+`cert-manager` will renew the certificate 20 minutes before expiration.
+
+### `certManager.length`
+
+| Type | Default |
+|------|---------|
+| `int` | `4096` |
+
+`certManager.length` is the RSA key length. Defaults to 4096.
+
 ## `annotations`
 
 `annotations` contains annotations to apply to the different Kubernetes
@@ -441,6 +543,15 @@ for more details.
 
 `annotations.pod` are annotations to set on the Pods.
 
+### `annotations.certSecret`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`annotations.certSecret` are annotations to set on the certificate secrets
+generated by cert-manager v1.5+ when `certManager.enabled` is true
+
 ## `extraLabels`
 
 `extraLabels` contains additional Kubernetes labels to apply on the resources
@@ -471,6 +582,15 @@ for more information.
 | `object` | `{}` |
 
 `extraLabels.pod` are labels to set on the Pods.
+
+### `extraLabels.certSecret`
+
+| Type | Default |
+|------|---------|
+| `object` | `{}` |
+
+`extraLabels.certSecret` are labels to set on the certificate secrets
+generated by cert-manager v1.5+ when `certManager.enabled` is true.
 
 ## `image`
 

--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -418,14 +418,16 @@ tokenSpecOverride:
 ## `certManager`
 
 `certManager` controls whether the chart uses `cert-manager` to provision TLS certificates
-for mTLS connection between the plugin and Fluentd.
+for mTLS connection between the plugin and Fluentd. If enabled, `cert-manager` will create two
+Kubernetes secrets in the plugin's release namespace:
+the Fluentd server credentials (CA cert, server cert, server key)
+and the plugin client credentials (CA cert, client cert, client key).
 
 <Admonition type="note" title="Installing cert manager">
 You must install and configure `cert-manager` in your Kubernetes cluster yourself.
 
 See the [cert-manager Helm install instructions](https://cert-manager.io/docs/installation/helm/)
-and the relevant sections of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx)
-and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+for more information.
 </Admonition>
 
 ### `certManager.enabled`
@@ -434,7 +436,7 @@ and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) gui
 |------|---------|
 | `bool` | `false` |
 
-`certManager.enabled` controls if cert-manager should be used to provision TLS certificates for the event handler plugin.
+`certManager.enabled` controls if cert-manager should be used to provision TLS certificates for the plugin.
 
 ### `certManager.issuerName`
 
@@ -442,13 +444,13 @@ and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) gui
 |------|---------|
 | `string` | `""` |
 
-`certManager.issuerName` is the name of the `Issuer` or `ClusterIssuer` to use for issuing certificates.
+`certManager.issuerName` is the name of the `Issuer` or `ClusterIssuer` to use for issuing Fluentd server and client certificates.
+If using `Issuer`, it should be in the same namespace as the plugin's release namespace.
 
 <Admonition type="note" title="Configuring an Issuer">
-You must install and configure an appropriate `Issuer` supporting a DNS01 challenge yourself.
+You must install and configure an appropriate `Issuer` or `ClusterIssuer` yourself.
 
-Please see the [cert-manager DNS01 docs](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers) and the relevant sections
-of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx) and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+See the [cert-manager Issuers documentation](https://cert-manager.io/docs/configuration/issuers/) for more information.
 </Admonition>
 
 ### `certManager.issuerKind`
@@ -458,7 +460,7 @@ of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx) 
 | `string` | `"Issuer"` |
 
 `certManager.issuerKind` is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
-Defaults to 'Issuer' to keep permissions scoped to the plugin's namespace.
+Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.
 
 ### `certManager.issuerGroup`
 

--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -451,16 +451,15 @@ the Fluentd server and client certificates.
 | `bool` | `true` |
 
 `certManager.issuer.create` controls if the chart should create
-a private CA issuer to issue the certificates.
-This is a CA issuer using a root certificate issued from a `SelfSigned` issuer.
+a private CA issuer to issue the Fluentd server and client certificates.
 
-See the [cert-manager `SelfSigned` Issuer documentation
+See the [cert-manager Bootstrapping CA Issuers documentation
 ](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers) for more information.
 
-<Admonition type="note" title="Configuring your own Issuer">
-If `certManager.issuer.create` is false, you must install and
-configure an appropriate issuer yourself.
-If using your own issuer, it should be in the same namespace as the plugin's release namespace.
+<Admonition type="warning" title="Creating the CA Issuer with the Chart">
+If `certManager.issuer.create` is true, the chart will create a new private CA issuer.
+This means existing Fluentd deployments may need to be restarted to load the new certificates.
+As such, it is recommended to use your own issuer in production.
 
 See the [cert-manager Issuers documentation
 ](https://cert-manager.io/docs/configuration/issuers/) for more information.
@@ -473,6 +472,16 @@ See the [cert-manager Issuers documentation
 | `string` | `""` |
 
 `certManager.issuer.name` is the `Name` of the issuer. Unused if `certManager.issuer.create` is true.
+
+<Admonition type="note" title="Configuring your own Issuer">
+If `certManager.issuer.create` is false, you must install and
+configure an appropriate issuer yourself.
+If configuring an `Issuer` resource, it should be in the same namespace as the plugin's release namespace.
+Alternatively, you can use `ClusterIssuer` for a cluster-wide issuer.
+
+See the [cert-manager Issuers documentation
+](https://cert-manager.io/docs/configuration/issuers/) for more information.
+</Admonition>
 
 #### `certManager.issuer.kind`
 

--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -422,6 +422,7 @@ for mTLS connection between the plugin and Fluentd. If enabled, `cert-manager` w
 Kubernetes secrets in the plugin's release namespace:
 the Fluentd server credentials (CA cert, server cert, server key)
 and the plugin client credentials (CA cert, client cert, client key).
+The TLS certificates use PKCS#8 encoding and ECDSA encryption.
 
 <Admonition type="note" title="Installing cert manager">
 You must install and configure `cert-manager` in your Kubernetes cluster yourself.
@@ -436,39 +437,59 @@ for more information.
 |------|---------|
 | `bool` | `false` |
 
-`certManager.enabled` controls if cert-manager should be used to provision TLS certificates for the plugin.
+`certManager.enabled` controls if `cert-manager` should be used to provision TLS certificates for the plugin.
 
-### `certManager.issuerName`
+### `certManager.issuer`
+
+`certManager.issuer` is the `cert-manager` `Issuer` or `ClusterIssuer` that will issue
+the Fluentd server and client certificates.
+
+#### `certManager.issuer.create`
+
+| Type | Default |
+|------|---------|
+| `bool` | `true` |
+
+`certManager.issuer.create` controls if the chart should create
+a private CA issuer to issue the certificates.
+This is a CA issuer using a root certificate issued from a `SelfSigned` issuer.
+
+See the [cert-manager `SelfSigned` Issuer documentation
+](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers) for more information.
+
+<Admonition type="note" title="Configuring your own Issuer">
+If `certManager.issuer.create` is false, you must install and
+configure an appropriate issuer yourself.
+If using your own issuer, it should be in the same namespace as the plugin's release namespace.
+
+See the [cert-manager Issuers documentation
+](https://cert-manager.io/docs/configuration/issuers/) for more information.
+</Admonition>
+
+#### `certManager.issuer.name`
 
 | Type | Default |
 |------|---------|
 | `string` | `""` |
 
-`certManager.issuerName` is the name of the `Issuer` or `ClusterIssuer` to use for issuing Fluentd server and client certificates.
-If using `Issuer`, it should be in the same namespace as the plugin's release namespace.
+`certManager.issuer.name` is the `Name` of the issuer. Unused if `certManager.issuer.create` is true.
 
-<Admonition type="note" title="Configuring an Issuer">
-You must install and configure an appropriate `Issuer` or `ClusterIssuer` yourself.
-
-See the [cert-manager Issuers documentation](https://cert-manager.io/docs/configuration/issuers/) for more information.
-</Admonition>
-
-### `certManager.issuerKind`
+#### `certManager.issuer.kind`
 
 | Type | Default |
 |------|---------|
 | `string` | `"Issuer"` |
 
-`certManager.issuerKind` is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+`certManager.issuer.kind` is the `Kind` of the issuer. Unused if `certManager.issuer.create` is true.
 Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.
 
-### `certManager.issuerGroup`
+#### `certManager.issuer.group`
 
 | Type | Default |
 |------|---------|
 | `string` | `"cert-manager.io"` |
 
-`certManager.issuerGroup` is the `Group` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+`certManager.issuer.group` is the `Group` of the issuer. Unused if `certManager.issuer.create` is true.
 Defaults to 'cert-manager.io' to use built-in issuers.
 
 ### `certManager.dnsNames`
@@ -505,14 +526,6 @@ Defaults to 'cert-manager.io' to use built-in issuers.
 This must be less than `certManager.ttl`. When empty, defaults to 1/3 of the issued
 certificate's time-to-live duration. For example, if a certificate is valid for 60 minutes,
 `cert-manager` will renew the certificate 20 minutes before expiration.
-
-### `certManager.length`
-
-| Type | Default |
-|------|---------|
-| `int` | `4096` |
-
-`certManager.length` is the RSA key length. Defaults to 4096.
 
 ## `annotations`
 

--- a/examples/chart/event-handler/.lint/cert-manager-enabled.yaml
+++ b/examples/chart/event-handler/.lint/cert-manager-enabled.yaml
@@ -1,0 +1,7 @@
+certManager:
+  enabled: true
+  issuerName: test-issuer
+  issuerGroup: test.cert-manager.io
+  issuerKind: TestClusterIssuer
+  namespace: test-namespace
+  dnsNames: ["test.example.com", "test2.example.com"]

--- a/examples/chart/event-handler/.lint/cert-manager-issuer-not-enabled.yaml
+++ b/examples/chart/event-handler/.lint/cert-manager-issuer-not-enabled.yaml
@@ -2,3 +2,8 @@ certManager:
   enabled: true
   namespace: test-namespace
   dnsNames: ["test.example.com", "test2.example.com"]
+  issuer:
+    create: false
+    name: test-issuer
+    kind: Issuer
+    group: cert-manager.io

--- a/examples/chart/event-handler/templates/_helpers.tpl
+++ b/examples/chart/event-handler/templates/_helpers.tpl
@@ -140,3 +140,17 @@ Create the full TeleportProvisionToken join spec.
 {{- .Values.crd.tokenSpecOverride | toYaml -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name for the Fluentd server TLS certificate secret.
+*/}}
+{{- define "event-handler.certManager.serverCertSecretName" -}}
+{{ include "event-handler.fullname" . }}-server-tls
+{{- end -}}
+
+{{/*
+Create the name for the Fluentd client TLS certificate secret.
+*/}}
+{{- define "event-handler.certManager.clientCertSecretName" -}}
+{{ include "event-handler.fullname" . }}-client-tls
+{{- end -}}

--- a/examples/chart/event-handler/templates/_helpers.tpl
+++ b/examples/chart/event-handler/templates/_helpers.tpl
@@ -154,3 +154,18 @@ Create the name for the Fluentd client TLS certificate secret.
 {{- define "event-handler.certManager.clientCertSecretName" -}}
 {{ include "event-handler.fullname" . }}-client-tls
 {{- end -}}
+
+{{/*
+Create the issuer for the cert-manager.
+*/}}
+{{- define "event-handler.certManager.issuer" -}}
+{{- if .Values.certManager.issuer.create -}}
+name: {{ include "event-handler.fullname" . }}-ca-issuer
+kind: Issuer
+group: cert-manager.io
+{{- else -}}
+name: {{ required "certManager.issuer.name is required in chart values" .Values.certManager.issuer.name }}
+kind: {{ required "certManager.issuer.kind is required in chart values" .Values.certManager.issuer.kind }}
+group: {{ required "certManager.issuer.group is required in chart values" .Values.certManager.issuer.group }}
+{{- end -}}
+{{- end -}}

--- a/examples/chart/event-handler/templates/certificate.yaml
+++ b/examples/chart/event-handler/templates/certificate.yaml
@@ -11,16 +11,24 @@ metadata:
     {{- include "event-handler.labels" . | nindent 4 }}
 spec:
   secretName: "{{ include "event-handler.certManager.serverCertSecretName" . }}"
-  duration: {{ .Values.certManager.ttl }}
+  duration: {{ required "certManager.ttl is required in chart values" .Values.certManager.ttl | quote }}
+  {{- if .Values.certManager.renewBefore }}
   renewBefore: {{ .Values.certManager.renewBefore }}
+  {{- end }}
   privateKey:
     algorithm: ECDSA
     encoding: PKCS8
     size: 256
   usages:
     - server auth
-  dnsNames: {{ .Values.certManager.dnsNames }}
-  ipAddresses: {{ .Values.certManager.ipAddresses }}
+  {{- if .Values.certManager.dnsNames }}
+  dnsNames:
+    {{- .Values.certManager.dnsNames | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if .Values.certManager.ipAddresses }}
+  ipAddresses:
+    {{- .Values.certManager.ipAddresses | toYaml | nindent 4 }}
+  {{- end }}
   issuerRef:
     {{- include "event-handler.certManager.issuer" . | nindent 4 }}
   {{- if or .Values.annotations.certSecret .Values.extraLabels.certSecret }}
@@ -44,8 +52,10 @@ metadata:
     {{- include "event-handler.labels" . | nindent 4 }}
 spec:
   secretName: "{{ include "event-handler.certManager.clientCertSecretName" . }}"
-  duration: {{ .Values.certManager.ttl }}
+  duration: {{ required "certManager.ttl is required in chart values" .Values.certManager.ttl | quote }}
+  {{- if .Values.certManager.renewBefore }}
   renewBefore: {{ .Values.certManager.renewBefore }}
+  {{- end }}
   privateKey:
     algorithm: ECDSA
     encoding: PKCS8

--- a/examples/chart/event-handler/templates/certificate.yaml
+++ b/examples/chart/event-handler/templates/certificate.yaml
@@ -14,15 +14,15 @@ spec:
   duration: {{ .Values.certManager.ttl }}
   renewBefore: {{ .Values.certManager.renewBefore }}
   privateKey:
-    size: {{ .Values.certManager.length }}
+    algorithm: ECDSA
+    encoding: PKCS8
+    size: 256
   usages:
     - server auth
   dnsNames: {{ .Values.certManager.dnsNames }}
   ipAddresses: {{ .Values.certManager.ipAddresses }}
   issuerRef:
-    name: {{ required "certManager.issuerName is required in chart values" .Values.certManager.issuerName }}
-    kind: {{ required "certManager.issuerKind is required in chart values" .Values.certManager.issuerKind }}
-    group: {{ required "certManager.issuerGroup is required in chart values" .Values.certManager.issuerGroup }}
+    {{- include "event-handler.certManager.issuer" . | nindent 4 }}
   {{- if or .Values.annotations.certSecret .Values.extraLabels.certSecret }}
   secretTemplate:
     {{- with .Values.annotations.certSecret }}
@@ -47,14 +47,14 @@ spec:
   duration: {{ .Values.certManager.ttl }}
   renewBefore: {{ .Values.certManager.renewBefore }}
   privateKey:
-    size: {{ .Values.certManager.length }}
+    algorithm: ECDSA
+    encoding: PKCS8
+    size: 256
   usages:
     - client auth
   commonName: {{ include "event-handler.fullname" . }}
   issuerRef:
-    name: {{ required "certManager.issuerName is required in chart values" .Values.certManager.issuerName }}
-    kind: {{ required "certManager.issuerKind is required in chart values" .Values.certManager.issuerKind }}
-    group: {{ required "certManager.issuerGroup is required in chart values" .Values.certManager.issuerGroup }}
+    {{- include "event-handler.certManager.issuer" . | nindent 4 }}
   {{- if or .Values.annotations.certSecret .Values.extraLabels.certSecret }}
   secretTemplate:
     {{- with .Values.annotations.certSecret }}

--- a/examples/chart/event-handler/templates/certificate.yaml
+++ b/examples/chart/event-handler/templates/certificate.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.certManager.enabled -}}
+{{- if and (empty .Values.certManager.dnsNames) (empty .Values.certManager.ipAddresses) -}}
+{{ $_ := required "certManager.dnsNames and certManager.ipAddresses cannot both be empty in chart values" "" }}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "event-handler.fullname" . }}-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "event-handler.labels" . | nindent 4 }}
+spec:
+  secretName: "{{ include "event-handler.certManager.serverCertSecretName" . }}"
+  duration: {{ .Values.certManager.ttl }}
+  renewBefore: {{ .Values.certManager.renewBefore }}
+  privateKey:
+    size: {{ .Values.certManager.length }}
+  usages:
+    - server auth
+  dnsNames: {{ .Values.certManager.dnsNames }}
+  ipAddresses: {{ .Values.certManager.ipAddresses }}
+  issuerRef:
+    name: {{ required "certManager.issuerName is required in chart values" .Values.certManager.issuerName }}
+    kind: {{ required "certManager.issuerKind is required in chart values" .Values.certManager.issuerKind }}
+    group: {{ required "certManager.issuerGroup is required in chart values" .Values.certManager.issuerGroup }}
+  {{- if or .Values.annotations.certSecret .Values.extraLabels.certSecret }}
+  secretTemplate:
+    {{- with .Values.annotations.certSecret }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.extraLabels.certSecret }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "event-handler.fullname" . }}-client
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "event-handler.labels" . | nindent 4 }}
+spec:
+  secretName: "{{ include "event-handler.certManager.clientCertSecretName" . }}"
+  duration: {{ .Values.certManager.ttl }}
+  renewBefore: {{ .Values.certManager.renewBefore }}
+  privateKey:
+    size: {{ .Values.certManager.length }}
+  usages:
+    - client auth
+  commonName: {{ include "event-handler.fullname" . }}
+  issuerRef:
+    name: {{ required "certManager.issuerName is required in chart values" .Values.certManager.issuerName }}
+    kind: {{ required "certManager.issuerKind is required in chart values" .Values.certManager.issuerKind }}
+    group: {{ required "certManager.issuerGroup is required in chart values" .Values.certManager.issuerGroup }}
+  {{- if or .Values.annotations.certSecret .Values.extraLabels.certSecret }}
+  secretTemplate:
+    {{- with .Values.annotations.certSecret }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.extraLabels.certSecret }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/examples/chart/event-handler/templates/deployment.yaml
+++ b/examples/chart/event-handler/templates/deployment.yaml
@@ -76,14 +76,7 @@ spec:
             - name: teleport-identity
               mountPath: /var/lib/teleport/plugins/event-handler/teleport-identity
             - name: certificate
-              mountPath: /var/lib/teleport/plugins/event-handler/ca.crt
-              subPath: {{ .Values.fluentd.certificate.caPath }}
-            - name: certificate
-              mountPath: /var/lib/teleport/plugins/event-handler/client.crt
-              subPath: {{ .Values.fluentd.certificate.certPath }}
-            - name: certificate
-              mountPath: /var/lib/teleport/plugins/event-handler/client.key
-              subPath: {{ .Values.fluentd.certificate.keyPath }}
+              mountPath: /var/lib/teleport/plugins/event-handler
             {{- if .Values.tls.existingCASecretName }}
             - mountPath: /etc/teleport-tls-ca
               name: "teleport-tls-ca"
@@ -117,10 +110,31 @@ spec:
           secret:
             secretName: {{ include "event-handler.identitySecretName" . | quote }}
             defaultMode: 0600
+        {{- if .Values.certManager.enabled }}
+        - name: certificate
+          secret:
+            secretName: {{ include "event-handler.certManager.clientCertSecretName" . | quote }}
+            items:
+              - key: ca.crt
+                path: ca.crt
+              - key: tls.crt
+                path: client.crt
+              - key: tls.key
+                path: client.key
+            defaultMode: 0600
+        {{- else }}
         - name: certificate
           secret:
             secretName: "{{ .Values.fluentd.certificate.secretName }}"
+            items:
+              - key: {{ .Values.fluentd.certificate.caPath }}
+                path: ca.crt
+              - key: {{ .Values.fluentd.certificate.certPath }}
+                path: client.crt
+              - key: {{ .Values.fluentd.certificate.keyPath }}
+                path: client.key
             defaultMode: 0600
+        {{- end }}
         {{- if .Values.tls.existingCASecretName }}
         - name: "teleport-tls-ca"
           secret:

--- a/examples/chart/event-handler/templates/issuer.yaml
+++ b/examples/chart/event-handler/templates/issuer.yaml
@@ -1,0 +1,36 @@
+{{- if and .Values.certManager.enabled .Values.certManager.issuer.create -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "event-handler.fullname" . }}-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "event-handler.fullname" . }}-selfsigned-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  isCA: true
+  commonName: {{ include "event-handler.fullname" . }}-selfsigned-ca
+  secretName: {{ include "event-handler.fullname" . }}-root-secret
+  privateKey:
+    algorithm: ECDSA
+    encoding: PKCS8
+    size: 256
+  issuerRef:
+    name: {{ include "event-handler.fullname" . }}-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "event-handler.fullname" . }}-ca-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ include "event-handler.fullname" . }}-root-secret
+{{- end -}}

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -13,9 +13,9 @@ should request certificates when certManager enabled:
       namespace: NAMESPACE
     spec:
       dnsNames:
-      - test.example.com test2.example.com
+      - test.example.com
+      - test2.example.com
       duration: 87600h
-      ipAddresses: []
       issuerRef:
         group: cert-manager.io
         kind: Issuer
@@ -24,7 +24,6 @@ should request certificates when certManager enabled:
         algorithm: ECDSA
         encoding: PKCS8
         size: 256
-      renewBefore: null
       secretName: RELEASE-NAME-teleport-plugin-event-handler-server-tls
       usages:
       - server auth
@@ -51,7 +50,6 @@ should request certificates when certManager enabled:
         algorithm: ECDSA
         encoding: PKCS8
         size: 256
-      renewBefore: null
       secretName: RELEASE-NAME-teleport-plugin-event-handler-client-tls
       usages:
       - client auth

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -17,11 +17,13 @@ should request certificates when certManager enabled:
       duration: 87600h
       ipAddresses: []
       issuerRef:
-        group: test.cert-manager.io
-        kind: TestClusterIssuer
-        name: test-issuer
+        group: cert-manager.io
+        kind: Issuer
+        name: RELEASE-NAME-teleport-plugin-event-handler-ca-issuer
       privateKey:
-        size: 4096
+        algorithm: ECDSA
+        encoding: PKCS8
+        size: 256
       renewBefore: null
       secretName: RELEASE-NAME-teleport-plugin-event-handler-server-tls
       usages:
@@ -42,11 +44,13 @@ should request certificates when certManager enabled:
       commonName: RELEASE-NAME-teleport-plugin-event-handler
       duration: 87600h
       issuerRef:
-        group: test.cert-manager.io
-        kind: TestClusterIssuer
-        name: test-issuer
+        group: cert-manager.io
+        kind: Issuer
+        name: RELEASE-NAME-teleport-plugin-event-handler-ca-issuer
       privateKey:
-        size: 4096
+        algorithm: ECDSA
+        encoding: PKCS8
+        size: 256
       renewBefore: null
       secretName: RELEASE-NAME-teleport-plugin-event-handler-client-tls
       usages:

--- a/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/certificate_test.yaml.snap
@@ -1,0 +1,53 @@
+should request certificates when certManager enabled:
+  1: |
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-event-handler
+        app.kubernetes.io/version: 19.0.0-dev
+        helm.sh/chart: teleport-plugin-event-handler-19.0.0-dev
+      name: RELEASE-NAME-teleport-plugin-event-handler-server
+      namespace: NAMESPACE
+    spec:
+      dnsNames:
+      - test.example.com test2.example.com
+      duration: 87600h
+      ipAddresses: []
+      issuerRef:
+        group: test.cert-manager.io
+        kind: TestClusterIssuer
+        name: test-issuer
+      privateKey:
+        size: 4096
+      renewBefore: null
+      secretName: RELEASE-NAME-teleport-plugin-event-handler-server-tls
+      usages:
+      - server auth
+  2: |
+    apiVersion: cert-manager.io/v1
+    kind: Certificate
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-event-handler
+        app.kubernetes.io/version: 19.0.0-dev
+        helm.sh/chart: teleport-plugin-event-handler-19.0.0-dev
+      name: RELEASE-NAME-teleport-plugin-event-handler-client
+      namespace: NAMESPACE
+    spec:
+      commonName: RELEASE-NAME-teleport-plugin-event-handler
+      duration: 87600h
+      issuerRef:
+        group: test.cert-manager.io
+        kind: TestClusterIssuer
+        name: test-issuer
+      privateKey:
+        size: 4096
+      renewBefore: null
+      secretName: RELEASE-NAME-teleport-plugin-event-handler-client-tls
+      usages:
+      - client auth

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -50,15 +50,8 @@ should match the snapshot:
               subPath: teleport-event-handler.toml
             - mountPath: /var/lib/teleport/plugins/event-handler/teleport-identity
               name: teleport-identity
-            - mountPath: /var/lib/teleport/plugins/event-handler/ca.crt
+            - mountPath: /var/lib/teleport/plugins/event-handler
               name: certificate
-              subPath: ca.crt
-            - mountPath: /var/lib/teleport/plugins/event-handler/client.crt
-              name: certificate
-              subPath: client.crt
-            - mountPath: /var/lib/teleport/plugins/event-handler/client.key
-              name: certificate
-              subPath: client.key
           securityContext: {}
           volumes:
           - configMap:
@@ -72,6 +65,13 @@ should match the snapshot:
           - name: certificate
             secret:
               defaultMode: 384
+              items:
+              - key: ca.crt
+                path: ca.crt
+              - key: client.crt
+                path: client.crt
+              - key: client.key
+                path: client.key
               secretName: ""
 should mount tls.existingCASecretName and set environment when set in values:
   1: |
@@ -102,15 +102,8 @@ should mount tls.existingCASecretName and set environment when set in values:
         subPath: teleport-event-handler.toml
       - mountPath: /var/lib/teleport/plugins/event-handler/teleport-identity
         name: teleport-identity
-      - mountPath: /var/lib/teleport/plugins/event-handler/ca.crt
+      - mountPath: /var/lib/teleport/plugins/event-handler
         name: certificate
-        subPath: ca.crt
-      - mountPath: /var/lib/teleport/plugins/event-handler/client.crt
-        name: certificate
-        subPath: client.crt
-      - mountPath: /var/lib/teleport/plugins/event-handler/client.key
-        name: certificate
-        subPath: client.key
       - mountPath: /etc/teleport-tls-ca
         name: teleport-tls-ca
         readOnly: true
@@ -127,6 +120,13 @@ should mount tls.existingCASecretName and set environment when set in values:
     - name: certificate
       secret:
         defaultMode: 384
+        items:
+        - key: ca.crt
+          path: ca.crt
+        - key: client.crt
+          path: client.crt
+        - key: client.key
+          path: client.key
         secretName: ""
     - name: teleport-tls-ca
       secret:

--- a/examples/chart/event-handler/tests/certificate_test.yaml
+++ b/examples/chart/event-handler/tests/certificate_test.yaml
@@ -1,4 +1,4 @@
-suite: Test certificate
+suite: Test cert-manager certificate
 templates:
   - certificate.yaml
 tests:
@@ -8,12 +8,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 2
-      - documentIndex: 0
-        isKind:
-          of: Certificate
-      - documentIndex: 1
-        isKind:
-          of: Certificate
+      - containsDocument:
+          kind: Certificate
+          apiVersion: cert-manager.io/v1
+          name: RELEASE-NAME-teleport-plugin-event-handler-server
+      - containsDocument:
+          kind: Certificate
+          apiVersion: cert-manager.io/v1
+          name: RELEASE-NAME-teleport-plugin-event-handler-client
       - matchSnapshot: {}
   - it: should not request certificates when certManager not enabled
     set:
@@ -58,18 +60,18 @@ tests:
     set:
       certManager:
         enabled: true
-        issuerName: test-issuer
-        issuerGroup: test.cert-manager.io
-        issuerKind: TestClusterIssuer
         namespace: test-namespace
     asserts:
       - failedTemplate:
           errorMessage: "certManager.dnsNames and certManager.ipAddresses cannot both be empty in chart values"
-  - it: should fail if any of certManager.issuerName, certManager.issuerKind, certManager.issuerGroup are not set
+  - it: should fail if certManager.issuer.create is false and 
+        any of certManager.issuer.name, certManager.issuer.kind, certManager.issuer.group are not set
+    values:
+      - ../.lint/cert-manager-enabled.yaml
     set:
       certManager:
-        enabled: true
-        dnsNames: ["test.example.com"]
+        issuer:
+          create: false
     asserts:
       - failedTemplate:
-          errorMessage: "certManager.issuerName is required in chart values"
+          errorMessage: "certManager.issuer.name is required in chart values"

--- a/examples/chart/event-handler/tests/certificate_test.yaml
+++ b/examples/chart/event-handler/tests/certificate_test.yaml
@@ -1,0 +1,75 @@
+suite: Test certificate
+templates:
+  - certificate.yaml
+tests:
+  - it: should request certificates when certManager enabled
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: Certificate
+      - documentIndex: 1
+        isKind:
+          of: Certificate
+      - matchSnapshot: {}
+  - it: should not request certificates when certManager not enabled
+    set:
+      certManager:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not set certificate annotations or extraLabels when not set in values
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    asserts:
+      - isNull:
+          path: spec.secretTemplate
+  - it: sets annotations in certificate secrets when set in values
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    set:
+      annotations:
+        certSecret:
+          keyA: valA
+          keyB: valB
+    asserts:
+      - equal:
+          path: spec.secretTemplate.annotations
+          value:
+            keyA: valA
+            keyB: valB
+  - it: sets extraLabels on certificate secrets when set in values
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    set:
+      extraLabels:
+        certSecret:
+          test-key: test-label-cert-secret
+    asserts:
+      - isSubset:
+          path: spec.secretTemplate.labels
+          content:
+            test-key: test-label-cert-secret
+  - it: should fail if both certManager.dnsNames and certManager.ipAddresses are not set
+    set:
+      certManager:
+        enabled: true
+        issuerName: test-issuer
+        issuerGroup: test.cert-manager.io
+        issuerKind: TestClusterIssuer
+        namespace: test-namespace
+    asserts:
+      - failedTemplate:
+          errorMessage: "certManager.dnsNames and certManager.ipAddresses cannot both be empty in chart values"
+  - it: should fail if any of certManager.issuerName, certManager.issuerKind, certManager.issuerGroup are not set
+    set:
+      certManager:
+        enabled: true
+        dnsNames: ["test.example.com"]
+    asserts:
+      - failedTemplate:
+          errorMessage: "certManager.issuerName is required in chart values"

--- a/examples/chart/event-handler/tests/deployment_test.yaml
+++ b/examples/chart/event-handler/tests/deployment_test.yaml
@@ -130,3 +130,40 @@ tests:
           content:
             name: TEST_ENV
             value: test-value
+  - it: should not mount cert-manager TLS secrets when certManager.enabled is false
+    asserts:
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: teleport-tls
+            secret:
+              secretName: teleport-tls
+              defaultMode: 0600
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/teleport-tls
+            name: teleport-tls
+  - it: should mount cert-manager TLS secrets when certManager.enabled is true
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: certificate
+            secret:
+              secretName: RELEASE-NAME-teleport-plugin-event-handler-client-tls
+              items:
+                - key: ca.crt
+                  path: ca.crt
+                - key: tls.crt
+                  path: client.crt
+                - key: tls.key
+                  path: client.key
+              defaultMode: 0600
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /var/lib/teleport/plugins/event-handler
+            name: certificate

--- a/examples/chart/event-handler/tests/issuer_test.yaml
+++ b/examples/chart/event-handler/tests/issuer_test.yaml
@@ -1,0 +1,29 @@
+suite: Test cert-manager issuer
+templates:
+  - issuer.yaml
+tests:
+  - it: should create CA Issuer if certManager.enabled is true
+    values:
+      - ../.lint/cert-manager-enabled.yaml
+    asserts:
+      - hasDocuments:
+          count: 3
+      - containsDocument:
+          kind: Issuer
+          apiVersion: cert-manager.io/v1
+          name: RELEASE-NAME-teleport-plugin-event-handler-selfsigned-issuer
+      - containsDocument:
+          kind: Certificate
+          apiVersion: cert-manager.io/v1
+          name: RELEASE-NAME-teleport-plugin-event-handler-selfsigned-ca
+      - containsDocument:
+          kind: Issuer
+          apiVersion: cert-manager.io/v1
+          name: RELEASE-NAME-teleport-plugin-event-handler-ca-issuer
+  - it: should not create CA Issuer if certManager.enabled is false
+    set:
+      certManager:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -222,29 +222,31 @@ crd:
   tokenSpecOverride: {}
 
 # certManager -- controls whether the chart uses `cert-manager` to provision TLS certificates
-# for mTLS connection between the plugin and Fluentd.
+# for mTLS connection between the plugin and Fluentd. If enabled, `cert-manager` will create two
+# Kubernetes secrets in the plugin's release namespace:
+# the Fluentd server credentials (CA cert, server cert, server key)
+# and the plugin client credentials (CA cert, client cert, client key).
 #
 # <Admonition type="note" title="Installing cert manager">
 # You must install and configure `cert-manager` in your Kubernetes cluster yourself.
 #
 # See the [cert-manager Helm install instructions](https://cert-manager.io/docs/installation/helm/)
-# and the relevant sections of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx)
-# and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+# for more information.
 # </Admonition>
 certManager:
-  # certManager.enabled(bool) -- controls if cert-manager should be used to provision TLS certificates for the event handler plugin.
+  # certManager.enabled(bool) -- controls if cert-manager should be used to provision TLS certificates for the plugin.
   enabled: false
-  # certManager.issuerName(string) -- is the name of the `Issuer` or `ClusterIssuer` to use for issuing certificates.
+  # certManager.issuerName(string) -- is the name of the `Issuer` or `ClusterIssuer` to use for issuing Fluentd server and client certificates.
+  # If using `Issuer`, it should be in the same namespace as the plugin's release namespace.
   #
   # <Admonition type="note" title="Configuring an Issuer">
-  # You must install and configure an appropriate `Issuer` supporting a DNS01 challenge yourself.
+  # You must install and configure an appropriate `Issuer` or `ClusterIssuer` yourself.
   #
-  # Please see the [cert-manager DNS01 docs](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers) and the relevant sections
-  # of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx) and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+  # See the [cert-manager Issuers documentation](https://cert-manager.io/docs/configuration/issuers/) for more information.
   # </Admonition>
   issuerName: ""
   # certManager.issuerKind(string) -- is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
-  # Defaults to 'Issuer' to keep permissions scoped to the plugin's namespace.
+  # Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.
   issuerKind: Issuer
   # certManager.issuerGroup(string) -- is the `Group` of the `Issuer` to be used when issuing certificates with `cert-manager`.
   # Defaults to 'cert-manager.io' to use built-in issuers.

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -226,6 +226,7 @@ crd:
 # Kubernetes secrets in the plugin's release namespace:
 # the Fluentd server credentials (CA cert, server cert, server key)
 # and the plugin client credentials (CA cert, client cert, client key).
+# The TLS certificates use PKCS#8 encoding and ECDSA encryption.
 #
 # <Admonition type="note" title="Installing cert manager">
 # You must install and configure `cert-manager` in your Kubernetes cluster yourself.
@@ -234,23 +235,35 @@ crd:
 # for more information.
 # </Admonition>
 certManager:
-  # certManager.enabled(bool) -- controls if cert-manager should be used to provision TLS certificates for the plugin.
+  # certManager.enabled(bool) -- controls if `cert-manager` should be used to provision TLS certificates for the plugin.
   enabled: false
-  # certManager.issuerName(string) -- is the name of the `Issuer` or `ClusterIssuer` to use for issuing Fluentd server and client certificates.
-  # If using `Issuer`, it should be in the same namespace as the plugin's release namespace.
-  #
-  # <Admonition type="note" title="Configuring an Issuer">
-  # You must install and configure an appropriate `Issuer` or `ClusterIssuer` yourself.
-  #
-  # See the [cert-manager Issuers documentation](https://cert-manager.io/docs/configuration/issuers/) for more information.
-  # </Admonition>
-  issuerName: ""
-  # certManager.issuerKind(string) -- is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
-  # Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.
-  issuerKind: Issuer
-  # certManager.issuerGroup(string) -- is the `Group` of the `Issuer` to be used when issuing certificates with `cert-manager`.
-  # Defaults to 'cert-manager.io' to use built-in issuers.
-  issuerGroup: cert-manager.io
+  # certManager.issuer -- is the `cert-manager` `Issuer` or `ClusterIssuer` that will issue
+  # the Fluentd server and client certificates.
+  issuer:
+    # certManager.issuer.create(bool) -- controls if the chart should create
+    # a private CA issuer to issue the certificates.
+    # This is a CA issuer using a root certificate issued from a `SelfSigned` issuer.
+    #
+    # See the [cert-manager `SelfSigned` Issuer documentation
+    # ](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers) for more information.
+    #
+    # <Admonition type="note" title="Configuring your own Issuer">
+    # If `certManager.issuer.create` is false, you must install and
+    # configure an appropriate issuer yourself.
+    # If using your own issuer, it should be in the same namespace as the plugin's release namespace.
+    #
+    # See the [cert-manager Issuers documentation
+    # ](https://cert-manager.io/docs/configuration/issuers/) for more information.
+    # </Admonition>
+    create: true
+    # certManager.issuer.name(string) -- is the `Name` of the issuer. Unused if `certManager.issuer.create` is true.
+    name: ""
+    # certManager.issuer.kind(string) -- is the `Kind` of the issuer. Unused if `certManager.issuer.create` is true.
+    # Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.
+    kind: Issuer
+    # certManager.issuer.group(string) -- is the `Group` of the issuer. Unused if `certManager.issuer.create` is true.
+    # Defaults to 'cert-manager.io' to use built-in issuers.
+    group: cert-manager.io
   # certManager.dnsNames(list) -- is the DNS names for the Fluentd forwarder, populating the SANs extension of the server certificate.
   dnsNames: []
   # certManager.ipAddresses(list) -- is the IP addresses for the Fluentd forwarder, populating the SANs extension of the server certificate.
@@ -262,8 +275,6 @@ certManager:
   # certificate's time-to-live duration. For example, if a certificate is valid for 60 minutes,
   # `cert-manager` will renew the certificate 20 minutes before expiration.
   renewBefore: ""
-  # certManager.length(int) -- is the RSA key length. Defaults to 4096.
-  length: 4096
 
 persistentVolumeClaim:
   enabled: false

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -241,22 +241,31 @@ certManager:
   # the Fluentd server and client certificates.
   issuer:
     # certManager.issuer.create(bool) -- controls if the chart should create
-    # a private CA issuer to issue the certificates.
-    # This is a CA issuer using a root certificate issued from a `SelfSigned` issuer.
+    # a private CA issuer to issue the Fluentd server and client certificates.
     #
-    # See the [cert-manager `SelfSigned` Issuer documentation
+    # See the [cert-manager Bootstrapping CA Issuers documentation
     # ](https://cert-manager.io/docs/configuration/selfsigned/#bootstrapping-ca-issuers) for more information.
     #
-    # <Admonition type="note" title="Configuring your own Issuer">
-    # If `certManager.issuer.create` is false, you must install and
-    # configure an appropriate issuer yourself.
-    # If using your own issuer, it should be in the same namespace as the plugin's release namespace.
+    # <Admonition type="warning" title="Creating the CA Issuer with the Chart">
+    # If `certManager.issuer.create` is true, the chart will create a new private CA issuer.
+    # This means existing Fluentd deployments may need to be restarted to load the new certificates.
+    # As such, it is recommended to use your own issuer in production.
     #
     # See the [cert-manager Issuers documentation
     # ](https://cert-manager.io/docs/configuration/issuers/) for more information.
     # </Admonition>
     create: true
     # certManager.issuer.name(string) -- is the `Name` of the issuer. Unused if `certManager.issuer.create` is true.
+    #
+    # <Admonition type="note" title="Configuring your own Issuer">
+    # If `certManager.issuer.create` is false, you must install and
+    # configure an appropriate issuer yourself.
+    # If configuring an `Issuer` resource, it should be in the same namespace as the plugin's release namespace.
+    # Alternatively, you can use `ClusterIssuer` for a cluster-wide issuer.
+    #
+    # See the [cert-manager Issuers documentation
+    # ](https://cert-manager.io/docs/configuration/issuers/) for more information.
+    # </Admonition>
     name: ""
     # certManager.issuer.kind(string) -- is the `Kind` of the issuer. Unused if `certManager.issuer.create` is true.
     # Defaults to 'Issuer' to keep permissions scoped to the plugin's release namespace.

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -36,8 +36,8 @@ teleport:
   #   auth_id: #...
   # ```
   #
-  # Check out the [Export Events with Fluentd]
-  # (../../zero-trust-access/export-audit-events/fluentd.mdx) guide
+  # Check out the [Export Events with Fluentd
+  # ](../../zero-trust-access/export-audit-events/fluentd.mdx) guide
   # for more information about how to acquire these credentials.
   identitySecretName: ""
   # teleport.identitySecretPath(string) -- is the key in the Kubernetes secret
@@ -75,7 +75,7 @@ eventHandler:
   skipSessionTypes: []
   # eventHandler.startTime(string) -- is the start time to start ingestion from (RFC3339 format).
   startTime: ""
-  # eventHandler.dryRun(bool) -- enables dry run without sending events to fluentd.
+  # eventHandler.dryRun(bool) -- enables dry run without sending events to Fluentd.
   dryRun: false
   # eventHandler.concurrency(int) -- is the number of concurrent sessions to process. By default, this is set to 5.
   concurrency: 5
@@ -91,12 +91,14 @@ eventHandler:
     # eventHandler.lock.for(string) -- is the time period for which user gets lock.
     for: ""
 
-# fluentd -- contains the configuration for the fluentd forwarder.
+# fluentd -- contains the configuration for the Fluentd forwarder.
 fluentd:
   # fluentd.url(string) -- is the Fluentd URL where the events will be sent.
   url: ""
   # fluentd.sessionUrl(string) -- is the Fluentd URL where the session logs will be sent.
   sessionUrl: ""
+  # fluentd.certificate -- contains the configuration for the plugin's Fluentd client certificates.
+  # When `certManager.enabled` is true, `cert-manager` will use its own secrets, so this section is unused.
   certificate:
     # fluentd.certificate.secretName(string) -- is the secret containing the credentials to connect to Fluentd.
     # It must contain the CA certificate, the client key and the client certificate.
@@ -219,6 +221,48 @@ crd:
   # ```
   tokenSpecOverride: {}
 
+# certManager -- controls whether the chart uses `cert-manager` to provision TLS certificates
+# for mTLS connection between the plugin and Fluentd.
+#
+# <Admonition type="note" title="Installing cert manager">
+# You must install and configure `cert-manager` in your Kubernetes cluster yourself.
+#
+# See the [cert-manager Helm install instructions](https://cert-manager.io/docs/installation/helm/)
+# and the relevant sections of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx)
+# and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+# </Admonition>
+certManager:
+  # certManager.enabled(bool) -- controls if cert-manager should be used to provision TLS certificates for the event handler plugin.
+  enabled: false
+  # certManager.issuerName(string) -- is the name of the `Issuer` or `ClusterIssuer` to use for issuing certificates.
+  #
+  # <Admonition type="note" title="Configuring an Issuer">
+  # You must install and configure an appropriate `Issuer` supporting a DNS01 challenge yourself.
+  #
+  # Please see the [cert-manager DNS01 docs](https://cert-manager.io/docs/configuration/acme/dns01/#supported-dns01-providers) and the relevant sections
+  # of the [AWS](../../zero-trust-access/deploy-a-cluster/helm-deployments/aws.mdx) and [GCP](../../zero-trust-access/deploy-a-cluster/helm-deployments/gcp.mdx) guides for more information.
+  # </Admonition>
+  issuerName: ""
+  # certManager.issuerKind(string) -- is the `Kind` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+  # Defaults to 'Issuer' to keep permissions scoped to the plugin's namespace.
+  issuerKind: Issuer
+  # certManager.issuerGroup(string) -- is the `Group` of the `Issuer` to be used when issuing certificates with `cert-manager`.
+  # Defaults to 'cert-manager.io' to use built-in issuers.
+  issuerGroup: cert-manager.io
+  # certManager.dnsNames(list) -- is the DNS names for the Fluentd forwarder, populating the SANs extension of the server certificate.
+  dnsNames: []
+  # certManager.ipAddresses(list) -- is the IP addresses for the Fluentd forwarder, populating the SANs extension of the server certificate.
+  ipAddresses: []
+  # certManager.ttl(string) -- is the time-to-live duration for the TLS certificates. Defaults to 87600 hours (10 years).
+  ttl: "87600h"
+  # certManager.renewBefore(string) -- is the time before `certManager.ttl` to renew the TLS certificates.
+  # This must be less than `certManager.ttl`. When empty, defaults to 1/3 of the issued
+  # certificate's time-to-live duration. For example, if a certificate is valid for 60 minutes,
+  # `cert-manager` will renew the certificate 20 minutes before expiration.
+  renewBefore: ""
+  # certManager.length(int) -- is the RSA key length. Defaults to 4096.
+  length: 4096
+
 persistentVolumeClaim:
   enabled: false
   size: 1Gi
@@ -237,6 +281,9 @@ annotations:
   deployment: {}
   # annotations.pod(object) -- are annotations to set on the Pods.
   pod: {}
+  # annotations.certSecret(object) --  are annotations to set on the certificate secrets
+  # generated by cert-manager v1.5+ when `certManager.enabled` is true
+  certSecret: {}
   
 # extraLabels -- contains additional Kubernetes labels to apply on the resources
 # created by the chart. See [the Kubernetes label documentation
@@ -249,6 +296,9 @@ extraLabels:
   deployment: {}
   # extraLabels.pod(object) -- are labels to set on the Pods.
   pod: {}
+  # extraLabels.certSecret(object) -- are labels to set on the certificate secrets
+  # generated by cert-manager v1.5+ when `certManager.enabled` is true.
+  certSecret: {}
 
 #
 # Deployment


### PR DESCRIPTION
Part of #60411

This PR adds an opt-in feature for `teleport-plugin-event-handler` chart to use `cert-manager` certificates for the mTLS connection between the event handler and Fluentd endpoint.

Context: To establish mTLS connection between the event handler client and Fluentd server, you need Fluentd client and server certificates. The original `teleport-event-handler configure` command creates this for the user, to then mount the client certificate to a Kubernetes Secret for the event handler client to use. With this PR, you can use the `cert-manager` chart to create the mTLS certificates within the helm configuration file, eliminating the need to run a remote binary.

Users need to set up `cert-manager` in Kubernetes cluster on their own. The chart can create a CA Issuer to issue the mTLS certificates via `certManager.issuer.create`. Otherwise, the user can specify their own private CA Issuer.
The server credentials (ca cert, server cert/key) are stored in `teleport-plugin-event-handler-server-tls` Secret, and the  client credentials (ca cert, client cert/key) are stored in `teleport-plugin-event-handler-client-tls` Secret.

The `teleport-plugin-event-handler` should be installed in the same namespace as Fluentd, so the generated server Secret can be directly mounted into `fluent.conf`. Otherwise, the user can set up the Fluentd's server credentials externally and not use the chart's generated server Secret.

<details><summary>values.yaml</summary>
<p>

```yaml
certManager:
  enabled: true
  issuer:
    # certManager.issuer.create creates a CA Issuer that uses a self-signed root certificate. 
    # This is fine since event handler and Fluentd establish an internal mTLS connection.
    create: true
  dnsNames: ["fluentd.fluentd.svc.cluster.local"]
  ipAddresses: []

fluentd:
  url: "https://fluentd.fluentd.svc.cluster.local:8888/events.log"
  sessionUrl: "https://fluentd.fluentd.svc.cluster.local:8888/session"
# fluentd.certificate is untouched if using cert-manager
  certificate:
    secretName: ""
    caPath: "ca.crt"
    certPath: "client.crt"
    keyPath: "client.key"
```

</p>
</details> 

<details><summary>Manual Tests</summary>
<p>

- [x]  When `certManager.enabled: true`:
    - [x]  When `certManager.issuer.create: true`:
       - [x] Verify Issuer/Certificate resources for the CA Issuer are created in Kubernetes cluster
    - [x]  Verify `certManager` Certificate resources are created in Kubernetes cluster
    - [x]  Verify Kubernetes Secret resources are created, one for (fluentd ca cert, server cert, server key), and one for (fluentd ca cert, client cert, client key)
- [x]  Verify no `cert-manager` Certificate is created when `certManager.enabled: false`
- [x]  Verify `teleport-plugin-event-handler` begins forwarding audit events to the fluentd forwarder

</p>
</details>

changelog: Added opt-in support to use `cert-manager` certificates for `teleport-plugin-event-handler` helm chart