### PR TITLE
Update example installer script

### DIFF
--- a/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-provider/resources/installer.mdx
@@ -32,61 +32,36 @@ resource "teleport_installer" "example" {
   }
 
   spec = {
-    # This is the default installer script. Edit it to customize the commands
-    # that the Teleport Discovery Service configures virtual machines to run to
-    # install Teleport on startup.
+    # This "custom" script is actually the default installer script ($ tctl get installer/default-installer).
+    # Edit it to customize the commands that the Teleport Discovery Service
+    # configures virtual machines to run to install Teleport on startup.
     script = <<EOF
 #!/usr/bin/env sh
 set -eu
 
-cdnBaseURL='https://cdn.teleport.dev'
-teleportVersion='v{{.MajorVersion}}'
-teleportFlavor='teleport-ent' # teleport or teleport-ent
-successMessage='Teleport is installed and running.'
-teleportArgs='install autodiscover-node --public-proxy-addr={{.PublicProxyAddr}} --teleport-package={{.TeleportPackage}} --repo-channel={{.RepoChannel}} --auto-upgrade={{.AutomaticUpgrades}} --azure-client-id={{.AzureClientID}}'
 
-# shellcheck disable=all
-# Use $HOME or / as base dir
-tempDir=$(mktemp -d -p $${HOME:-}/)
-OS=$(uname -s)
-ARCH=$(uname -m)
-# shellcheck enable=all
+INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
 
-trap 'rm -rf -- "$tempDir"' EXIT
+echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
 
-teleportTarballName() {
-    if [ $${OS} = "Darwin" ]; then
-        echo $${teleportFlavor}-$${teleportVersion}-darwin-universal-bin.tar.gz
-        return 0
-    fi;
+TEMP_INSTALLER_SCRIPT="$(mktemp)"
+curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
-    if [ $${OS} != "Linux" ]; then
-        echo "Only MacOS and Linux are supported." >&2
-        return 1
-    fi;
+chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-    if [ $${ARCH} = "armv7l" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-arm-bin.tar.gz"
-    elif [ $${ARCH} = "aarch64" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-arm64-bin.tar.gz"
-    elif [ $${ARCH} = "x86_64" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-amd64-bin.tar.gz"
-    elif [ $${ARCH} = "i686" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-386-bin.tar.gz"
-    else
-        echo "Invalid Linux architecture $${ARCH}." >&2
-        return 1
-    fi;
+sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+rm "$TEMP_INSTALLER_SCRIPT"
+
+
+echo "Configuring the Teleport agent"
+
+set +x
+TELEPORT_BINARY=/usr/local/bin/teleport
+[ -z "$${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/$${TELEPORT_INSTALL_SUFFIX}/bin/teleport
+
+sudo -E "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr={{.PublicProxyAddr}} --teleport-package={{.TeleportPackage}} --repo-channel={{.RepoChannel}} --auto-upgrade={{.AutomaticUpgrades}} --azure-client-id={{.AzureClientID}} $@
+  }
 }
-
-main() {
-    tarballName=$(teleportTarballName)
-    echo "Downloading from $${cdnBaseURL}/$${tarballName} and extracting teleport to $${tempDir} ..."
-    curl --show-error --fail --location $${cdnBaseURL}/$${tarballName} | tar xzf - -C $${tempDir} $${teleportFlavor}/teleport
-
-    mkdir -p $${tempDir}/bin
-    mv $${tempDir}/$${teleportFlavor}/teleport $${tempDir}/bin/teleport
-    echo "> $${tempDir}/bin/teleport $${teleportArgs} $@"
-    sudo $${tempDir}/bin/teleport $${teleportArgs} $@ && echo $successMessage
-}
-
-main $@
 EOF
   }
 }

--- a/integrations/terraform/examples/resources/teleport_installer/resource.tf
+++ b/integrations/terraform/examples/resources/teleport_installer/resource.tf
@@ -11,61 +11,36 @@ resource "teleport_installer" "example" {
   }
 
   spec = {
-    # This is the default installer script. Edit it to customize the commands
-    # that the Teleport Discovery Service configures virtual machines to run to
-    # install Teleport on startup.
+    # This "custom" script is actually the default installer script ($ tctl get installer/default-installer).
+    # Edit it to customize the commands that the Teleport Discovery Service
+    # configures virtual machines to run to install Teleport on startup.
     script = <<EOF
 #!/usr/bin/env sh
 set -eu
 
-cdnBaseURL='https://cdn.teleport.dev'
-teleportVersion='v{{.MajorVersion}}'
-teleportFlavor='teleport-ent' # teleport or teleport-ent
-successMessage='Teleport is installed and running.'
-teleportArgs='install autodiscover-node --public-proxy-addr={{.PublicProxyAddr}} --teleport-package={{.TeleportPackage}} --repo-channel={{.RepoChannel}} --auto-upgrade={{.AutomaticUpgrades}} --azure-client-id={{.AzureClientID}}'
 
-# shellcheck disable=all
-# Use $HOME or / as base dir
-tempDir=$(mktemp -d -p $${HOME:-}/)
-OS=$(uname -s)
-ARCH=$(uname -m)
-# shellcheck enable=all
+INSTALL_SCRIPT_URL="https://{{.PublicProxyAddr}}/scripts/install.sh"
 
-trap 'rm -rf -- "$tempDir"' EXIT
+echo "Offloading the installation part to the generic Teleport install script hosted at: $INSTALL_SCRIPT_URL"
 
-teleportTarballName() {
-    if [ $${OS} = "Darwin" ]; then
-        echo $${teleportFlavor}-$${teleportVersion}-darwin-universal-bin.tar.gz
-        return 0
-    fi;
+TEMP_INSTALLER_SCRIPT="$(mktemp)"
+curl -sSf "$INSTALL_SCRIPT_URL" -o "$TEMP_INSTALLER_SCRIPT"
 
-    if [ $${OS} != "Linux" ]; then
-        echo "Only MacOS and Linux are supported." >&2
-        return 1
-    fi;
+chmod +x "$TEMP_INSTALLER_SCRIPT"
 
-    if [ $${ARCH} = "armv7l" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-arm-bin.tar.gz"
-    elif [ $${ARCH} = "aarch64" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-arm64-bin.tar.gz"
-    elif [ $${ARCH} = "x86_64" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-amd64-bin.tar.gz"
-    elif [ $${ARCH} = "i686" ]; then echo "$${teleportFlavor}-$${teleportVersion}-linux-386-bin.tar.gz"
-    else
-        echo "Invalid Linux architecture $${ARCH}." >&2
-        return 1
-    fi;
+sudo -E "$TEMP_INSTALLER_SCRIPT" || (echo "The install script ($TEMP_INSTALLER_SCRIPT) returned a non-zero exit code" && exit 1)
+rm "$TEMP_INSTALLER_SCRIPT"
+
+
+echo "Configuring the Teleport agent"
+
+set +x
+TELEPORT_BINARY=/usr/local/bin/teleport
+[ -z "$${TELEPORT_INSTALL_SUFFIX:-}" ] || TELEPORT_BINARY=/opt/teleport/$${TELEPORT_INSTALL_SUFFIX}/bin/teleport
+
+sudo -E "$TELEPORT_BINARY" install autodiscover-node --public-proxy-addr={{.PublicProxyAddr}} --teleport-package={{.TeleportPackage}} --repo-channel={{.RepoChannel}} --auto-upgrade={{.AutomaticUpgrades}} --azure-client-id={{.AzureClientID}} $@
+  }
 }
-
-main() {
-    tarballName=$(teleportTarballName)
-    echo "Downloading from $${cdnBaseURL}/$${tarballName} and extracting teleport to $${tempDir} ..."
-    curl --show-error --fail --location $${cdnBaseURL}/$${tarballName} | tar xzf - -C $${tempDir} $${teleportFlavor}/teleport
-
-    mkdir -p $${tempDir}/bin
-    mv $${tempDir}/$${teleportFlavor}/teleport $${tempDir}/bin/teleport
-    echo "> $${tempDir}/bin/teleport $${teleportArgs} $@"
-    sudo $${tempDir}/bin/teleport $${teleportArgs} $@ && echo $successMessage
-}
-
-main $@
 EOF
   }
 }


### PR DESCRIPTION
The original example doesn't work anymore and it's not clear to me if it ever worked.

I updated it to match the current default installer and I tested (with real terraform config) that it worked to auto-discover Azure VMs.