### PR TITLE
MWI: Add a troubleshooting note for blocked proxies, clarify outputs

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -515,6 +515,7 @@
     "envfile",
     "enzos",
     "errcode",
+    "errgroup",
     "etcdctl",
     "evtx",
     "exadata",

--- a/docs/pages/machine-workload-identity/troubleshooting.mdx
+++ b/docs/pages/machine-workload-identity/troubleshooting.mdx
@@ -358,3 +358,63 @@ To fix this, set a variable of `TBOT_USE_PROXY_ADDR=yes` in the environment of t
 `tbot` process. This configures `tbot` to prefer using the address that you have
 explicitly provided. This only functions correctly in cases where TLS
 routing/multiplexing is enabled for the Teleport cluster.
+
+## Using `tbot` in an environment without an accessible Teleport Proxy Service
+
+By default, when using the `identity` output service, the `tbot` client queries
+the Proxy Service to fetch information about available Teleport clusters,
+including any available [leaf clusters](../core-concepts.mdx#trusted-clusters),
+which is required to generate a usable `ssh_config`.
+
+If running in an environment where `tbot` is configured to communicate directly
+with the Teleport Auth Service via the `auth_server` configuration option, but
+cannot communicate with the Teleport Proxy Service, the identity output service
+will fail to generate an `ssh_config` with an error like the following:
+
+```
+2026-01-21T18:11:16.320-07:00 ERRO [TBOT:PROX] Failed to ping proxy error:[
+ERROR REPORT:
+Original Error: *url.Error Get &#34;https://teleport.example.com:443/webapi/find&#34;: dial tcp 1.2.3.4:443: connect: connection refused
+Stack Trace:
+	github.com/gravitational/teleport/api@v0.0.0/client/webclient/webclient.go:167 github.com/gravitational/teleport/api/client/webclient.doWithFallback
+	github.com/gravitational/teleport/api@v0.0.0/client/webclient/webclient.go:218 github.com/gravitational/teleport/api/client/webclient.findWithClient
+	github.com/gravitational/teleport/api@v0.0.0/client/webclient/webclient.go:192 github.com/gravitational/teleport/api/client/webclient.Find
+	github.com/gravitational/teleport/lib/tbot/internal/caching_proxy_pinger.go:104 github.com/gravitational/teleport/lib/tbot/internal.(*CachingProxyPinger).Ping
+	github.com/gravitational/teleport/lib/tbot/services/identity/output.go:198 github.com/gravitational/teleport/lib/tbot/services/identity.(*OutputService).generate
+	github.com/gravitational/teleport/lib/tbot/internal/loop.go:161 github.com/gravitational/teleport/lib/tbot/internal.RunOnInterval
+	github.com/gravitational/teleport/lib/tbot/services/identity/output.go:113 github.com/gravitational/teleport/lib/tbot/services/identity.(*OutputService).Run
+	github.com/gravitational/teleport/lib/tbot/bot/bot.go:103 github.com/gravitational/teleport/lib/tbot/bot.(*Bot).Run.func2
+	golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93 golang.org/x/sync/errgroup.(*Group).Go.func1
+	runtime/asm_amd64.s:1693 runtime.goexit
+User Message: Get &#34;https://teleport.example.com:443/webapi/find&#34;: dial tcp 1.2.3.4:443: connect: connection refused] internal/caching_proxy_pinger.go:110
+```
+
+As in many cases the `ssh_config` is required for downstream applications to
+function, this is expected behavior. However, if you do not require the
+`ssh_config`, you can disable it by setting `ssh_config: "off"` in the settings
+for your identity output service:
+
+```yaml
+version: v2
+auth_server: teleport.example.com:3025
+onboarding:
+  token: '...snip...'
+  join_method: token
+storage:
+  type: directory
+  path: ./storage
+services:
+  - type: identity
+    destination:
+      type: directory
+      path: ./destination
+    ssh_config: "off"
+```
+
+If desired, you can [read more about the identity output service config
+options](../reference/machine-workload-identity/configuration.mdx#identity).
+
+Note that other `tbot` services may also attempt to connect to the Proxy
+Service, and may fail similarly if blocked. For best compatibility, the `tbot`
+client should generally be given network access to the Proxy Service, even if
+configured to connect to the Auth Service directly.

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -153,23 +153,22 @@ storage:
   type: directory
   path: /var/lib/teleport/bot
 
-# outputs specifies what artifacts `tbot` should generate and renew when it
-# runs.
-#
-# See the full list of supported outputs and their configuration options
-# under the Outputs section of this reference page.
-outputs:
-  - type: identity
-    destination:
-      type: directory
-      path: /opt/machine-id
-
 # services specify which `tbot` sub-services should be enabled and how they
 # should be configured.
 #
 # See the full list of supported services and their configuration options
 # under the Services section of this reference page.
 services:
+  - type: identity
+    destination:
+      type: directory
+      path: /opt/machine-id
+
+# outputs is synonymous to `services` and exists for legacy compatibility. All
+# services specified in both `services` and `outputs` will be enabled. You
+# should not duplicate any entries between the two fields, and should prefer to
+# keep configuration within the `services` field where possible.
+outputs:
   - type: example
 ```
 
@@ -207,11 +206,11 @@ services:
       path: ./tbot-user
 ```
 
-## Outputs
+## Output Services
 
-Outputs define what actions `tbot` should take when it runs. They describe
-the format of the certificates to be generated, the roles used to generate the certificates, and the
-destination where they should be written.
+Output services define what actions `tbot` should take when it runs. They
+describe the format of the certificates to be generated, the roles used to
+generate the certificates, and the destination where they should be written.
 
 There are multiple types of output. Select the one that is most appropriate for
 your intended use-case.
@@ -769,9 +768,9 @@ svid:
 ## Services
 
 Services are configurable long-lived components that run within `tbot`. Unlike
-Outputs, they may not necessarily generate artifacts. Typically, services
-provide supporting functionality for machine to machine access, for example,
-opening tunnels or providing APIs.
+Output Services, they may not necessarily generate artifacts. Typically,
+services provide supporting functionality for machine to machine access, for
+example, opening tunnels or providing APIs.
 
 ### `workload-identity-api`
 

--- a/docs/pages/reference/machine-workload-identity/configuration.mdx
+++ b/docs/pages/reference/machine-workload-identity/configuration.mdx
@@ -217,7 +217,7 @@ your intended use-case.
 
 ### `identity`
 
-The `identity` output can be used to authenticate:
+The `identity` output service can be used to authenticate:
 
 - SSH access to your Teleport servers, using `tsh`, openssh and tools like
   ansible.
@@ -248,8 +248,8 @@ allow_reissue: false
 
 ### `application`
 
-The `application` output is used to generate credentials that can be used to
-access applications that have been configured with Teleport.
+The `application` output service is used to generate credentials that can be
+used to access applications that have been configured with Teleport.
 
 See the [Machine & Workload Identity with Applications guide](../../machine-workload-identity/access-guides/applications.mdx)
 to see the `application` output used in context.
@@ -268,8 +268,8 @@ app_name: grafana
 
 ### `database`
 
-The `database` output is used to generate credentials that can be used to
-access databases that have been configured with Teleport.
+The `database` output service is used to generate credentials that can be used
+to access databases that have been configured with Teleport.
 
 See the [Machine & Workload Identity with Databases guide](../../machine-workload-identity/access-guides/databases.mdx)
 to see the `database` output used in context.
@@ -341,8 +341,8 @@ disable_exec_plugin: false
 
 ### `kubernetes/v2`
 
-The `kubernetes/v2` output type can be used to access many Kubernetes clusters
-as individual contexts within the same `kubeconfig.yaml`.
+The `kubernetes/v2` output service can be used to access many Kubernetes
+clusters as individual contexts within the same `kubeconfig.yaml`.
 
 ```yaml
 type: kubernetes/v2
@@ -435,8 +435,8 @@ by restarting `tbot`, or signaling it with `pkill -usr1 tbot`.
 
 ### `kubernetes/argo-cd`
 
-The `kubernetes/argo-cd` output type can be used to enable Argo CD to securely
-connect to external Kubernetes clusters.
+The `kubernetes/argo-cd` output service can be used to enable Argo CD to
+securely connect to external Kubernetes clusters.
 
 It works by "declaratively" managing cluster credentials
 [using Kubernetes secrets](https://argo-cd.readthedocs.io/en/release-1.8/operator-manual/declarative-setup/#clusters).
@@ -562,11 +562,11 @@ name: my-service-name
 
 ### `ssh_host`
 
-The `ssh_host` output is used to generate the artifacts required to configure
-an OpenSSH server with Teleport in order to allow Teleport users to connect to
-it.
+The `ssh_host` output service is used to generate the artifacts required to
+configure an OpenSSH server with Teleport in order to allow Teleport users to
+connect to it.
 
-The output generates the following artifacts:
+The output service generates the following artifacts:
 - `ssh_host-cert.pub`: an SSH certificate signed by the Teleport host certificate authority.
 - `ssh_host`: the private key associated with the SSH host certificate.
 - `ssh_host-user-ca.pub`: an export of the Teleport user certificate authority in an OpenSSH compatible format.
@@ -585,8 +585,8 @@ principals:
 
 ### `workload-identity-x509`
 
-The `workload-identity-x509` output is used to issue an X509 workload identity
-credential and write this to a configured destination.
+The `workload-identity-x509` output service is used to issue an X509 workload
+identity credential and write this to a configured destination.
 
 The output generates the following artifacts:
 
@@ -607,7 +607,7 @@ type: workload-identity-x509
 
 ### `workload-identity-jwt`
 
-The `workload-identity-jwt` output is used to issue a JWT workload identity
+The `workload-identity-jwt` output service used to issue a JWT workload identity
 credential and write this to a configured destination.
 
 The JWT workload identity credential is compatible with the [SPIFFE JWT SVID
@@ -638,14 +638,14 @@ audiences:
 
 ### `workload-identity-aws-roles-anywhere`
 
-The `workload-identity-aws-roles-anywhere` output is used to issue an X509
+The `workload-identity-aws-roles-anywhere` output service used to issue an X509
 workload identity credential, exchange this for short-lived AWS credentials
 using Roles Anywhere, and write these to a configured destination.
 
 The credentials are written in the [AWS shared credentials file format](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html#file-format-creds),
 which is compatible with the AWS CLI and SDKs.
 
-The output generates the following artifacts:
+The output service generates the following artifacts:
 
 - `aws_credentials`: the CLI and SDK compatible AWS shared credentials file.
 


### PR DESCRIPTION
This adds a section to the troubleshooting page for using tbot when the proxy is inaccessible (but auth is available). The proxy requirement was technically noted in the config reference, but was easy to miss and not really possible to find in reverse if you were experiencing the issue already.

It also tweaks some of the phrasing on the configuration reference to refer to outputs as output services, which came up in the same support interaction.

See also: #63051