### PR TITLE
docs: Add description to Public Certificates & Encryption Keys page

### DIFF
--- a/docs/pages/reference/public-certificates.mdx
+++ b/docs/pages/reference/public-certificates.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Public Certificates & Encryption Keys"
+description: "Provides certificates and public keys used to sign Teleport software."
 ---
 
 We use the following certificates and public keys to sign our software. Many of


### PR DESCRIPTION
While browsing the docs, I discovered that the auto-generated description for this page that's visible on https://goteleport.com/docs/reference/ is pretty bad:

> We use the following certificates and public keys to sign our software. Many of

This PR fixes this by adding a specific description, following the format of other pages from the References section.