### PR TITLE
Add inference resource access controls to UserACL

### DIFF
--- a/lib/services/useracl.go
+++ b/lib/services/useracl.go
@@ -128,6 +128,12 @@ type UserACL struct {
 	WorkloadIdentity ResourceAccess `json:"workloadIdentity"`
 	// ClientIPRestriction defines access to Cloud IP Restrictions
 	ClientIPRestriction ResourceAccess `json:"clientIpRestriction"`
+	// InferenceModel defines access to session summaries inference model.
+	InferenceModel ResourceAccess `json:"inferenceModel"`
+	// InferencePolicy defines access to session summaries inference policy.
+	InferencePolicy ResourceAccess `json:"inferencePolicy"`
+	// InferenceSecret defines access to session summaries inference secret.
+	InferenceSecret ResourceAccess `json:"inferenceSecret"`
 }
 
 func hasAccess(roleSet RoleSet, ctx *Context, kind string, verbs ...string) bool {
@@ -287,5 +293,8 @@ func NewUserACL(user types.User, userRoles RoleSet, features proto.Features, des
 		GitServers:              gitServersAccess,
 		WorkloadIdentity:        workloadIdentity,
 		ClientIPRestriction:     clientIPRestrictions,
+		InferenceModel:          newAccess(userRoles, ctx, types.KindInferenceModel),
+		InferencePolicy:         newAccess(userRoles, ctx, types.KindInferencePolicy),
+		InferenceSecret:         newAccess(userRoles, ctx, types.KindInferenceSecret),
 	}
 }

--- a/lib/services/useracl_test.go
+++ b/lib/services/useracl_test.go
@@ -59,6 +59,18 @@ func TestNewUserACL(t *testing.T) {
 			Resources: []string{types.KindClientIPRestriction},
 			Verbs:     RW(),
 		},
+		{
+			Resources: []string{types.KindInferenceModel},
+			Verbs:     RW(),
+		},
+		{
+			Resources: []string{types.KindInferencePolicy},
+			Verbs:     RW(),
+		},
+		{
+			Resources: []string{types.KindInferenceSecret},
+			Verbs:     RW(),
+		},
 	})
 
 	// not setting the rule, or explicitly denying, both denies Access
@@ -116,6 +128,10 @@ func TestNewUserACL(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.GitServers, denied))
 	// cloud IP restrictions should be denied because features doesn't include Cloud
 	require.Empty(t, cmp.Diff(userContext.ClientIPRestriction, denied))
+
+	require.Empty(t, cmp.Diff(userContext.InferenceModel, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.InferencePolicy, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.InferenceSecret, allowedRW))
 
 	// test enabling of the 'Use' verb
 	require.Empty(t, cmp.Diff(userContext.Integrations, ResourceAccess{true, true, true, true, true, true}))


### PR DESCRIPTION
Extends UserACL with InferenceModel, InferencePolicy, and InferenceSecret resource access controls to support session summaries inference features.