### PR TITLE
Update CRL on CA resource changes

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -1367,9 +1367,13 @@ func (m *monitorErrorSender) WriteString(s string) (n int, err error) {
 	return len(s), nil
 }
 
-// runCRLUpdateLoop publishes the Certificate Revocation List to the given
-// LDAP server. It continues to do so every 5 minutes (by default) to make sure it is present
-// and in the correct location.
+// runCRLUpdateLoop publishes the Certificate Revocation List to the given LDAP
+// server.
+//
+// It publishes all known CRLs of the WindowsCA:
+//   - Immediately, once called,
+//   - Periodically, as defined by PublishCRLInterval; and
+//   - Whenever the CA is updated, using a types.Watcher.
 func (s *WindowsService) runCRLUpdateLoop() {
 	t := s.cfg.Clock.NewTicker(retryutils.SeventhJitter(s.cfg.PublishCRLInterval))
 	defer t.Stop()

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -106,6 +106,12 @@ var computerAttributes = []string{
 	attrPrimaryGroupID,
 }
 
+// certificateStoreClient is a stand in interface for
+// winpki.certificateStoreClient.
+type certificateStoreClient interface {
+	Update(ctx context.Context, tc *tls.Config) error
+}
+
 // WindowsService implements the RDP-based Windows desktop access service.
 //
 // This service accepts mTLS connections from the proxy, establishes RDP
@@ -115,7 +121,7 @@ type WindowsService struct {
 	cfg        WindowsServiceConfig
 	middleware *authz.Middleware
 
-	ca *winpki.CertificateStoreClient
+	ca certificateStoreClient
 
 	// lastDiscoveryResults stores the results of the most recent LDAP search
 	// when desktop discovery is enabled.

--- a/lib/srv/desktop/windows_server_test.go
+++ b/lib/srv/desktop/windows_server_test.go
@@ -23,6 +23,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/base32"
 	"io"
@@ -33,6 +34,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -46,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/tlsca"
 	logutils "github.com/gravitational/teleport/lib/utils/log"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/winpki"
 )
 
@@ -555,4 +558,156 @@ func TestLoadTLSConfigForLDAP(t *testing.T) {
 			require.NotNil(t, cfg)
 		}
 	})
+}
+
+func TestCRLUpdateSchedule(t *testing.T) {
+	t.Parallel()
+
+	const clusterName = "zarq"
+	clock := clockwork.NewFakeClock()
+	testAuth, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: clusterName,
+		Clock:       clock,
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, testAuth.Close()) })
+
+	var runCRLLoopWG sync.WaitGroup
+	// IMPORTANT! Must t.Cleanup before "cancel" (ie, cancel() needs to happen
+	// first).
+	t.Cleanup(func() {
+		t.Log("Waiting for runCRLUpdateLoop() WaitGroup")
+		runCRLLoopWG.Wait()
+	})
+
+	wsCtx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	caClient := newMockCertificateStoreClient(t)
+	const publishInterval = 5 * time.Minute // Arbitrary. We use fake time.
+
+	// Create a "fake" WindowsService instance. This only needs enough setup to do
+	// runCRLUpdateLoop().
+	winService := &WindowsService{
+		cfg: WindowsServiceConfig{
+			Logger:             logtest.NewLogger(),
+			Clock:              clock,
+			AccessPoint:        testAuth.AuthServer,
+			PublishCRLInterval: publishInterval,
+		},
+		// Mock the actual CRL publishing.
+		ca: caClient,
+		// Short-circuit the "loadTLSConfigForLDAPlogic.
+		ldapTLSConfig:          &tls.Config{},
+		ldapTLSConfigExpiresAt: clock.Now().Add(1000000 * time.Hour), // Arbitrary. "Never" expires.
+		// ctx for background methods.
+		closeCtx: wsCtx,
+		close:    cancel,
+	}
+
+	runCRLLoopWG.Go(func() {
+		t.Log("Calling runCRLUpdateLoop()")
+		winService.runCRLUpdateLoop()
+	})
+
+	var wantUpdates int
+	waitForNextCRLUpdate := func(t *testing.T) {
+		wantUpdates++
+		caClient.WaitForUpdate(t, wantUpdates)
+	}
+
+	// First run of the loop invokes the update right away.
+	waitForNextCRLUpdate(t)
+
+	t.Run("update by elapsed time", func(t *testing.T) {
+		// Don't t.Parallel().
+
+		clock.Advance(publishInterval)
+		waitForNextCRLUpdate(t)
+	})
+
+	t.Run("update by CA event", func(t *testing.T) {
+		// Don't t.Parallel().
+
+		ctx := t.Context()
+		authServer := testAuth.AuthServer
+
+		// Fetch current WindowsCA.
+		id := types.CertAuthID{
+			Type:       types.WindowsCA,
+			DomainName: clusterName,
+		}
+		ca, err := authServer.GetCertAuthority(ctx, id, true /* loadKeys */)
+		require.NoError(t, err)
+
+		// Simulate a rotation by addding an entry to AdditionalTrustedKeys.
+		keyPEM, certPEM, err := tlsca.GenerateSelfSignedCA(pkix.Name{
+			Organization: []string{clusterName},
+			CommonName:   clusterName,
+		}, nil /* dnsNames */, 1*time.Hour /* ttl */)
+		require.NoError(t, err)
+		atk := ca.GetAdditionalTrustedKeys()
+		atk.TLS = append(atk.TLS, &types.TLSKeyPair{
+			Cert: certPEM,
+			Key:  keyPEM,
+			CRL:  []byte("fake CRL"),
+		})
+		require.NoError(t, ca.SetAdditionalTrustedKeys(atk))
+
+		// Update. This generates a CA event.
+		t.Log("Calling UpdateCertAuthority")
+		_, err = authServer.UpdateCertAuthority(ctx, ca)
+		require.NoError(t, err)
+
+		waitForNextCRLUpdate(t)
+	})
+}
+
+type mockCertificateStoreClient struct {
+	logf func(string, ...any)
+
+	mu       sync.Mutex
+	wait     chan struct{} // waits on the next numCalls update
+	numCalls int
+}
+
+func newMockCertificateStoreClient(t *testing.T) *mockCertificateStoreClient {
+	c := &mockCertificateStoreClient{
+		logf: t.Logf,
+		wait: make(chan struct{}),
+	}
+	return c
+}
+
+func (c *mockCertificateStoreClient) Update(ctx context.Context, tc *tls.Config) error {
+	c.mu.Lock()
+	c.numCalls++
+	close(c.wait)
+	c.wait = make(chan struct{})
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *mockCertificateStoreClient) WaitForUpdate(t *testing.T, wantCalls int) {
+	// Arbitrary. 1s should be plenty of time for a mocked update.
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+	defer cancel()
+
+	for {
+		c.mu.Lock()
+		if c.numCalls == wantCalls {
+			c.mu.Unlock()
+			return
+		}
+		ch := c.wait
+		c.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			t.Fatal("Timed out before update")
+		case <-ch:
+			continue
+		}
+	}
 }

--- a/lib/winpki/certificate_authority.go
+++ b/lib/winpki/certificate_authority.go
@@ -83,18 +83,27 @@ func (c *CertificateStoreClient) Update(ctx context.Context, tc *tls.Config) err
 		return trace.Wrap(err)
 	}
 	for _, ca := range certAuthorities {
-		for _, keyPair := range ca.GetActiveKeys().TLS {
-			if len(keyPair.CRL) == 0 {
-				continue
-			}
+		for _, keySet := range [][]*types.TLSKeyPair{
+			ca.GetActiveKeys().TLS,
+			ca.GetAdditionalTrustedKeys().TLS,
+		} {
+			for _, keyPair := range keySet {
+				if len(keyPair.CRL) == 0 {
+					continue
+				}
 
-			cert, err := tlsca.ParseCertificatePEM(keyPair.Cert)
-			if err != nil {
-				return trace.Wrap(err)
-			}
+				cert, err := tlsca.ParseCertificatePEM(keyPair.Cert)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				c.cfg.Logger.DebugContext(ctx, "Processing CA key pair",
+					"issuer", cert.Issuer,
+					"subject", cert.Subject,
+				)
 
-			if err := c.updateCRL(ctx, c.cfg.ClusterName, cert.SubjectKeyId, keyPair.CRL, caType, tc); err != nil {
-				return trace.Wrap(err)
+				if err := c.updateCRL(ctx, c.cfg.ClusterName, cert.SubjectKeyId, keyPair.CRL, caType, tc); err != nil {
+					return trace.Wrap(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Update Windows LDAP CRLs based on CA events.

This should tighten the loop during CA rotations, making the CRL readily available instead of [the usual 5m interval][1] in which the loop executes. CRLs are key component of (LDAP-based) Windows Desktop Access, without the CRL any RDP connection attempts will fail.

Tested manually against an LDAP/AD-based Windows Desktop setup, in addition to the mocked/automated tests.

#10111

[1]: https://github.com/gravitational/teleport/blob/a4e15ad9b3f0e4460c09cbcd0e48460c539f447c/lib/srv/desktop/windows_server.go#L251