### PR TITLE
TDPB Teleport Connect

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -524,8 +524,8 @@ func (c *Client) ClusterDetails(ctx context.Context) (ClusterDetails, error) {
 
 // ProxyWindowsDesktopSession establishes a connection to the target desktop over a bidirectional stream.
 // The caller is required to pass a valid desktop certificate.
-func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, windowsDesktopCert tls.Certificate, rootCAs *x509.CertPool) (*tls.Conn, error) {
-	session, err := c.transport.ProxyWindowsDesktopSession(ctx, cluster, desktopName, windowsDesktopCert, rootCAs)
+func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, windowsDesktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
+	session, err := c.transport.ProxyWindowsDesktopSession(ctx, cluster, desktopName, windowsDesktopCert, rootCAs, protocol)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -18,7 +18,6 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"encoding/asn1"
 	"net"
 	"slices"
@@ -524,8 +523,8 @@ func (c *Client) ClusterDetails(ctx context.Context) (ClusterDetails, error) {
 
 // ProxyWindowsDesktopSession establishes a connection to the target desktop over a bidirectional stream.
 // The caller is required to pass a valid desktop certificate.
-func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, windowsDesktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
-	session, err := c.transport.ProxyWindowsDesktopSession(ctx, cluster, desktopName, windowsDesktopCert, rootCAs, protocol)
+func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, config transportv1.WindowsDesktopSessionConfig) (*tls.Conn, error) {
+	session, err := c.transport.ProxyWindowsDesktopSession(ctx, config)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/api/client/proxy/transport/transportv1/client.go
+++ b/api/client/proxy/transport/transportv1/client.go
@@ -118,6 +118,7 @@ func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel cont
 	conn := streamutils.NewConn(desktopReadWriter, &net.TCPAddr{}, &net.TCPAddr{})
 	tlsConfig := &tls.Config{
 		ServerName:   desktopName + DesktopSNISuffix,
+		NextProtos:   []string{"teleport-tdpb-1.0"},
 		Certificates: []tls.Certificate{desktopCert},
 		RootCAs:      rootCAs,
 	}

--- a/api/client/proxy/transport/transportv1/client.go
+++ b/api/client/proxy/transport/transportv1/client.go
@@ -72,9 +72,19 @@ const (
 	DesktopSNISuffix = ".desktop." + constants.APIDomain
 )
 
+// WindowsDesktopSessionConfig defines configuration parameters
+// required to proxy a Windows desktop connection.
+type WindowsDesktopSessionConfig struct {
+	Cluster     string
+	DesktopName string
+	DesktopCert tls.Certificate
+	RootCAs     *x509.CertPool
+	Protocol    string
+}
+
 // ProxyWindowsDesktopSession establishes a connection to the target desktop over a bidirectional stream.
 // The caller is required to pass a valid desktop certificate.
-func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
+func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, config WindowsDesktopSessionConfig) (*tls.Conn, error) {
 	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	stop := context.AfterFunc(ctx, cancel)
 	defer stop()
@@ -85,7 +95,7 @@ func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string,
 		return nil, trace.Wrap(err, "unable to establish desktop session")
 	}
 
-	nc, err := c.dialProxyWindowsDesktopSession(ctx, cancel, stream, cluster, desktopName, desktopCert, rootCAs, protocol)
+	nc, err := c.dialProxyWindowsDesktopSession(ctx, cancel, stream, config)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
@@ -99,11 +109,11 @@ func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string,
 	return nc, nil
 }
 
-func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel context.CancelFunc, stream grpc.BidiStreamingClient[transportv1pb.ProxyWindowsDesktopSessionRequest, transportv1pb.ProxyWindowsDesktopSessionResponse], cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
+func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel context.CancelFunc, stream grpc.BidiStreamingClient[transportv1pb.ProxyWindowsDesktopSessionRequest, transportv1pb.ProxyWindowsDesktopSessionResponse], config WindowsDesktopSessionConfig) (*tls.Conn, error) {
 	err := stream.Send(&transportv1pb.ProxyWindowsDesktopSessionRequest{
 		DialTarget: &transportv1pb.TargetWindowsDesktop{
-			DesktopName: desktopName,
-			Cluster:     cluster,
+			DesktopName: config.DesktopName,
+			Cluster:     config.Cluster,
 		},
 	})
 	if err != nil {
@@ -117,10 +127,10 @@ func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel cont
 
 	conn := streamutils.NewConn(desktopReadWriter, &net.TCPAddr{}, &net.TCPAddr{})
 	tlsConfig := &tls.Config{
-		ServerName:   desktopName + DesktopSNISuffix,
-		NextProtos:   []string{protocol},
-		Certificates: []tls.Certificate{desktopCert},
-		RootCAs:      rootCAs,
+		ServerName:   config.DesktopName + DesktopSNISuffix,
+		NextProtos:   []string{config.Protocol},
+		Certificates: []tls.Certificate{config.DesktopCert},
+		RootCAs:      config.RootCAs,
 	}
 	tlsConn := tls.Client(conn, tlsConfig)
 	if err = tlsConn.HandshakeContext(ctx); err != nil {

--- a/api/client/proxy/transport/transportv1/client.go
+++ b/api/client/proxy/transport/transportv1/client.go
@@ -74,7 +74,7 @@ const (
 
 // ProxyWindowsDesktopSession establishes a connection to the target desktop over a bidirectional stream.
 // The caller is required to pass a valid desktop certificate.
-func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool) (*tls.Conn, error) {
+func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
 	connCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 	stop := context.AfterFunc(ctx, cancel)
 	defer stop()
@@ -85,7 +85,7 @@ func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string,
 		return nil, trace.Wrap(err, "unable to establish desktop session")
 	}
 
-	nc, err := c.dialProxyWindowsDesktopSession(ctx, cancel, stream, cluster, desktopName, desktopCert, rootCAs)
+	nc, err := c.dialProxyWindowsDesktopSession(ctx, cancel, stream, cluster, desktopName, desktopCert, rootCAs, protocol)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
@@ -99,7 +99,7 @@ func (c *Client) ProxyWindowsDesktopSession(ctx context.Context, cluster string,
 	return nc, nil
 }
 
-func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel context.CancelFunc, stream grpc.BidiStreamingClient[transportv1pb.ProxyWindowsDesktopSessionRequest, transportv1pb.ProxyWindowsDesktopSessionResponse], cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool) (*tls.Conn, error) {
+func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel context.CancelFunc, stream grpc.BidiStreamingClient[transportv1pb.ProxyWindowsDesktopSessionRequest, transportv1pb.ProxyWindowsDesktopSessionResponse], cluster string, desktopName string, desktopCert tls.Certificate, rootCAs *x509.CertPool, protocol string) (*tls.Conn, error) {
 	err := stream.Send(&transportv1pb.ProxyWindowsDesktopSessionRequest{
 		DialTarget: &transportv1pb.TargetWindowsDesktop{
 			DesktopName: desktopName,
@@ -118,7 +118,7 @@ func (c *Client) dialProxyWindowsDesktopSession(ctx context.Context, cancel cont
 	conn := streamutils.NewConn(desktopReadWriter, &net.TCPAddr{}, &net.TCPAddr{})
 	tlsConfig := &tls.Config{
 		ServerName:   desktopName + DesktopSNISuffix,
-		NextProtos:   []string{"teleport-tdpb-1.0"},
+		NextProtos:   []string{protocol},
 		Certificates: []tls.Certificate{desktopCert},
 		RootCAs:      rootCAs,
 	}

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -28,12 +28,15 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/proxy"
+	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
 	streamutils "github.com/gravitational/teleport/api/utils/grpc/stream"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/legacy"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/tdpb"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/utils/slices"
 )
 
 // Session uniquely describes a desktop session.
@@ -117,20 +120,12 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		return trace.Wrap(err)
 	}
 
+	// conn is the server connection
 	conn, err := proxyClient.ProxyWindowsDesktopSession(ctx, clusterClient.SiteName, s.desktopName(), cert, tlsConfig.RootCAs)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer conn.Close()
-
-	// Now that we have a connection to the desktop service, we can
-	// send the username.
-	tdpConn := tdp.NewConn(conn, legacy.Decode)
-	defer tdpConn.Close()
-	err = tdpConn.WriteMessage(legacy.ClientUsername{Username: s.login})
-	if err != nil {
-		return trace.Wrap(err)
-	}
 
 	downstreamRW, err := streamutils.NewReadWriter(
 		&clientStream{
@@ -142,20 +137,65 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		return trace.Wrap(err)
 	}
 
+	// Client defaults to TDPB
+	clientConn := tdp.NewConn(downstreamRW, tdp.DecoderAdapter(tdpb.DecodePermissive))
+	// Receive, enrich, and forward the ClientHello message
+	msg, err := clientConn.ReadMessage()
+	if err != nil {
+		return trace.WrapWithMessage(err, "error listening for client hello")
+	}
+
+	hello, ok := msg.(*tdpb.ClientHello)
+	if !ok {
+		return trace.Errorf("expected ClientHello message but received %T", msg)
+	}
+
+	// Enrich with username
+	hello.Username = s.login
+
+	protocol := conn.ConnectionState().NegotiatedProtocol
+	var tdpServerConn *tdp.Conn
+	if protocol == "teleport-tdpb-1.0" {
+		// Use TDPB decoder
+		tdpServerConn = tdp.NewConn(conn, tdp.DecoderAdapter(tdpb.DecodePermissive))
+		// Send the client hello
+		if err := tdpServerConn.WriteMessage(hello); err != nil {
+			return trace.Wrap(err)
+		}
+	} else {
+		// Use default TDP decoder
+		tdpServerConn = tdp.NewConn(conn, legacy.Decode)
+		defer tdpServerConn.Close()
+
+		// Now that we have a connection to the desktop service, we can
+		// send the username, client screenspec, and keyboard layout
+		for _, msg := range []tdp.Message{
+			legacy.ClientUsername{Username: s.login},
+			legacy.ClientScreenSpec{Width: hello.ScreenSpec.Width, Height: hello.ScreenSpec.Height},
+			legacy.ClientKeyboardLayout{KeyboardLayout: hello.KeyboardLayout},
+		} {
+			err = tdpServerConn.WriteMessage(msg)
+			if err != nil {
+				return trace.Wrap(err, "error sending %T message", msg)
+			}
+		}
+
+	}
+
 	fsHandle := fsRequestHandler{
 		directoryAccessProvider: s,
 	}
 
-	serverConn := tdp.NewConn(conn, legacy.Decode)
-	tdpConnProxy := tdp.NewConnProxy(tdp.NewConn(downstreamRW, legacy.Decode), tdp.NewReadWriteInterceptor(serverConn, func(message tdp.Message) ([]tdp.Message, error) {
+	// Install FS interceptor
+	serverConn := tdp.NewReadWriteInterceptor(tdpServerConn, func(message tdp.Message) ([]tdp.Message, error) {
 		msg, intErr := fsHandle.process(message, func(message tdp.Message) error {
-			return trace.Wrap(serverConn.WriteMessage(message))
+			return trace.Wrap(tdpServerConn.WriteMessage(message))
 		})
 		if intErr != nil {
 			// Treat all file system errors as warnings, do not interrupt the connection.
-			return []tdp.Message{legacy.Alert{
+			return []tdp.Message{&tdpb.Alert{
 				Message:  intErr.Error(),
-				Severity: legacy.SeverityWarning,
+				Severity: tdpbv1.AlertSeverity_ALERT_SEVERITY_WARNING,
 			}}, nil
 		}
 
@@ -163,7 +203,14 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 			return []tdp.Message{msg}, nil
 		}
 		return nil, nil
-	}, nil))
+	}, nil)
+
+	if protocol != "teleport-tdpb-1.0" {
+		// Wrap this in another interceptor to handle TDP translation
+		serverConn = tdp.NewReadWriteInterceptor(serverConn, tdpb.TranslateToModern, tdpb.TranslateToLegacy)
+	}
+
+	tdpConnProxy := tdp.NewConnProxy(clientConn, serverConn)
 
 	return trace.Wrap(tdpConnProxy.Run())
 }
@@ -194,7 +241,7 @@ func (d clientStream) Recv() ([]byte, error) {
 	}
 
 	// Check if the message sent from the renderer is allowed.
-	decoded, err := legacy.Decode(bytes.NewBuffer(data))
+	decoded, err := tdpb.DecodeStrict(bytes.NewBuffer(data))
 	if err != nil {
 		return nil, trace.Wrap(err, "could not decode desktop message")
 	}
@@ -213,14 +260,7 @@ func (d clientStream) Recv() ([]byte, error) {
 // by tshd and should not originate from the renderer process.
 func isClientMessageAllowed(msg tdp.Message) error {
 	switch msg.(type) {
-	case legacy.SharedDirectoryInfoResponse,
-		legacy.SharedDirectoryCreateResponse,
-		legacy.SharedDirectoryDeleteResponse,
-		legacy.SharedDirectoryReadResponse,
-		legacy.SharedDirectoryWriteResponse,
-		legacy.SharedDirectoryMoveResponse,
-		legacy.SharedDirectoryListResponse,
-		legacy.SharedDirectoryTruncateResponse:
+	case *tdpb.SharedDirectoryResponse:
 		return trace.AccessDenied("file system messages are not allowed from the renderer process")
 	default:
 		return nil
@@ -242,22 +282,27 @@ type directoryAccessProvider interface {
 
 func (d *fsRequestHandler) process(msg tdp.Message, sendToServer func(message tdp.Message) error) (tdp.Message, error) {
 	switch r := msg.(type) {
-	case legacy.SharedDirectoryInfoRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryInfoRequest(r, sendToServer))
-	case legacy.SharedDirectoryListRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryListRequest(r, sendToServer))
-	case legacy.SharedDirectoryReadRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryReadRequest(r, sendToServer))
-	case legacy.SharedDirectoryMoveRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryMoveRequest(r, sendToServer))
-	case legacy.SharedDirectoryWriteRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryWriteRequest(r, sendToServer))
-	case legacy.SharedDirectoryTruncateRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryTruncateRequest(r, sendToServer))
-	case legacy.SharedDirectoryCreateRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryCreateRequest(r, sendToServer))
-	case legacy.SharedDirectoryDeleteRequest:
-		return nil, trace.Wrap(d.handleSharedDirectoryDeleteRequest(r, sendToServer))
+	case *tdpb.SharedDirectoryRequest:
+		switch op := r.Operation.(type) {
+		case *tdpbv1.SharedDirectoryRequest_Info_:
+			return nil, trace.Wrap(d.handleSharedDirectoryInfoRequest(r.CompletionId, op.Info, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Create_:
+			return nil, trace.Wrap(d.handleSharedDirectoryCreateRequest(r.CompletionId, op.Create, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Delete_:
+			return nil, trace.Wrap(d.handleSharedDirectoryDeleteRequest(r.CompletionId, op.Delete, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_List_:
+			return nil, trace.Wrap(d.handleSharedDirectoryListRequest(r.CompletionId, op.List, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Read_:
+			return nil, trace.Wrap(d.handleSharedDirectoryReadRequest(r.CompletionId, op.Read, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Write_:
+			return nil, trace.Wrap(d.handleSharedDirectoryWriteRequest(r.CompletionId, op.Write, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Move_:
+			return nil, trace.Wrap(d.handleSharedDirectoryMoveRequest(r.CompletionId, op.Move, sendToServer))
+		case *tdpbv1.SharedDirectoryRequest_Truncate_:
+			return nil, trace.Wrap(d.handleSharedDirectoryTruncateRequest(r.CompletionId, op.Truncate, sendToServer))
+		default:
+			return msg, nil
+		}
 	default:
 		return msg, nil
 	}
@@ -272,7 +317,7 @@ const (
 	SharedDirectoryErrCodeAlreadyExists
 )
 
-func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(r legacy.SharedDirectoryInfoRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Info, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -280,28 +325,29 @@ func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(r legacy.SharedDirec
 
 	info, err := dirAccess.Stat(r.Path)
 	if err == nil {
-		return trace.Wrap(sendToServer(legacy.SharedDirectoryInfoResponse{
-			CompletionID: r.CompletionID,
-			ErrCode:      uint32(SharedDirectoryErrCodeNil),
-			Fso:          toFso(info),
+		return trace.Wrap(sendToServer(&tdpb.SharedDirectoryResponse{
+			CompletionId: completionID,
+			ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+			Operation: &tdpbv1.SharedDirectoryResponse_Info_{
+				Info: &tdpbv1.SharedDirectoryResponse_Info{
+					Fso: toFso(info),
+				},
+			},
 		}))
 	}
 	if errors.Is(err, os.ErrNotExist) {
-		return trace.Wrap(sendToServer(legacy.SharedDirectoryInfoResponse{
-			CompletionID: r.CompletionID,
-			ErrCode:      uint32(SharedDirectoryErrCodeDoesNotExist),
-			Fso: legacy.FileSystemObject{
-				LastModified: 0,
-				Size:         0,
-				FileType:     0,
-				IsEmpty:      0,
-				Path:         "",
-			}}))
+		return trace.Wrap(sendToServer(&tdpb.SharedDirectoryResponse{
+			CompletionId: completionID,
+			ErrorCode:    uint32(SharedDirectoryErrCodeDoesNotExist),
+			Operation: &tdpbv1.SharedDirectoryResponse_Info_{
+				Info: &tdpbv1.SharedDirectoryResponse_Info{},
+			},
+		}))
 	}
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryListRequest(r legacy.SharedDirectoryListRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryListRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_List, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -311,20 +357,19 @@ func (d *fsRequestHandler) handleSharedDirectoryListRequest(r legacy.SharedDirec
 		return trace.Wrap(err)
 	}
 
-	fsoList := make([]legacy.FileSystemObject, len(contents))
-	for i, content := range contents {
-		fsoList[i] = toFso(content)
-	}
-
-	err = sendToServer(legacy.SharedDirectoryListResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeNil),
-		FsoList:      fsoList,
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_List_{
+			List: &tdpbv1.SharedDirectoryResponse_List{
+				FsoList: slices.Map(contents, toFso),
+			},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryReadRequest(r legacy.SharedDirectoryReadRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryReadRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Read, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -336,19 +381,22 @@ func (d *fsRequestHandler) handleSharedDirectoryReadRequest(r legacy.SharedDirec
 		return trace.Wrap(err)
 	}
 
-	err = sendToServer(legacy.SharedDirectoryReadResponse{
-		CompletionID:   r.CompletionID,
-		ErrCode:        uint32(SharedDirectoryErrCodeNil),
-		ReadDataLength: uint32(n),
-		ReadData:       buf[:n],
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_Read_{
+			Read: &tdpbv1.SharedDirectoryResponse_Read{
+				Data: buf[:n],
+			},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(r legacy.SharedDirectoryMoveRequest, sendToServer func(message tdp.Message) error) error {
-	err := sendToServer(legacy.SharedDirectoryMoveResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeFailed),
+func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(completionID uint32, _ *tdpbv1.SharedDirectoryRequest_Move, sendToServer func(message tdp.Message) error) error {
+	err := sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeFailed),
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -357,25 +405,29 @@ func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(r legacy.SharedDirec
 	return trace.NotImplemented("Moving or renaming files and directories within a shared directory is not supported.")
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(r legacy.SharedDirectoryWriteRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryWriteRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Write, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	bytesWritten, err := dirAccess.Write(r.Path, int64(r.Offset), r.WriteData)
+	bytesWritten, err := dirAccess.Write(r.Path, int64(r.Offset), r.Data)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	err = sendToServer(legacy.SharedDirectoryWriteResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeNil),
-		BytesWritten: uint32(bytesWritten),
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_Write_{
+			Write: &tdpbv1.SharedDirectoryResponse_Write{
+				BytesWritten: uint32(bytesWritten),
+			},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(r legacy.SharedDirectoryTruncateRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Truncate, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -385,14 +437,17 @@ func (d *fsRequestHandler) handleSharedDirectoryTruncateRequest(r legacy.SharedD
 		return trace.Wrap(err)
 	}
 
-	err = sendToServer(legacy.SharedDirectoryTruncateResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeNil),
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_Truncate_{
+			Truncate: &tdpbv1.SharedDirectoryResponse_Truncate{},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(r legacy.SharedDirectoryCreateRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Create, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -407,15 +462,19 @@ func (d *fsRequestHandler) handleSharedDirectoryCreateRequest(r legacy.SharedDir
 		return trace.Wrap(err)
 	}
 
-	err = sendToServer(legacy.SharedDirectoryCreateResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeNil),
-		Fso:          toFso(info),
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_Create_{
+			Create: &tdpbv1.SharedDirectoryResponse_Create{
+				Fso: toFso(info),
+			},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(r legacy.SharedDirectoryDeleteRequest, sendToServer func(message tdp.Message) error) error {
+func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(completionID uint32, r *tdpbv1.SharedDirectoryRequest_Delete, sendToServer func(message tdp.Message) error) error {
 	dirAccess, err := d.directoryAccessProvider.GetDirectoryAccess()
 	if err != nil {
 		return trace.Wrap(err)
@@ -425,24 +484,22 @@ func (d *fsRequestHandler) handleSharedDirectoryDeleteRequest(r legacy.SharedDir
 		return trace.Wrap(err)
 	}
 
-	err = sendToServer(legacy.SharedDirectoryDeleteResponse{
-		CompletionID: r.CompletionID,
-		ErrCode:      uint32(SharedDirectoryErrCodeNil),
+	err = sendToServer(&tdpb.SharedDirectoryResponse{
+		CompletionId: completionID,
+		ErrorCode:    uint32(SharedDirectoryErrCodeNil),
+		Operation: &tdpbv1.SharedDirectoryResponse_Delete_{
+			Delete: &tdpbv1.SharedDirectoryResponse_Delete{},
+		},
 	})
 	return trace.Wrap(err)
 }
 
-func toFso(info *FileOrDirInfo) legacy.FileSystemObject {
-	obj := legacy.FileSystemObject{
+func toFso(info *FileOrDirInfo) *tdpbv1.FileSystemObject {
+	return &tdpbv1.FileSystemObject{
 		LastModified: uint64(info.LastModified),
 		Size:         uint64(info.Size),
 		FileType:     uint32(info.FileType),
-		IsEmpty:      1,
+		IsEmpty:      info.IsEmpty,
 		Path:         info.Path,
 	}
-	if info.IsEmpty {
-		obj.IsEmpty = 0
-	}
-
-	return obj
 }

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/client/proxy"
+	"github.com/gravitational/teleport/api/client/proxy/transport/transportv1"
 	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
 	streamutils "github.com/gravitational/teleport/api/utils/grpc/stream"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
@@ -121,7 +122,13 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	}
 
 	// conn is the server connection
-	conn, err := proxyClient.ProxyWindowsDesktopSession(ctx, clusterClient.SiteName, s.desktopName(), cert, tlsConfig.RootCAs, tdpb.ProtocolName)
+	conn, err := proxyClient.ProxyWindowsDesktopSession(ctx, transportv1.WindowsDesktopSessionConfig{
+		Cluster:     clusterClient.SiteName,
+		DesktopName: s.desktopName(),
+		DesktopCert: cert,
+		RootCAs:     tlsConfig.RootCAs,
+		Protocol:    tdpb.ProtocolName,
+	})
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -409,6 +409,7 @@ func (d *fsRequestHandler) handleSharedDirectoryMoveRequest(completionID uint32,
 	err := sendToServer(&tdpb.SharedDirectoryResponse{
 		CompletionId: completionID,
 		ErrorCode:    uint32(SharedDirectoryErrCodeFailed),
+		Operation:    &tdpbv1.SharedDirectoryResponse_Move_{},
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -157,7 +157,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	// (Username, ClientScreenSpec, ClientKeyboardLayout) depends on
 	// the server's serverProtocol selection.
 	serverProtocol := conn.ConnectionState().NegotiatedProtocol
-	var tdpServerConn *tdp.Conn
+	var tdpServerConn tdp.MessageReadWriteCloser
 	if serverProtocol == tdpb.ProtocolName {
 		// Use TDPB decoder
 		tdpServerConn = tdp.NewConn(conn, tdp.DecoderAdapter(tdpb.DecodePermissive))
@@ -182,6 +182,12 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 				return trace.Wrap(err, "error sending %T message", msg)
 			}
 		}
+
+		// Aside from this block, Teleport Connect will be speaking TDPB.
+		// Install a translation layer to convert inbound messages to TDPB, and
+		// outbound messages to TDP for compatibility with this legacy WDS instance.
+		tdpServerConn = tdp.NewReadWriteInterceptor(tdpServerConn, tdpb.TranslateToModern, tdpb.TranslateToLegacy)
+
 	}
 
 	fsHandle := fsRequestHandler{
@@ -206,11 +212,6 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		}
 		return nil, nil
 	}, nil)
-
-	if serverProtocol != tdpb.ProtocolName {
-		// Wrap this in another interceptor to handle TDP translation
-		serverConn = tdp.NewReadWriteInterceptor(serverConn, tdpb.TranslateToModern, tdpb.TranslateToLegacy)
-	}
 
 	tdpConnProxy := tdp.NewConnProxy(clientConn, serverConn)
 

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -161,7 +161,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	hello.Username = s.login
 
 	// Whether we forward the ClientHello as-is, or send a triple
-	// (Username, ClientScreenSpec, ClientKeyboardLayout) depends on
+	// (Username, ClientScreenSpec, ClientScreenSpec) depends on
 	// the server's serverProtocol selection.
 	serverProtocol := conn.ConnectionState().NegotiatedProtocol
 	var tdpServerConn tdp.MessageReadWriteCloser
@@ -178,11 +178,15 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		defer tdpServerConn.Close()
 
 		// Now that we have a connection to the desktop service, we can
-		// send the username, clientScreenSpec, and clientKeyboardlayout.
+		// send the username, and clientScreenSpec messages.
 		for _, msg := range []tdp.Message{
 			legacy.ClientUsername{Username: s.login},
 			legacy.ClientScreenSpec{Width: hello.ScreenSpec.Width, Height: hello.ScreenSpec.Height},
-			legacy.ClientKeyboardLayout{KeyboardLayout: hello.KeyboardLayout},
+			// For backwards compatibility with v17 Windows Desktop Servers, send a duplicate
+			// client screenspec message. This satisfies v18's requirement to receive exactly
+			// 3 handshake messages, while preventing v17 from receiving a keyboard message that
+			// it does not support. Teleport Connect doesn't support non-default keyboard layouts anyhow.
+			legacy.ClientScreenSpec{Width: hello.ScreenSpec.Width, Height: hello.ScreenSpec.Height},
 		} {
 			err = tdpServerConn.WriteMessage(msg)
 			if err != nil {

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -342,7 +342,9 @@ func (d *fsRequestHandler) handleSharedDirectoryInfoRequest(completionID uint32,
 			CompletionId: completionID,
 			ErrorCode:    uint32(SharedDirectoryErrCodeDoesNotExist),
 			Operation: &tdpbv1.SharedDirectoryResponse_Info_{
-				Info: &tdpbv1.SharedDirectoryResponse_Info{},
+				Info: &tdpbv1.SharedDirectoryResponse_Info{
+					Fso: &tdpbv1.FileSystemObject{},
+				},
 			},
 		}))
 	}

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -157,6 +157,10 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		return trace.Errorf("expected ClientHello message but received %T", msg)
 	}
 
+	if hello.ScreenSpec == nil {
+		return trace.Errorf("received ClientHello with missing screen spec")
+	}
+
 	// Enrich with username
 	hello.Username = s.login
 

--- a/lib/teleterm/services/desktop/desktop.go
+++ b/lib/teleterm/services/desktop/desktop.go
@@ -121,7 +121,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	}
 
 	// conn is the server connection
-	conn, err := proxyClient.ProxyWindowsDesktopSession(ctx, clusterClient.SiteName, s.desktopName(), cert, tlsConfig.RootCAs)
+	conn, err := proxyClient.ProxyWindowsDesktopSession(ctx, clusterClient.SiteName, s.desktopName(), cert, tlsConfig.RootCAs, tdpb.ProtocolName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -158,7 +158,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 	// the server's serverProtocol selection.
 	serverProtocol := conn.ConnectionState().NegotiatedProtocol
 	var tdpServerConn *tdp.Conn
-	if serverProtocol == "teleport-tdpb-1.0" {
+	if serverProtocol == tdpb.ProtocolName {
 		// Use TDPB decoder
 		tdpServerConn = tdp.NewConn(conn, tdp.DecoderAdapter(tdpb.DecodePermissive))
 		// Send the client hello
@@ -207,7 +207,7 @@ func (s *Session) Start(ctx context.Context, stream grpc.BidiStreamingServer[api
 		return nil, nil
 	}, nil)
 
-	if serverProtocol != "teleport-tdpb-1.0" {
+	if serverProtocol != tdpb.ProtocolName {
 		// Wrap this in another interceptor to handle TDP translation
 		serverConn = tdp.NewReadWriteInterceptor(serverConn, tdpb.TranslateToModern, tdpb.TranslateToLegacy)
 	}

--- a/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
+++ b/web/packages/teleterm/src/ui/DocumentDesktopSession/DocumentDesktopSession.tsx
@@ -101,7 +101,8 @@ function DesktopSessionComponent(props: {
           shareDirectoryInTshd(appCtx.mainProcessClient, {
             desktopUri,
             login,
-          })
+          }),
+        { mode: 'tdpb' }
       )
   );
 


### PR DESCRIPTION
This PR implements TDPB support for Teleport Connect as defined in #60617.

<!-- Include manual testing efforts to verify the change. -->
<!-- Detail where the tests where run and what configurations were used. -->
<!-- Include all the test cases which were run to validate the change. -->

## Manual Test Plan
### Test Environment
- Local cluster with Windows Desktop Service and a reachable Windows Desktop instance in EC2.
- Complete the following test cases while connecting to a WDS instance on `master` (compatibility with a TDPB capable server)
- Complete the following test cases while connecting to a WDS instance on `v18` (compatibility with a "legacy" TDP server)
### Test Cases

- Basic Operations
  - [x] Desktop connection succeeds.
  - [x] Basic interactive operations (mouse movement, vertical scroll, mouse button, keyboard input, click and drag) work.
  - [x] Canvas automatically resizes when Teleport Connect window is resized 
- Shared Directory
    - [x] All files and directories in the shared directory are listed
    - [x] Folders within the shared directory can be traversed using explorer
    - [x] Text file can be opened in shared directory and contents read
    - [x] Text file can be edited and saved in shared directory
    - [x] Files can be copy-pasted both into and out of the shared directory
    - [x] Files can be cut-pasted both into and out of the shared directory
    - [x] Files can be dragged and dropped both into and out of the shared directory
    - [x] Files can be deleted from the shared directory from the remote desktop
- Clipboard operations
  - [x] Copy text from local workstation, paste into remote desktop
  - [x] Copy text from remote desktop, paste into local workstation
- Per Session MFA
  - [x] When configured, SSO MFA succeeds
- [x] All test cases above succeed when connecting to a WDS instance on `master`
- [x] All test cases above succeed when connecting to a WDS  instance on `v18.x`