### PR TITLE
[v18] Collect user tasks for Azure VM discovery

### DIFF
--- a/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
+++ b/api/gen/proto/go/teleport/usertasks/v1/user_tasks.pb.go
@@ -156,9 +156,12 @@ type UserTaskSpec struct {
 	DiscoverEks *DiscoverEKS `protobuf:"bytes,6,opt,name=discover_eks,json=discoverEks,proto3" json:"discover_eks,omitempty"`
 	// DiscoverRDS contains the AWS RDS databases that failed to auto enroll into the cluster.
 	// Present when TaskType is discover-rds.
-	DiscoverRds   *DiscoverRDS `protobuf:"bytes,7,opt,name=discover_rds,json=discoverRds,proto3" json:"discover_rds,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	DiscoverRds *DiscoverRDS `protobuf:"bytes,7,opt,name=discover_rds,json=discoverRds,proto3" json:"discover_rds,omitempty"`
+	// DiscoverAzureVM contains the Azure VMs that failed to auto enroll into the cluster.
+	// Present when TaskType is discover-azure-vm.
+	DiscoverAzureVm *DiscoverAzureVM `protobuf:"bytes,8,opt,name=discover_azure_vm,json=discoverAzureVm,proto3" json:"discover_azure_vm,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *UserTaskSpec) Reset() {
@@ -236,6 +239,13 @@ func (x *UserTaskSpec) GetDiscoverEks() *DiscoverEKS {
 func (x *UserTaskSpec) GetDiscoverRds() *DiscoverRDS {
 	if x != nil {
 		return x.DiscoverRds
+	}
+	return nil
+}
+
+func (x *UserTaskSpec) GetDiscoverAzureVm() *DiscoverAzureVM {
+	if x != nil {
+		return x.DiscoverAzureVm
 	}
 	return nil
 }
@@ -769,6 +779,170 @@ func (x *DiscoverRDSDatabase) GetSyncTime() *timestamppb.Timestamp {
 	return nil
 }
 
+// DiscoverAzureVM contains the VMs that failed to auto-enroll into the cluster.
+type DiscoverAzureVM struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Instances maps a VM ID to the result of enrolling that VM into teleport.
+	Instances map[string]*DiscoverAzureVMInstance `protobuf:"bytes,1,rep,name=instances,proto3" json:"instances,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// SubscriptionID is the Azure Subscription ID for the VMs.
+	SubscriptionId string `protobuf:"bytes,2,opt,name=subscription_id,json=subscriptionId,proto3" json:"subscription_id,omitempty"`
+	// ResourceGroup is the Azure Resource Group where VMs are located.
+	ResourceGroup string `protobuf:"bytes,3,opt,name=resource_group,json=resourceGroup,proto3" json:"resource_group,omitempty"`
+	// Region is the Azure Region where Teleport failed to enroll VMs.
+	Region        string `protobuf:"bytes,4,opt,name=region,proto3" json:"region,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverAzureVM) Reset() {
+	*x = DiscoverAzureVM{}
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverAzureVM) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverAzureVM) ProtoMessage() {}
+
+func (x *DiscoverAzureVM) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverAzureVM.ProtoReflect.Descriptor instead.
+func (*DiscoverAzureVM) Descriptor() ([]byte, []int) {
+	return file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *DiscoverAzureVM) GetInstances() map[string]*DiscoverAzureVMInstance {
+	if x != nil {
+		return x.Instances
+	}
+	return nil
+}
+
+func (x *DiscoverAzureVM) GetSubscriptionId() string {
+	if x != nil {
+		return x.SubscriptionId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetResourceGroup() string {
+	if x != nil {
+		return x.ResourceGroup
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVM) GetRegion() string {
+	if x != nil {
+		return x.Region
+	}
+	return ""
+}
+
+// DiscoverAzureVMInstance contains the result of enrolling an Azure VM.
+type DiscoverAzureVMInstance struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// VM ID is the Azure VM ID that uniquely identifies the virtual machine.
+	VmId string `protobuf:"bytes,1,opt,name=vm_id,json=vmId,proto3" json:"vm_id,omitempty"`
+	// Resource ID allows locating the VM in resource hierarchy.
+	ResourceId string `protobuf:"bytes,2,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
+	// Name is the VM name.
+	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// DiscoveryConfig is the discovery config name that originated this VM enrollment.
+	DiscoveryConfig string `protobuf:"bytes,4,opt,name=discovery_config,json=discoveryConfig,proto3" json:"discovery_config,omitempty"`
+	// DiscoveryGroup is the DiscoveryGroup name that originated this task.
+	DiscoveryGroup string `protobuf:"bytes,5,opt,name=discovery_group,json=discoveryGroup,proto3" json:"discovery_group,omitempty"`
+	// SyncTime is the timestamp when the error was produced.
+	SyncTime      *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_time,json=syncTime,proto3" json:"sync_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *DiscoverAzureVMInstance) Reset() {
+	*x = DiscoverAzureVMInstance{}
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DiscoverAzureVMInstance) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DiscoverAzureVMInstance) ProtoMessage() {}
+
+func (x *DiscoverAzureVMInstance) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_usertasks_v1_user_tasks_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DiscoverAzureVMInstance.ProtoReflect.Descriptor instead.
+func (*DiscoverAzureVMInstance) Descriptor() ([]byte, []int) {
+	return file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *DiscoverAzureVMInstance) GetVmId() string {
+	if x != nil {
+		return x.VmId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetResourceId() string {
+	if x != nil {
+		return x.ResourceId
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetDiscoveryConfig() string {
+	if x != nil {
+		return x.DiscoveryConfig
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetDiscoveryGroup() string {
+	if x != nil {
+		return x.DiscoveryGroup
+	}
+	return ""
+}
+
+func (x *DiscoverAzureVMInstance) GetSyncTime() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SyncTime
+	}
+	return nil
+}
+
 var File_teleport_usertasks_v1_user_tasks_proto protoreflect.FileDescriptor
 
 const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
@@ -780,7 +954,7 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\x128\n" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x127\n" +
 	"\x04spec\x18\x05 \x01(\v2#.teleport.usertasks.v1.UserTaskSpecR\x04spec\x12=\n" +
-	"\x06status\x18\x06 \x01(\v2%.teleport.usertasks.v1.UserTaskStatusR\x06status\"\xd7\x02\n" +
+	"\x06status\x18\x06 \x01(\v2%.teleport.usertasks.v1.UserTaskStatusR\x06status\"\xab\x03\n" +
 	"\fUserTaskSpec\x12 \n" +
 	"\vintegration\x18\x01 \x01(\tR\vintegration\x12\x1b\n" +
 	"\ttask_type\x18\x02 \x01(\tR\btaskType\x12\x1d\n" +
@@ -789,7 +963,8 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x05state\x18\x04 \x01(\tR\x05state\x12E\n" +
 	"\fdiscover_ec2\x18\x05 \x01(\v2\".teleport.usertasks.v1.DiscoverEC2R\vdiscoverEc2\x12E\n" +
 	"\fdiscover_eks\x18\x06 \x01(\v2\".teleport.usertasks.v1.DiscoverEKSR\vdiscoverEks\x12E\n" +
-	"\fdiscover_rds\x18\a \x01(\v2\".teleport.usertasks.v1.DiscoverRDSR\vdiscoverRds\"X\n" +
+	"\fdiscover_rds\x18\a \x01(\v2\".teleport.usertasks.v1.DiscoverRDSR\vdiscoverRds\x12R\n" +
+	"\x11discover_azure_vm\x18\b \x01(\v2&.teleport.usertasks.v1.DiscoverAzureVMR\x0fdiscoverAzureVm\"X\n" +
 	"\x0eUserTaskStatus\x12F\n" +
 	"\x11last_state_change\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0flastStateChange\"\xcd\x02\n" +
 	"\vDiscoverEC2\x12O\n" +
@@ -840,6 +1015,22 @@ const file_teleport_usertasks_v1_user_tasks_proto_rawDesc = "" +
 	"\x06engine\x18\x03 \x01(\tR\x06engine\x12)\n" +
 	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
 	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
+	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTime\"\xbc\x02\n" +
+	"\x0fDiscoverAzureVM\x12S\n" +
+	"\tinstances\x18\x01 \x03(\v25.teleport.usertasks.v1.DiscoverAzureVM.InstancesEntryR\tinstances\x12'\n" +
+	"\x0fsubscription_id\x18\x02 \x01(\tR\x0esubscriptionId\x12%\n" +
+	"\x0eresource_group\x18\x03 \x01(\tR\rresourceGroup\x12\x16\n" +
+	"\x06region\x18\x04 \x01(\tR\x06region\x1al\n" +
+	"\x0eInstancesEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12D\n" +
+	"\x05value\x18\x02 \x01(\v2..teleport.usertasks.v1.DiscoverAzureVMInstanceR\x05value:\x028\x01\"\xf0\x01\n" +
+	"\x17DiscoverAzureVMInstance\x12\x13\n" +
+	"\x05vm_id\x18\x01 \x01(\tR\x04vmId\x12\x1f\n" +
+	"\vresource_id\x18\x02 \x01(\tR\n" +
+	"resourceId\x12\x12\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\x12)\n" +
+	"\x10discovery_config\x18\x04 \x01(\tR\x0fdiscoveryConfig\x12'\n" +
+	"\x0fdiscovery_group\x18\x05 \x01(\tR\x0ediscoveryGroup\x127\n" +
 	"\tsync_time\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\bsyncTimeBVZTgithub.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1;usertasksv1b\x06proto3"
 
 var (
@@ -854,45 +1045,52 @@ func file_teleport_usertasks_v1_user_tasks_proto_rawDescGZIP() []byte {
 	return file_teleport_usertasks_v1_user_tasks_proto_rawDescData
 }
 
-var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_usertasks_v1_user_tasks_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_teleport_usertasks_v1_user_tasks_proto_goTypes = []any{
-	(*UserTask)(nil),              // 0: teleport.usertasks.v1.UserTask
-	(*UserTaskSpec)(nil),          // 1: teleport.usertasks.v1.UserTaskSpec
-	(*UserTaskStatus)(nil),        // 2: teleport.usertasks.v1.UserTaskStatus
-	(*DiscoverEC2)(nil),           // 3: teleport.usertasks.v1.DiscoverEC2
-	(*DiscoverEC2Instance)(nil),   // 4: teleport.usertasks.v1.DiscoverEC2Instance
-	(*DiscoverEKS)(nil),           // 5: teleport.usertasks.v1.DiscoverEKS
-	(*DiscoverEKSCluster)(nil),    // 6: teleport.usertasks.v1.DiscoverEKSCluster
-	(*DiscoverRDS)(nil),           // 7: teleport.usertasks.v1.DiscoverRDS
-	(*DiscoverRDSDatabase)(nil),   // 8: teleport.usertasks.v1.DiscoverRDSDatabase
-	nil,                           // 9: teleport.usertasks.v1.DiscoverEC2.InstancesEntry
-	nil,                           // 10: teleport.usertasks.v1.DiscoverEKS.ClustersEntry
-	nil,                           // 11: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
-	(*v1.Metadata)(nil),           // 12: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil), // 13: google.protobuf.Timestamp
+	(*UserTask)(nil),                // 0: teleport.usertasks.v1.UserTask
+	(*UserTaskSpec)(nil),            // 1: teleport.usertasks.v1.UserTaskSpec
+	(*UserTaskStatus)(nil),          // 2: teleport.usertasks.v1.UserTaskStatus
+	(*DiscoverEC2)(nil),             // 3: teleport.usertasks.v1.DiscoverEC2
+	(*DiscoverEC2Instance)(nil),     // 4: teleport.usertasks.v1.DiscoverEC2Instance
+	(*DiscoverEKS)(nil),             // 5: teleport.usertasks.v1.DiscoverEKS
+	(*DiscoverEKSCluster)(nil),      // 6: teleport.usertasks.v1.DiscoverEKSCluster
+	(*DiscoverRDS)(nil),             // 7: teleport.usertasks.v1.DiscoverRDS
+	(*DiscoverRDSDatabase)(nil),     // 8: teleport.usertasks.v1.DiscoverRDSDatabase
+	(*DiscoverAzureVM)(nil),         // 9: teleport.usertasks.v1.DiscoverAzureVM
+	(*DiscoverAzureVMInstance)(nil), // 10: teleport.usertasks.v1.DiscoverAzureVMInstance
+	nil,                             // 11: teleport.usertasks.v1.DiscoverEC2.InstancesEntry
+	nil,                             // 12: teleport.usertasks.v1.DiscoverEKS.ClustersEntry
+	nil,                             // 13: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
+	nil,                             // 14: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
+	(*v1.Metadata)(nil),             // 15: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),   // 16: google.protobuf.Timestamp
 }
 var file_teleport_usertasks_v1_user_tasks_proto_depIdxs = []int32{
-	12, // 0: teleport.usertasks.v1.UserTask.metadata:type_name -> teleport.header.v1.Metadata
+	15, // 0: teleport.usertasks.v1.UserTask.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.usertasks.v1.UserTask.spec:type_name -> teleport.usertasks.v1.UserTaskSpec
 	2,  // 2: teleport.usertasks.v1.UserTask.status:type_name -> teleport.usertasks.v1.UserTaskStatus
 	3,  // 3: teleport.usertasks.v1.UserTaskSpec.discover_ec2:type_name -> teleport.usertasks.v1.DiscoverEC2
 	5,  // 4: teleport.usertasks.v1.UserTaskSpec.discover_eks:type_name -> teleport.usertasks.v1.DiscoverEKS
 	7,  // 5: teleport.usertasks.v1.UserTaskSpec.discover_rds:type_name -> teleport.usertasks.v1.DiscoverRDS
-	13, // 6: teleport.usertasks.v1.UserTaskStatus.last_state_change:type_name -> google.protobuf.Timestamp
-	9,  // 7: teleport.usertasks.v1.DiscoverEC2.instances:type_name -> teleport.usertasks.v1.DiscoverEC2.InstancesEntry
-	13, // 8: teleport.usertasks.v1.DiscoverEC2Instance.sync_time:type_name -> google.protobuf.Timestamp
-	10, // 9: teleport.usertasks.v1.DiscoverEKS.clusters:type_name -> teleport.usertasks.v1.DiscoverEKS.ClustersEntry
-	13, // 10: teleport.usertasks.v1.DiscoverEKSCluster.sync_time:type_name -> google.protobuf.Timestamp
-	11, // 11: teleport.usertasks.v1.DiscoverRDS.databases:type_name -> teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
-	13, // 12: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
-	4,  // 13: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
-	6,  // 14: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
-	8,  // 15: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	9,  // 6: teleport.usertasks.v1.UserTaskSpec.discover_azure_vm:type_name -> teleport.usertasks.v1.DiscoverAzureVM
+	16, // 7: teleport.usertasks.v1.UserTaskStatus.last_state_change:type_name -> google.protobuf.Timestamp
+	11, // 8: teleport.usertasks.v1.DiscoverEC2.instances:type_name -> teleport.usertasks.v1.DiscoverEC2.InstancesEntry
+	16, // 9: teleport.usertasks.v1.DiscoverEC2Instance.sync_time:type_name -> google.protobuf.Timestamp
+	12, // 10: teleport.usertasks.v1.DiscoverEKS.clusters:type_name -> teleport.usertasks.v1.DiscoverEKS.ClustersEntry
+	16, // 11: teleport.usertasks.v1.DiscoverEKSCluster.sync_time:type_name -> google.protobuf.Timestamp
+	13, // 12: teleport.usertasks.v1.DiscoverRDS.databases:type_name -> teleport.usertasks.v1.DiscoverRDS.DatabasesEntry
+	16, // 13: teleport.usertasks.v1.DiscoverRDSDatabase.sync_time:type_name -> google.protobuf.Timestamp
+	14, // 14: teleport.usertasks.v1.DiscoverAzureVM.instances:type_name -> teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry
+	16, // 15: teleport.usertasks.v1.DiscoverAzureVMInstance.sync_time:type_name -> google.protobuf.Timestamp
+	4,  // 16: teleport.usertasks.v1.DiscoverEC2.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverEC2Instance
+	6,  // 17: teleport.usertasks.v1.DiscoverEKS.ClustersEntry.value:type_name -> teleport.usertasks.v1.DiscoverEKSCluster
+	8,  // 18: teleport.usertasks.v1.DiscoverRDS.DatabasesEntry.value:type_name -> teleport.usertasks.v1.DiscoverRDSDatabase
+	10, // 19: teleport.usertasks.v1.DiscoverAzureVM.InstancesEntry.value:type_name -> teleport.usertasks.v1.DiscoverAzureVMInstance
+	20, // [20:20] is the sub-list for method output_type
+	20, // [20:20] is the sub-list for method input_type
+	20, // [20:20] is the sub-list for extension type_name
+	20, // [20:20] is the sub-list for extension extendee
+	0,  // [0:20] is the sub-list for field type_name
 }
 
 func init() { file_teleport_usertasks_v1_user_tasks_proto_init() }
@@ -906,7 +1104,7 @@ func file_teleport_usertasks_v1_user_tasks_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_usertasks_v1_user_tasks_proto_rawDesc), len(file_teleport_usertasks_v1_user_tasks_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/usertasks/v1/user_tasks.proto
+++ b/api/proto/teleport/usertasks/v1/user_tasks.proto
@@ -65,6 +65,9 @@ message UserTaskSpec {
   // DiscoverRDS contains the AWS RDS databases that failed to auto enroll into the cluster.
   // Present when TaskType is discover-rds.
   DiscoverRDS discover_rds = 7;
+  // DiscoverAzureVM contains the Azure VMs that failed to auto enroll into the cluster.
+  // Present when TaskType is discover-azure-vm.
+  DiscoverAzureVM discover_azure_vm = 8;
 }
 
 // UserTaskStatus contains the current status for the UserTask.
@@ -159,6 +162,34 @@ message DiscoverRDSDatabase {
   // Eg, aurora-postgresql, postgresql
   string engine = 3;
   // DiscoveryConfig is the discovery config name that originated this database enrollment.
+  string discovery_config = 4;
+  // DiscoveryGroup is the DiscoveryGroup name that originated this task.
+  string discovery_group = 5;
+  // SyncTime is the timestamp when the error was produced.
+  google.protobuf.Timestamp sync_time = 6;
+}
+
+// DiscoverAzureVM contains the VMs that failed to auto-enroll into the cluster.
+message DiscoverAzureVM {
+  // Instances maps a VM ID to the result of enrolling that VM into teleport.
+  map<string, DiscoverAzureVMInstance> instances = 1;
+  // SubscriptionID is the Azure Subscription ID for the VMs.
+  string subscription_id = 2;
+  // ResourceGroup is the Azure Resource Group where VMs are located.
+  string resource_group = 3;
+  // Region is the Azure Region where Teleport failed to enroll VMs.
+  string region = 4;
+}
+
+// DiscoverAzureVMInstance contains the result of enrolling an Azure VM.
+message DiscoverAzureVMInstance {
+  // VM ID is the Azure VM ID that uniquely identifies the virtual machine.
+  string vm_id = 1;
+  // Resource ID allows locating the VM in resource hierarchy.
+  string resource_id = 2;
+  // Name is the VM name.
+  string name = 3;
+  // DiscoveryConfig is the discovery config name that originated this VM enrollment.
   string discovery_config = 4;
   // DiscoveryGroup is the DiscoveryGroup name that originated this task.
   string discovery_group = 5;

--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -19,6 +19,7 @@
 package usertasks
 
 import (
+	"bytes"
 	"encoding/binary"
 	"slices"
 	"strconv"
@@ -130,6 +131,47 @@ func NewDiscoverRDSUserTask(spec *usertasksv1.UserTaskSpec, opts ...UserTaskOpti
 	return ut, nil
 }
 
+// TaskGroup is the minimal grouping of tasks: each task is expected to have issue type and integration set.
+type TaskGroup struct {
+	// Integration is integration name.
+	Integration string
+	// IssueType is one of recognized issue types.
+	IssueType string
+}
+
+// NewDiscoverAzureVMUserTask creates a new Discover Azure VM User Task..
+func NewDiscoverAzureVMUserTask(tg TaskGroup, expiryTime time.Time, data *usertasksv1.DiscoverAzureVM) (*usertasksv1.UserTask, error) {
+	taskName := taskNameForDiscoverAzureVM(tg, taskNameForDiscoverAzureVMParts{
+		SubscriptionID: data.GetSubscriptionId(),
+		ResourceGroup:  data.GetResourceGroup(),
+		Region:         data.GetRegion(),
+	})
+
+	ut := &usertasksv1.UserTask{
+		Kind:    types.KindUserTask,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name:    taskName,
+			Expires: timestamppb.New(expiryTime),
+		},
+		Spec: &usertasksv1.UserTaskSpec{
+			State:    TaskStateOpen,
+			TaskType: TaskTypeDiscoverAzureVM,
+
+			Integration: tg.Integration,
+			IssueType:   tg.IssueType,
+
+			DiscoverAzureVm: data,
+		},
+	}
+
+	if err := ValidateUserTask(ut); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ut, nil
+}
+
 const (
 	// TaskStateOpen identifies an issue with an instance that is not yet resolved.
 	TaskStateOpen = "OPEN"
@@ -154,6 +196,11 @@ const (
 	// when an auto-enrollment of an RDS database fails or needs attention.
 	// UserTasks that have this Task Type must include the DiscoverRDS field.
 	TaskTypeDiscoverRDS = "discover-rds"
+
+	// TaskTypeDiscoverAzureVM identifies a User Tasks that is created
+	// when an auto-enrollment of an Azure VM fails.
+	// UserTasks that have this Task Type must include the DiscoverAzureVM field.
+	TaskTypeDiscoverAzureVM = "discover-azure-vm"
 )
 
 // List of Auto Discover EC2 issues identifiers.
@@ -243,6 +290,34 @@ var DiscoverRDSIssueTypes = []string{
 	AutoDiscoverRDSIssueIAMAuthenticationDisabled,
 }
 
+// List of Auto Discover Azure VM issues identifiers.
+// This value is used to populate the UserTasks.Spec.IssueType for Discover Azure VM tasks.
+const (
+	// AutoDiscoverAzureVMIssueMissingRunCommandsPermission is used to identify VMs that failed to auto-enroll
+	// because the Azure integration is missing runCommands permissions (runCommands/write or runCommands/read).
+	AutoDiscoverAzureVMIssueMissingRunCommandsPermission = "azure-vm-missing-run-commands-permission"
+
+	// AutoDiscoverAzureVMIssueVMNotRunning is used to identify VMs that failed to auto-enroll
+	// because the VM is deallocated or stopped.
+	AutoDiscoverAzureVMIssueVMNotRunning = "azure-vm-not-running"
+
+	// AutoDiscoverAzureVMIssueVMAgentNotAvailable is used to identify VMs that failed to auto-enroll
+	// because the Azure VM agent is not running or not available.
+	AutoDiscoverAzureVMIssueVMAgentNotAvailable = "azure-vm-agent-not-available"
+
+	// AutoDiscoverAzureVMIssueEnrollmentError is a generic issue type for errors during VM enrollment
+	// when no more specific cause could be determined.
+	AutoDiscoverAzureVMIssueEnrollmentError = "azure-vm-enrollment-error"
+)
+
+// DiscoverAzureVMIssueTypes is a list of issue types that can occur when trying to auto enroll Azure VMs.
+var DiscoverAzureVMIssueTypes = []string{
+	AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+	AutoDiscoverAzureVMIssueVMNotRunning,
+	AutoDiscoverAzureVMIssueVMAgentNotAvailable,
+	AutoDiscoverAzureVMIssueEnrollmentError,
+}
+
 // ValidateUserTask validates the UserTask object without modifying it.
 func ValidateUserTask(ut *usertasksv1.UserTask) error {
 	switch {
@@ -273,6 +348,10 @@ func ValidateUserTask(ut *usertasksv1.UserTask) error {
 		}
 	case TaskTypeDiscoverRDS:
 		if err := validateDiscoverRDSTaskType(ut); err != nil {
+			return trace.Wrap(err)
+		}
+	case TaskTypeDiscoverAzureVM:
+		if err := validateDiscoverAzureVMTaskType(ut); err != nil {
 			return trace.Wrap(err)
 		}
 	default:
@@ -450,6 +529,69 @@ func validateDiscoverRDSTaskType(ut *usertasksv1.UserTask) error {
 	return nil
 }
 
+func validateDiscoverAzureVMTaskType(ut *usertasksv1.UserTask) error {
+	spec := ut.Spec
+	if spec == nil {
+		return trace.BadParameter("%s: spec field is required", TaskTypeDiscoverAzureVM)
+	}
+	switch {
+	case spec.Integration == "":
+		return trace.BadParameter("%s: integration cannot be empty", TaskTypeDiscoverAzureVM)
+	case !slices.Contains(DiscoverAzureVMIssueTypes, spec.IssueType):
+		return trace.BadParameter("%s: issue_type must be one of %v, got %q", TaskTypeDiscoverAzureVM, DiscoverAzureVMIssueTypes, spec.IssueType)
+	}
+
+	discover := spec.DiscoverAzureVm
+	if discover == nil {
+		return trace.BadParameter("%s: discover_azure_vm field is required", TaskTypeDiscoverAzureVM)
+	}
+	switch {
+	case discover.SubscriptionId == "":
+		return trace.BadParameter("%s: discover_azure_vm.subscription_id field is required", TaskTypeDiscoverAzureVM)
+	case discover.ResourceGroup == "":
+		return trace.BadParameter("%s: discover_azure_vm.resource_group field is required", TaskTypeDiscoverAzureVM)
+	case discover.Region == "":
+		return trace.BadParameter("%s: discover_azure_vm.region field is required", TaskTypeDiscoverAzureVM)
+	}
+	expectedTaskName := taskNameForDiscoverAzureVM(
+		TaskGroup{
+			Integration: spec.Integration,
+			IssueType:   spec.IssueType,
+		},
+		taskNameForDiscoverAzureVMParts{
+			SubscriptionID: discover.SubscriptionId,
+			ResourceGroup:  discover.ResourceGroup,
+			Region:         discover.Region,
+		})
+	if ut.Metadata.Name != expectedTaskName {
+		return trace.BadParameter("%s: task name must be %s, got %s",
+			TaskTypeDiscoverAzureVM,
+			expectedTaskName,
+			ut.Metadata.Name,
+		)
+	}
+	if len(discover.Instances) == 0 {
+		return trace.BadParameter("%s: discover_azure_vm.instances field is required", TaskTypeDiscoverAzureVM)
+	}
+	for vmID, vmIssue := range discover.Instances {
+		switch {
+		case vmIssue == nil:
+			return trace.BadParameter("%s: discover_azure_vm.instances[%s] is nil", TaskTypeDiscoverAzureVM, vmID)
+		case vmIssue.VmId == "":
+			return trace.BadParameter("%s: discover_azure_vm.instances[%s].vm_id field is required", TaskTypeDiscoverAzureVM, vmID)
+		case vmIssue.DiscoveryConfig == "":
+			return trace.BadParameter("%s: discover_azure_vm.instances[%s].discovery_config field is required", TaskTypeDiscoverAzureVM, vmID)
+		case vmIssue.DiscoveryGroup == "":
+			return trace.BadParameter("%s: discover_azure_vm.instances[%s].discovery_group field is required", TaskTypeDiscoverAzureVM, vmID)
+		case vmID == "":
+			return trace.BadParameter("%s: discover_azure_vm.instances map key is empty", TaskTypeDiscoverAzureVM)
+		case vmID != vmIssue.VmId:
+			return trace.BadParameter("%s: discover_azure_vm.instances map key %s does not match vm_id %s", TaskTypeDiscoverAzureVM, vmID, vmIssue.VmId)
+		}
+	}
+	return nil
+}
+
 // TaskNameForDiscoverEC2Parts are the fields that deterministically compute a Discover EC2 task name.
 // To be used with TaskNameForDiscoverEC2 function.
 type TaskNameForDiscoverEC2Parts struct {
@@ -540,3 +682,34 @@ func TaskNameForDiscoverRDS(parts TaskNameForDiscoverRDSParts) string {
 
 // discoverRDSNamespace is an UUID that represents the name space to be used for generating UUIDs for DiscoverRDS User Task names.
 var discoverRDSNamespace = uuid.NewSHA1(uuid.Nil, []byte("discover-rds"))
+
+// taskNameForDiscoverAzureVMParts are the fields that deterministically compute a Discover Azure VM task name.
+// To be used with TaskNameForDiscoverAzureVM function.
+type taskNameForDiscoverAzureVMParts struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Region         string
+}
+
+// taskNameForDiscoverAzureVM returns a deterministic name for the DiscoverAzureVM task type.
+// This method is used to ensure a single UserTask is created to report issues in enrolling Azure VMs for a given integration, issue type, subscription id, resource group and region.
+func taskNameForDiscoverAzureVM(tg TaskGroup, parts taskNameForDiscoverAzureVMParts) string {
+	return taskNameFromParts(discoverAzureVMNamespace,
+		tg.Integration, tg.IssueType,
+		parts.SubscriptionID, parts.ResourceGroup, parts.Region,
+	)
+}
+
+func taskNameFromParts(namespace uuid.UUID, parts ...string) string {
+	var buf bytes.Buffer
+
+	for _, part := range parts {
+		_ = binary.Write(&buf, binary.LittleEndian, uint64(len(part)))
+		buf.WriteString(part)
+	}
+
+	return uuid.NewSHA1(namespace, buf.Bytes()).String()
+}
+
+// discoverAzureVMNamespace is an UUID that represents the name space to be used for generating UUIDs for DiscoverAzureVM User Task names.
+var discoverAzureVMNamespace = uuid.NewSHA1(uuid.Nil, []byte("discover-azure-vm"))

--- a/lib/srv/discovery/azure_vm_error_parser.go
+++ b/lib/srv/discovery/azure_vm_error_parser.go
@@ -1,0 +1,60 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/gravitational/teleport/api/types/usertasks"
+)
+
+// classifyAzureVMEnrollmentError classifies Azure API errors into user-facing
+// messages for VM auto-discovery. This is best-effort based on error strings
+// which may change without notice. The matching logic may require future
+// adjustments to track upstream changes, as well as expansion to handle new
+// error patterns. Unrecognized errors will return a generic message; the user
+// should check server logs for the underlying error details.
+func classifyAzureVMEnrollmentError(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	errMsg := err.Error()
+
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		switch {
+		case respErr.StatusCode == 403 && respErr.ErrorCode == "AuthorizationFailed":
+			if strings.Contains(errMsg, "runCommands") {
+				return usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission
+			}
+		case respErr.StatusCode == 409 && respErr.ErrorCode == "OperationNotAllowed":
+			if strings.Contains(errMsg, "VM is not running") {
+				return usertasks.AutoDiscoverAzureVMIssueVMNotRunning
+			}
+			if strings.Contains(errMsg, "extension operations are disallowed") {
+				return usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable
+			}
+		}
+	}
+
+	// generic error
+	return usertasks.AutoDiscoverAzureVMIssueEnrollmentError
+}

--- a/lib/srv/discovery/azure_vm_error_parser_test.go
+++ b/lib/srv/discovery/azure_vm_error_parser_test.go
@@ -1,0 +1,101 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package discovery
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/usertasks"
+)
+
+func TestClassifyAzureVMEnrollmentError(t *testing.T) {
+	azureError := func(statusCode int, errorCode, errorMessage string) error {
+		resp := &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(errorMessage)),
+			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
+		}
+		return runtime.NewResponseErrorWithErrorCode(resp, errorCode)
+	}
+
+	tests := []struct {
+		name              string
+		err               error
+		expectedIssueType string
+	}{
+		{
+			name:              "nil error",
+			err:               nil,
+			expectedIssueType: "",
+		},
+		{
+			name:              "unrecognized error",
+			err:               errors.New("something went wrong"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "403 AuthorizationFailed with runCommands/write",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+		},
+		{
+			name:              "403 AuthorizationFailed with runCommands/read",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/read'"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+		},
+		{
+			name:              "403 AuthorizationFailed without runCommands",
+			err:               azureError(403, "AuthorizationFailed", "does not have authorization to perform some other action"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "409 OperationNotAllowed VM not running",
+			err:               azureError(409, "OperationNotAllowed", "Cannot modify extensions in the VM when the VM is not running"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueVMNotRunning,
+		},
+		{
+			name:              "409 OperationNotAllowed extension operations disallowed",
+			err:               azureError(409, "OperationNotAllowed", "This operation cannot be performed when extension operations are disallowed. To allow, please ensure VM Agent is installed on the VM and the osProfile.allowExtensionOperations property is true."),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueVMAgentNotAvailable,
+		},
+		{
+			name:              "409 OperationNotAllowed other message",
+			err:               azureError(409, "OperationNotAllowed", "some other operation not allowed error"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+		{
+			name:              "500 InternalServerError",
+			err:               azureError(500, "InternalServerError", "An internal error occurred"),
+			expectedIssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := classifyAzureVMEnrollmentError(tt.err)
+			require.Equal(t, tt.expectedIssueType, result, "issue type mismatch")
+		})
+	}
+}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -1382,8 +1382,9 @@ func (s *Server) enrollAzureVirtualMachines(log *slog.Logger, instances *server.
 
 			break
 		}
-		log.WarnContext(s.ctx, "Failed to install on VM",
-			"vm_id", azure.StringVal(failure.Instance.ID),
+		log.WarnContext(s.ctx, "Failed to install Teleport on a virtual machine",
+			"vm_id", azure.StringVal(failure.Instance.Properties.VMID),
+			"resource_id", azure.StringVal(failure.Instance.ID),
 			"install_error", failure.Error,
 		)
 	}
@@ -1423,14 +1424,20 @@ func (s *Server) startAzureServerDiscovery() {
 	}
 
 	var sm *resourceStatusMap
+	var vmTasks *azureVMTasks
+	var runStart time.Time
 
 	azureWatcher = server.NewWatcher(
 		s.ctx,
 		server.WithPreFetchHookFn(func(fetchers []server.Fetcher[*server.AzureInstances]) {
+			s.Log.InfoContext(s.ctx, "Azure VM discovery iteration starting")
+			runStart = s.clock.Now()
+
 			if len(fetchers) > 0 {
 				s.submitFetchEvent(types.CloudAzure, types.AzureMatcherVM)
 			}
 			sm = newStatusMap(types.AzureMatcherVM)
+			vmTasks = &azureVMTasks{}
 
 			// Initialize the status map with an entry per fetcher (discoveryConfig + integration).
 			// The per-instance hook only receives the slice of instance groups; when a fetcher
@@ -1454,7 +1461,7 @@ func (s *Server) startAzureServerDiscovery() {
 					integration:         group.Integration,
 				}
 				s.Log.DebugContext(s.ctx, "Processing instance group", "group", fgKey, "instances", len(group.Instances))
-				results := s.installAzureServers(group)
+				results := s.installAzureServers(group, vmTasks)
 				sm.add(fgKey, results)
 			}
 		}),
@@ -1462,6 +1469,10 @@ func (s *Server) startAzureServerDiscovery() {
 			// update statuses of relevant discovery configs.
 			s.azureVMStatus.Store(sm)
 			s.updateDiscoveryConfigStatus(sm.discoveryConfigs()...)
+			// upsert user tasks for failed enrollments.
+			vmTasks.upsertAll(s.taskUpdater())
+
+			s.Log.InfoContext(s.ctx, "Azure VM discovery iteration completed", "elapsed", s.clock.Since(runStart))
 		}),
 		server.WithPollInterval[*server.AzureInstances](s.PollInterval),
 		server.WithTriggerFetchC[*server.AzureInstances](s.newDiscoveryConfigChangedSub()),
@@ -1476,7 +1487,7 @@ func (s *Server) startAzureServerDiscovery() {
 	go azureWatcher.Run()
 }
 
-func (s *Server) installAzureServers(instances *server.AzureInstances) (results map[statusType]int) {
+func (s *Server) installAzureServers(instances *server.AzureInstances, vmTasks *azureVMTasks) (results map[statusType]int) {
 	results = make(map[statusType]int)
 
 	log := s.Log.With(
@@ -1511,17 +1522,60 @@ func (s *Server) installAzureServers(instances *server.AzureInstances) (results 
 		return
 	}
 
+	addFailedEnrollment := func(vm *armcompute.VirtualMachine, issueType string) {
+		// Static matchers don't have a discovery config resource, so skip creating user tasks
+		// because validation requires a discovery config name.
+		if instances.DiscoveryConfigName == noDiscoveryConfig {
+			return
+		}
+
+		tg := usertasks.TaskGroup{
+			Integration: instances.Integration,
+			IssueType:   issueType,
+		}
+		vmTasks.addFailedEnrollment(
+			tg,
+			azureVMTaskKey{
+				subscriptionID: instances.SubscriptionID,
+				resourceGroup:  instances.ResourceGroup,
+				region:         instances.Region,
+			},
+			&usertasksv1.DiscoverAzureVMInstance{
+				VmId:            azure.StringVal(vm.Properties.VMID),
+				ResourceId:      azure.StringVal(vm.ID),
+				Name:            azure.StringVal(vm.Name),
+				DiscoveryConfig: instances.DiscoveryConfigName,
+				DiscoveryGroup:  s.DiscoveryGroup,
+				SyncTime:        timestamppb.New(s.clock.Now()),
+			},
+		)
+	}
+
 	log.DebugContext(s.ctx, "Running Teleport installation on virtual machines", "vms", genAzureInstancesLogStr(instances.Instances))
 	failures, err := s.enrollAzureVirtualMachines(log, instances)
 	if err != nil {
-		// we don't expect err to be non-nil for individual enrollment failures.
-		// we will assume all of them failed e.g. due to API-level permission issue.
-		log.ErrorContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err)
-		results[statusFailed] = needInstall
+		// treat non-nil err as deployment failure affecting all machines.
+		log.WarnContext(s.ctx, "Failed to enroll discovered Azure VMs", "error", err, "count", len(instances.Instances))
+		results[statusFailed] = len(instances.Instances)
+
+		issueType := classifyAzureVMEnrollmentError(err)
+		for _, vm := range instances.Instances {
+			addFailedEnrollment(vm, issueType)
+		}
 		return
 	}
+
+	if len(failures) > 0 {
+		log.WarnContext(s.ctx, "Failed to enroll some discovered Azure VMs", "count", len(failures))
+	}
+
 	// count individual failed enrollments.
 	results[statusFailed] = len(failures)
+
+	// Record failures as user tasks.
+	for _, failure := range failures {
+		addFailedEnrollment(failure.Instance, classifyAzureVMEnrollmentError(failure.Error))
+	}
 
 	pendingCount := len(instances.Instances) - len(failures)
 	if pendingCount > 0 {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -36,6 +37,7 @@ import (
 
 	"cloud.google.com/go/container/apiv1/containerpb"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	azruntime "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
@@ -62,6 +64,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,6 +73,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
@@ -78,6 +82,7 @@ import (
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
 	"github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/clientutils"
 	"github.com/gravitational/teleport/lib/auth"
@@ -2973,15 +2978,20 @@ func mustNewDatabase(t *testing.T, meta types.Metadata, spec types.DatabaseSpecV
 type mockAzureRunCommandClient struct {
 	mu                 sync.Mutex
 	installedInstances map[string]struct{}
+	runErr             error
 }
 
 func (m *mockAzureRunCommandClient) Run(_ context.Context, req azure.RunCommandRequest) error {
 	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.runErr != nil {
+		return m.runErr
+	}
 	if m.installedInstances == nil {
 		m.installedInstances = make(map[string]struct{})
 	}
 	m.installedInstances[req.VMName] = struct{}{}
-	m.mu.Unlock()
 	return nil
 }
 
@@ -3042,7 +3052,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 	}
 
 	vmMatcher := vmMatcherFn()
-	defaultDiscoveryConfig, err := discoveryconfig.NewDiscoveryConfig(
+
+	cfg, err := discoveryconfig.NewDiscoveryConfig(
 		header.Metadata{Name: uuid.NewString()},
 		discoveryconfig.Spec{
 			DiscoveryGroup: defaultDiscoveryGroup,
@@ -3053,6 +3064,10 @@ func TestAzureVMDiscovery(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
+
+	defaultDiscoveryConfig := func() *discoveryconfig.DiscoveryConfig {
+		return cfg.Clone()
+	}
 
 	foundAzureVMs := func() []*armcompute.VirtualMachine {
 		return []*armcompute.VirtualMachine{
@@ -3104,6 +3119,15 @@ func TestAzureVMDiscovery(t *testing.T) {
 	presentNodeAlt := presentNode.DeepCopy().(*types.ServerV2)
 	presentNodeAlt.Metadata.Labels["teleport.internal/vm-id"] = "alternate-vmid"
 
+	azureError := func(statusCode int, errorCode, message string) error {
+		resp := &http.Response{
+			StatusCode: statusCode,
+			Body:       io.NopCloser(strings.NewReader(message)),
+			Request:    &http.Request{Method: http.MethodPut, URL: &url.URL{}},
+		}
+		return azruntime.NewResponseErrorWithErrorCode(resp, errorCode)
+	}
+
 	tests := []struct {
 		name                     string
 		presentVMs               []types.Server
@@ -3111,6 +3135,8 @@ func TestAzureVMDiscovery(t *testing.T) {
 		staticMatchers           Matchers
 		wantInstalledInstances   []string
 		expectedIntegrationNames []string
+		runError                 error
+		userTasksCheck           func(*testing.T, UserTaskLister)
 	}{
 		{
 			name:                   "no nodes present, 1 found",
@@ -3133,9 +3159,74 @@ func TestAzureVMDiscovery(t *testing.T) {
 		{
 			name:                   "no nodes present, 1 found using dynamic matchers",
 			presentVMs:             []types.Server{},
-			discoveryConfig:        defaultDiscoveryConfig,
+			discoveryConfig:        defaultDiscoveryConfig(),
 			staticMatchers:         Matchers{},
 			wantInstalledInstances: []string{"testvm", "testvm-integration"},
+		},
+		{
+			name:                   "installation failure creates user task",
+			presentVMs:             []types.Server{},
+			discoveryConfig:        defaultDiscoveryConfig(),
+			staticMatchers:         Matchers{},
+			wantInstalledInstances: []string{},
+			runError:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+				var tasks []*usertasksv1.UserTask
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					var err error
+					tasks, _, err = lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+					require.NoError(c, err)
+					require.Len(c, tasks, 1)
+				}, 3*time.Second, 100*time.Millisecond)
+
+				expectedTask := &usertasksv1.UserTask{
+					Kind:    types.KindUserTask,
+					Version: types.V1,
+					Metadata: &headerv1.Metadata{
+						Name: "d09fef6d-2454-5bdd-80c7-db7edddf2a2e", // stable hash
+					},
+					Spec: &usertasksv1.UserTaskSpec{
+						Integration: dummyIntegration,
+						TaskType:    usertasks.TaskTypeDiscoverAzureVM,
+						IssueType:   usertasks.AutoDiscoverAzureVMIssueMissingRunCommandsPermission,
+						State:       usertasks.TaskStateOpen,
+						DiscoverAzureVm: &usertasksv1.DiscoverAzureVM{
+							Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
+								"test-vmid-integration": {
+									VmId:            "test-vmid-integration",
+									Name:            "testvm-integration",
+									DiscoveryConfig: defaultDiscoveryConfig().GetName(),
+									DiscoveryGroup:  defaultDiscoveryGroup,
+								},
+							},
+							SubscriptionId: "testsub",
+							ResourceGroup:  "testrg",
+							Region:         "westcentralus",
+						},
+					},
+					Status: nil,
+				}
+
+				require.Empty(t, cmp.Diff(expectedTask, tasks[0],
+					protocmp.Transform(),
+					protocmp.IgnoreFields(&headerv1.Metadata{}, "expires", "revision"),
+					protocmp.IgnoreFields(&usertasksv1.DiscoverAzureVMInstance{}, "sync_time"),
+				))
+			},
+		},
+		{
+			name:                   "static matcher failure does not create user task",
+			presentVMs:             []types.Server{},
+			staticMatchers:         vmMatcherFn(),
+			wantInstalledInstances: []string{},
+			runError:               azureError(403, "AuthorizationFailed", "does not have authorization to perform action 'Microsoft.Compute/virtualMachines/runCommands/write'"),
+			userTasksCheck: func(t *testing.T, lister UserTaskLister) {
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					tasks, _, err := lister.ListUserTasks(t.Context(), 200, "", &usertasksv1.ListUserTasksFilters{})
+					require.NoError(c, err)
+					require.Empty(c, tasks)
+				}, 3*time.Second, 100*time.Millisecond)
+			},
 		},
 	}
 
@@ -3144,7 +3235,9 @@ func TestAzureVMDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			runClient := &mockAzureRunCommandClient{}
+			runClient := &mockAzureRunCommandClient{
+				runErr: tc.runError,
+			}
 
 			initAzureClients := func(opts ...azure.ClientsOption) (azure.Clients, error) {
 				return &azuretest.Clients{
@@ -3233,11 +3326,16 @@ func TestAzureVMDiscovery(t *testing.T) {
 				} else {
 					require.Equal(c, tc.wantInstalledInstances, runClient.getInstalled())
 				}
-				// all current tests install at least one VM, so this cannot be zero.
-				// multiple installations will trigger just one event.
-				const expectedEventCount = 1
-				require.Equal(c, expectedEventCount, reporter.ResourceCreateEventCount())
+				expectedEvents := 1
+				if tc.runError != nil {
+					expectedEvents = 0
+				}
+				require.Equal(c, expectedEvents, reporter.ResourceCreateEventCount())
 			}, 500*time.Millisecond, 50*time.Millisecond)
+
+			if tc.userTasksCheck != nil {
+				tc.userTasksCheck(t, tlsServer.Auth())
+			}
 
 			// make sure azure client cache has expected entries
 			for _, integrationName := range tc.expectedIntegrationNames {

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -19,16 +19,26 @@
 package discovery
 
 import (
+	"context"
 	"maps"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/discoveryconfig"
+	"github.com/gravitational/teleport/api/types/usertasks"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
 func TestTruncateErrorMessage(t *testing.T) {
@@ -74,15 +84,9 @@ func (m *mockInstance) GetDiscoveryGroup() string {
 }
 
 func TestMergeExistingInstances(t *testing.T) {
-	clock := clockwork.NewFakeClock()
-	pollInterval := 10 * time.Minute
-	s := &Server{
-		Config: &Config{
-			clock:          clock,
-			PollInterval:   pollInterval,
-			DiscoveryGroup: "group-1",
-		},
-	}
+	s, _ := newTaskUpdater(t)
+	clock := s.clock
+	pollInterval := s.PollInterval
 
 	now := clock.Now()
 	tooOld := now.Add(-3 * pollInterval)
@@ -160,6 +164,342 @@ func TestMergeExistingInstances(t *testing.T) {
 			workingCopy := maps.Clone(tt.freshInstances)
 			mergeExistingInstances(s, tt.oldInstances, workingCopy)
 			require.Equal(t, tt.expected, workingCopy)
+		})
+	}
+}
+
+func TestMergeUpsertUserTask(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	syncTime := timestamppb.New(clock.Now())
+
+	newTask := func(t *testing.T, tag string) *usertasksv1.UserTask {
+		ut, err := usertasks.NewDiscoverAzureVMUserTask(
+			usertasks.TaskGroup{
+				Integration: "my-int",
+				IssueType:   usertasks.AutoDiscoverAzureVMIssueEnrollmentError,
+			},
+			clock.Now().Add(20*time.Minute),
+			&usertasksv1.DiscoverAzureVM{
+				Instances: map[string]*usertasksv1.DiscoverAzureVMInstance{
+					tag: {
+						VmId:            tag,
+						DiscoveryConfig: tag,
+						DiscoveryGroup:  tag,
+						SyncTime:        syncTime,
+					},
+				},
+				// these feed into task name, in addition to the task group above.
+				SubscriptionId: "sub-123",
+				ResourceGroup:  "rg-123",
+				Region:         "westus",
+			},
+		)
+		require.NoError(t, err)
+		return ut
+	}
+
+	tests := []struct {
+		name         string
+		existingTask *usertasksv1.UserTask
+		newTask      *usertasksv1.UserTask
+		mergeCalled  bool
+	}{
+		{
+			name:         "no existing task - merge not called",
+			existingTask: nil,
+			newTask:      newTask(t, "foo"),
+			mergeCalled:  false,
+		},
+		{
+			name:         "existing task with spec - merge is called",
+			existingTask: newTask(t, "bar"),
+			newTask:      newTask(t, "foo"),
+			mergeCalled:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ap := newTaskUpdater(t, tt.existingTask)
+
+			mergeCalled := false
+			mergeFunc := func(oldSpec *usertasksv1.UserTaskSpec, newSpec *usertasksv1.UserTaskSpec) {
+				mergeCalled = true
+			}
+
+			require.NoError(t, s.mergeUpsertUserTask(tt.newTask, mergeFunc))
+			require.Equal(t, tt.mergeCalled, mergeCalled, "mergeCalled mismatch")
+
+			// Verify the task was upserted
+			upsertedTask, err := ap.GetUserTask(s.ctx, tt.newTask.GetMetadata().GetName())
+			require.NoError(t, err)
+			require.NotNil(t, upsertedTask)
+			require.Empty(t, cmp.Diff(tt.newTask.Spec, upsertedTask.Spec, protocmp.Transform()))
+		})
+	}
+}
+
+type mocktaskUpdaterAccessPoint struct {
+	types.Semaphores
+
+	mu sync.Mutex
+
+	tasks map[string]*usertasksv1.UserTask
+}
+
+func (m *mocktaskUpdaterAccessPoint) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return &types.SemaphoreLease{}, nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	return nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.tasks[req.GetMetadata().GetName()] = req
+
+	return req, nil
+}
+
+func (m *mocktaskUpdaterAccessPoint) GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	task, ok := m.tasks[name]
+	if !ok {
+		return nil, trace.NotFound("task %q not found", name)
+	}
+	return task, nil
+}
+
+func newTaskUpdater(t *testing.T, existingTasks ...*usertasksv1.UserTask) (*taskUpdater, *mocktaskUpdaterAccessPoint) {
+	t.Helper()
+
+	clock := clockwork.NewFakeClock()
+
+	ap := &mocktaskUpdaterAccessPoint{
+		tasks: make(map[string]*usertasksv1.UserTask),
+	}
+
+	manager := &taskUpdater{
+		ctx:   t.Context(),
+		clock: clock,
+
+		DiscoveryGroup: "group-1",
+		ServerID:       "discover-server-id",
+		PollInterval:   10 * time.Minute,
+		Log:            logtest.NewLogger(),
+		AccessPoint:    ap,
+	}
+
+	for _, task := range existingTasks {
+		if task == nil {
+			continue
+		}
+		_, err := manager.AccessPoint.UpsertUserTask(manager.ctx, task)
+		require.NoError(t, err)
+	}
+
+	return manager, ap
+}
+
+func TestAzureVMTasks_AddFailedEnrollment(t *testing.T) {
+	t.Parallel()
+
+	var testTaskGroup = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError}
+	var testTaskGroupAlt = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueVMNotRunning}
+	var testAzureKey = azureVMTaskKey{subscriptionID: "sub-1", resourceGroup: "rg-1", region: "westus"}
+	var testAzureKeyAlt = azureVMTaskKey{subscriptionID: "sub-2", resourceGroup: "rg-2", region: "eastus"}
+
+	syncTime := timestamppb.New(time.Now())
+
+	vm := func(tag string) *usertasksv1.DiscoverAzureVMInstance {
+		return &usertasksv1.DiscoverAzureVMInstance{
+			VmId:            tag,
+			DiscoveryConfig: "dc-01",
+			DiscoveryGroup:  "group-1",
+			SyncTime:        syncTime,
+		}
+	}
+
+	azureData := func(key azureVMTaskKey, instances ...string) *usertasksv1.DiscoverAzureVM {
+		data := &usertasksv1.DiscoverAzureVM{
+			SubscriptionId: key.subscriptionID,
+			ResourceGroup:  key.resourceGroup,
+			Region:         key.region,
+			Instances:      make(map[string]*usertasksv1.DiscoverAzureVMInstance),
+		}
+		for _, instance := range instances {
+			data.Instances[instance] = vm(instance)
+		}
+		return data
+	}
+
+	tests := []struct {
+		name     string
+		mutate   func(tasks *azureVMTasks)
+		expected map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM
+	}{
+		{
+			name: "empty integration is ignored",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(usertasks.TaskGroup{Integration: "", IssueType: "x"}, testAzureKey, vm("foo"))
+			},
+		},
+		{
+			name: "empty issue type is ignored",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(usertasks.TaskGroup{Integration: "x", IssueType: ""}, testAzureKey, vm("foo"))
+			},
+		},
+		{
+			name: "creates task group and adds VM",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo"),
+				},
+			},
+		},
+		{
+			name: "adds multiple VMs to same key",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo", "bar"),
+				},
+			},
+		},
+		{
+			name: "different issue types create separate groups",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroupAlt, testAzureKey, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey: azureData(testAzureKey, "foo"),
+				},
+				testTaskGroupAlt: {
+					testAzureKey: azureData(testAzureKey, "bar"),
+				},
+			},
+		},
+		{
+			name: "different azure keys create separate entries",
+			mutate: func(tasks *azureVMTasks) {
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKey, vm("foo"))
+				tasks.addFailedEnrollment(testTaskGroup, testAzureKeyAlt, vm("bar"))
+			},
+			expected: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+				testTaskGroup: {
+					testAzureKey:    azureData(testAzureKey, "foo"),
+					testAzureKeyAlt: azureData(testAzureKeyAlt, "bar"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tasks := &azureVMTasks{}
+			tt.mutate(tasks)
+			require.Empty(t, cmp.Diff(tt.expected, tasks.taskGroups, protocmp.Transform()))
+		})
+	}
+}
+
+func TestAzureVMTasks_UpsertAll(t *testing.T) {
+	t.Parallel()
+
+	var testTaskGroup = usertasks.TaskGroup{Integration: "my-int", IssueType: usertasks.AutoDiscoverAzureVMIssueEnrollmentError}
+	var testAzureKey = azureVMTaskKey{subscriptionID: "sub-1", resourceGroup: "rg-1", region: "westus"}
+	var testAzureKeyAlt = azureVMTaskKey{subscriptionID: "sub-2", resourceGroup: "rg-2", region: "eastus"}
+
+	azureData := func(key azureVMTaskKey, instances ...string) *usertasksv1.DiscoverAzureVM {
+		data := &usertasksv1.DiscoverAzureVM{
+			SubscriptionId: key.subscriptionID,
+			ResourceGroup:  key.resourceGroup,
+			Region:         key.region,
+			Instances:      make(map[string]*usertasksv1.DiscoverAzureVMInstance),
+		}
+		for _, instance := range instances {
+			data.Instances[instance] = &usertasksv1.DiscoverAzureVMInstance{
+				VmId:            instance,
+				DiscoveryConfig: "dc-01",
+				DiscoveryGroup:  "group-1",
+				SyncTime:        timestamppb.New(time.Now()),
+			}
+		}
+		return data
+	}
+
+	tests := []struct {
+		name          string
+		tasks         *azureVMTasks
+		existingTasks []*usertasksv1.UserTask
+		expectedTasks int
+	}{
+		{
+			name:          "nil taskGroups does not panic",
+			tasks:         &azureVMTasks{},
+			expectedTasks: 0,
+		},
+		{
+			name: "empty instances are skipped",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {testAzureKey: azureData(testAzureKey)},
+				},
+			},
+			expectedTasks: 0,
+		},
+		{
+			name: "upserts single task",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {
+						testAzureKey: azureData(testAzureKey, "foo"),
+					},
+				},
+			},
+			expectedTasks: 1,
+		},
+		{
+			name: "upserts multiple tasks for different keys",
+			tasks: &azureVMTasks{
+				taskGroups: map[usertasks.TaskGroup]map[azureVMTaskKey]*usertasksv1.DiscoverAzureVM{
+					testTaskGroup: {
+						testAzureKey:    azureData(testAzureKey, "foo"),
+						testAzureKeyAlt: azureData(testAzureKeyAlt, "bar"),
+					},
+				},
+			},
+			expectedTasks: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, ap := newTaskUpdater(t, tt.existingTasks...)
+
+			tt.tasks.upsertAll(s)
+
+			tasks := slices.Collect(maps.Values(ap.tasks))
+			require.Len(t, tasks, tt.expectedTasks)
 		})
 	}
 }

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -230,7 +230,8 @@ func (f *azureInstanceFetcher) GetInstances(ctx context.Context, _ bool) ([]*Azu
 			if err != nil {
 				f.Logger.WarnContext(ctx, "Skipping Teleport installation on Azure VM - failed to infer resource group from vm id",
 					"subscription_id", f.Subscription,
-					"vm_id", azure.StringVal(vm.ID),
+					"vm_id", azure.StringVal(vm.Properties.VMID),
+					"resource_id", azure.StringVal(vm.ID),
 					"error", err,
 				)
 				continue

--- a/lib/usertasks/descriptions/azure-vm-agent-not-available.md
+++ b/lib/usertasks/descriptions/azure-vm-agent-not-available.md
@@ -1,0 +1,28 @@
+# VM agent not available
+
+Teleport could not reach the Azure VM agent to run the enrollment command on this VM.
+Azure reported that extension operations are disallowed.
+
+This usually means one of the following:
+
+**VM agent not installed or unhealthy**
+
+Ensure the Azure VM agent is installed and running.
+
+See Azure documentation for details: [Azure Linux VM agent](https://learn.microsoft.com/azure/virtual-machines/extensions/agent-linux).
+
+**Extensions disabled**
+
+Confirm that `osProfile.allowExtensionOperations` is set to `true` on the VM.
+
+You can check this setting using the Azure CLI:
+
+```bash
+az vm show \
+  --resource-group <resource-group> \
+  --name <vm-name> \
+  --query "osProfile.allowExtensionOperations"
+
+```
+
+If a policy disables extension operations, Run Command will not work.

--- a/lib/usertasks/descriptions/azure-vm-enrollment-error.md
+++ b/lib/usertasks/descriptions/azure-vm-enrollment-error.md
@@ -1,0 +1,3 @@
+# Enrollment failed
+Teleport could not auto enroll the Azure VM due to an unexpected error.
+

--- a/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
+++ b/lib/usertasks/descriptions/azure-vm-missing-run-commands-permission.md
@@ -1,0 +1,11 @@
+# Missing Run Command permissions
+Teleport uses Azure VM Run Command to install the Teleport agent during auto enrollment.
+The Azure identity used by this integration does not have the permissions required to execute commands on this VM.
+
+To fix this, grant the identity a role that includes the following permissions:
+- `Microsoft.Compute/virtualMachines/runCommand/action`
+- `Microsoft.Compute/virtualMachines/runCommands/read`
+- `Microsoft.Compute/virtualMachines/runCommands/write`
+- `Microsoft.Compute/virtualMachines/runCommands/delete`
+
+You can assign these permissions at the Subscription level for broad access, or limit the scope to the Resource Group.

--- a/lib/usertasks/descriptions/azure-vm-not-running.md
+++ b/lib/usertasks/descriptions/azure-vm-not-running.md
@@ -1,0 +1,5 @@
+# VMs not running
+
+Teleport uses Azure Run Command to install the agent, which requires VMs to be in a running state.
+
+The enrollment will be retried automatically once the machines reach the Running state.

--- a/lib/usertasks/descriptions_test.go
+++ b/lib/usertasks/descriptions_test.go
@@ -31,6 +31,7 @@ func TestAllDescriptions(t *testing.T) {
 		usertasksapi.DiscoverEC2IssueTypes,
 		usertasksapi.DiscoverEKSIssueTypes,
 		usertasksapi.DiscoverRDSIssueTypes,
+		usertasksapi.DiscoverAzureVMIssueTypes,
 	} {
 		for _, issueType := range issueGroup {
 			title, description := DescriptionForDiscoverEC2Issue(issueType)


### PR DESCRIPTION
Backport #62901 to branch/v18

Depends on https://github.com/gravitational/teleport/pull/62731.

Changelog: VM installation errors will be captured as user tasks for Azure Discovery flows.