### PR TITLE
[v18] Unify behavior of the uploaders

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -5073,10 +5073,16 @@ readLoop:
 	require.True(t, hasLeave, "session leave event not found")
 	require.True(t, hasEnd, "session end event not found")
 
-	// ensure session upload directory is empty
+	// ensure session upload directory is empty, apart from the pending directory
 	fi, err := os.ReadDir(sessionsDir)
 	require.NoError(t, err)
-	require.Empty(t, fi)
+	require.Len(t, fi, 1)
+	assert.Equal(t, "pending", fi[0].Name())
+	assert.True(t, fi[0].IsDir())
+
+	fi, err = os.ReadDir(filepath.Join(sessionsDir, "pending"))
+	require.NoError(t, err)
+	assert.Empty(t, fi)
 }
 
 // testPAM checks that Teleport PAM integration works correctly. In this case

--- a/lib/events/azsessions/azsessions.go
+++ b/lib/events/azsessions/azsessions.go
@@ -269,6 +269,12 @@ func (h *Handler) sessionBlob(sessionID session.ID) *blockblob.Client {
 	return h.session.NewBlockBlobClient(sessionName(sessionID))
 }
 
+// pendingSummaryBlob returns a BlockBlobClient for the blob of the a pending
+// session summary.
+func (h *Handler) pendingSummaryBlob(sessionID session.ID) *blockblob.Client {
+	return h.inprogress.NewBlockBlobClient(summaryName(sessionID))
+}
+
 // summaryBlob returns a BlockBlobClient for the blob of the session summary.
 func (h *Handler) summaryBlob(sessionID session.ID) *blockblob.Client {
 	return h.session.NewBlockBlobClient(summaryName(sessionID))
@@ -298,31 +304,74 @@ func (h *Handler) partBlob(upload events.StreamUpload, partNumber int64) *blockb
 
 // Upload implements [events.UploadHandler] and uploads a session recording.
 func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadBlob(ctx, sessionID, h.sessionBlob(sessionID), reader)
+	path, err := h.uploadBlob(ctx, sessionID, h.sessionBlob(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
-// UploadSummary implements [events.UploadHandler] and uploads a session
-// summary.
+// UploadPendingSummary implements [events.UploadHandler] and uploads a pending
+// session summary. This function can be called multiple times for a given
+// sessionID to update the state.
+func (h *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	path, err := h.uploadBlob(ctx, sessionID, h.pendingSummaryBlob(sessionID), reader, withOverwrite())
+	return path, trace.Wrap(err)
+}
+
+// UploadSummary implements [events.UploadHandler] and uploads a final version
+// of session summary and deletes the pending one. This function can be called
+// only once for a given sessionID; subsequent calls will return an error.
 func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadBlob(ctx, sessionID, h.summaryBlob(sessionID), reader)
+	path, err := h.uploadBlob(ctx, sessionID, h.summaryBlob(sessionID), reader)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	_, err = cErr(h.pendingSummaryBlob(sessionID).Delete(ctx, nil))
+	if err != nil && !trace.IsNotFound(err) {
+		return "", trace.Wrap(err)
+	}
+
+	return path, nil
 }
 
 // UploadMetadata implements [events.UploadHandler] and uploads the session
 // metadata.
 func (h *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadBlob(ctx, sessionID, h.metadataBlob(sessionID), reader)
+	path, err := h.uploadBlob(ctx, sessionID, h.metadataBlob(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
 // UploadThumbnail implements [events.UploadHandler] and uploads the session
 // thumbnail.
 func (h *Handler) UploadThumbnail(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadBlob(ctx, sessionID, h.thumbnailBlob(sessionID), reader)
+	path, err := h.uploadBlob(ctx, sessionID, h.thumbnailBlob(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
-func (h *Handler) uploadBlob(ctx context.Context, sessionID session.ID, blob *blockblob.Client, reader io.Reader) (string, error) {
-	if _, err := cErr(blob.UploadStream(ctx, reader, &blockblob.UploadStreamOptions{
-		AccessConditions: &blobDoesNotExist,
-	})); err != nil {
+type blobUploadConfig struct {
+	overwrite bool
+}
+
+type blobUploadOption func(*blobUploadConfig)
+
+func withOverwrite() blobUploadOption {
+	return func(cfg *blobUploadConfig) {
+		cfg.overwrite = true
+	}
+}
+
+func (h *Handler) uploadBlob(
+	ctx context.Context, sessionID session.ID, blob *blockblob.Client, reader io.Reader, opts ...blobUploadOption,
+) (string, error) {
+	cfg := blobUploadConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	usOpts := blockblob.UploadStreamOptions{}
+	if !cfg.overwrite {
+		usOpts.AccessConditions = &blobDoesNotExist
+	}
+	if _, err := cErr(blob.UploadStream(ctx, reader, &usOpts)); err != nil {
 		return "", trace.Wrap(err)
 	}
 	h.log.DebugContext(ctx, "Blob uploaded.", fieldSessionID, sessionID)
@@ -332,22 +381,35 @@ func (h *Handler) uploadBlob(ctx context.Context, sessionID session.ID, blob *bl
 
 // Download implements [events.UploadHandler] and downloads a session recording.
 func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadBlob(ctx, sessionID, h.sessionBlob(sessionID), writer)
+	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.sessionBlob(sessionID), writer))
 }
 
-// DownloadSummary implements [events.UploadHandler] and downloads a session summary.
+// DownloadSummary implements [events.UploadHandler] and downloads a final
+// session summary.
 func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadBlob(ctx, sessionID, h.summaryBlob(sessionID), writer)
+	// Happy path: the final summary exists.
+	err := h.downloadBlob(ctx, sessionID, h.summaryBlob(sessionID), writer)
+	if trace.IsNotFound(err) {
+		// Final summary doesn't exist, try the pending one.
+		err = h.downloadBlob(ctx, sessionID, h.pendingSummaryBlob(sessionID), writer)
+		if trace.IsNotFound(err) {
+			// One more check for the final summary to prevent a race condition where
+			// the final one got created and the pending one got removed between the
+			// two checks above.
+			err = h.downloadBlob(ctx, sessionID, h.summaryBlob(sessionID), writer)
+		}
+	}
+	return trace.Wrap(err)
 }
 
 // DownloadMetadata implements [events.UploadHandler] and downloads a session's metadata.
 func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadBlob(ctx, sessionID, h.metadataBlob(sessionID), writer)
+	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.metadataBlob(sessionID), writer))
 }
 
 // DownloadThumbnail implements [events.UploadHandler] and downloads a session's thumbnail.
 func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadBlob(ctx, sessionID, h.thumbnailBlob(sessionID), writer)
+	return trace.Wrap(h.downloadBlob(ctx, sessionID, h.thumbnailBlob(sessionID), writer))
 }
 
 func (h *Handler) downloadBlob(ctx context.Context, sessionID session.ID, blob *blockblob.Client, writer events.RandomAccessWriter) error {

--- a/lib/events/filesessions/fileuploader.go
+++ b/lib/events/filesessions/fileuploader.go
@@ -91,6 +91,12 @@ func NewHandler(cfg Config) (*Handler, error) {
 		Config:       cfg,
 		fileRecorder: NewPlainFileRecorder(logger, cfg.OpenFile),
 	}
+
+	err := os.MkdirAll(h.pendingSummariesPath(), teleport.PrivateDirMode)
+	if err != nil {
+		return nil, trace.ConvertSystemError(err)
+	}
+
 	return h, nil
 }
 
@@ -112,22 +118,34 @@ func (l *Handler) Close() error {
 
 // Download reads a session recording from a local directory.
 func (l *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return downloadFile(l.recordingPath(sessionID), writer)
+	return trace.Wrap(downloadFile(l.recordingPath(sessionID), writer))
 }
 
 // DownloadSummary reads a session summary from a local directory.
 func (l *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return downloadFile(l.summaryPath(sessionID), writer)
+	// Happy path: the final summary exists.
+	err := downloadFile(l.summaryPath(sessionID), writer)
+	if trace.IsNotFound(err) {
+		// Final summary doesn't exist, try the pending one.
+		err = downloadFile(l.pendingSummaryPath(sessionID), writer)
+		if trace.IsNotFound(err) {
+			// One more check for the final summary to prevent a race condition where
+			// the final one got created and the pending one got removed between the
+			// two checks above.
+			err = downloadFile(l.summaryPath(sessionID), writer)
+		}
+	}
+	return trace.Wrap(err)
 }
 
 // DownloadMetadata reads session metadata from a local directory.
 func (l *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return downloadFile(l.metadataPath(sessionID), writer)
+	return trace.Wrap(downloadFile(l.metadataPath(sessionID), writer))
 }
 
 // DownloadThumbnail reads a session thumbnail from a local directory.
 func (l *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return downloadFile(l.thumbnailPath(sessionID), writer)
+	return trace.Wrap(downloadFile(l.thumbnailPath(sessionID), writer))
 }
 
 func downloadFile(path string, writer events.RandomAccessWriter) error {
@@ -145,12 +163,32 @@ func downloadFile(path string, writer events.RandomAccessWriter) error {
 
 // Upload writes a session recording to a local directory.
 func (l *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return uploadFile(l.recordingPath(sessionID), reader)
+	s, err := uploadFile(l.recordingPath(sessionID), reader)
+	return s, trace.Wrap(err)
 }
 
-// UploadSummary writes a session summary to a local directory.
+// UploadPendingSummary writes a pending session summary to a local directory.
+// This function can be called multiple times for a given sessionID to update
+// the state.
+func (l *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	return uploadFile(l.pendingSummaryPath(sessionID), reader, withOverwrite())
+}
+
+// UploadSummary writes a final version of session summary and removes the
+// pending one. This function can be called only once for a given sessionID;
+// subsequent calls will return an error.
 func (l *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return uploadFile(l.summaryPath(sessionID), reader)
+	name, err := uploadFile(l.summaryPath(sessionID), reader)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	err = os.Remove(l.pendingSummaryPath(sessionID))
+	if err != nil && !trace.IsNotFound(err) {
+		return "", trace.Wrap(err)
+	}
+
+	return name, nil
 }
 
 // UploadMetadata writes session metadata to a local directory.
@@ -163,8 +201,29 @@ func (l *Handler) UploadThumbnail(ctx context.Context, sessionID session.ID, rea
 	return uploadFile(l.thumbnailPath(sessionID), reader)
 }
 
-func uploadFile(path string, reader io.Reader) (string, error) {
-	f, err := os.Create(path)
+type fileUploadConfig struct {
+	overwrite bool
+}
+
+type fileUploadOption func(*fileUploadConfig)
+
+func withOverwrite() fileUploadOption {
+	return func(cfg *fileUploadConfig) {
+		cfg.overwrite = true
+	}
+}
+
+func uploadFile(path string, reader io.Reader, opts ...fileUploadOption) (string, error) {
+	cfg := fileUploadConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	flags := os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	if !cfg.overwrite {
+		flags |= os.O_EXCL
+	}
+	f, err := os.OpenFile(path, flags, 0666)
 	if err != nil {
 		return "", trace.ConvertSystemError(err)
 	}
@@ -177,6 +236,14 @@ func uploadFile(path string, reader io.Reader) (string, error) {
 
 func (l *Handler) recordingPath(sessionID session.ID) string {
 	return filepath.Join(l.Directory, string(sessionID)+tarExt)
+}
+
+func (l *Handler) pendingSummariesPath() string {
+	return filepath.Join(l.Directory, "pending")
+}
+
+func (l *Handler) pendingSummaryPath(sessionID session.ID) string {
+	return filepath.Join(l.pendingSummariesPath(), string(sessionID)+summaryExt)
 }
 
 func (l *Handler) summaryPath(sessionID session.ID) string {

--- a/lib/events/gcssessions/gcshandler.go
+++ b/lib/events/gcssessions/gcshandler.go
@@ -88,6 +88,8 @@ const (
 	kmsKeyName = "keyName"
 	// pathPropertyKey
 	pathPropertyKey = "path"
+	// pendingPrefix is a prefix of the pending summaries path
+	pendingPrefix = "pending"
 )
 
 // Config is handler configuration
@@ -238,43 +240,81 @@ func (h *Handler) Close() error {
 // Upload reads the content of a session recording from a reader and uploads it
 // to a GCS bucket. If successful, it returns URL of the uploaded object.
 func (h *Handler) Upload(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadFile(ctx, h.recordingPath(sessionID), reader)
+	path, err := h.uploadFile(ctx, h.recordingPath(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
-// UploadSummary reads the content of a session summary from a reader and
-// uploads it to a GCS bucket. If successful, it returns URL of the uploaded
-// object.
+// UploadPendingSummary reads the content of a pending session summary from a
+// reader and uploads it to a GCS bucket. If successful, it returns URL of the
+// uploaded object. This function can be called multiple times for a given
+// sessionID to update the state.
+func (h *Handler) UploadPendingSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	path, err := h.uploadFile(ctx, h.pendingSummaryPath(sessionID), reader, withOverwrite())
+	return path, trace.Wrap(err)
+}
+
+// UploadSummary reads the content of a final version of session summary from a
+// reader and uploads it to a GCS bucket. The pending version, if any, is
+// removed. If successful, it returns URL of the uploaded object. This function
+// can be called only once for a given sessionID; subsequent calls will return
+// an error.
 func (h *Handler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadFile(ctx, h.summaryPath(sessionID), reader)
+	path, err := h.uploadFile(ctx, h.summaryPath(sessionID), reader)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	pendingObj := h.gcsClient.Bucket(h.Config.Bucket).Object(h.pendingSummaryPath(sessionID))
+	err = convertGCSError(pendingObj.Delete(ctx))
+	if err != nil && !trace.IsNotFound(err) {
+		return "", trace.Wrap(err)
+	}
+	return path, nil
 }
 
 // UploadMetadata reads the session metadata from a reader and uploads it to a GCS
 // bucket. If successful, it returns URL of the uploaded object.
 func (h *Handler) UploadMetadata(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadFile(ctx, h.metadataPath(sessionID), reader)
+	path, err := h.uploadFile(ctx, h.metadataPath(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
 // UploadThumbnail reads the session thumbnail from a reader and uploads it to a GCS
 // bucket. If successful, it returns URL of the uploaded object.
 func (h *Handler) UploadThumbnail(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
-	return h.uploadFile(ctx, h.thumbnailPath(sessionID), reader)
+	path, err := h.uploadFile(ctx, h.thumbnailPath(sessionID), reader)
+	return path, trace.Wrap(err)
 }
 
-func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader) (string, error) {
-	h.logger.DebugContext(ctx, "Uploading object to GCS", "path", path)
+type fileUploadConfig struct {
+	overwrite bool
+}
 
-	// Make sure we don't overwrite an existing recording.
-	_, err := h.gcsClient.Bucket(h.Config.Bucket).Object(path).Attrs(ctx)
-	if !errors.Is(err, storage.ErrObjectNotExist) {
-		if err != nil {
-			return "", convertGCSError(err)
-		}
-		return "", trace.AlreadyExists("file %q already exists in GCS", path)
+type fileUploadOption func(*fileUploadConfig)
+
+func withOverwrite() fileUploadOption {
+	return func(cfg *fileUploadConfig) {
+		cfg.overwrite = true
+	}
+}
+
+func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader, opts ...fileUploadOption) (string, error) {
+	cfg := fileUploadConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
-	writer := h.gcsClient.Bucket(h.Config.Bucket).Object(path).NewWriter(ctx)
+	h.logger.DebugContext(ctx, "Uploading object to GCS", "path", path)
+
+	obj := h.gcsClient.Bucket(h.Config.Bucket).Object(path)
+	if !cfg.overwrite {
+		// Make sure we don't overwrite an existing recording.
+		obj = obj.If(storage.Conditions{DoesNotExist: true})
+	}
+
+	writer := obj.NewWriter(ctx)
 	start := time.Now()
-	_, err = io.Copy(writer, reader)
+	_, err := io.Copy(writer, reader)
 	// Always close the writer, even if upload failed.
 	closeErr := writer.Close()
 	if err == nil {
@@ -292,28 +332,40 @@ func (h *Handler) uploadFile(ctx context.Context, path string, reader io.Reader)
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
 func (h *Handler) Download(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadFile(ctx, h.recordingPath(sessionID), writer)
+	return trace.Wrap(h.downloadFile(ctx, h.recordingPath(sessionID), writer))
 }
 
 // DownloadSummary downloads a session summary from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
 func (h *Handler) DownloadSummary(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadFile(ctx, h.summaryPath(sessionID), writer)
+	// Happy path: the final summary exists.
+	err := h.downloadFile(ctx, h.summaryPath(sessionID), writer)
+	if trace.IsNotFound(err) {
+		// Final summary doesn't exist, try the pending one.
+		err = h.downloadFile(ctx, h.pendingSummaryPath(sessionID), writer)
+		if trace.IsNotFound(err) {
+			// One more check for the final summary to prevent a race condition where
+			// the final one got created and the pending one got removed between the
+			// two checks above.
+			err = h.downloadFile(ctx, h.summaryPath(sessionID), writer)
+		}
+	}
+	return trace.Wrap(err)
 }
 
 // DownloadMetadata downloads a session's metadata from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
 func (h *Handler) DownloadMetadata(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadFile(ctx, h.metadataPath(sessionID), writer)
+	return trace.Wrap(h.downloadFile(ctx, h.metadataPath(sessionID), writer))
 }
 
 // DownloadThumbnail downloads a session's thumbnail from a GCS bucket and writes the
 // result into a writer. Returns trace.NotFound error if the recording is not
 // found.
 func (h *Handler) DownloadThumbnail(ctx context.Context, sessionID session.ID, writer events.RandomAccessWriter) error {
-	return h.downloadFile(ctx, h.thumbnailPath(sessionID), writer)
+	return trace.Wrap(h.downloadFile(ctx, h.thumbnailPath(sessionID), writer))
 }
 
 func (h *Handler) downloadFile(ctx context.Context, path string, writer events.RandomAccessWriter) error {
@@ -341,6 +393,13 @@ func (h *Handler) recordingPath(sessionID session.ID) string {
 		return string(sessionID) + ".tar"
 	}
 	return strings.TrimPrefix(path.Join(h.Path, string(sessionID)+".tar"), slash)
+}
+
+func (h *Handler) pendingSummaryPath(sessionID session.ID) string {
+	if h.Path == "" {
+		return path.Join(pendingPrefix, string(sessionID)+".summary.json")
+	}
+	return strings.TrimPrefix(path.Join(h.Path, pendingPrefix, string(sessionID)+".summary.json"), slash)
 }
 
 func (h *Handler) summaryPath(sessionID session.ID) string {

--- a/lib/events/membuffer.go
+++ b/lib/events/membuffer.go
@@ -1,0 +1,53 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package events
+
+import (
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
+)
+
+// MemBuffer is a in-memory byte buffer that implements both io.Writer and
+// io.WriterAt interfaces.
+type MemBuffer struct {
+	buf manager.WriteAtBuffer
+	// mu is a mutex to protect concurrent writes to the buffer. Even though the
+	// underlying buffer is thread-safe, we need to prevent a race condition in
+	// [MemBuffer.Write] between checking the length of the buffer and writing to
+	// it.
+	mu sync.Mutex
+}
+
+func (b *MemBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.WriteAt(p, int64(len(b.buf.Bytes())))
+}
+
+func (b *MemBuffer) WriteAt(p []byte, pos int64) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.WriteAt(p, pos)
+}
+
+// Bytes return the underlying byte slice.
+func (b *MemBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Bytes()
+}

--- a/lib/events/membuffer_test.go
+++ b/lib/events/membuffer_test.go
@@ -1,0 +1,44 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemBuffer(t *testing.T) {
+	t.Parallel()
+
+	buf := &MemBuffer{}
+
+	n, err := buf.WriteAt([]byte(" likes "), 5)
+	require.NoError(t, err)
+	assert.Equal(t, 7, n)
+
+	n, err = buf.WriteAt([]byte("Alice"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	n, err = buf.Write([]byte("Bob"))
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	assert.Equal(t, "Alice likes Bob", string(buf.Bytes()))
+}

--- a/lib/events/s3sessions/s3client.go
+++ b/lib/events/s3sessions/s3client.go
@@ -38,4 +38,5 @@ type s3Client interface {
 	ListParts(ctx context.Context, params *s3.ListPartsInput, optFns ...func(*s3.Options)) (*s3.ListPartsOutput, error)
 	ListMultipartUploads(ctx context.Context, params *s3.ListMultipartUploadsInput, optFns ...func(*s3.Options)) (*s3.ListMultipartUploadsOutput, error)
 	UploadPart(ctx context.Context, params *s3.UploadPartInput, optFns ...func(*s3.Options)) (*s3.UploadPartOutput, error)
+	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 }

--- a/lib/events/s3sessions/s3handler_test.go
+++ b/lib/events/s3sessions/s3handler_test.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -36,10 +37,15 @@ import (
 
 // TestStreams tests various streaming upload scenarios
 func TestStreams(t *testing.T) {
+	bucket := os.Getenv("TELEPORT_TEST_AUDIT_SESSIONS_S3_BUCKET")
+	if bucket == "" {
+		bucket = "teleport-unit-tests"
+	}
+
 	handler, err := NewHandler(context.Background(), Config{
 		Region: "us-west-1",
 		Path:   "/test/",
-		Bucket: "teleport-unit-tests",
+		Bucket: bucket,
 	})
 	require.NoError(t, err)
 

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -47,16 +48,22 @@ import (
 // UploadDownload tests uploads and downloads
 func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 	val := "hello, how is it going? this is the uploaded file"
+	ctx := t.Context()
 	id := session.NewID()
-	_, err := handler.Upload(context.TODO(), id, bytes.NewBuffer([]byte(val)))
+
+	_, err := handler.Upload(ctx, id, strings.NewReader(val))
 	require.NoError(t, err)
+
+	// Attempt to overwrite an existing file. This should fail.
+	_, err = handler.Upload(ctx, id, strings.NewReader("impostor"))
+	require.Error(t, err)
 
 	f, err := os.CreateTemp("", string(id))
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.Download(context.TODO(), id, f)
+	err = handler.Download(ctx, id, f)
 	require.NoError(t, err)
 
 	_, err = f.Seek(0, 0)
@@ -64,30 +71,57 @@ func UploadDownload(t *testing.T, handler events.MultipartHandler) {
 
 	data, err := io.ReadAll(f)
 	require.NoError(t, err)
-	require.Equal(t, string(data), val)
+	require.Equal(t, val, string(data))
 }
 
 // UploadDownloadSummary tests summary uploads and downloads
 func UploadDownloadSummary(t *testing.T, handler events.MultipartHandler) {
-	val := "this is the summary file"
+	ctx := t.Context()
 	id := session.NewID()
-	_, err := handler.UploadSummary(t.Context(), id, bytes.NewBuffer([]byte(val)))
+
+	_, err := handler.UploadPendingSummary(ctx, id, strings.NewReader("pending summary"))
 	require.NoError(t, err)
 
-	f, err := os.CreateTemp("", string(id))
+	var pendingBuf events.MemBuffer
+	err = handler.DownloadSummary(ctx, id, &pendingBuf)
 	require.NoError(t, err)
-	defer os.Remove(f.Name())
-	defer f.Close()
+	assert.Equal(t, "pending summary", string(pendingBuf.Bytes()))
 
-	err = handler.DownloadSummary(context.TODO(), id, f)
-	require.NoError(t, err)
-
-	_, err = f.Seek(0, 0)
+	// Override previous pending state.
+	_, err = handler.UploadPendingSummary(ctx, id, strings.NewReader("updated pending summary"))
 	require.NoError(t, err)
 
-	data, err := io.ReadAll(f)
+	// Download the pending version.
+	var pendingBuf2 events.MemBuffer
+	err = handler.DownloadSummary(ctx, id, &pendingBuf2)
 	require.NoError(t, err)
-	require.Equal(t, string(data), val)
+	assert.Equal(t, "updated pending summary", string(pendingBuf2.Bytes()))
+
+	// Upload the final version.
+	_, err = handler.UploadSummary(ctx, id, strings.NewReader("final summary"))
+	require.NoError(t, err)
+
+	// Attempt to overwrite an existing file. This should fail.
+	_, err = handler.UploadSummary(ctx, id, strings.NewReader("impostor"))
+	require.Error(t, err)
+
+	// Download the final version.
+	var finalBuf events.MemBuffer
+	err = handler.DownloadSummary(ctx, id, &finalBuf)
+	require.NoError(t, err)
+	assert.Equal(t, "final summary", string(finalBuf.Bytes()))
+
+	// Upload one more file, this time right to the final state (test if it's
+	// possible to upload one without a pending state).
+	id2 := session.NewID()
+	_, err = handler.UploadSummary(ctx, id2, strings.NewReader("final summary 2"))
+	require.NoError(t, err)
+
+	// Download the final version of the second file.
+	var finalBuf2 events.MemBuffer
+	err = handler.DownloadSummary(ctx, id2, &finalBuf2)
+	require.NoError(t, err)
+	assert.Equal(t, "final summary 2", string(finalBuf2.Bytes()))
 }
 
 // UploadDownloadMetadata tests metadata uploads and downloads

--- a/lib/events/uploader.go
+++ b/lib/events/uploader.go
@@ -33,10 +33,19 @@ type UploadHandler interface {
 	Upload(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// Download downloads a session recording and writes it to a writer.
 	Download(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
-	// UploadSummary uploads a session summary and returns a URL with uploaded
-	// file in case of success.
+	// UploadPendingSummary uploads a pending session summary and returns a URL
+	// with uploaded file in case of success. This function can be called
+	// multiple times for a given sessionID to update the state. A pending
+	// session summary is any summary state that can still be later overwritten.
+	// It should still be contained in the same structure as the final one, but
+	// missing some data (in particular, the summary content itself).
+	UploadPendingSummary(ctx context.Context, sesisonID session.ID, readCloser io.Reader) (string, error)
+	// UploadSummary uploads a final session summary and returns a URL with
+	// uploaded file in case of success. This function can be called only once
+	// for a given sessionID; subsequent calls will return an error.
 	UploadSummary(ctx context.Context, sessionID session.ID, readCloser io.Reader) (string, error)
 	// DownloadSummary downloads a session summary and writes it to a writer.
+	// Returns a "not found" error if there's no such summary.
 	DownloadSummary(ctx context.Context, sessionID session.ID, writer RandomAccessWriter) error
 	// UploadMetadata uploads session metadata and returns a URL with the uploaded
 	// file in case of success. Session metadata is a file with a [recordingmetadatav1.SessionRecordingMetadata]

--- a/lib/integrations/externalauditstorage/error_counter.go
+++ b/lib/integrations/externalauditstorage/error_counter.go
@@ -373,6 +373,13 @@ func (c *ErrorCountingSessionHandler) Upload(ctx context.Context, sessionID sess
 	return res, err
 }
 
+// UploadPendingSummary calls [c.wrapped.UploadPendingSummary] and counts the error or success.
+func (c *ErrorCountingSessionHandler) UploadPendingSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
+	res, err := c.wrapped.UploadPendingSummary(ctx, sessionID, reader)
+	c.uploads.observe(err)
+	return res, err
+}
+
 // UploadSummary calls [c.wrapped.UploadSummary] and counts the error or success.
 func (c *ErrorCountingSessionHandler) UploadSummary(ctx context.Context, sessionID session.ID, reader io.Reader) (string, error) {
 	res, err := c.wrapped.UploadSummary(ctx, sessionID, reader)


### PR DESCRIPTION
Backport #60534 to branch/v18

Manual conflicts resolved: all `go.mod` and `go.sum` files were reverted, since the library that I updated as a part of the original PR got independently updated on v18.

Tested manually with all providers (S3, Azure, GCS, local files), including sync mode and encrypted sessions.