### PR TITLE
Update fixture for audit event `T1013W` (faliure during headless login approval)

### DIFF
--- a/docs/pages/reference/audit-events.mdx
+++ b/docs/pages/reference/audit-events.mdx
@@ -6760,7 +6760,7 @@ Example:
   "event": "user.login",
   "method": "headless",
   "ei": 0,
-  "success": true,
+  "success": false,
   "time": "2019-04-22T00:49:03Z",
   "uid": "173d6b6e-d613-44be-8ff6-f9f893791ef5",
   "user": "admin@example.com",

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -2744,7 +2744,7 @@ export const events = [
     event: 'user.login',
     method: 'headless',
     ei: 0,
-    success: true,
+    success: false,
     time: '2019-04-22T00:49:03Z',
     uid: '173d6b6e-d613-44be-8ff6-f9f893791ef5',
     user: 'admin@example.com',


### PR DESCRIPTION
The fixture erroneously said that `success` is `true`, even though it's `true` only for `T1013I`.

https://github.com/gravitational/teleport/blob/7d2d2a891d412e45c35cc736b534d9bcce68e53a/lib/auth/auth_with_roles.go#L8274

https://github.com/gravitational/teleport/blob/318a2a34e7ee39fa25e1964bd8d2f99060e3b641/lib/events/codes.go#L79-L80