### PR TITLE
tctl resource: convert ScopedRole and ScopedRoleAssignment to new handler format

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -34,7 +34,6 @@ import (
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
 	healthcheckconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/healthcheckconfig/v1"
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
-	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/externalauditstorage"
@@ -756,70 +755,6 @@ func (c *healthCheckConfigCollection) WriteText(w io.Writer, verbose bool) error
 
 	// stable sort by name.
 	t.SortRowsBy([]int{0}, true)
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type scopedRoleCollection struct {
-	items []*scopedaccessv1.ScopedRole
-}
-
-func (c *scopedRoleCollection) Resources() []types.Resource {
-	out := make([]types.Resource, 0, len(c.items))
-	for _, item := range c.items {
-		out = append(out, types.Resource153ToLegacy(item))
-	}
-	return out
-}
-
-func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"Scope", "Name"}
-	var rows [][]string
-	for _, item := range c.items {
-		rows = append(rows, []string{
-			item.GetScope(),
-			item.GetMetadata().GetName(),
-		})
-	}
-
-	t := asciitable.MakeTable(headers, rows...)
-
-	_, err := t.AsBuffer().WriteTo(w)
-	return trace.Wrap(err)
-}
-
-type scopedRoleAssignmentCollection struct {
-	items []*scopedaccessv1.ScopedRoleAssignment
-}
-
-func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
-	out := make([]types.Resource, 0, len(c.items))
-	for _, item := range c.items {
-		out = append(out, types.Resource153ToLegacy(item))
-	}
-	return out
-}
-
-func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
-	headers := []string{"Scope", "Name", "User", "Assigns"}
-	var rows [][]string
-
-	for _, item := range c.items {
-		var assigns []string
-		for _, subAssignment := range item.GetSpec().GetAssignments() {
-			assigns = append(assigns, fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope()))
-		}
-
-		rows = append(rows, []string{
-			item.GetScope(),
-			item.GetMetadata().GetName(),
-			item.GetSpec().GetUser(),
-			strings.Join(assigns, ", "),
-		})
-	}
-
-	t := asciitable.MakeTable(headers, rows...)
-
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
 	"github.com/gravitational/teleport/lib/services"
 )
 
@@ -89,6 +90,8 @@ func Handlers() map[string]Handler {
 		types.KindWorkloadIdentityX509IssuerOverride: workloadIdentityX509IssuerOverrideHandler(),
 		types.KindWorkloadIdentityX509Revocation:     workloadIdentityX509RevocationHandler(),
 		types.KindAppAuthConfig:                      appAuthConfigHandler(),
+		scopedaccess.KindScopedRole:                  scopedRoleHandler(),
+		scopedaccess.KindScopedRoleAssignment:        scopedRoleAssignmentHandler(),
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -44,21 +44,20 @@ func NewScopedRoleCollection(roles []*scopedaccessv1.ScopedRole) Collection {
 
 func (c *scopedRoleCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.roles))
-	for _, resource := range c.roles {
-		r = append(r, types.Resource153ToLegacy(resource))
+	for i, resource := range c.roles {
+		r[i] = types.Resource153ToLegacy(resource)
 	}
 	return r
 }
 
-// WriteText implements [Collection].
 func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Scope", "Name"}
-	var rows [][]string
-	for _, item := range c.roles {
-		rows = append(rows, []string{
+	rows := make([][]string, len(c.roles))
+	for i, item := range c.roles {
+		rows[i] = []string{
 			item.GetScope(),
 			item.GetMetadata().GetName(),
-		})
+		}
 	}
 
 	t := asciitable.MakeTable(headers, rows...)
@@ -73,7 +72,7 @@ func scopedRoleHandler() Handler {
 		createHandler: createScopedRole,
 		updateHandler: updateScopedRole,
 		deleteHandler: deleteScopedRole,
-		description:   "A scoped role is a role with scoped permissions and resources that can be assigned to users",
+		description:   "A scoped set permissions and resources that can be granted to users",
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -1,0 +1,154 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/gravitational/trace"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type scopedRoleCollection struct {
+	roles []*scopedaccessv1.ScopedRole
+}
+
+func NewScopedRoleCollection(roles []*scopedaccessv1.ScopedRole) Collection {
+	return &scopedRoleCollection{
+		roles: roles,
+	}
+}
+
+func (c *scopedRoleCollection) Resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.roles))
+	for _, resource := range c.roles {
+		r = append(r, types.Resource153ToLegacy(resource))
+	}
+	return r
+}
+
+// WriteText implements [Collection].
+func (c *scopedRoleCollection) WriteText(w io.Writer, verbose bool) error {
+	headers := []string{"Scope", "Name"}
+	var rows [][]string
+	for _, item := range c.roles {
+		rows = append(rows, []string{
+			item.GetScope(),
+			item.GetMetadata().GetName(),
+		})
+	}
+
+	t := asciitable.MakeTable(headers, rows...)
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func scopedRoleHandler() Handler {
+	return Handler{
+		getHandler:    getScopedRole,
+		createHandler: createScopedRole,
+		updateHandler: updateScopedRole,
+		deleteHandler: deleteScopedRole,
+		description:   "A scoped role is a role with scoped permissions and resources that can be assigned to users",
+	}
+}
+
+func createScopedRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if opts.Force {
+		return trace.BadParameter("scoped role creation does not support --force")
+	}
+
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRole](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err := client.ScopedAccessServiceClient().CreateScopedRole(ctx, &scopedaccessv1.CreateScopedRoleRequest{
+		Role: r,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		scopedaccess.KindScopedRole+" %q has been created\n",
+		r.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func updateScopedRole(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRole](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if _, err = client.ScopedAccessServiceClient().UpdateScopedRole(ctx, &scopedaccessv1.UpdateScopedRoleRequest{
+		Role: r,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		scopedaccess.KindScopedRole+" %q has been updated\n",
+		r.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func getScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		rsp, err := client.ScopedAccessServiceClient().GetScopedRole(ctx, &scopedaccessv1.GetScopedRoleRequest{
+			Name: ref.Name,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &scopedRoleCollection{roles: []*scopedaccessv1.ScopedRole{rsp.Role}}, nil
+	}
+
+	items, err := stream.Collect(scopedutils.RangeScopedRoles(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRolesRequest{}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &scopedRoleCollection{roles: items}, nil
+}
+
+func deleteScopedRole(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if _, err := client.ScopedAccessServiceClient().DeleteScopedRole(ctx, &scopedaccessv1.DeleteScopedRoleRequest{
+		Name: ref.Name,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf(
+		scopedaccess.KindScopedRole+" %q has been deleted\n",
+		ref.Name,
+	)
+	return nil
+}

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -43,7 +43,7 @@ func NewScopedRoleCollection(roles []*scopedaccessv1.ScopedRole) Collection {
 }
 
 func (c *scopedRoleCollection) Resources() []types.Resource {
-	r := make([]types.Resource, 0, len(c.roles))
+	r := make([]types.Resource, len(c.roles))
 	for i, resource := range c.roles {
 		r[i] = types.Resource153ToLegacy(resource)
 	}
@@ -72,7 +72,7 @@ func scopedRoleHandler() Handler {
 		createHandler: createScopedRole,
 		updateHandler: updateScopedRole,
 		deleteHandler: deleteScopedRole,
-		description:   "A scoped set permissions and resources that can be granted to users",
+		description:   "A scoped set of permissions and resources that can be granted to users",
 	}
 }
 
@@ -93,7 +93,7 @@ func createScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	}
 
 	fmt.Printf(
-		scopedaccess.KindScopedRole+" %q has been created\n",
+		scopedaccess.KindScopedRole+" %q created\n",
 		r.GetMetadata().GetName(),
 	)
 
@@ -113,7 +113,7 @@ func updateScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	}
 
 	fmt.Printf(
-		scopedaccess.KindScopedRole+" %q has been updated\n",
+		scopedaccess.KindScopedRole+" %q updated\n",
 		r.GetMetadata().GetName(),
 	)
 
@@ -146,7 +146,8 @@ func deleteScopedRole(ctx context.Context, client *authclient.Client, ref servic
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
-		scopedaccess.KindScopedRole+" %q has been deleted\n",
+		"%q %q has been deleted\n",
+		scopedaccess.KindScopedRole,
 		ref.Name,
 	)
 	return nil

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -93,7 +93,8 @@ func createScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	}
 
 	fmt.Printf(
-		scopedaccess.KindScopedRole+" %q created\n",
+		"%v %q has been created\n",
+		scopedaccess.KindScopedRole,
 		r.GetMetadata().GetName(),
 	)
 
@@ -113,7 +114,8 @@ func updateScopedRole(ctx context.Context, client *authclient.Client, raw servic
 	}
 
 	fmt.Printf(
-		scopedaccess.KindScopedRole+" %q updated\n",
+		"%v %q has been updated\n",
+		scopedaccess.KindScopedRole,
 		r.GetMetadata().GetName(),
 	)
 
@@ -146,7 +148,7 @@ func deleteScopedRole(ctx context.Context, client *authclient.Client, ref servic
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
-		"%q %q has been deleted\n",
+		"%v %q has been deleted\n",
 		scopedaccess.KindScopedRole,
 		ref.Name,
 	)

--- a/tool/tctl/common/resources/scoped_role.go
+++ b/tool/tctl/common/resources/scoped_role.go
@@ -72,7 +72,7 @@ func scopedRoleHandler() Handler {
 		createHandler: createScopedRole,
 		updateHandler: updateScopedRole,
 		deleteHandler: deleteScopedRole,
-		description:   "A scoped set of permissions and resources that can be granted to users",
+		description:   "A set of permissions that can be granted to users at a limited scope",
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -45,29 +45,28 @@ func NewScopedRoleAssignmentCollection(roles []*scopedaccessv1.ScopedRoleAssignm
 
 func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
 	r := make([]types.Resource, 0, len(c.roleAssignments))
-	for _, resource := range c.roleAssignments {
-		r = append(r, types.Resource153ToLegacy(resource))
+	for i, resource := range c.roleAssignments {
+		r[i] = types.Resource153ToLegacy(resource)
 	}
 	return r
 }
 
-// WriteText implements [Collection].
 func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
 	headers := []string{"Scope", "Name", "User", "Assigns"}
-	var rows [][]string
+	rows := make([][]string, len(c.roleAssignments))
 
-	for _, item := range c.roleAssignments {
-		var assigns []string
-		for _, subAssignment := range item.GetSpec().GetAssignments() {
-			assigns = append(assigns, fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope()))
+	for i, item := range c.roleAssignments {
+		assigns := make([]string, len(item.GetSpec().GetAssignments()))
+		for i, subAssignment := range item.GetSpec().GetAssignments() {
+			assigns[i] = fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope())
 		}
 
-		rows = append(rows, []string{
+		rows[i] = []string{
 			item.GetScope(),
 			item.GetMetadata().GetName(),
 			item.GetSpec().GetUser(),
 			strings.Join(assigns, ", "),
-		})
+		}
 	}
 
 	t := asciitable.MakeTable(headers, rows...)

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -57,8 +57,8 @@ func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) er
 
 	for i, item := range c.roleAssignments {
 		assigns := make([]string, len(item.GetSpec().GetAssignments()))
-		for i, subAssignment := range item.GetSpec().GetAssignments() {
-			assigns[i] = fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope())
+		for j, subAssignment := range item.GetSpec().GetAssignments() {
+			assigns[j] = fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope())
 		}
 
 		rows[i] = []string{
@@ -102,7 +102,7 @@ func createScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	}
 
 	fmt.Printf(
-		"%q %q creates\n",
+		"%v %q has been created\n",
 		scopedaccess.KindScopedRoleAssignment,
 		rsp.GetAssignment().GetMetadata().GetName(), // must extract from rsp since assignment names are generated server-side
 	)
@@ -136,7 +136,8 @@ func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 		return trace.Wrap(err)
 	}
 	fmt.Printf(
-		scopedaccess.KindScopedRoleAssignment+" %q has been deleted\n",
+		"%v %q has been deleted\n",
+		scopedaccess.KindScopedRoleAssignment,
 		ref.Name,
 	)
 	return nil

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -1,0 +1,143 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package resources
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+
+	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	scopedaccess "github.com/gravitational/teleport/lib/scopes/access"
+	scopedutils "github.com/gravitational/teleport/lib/scopes/utils"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type scopedRoleAssignmentCollection struct {
+	roleAssignments []*scopedaccessv1.ScopedRoleAssignment
+}
+
+func NewScopedRoleAssignmentCollection(roles []*scopedaccessv1.ScopedRoleAssignment) Collection {
+	return &scopedRoleAssignmentCollection{
+		roleAssignments: roles,
+	}
+}
+
+func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
+	r := make([]types.Resource, 0, len(c.roleAssignments))
+	for _, resource := range c.roleAssignments {
+		r = append(r, types.Resource153ToLegacy(resource))
+	}
+	return r
+}
+
+// WriteText implements [Collection].
+func (c *scopedRoleAssignmentCollection) WriteText(w io.Writer, verbose bool) error {
+	headers := []string{"Scope", "Name", "User", "Assigns"}
+	var rows [][]string
+
+	for _, item := range c.roleAssignments {
+		var assigns []string
+		for _, subAssignment := range item.GetSpec().GetAssignments() {
+			assigns = append(assigns, fmt.Sprintf("%s -> %s", subAssignment.GetRole(), subAssignment.GetScope()))
+		}
+
+		rows = append(rows, []string{
+			item.GetScope(),
+			item.GetMetadata().GetName(),
+			item.GetSpec().GetUser(),
+			strings.Join(assigns, ", "),
+		})
+	}
+
+	t := asciitable.MakeTable(headers, rows...)
+
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func scopedRoleAssignmentHandler() Handler {
+	return Handler{
+		getHandler:    getScopedRoleAssignment,
+		createHandler: createScopedRoleAssignment,
+		deleteHandler: deleteScopedRoleAssignment,
+		description:   "A scoped role assignment assigns scoped roles to users at scopes",
+	}
+}
+
+func createScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	if opts.Force {
+		return trace.BadParameter("scoped role assignment creation does not support --force")
+	}
+
+	r, err := services.UnmarshalProtoResource[*scopedaccessv1.ScopedRoleAssignment](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	rsp, err := client.ScopedAccessServiceClient().CreateScopedRoleAssignment(ctx, &scopedaccessv1.CreateScopedRoleAssignmentRequest{
+		Assignment: r,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		scopedaccess.KindScopedRoleAssignment+" %q has been created\n",
+		rsp.GetAssignment().GetMetadata().GetName(), // must extract from rsp since assignment names are generated server-side
+	)
+
+	return nil
+}
+
+func getScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	if ref.Name != "" {
+		rsp, err := client.ScopedAccessServiceClient().GetScopedRoleAssignment(ctx, &scopedaccessv1.GetScopedRoleAssignmentRequest{
+			Name: ref.Name,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &scopedRoleAssignmentCollection{roleAssignments: []*scopedaccessv1.ScopedRoleAssignment{rsp.Assignment}}, nil
+	}
+
+	items, err := stream.Collect(scopedutils.RangeScopedRoleAssignments(ctx, client.ScopedAccessServiceClient(), &scopedaccessv1.ListScopedRoleAssignmentsRequest{}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &scopedRoleAssignmentCollection{roleAssignments: items}, nil
+}
+
+func deleteScopedRoleAssignment(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if _, err := client.ScopedAccessServiceClient().DeleteScopedRoleAssignment(ctx, &scopedaccessv1.DeleteScopedRoleAssignmentRequest{
+		Name: ref.Name,
+	}); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf(
+		scopedaccess.KindScopedRoleAssignment+" %q has been deleted\n",
+		ref.Name,
+	)
+	return nil
+}

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -80,7 +80,7 @@ func scopedRoleAssignmentHandler() Handler {
 		getHandler:    getScopedRoleAssignment,
 		createHandler: createScopedRoleAssignment,
 		deleteHandler: deleteScopedRoleAssignment,
-		description:   "A scoped role assignment assigns scoped roles to users at scopes",
+		description:   "A scoped role assignment binds scoped role permissions to a user at a limited scope",
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_role_assignment.go
+++ b/tool/tctl/common/resources/scoped_role_assignment.go
@@ -44,7 +44,7 @@ func NewScopedRoleAssignmentCollection(roles []*scopedaccessv1.ScopedRoleAssignm
 }
 
 func (c *scopedRoleAssignmentCollection) Resources() []types.Resource {
-	r := make([]types.Resource, 0, len(c.roleAssignments))
+	r := make([]types.Resource, len(c.roleAssignments))
 	for i, resource := range c.roleAssignments {
 		r[i] = types.Resource153ToLegacy(resource)
 	}
@@ -102,7 +102,8 @@ func createScopedRoleAssignment(ctx context.Context, client *authclient.Client, 
 	}
 
 	fmt.Printf(
-		scopedaccess.KindScopedRoleAssignment+" %q has been created\n",
+		"%q %q creates\n",
+		scopedaccess.KindScopedRoleAssignment,
 		rsp.GetAssignment().GetMetadata().GetName(), // must extract from rsp since assignment names are generated server-side
 	)
 


### PR DESCRIPTION
Purpose:

Update code to use new handler format:
https://github.com/gravitational/teleport/issues/60370

Implementation:

Updated `ScopedRole` and `ScopedRoleAssignment` resource commands.
Updated the `resource_command_test.go` since the new handler no longer writes to a buffer when creating.