### PR TITLE
[v18] chore: Bump OpenSSL to 3.0.19

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -46,9 +46,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.16 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.19 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5' ] && \
+    [ "$(git rev-parse HEAD)" = 'a22063cd69a077cc68bb4c10e9f351f75899b194' ] && \
     ./config --release -fPIC --libdir=/usr/local/lib && \
     make -j"$(nproc)" && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -57,11 +57,13 @@ RUN yum groupinstall -y 'Development Tools' && \
       expat-devel  \
       gettext-devel \
       openssl-devel \
-      zlib-devel \
       perl-CPAN \
+      perl-Time-Piece \
       perl-devel \
       scl-utils \
-      wget && \
+      wget \
+      zlib-devel \
+      && \
     yum clean all && \
     /tmp/fix-yum-repo-list.sh
 
@@ -126,9 +128,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.11.0 && \
 # Specific install arguments used to skip docs.
 # Note that FIPS is enabled as part of this build, but it is unused without the
 # necessary configuration (which is included as part of the separate FIPS buildbox).
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.16 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.19 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = 'fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5' ] && \
+    [ "$(git rev-parse HEAD)" = 'a22063cd69a077cc68bb4c10e9f351f75899b194' ] && \
     ./config enable-fips --release -fPIC --libdir=/usr/local/lib64 && \
     make -j"$(nproc)" && \
     make install_sw install_ssldirs install_fips

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -23,8 +23,8 @@ fi
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.11.0
 readonly CBOR_COMMIT=170bee2b82cdb7b2ed25af301f62cb6efdd40ec1
-readonly CRYPTO_VERSION=openssl-3.0.16
-readonly CRYPTO_COMMIT=fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5
+readonly CRYPTO_VERSION=openssl-3.0.19
+readonly CRYPTO_COMMIT=a22063cd69a077cc68bb4c10e9f351f75899b194
 readonly FIDO2_VERSION=1.15.0
 readonly FIDO2_COMMIT=f87c19c9487c0131531314d9ccb475ea5325794e
 

--- a/build.assets/buildbox/pkgconfig/libcrypto-static.pc
+++ b/build.assets/buildbox/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.16
+Version: 3.0.19
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/buildbox/thirdparty-libs.mk
+++ b/build.assets/buildbox/thirdparty-libs.mk
@@ -160,9 +160,9 @@ tp-build-libcbor: fetch-git-libcbor
 # -----------------------------------------------------------------------------
 # openssl
 
-openssl_VERSION = 3.0.16
+openssl_VERSION = 3.0.19
 openssl_GIT_REF = openssl-$(openssl_VERSION)
-openssl_GIT_REF_HASH = fa1e5dfb142bb1c26c3c38a10aafa7a095df52e5
+openssl_GIT_REF_HASH = a22063cd69a077cc68bb4c10e9f351f75899b194
 openssl_GIT_REPO = https://github.com/openssl/openssl
 openssl_SRCDIR = $(call tp-src-dir,openssl)
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.16
+Version: 3.0.19
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.16
+Version: 3.0.19
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Backport #63200 to branch/v18.

Changelog: Updated OpenSSL to 3.0.19