### PR TITLE
Web UI: use cluster version for AWS Discover TF module

### DIFF
--- a/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
@@ -50,6 +50,7 @@ import {
   IntegrationWithSummary,
   Regions,
 } from 'teleport/services/integrations';
+import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeleteIntegrationSection } from './DeleteIntegrationSection';
 
@@ -65,6 +66,7 @@ export function SettingsTab({
   onInfoGuideTabChange: (tab: InfoGuideTab) => void;
 }) {
   const integrationName = stats.name;
+  const { clusterVersion } = useClusterVersion();
   const [configCopied, setConfigCopied] = useState(false);
 
   const handleConfigCopy = () => {
@@ -128,8 +130,9 @@ export function SettingsTab({
         integrationName,
         regions: regions,
         ec2Config: ec2Config,
+        version: clusterVersion,
       }),
-    [integrationName, regions, ec2Config]
+    [integrationName, regions, ec2Config, clusterVersion]
   );
 
   const { infoGuideConfig: currentInfoGuideConfig, setInfoGuideConfig } =

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -54,6 +54,7 @@ import {
   IntegrationKind,
   integrationService,
 } from 'teleport/services/integrations';
+import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeploymentMethodSection } from './DeploymentMethodSection';
 import {
@@ -75,6 +76,8 @@ export type InfoGuideTab = 'info' | 'terraform' | null;
 
 export function EnrollAws() {
   useNoMinWidth();
+
+  const { clusterVersion } = useClusterVersion();
 
   const [integrationName, setIntegrationName] = useState('');
 
@@ -102,8 +105,9 @@ export function EnrollAws() {
         integrationName,
         regions,
         ec2Config,
+        version: clusterVersion,
       }),
-    [integrationName, regions, ec2Config]
+    [integrationName, regions, ec2Config, clusterVersion]
   );
 
   const copyConfigButtonRef = useRef<HTMLButtonElement>(null);

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/Prerequisites.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/Prerequisites.tsx
@@ -52,10 +52,7 @@ export function Prerequisites() {
             <li>
               <Text fontWeight="medium">Teleport Terraform Provider:</Text>
               <Text>Authenticate to your Teleport cluster</Text>
-              <ExternalLink href="#">
-                {
-                  // TODO(alexhemard): add real URL
-                }
+              <ExternalLink href="https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/">
                 Teleport Provider Configuration
                 <ArrowSquareOut size="small" />
               </ExternalLink>
@@ -63,10 +60,7 @@ export function Prerequisites() {
             <li>
               <Text fontWeight="medium">AWS Terraform Provider:</Text>
               <Text>Configure AWS credentials for IAM management</Text>
-              <ExternalLink href="#">
-                {
-                  // TODO(alexhemard): add real URL
-                }
+              <ExternalLink href="https://registry.terraform.io/providers/hashicorp/aws/latest/docs">
                 AWS Provider Configuration <ArrowSquareOut size="small" />
               </ExternalLink>
             </li>

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { parse as parseVersion } from 'shared/utils/semVer';
+
 import cfg from 'teleport/config';
 import { Regions as AwsRegion } from 'teleport/services/integrations';
 
@@ -26,17 +28,30 @@ export type AwsDiscoverTerraformModuleConfig = {
   integrationName: string;
   regions: WildcardRegion | AwsRegion[];
   ec2Config: Ec2Config;
+  version: string;
 };
 
-const MODULE_SOURCE = cfg.terraform.discoveryAwsModuleRegistry;
-// TODO(alexhemard): derive version from useClusterVersion hook
-const MODULE_VERSION = '~> 19.0';
+const TF_MODULE = '/teleport/discover/aws';
+
+const isStaging = (version: string): boolean => {
+  const parsed = parseVersion(version);
+  if (!parsed) return false;
+
+  return parsed.prerelease.length > 0;
+};
 
 export const buildTerraformConfig = ({
   integrationName,
   regions,
   ec2Config,
+  version,
 }: AwsDiscoverTerraformModuleConfig): string => {
+  const tfRegistry = isStaging(version)
+    ? cfg.terraform.stagingRegistry
+    : cfg.terraform.registry;
+
+  const moduleSrc = `${tfRegistry}${TF_MODULE}`;
+
   const matchAwsTypes = ec2Config.enabled ? ['ec2'] : null;
 
   const integrationNameOrNull = integrationName.trim() || null;
@@ -67,8 +82,8 @@ export const buildTerraformConfig = ({
 
   const tfModule = hcl`# Terraform Module
 module "aws_discovery" {
-  source  = ${MODULE_SOURCE}
-  version = ${MODULE_VERSION}
+  source  = ${moduleSrc}
+  version = ${version}
 
   teleport_integration_use_name_prefix = ${integrationNameOrNull ? false : null}
 

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -105,9 +105,8 @@ const cfg = {
 
   // terraform contains terraform related configuration
   terraform: {
-    // discoveryAwsModuleRegistry contains the registry for the AWS discovery terraform module
-    discoveryAwsModuleRegistry:
-      'terraform.releases.teleport.dev/teleport/discovery/aws',
+    registry: 'terraform.releases.teleport.dev',
+    stagingRegistry: 'terraform-staging.releases.teleport.dev',
   },
 
   // enterprise non-exact routes will be merged into this


### PR DESCRIPTION
### Description

Issue: https://github.com/gravitational/teleport/issues/60813
Previously: https://github.com/gravitational/teleport/pull/62155

This PR uses the cluster version for the AWS Discover Terraform Module.

If a development version is used, it will use the staging CDN 
