### PR TITLE
Adding `ec2` and `iam` join methods to scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -159,8 +159,10 @@ type ScopedTokenSpec struct {
 	// Immutable labels that should be applied to any resulting resources provisioned
 	// using this token.
 	ImmutableLabels *ImmutableLabels `protobuf:"bytes,5,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+	Aws           *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedTokenSpec) Reset() {
@@ -224,6 +226,13 @@ func (x *ScopedTokenSpec) GetUsageMode() string {
 func (x *ScopedTokenSpec) GetImmutableLabels() *ImmutableLabels {
 	if x != nil {
 		return x.ImmutableLabels
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAws() *AWS {
+	if x != nil {
+		return x.Aws
 	}
 	return nil
 }
@@ -698,6 +707,160 @@ func (x *StaticScopedTokensSpec) GetTokens() []*ScopedToken {
 	return nil
 }
 
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+type AWS struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AWS_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The TTL to use for AWS EC2 Instance Identity Documents used
+	// to join the cluster with this token.
+	AwsIidTtl int64 `protobuf:"varint,2,opt,name=aws_iid_ttl,json=awsIidTtl,proto3" json:"aws_iid_ttl,omitempty"`
+	// Integration name which provides credentials for validating join attempts.
+	// Currently only in use for validating the AWS Organization ID in the IAM Join method.
+	Integration   string `protobuf:"bytes,3,opt,name=integration,proto3" json:"integration,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AWS) Reset() {
+	*x = AWS{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS) ProtoMessage() {}
+
+func (x *AWS) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS.ProtoReflect.Descriptor instead.
+func (*AWS) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *AWS) GetAllow() []*AWS_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AWS) GetAwsIidTtl() int64 {
+	if x != nil {
+		return x.AwsIidTtl
+	}
+	return 0
+}
+
+func (x *AWS) GetIntegration() string {
+	if x != nil {
+		return x.Integration
+	}
+	return ""
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with AWS join methods.
+type AWS_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The AWS account ID.
+	AwsAccount string `protobuf:"bytes,1,opt,name=aws_account,json=awsAccount,proto3" json:"aws_account,omitempty"`
+	// List of AWS regions a node is allowed to join from when using the
+	// EC2 join method.
+	AwsRegions []string `protobuf:"bytes,2,rep,name=aws_regions,json=awsRegions,proto3" json:"aws_regions,omitempty"`
+	// The ARN of the role the Auth Service will assume in order to call the
+	// EC2 API when using the EC2 join method.
+	AwsRole string `protobuf:"bytes,3,opt,name=aws_role,json=awsRole,proto3" json:"aws_role,omitempty"`
+	// The ARN of the joining identity for use with the IAM join method.
+	// Supports wildcards "*" and "?".
+	AwsArn string `protobuf:"bytes,4,opt,name=aws_arn,json=awsArn,proto3" json:"aws_arn,omitempty"`
+	// The organization ID that the joining AWS identity must belong to
+	// when using the IAM join method.
+	AwsOrganizationId string `protobuf:"bytes,5,opt,name=aws_organization_id,json=awsOrganizationId,proto3" json:"aws_organization_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *AWS_Rule) Reset() {
+	*x = AWS_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS_Rule) ProtoMessage() {}
+
+func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS_Rule.ProtoReflect.Descriptor instead.
+func (*AWS_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9, 0}
+}
+
+func (x *AWS_Rule) GetAwsAccount() string {
+	if x != nil {
+		return x.AwsAccount
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsRegions() []string {
+	if x != nil {
+		return x.AwsRegions
+	}
+	return nil
+}
+
+func (x *AWS_Rule) GetAwsRole() string {
+	if x != nil {
+		return x.AwsRole
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsArn() string {
+	if x != nil {
+		return x.AwsArn
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsOrganizationId() string {
+	if x != nil {
+		return x.AwsOrganizationId
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -710,7 +873,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe6\x01\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x99\x02\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -718,7 +881,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"joinMethod\x12\x1d\n" +
 	"\n" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
-	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\"\xb6\x01\n" +
+	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
+	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -750,7 +914,19 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12F\n" +
 	"\x04spec\x18\x06 \x01(\v22.teleport.scopes.joining.v1.StaticScopedTokensSpecR\x04spec\"Y\n" +
 	"\x16StaticScopedTokensSpec\x12?\n" +
-	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokensBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokens\"\xb2\x02\n" +
+	"\x03AWS\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.AWS.RuleR\x05allow\x12\x1e\n" +
+	"\vaws_iid_ttl\x18\x02 \x01(\x03R\tawsIidTtl\x12 \n" +
+	"\vintegration\x18\x03 \x01(\tR\vintegration\x1a\xac\x01\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vaws_account\x18\x01 \x01(\tR\n" +
+	"awsAccount\x12\x1f\n" +
+	"\vaws_regions\x18\x02 \x03(\tR\n" +
+	"awsRegions\x12\x19\n" +
+	"\baws_role\x18\x03 \x01(\tR\aawsRole\x12\x17\n" +
+	"\aaws_arn\x18\x04 \x01(\tR\x06awsArn\x12.\n" +
+	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -764,7 +940,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -775,29 +951,33 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ImmutableLabels)(nil),        // 6: teleport.scopes.joining.v1.ImmutableLabels
 	(*StaticScopedTokens)(nil),     // 7: teleport.scopes.joining.v1.StaticScopedTokens
 	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
-	nil,                            // 9: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*v1.Metadata)(nil),            // 10: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
+	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
+	nil,                            // 10: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 11: teleport.scopes.joining.v1.AWS.Rule
+	(*v1.Metadata)(nil),            // 12: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	12, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
-	11, // 4: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	11, // 5: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 6: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 7: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 8: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	9,  // 9: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	10, // 10: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 11: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 12: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
+	13, // 5: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	13, // 6: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 7: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 8: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 9: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	10, // 10: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	12, // 11: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 12: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 13: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 14: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -814,7 +994,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -70,6 +70,9 @@ message ScopedTokenSpec {
   // Immutable labels that should be applied to any resulting resources provisioned
   // using this token.
   ImmutableLabels immutable_labels = 5;
+
+  // The AWS-specific configuration used with the "ec2" and "iam" join methods.
+  AWS aws = 6;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -153,4 +156,38 @@ message StaticScopedTokens {
 message StaticScopedTokensSpec {
   // The statically parsed scoped tokens.
   repeated ScopedToken tokens = 1;
+}
+
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+message AWS {
+  // A rule that a joining node must match in order to use the associated token
+  // with AWS join methods.
+  message Rule {
+    // The AWS account ID.
+    string aws_account = 1;
+    // List of AWS regions a node is allowed to join from when using the
+    // EC2 join method.
+    repeated string aws_regions = 2;
+    // The ARN of the role the Auth Service will assume in order to call the
+    // EC2 API when using the EC2 join method.
+    string aws_role = 3;
+    // The ARN of the joining identity for use with the IAM join method.
+    // Supports wildcards "*" and "?".
+    string aws_arn = 4;
+    // The organization ID that the joining AWS identity must belong to
+    // when using the IAM join method.
+    string aws_organization_id = 5;
+  }
+
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+
+  // The TTL to use for AWS EC2 Instance Identity Documents used
+  // to join the cluster with this token.
+  int64 aws_iid_ttl = 2;
+
+  // Integration name which provides credentials for validating join attempts.
+  // Currently only in use for validating the AWS Organization ID in the IAM Join method.
+  string integration = 3;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -145,6 +145,9 @@ type ProvisionToken interface {
 	SetLabels(map[string]string)
 	// GetAllowRules returns the list of allow rules
 	GetAllowRules() []*TokenRule
+	// GetAWSAllowRules returns the list of AWS-specific allow rules. GetAllowRules is kept for backwards compatibility,
+	// but GetAWSAllowRules should be preferred.
+	GetAWSAllowRules() []*TokenRule
 	// SetAllowRules sets the allow rules
 	SetAllowRules([]*TokenRule)
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
@@ -512,9 +515,14 @@ func (p *ProvisionTokenV2) SetLabels(l map[string]string) {
 	p.Metadata.Labels = l
 }
 
-// GetAllowRules returns the list of allow rules
-func (p *ProvisionTokenV2) GetAllowRules() []*TokenRule {
+// GetAWSAllowRules returns the list of AWS-specific allow rules
+func (p *ProvisionTokenV2) GetAWSAllowRules() []*TokenRule {
 	return p.Spec.Allow
+}
+
+// GetAllowRules returns the list of allow rules.
+func (p *ProvisionTokenV2) GetAllowRules() []*TokenRule {
+	return p.GetAWSAllowRules()
 }
 
 // SetAllowRules sets the allow rules.

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken.go
@@ -186,14 +186,14 @@ func updateTokenIAMJoin(ctx context.Context, req upsertIAMJoinTokenRequest, rule
 	uniqueRoles := utils.Deduplicate(allRoles)
 	existingToken.SetRoles(uniqueRoles)
 
-	for _, rule := range existingToken.GetAllowRules() {
+	for _, rule := range existingToken.GetAWSAllowRules() {
 		if rule.AWSAccount == req.accountID && rule.AWSARN == req.awsARN {
 
 			return nil, trace.AlreadyExists("rule already exists")
 		}
 	}
 
-	existingToken.SetAllowRules(append(existingToken.GetAllowRules(), rule))
+	existingToken.SetAllowRules(append(existingToken.GetAWSAllowRules(), rule))
 
 	return existingToken, nil
 }

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
@@ -68,11 +68,11 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 
 		require.Equal(t, "t", iamToken.GetName())
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
-		require.Len(t, iamToken.GetAllowRules(), 1)
+		require.Len(t, iamToken.GetAWSAllowRules(), 1)
 		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		}, iamToken.GetAllowRules()[0])
+		}, iamToken.GetAWSAllowRules()[0])
 	})
 
 	t.Run("when token exist but is missing the required allow rule and system role, it is updated", func(t *testing.T) {
@@ -102,12 +102,12 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "t", iamToken.GetName())
-		require.Len(t, iamToken.GetAllowRules(), 1)
+		require.Len(t, iamToken.GetAWSAllowRules(), 1)
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
 		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		}, iamToken.GetAllowRules()[0])
+		}, iamToken.GetAWSAllowRules()[0])
 	})
 
 	t.Run("when token exist but has an invalid join method, it returns an error", func(t *testing.T) {

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -63,7 +63,7 @@ func ec2ClientFromConfig(cfg aws.Config) EC2Client {
 // checkEC2AllowRules checks that the iid matches at least one of the allow
 // rules of the given token.
 func checkEC2AllowRules(ctx context.Context, params *CheckEC2RequestParams, iid *imds.InstanceIdentityDocument) error {
-	allowRules := params.ProvisionToken.GetAllowRules()
+	allowRules := params.ProvisionToken.GetAWSAllowRules()
 	for _, rule := range allowRules {
 		// if this rule specifies an AWS account, the IID must match
 		if len(rule.AWSAccount) > 0 {

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -282,7 +282,7 @@ func arnMatches(pattern, arn string) (bool, error) {
 // checkIAMAllowRules checks if the given identity matches any of the given
 // allowRules.
 func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, organizationIDFetcher *organizationsIDFetcher) error {
-	for _, rule := range params.ProvisionToken.GetAllowRules() {
+	for _, rule := range params.ProvisionToken.GetAWSAllowRules() {
 		// if this rule specifies an AWS account, the identity must match
 		if rule.AWSAccount != "" {
 			if rule.AWSAccount != identity.Account {

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -30,11 +30,15 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/defaults"
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/join/ec2join"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type ec2Instance struct {
@@ -478,6 +482,29 @@ func TestJoinEC2(t *testing.T) {
 			err = testServer.Auth().UpsertToken(t.Context(), token)
 			require.NoError(t, err)
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = testServer.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := testServer.Auth().DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			testServer.Auth().SetEC2ClientForEC2JoinMethod(tc.ec2Client)
 
 			t.Run("new", func(t *testing.T) {
@@ -508,6 +535,26 @@ func TestJoinEC2(t *testing.T) {
 						Role:     types.RoleNode,
 						NodeName: "testnode",
 						HostUUID: tc.requestHostID,
+					},
+					AuthClient: nopClient,
+					GetInstanceIdentityDocumentFunc: func(_ context.Context) ([]byte, error) {
+						return tc.document, nil
+					},
+				})
+				tc.expectError(t, err)
+			})
+			t.Run("scoped", func(t *testing.T) {
+				if tc.requestHostID == badInstanceID {
+					// New join method does not allow the client to request a
+					// specific host ID, so the join would pass and fail the
+					// error assertion.
+					t.Skip()
+				}
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: scopedToken.GetMetadata().GetName(),
+					ID: state.IdentityID{
+						Role:     types.RoleInstance,
+						NodeName: "testnode",
 					},
 					AuthClient: nopClient,
 					GetInstanceIdentityDocumentFunc: func(_ context.Context) ([]byte, error) {

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -1,0 +1,95 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package jointest
+
+import (
+	"cmp"
+
+	"github.com/gravitational/trace"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// ScopedTokenFromProvisionTokenSpec is a test helper that creates a scoped token using a [types.ProvisionTokenSpecV2]
+// as a base. The override parameter can be used to provide override values that should be used instead of the base token
+// values. This is mostly useful for testing.
+func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	roles := types.SystemRoles(base.Roles).StringSlice()
+	if len(roles) == 0 {
+		roles = override.GetSpec().GetRoles()
+	}
+
+	// scoped tokens can't be created without a join method, so we replicate ProvisionTokenV2.CheckAndSetDefaults() here
+	// for testing purposes
+	if base.JoinMethod == types.JoinMethodUnspecified {
+		base.JoinMethod = types.JoinMethodToken
+		if len(base.Allow) > 0 {
+			base.JoinMethod = types.JoinMethodEC2
+		}
+	}
+
+	scopedToken := &joiningv1.ScopedToken{
+		Kind:     types.KindScopedToken,
+		Version:  types.V1,
+		Scope:    override.GetScope(),
+		Metadata: override.GetMetadata(),
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: override.GetSpec().GetAssignedScope(),
+			JoinMethod:    cmp.Or(override.GetSpec().GetJoinMethod(), string(base.JoinMethod)),
+			Roles:         roles,
+			UsageMode:     override.GetSpec().GetUsageMode(),
+		},
+	}
+
+	switch base.JoinMethod {
+	case types.JoinMethodEC2:
+		allow := make([]*joiningv1.AWS_Rule, len(base.Allow))
+		for i, rule := range base.Allow {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:     allow,
+			AwsIidTtl: int64(base.AWSIIDTTL),
+		}
+	case types.JoinMethodIAM:
+		allow := make([]*joiningv1.AWS_Rule, len(base.Allow))
+		for i, rule := range base.Allow {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:       allow,
+			Integration: base.Integration,
+		}
+	default:
+		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
+	}
+
+	return scopedToken, nil
+}

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -48,8 +48,8 @@ type Token interface {
 	// GetAssignedScope returns the scope that will be assigned to provisioned resources
 	// provisioned using the wrapped [joiningv1.ScopedToken].
 	GetAssignedScope() string
-	// GetAllowRules returns the list of allow rules.
-	GetAllowRules() []*types.TokenRule
+	// GetAWSAllowRules returns the list of AWS-specific allow rules.
+	GetAWSAllowRules() []*types.TokenRule
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() types.Duration
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -37,6 +37,8 @@ var rolesSupportingScopes = types.SystemRoles{
 
 var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodToken): {},
+	string(types.JoinMethodEC2):   {},
+	string(types.JoinMethodIAM):   {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -268,20 +270,36 @@ func (t *Token) GetAssignedScope() string {
 	return t.scoped.GetSpec().GetAssignedScope()
 }
 
-// GetAllowRules returns the list of allow rules.
-func (t *Token) GetAllowRules() []*types.TokenRule {
-	return nil
+// GetAWSAllowRules returns the list of AWS-specific allow rules.
+func (t *Token) GetAWSAllowRules() []*types.TokenRule {
+	allow := make([]*types.TokenRule, len(t.scoped.GetSpec().GetAws().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAws().GetAllow() {
+		allow[i] = &types.TokenRule{
+			AWSAccount:        rule.GetAwsAccount(),
+			AWSRegions:        rule.GetAwsRegions(),
+			AWSRole:           rule.GetAwsRole(),
+			AWSARN:            rule.GetAwsArn(),
+			AWSOrganizationID: rule.GetAwsOrganizationId(),
+		}
+	}
+
+	return allow
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (t *Token) GetAWSIIDTTL() types.Duration {
-	return types.NewDuration(0)
+	ttl := t.scoped.GetSpec().GetAws().GetAwsIidTtl()
+	if ttl == 0 {
+		// default to 5 minute ttl if unspecified
+		return types.Duration(5 * time.Minute)
+	}
+	return types.Duration(ttl)
 }
 
 // GetIntegration returns the Integration field which is used to provide
 // credentials that will be used when validating the AWS Organization if required by an IAM Token.
 func (t *Token) GetIntegration() string {
-	return ""
+	return t.scoped.GetSpec().GetAws().GetIntegration()
 }
 
 // GetSecret returns the token's secret value.

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -376,7 +376,7 @@ func (h *Handler) createTokenForDiscoveryHandle(w http.ResponseWriter, r *http.R
 
 		if err == nil {
 			// check if the token found has the right rules
-			if t.GetJoinMethod() != types.JoinMethodIAM || !isSameRuleSet(req.Allow, t.GetAllowRules()) {
+			if t.GetJoinMethod() != types.JoinMethodIAM || !isSameRuleSet(req.Allow, t.GetAWSAllowRules()) {
 				return nil, trace.BadParameter("failed to create token: token with name %q already exists and does not have the expected allow rules", tokenName)
 			}
 

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -74,7 +74,7 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 		IsStatic:      token.IsStatic(),
 		IsCloudSystem: isCloudSystem,
 		Method:        token.GetJoinMethod(),
-		Allow:         token.GetAllowRules(),
+		Allow:         token.GetAWSAllowRules(),
 		Content:       string(content[:]),
 	}
 


### PR DESCRIPTION
This PR adds support for `ec2` and `iam` join methods when using scoped tokens.

# Manual testing
- [x] Create a scoped token that uses the `ec2` join method `tctl scoped tokens add --type node --join-method ec2 --scope /local --assign-scope /local`
- [x] Create a scoped token that uses the `iam` join method `tctl scoped tokens add --type node --join-method iam --scope /local --assign-scope /local`
- [x] Provision an EC2 node using the scoped token.
- [x] Provision an IAM node using the scoped token.
