### PR TITLE
Adding `github` and `gitlab` join methods to scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -159,8 +159,10 @@ type ScopedTokenSpec struct {
 	// Immutable labels that should be applied to any resulting resources provisioned
 	// using this token.
 	ImmutableLabels *ImmutableLabels `protobuf:"bytes,5,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+	Aws           *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedTokenSpec) Reset() {
@@ -224,6 +226,13 @@ func (x *ScopedTokenSpec) GetUsageMode() string {
 func (x *ScopedTokenSpec) GetImmutableLabels() *ImmutableLabels {
 	if x != nil {
 		return x.ImmutableLabels
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAws() *AWS {
+	if x != nil {
+		return x.Aws
 	}
 	return nil
 }
@@ -698,6 +707,150 @@ func (x *StaticScopedTokensSpec) GetTokens() []*ScopedToken {
 	return nil
 }
 
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+type AWS struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AWS_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The TTL to use for AWS EC2 Instance Identity Documents used
+	// to join the cluster with this token.
+	AwsIidTtl     int64 `protobuf:"varint,2,opt,name=aws_iid_ttl,json=awsIidTtl,proto3" json:"aws_iid_ttl,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AWS) Reset() {
+	*x = AWS{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS) ProtoMessage() {}
+
+func (x *AWS) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS.ProtoReflect.Descriptor instead.
+func (*AWS) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *AWS) GetAllow() []*AWS_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AWS) GetAwsIidTtl() int64 {
+	if x != nil {
+		return x.AwsIidTtl
+	}
+	return 0
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with AWS join methods.
+type AWS_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The AWS account ID.
+	AwsAccount string `protobuf:"bytes,1,opt,name=aws_account,json=awsAccount,proto3" json:"aws_account,omitempty"`
+	// List of AWS regions a node is allowed to join from when using the
+	// EC2 join method.
+	AwsRegions []string `protobuf:"bytes,2,rep,name=aws_regions,json=awsRegions,proto3" json:"aws_regions,omitempty"`
+	// The ARN of the role the Auth Service will assume in order to call the
+	// EC2 API when using the EC2 join method.
+	AwsRole string `protobuf:"bytes,3,opt,name=aws_role,json=awsRole,proto3" json:"aws_role,omitempty"`
+	// The ARN of the joining identity for use with the IAM join method.
+	// Supports wildcards "*" and "?".
+	AwsArn string `protobuf:"bytes,4,opt,name=aws_arn,json=awsArn,proto3" json:"aws_arn,omitempty"`
+	// The organization ID that the joining AWS identity must belong to
+	// when using the IAM join method.
+	AwsOrganizationId string `protobuf:"bytes,5,opt,name=aws_organization_id,json=awsOrganizationId,proto3" json:"aws_organization_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *AWS_Rule) Reset() {
+	*x = AWS_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS_Rule) ProtoMessage() {}
+
+func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS_Rule.ProtoReflect.Descriptor instead.
+func (*AWS_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9, 0}
+}
+
+func (x *AWS_Rule) GetAwsAccount() string {
+	if x != nil {
+		return x.AwsAccount
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsRegions() []string {
+	if x != nil {
+		return x.AwsRegions
+	}
+	return nil
+}
+
+func (x *AWS_Rule) GetAwsRole() string {
+	if x != nil {
+		return x.AwsRole
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsArn() string {
+	if x != nil {
+		return x.AwsArn
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsOrganizationId() string {
+	if x != nil {
+		return x.AwsOrganizationId
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -710,7 +863,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe6\x01\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x99\x02\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -718,7 +871,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"joinMethod\x12\x1d\n" +
 	"\n" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
-	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\"\xb6\x01\n" +
+	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
+	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -750,7 +904,18 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12F\n" +
 	"\x04spec\x18\x06 \x01(\v22.teleport.scopes.joining.v1.StaticScopedTokensSpecR\x04spec\"Y\n" +
 	"\x16StaticScopedTokensSpec\x12?\n" +
-	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokensBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokens\"\x90\x02\n" +
+	"\x03AWS\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.AWS.RuleR\x05allow\x12\x1e\n" +
+	"\vaws_iid_ttl\x18\x02 \x01(\x03R\tawsIidTtl\x1a\xac\x01\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vaws_account\x18\x01 \x01(\tR\n" +
+	"awsAccount\x12\x1f\n" +
+	"\vaws_regions\x18\x02 \x03(\tR\n" +
+	"awsRegions\x12\x19\n" +
+	"\baws_role\x18\x03 \x01(\tR\aawsRole\x12\x17\n" +
+	"\aaws_arn\x18\x04 \x01(\tR\x06awsArn\x12.\n" +
+	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -764,7 +929,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -775,29 +940,33 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ImmutableLabels)(nil),        // 6: teleport.scopes.joining.v1.ImmutableLabels
 	(*StaticScopedTokens)(nil),     // 7: teleport.scopes.joining.v1.StaticScopedTokens
 	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
-	nil,                            // 9: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*v1.Metadata)(nil),            // 10: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
+	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
+	nil,                            // 10: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 11: teleport.scopes.joining.v1.AWS.Rule
+	(*v1.Metadata)(nil),            // 12: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	12, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
-	11, // 4: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	11, // 5: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 6: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 7: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 8: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	9,  // 9: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	10, // 10: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 11: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 12: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
+	13, // 5: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	13, // 6: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 7: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 8: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 9: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	10, // 10: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	12, // 11: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 12: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 13: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 14: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	15, // [15:15] is the sub-list for method output_type
+	15, // [15:15] is the sub-list for method input_type
+	15, // [15:15] is the sub-list for extension type_name
+	15, // [15:15] is the sub-list for extension extendee
+	0,  // [0:15] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -814,7 +983,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -160,7 +160,9 @@ type ScopedTokenSpec struct {
 	// using this token.
 	ImmutableLabels *ImmutableLabels `protobuf:"bytes,5,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
 	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
-	Aws           *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	Aws *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	// The GCP-specific configuration used with the "gcp" join method.
+	Gcp           *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -233,6 +235,13 @@ func (x *ScopedTokenSpec) GetImmutableLabels() *ImmutableLabels {
 func (x *ScopedTokenSpec) GetAws() *AWS {
 	if x != nil {
 		return x.Aws
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetGcp() *GCP {
+	if x != nil {
+		return x.Gcp
 	}
 	return nil
 }
@@ -774,6 +783,54 @@ func (x *AWS) GetIntegration() string {
 	return ""
 }
 
+// The GCP-specific configuration used with the "gcp" join method.
+// ProvisionTokenSpecV2.
+type GCP struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*GCP_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GCP) Reset() {
+	*x = GCP{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP) ProtoMessage() {}
+
+func (x *GCP) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP.ProtoReflect.Descriptor instead.
+func (*GCP) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GCP) GetAllow() []*GCP_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -798,7 +855,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -810,7 +867,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -861,6 +918,71 @@ func (x *AWS_Rule) GetAwsOrganizationId() string {
 	return ""
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "gcp" join method.
+type GCP_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of project IDs (e.g. `<example-id-123456>`).
+	ProjectIds []string `protobuf:"bytes,1,rep,name=project_ids,json=projectIds,proto3" json:"project_ids,omitempty"`
+	// A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+	Locations []string `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
+	// A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+	ServiceAccounts []string `protobuf:"bytes,3,rep,name=service_accounts,json=serviceAccounts,proto3" json:"service_accounts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *GCP_Rule) Reset() {
+	*x = GCP_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP_Rule) ProtoMessage() {}
+
+func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP_Rule.ProtoReflect.Descriptor instead.
+func (*GCP_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10, 0}
+}
+
+func (x *GCP_Rule) GetProjectIds() []string {
+	if x != nil {
+		return x.ProjectIds
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetLocations() []string {
+	if x != nil {
+		return x.Locations
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetServiceAccounts() []string {
+	if x != nil {
+		return x.ServiceAccounts
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -873,7 +995,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x99\x02\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xcc\x02\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -882,7 +1004,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
 	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
-	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\"\xb6\x01\n" +
+	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
+	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -926,7 +1049,14 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"awsRegions\x12\x19\n" +
 	"\baws_role\x18\x03 \x01(\tR\aawsRole\x12\x17\n" +
 	"\aaws_arn\x18\x04 \x01(\tR\x06awsArn\x12.\n" +
-	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationId\"\xb3\x01\n" +
+	"\x03GCP\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.GCP.RuleR\x05allow\x1ap\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vproject_ids\x18\x01 \x03(\tR\n" +
+	"projectIds\x12\x1c\n" +
+	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccountsBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -940,7 +1070,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -952,32 +1082,36 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*StaticScopedTokens)(nil),     // 7: teleport.scopes.joining.v1.StaticScopedTokens
 	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
 	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
-	nil,                            // 10: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 11: teleport.scopes.joining.v1.AWS.Rule
-	(*v1.Metadata)(nil),            // 12: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
+	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
+	nil,                            // 11: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 12: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 13: teleport.scopes.joining.v1.GCP.Rule
+	(*v1.Metadata)(nil),            // 14: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	12, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
 	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
-	13, // 5: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	13, // 6: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 7: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 8: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 9: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	10, // 10: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	12, // 11: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 12: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 13: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 14: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
+	15, // 6: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	15, // 7: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 8: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 9: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 10: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	11, // 11: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	14, // 12: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 13: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 14: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	12, // 15: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	13, // 16: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -994,7 +1128,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -166,7 +166,9 @@ type ScopedTokenSpec struct {
 	// The Azure-specific configuration used with the "azure" join method.
 	Azure *Azure `protobuf:"bytes,8,opt,name=azure,proto3" json:"azure,omitempty"`
 	// The AzureDevops-specific configuration used with the "azure_devops" join method.
-	AzureDevops   *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
+	AzureDevops *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
+	// The Oracle-specific configuration used with the "oracle" join method.
+	Oracle        *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -260,6 +262,13 @@ func (x *ScopedTokenSpec) GetAzure() *Azure {
 func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
 	if x != nil {
 		return x.AzureDevops
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetOracle() *Oracle {
+	if x != nil {
+		return x.Oracle
 	}
 	return nil
 }
@@ -954,6 +963,53 @@ func (x *AzureDevops) GetOrganizationId() string {
 	return ""
 }
 
+// The Oracle-specific configuration used with the "oracle" join method.
+type Oracle struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*Oracle_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Oracle) Reset() {
+	*x = Oracle{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Oracle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Oracle) ProtoMessage() {}
+
+func (x *Oracle) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Oracle.ProtoReflect.Descriptor instead.
+func (*Oracle) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *Oracle) GetAllow() []*Oracle_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -978,7 +1034,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -990,7 +1046,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1057,7 +1113,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1069,7 +1125,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1120,7 +1176,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1132,7 +1188,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1204,7 +1260,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1216,7 +1272,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1288,6 +1344,83 @@ func (x *AzureDevops_Rule) GetRepositoryRef() string {
 	return ""
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "oracle" join method.
+type Oracle_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The OCID of the instance's tenancy. Required.
+	Tenancy string `protobuf:"bytes,1,opt,name=tenancy,proto3" json:"tenancy,omitempty"`
+	// A list of the OCIDs of compartments an instance is allowed to join from. Only direct
+	// parents are allowed, i.e. no nested compartments. If empty, any compartment is allowed.
+	ParentCompartments []string `protobuf:"bytes,2,rep,name=parent_compartments,json=parentCompartments,proto3" json:"parent_compartments,omitempty"`
+	// A list of regions an instance is allowed to join from. Both full region names ("us-phoenix-1")
+	// and abbreviations ("phx") are allowed. If empty, any region is allowed.
+	Regions []string `protobuf:"bytes,3,rep,name=regions,proto3" json:"regions,omitempty"`
+	// A list of the OCIDs of specific instances that are allowed to join. If empty, any instance
+	// matching the other fields in the rule is allowed. Limited to 100 instance OCIDs per rule.
+	Instances     []string `protobuf:"bytes,4,rep,name=instances,proto3" json:"instances,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Oracle_Rule) Reset() {
+	*x = Oracle_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Oracle_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Oracle_Rule) ProtoMessage() {}
+
+func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Oracle_Rule.ProtoReflect.Descriptor instead.
+func (*Oracle_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{13, 0}
+}
+
+func (x *Oracle_Rule) GetTenancy() string {
+	if x != nil {
+		return x.Tenancy
+	}
+	return ""
+}
+
+func (x *Oracle_Rule) GetParentCompartments() []string {
+	if x != nil {
+		return x.ParentCompartments
+	}
+	return nil
+}
+
+func (x *Oracle_Rule) GetRegions() []string {
+	if x != nil {
+		return x.Regions
+	}
+	return nil
+}
+
+func (x *Oracle_Rule) GetInstances() []string {
+	if x != nil {
+		return x.Instances
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -1300,7 +1433,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xd1\x03\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x8d\x04\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1312,7 +1445,9 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
 	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\x127\n" +
 	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
-	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\"\xb6\x01\n" +
+	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\x12:\n" +
+	"\x06oracle\x18\n" +
+	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1381,7 +1516,14 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\rdefinition_id\x18\x05 \x01(\tR\fdefinitionId\x12%\n" +
 	"\x0erepository_uri\x18\x06 \x01(\tR\rrepositoryUri\x12-\n" +
 	"\x12repository_version\x18\a \x01(\tR\x11repositoryVersion\x12%\n" +
-	"\x0erepository_ref\x18\b \x01(\tR\rrepositoryRefBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x0erepository_ref\x18\b \x01(\tR\rrepositoryRef\"\xd3\x01\n" +
+	"\x06Oracle\x12=\n" +
+	"\x05allow\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.Oracle.RuleR\x05allow\x1a\x89\x01\n" +
+	"\x04Rule\x12\x18\n" +
+	"\atenancy\x18\x01 \x01(\tR\atenancy\x12/\n" +
+	"\x13parent_compartments\x18\x02 \x03(\tR\x12parentCompartments\x12\x18\n" +
+	"\aregions\x18\x03 \x03(\tR\aregions\x12\x1c\n" +
+	"\tinstances\x18\x04 \x03(\tR\tinstancesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1395,7 +1537,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -1410,16 +1552,18 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
 	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
 	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
-	nil,                            // 13: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 14: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 15: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),             // 16: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),       // 17: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*v1.Metadata)(nil),            // 18: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 19: google.protobuf.Timestamp
+	(*Oracle)(nil),                 // 13: teleport.scopes.joining.v1.Oracle
+	nil,                            // 14: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 15: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 16: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 17: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 18: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),            // 19: teleport.scopes.joining.v1.Oracle.Rule
+	(*v1.Metadata)(nil),            // 20: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	18, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	20, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -1427,24 +1571,26 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
 	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
 	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
-	19, // 8: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	19, // 9: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 10: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 11: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 12: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	13, // 13: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	18, // 14: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 15: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 16: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	14, // 17: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	15, // 18: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	16, // 19: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	17, // 20: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	21, // [21:21] is the sub-list for method output_type
-	21, // [21:21] is the sub-list for method input_type
-	21, // [21:21] is the sub-list for extension type_name
-	21, // [21:21] is the sub-list for extension extendee
-	0,  // [0:21] is the sub-list for field type_name
+	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
+	21, // 9: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	21, // 10: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 11: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 12: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 13: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	14, // 14: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	20, // 15: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 16: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 17: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	15, // 18: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	16, // 19: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	17, // 20: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	18, // 21: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	19, // 22: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1461,7 +1607,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   18,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -170,7 +170,9 @@ type ScopedTokenSpec struct {
 	// The Oracle-specific configuration used with the "oracle" join method.
 	Oracle *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
 	// The GitHub-specific configuration used with the "github" join method.
-	Github        *Github `protobuf:"bytes,11,opt,name=github,proto3" json:"github,omitempty"`
+	Github *Github `protobuf:"bytes,11,opt,name=github,proto3" json:"github,omitempty"`
+	// The GitLab-specific configuration used with the "gitlab" join method.
+	Gitlab        *GitLab `protobuf:"bytes,12,opt,name=gitlab,proto3" json:"gitlab,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -278,6 +280,13 @@ func (x *ScopedTokenSpec) GetOracle() *Oracle {
 func (x *ScopedTokenSpec) GetGithub() *Github {
 	if x != nil {
 		return x.Github
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetGitlab() *GitLab {
+	if x != nil {
+		return x.Gitlab
 	}
 	return nil
 }
@@ -1111,6 +1120,75 @@ func (x *Github) GetStaticJwks() string {
 	return ""
 }
 
+// The GitLab-specific configuration used with the "gitlab" join method.
+type GitLab struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Allow is a list of TokenRules, nodes using this token must match one
+	// allow rule to use this token.
+	Allow []*GitLab_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The domain of your GitLab instance. This will default to `gitlab.com` - but can
+	// be set to the domain of your self-hosted GitLab
+	// e.g `gitlab.example.com`.
+	Domain string `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
+	// Disables fetching of the GitLab signing keys via the JWKS/OIDC endpoints, and
+	// allows them to be directly specified. This allows joining from GitLab CI instances
+	// that are not reachable by the Teleport Auth Service.
+	StaticJwks    string `protobuf:"bytes,3,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GitLab) Reset() {
+	*x = GitLab{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitLab) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitLab) ProtoMessage() {}
+
+func (x *GitLab) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitLab.ProtoReflect.Descriptor instead.
+func (*GitLab) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *GitLab) GetAllow() []*GitLab_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *GitLab) GetDomain() string {
+	if x != nil {
+		return x.Domain
+	}
+	return ""
+}
+
+func (x *GitLab) GetStaticJwks() string {
+	if x != nil {
+		return x.StaticJwks
+	}
+	return ""
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -1135,7 +1213,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1147,7 +1225,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1214,7 +1292,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1226,7 +1304,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1277,7 +1355,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1289,7 +1367,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1361,7 +1439,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1373,7 +1451,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1466,7 +1544,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1478,7 +1556,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1552,7 +1630,7 @@ type Github_Rule struct {
 
 func (x *Github_Rule) Reset() {
 	*x = Github_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1564,7 +1642,7 @@ func (x *Github_Rule) String() string {
 func (*Github_Rule) ProtoMessage() {}
 
 func (x *Github_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1636,6 +1714,219 @@ func (x *Github_Rule) GetRefType() string {
 	return ""
 }
 
+// The fields mapped from `lib/join/gitlab.IDTokenClaims`. Not all fields should be included,
+// only ones that we expect to be useful when trying to create rules around which workflows
+// should be allowed to authenticate against a cluster.
+type GitLab_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Roughly uniquely identifies the workload. Example:
+	// `project_path:mygroup/my-project:ref_type:branch:ref:main`
+	// project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// Allows access to be limited to jobs triggered by a specific git ref.
+	// Ensure this is used in combination with ref_type.
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	Ref string `protobuf:"bytes,2,opt,name=ref,proto3" json:"ref,omitempty"`
+	// Allows access to be limited to jobs triggered by a specific git
+	// ref type. Example:
+	// `branch` or `tag`
+	RefType string `protobuf:"bytes,3,opt,name=ref_type,json=refType,proto3" json:"ref_type,omitempty"`
+	// Used to limit access to jobs in a group or user's projects.
+	// Example:
+	// `mygroup`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	NamespacePath string `protobuf:"bytes,4,opt,name=namespace_path,json=namespacePath,proto3" json:"namespace_path,omitempty"`
+	// Used to limit access to jobs belonging to an individual project.
+	// Example:
+	// `mygroup/myproject`
+	//
+	// This field supports "glob-style" matching:
+	// - Use '*' to match zero or more characters.
+	// - Use '?' to match any single character.
+	ProjectPath string `protobuf:"bytes,5,opt,name=project_path,json=projectPath,proto3" json:"project_path,omitempty"`
+	// Limits access by the job pipeline source type.
+	// https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
+	// Example: `web`
+	PipelineSource string `protobuf:"bytes,6,opt,name=pipeline_source,json=pipelineSource,proto3" json:"pipeline_source,omitempty"`
+	// Limits access by the environment the job deploys to
+	// (if one is associated)
+	Environment string `protobuf:"bytes,7,opt,name=environment,proto3" json:"environment,omitempty"`
+	// The username of the user executing the job
+	UserLogin string `protobuf:"bytes,8,opt,name=user_login,json=userLogin,proto3" json:"user_login,omitempty"`
+	// The ID of the user executing the job
+	UserId string `protobuf:"bytes,9,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	// The email of the user executing the job
+	UserEmail string `protobuf:"bytes,10,opt,name=user_email,json=userEmail,proto3" json:"user_email,omitempty"`
+	// True if the Git ref is protected, false otherwise.
+	RefProtected *bool `protobuf:"varint,11,opt,name=ref_protected,json=refProtected,proto3,oneof" json:"ref_protected,omitempty"`
+	// True if the Git ref is protected, false otherwise.
+	EnvironmentProtected *bool `protobuf:"varint,12,opt,name=environment_protected,json=environmentProtected,proto3,oneof" json:"environment_protected,omitempty"`
+	// The git commit SHA for the ci_config_ref_uri.
+	CiConfigSha string `protobuf:"bytes,13,opt,name=ci_config_sha,json=ciConfigSha,proto3" json:"ci_config_sha,omitempty"`
+	// The ref path to the top-level pipeline definition, for example,
+	// gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
+	CiConfigRefUri string `protobuf:"bytes,14,opt,name=ci_config_ref_uri,json=ciConfigRefUri,proto3" json:"ci_config_ref_uri,omitempty"`
+	// The deployment tier of the environment the job specifies
+	DeploymentTier string `protobuf:"bytes,15,opt,name=deployment_tier,json=deploymentTier,proto3" json:"deployment_tier,omitempty"`
+	// The visibility of the project where the pipeline is running.
+	// Can be internal, private, or public.
+	ProjectVisibility string `protobuf:"bytes,16,opt,name=project_visibility,json=projectVisibility,proto3" json:"project_visibility,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GitLab_Rule) Reset() {
+	*x = GitLab_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GitLab_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GitLab_Rule) ProtoMessage() {}
+
+func (x *GitLab_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GitLab_Rule.ProtoReflect.Descriptor instead.
+func (*GitLab_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{15, 0}
+}
+
+func (x *GitLab_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetRef() string {
+	if x != nil {
+		return x.Ref
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetRefType() string {
+	if x != nil {
+		return x.RefType
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetNamespacePath() string {
+	if x != nil {
+		return x.NamespacePath
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetProjectPath() string {
+	if x != nil {
+		return x.ProjectPath
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetPipelineSource() string {
+	if x != nil {
+		return x.PipelineSource
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetUserLogin() string {
+	if x != nil {
+		return x.UserLogin
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetUserEmail() string {
+	if x != nil {
+		return x.UserEmail
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetRefProtected() bool {
+	if x != nil && x.RefProtected != nil {
+		return *x.RefProtected
+	}
+	return false
+}
+
+func (x *GitLab_Rule) GetEnvironmentProtected() bool {
+	if x != nil && x.EnvironmentProtected != nil {
+		return *x.EnvironmentProtected
+	}
+	return false
+}
+
+func (x *GitLab_Rule) GetCiConfigSha() string {
+	if x != nil {
+		return x.CiConfigSha
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetCiConfigRefUri() string {
+	if x != nil {
+		return x.CiConfigRefUri
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetDeploymentTier() string {
+	if x != nil {
+		return x.DeploymentTier
+	}
+	return ""
+}
+
+func (x *GitLab_Rule) GetProjectVisibility() string {
+	if x != nil {
+		return x.ProjectVisibility
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -1648,7 +1939,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xc9\x04\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x85\x05\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1663,7 +1954,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\x12:\n" +
 	"\x06oracle\x18\n" +
 	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\x12:\n" +
-	"\x06github\x18\v \x01(\v2\".teleport.scopes.joining.v1.GithubR\x06github\"\xb6\x01\n" +
+	"\x06github\x18\v \x01(\v2\".teleport.scopes.joining.v1.GithubR\x06github\x12:\n" +
+	"\x06gitlab\x18\f \x01(\v2\".teleport.scopes.joining.v1.GitLabR\x06gitlab\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1756,7 +2048,34 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\venvironment\x18\x05 \x01(\tR\venvironment\x12\x14\n" +
 	"\x05actor\x18\x06 \x01(\tR\x05actor\x12\x10\n" +
 	"\x03ref\x18\a \x01(\tR\x03ref\x12\x19\n" +
-	"\bref_type\x18\b \x01(\tR\arefTypeBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\bref_type\x18\b \x01(\tR\arefType\"\xeb\x05\n" +
+	"\x06GitLab\x12=\n" +
+	"\x05allow\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.GitLab.RuleR\x05allow\x12\x16\n" +
+	"\x06domain\x18\x02 \x01(\tR\x06domain\x12\x1f\n" +
+	"\vstatic_jwks\x18\x03 \x01(\tR\n" +
+	"staticJwks\x1a\xe8\x04\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12\x10\n" +
+	"\x03ref\x18\x02 \x01(\tR\x03ref\x12\x19\n" +
+	"\bref_type\x18\x03 \x01(\tR\arefType\x12%\n" +
+	"\x0enamespace_path\x18\x04 \x01(\tR\rnamespacePath\x12!\n" +
+	"\fproject_path\x18\x05 \x01(\tR\vprojectPath\x12'\n" +
+	"\x0fpipeline_source\x18\x06 \x01(\tR\x0epipelineSource\x12 \n" +
+	"\venvironment\x18\a \x01(\tR\venvironment\x12\x1d\n" +
+	"\n" +
+	"user_login\x18\b \x01(\tR\tuserLogin\x12\x17\n" +
+	"\auser_id\x18\t \x01(\tR\x06userId\x12\x1d\n" +
+	"\n" +
+	"user_email\x18\n" +
+	" \x01(\tR\tuserEmail\x12(\n" +
+	"\rref_protected\x18\v \x01(\bH\x00R\frefProtected\x88\x01\x01\x128\n" +
+	"\x15environment_protected\x18\f \x01(\bH\x01R\x14environmentProtected\x88\x01\x01\x12\"\n" +
+	"\rci_config_sha\x18\r \x01(\tR\vciConfigSha\x12)\n" +
+	"\x11ci_config_ref_uri\x18\x0e \x01(\tR\x0eciConfigRefUri\x12'\n" +
+	"\x0fdeployment_tier\x18\x0f \x01(\tR\x0edeploymentTier\x12-\n" +
+	"\x12project_visibility\x18\x10 \x01(\tR\x11projectVisibilityB\x10\n" +
+	"\x0e_ref_protectedB\x18\n" +
+	"\x16_environment_protectedBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1770,7 +2089,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -1787,18 +2106,20 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
 	(*Oracle)(nil),                 // 13: teleport.scopes.joining.v1.Oracle
 	(*Github)(nil),                 // 14: teleport.scopes.joining.v1.Github
-	nil,                            // 15: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 16: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 17: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),             // 18: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),       // 19: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),            // 20: teleport.scopes.joining.v1.Oracle.Rule
-	(*Github_Rule)(nil),            // 21: teleport.scopes.joining.v1.Github.Rule
-	(*v1.Metadata)(nil),            // 22: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 23: google.protobuf.Timestamp
+	(*GitLab)(nil),                 // 15: teleport.scopes.joining.v1.GitLab
+	nil,                            // 16: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 17: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 18: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 19: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 20: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),            // 21: teleport.scopes.joining.v1.Oracle.Rule
+	(*Github_Rule)(nil),            // 22: teleport.scopes.joining.v1.Github.Rule
+	(*GitLab_Rule)(nil),            // 23: teleport.scopes.joining.v1.GitLab.Rule
+	(*v1.Metadata)(nil),            // 24: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 25: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	22, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	24, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -1808,26 +2129,28 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
 	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
 	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.github:type_name -> teleport.scopes.joining.v1.Github
-	23, // 10: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	23, // 11: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 12: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 13: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 14: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	15, // 15: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	22, // 16: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 17: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 18: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	16, // 19: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	17, // 20: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	18, // 21: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	19, // 22: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	20, // 23: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	21, // 24: teleport.scopes.joining.v1.Github.allow:type_name -> teleport.scopes.joining.v1.Github.Rule
-	25, // [25:25] is the sub-list for method output_type
-	25, // [25:25] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	15, // 10: teleport.scopes.joining.v1.ScopedTokenSpec.gitlab:type_name -> teleport.scopes.joining.v1.GitLab
+	25, // 11: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	25, // 12: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 13: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 14: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 15: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	16, // 16: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	24, // 17: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 18: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 19: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	17, // 20: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	18, // 21: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	19, // 22: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	20, // 23: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	21, // 24: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	22, // 25: teleport.scopes.joining.v1.Github.allow:type_name -> teleport.scopes.joining.v1.Github.Rule
+	23, // 26: teleport.scopes.joining.v1.GitLab.allow:type_name -> teleport.scopes.joining.v1.GitLab.Rule
+	27, // [27:27] is the sub-list for method output_type
+	27, // [27:27] is the sub-list for method input_type
+	27, // [27:27] is the sub-list for extension type_name
+	27, // [27:27] is the sub-list for extension extendee
+	0,  // [0:27] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1838,13 +2161,14 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 	file_teleport_scopes_joining_v1_token_proto_msgTypes[4].OneofWrappers = []any{
 		(*UsageStatus_SingleUse)(nil),
 	}
+	file_teleport_scopes_joining_v1_token_proto_msgTypes[23].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   22,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -168,7 +168,9 @@ type ScopedTokenSpec struct {
 	// The AzureDevops-specific configuration used with the "azure_devops" join method.
 	AzureDevops *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
 	// The Oracle-specific configuration used with the "oracle" join method.
-	Oracle        *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
+	Oracle *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
+	// The GitHub-specific configuration used with the "github" join method.
+	Github        *Github `protobuf:"bytes,11,opt,name=github,proto3" json:"github,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -269,6 +271,13 @@ func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
 func (x *ScopedTokenSpec) GetOracle() *Oracle {
 	if x != nil {
 		return x.Oracle
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetGithub() *Github {
+	if x != nil {
+		return x.Github
 	}
 	return nil
 }
@@ -1010,6 +1019,98 @@ func (x *Oracle) GetAllow() []*Oracle_Rule {
 	return nil
 }
 
+// The GitHub-specific configuration used with the "github" join method.
+type Github struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*Github_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// Allows joining from runners associated with a GitHub Enterprise Server instance.
+	// When unconfigured, tokens will be validated against github.com, but when configured
+	// to the host of a GHES instance, then the tokens will be validated against host.
+	//
+	// This value should be the hostname of the GHES instance, and should not
+	// include the scheme or a path. The instance must be accessible over HTTPS
+	// at this hostname and the certificate must be trusted by the Auth Service.
+	EnterpriseServerHost string `protobuf:"bytes,2,opt,name=enterprise_server_host,json=enterpriseServerHost,proto3" json:"enterprise_server_host,omitempty"`
+	// Allows the slug of a GitHub Enterprise organisation to be
+	// included in the expected issuer of the OIDC tokens. This is for
+	// compatibility with the `include_enterprise_slug` option in GHE.
+	//
+	// This field should be set to the slug of your enterprise if this is enabled. If
+	// this is not enabled, then this field must be left empty. This field cannot
+	// be specified if `enterprise_server_host` is specified.
+	//
+	// See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+	// for more information about customized issuer values.
+	EnterpriseSlug string `protobuf:"bytes,3,opt,name=enterprise_slug,json=enterpriseSlug,proto3" json:"enterprise_slug,omitempty"`
+	// Disables fetching of the GHES signing keys via the JWKS/OIDC
+	// endpoints, and allows them to be directly specified. This allows joining
+	// from GitHub Actions in GHES instances that are not reachable by the
+	// Teleport Auth Service.
+	StaticJwks    string `protobuf:"bytes,4,opt,name=static_jwks,json=staticJwks,proto3" json:"static_jwks,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Github) Reset() {
+	*x = Github{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github) ProtoMessage() {}
+
+func (x *Github) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Github.ProtoReflect.Descriptor instead.
+func (*Github) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *Github) GetAllow() []*Github_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *Github) GetEnterpriseServerHost() string {
+	if x != nil {
+		return x.EnterpriseServerHost
+	}
+	return ""
+}
+
+func (x *Github) GetEnterpriseSlug() string {
+	if x != nil {
+		return x.EnterpriseSlug
+	}
+	return ""
+}
+
+func (x *Github) GetStaticJwks() string {
+	if x != nil {
+		return x.StaticJwks
+	}
+	return ""
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -1034,7 +1135,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1046,7 +1147,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1113,7 +1214,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1125,7 +1226,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1176,7 +1277,7 @@ type Azure_Rule struct {
 
 func (x *Azure_Rule) Reset() {
 	*x = Azure_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1188,7 +1289,7 @@ func (x *Azure_Rule) String() string {
 func (*Azure_Rule) ProtoMessage() {}
 
 func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1260,7 +1361,7 @@ type AzureDevops_Rule struct {
 
 func (x *AzureDevops_Rule) Reset() {
 	*x = AzureDevops_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1272,7 +1373,7 @@ func (x *AzureDevops_Rule) String() string {
 func (*AzureDevops_Rule) ProtoMessage() {}
 
 func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1365,7 +1466,7 @@ type Oracle_Rule struct {
 
 func (x *Oracle_Rule) Reset() {
 	*x = Oracle_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1377,7 +1478,7 @@ func (x *Oracle_Rule) String() string {
 func (*Oracle_Rule) ProtoMessage() {}
 
 func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1421,6 +1522,120 @@ func (x *Oracle_Rule) GetInstances() []string {
 	return nil
 }
 
+// The fields mapped from `lib/githubactions.IDToken`. Not all fields should be included,
+// only ones that we expect to be useful when trying to create rules around which workflows
+// should be allowed to authenticate against a cluster.
+type Github_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Sub, also known as Subject, is a string that roughly uniquely identifies
+	// the workload. The format of this varies depending on the type of github
+	// action run.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// The repository from where the workflow is running.
+	// This includes the name of the owner e.g `gravitational/teleport`
+	Repository string `protobuf:"bytes,2,opt,name=repository,proto3" json:"repository,omitempty"`
+	// The name of the organization in which the repository is stored.
+	RepositoryOwner string `protobuf:"bytes,3,opt,name=repository_owner,json=repositoryOwner,proto3" json:"repository_owner,omitempty"`
+	// The name of the workflow.
+	Workflow string `protobuf:"bytes,4,opt,name=workflow,proto3" json:"workflow,omitempty"`
+	// The name of the environment used by the job.
+	Environment string `protobuf:"bytes,5,opt,name=environment,proto3" json:"environment,omitempty"`
+	// The personal account that initiated the workflow run.
+	Actor string `protobuf:"bytes,6,opt,name=actor,proto3" json:"actor,omitempty"`
+	// The git ref that triggered the workflow run.
+	Ref string `protobuf:"bytes,7,opt,name=ref,proto3" json:"ref,omitempty"`
+	// The type of ref, for example: "branch".
+	RefType       string `protobuf:"bytes,8,opt,name=ref_type,json=refType,proto3" json:"ref_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Github_Rule) Reset() {
+	*x = Github_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Github_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Github_Rule) ProtoMessage() {}
+
+func (x *Github_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Github_Rule.ProtoReflect.Descriptor instead.
+func (*Github_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{14, 0}
+}
+
+func (x *Github_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepository() string {
+	if x != nil {
+		return x.Repository
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRepositoryOwner() string {
+	if x != nil {
+		return x.RepositoryOwner
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetWorkflow() string {
+	if x != nil {
+		return x.Workflow
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetEnvironment() string {
+	if x != nil {
+		return x.Environment
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetActor() string {
+	if x != nil {
+		return x.Actor
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRef() string {
+	if x != nil {
+		return x.Ref
+	}
+	return ""
+}
+
+func (x *Github_Rule) GetRefType() string {
+	if x != nil {
+		return x.RefType
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -1433,7 +1648,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x8d\x04\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xc9\x04\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1447,7 +1662,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
 	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\x12:\n" +
 	"\x06oracle\x18\n" +
-	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\"\xb6\x01\n" +
+	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\x12:\n" +
+	"\x06github\x18\v \x01(\v2\".teleport.scopes.joining.v1.GithubR\x06github\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1523,7 +1739,24 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\atenancy\x18\x01 \x01(\tR\atenancy\x12/\n" +
 	"\x13parent_compartments\x18\x02 \x03(\tR\x12parentCompartments\x12\x18\n" +
 	"\aregions\x18\x03 \x03(\tR\aregions\x12\x1c\n" +
-	"\tinstances\x18\x04 \x03(\tR\tinstancesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\tinstances\x18\x04 \x03(\tR\tinstances\"\xae\x03\n" +
+	"\x06Github\x12=\n" +
+	"\x05allow\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.Github.RuleR\x05allow\x124\n" +
+	"\x16enterprise_server_host\x18\x02 \x01(\tR\x14enterpriseServerHost\x12'\n" +
+	"\x0fenterprise_slug\x18\x03 \x01(\tR\x0eenterpriseSlug\x12\x1f\n" +
+	"\vstatic_jwks\x18\x04 \x01(\tR\n" +
+	"staticJwks\x1a\xe4\x01\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12\x1e\n" +
+	"\n" +
+	"repository\x18\x02 \x01(\tR\n" +
+	"repository\x12)\n" +
+	"\x10repository_owner\x18\x03 \x01(\tR\x0frepositoryOwner\x12\x1a\n" +
+	"\bworkflow\x18\x04 \x01(\tR\bworkflow\x12 \n" +
+	"\venvironment\x18\x05 \x01(\tR\venvironment\x12\x14\n" +
+	"\x05actor\x18\x06 \x01(\tR\x05actor\x12\x10\n" +
+	"\x03ref\x18\a \x01(\tR\x03ref\x12\x19\n" +
+	"\bref_type\x18\b \x01(\tR\arefTypeBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1537,7 +1770,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 22)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -1553,17 +1786,19 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
 	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
 	(*Oracle)(nil),                 // 13: teleport.scopes.joining.v1.Oracle
-	nil,                            // 14: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 15: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 16: teleport.scopes.joining.v1.GCP.Rule
-	(*Azure_Rule)(nil),             // 17: teleport.scopes.joining.v1.Azure.Rule
-	(*AzureDevops_Rule)(nil),       // 18: teleport.scopes.joining.v1.AzureDevops.Rule
-	(*Oracle_Rule)(nil),            // 19: teleport.scopes.joining.v1.Oracle.Rule
-	(*v1.Metadata)(nil),            // 20: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
+	(*Github)(nil),                 // 14: teleport.scopes.joining.v1.Github
+	nil,                            // 15: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 16: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 17: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 18: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 19: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),            // 20: teleport.scopes.joining.v1.Oracle.Rule
+	(*Github_Rule)(nil),            // 21: teleport.scopes.joining.v1.Github.Rule
+	(*v1.Metadata)(nil),            // 22: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 23: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	20, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	22, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
@@ -1572,25 +1807,27 @@ var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
 	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
 	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
 	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
-	21, // 9: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	21, // 10: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 11: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 12: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 13: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	14, // 14: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	20, // 15: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 16: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 17: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	15, // 18: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	16, // 19: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	17, // 20: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
-	18, // 21: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
-	19, // 22: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
-	23, // [23:23] is the sub-list for method output_type
-	23, // [23:23] is the sub-list for method input_type
-	23, // [23:23] is the sub-list for extension type_name
-	23, // [23:23] is the sub-list for extension extendee
-	0,  // [0:23] is the sub-list for field type_name
+	14, // 9: teleport.scopes.joining.v1.ScopedTokenSpec.github:type_name -> teleport.scopes.joining.v1.Github
+	23, // 10: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	23, // 11: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 12: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 13: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 14: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	15, // 15: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	22, // 16: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 17: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 18: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	16, // 19: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	17, // 20: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	18, // 21: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	19, // 22: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	20, // 23: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	21, // 24: teleport.scopes.joining.v1.Github.allow:type_name -> teleport.scopes.joining.v1.Github.Rule
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1607,7 +1844,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   20,
+			NumMessages:   22,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -162,7 +162,11 @@ type ScopedTokenSpec struct {
 	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
 	Aws *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
 	// The GCP-specific configuration used with the "gcp" join method.
-	Gcp           *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
+	Gcp *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
+	// The Azure-specific configuration used with the "azure" join method.
+	Azure *Azure `protobuf:"bytes,8,opt,name=azure,proto3" json:"azure,omitempty"`
+	// The AzureDevops-specific configuration used with the "azure_devops" join method.
+	AzureDevops   *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -242,6 +246,20 @@ func (x *ScopedTokenSpec) GetAws() *AWS {
 func (x *ScopedTokenSpec) GetGcp() *GCP {
 	if x != nil {
 		return x.Gcp
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzure() *Azure {
+	if x != nil {
+		return x.Azure
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
+	if x != nil {
+		return x.AzureDevops
 	}
 	return nil
 }
@@ -831,6 +849,111 @@ func (x *GCP) GetAllow() []*GCP_Rule {
 	return nil
 }
 
+// The Azure-specific configuration used with the "azure" join method.
+type Azure struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*Azure_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Azure) Reset() {
+	*x = Azure{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure) ProtoMessage() {}
+
+func (x *Azure) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure.ProtoReflect.Descriptor instead.
+func (*Azure) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *Azure) GetAllow() []*Azure_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+type AzureDevops struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AzureDevops_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The UUID of the Azure DevOps organization that this join token will grant access to.
+	// This is used to identify the correct issuer verification of the ID token.
+	// This is a required field.
+	OrganizationId string `protobuf:"bytes,2,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AzureDevops) Reset() {
+	*x = AzureDevops{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops) ProtoMessage() {}
+
+func (x *AzureDevops) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops.ProtoReflect.Descriptor instead.
+func (*AzureDevops) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *AzureDevops) GetAllow() []*AzureDevops_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AzureDevops) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -855,7 +978,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -867,7 +990,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -934,7 +1057,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -946,7 +1069,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -983,6 +1106,188 @@ func (x *GCP_Rule) GetServiceAccounts() []string {
 	return nil
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "azure" join method.
+type Azure_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The Azure subscription.
+	Subscription string `protobuf:"bytes,1,opt,name=subscription,proto3" json:"subscription,omitempty"`
+	// A list of Azure resource groups the node is allowed to join from.
+	ResourceGroups []string `protobuf:"bytes,2,rep,name=resource_groups,json=resourceGroups,proto3" json:"resource_groups,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Azure_Rule) Reset() {
+	*x = Azure_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure_Rule) ProtoMessage() {}
+
+func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure_Rule.ProtoReflect.Descriptor instead.
+func (*Azure_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11, 0}
+}
+
+func (x *Azure_Rule) GetSubscription() string {
+	if x != nil {
+		return x.Subscription
+	}
+	return ""
+}
+
+func (x *Azure_Rule) GetResourceGroups() []string {
+	if x != nil {
+		return x.ResourceGroups
+	}
+	return nil
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "azure_devops" join method.
+type AzureDevops_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The subject string that roughly uniquely identifies the workload. Example:
+	// `p://my-organization/my-project/my-pipeline`
+	// Mapped from the `sub` claim.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// The name of the AZDO project. Example:
+	// `my-project`.
+	// Mapped out of the `sub` claim.
+	ProjectName string `protobuf:"bytes,2,opt,name=project_name,json=projectName,proto3" json:"project_name,omitempty"`
+	// The name of the AZDO pipeline. Example:
+	// `my-pipeline`.
+	// Mapped out of the `sub` claim.
+	PipelineName string `protobuf:"bytes,3,opt,name=pipeline_name,json=pipelineName,proto3" json:"pipeline_name,omitempty"`
+	// The ID of the AZDO pipeline. Example:
+	// `271ef6f7-0000-0000-0000-4b54d9129990`
+	// Mapped from the `prj_id` claim.
+	ProjectId string `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// The ID of the AZDO pipeline definition. Example:
+	// `1`
+	// Mapped from the `def_id` claim.
+	DefinitionId string `protobuf:"bytes,5,opt,name=definition_id,json=definitionId,proto3" json:"definition_id,omitempty"`
+	// The URI of the repository the pipeline is using. Example:
+	// `https://github.com/gravitational/teleport.git`.
+	// Mapped from the `rpo_uri` claim.
+	RepositoryUri string `protobuf:"bytes,6,opt,name=repository_uri,json=repositoryUri,proto3" json:"repository_uri,omitempty"`
+	// The individual commit of the repository the pipeline is using. Example:
+	// `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+	// Mapped from the `rpo_ver` claim.
+	RepositoryVersion string `protobuf:"bytes,7,opt,name=repository_version,json=repositoryVersion,proto3" json:"repository_version,omitempty"`
+	// The reference of the repository the pipeline is using. Example:
+	// `refs/heads/main`.
+	// Mapped from the `rpo_ref` claim.
+	RepositoryRef string `protobuf:"bytes,8,opt,name=repository_ref,json=repositoryRef,proto3" json:"repository_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AzureDevops_Rule) Reset() {
+	*x = AzureDevops_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops_Rule) ProtoMessage() {}
+
+func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops_Rule.ProtoReflect.Descriptor instead.
+func (*AzureDevops_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12, 0}
+}
+
+func (x *AzureDevops_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectName() string {
+	if x != nil {
+		return x.ProjectName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetPipelineName() string {
+	if x != nil {
+		return x.PipelineName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetDefinitionId() string {
+	if x != nil {
+		return x.DefinitionId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryUri() string {
+	if x != nil {
+		return x.RepositoryUri
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryVersion() string {
+	if x != nil {
+		return x.RepositoryVersion
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryRef() string {
+	if x != nil {
+		return x.RepositoryRef
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -995,7 +1300,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xcc\x02\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xd1\x03\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1005,7 +1310,9 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
 	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
 	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
-	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\"\xb6\x01\n" +
+	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\x127\n" +
+	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
+	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1056,7 +1363,25 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\vproject_ids\x18\x01 \x03(\tR\n" +
 	"projectIds\x12\x1c\n" +
 	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
-	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccountsBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccounts\"\x9a\x01\n" +
+	"\x05Azure\x12<\n" +
+	"\x05allow\x18\x01 \x03(\v2&.teleport.scopes.joining.v1.Azure.RuleR\x05allow\x1aS\n" +
+	"\x04Rule\x12\"\n" +
+	"\fsubscription\x18\x01 \x01(\tR\fsubscription\x12'\n" +
+	"\x0fresource_groups\x18\x02 \x03(\tR\x0eresourceGroups\"\x9e\x03\n" +
+	"\vAzureDevops\x12B\n" +
+	"\x05allow\x18\x01 \x03(\v2,.teleport.scopes.joining.v1.AzureDevops.RuleR\x05allow\x12'\n" +
+	"\x0forganization_id\x18\x02 \x01(\tR\x0eorganizationId\x1a\xa1\x02\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12!\n" +
+	"\fproject_name\x18\x02 \x01(\tR\vprojectName\x12#\n" +
+	"\rpipeline_name\x18\x03 \x01(\tR\fpipelineName\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x04 \x01(\tR\tprojectId\x12#\n" +
+	"\rdefinition_id\x18\x05 \x01(\tR\fdefinitionId\x12%\n" +
+	"\x0erepository_uri\x18\x06 \x01(\tR\rrepositoryUri\x12-\n" +
+	"\x12repository_version\x18\a \x01(\tR\x11repositoryVersion\x12%\n" +
+	"\x0erepository_ref\x18\b \x01(\tR\rrepositoryRefBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1070,7 +1395,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -1083,35 +1408,43 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
 	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
 	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
-	nil,                            // 11: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 12: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 13: teleport.scopes.joining.v1.GCP.Rule
-	(*v1.Metadata)(nil),            // 14: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
+	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
+	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
+	nil,                            // 13: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 14: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 15: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 16: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 17: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*v1.Metadata)(nil),            // 18: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 19: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	14, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	18, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
 	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
 	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
-	15, // 6: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	15, // 7: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 8: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 9: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 10: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	11, // 11: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	14, // 12: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 13: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 14: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	12, // 15: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	13, // 16: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
+	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
+	19, // 8: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	19, // 9: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 10: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 11: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 12: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	13, // 13: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	18, // 14: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 15: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 16: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	14, // 17: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	15, // 18: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	16, // 19: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	17, // 20: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1128,7 +1461,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -715,7 +715,10 @@ type AWS struct {
 	Allow []*AWS_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
 	// The TTL to use for AWS EC2 Instance Identity Documents used
 	// to join the cluster with this token.
-	AwsIidTtl     int64 `protobuf:"varint,2,opt,name=aws_iid_ttl,json=awsIidTtl,proto3" json:"aws_iid_ttl,omitempty"`
+	AwsIidTtl int64 `protobuf:"varint,2,opt,name=aws_iid_ttl,json=awsIidTtl,proto3" json:"aws_iid_ttl,omitempty"`
+	// Integration name which provides credentials for validating join attempts.
+	// Currently only in use for validating the AWS Organization ID in the IAM Join method.
+	Integration   string `protobuf:"bytes,3,opt,name=integration,proto3" json:"integration,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -762,6 +765,13 @@ func (x *AWS) GetAwsIidTtl() int64 {
 		return x.AwsIidTtl
 	}
 	return 0
+}
+
+func (x *AWS) GetIntegration() string {
+	if x != nil {
+		return x.Integration
+	}
+	return ""
 }
 
 // A rule that a joining node must match in order to use the associated token
@@ -904,10 +914,11 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12F\n" +
 	"\x04spec\x18\x06 \x01(\v22.teleport.scopes.joining.v1.StaticScopedTokensSpecR\x04spec\"Y\n" +
 	"\x16StaticScopedTokensSpec\x12?\n" +
-	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokens\"\x90\x02\n" +
+	"\x06tokens\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x06tokens\"\xb2\x02\n" +
 	"\x03AWS\x12:\n" +
 	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.AWS.RuleR\x05allow\x12\x1e\n" +
-	"\vaws_iid_ttl\x18\x02 \x01(\x03R\tawsIidTtl\x1a\xac\x01\n" +
+	"\vaws_iid_ttl\x18\x02 \x01(\x03R\tawsIidTtl\x12 \n" +
+	"\vintegration\x18\x03 \x01(\tR\vintegration\x1a\xac\x01\n" +
 	"\x04Rule\x12\x1f\n" +
 	"\vaws_account\x18\x01 \x01(\tR\n" +
 	"awsAccount\x12\x1f\n" +

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -85,6 +85,9 @@ message ScopedTokenSpec {
 
   // The GitHub-specific configuration used with the "github" join method.
   Github github = 11;
+
+  // The GitLab-specific configuration used with the "gitlab" join method.
+  GitLab gitlab = 12;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -361,4 +364,103 @@ message Github {
   // from GitHub Actions in GHES instances that are not reachable by the
   // Teleport Auth Service.
   string static_jwks = 4;
+}
+
+// The GitLab-specific configuration used with the "gitlab" join method.
+message GitLab {
+  // The fields mapped from `lib/join/gitlab.IDTokenClaims`. Not all fields should be included,
+  // only ones that we expect to be useful when trying to create rules around which workflows
+  // should be allowed to authenticate against a cluster.
+  message Rule {
+    // Roughly uniquely identifies the workload. Example:
+    // `project_path:mygroup/my-project:ref_type:branch:ref:main`
+    // project_path:GROUP/PROJECT:ref_type:TYPE:ref:BRANCH_NAME
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string sub = 1;
+
+    // Allows access to be limited to jobs triggered by a specific git ref.
+    // Ensure this is used in combination with ref_type.
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string ref = 2;
+
+    // Allows access to be limited to jobs triggered by a specific git
+    // ref type. Example:
+    // `branch` or `tag`
+    string ref_type = 3;
+
+    // Used to limit access to jobs in a group or user's projects.
+    // Example:
+    // `mygroup`
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string namespace_path = 4;
+
+    // Used to limit access to jobs belonging to an individual project.
+    // Example:
+    // `mygroup/myproject`
+    //
+    // This field supports "glob-style" matching:
+    // - Use '*' to match zero or more characters.
+    // - Use '?' to match any single character.
+    string project_path = 5;
+
+    // Limits access by the job pipeline source type.
+    // https://docs.gitlab.com/ee/ci/jobs/job_control.html#common-if-clauses-for-rules
+    // Example: `web`
+    string pipeline_source = 6;
+
+    // Limits access by the environment the job deploys to
+    // (if one is associated)
+    string environment = 7;
+
+    // The username of the user executing the job
+    string user_login = 8;
+
+    // The ID of the user executing the job
+    string user_id = 9;
+
+    // The email of the user executing the job
+    string user_email = 10;
+
+    // True if the Git ref is protected, false otherwise.
+    optional bool ref_protected = 11;
+
+    // True if the Git ref is protected, false otherwise.
+    optional bool environment_protected = 12;
+
+    // The git commit SHA for the ci_config_ref_uri.
+    string ci_config_sha = 13;
+
+    // The ref path to the top-level pipeline definition, for example,
+    // gitlab.example.com/my-group/my-project//.gitlab-ci.yml@refs/heads/main.
+    string ci_config_ref_uri = 14;
+
+    // The deployment tier of the environment the job specifies
+    string deployment_tier = 15;
+    // The visibility of the project where the pipeline is running.
+    // Can be internal, private, or public.
+    string project_visibility = 16;
+  }
+
+  // Allow is a list of TokenRules, nodes using this token must match one
+  // allow rule to use this token.
+  repeated Rule allow = 1;
+
+  // The domain of your GitLab instance. This will default to `gitlab.com` - but can
+  // be set to the domain of your self-hosted GitLab
+  // e.g `gitlab.example.com`.
+  string domain = 2;
+
+  // Disables fetching of the GitLab signing keys via the JWKS/OIDC endpoints, and
+  // allows them to be directly specified. This allows joining from GitLab CI instances
+  // that are not reachable by the Teleport Auth Service.
+  string static_jwks = 3;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -186,4 +186,8 @@ message AWS {
   // The TTL to use for AWS EC2 Instance Identity Documents used
   // to join the cluster with this token.
   int64 aws_iid_ttl = 2;
+
+  // Integration name which provides credentials for validating join attempts.
+  // Currently only in use for validating the AWS Organization ID in the IAM Join method.
+  string integration = 3;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -82,6 +82,9 @@ message ScopedTokenSpec {
   AzureDevops azure_devops = 9;
   // The Oracle-specific configuration used with the "oracle" join method.
   Oracle oracle = 10;
+
+  // The GitHub-specific configuration used with the "github" join method.
+  Github github = 11;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -301,4 +304,61 @@ message Oracle {
   // A list of Rules for allowing use of this token. A node must match at least one
   // allow rule in order to use this token.
   repeated Rule allow = 1;
+}
+
+// The GitHub-specific configuration used with the "github" join method.
+message Github {
+  // The fields mapped from `lib/githubactions.IDToken`. Not all fields should be included,
+  // only ones that we expect to be useful when trying to create rules around which workflows
+  // should be allowed to authenticate against a cluster.
+  message Rule {
+    // Sub, also known as Subject, is a string that roughly uniquely identifies
+    // the workload. The format of this varies depending on the type of github
+    // action run.
+    string sub = 1;
+    // The repository from where the workflow is running.
+    // This includes the name of the owner e.g `gravitational/teleport`
+    string repository = 2;
+    // The name of the organization in which the repository is stored.
+    string repository_owner = 3;
+    // The name of the workflow.
+    string workflow = 4;
+    // The name of the environment used by the job.
+    string environment = 5;
+    // The personal account that initiated the workflow run.
+    string actor = 6;
+    // The git ref that triggered the workflow run.
+    string ref = 7;
+    // The type of ref, for example: "branch".
+    string ref_type = 8;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+
+  // Allows joining from runners associated with a GitHub Enterprise Server instance.
+  // When unconfigured, tokens will be validated against github.com, but when configured
+  // to the host of a GHES instance, then the tokens will be validated against host.
+  //
+  // This value should be the hostname of the GHES instance, and should not
+  // include the scheme or a path. The instance must be accessible over HTTPS
+  // at this hostname and the certificate must be trusted by the Auth Service.
+  string enterprise_server_host = 2;
+
+  // Allows the slug of a GitHub Enterprise organisation to be
+  // included in the expected issuer of the OIDC tokens. This is for
+  // compatibility with the `include_enterprise_slug` option in GHE.
+  //
+  // This field should be set to the slug of your enterprise if this is enabled. If
+  // this is not enabled, then this field must be left empty. This field cannot
+  // be specified if `enterprise_server_host` is specified.
+  //
+  // See https://docs.github.com/en/enterprise-cloud@latest/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#customizing-the-issuer-value-for-an-enterprise
+  // for more information about customized issuer values.
+  string enterprise_slug = 3;
+  // Disables fetching of the GHES signing keys via the JWKS/OIDC
+  // endpoints, and allows them to be directly specified. This allows joining
+  // from GitHub Actions in GHES instances that are not reachable by the
+  // Teleport Auth Service.
+  string static_jwks = 4;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -80,6 +80,8 @@ message ScopedTokenSpec {
   Azure azure = 8;
   // The AzureDevops-specific configuration used with the "azure_devops" join method.
   AzureDevops azure_devops = 9;
+  // The Oracle-specific configuration used with the "oracle" join method.
+  Oracle oracle = 10;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -277,4 +279,26 @@ message AzureDevops {
   // This is used to identify the correct issuer verification of the ID token.
   // This is a required field.
   string organization_id = 2;
+}
+
+// The Oracle-specific configuration used with the "oracle" join method.
+message Oracle {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "oracle" join method.
+  message Rule {
+    // The OCID of the instance's tenancy. Required.
+    string tenancy = 1;
+    // A list of the OCIDs of compartments an instance is allowed to join from. Only direct
+    // parents are allowed, i.e. no nested compartments. If empty, any compartment is allowed.
+    repeated string parent_compartments = 2;
+    // A list of regions an instance is allowed to join from. Both full region names ("us-phoenix-1")
+    // and abbreviations ("phx") are allowed. If empty, any region is allowed.
+    repeated string regions = 3;
+    // A list of the OCIDs of specific instances that are allowed to join. If empty, any instance
+    // matching the other fields in the rule is allowed. Limited to 100 instance OCIDs per rule.
+    repeated string instances = 4;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -70,6 +70,9 @@ message ScopedTokenSpec {
   // Immutable labels that should be applied to any resulting resources provisioned
   // using this token.
   ImmutableLabels immutable_labels = 5;
+
+  // The AWS-specific configuration used with the "ec2" and "iam" join methods.
+  AWS aws = 6;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -153,4 +156,34 @@ message StaticScopedTokens {
 message StaticScopedTokensSpec {
   // The statically parsed scoped tokens.
   repeated ScopedToken tokens = 1;
+}
+
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+message AWS {
+  // A rule that a joining node must match in order to use the associated token
+  // with AWS join methods.
+  message Rule {
+    // The AWS account ID.
+    string aws_account = 1;
+    // List of AWS regions a node is allowed to join from when using the
+    // EC2 join method.
+    repeated string aws_regions = 2;
+    // The ARN of the role the Auth Service will assume in order to call the
+    // EC2 API when using the EC2 join method.
+    string aws_role = 3;
+    // The ARN of the joining identity for use with the IAM join method.
+    // Supports wildcards "*" and "?".
+    string aws_arn = 4;
+    // The organization ID that the joining AWS identity must belong to
+    // when using the IAM join method.
+    string aws_organization_id = 5;
+  }
+
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+
+  // The TTL to use for AWS EC2 Instance Identity Documents used
+  // to join the cluster with this token.
+  int64 aws_iid_ttl = 2;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -76,6 +76,10 @@ message ScopedTokenSpec {
 
   // The GCP-specific configuration used with the "gcp" join method.
   GCP gcp = 7;
+  // The Azure-specific configuration used with the "azure" join method.
+  Azure azure = 8;
+  // The AzureDevops-specific configuration used with the "azure_devops" join method.
+  AzureDevops azure_devops = 9;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -211,4 +215,66 @@ message GCP {
   // A list of Rules for allowing use of this token. A node must match at least one
   // allow rule in order to use this token.
   repeated Rule allow = 1;
+}
+
+// The Azure-specific configuration used with the "azure" join method.
+message Azure {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure" join method.
+  message Rule {
+    // The Azure subscription.
+    string subscription = 1;
+    // A list of Azure resource groups the node is allowed to join from.
+    repeated string resource_groups = 2;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+message AzureDevops {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure_devops" join method.
+  message Rule {
+    // The subject string that roughly uniquely identifies the workload. Example:
+    // `p://my-organization/my-project/my-pipeline`
+    // Mapped from the `sub` claim.
+    string sub = 1;
+    // The name of the AZDO project. Example:
+    // `my-project`.
+    // Mapped out of the `sub` claim.
+    string project_name = 2;
+    // The name of the AZDO pipeline. Example:
+    // `my-pipeline`.
+    // Mapped out of the `sub` claim.
+    string pipeline_name = 3;
+    // The ID of the AZDO pipeline. Example:
+    // `271ef6f7-0000-0000-0000-4b54d9129990`
+    // Mapped from the `prj_id` claim.
+    string project_id = 4;
+    // The ID of the AZDO pipeline definition. Example:
+    // `1`
+    // Mapped from the `def_id` claim.
+    string definition_id = 5;
+    // The URI of the repository the pipeline is using. Example:
+    // `https://github.com/gravitational/teleport.git`.
+    // Mapped from the `rpo_uri` claim.
+    string repository_uri = 6;
+    // The individual commit of the repository the pipeline is using. Example:
+    // `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+    // Mapped from the `rpo_ver` claim.
+    string repository_version = 7;
+    // The reference of the repository the pipeline is using. Example:
+    // `refs/heads/main`.
+    // Mapped from the `rpo_ref` claim.
+    string repository_ref = 8;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+  // The UUID of the Azure DevOps organization that this join token will grant access to.
+  // This is used to identify the correct issuer verification of the ID token.
+  // This is a required field.
+  string organization_id = 2;
 }

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -73,6 +73,9 @@ message ScopedTokenSpec {
 
   // The AWS-specific configuration used with the "ec2" and "iam" join methods.
   AWS aws = 6;
+
+  // The GCP-specific configuration used with the "gcp" join method.
+  GCP gcp = 7;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -190,4 +193,22 @@ message AWS {
   // Integration name which provides credentials for validating join attempts.
   // Currently only in use for validating the AWS Organization ID in the IAM Join method.
   string integration = 3;
+}
+
+// The GCP-specific configuration used with the "gcp" join method.
+// ProvisionTokenSpecV2.
+message GCP {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "gcp" join method.
+  message Rule {
+    // A list of project IDs (e.g. `<example-id-123456>`).
+    repeated string project_ids = 1;
+    // A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+    repeated string locations = 2;
+    // A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+    repeated string service_accounts = 3;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -153,8 +153,8 @@ type ProvisionToken interface {
 	GetGCP() *ProvisionTokenSpecV2GCP
 	// GetGithub will return the GitHub rules within this token.
 	GetGithub() *ProvisionTokenSpecV2GitHub
-	// GetGitlabRules will return the GitLab rules within this token.
-	GetGitlabRules() *ProvisionTokenSpecV2GitLab
+	// GetGitlab will return the GitLab rules within this token.
+	GetGitlab() *ProvisionTokenSpecV2GitLab
 	// GetAzure will return the Azure specific configuration for this token.
 	GetAzure() *ProvisionTokenSpecV2Azure
 	// GetAzureDevops will return the AzureDevops specific configuration for this token.
@@ -533,8 +533,8 @@ func (p *ProvisionTokenV2) GetGithub() *ProvisionTokenSpecV2GitHub {
 	return p.Spec.GitHub
 }
 
-// GetGitlabRules will return the GitLab rules within this token.
-func (p *ProvisionTokenV2) GetGitlabRules() *ProvisionTokenSpecV2GitLab {
+// GetGitlab will return the GitLab rules within this token.
+func (p *ProvisionTokenV2) GetGitlab() *ProvisionTokenSpecV2GitLab {
 	return p.Spec.GitLab
 }
 

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -159,6 +159,8 @@ type ProvisionToken interface {
 	GetAzure() *ProvisionTokenSpecV2Azure
 	// GetAzureDevops will return the AzureDevops specific configuration for this token.
 	GetAzureDevops() *ProvisionTokenSpecV2AzureDevops
+	// GetOracle will return the Oracle specific configuration for this token.
+	GetOracle() *ProvisionTokenSpecV2Oracle
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -549,6 +551,11 @@ func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
 // GetAzureDevops will return the AzureDevops specific configuration for this token.
 func (p *ProvisionTokenV2) GetAzureDevops() *ProvisionTokenSpecV2AzureDevops {
 	return p.Spec.AzureDevops
+}
+
+// GetOracle will return the Oracle specific configuration for this token.
+func (p *ProvisionTokenV2) GetOracle() *ProvisionTokenSpecV2Oracle {
+	return p.Spec.Oracle
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -149,8 +149,8 @@ type ProvisionToken interface {
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
-	// GetGCPRules will return the GCP rules within this token.
-	GetGCPRules() *ProvisionTokenSpecV2GCP
+	// GetGCP will return the GCP rules within this token.
+	GetGCP() *ProvisionTokenSpecV2GCP
 	// GetGithubRules will return the GitHub rules within this token.
 	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetGitlabRules will return the GitLab rules within this token.
@@ -517,8 +517,8 @@ func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 	p.Spec.Allow = rules
 }
 
-// GetGCPRules will return the GCP rules within this token.
-func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
+// GetGCP will return the GCP-specific configuration for this token.
+func (p *ProvisionTokenV2) GetGCP() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
 }
 

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -157,6 +157,8 @@ type ProvisionToken interface {
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
 	// GetAzure will return the Azure specific configuration for this token.
 	GetAzure() *ProvisionTokenSpecV2Azure
+	// GetAzureDevops will return the AzureDevops specific configuration for this token.
+	GetAzureDevops() *ProvisionTokenSpecV2AzureDevops
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -542,6 +544,11 @@ func (p *ProvisionTokenV2) GetAWSIIDTTL() Duration {
 // GetAzure the Azure specific configuration for this token.
 func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
 	return p.Spec.Azure
+}
+
+// GetAzureDevops will return the AzureDevops specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzureDevops() *ProvisionTokenSpecV2AzureDevops {
+	return p.Spec.AzureDevops
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -151,8 +151,8 @@ type ProvisionToken interface {
 	GetIntegration() string
 	// GetGCP will return the GCP rules within this token.
 	GetGCP() *ProvisionTokenSpecV2GCP
-	// GetGithubRules will return the GitHub rules within this token.
-	GetGithubRules() *ProvisionTokenSpecV2GitHub
+	// GetGithub will return the GitHub rules within this token.
+	GetGithub() *ProvisionTokenSpecV2GitHub
 	// GetGitlabRules will return the GitLab rules within this token.
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
 	// GetAzure will return the Azure specific configuration for this token.
@@ -528,8 +528,8 @@ func (p *ProvisionTokenV2) GetGCP() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
 }
 
-// GetGithubRules will return the GitHub rules within this token.
-func (p *ProvisionTokenV2) GetGithubRules() *ProvisionTokenSpecV2GitHub {
+// GetGithub will return the GitHub rules within this token.
+func (p *ProvisionTokenV2) GetGithub() *ProvisionTokenSpecV2GitHub {
 	return p.Spec.GitHub
 }
 

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -155,6 +155,8 @@ type ProvisionToken interface {
 	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetGitlabRules will return the GitLab rules within this token.
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
+	// GetAzure will return the Azure specific configuration for this token.
+	GetAzure() *ProvisionTokenSpecV2Azure
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -535,6 +537,11 @@ func (p *ProvisionTokenV2) GetGitlabRules() *ProvisionTokenSpecV2GitLab {
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (p *ProvisionTokenV2) GetAWSIIDTTL() Duration {
 	return p.Spec.AWSIIDTTL
+}
+
+// GetAzure the Azure specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
+	return p.Spec.Azure
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -38,10 +38,10 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/provision"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -404,8 +404,8 @@ func claimsToIdentifiers(tokenClaims *AccessTokenClaims) (subscriptionID, resour
 	return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
 }
 
-func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token *types.ProvisionTokenV2) error {
-	for _, rule := range token.Spec.Azure.Allow {
+func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token provision.Token) error {
+	for _, rule := range token.GetAzure().Allow {
 		if rule.Subscription != attrs.Subscription {
 			continue
 		}
@@ -448,7 +448,7 @@ type CheckAzureRequestParams struct {
 	// AzureJoinConfig holds configurable options for Azure joining.
 	AzureJoinConfig *AzureJoinConfig
 	// Token is the token used for the incoming request.
-	Token *types.ProvisionTokenV2
+	Token provision.Token
 	// Challenge is the challenge that was issued.
 	Challenge string
 	// AttestedData is the Azure attested data that was returned by the joining

--- a/lib/join/gcp/gcp.go
+++ b/lib/join/gcp/gcp.go
@@ -143,7 +143,7 @@ func checkGCPAllowRules(token provision.Token, claims *IDTokenClaims) error {
 	// claim is not present in the IDToken. This happens when the joining node is not a GCE VM.
 	unmatchedLocation := false
 	// If a single rule passes, accept the IDToken.
-	for _, rule := range token.GetGCPRules().Allow {
+	for _, rule := range token.GetGCP().Allow {
 		if !slices.Contains(rule.ProjectIDs, compute.ProjectID) {
 			continue
 		}

--- a/lib/join/gitlab/gitlab.go
+++ b/lib/join/gitlab/gitlab.go
@@ -190,23 +190,23 @@ func CheckIDToken(ctx context.Context, params *CheckIDTokenParams) (*IDTokenClai
 		return nil, trace.AccessDenied("%s", err.Error())
 	}
 
-	token, ok := params.ProvisionToken.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("gitlab join method only supports ProvisionTokenV2, '%T' was provided", params.ProvisionToken)
+	gl := params.ProvisionToken.GetGitlab()
+	if gl == nil {
+		return nil, trace.BadParameter("token does not support gitlab join method")
 	}
 
 	var claims *IDTokenClaims
 	var err error
-	if token.Spec.GitLab.StaticJWKS != "" {
+	if gl.StaticJWKS != "" {
 		claims, err = params.Validator.ValidateTokenWithJWKS(
-			ctx, []byte(token.Spec.GitLab.StaticJWKS), string(params.IDToken),
+			ctx, []byte(gl.StaticJWKS), string(params.IDToken),
 		)
 		if err != nil {
 			return nil, trace.Wrap(err, "validating with static jwks")
 		}
 	} else {
 		claims, err = params.Validator.Validate(
-			ctx, token.Spec.GitLab.Domain, string(params.IDToken),
+			ctx, gl.Domain, string(params.IDToken),
 		)
 		if err != nil {
 			return nil, trace.Wrap(err, "validating with oidc")
@@ -218,10 +218,10 @@ func CheckIDToken(ctx context.Context, params *CheckIDTokenParams) (*IDTokenClai
 		"token", params.ProvisionToken.GetName(),
 	)
 
-	return claims, trace.Wrap(checkGitLabAllowRules(token, claims))
+	return claims, trace.Wrap(checkGitLabAllowRules(gl.Allow, claims))
 }
 
-func checkGitLabAllowRules(token *types.ProvisionTokenV2, claims *IDTokenClaims) error {
+func checkGitLabAllowRules(allow []*types.ProvisionTokenSpecV2GitLab_Rule, claims *IDTokenClaims) error {
 	// Helper for comparing a BoolOption with GitLabs string bool.
 	// Returns true if OK - returns false if not OK
 	boolEqual := func(want *types.BoolOption, got string) bool {
@@ -232,7 +232,7 @@ func checkGitLabAllowRules(token *types.ProvisionTokenV2, claims *IDTokenClaims)
 	}
 
 	// If a single rule passes, accept the IDToken
-	for i, rule := range token.Spec.GitLab.Allow {
+	for i, rule := range allow {
 		// Please consider keeping these field validators in the same order they
 		// are defined within the ProvisionTokenSpecV2GitLab proto spec.
 		subMatches, err := joinutils.GlobMatchAllowEmptyPattern(rule.Sub, claims.Sub)

--- a/lib/join/join_azuredevops_test.go
+++ b/lib/join/join_azuredevops_test.go
@@ -27,11 +27,15 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockAzureDevopsTokenValidator struct {
@@ -325,9 +329,44 @@ func TestJoinAzureDevops(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, auth.UpsertToken(ctx, token))
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = auth.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := auth.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			t.Run("new", func(t *testing.T) {
 				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
 					Token: token.GetName(),
+					ID: state.IdentityID{
+						Role:     types.RoleInstance,
+						NodeName: "testnode",
+					},
+					IDToken:    tt.idToken,
+					AuthClient: nopClient,
+				})
+				tt.assertError(t, err)
+			})
+			t.Run("scoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: "scoped_" + token.GetName(),
 					ID: state.IdentityID{
 						Role:     types.RoleInstance,
 						NodeName: "testnode",

--- a/lib/join/join_ec2_test.go
+++ b/lib/join/join_ec2_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/join/ec2join"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type ec2Instance struct {
@@ -524,6 +525,7 @@ func TestJoinEC2(t *testing.T) {
 					AssignedScope: "/test/one",
 					JoinMethod:    string(types.JoinMethodEC2),
 					Roles:         []string{types.RoleNode.String()},
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
 					Aws: &joiningv1.AWS{
 						Allow:     convertRules(token.GetAllowRules()),
 						AwsIidTtl: int64(token.GetAWSIIDTTL()),

--- a/lib/join/join_gcp_test.go
+++ b/lib/join/join_gcp_test.go
@@ -27,12 +27,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/join/gcp"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockGCPTokenValidator struct {
@@ -222,6 +226,29 @@ func TestJoinGCP(t *testing.T) {
 			require.NoError(t, auth.CreateToken(ctx, token))
 			tc.request.Token = tc.name
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = auth.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := auth.DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			nopClient, err := authServer.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 
@@ -251,6 +278,23 @@ func TestJoinGCP(t *testing.T) {
 			t.Run("new joinclient", func(t *testing.T) {
 				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 					Token:      tc.request.Token,
+					JoinMethod: types.JoinMethodGCP,
+					ID: state.IdentityID{
+						Role:     types.RoleInstance, // RoleNode is not allowed
+						NodeName: "testnode",
+					},
+					IDToken:    tc.request.IDToken,
+					AuthClient: nopClient,
+				})
+				tc.assertError(t, err)
+				if err != nil {
+					return
+				}
+			})
+
+			t.Run("scoped", func(t *testing.T) {
+				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token:      "scoped_" + tc.request.Token,
 					JoinMethod: types.JoinMethodGCP,
 					ID: state.IdentityID{
 						Role:     types.RoleInstance, // RoleNode is not allowed

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/join/iamjoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -831,6 +832,7 @@ func testIAMJoin(t *testing.T, tc *iamJoinTestCase) {
 			AssignedScope: "/test/one",
 			JoinMethod:    string(token.GetJoinMethod()),
 			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
 			Aws: &joiningv1.AWS{
 				Integration: token.GetIntegration(),
 				Allow:       convertRules(token.GetAllowRules()),

--- a/lib/join/join_iam_test.go
+++ b/lib/join/join_iam_test.go
@@ -39,6 +39,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -802,6 +804,54 @@ func testIAMJoin(t *testing.T, tc *iamJoinTestCase) {
 		assert.NoError(t, tc.authServer.Auth().DeleteToken(ctx, token.GetName()))
 	})
 
+	convertRules := func(rules []*types.TokenRule) []*joiningv1.AWS_Rule {
+		t.Helper()
+		out := make([]*joiningv1.AWS_Rule, len(rules))
+		for i, rule := range rules {
+			out[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+
+		return out
+	}
+
+	scopedToken := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Scope:   "/test",
+		Metadata: &headerv1.Metadata{
+			Name: "scoped_" + token.GetName(),
+		},
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test/one",
+			JoinMethod:    string(token.GetJoinMethod()),
+			Roles:         []string{types.RoleNode.String()},
+			Aws: &joiningv1.AWS{
+				Integration: token.GetIntegration(),
+				Allow:       convertRules(token.GetAllowRules()),
+			},
+		},
+	}
+
+	_, err = tc.authServer.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+		Token: scopedToken,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, err := tc.authServer.Auth().DeleteScopedToken(
+			t.Context(),
+			&joiningv1.DeleteScopedTokenRequest{
+				Name: scopedToken.GetMetadata().GetName(),
+			},
+		)
+		assert.NoError(t, err)
+	})
+
 	// Make an unauthenticated auth client that will be used for the join.
 	nopClient, err := tc.authServer.NewClient(authtest.TestNop())
 	require.NoError(t, err)
@@ -882,6 +932,56 @@ func testIAMJoin(t *testing.T, tc *iamJoinTestCase) {
 					Method:    "iam",
 					NodeName:  "test-node",
 					TokenName: "test-token",
+				},
+				evt,
+				protocmp.Transform(),
+				cmpopts.IgnoreMapEntries(func(key string, val any) bool {
+					return key == "Time" || key == "ID" || key == "TokenExpires"
+				}),
+			))
+		}, 5*time.Second, 5*time.Millisecond)
+	})
+	t.Run("scoped", func(t *testing.T) {
+		_, err := joinclient.Join(ctx, joinclient.JoinParams{
+			Token: "scoped_" + tc.requestTokenName,
+			ID: state.IdentityID{
+				Role:     types.RoleInstance,
+				NodeName: "test-node",
+			},
+			CreateSignedSTSIdentityRequestFunc: createSignedSTSIdentityRequest,
+			AuthClient:                         nopClient,
+		})
+		tc.assertError(t, err)
+
+		// If the challenge-response is expected to fail, assert that a join
+		// failure event was emitted with an error message about the client
+		// giving up on the join attempt.
+		if tc.challengeResponseErr == nil {
+			return
+		}
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			evt, err := lastEvent(ctx, tc.authServer.Auth(), tc.authServer.Auth().GetClock(), "instance.join")
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(
+				&apievents.InstanceJoin{
+					Metadata: apievents.Metadata{
+						Type: "instance.join",
+						Code: events.InstanceJoinFailureCode,
+					},
+					Status: apievents.Status{
+						Success: false,
+						Error: fmt.Sprintf(
+							"receiving challenge solution\n\tclient gave up on join attempt: challenge solution failed: creating signed sts:GetCallerIdentity request %s",
+							tc.challengeResponseErr,
+						),
+					},
+					ConnectionMetadata: apievents.ConnectionMetadata{
+						RemoteAddr: "127.0.0.1",
+					},
+					Role:      "Instance",
+					Method:    "iam",
+					NodeName:  "test-node",
+					TokenName: "scoped_test-token",
 				},
 				evt,
 				protocmp.Transform(),

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -141,6 +141,41 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 			EnterpriseSlug:       base.GetGithub().EnterpriseSlug,
 			StaticJwks:           base.GetGithub().StaticJWKS,
 		}
+	case types.JoinMethodGitLab:
+		allow := make([]*joiningv1.GitLab_Rule, len(base.GetGitlab().Allow))
+		for i, rule := range base.GetGitlab().Allow {
+			var refProtected, environmentProtected *bool
+			if rule.RefProtected != nil {
+				refProtected = &rule.RefProtected.Value
+			}
+
+			if rule.EnvironmentProtected != nil {
+				environmentProtected = &rule.EnvironmentProtected.Value
+			}
+			allow[i] = &joiningv1.GitLab_Rule{
+				Sub:                  rule.Sub,
+				Ref:                  rule.Ref,
+				RefType:              rule.RefType,
+				NamespacePath:        rule.NamespacePath,
+				ProjectPath:          rule.ProjectPath,
+				PipelineSource:       rule.PipelineSource,
+				Environment:          rule.Environment,
+				UserLogin:            rule.UserLogin,
+				UserId:               rule.UserID,
+				UserEmail:            rule.UserEmail,
+				RefProtected:         refProtected,
+				EnvironmentProtected: environmentProtected,
+				CiConfigSha:          rule.CIConfigSHA,
+				CiConfigRefUri:       rule.CIConfigRefURI,
+				DeploymentTier:       rule.DeploymentTier,
+				ProjectVisibility:    rule.ProjectVisibility,
+			}
+		}
+		scopedToken.Spec.Gitlab = &joiningv1.GitLab{
+			Allow:      allow,
+			Domain:     base.GetGitlab().Domain,
+			StaticJwks: base.GetGitlab().StaticJWKS,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -90,6 +90,24 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 		scopedToken.Spec.Azure = &joiningv1.Azure{
 			Allow: allow,
 		}
+	case types.JoinMethodAzureDevops:
+		allow := make([]*joiningv1.AzureDevops_Rule, len(base.GetAzureDevops().Allow))
+		for i, rule := range base.GetAzureDevops().Allow {
+			allow[i] = &joiningv1.AzureDevops_Rule{
+				Sub:               rule.Sub,
+				ProjectName:       rule.ProjectName,
+				PipelineName:      rule.PipelineName,
+				ProjectId:         rule.ProjectID,
+				DefinitionId:      rule.DefinitionID,
+				RepositoryUri:     rule.RepositoryURI,
+				RepositoryVersion: rule.RepositoryVersion,
+				RepositoryRef:     rule.RepositoryRef,
+			}
+		}
+		scopedToken.Spec.AzureDevops = &joiningv1.AzureDevops{
+			Allow:          allow,
+			OrganizationId: base.GetAzureDevops().OrganizationID,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -108,6 +108,19 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 			Allow:          allow,
 			OrganizationId: base.GetAzureDevops().OrganizationID,
 		}
+	case types.JoinMethodOracle:
+		allow := make([]*joiningv1.Oracle_Rule, len(base.GetOracle().Allow))
+		for i, rule := range base.GetOracle().Allow {
+			allow[i] = &joiningv1.Oracle_Rule{
+				Tenancy:            rule.Tenancy,
+				ParentCompartments: rule.ParentCompartments,
+				Regions:            rule.Regions,
+				Instances:          rule.Instances,
+			}
+		}
+		scopedToken.Spec.Oracle = &joiningv1.Oracle{
+			Allow: allow,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -67,6 +67,18 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 			Allow:       allow,
 			Integration: base.GetIntegration(),
 		}
+	case types.JoinMethodGCP:
+		allow := make([]*joiningv1.GCP_Rule, len(base.GetGCPRules().Allow))
+		for i, rule := range base.GetGCPRules().Allow {
+			allow[i] = &joiningv1.GCP_Rule{
+				ProjectIds:      rule.ProjectIDs,
+				Locations:       rule.Locations,
+				ServiceAccounts: rule.ServiceAccounts,
+			}
+		}
+		scopedToken.Spec.Gcp = &joiningv1.GCP{
+			Allow: allow,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -79,6 +79,17 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 		scopedToken.Spec.Gcp = &joiningv1.GCP{
 			Allow: allow,
 		}
+	case types.JoinMethodAzure:
+		allow := make([]*joiningv1.Azure_Rule, len(base.GetAzure().Allow))
+		for i, rule := range base.GetAzure().Allow {
+			allow[i] = &joiningv1.Azure_Rule{
+				Subscription:   rule.Subscription,
+				ResourceGroups: rule.ResourceGroups,
+			}
+		}
+		scopedToken.Spec.Azure = &joiningv1.Azure{
+			Allow: allow,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -68,8 +68,8 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 			Integration: base.GetIntegration(),
 		}
 	case types.JoinMethodGCP:
-		allow := make([]*joiningv1.GCP_Rule, len(base.GetGCPRules().Allow))
-		for i, rule := range base.GetGCPRules().Allow {
+		allow := make([]*joiningv1.GCP_Rule, len(base.GetGCP().Allow))
+		for i, rule := range base.GetGCP().Allow {
 			allow[i] = &joiningv1.GCP_Rule{
 				ProjectIds:      rule.ProjectIDs,
 				Locations:       rule.Locations,

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -121,6 +121,26 @@ func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.Sco
 		scopedToken.Spec.Oracle = &joiningv1.Oracle{
 			Allow: allow,
 		}
+	case types.JoinMethodGitHub:
+		allow := make([]*joiningv1.Github_Rule, len(base.GetGithub().Allow))
+		for i, rule := range base.GetGithub().Allow {
+			allow[i] = &joiningv1.Github_Rule{
+				Sub:             rule.Sub,
+				Repository:      rule.Repository,
+				RepositoryOwner: rule.RepositoryOwner,
+				Workflow:        rule.Workflow,
+				Environment:     rule.Environment,
+				Actor:           rule.Actor,
+				Ref:             rule.Ref,
+				RefType:         rule.RefType,
+			}
+		}
+		scopedToken.Spec.Github = &joiningv1.Github{
+			Allow:                allow,
+			EnterpriseServerHost: base.GetGithub().EnterpriseServerHost,
+			EnterpriseSlug:       base.GetGithub().EnterpriseSlug,
+			StaticJwks:           base.GetGithub().StaticJWKS,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -1,0 +1,75 @@
+package jointest
+
+import (
+	"cmp"
+
+	"github.com/gravitational/trace"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/join/provision"
+)
+
+// ScopedTokenFromProvisionToken is a test helper that creates a scoped token using a [provision.Token]
+// as a base. The override parameter can be used to provide override values that should
+// be used instead of the base token values. This is mostly useful
+// for testing.
+func ScopedTokenFromProvisionToken(base provision.Token, override *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	roles := base.GetRoles().StringSlice()
+	if len(roles) == 0 {
+		roles = override.GetSpec().GetRoles()
+	}
+
+	scopedToken := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Scope:   override.GetScope(),
+		Metadata: cmp.Or(override.GetMetadata(), &headerv1.Metadata{
+			Name: base.GetName(),
+		}),
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: override.GetSpec().GetAssignedScope(),
+			JoinMethod:    cmp.Or(override.GetSpec().GetJoinMethod(), string(base.GetJoinMethod())),
+			Roles:         roles,
+			UsageMode:     override.GetSpec().GetUsageMode(),
+		},
+	}
+
+	switch base.GetJoinMethod() {
+	case types.JoinMethodEC2:
+		allow := make([]*joiningv1.AWS_Rule, len(base.GetAllowRules()))
+		for i, rule := range base.GetAllowRules() {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:     allow,
+			AwsIidTtl: int64(base.GetAWSIIDTTL()),
+		}
+	case types.JoinMethodIAM:
+		allow := make([]*joiningv1.AWS_Rule, len(base.GetAllowRules()))
+		for i, rule := range base.GetAllowRules() {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:       allow,
+			Integration: base.GetIntegration(),
+		}
+	default:
+		return nil, trace.BadParameter("unsupported join method %q", base.GetJoinMethod())
+	}
+
+	return scopedToken, nil
+}

--- a/lib/join/oraclejoin/join_test.go
+++ b/lib/join/oraclejoin/join_test.go
@@ -43,6 +43,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
@@ -53,8 +55,10 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/joinclient/oracle"
+	"github.com/gravitational/teleport/lib/join/jointest"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/testutils"
@@ -352,15 +356,51 @@ func TestJoinOracle(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, server.Auth().UpsertToken(t.Context(), token))
 
-			_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
-				Token: tc.requestTokenName,
-				ID: state.IdentityID{
-					Role: types.RoleInstance,
+			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
 				},
-				AuthClient:       nopClient,
-				OracleIMDSClient: imdsClient,
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
 			})
-			tc.assertion(t, err)
+			require.NoError(t, err)
+			_, err = server.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := server.Auth().DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
+			t.Run("unscoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient:       nopClient,
+					OracleIMDSClient: imdsClient,
+				})
+				tc.assertion(t, err)
+			})
+
+			t.Run("scoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: "scoped_" + tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient:       nopClient,
+					OracleIMDSClient: imdsClient,
+				})
+				tc.assertion(t, err)
+			})
 		})
 	}
 }

--- a/lib/join/oraclejoin/rules.go
+++ b/lib/join/oraclejoin/rules.go
@@ -28,12 +28,8 @@ import (
 // CheckOracleAllowRules checks that a the oracle rules in a provision token
 // allow an OCI instance with the given claims to join the cluster.
 func CheckOracleAllowRules(claims *Claims, token provision.Token) error {
-	ptv2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return trace.Errorf("Oracle join method only supports ProvisionTokenV2")
-	}
 	instanceRegion := claims.Region()
-	for _, rule := range ptv2.Spec.Oracle.Allow {
+	for _, rule := range token.GetOracle().Allow {
 		if rule.Tenancy != claims.TenancyID {
 			// rule.Tenancy is required, if it doesn't match the instance skip this rule.
 			continue

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -58,4 +58,6 @@ type Token interface {
 	GetGCP() *types.ProvisionTokenSpecV2GCP
 	// GetAzure returns the Azure-specific configuration for this token.
 	GetAzure() *types.ProvisionTokenSpecV2Azure
+	// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -62,4 +62,7 @@ type Token interface {
 	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
 	// GetOracle returns the Oracle-specific configuration for this token.
 	GetOracle() *types.ProvisionTokenSpecV2Oracle
+	// GetGithub returns the Github-specific configuration used with the "github"
+	// join method.
+	GetGithub() *types.ProvisionTokenSpecV2GitHub
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -65,4 +65,7 @@ type Token interface {
 	// GetGithub returns the Github-specific configuration used with the "github"
 	// join method.
 	GetGithub() *types.ProvisionTokenSpecV2GitHub
+	// GetGitlab returns the Gitlab-specific configuration used with the "gitlab"
+	// join method.
+	GetGitlab() *types.ProvisionTokenSpecV2GitLab
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -56,4 +56,6 @@ type Token interface {
 	GetIntegration() string
 	// GetGCP returns the GCP-specific configuration for this token.
 	GetGCP() *types.ProvisionTokenSpecV2GCP
+	// GetAzure returns the Azure-specific configuration for this token.
+	GetAzure() *types.ProvisionTokenSpecV2Azure
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -60,4 +60,6 @@ type Token interface {
 	GetAzure() *types.ProvisionTokenSpecV2Azure
 	// GetAzureDevops returns the AzureDevops-specific configuration for this token.
 	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
+	// GetOracle returns the Oracle-specific configuration for this token.
+	GetOracle() *types.ProvisionTokenSpecV2Oracle
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -54,6 +54,6 @@ type Token interface {
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
-	// GetGCPRules returns the GCP-specific configuration for this token.
-	GetGCPRules() *types.ProvisionTokenSpecV2GCP
+	// GetGCP returns the GCP-specific configuration for this token.
+	GetGCP() *types.ProvisionTokenSpecV2GCP
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -54,4 +54,6 @@ type Token interface {
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
+	// GetGCPRules returns the GCP-specific configuration for this token.
+	GetGCPRules() *types.ProvisionTokenSpecV2GCP
 }

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -81,15 +80,10 @@ func (s *Server) handleAzureJoin(
 		return nil, trace.BadParameter("client did not send access token")
 	}
 
-	ptv2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
-	}
-
 	// Verify the client's identity and make sure it matches an allow rule in the provision token.
 	claims, err := azurejoin.CheckAzureRequest(stream.Context(), azurejoin.CheckAzureRequestParams{
 		AzureJoinConfig: s.cfg.AuthService.GetAzureJoinConfig(),
-		Token:           ptv2,
+		Token:           token,
 		Challenge:       challenge,
 		AttestedData:    solution.AttestedData,
 		Intermediate:    solution.Intermediate,

--- a/lib/join/server_azuredevops.go
+++ b/lib/join/server_azuredevops.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/provision"
 )
@@ -32,13 +31,8 @@ func (s *Server) validateAzureDevopsToken(
 	pt provision.Token,
 	idToken []byte,
 ) (any, *workloadidentityv1.JoinAttrs, error) {
-	ptv2, ok := pt.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, nil, trace.BadParameter("Azure Devops joining only supports ProvisionTokenV2, got %T", pt)
-	}
-
 	claims, err := azuredevops.CheckIDToken(ctx, &azuredevops.CheckIDTokenParams{
-		ProvisionToken: ptv2,
+		ProvisionToken: pt,
 		IDToken:        string(idToken),
 		Validator:      s.cfg.AuthService.GetAzureDevopsIDTokenValidator(),
 	})

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -38,6 +38,7 @@ var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodGCP):         {},
 	string(types.JoinMethodAzure):       {},
 	string(types.JoinMethodAzureDevops): {},
+	string(types.JoinMethodOracle):      {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -347,6 +348,23 @@ func (t *Token) GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops {
 	return &types.ProvisionTokenSpecV2AzureDevops{
 		Allow:          allow,
 		OrganizationID: t.scoped.GetSpec().GetAzureDevops().GetOrganizationId(),
+	}
+}
+
+// GetOracle returns the Oracle-specific configuration for this token.
+func (t *Token) GetOracle() *types.ProvisionTokenSpecV2Oracle {
+	allow := make([]*types.ProvisionTokenSpecV2Oracle_Rule, len(t.scoped.GetSpec().GetOracle().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetOracle().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Oracle_Rule{
+			Tenancy:            rule.GetTenancy(),
+			ParentCompartments: rule.GetParentCompartments(),
+			Regions:            rule.GetRegions(),
+			Instances:          rule.GetInstances(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Oracle{
+		Allow: allow,
 	}
 }
 

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -295,8 +295,8 @@ func (t *Token) GetIntegration() string {
 	return t.scoped.GetSpec().GetAws().GetIntegration()
 }
 
-// GetGCPRules returns the GCP-specific configuration for this token.
-func (t *Token) GetGCPRules() *types.ProvisionTokenSpecV2GCP {
+// GetGCP returns the GCP-specific configuration for this token.
+func (t *Token) GetGCP() *types.ProvisionTokenSpecV2GCP {
 	allow := make([]*types.ProvisionTokenSpecV2GCP_Rule, len(t.scoped.GetSpec().GetGcp().GetAllow()))
 	for i, rule := range t.scoped.GetSpec().GetGcp().GetAllow() {
 		allow[i] = &types.ProvisionTokenSpecV2GCP_Rule{

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -33,6 +33,7 @@ var rolesSupportingScopes = types.SystemRoles{
 
 var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodToken): {},
+	string(types.JoinMethodEC2):   {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -262,12 +263,23 @@ func (t *Token) GetAssignedScope() string {
 
 // GetAllowRules returns the list of allow rules.
 func (t *Token) GetAllowRules() []*types.TokenRule {
-	return nil
+	allow := make([]*types.TokenRule, len(t.scoped.GetSpec().GetAws().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAws().GetAllow() {
+		allow[i] = &types.TokenRule{
+			AWSAccount:        rule.GetAwsAccount(),
+			AWSRegions:        rule.GetAwsRegions(),
+			AWSRole:           rule.GetAwsRole(),
+			AWSARN:            rule.GetAwsArn(),
+			AWSOrganizationID: rule.GetAwsOrganizationId(),
+		}
+	}
+
+	return allow
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (t *Token) GetAWSIIDTTL() types.Duration {
-	return types.NewDuration(0)
+	return types.Duration(t.scoped.GetSpec().GetAws().GetAwsIidTtl())
 }
 
 // GetIntegration returns the Integration field which is used to provide

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -32,11 +32,12 @@ var rolesSupportingScopes = types.SystemRoles{
 }
 
 var joinMethodsSupportingScopes = map[string]struct{}{
-	string(types.JoinMethodToken): {},
-	string(types.JoinMethodEC2):   {},
-	string(types.JoinMethodIAM):   {},
-	string(types.JoinMethodGCP):   {},
-	string(types.JoinMethodAzure): {},
+	string(types.JoinMethodToken):       {},
+	string(types.JoinMethodEC2):         {},
+	string(types.JoinMethodIAM):         {},
+	string(types.JoinMethodGCP):         {},
+	string(types.JoinMethodAzure):       {},
+	string(types.JoinMethodAzureDevops): {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -324,6 +325,28 @@ func (t *Token) GetAzure() *types.ProvisionTokenSpecV2Azure {
 
 	return &types.ProvisionTokenSpecV2Azure{
 		Allow: allow,
+	}
+}
+
+// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+func (t *Token) GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops {
+	allow := make([]*types.ProvisionTokenSpecV2AzureDevops_Rule, len(t.scoped.GetSpec().GetAzureDevops().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzureDevops().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2AzureDevops_Rule{
+			Sub:               rule.GetSub(),
+			ProjectName:       rule.GetProjectName(),
+			PipelineName:      rule.GetPipelineName(),
+			ProjectID:         rule.GetProjectId(),
+			DefinitionID:      rule.GetDefinitionId(),
+			RepositoryURI:     rule.GetRepositoryUri(),
+			RepositoryVersion: rule.GetRepositoryVersion(),
+			RepositoryRef:     rule.GetRepositoryRef(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2AzureDevops{
+		Allow:          allow,
+		OrganizationID: t.scoped.GetSpec().GetAzureDevops().GetOrganizationId(),
 	}
 }
 

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -34,6 +34,7 @@ var rolesSupportingScopes = types.SystemRoles{
 var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodToken): {},
 	string(types.JoinMethodEC2):   {},
+	string(types.JoinMethodIAM):   {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -285,7 +286,7 @@ func (t *Token) GetAWSIIDTTL() types.Duration {
 // GetIntegration returns the Integration field which is used to provide
 // credentials that will be used when validating the AWS Organization if required by an IAM Token.
 func (t *Token) GetIntegration() string {
-	return ""
+	return t.scoped.GetSpec().GetAws().GetIntegration()
 }
 
 // GetSecret returns the token's secret value.

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -36,6 +36,7 @@ var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodEC2):   {},
 	string(types.JoinMethodIAM):   {},
 	string(types.JoinMethodGCP):   {},
+	string(types.JoinMethodAzure): {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -307,6 +308,21 @@ func (t *Token) GetGCP() *types.ProvisionTokenSpecV2GCP {
 	}
 
 	return &types.ProvisionTokenSpecV2GCP{
+		Allow: allow,
+	}
+}
+
+// GetAzure returns the Azure-specific configuration for this token.
+func (t *Token) GetAzure() *types.ProvisionTokenSpecV2Azure {
+	allow := make([]*types.ProvisionTokenSpecV2Azure_Rule, len(t.scoped.GetSpec().GetAzure().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzure().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Azure_Rule{
+			Subscription:   rule.GetSubscription(),
+			ResourceGroups: rule.GetResourceGroups(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Azure{
 		Allow: allow,
 	}
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -39,6 +39,7 @@ var joinMethodsSupportingScopes = map[string]struct{}{
 	string(types.JoinMethodAzure):       {},
 	string(types.JoinMethodAzureDevops): {},
 	string(types.JoinMethodOracle):      {},
+	string(types.JoinMethodGitHub):      {},
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -377,4 +378,33 @@ func GetScopedToken(token provision.Token) (*joiningv1.ScopedToken, bool) {
 	}
 
 	return wrapper.scoped, true
+}
+
+// GetGithub returns the Github-specific configuration used with the "github"
+// join method.
+func (t *Token) GetGithub() *types.ProvisionTokenSpecV2GitHub {
+	gh := t.scoped.GetSpec().GetGithub()
+	if gh == nil {
+		return nil
+	}
+
+	allow := make([]*types.ProvisionTokenSpecV2GitHub_Rule, len(gh.GetAllow()))
+	for i, rule := range gh.GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2GitHub_Rule{
+			Sub:             rule.GetSub(),
+			Repository:      rule.GetRepository(),
+			RepositoryOwner: rule.GetRepositoryOwner(),
+			Workflow:        rule.GetWorkflow(),
+			Environment:     rule.GetEnvironment(),
+			Actor:           rule.GetActor(),
+			Ref:             rule.GetRef(),
+			RefType:         rule.GetRefType(),
+		}
+	}
+	return &types.ProvisionTokenSpecV2GitHub{
+		Allow:                allow,
+		EnterpriseServerHost: gh.GetEnterpriseServerHost(),
+		EnterpriseSlug:       gh.GetEnterpriseSlug(),
+		StaticJWKS:           gh.GetStaticJwks(),
+	}
 }

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -87,7 +87,7 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 	}
 
 	if uiToken.Method == types.JoinMethodGitLab {
-		uiToken.Gitlab = token.GetGitlabRules()
+		uiToken.Gitlab = token.GetGitlab()
 	}
 
 	return uiToken, nil

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -83,7 +83,7 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 	}
 
 	if uiToken.Method == types.JoinMethodGitHub {
-		uiToken.Github = token.GetGithubRules()
+		uiToken.Github = token.GetGithub()
 	}
 
 	if uiToken.Method == types.JoinMethodGitLab {

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -79,7 +79,7 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 	}
 
 	if uiToken.Method == types.JoinMethodGCP {
-		uiToken.GCP = token.GetGCPRules()
+		uiToken.GCP = token.GetGCP()
 	}
 
 	if uiToken.Method == types.JoinMethodGitHub {


### PR DESCRIPTION
This PR adds support for the `github` and `gitlab` join methods when using scoped tokens.

# Manual testing
- [ ] Create a scoped token with `github` join method `tctl scoped token add --type node --join-method github --scope /local --assign-scope /local`
- [ ] Create a scoped token with `gitlab` join method `tctl scoped token add --type node --join-method gitlab --scope /local --assign-scope /local`
- [ ] Provision a node using the github scoped token
- [ ] Provision a node using the gitlab scoped token
