### PR TITLE
[v18][SCIM] fix SCIM event trimming

### DIFF
--- a/api/types/events/events.go
+++ b/api/types/events/events.go
@@ -163,7 +163,7 @@ func (m *Status) nonEmptyStrs() int {
 }
 
 func (m *Status) trimToMaxFieldSize(maxFieldSize int) Status {
-	var out Status
+	out := *m
 	out.Error = trimStr(m.Error, maxFieldSize)
 	out.UserMessage = trimStr(m.UserMessage, maxFieldSize)
 	return out
@@ -2677,26 +2677,44 @@ func (m *BoundKeypairJoinStateVerificationFailed) TrimToMaxSize(maxSize int) Aud
 	return out
 }
 
+func placeholder[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+	var empty T
+	return &empty
+}
+
 func (m *SCIMResourceEvent) TrimToMaxSize(maxSize int) AuditEvent {
 	if m.Size() <= maxSize {
 		return m
 	}
+
 	trimmed := utils.CloneProtoMsg(m)
+	trimmed.Status = Status{}
+	trimmed.SCIMCommonData = SCIMCommonData{
+		Request:  placeholder(m.Request),
+		Response: placeholder(m.Response),
+	}
+	trimmed.TeleportID = ""
+	trimmed.ExternalID = ""
+	trimmed.Display = ""
 
 	maxSize = adjustedMaxSize(trimmed, maxSize)
-	trimmableFieldCount := trimmed.Status.nonEmptyStrs() +
-		trimmed.SCIMCommonData.nonEmptyFields() +
+
+	trimmableFieldCount := m.Status.nonEmptyStrs() +
+		m.SCIMCommonData.nonEmptyFields() +
 		nonEmptyStrs(
-			trimmed.TeleportID,
-			trimmed.ExternalID,
-			trimmed.Display)
+			m.TeleportID,
+			m.ExternalID,
+			m.Display)
 	maxFieldsSize := maxSizePerField(maxSize, trimmableFieldCount)
 
 	trimmed.Status = m.Status.trimToMaxFieldSize(maxFieldsSize)
-	trimmed.SCIMCommonData = trimmed.SCIMCommonData.trimToMaxFieldSize(maxFieldsSize)
-	trimmed.TeleportID = trimStr(trimmed.TeleportID, maxFieldsSize)
-	trimmed.ExternalID = trimStr(trimmed.ExternalID, maxFieldsSize)
-	trimmed.Display = trimStr(trimmed.Display, maxFieldsSize)
+	trimmed.SCIMCommonData = m.SCIMCommonData.trimToMaxFieldSize(maxFieldsSize)
+	trimmed.TeleportID = trimStr(m.TeleportID, maxFieldsSize)
+	trimmed.ExternalID = trimStr(m.ExternalID, maxFieldsSize)
+	trimmed.Display = trimStr(m.Display, maxFieldsSize)
 
 	return trimmed
 }
@@ -2705,7 +2723,14 @@ func (m *SCIMListingEvent) TrimToMaxSize(maxSize int) AuditEvent {
 	if m.Size() <= maxSize {
 		return m
 	}
+
 	trimmed := utils.CloneProtoMsg(m)
+	trimmed.Status = Status{}
+	trimmed.SCIMCommonData = SCIMCommonData{
+		Request:  placeholder(m.Request),
+		Response: placeholder(m.Response),
+	}
+	trimmed.Filter = ""
 
 	maxSize = adjustedMaxSize(trimmed, maxSize)
 	trimmableFieldCount := m.Status.nonEmptyStrs() +
@@ -2714,8 +2739,8 @@ func (m *SCIMListingEvent) TrimToMaxSize(maxSize int) AuditEvent {
 	maxFieldsSize := maxSizePerField(maxSize, trimmableFieldCount)
 
 	trimmed.Status = m.Status.trimToMaxFieldSize(maxFieldsSize)
-	trimmed.SCIMCommonData = trimmed.SCIMCommonData.trimToMaxFieldSize(maxFieldsSize)
-	trimmed.Filter = trimStr(trimmed.Filter, maxFieldsSize)
+	trimmed.SCIMCommonData = m.SCIMCommonData.trimToMaxFieldSize(maxFieldsSize)
+	trimmed.Filter = trimStr(m.Filter, maxFieldsSize)
 
 	return trimmed
 }

--- a/api/types/events/events_test.go
+++ b/api/types/events/events_test.go
@@ -159,6 +159,81 @@ func TestTrimToMaxSize(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:    "SCIM Resource Event trimmed",
+			maxSize: 200,
+			in: &SCIMResourceEvent{
+				Metadata: Metadata{
+					Code: "TSCIM006I",
+					Type: "scim.patch",
+				},
+				Status: Status{
+					Success:     true,
+					Error:       "I am the very model of a modern Major General",
+					UserMessage: "I have information animal, vegetable and mineral",
+				},
+				SCIMCommonData: SCIMCommonData{
+					Integration:  "iiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiiii",
+					ResourceType: "ttttttttttttttttttttttttttttttttttttttttttt",
+					Request: &SCIMRequest{
+						ID:            "idididididididididididididididididididididid",
+						SourceAddress: "srcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrcsrc",
+						UserAgent:     "agentagentagentagentagentagentagentagentagent",
+						Method:        "PATCHPATCHPATCHPATCHPATCHPATCHPATCHPATCHPATCHPATCH",
+						Path:          "/Users/teleport-user-with-a-long-name",
+						Body: MustEncodeMap(map[string]any{
+							"Alpha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+						}),
+					},
+					Response: &SCIMResponse{
+						StatusCode: 404,
+						Body: MustEncodeMap(map[string]any{
+							"plain": "text",
+							"Gamma": "gggggggggggggggggggggggggggggggggggggggggg",
+						}),
+					},
+				},
+			},
+			want: &SCIMResourceEvent{
+				Metadata: Metadata{
+					Code: "TSCIM006I",
+					Type: "scim.patch",
+				},
+				Status: Status{
+					Success:     true,
+					Error:       "I am t",
+					UserMessage: "I have",
+				},
+				SCIMCommonData: SCIMCommonData{
+					Integration:  "iiiiii",
+					ResourceType: "tttttt",
+					Request: &SCIMRequest{
+						ID:            "ididid",
+						SourceAddress: "srcsrc",
+						UserAgent:     "agenta",
+						Method:        "PATCHP",
+						Path:          "/Users",
+						Body: MustEncodeMap(map[string]any{
+							"Alpha": "aaaaaa",
+						}),
+					},
+					Response: &SCIMResponse{
+						StatusCode: 404,
+						Body: MustEncodeMap(map[string]any{
+							"plain": "text",
+							"Gamma": "gggggg",
+						}),
+					},
+				},
+			},
+			cmpOpts: []cmp.Option{
+				cmp.Transformer("struct", func(s *Struct) map[string]any {
+					result, err := DecodeToMap(s)
+					require.NoError(t, err)
+					return result
+				}),
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The SCIM audit events were not calculating their trimmed size correctly. This PR fixes the size calculation.

It also fixes a bug in the Status trimmer that did not preserve the success field.

Addresses: #62841
Backports: #63172
