### PR TITLE
MWI: Add docs new background-friendly GitHub Actions

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -418,11 +418,20 @@ Use `tctl edit role/example-bot` to add the following to the role:
 ```yaml
 spec:
   allow:
-    # TODO: database rules
+    db_labels:
+      '*': '*'
+    db_names: [demo-db]
+    db_users: [demo-user]
+    rules:
+      - resources: [db_server, db]
+        verbs: [read, list]
 ```
 
-With that privileges granted, you can now create the GitHub Actions workflow.
-Create `.github/workflows/example.yaml`:
+Make sure to adjust the labels, names, and users as necessary to match your
+desired databases.
+
+With database privileges granted, you can now create the GitHub Actions
+workflow. Create `.github/workflows/example.yaml`:
 
 ```yaml
 # This is a basic workflow to help you get started, modify it for your needs.
@@ -462,14 +471,14 @@ jobs:
         # shown in `tsh db ls`
         service: postgres
         # The name of the specific database to connect to.
-        database: demo
+        database: demo-db
         # The username of the database user to connect as.
-        username: demo
+        username: demo-user
         # Configure the port for tbot's diagnostics service, used to coordinate
         # with the bot in the background. If running multiple background bots
         # (app tunnel/proxy, database tunnel, etc), make sure to give each a
         # unique port. If unset, the default shown below is used.
-        diagPort: 57263
+        diag-port: 57263
         # Enable the submission of anonymous usage telemetry. This helps us
         # shape the future development of `tbot`. You can disable this by
         # omitting this.
@@ -477,16 +486,16 @@ jobs:
 
     - name: Run a database command
       run: |
-        psql postgres://demo@localhost:5432/demo -c 'select 1;'
+        psql postgres://demo-user@localhost:5432/demo-db -c 'select 1;'
 ```
 
 Replace:
 
 - `example.teleport.sh:443` with the address of your Teleport Proxy Service.
 - `example-bot` with the name of the token you created in a previous step.
-- `service` with the name of your database server as configured in Teleport.
-- `database` with the database name to access.
-- `username` with the database username to connect as.
+- `postgres` with the name of your database server as configured in Teleport.
+- `demo-db` with the database name to access.
+- `demo-user` with the database username to connect as.
 
 Once the `teleport-actions/database-tunnel` action completes, a database tunnel
 will be running at the configured port (in this case, `localhost:5432`). You may
@@ -518,11 +527,17 @@ Use `tctl edit role/example-bot` to add the following to the role:
 ```yaml
 spec:
   allow:
-    # TODO: app rules
+    # Grants access to all applications.
+    app_labels:
+      '*': '*'
 ```
 
-With that privileges granted, you can now create the GitHub Actions workflow.
-Create `.github/workflows/example.yaml`:
+If desired, adjust the label selector in the role to restrict which applications
+the bot will be allowed to access. For more information, refer to our
+[dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
+
+Once privileges have been granted, you can now create the GitHub Actions
+workflow. Create `.github/workflows/example.yaml`:
 
 ```yaml
 # This is a basic workflow to help you get started, modify it for your needs.
@@ -559,6 +574,8 @@ jobs:
         token: example-bot
         # The name of the app to access.
         app: my-application
+        # Configure the listener address for the app tunnel.
+        listen: tcp://localhost:1234
         # Enable the submission of anonymous usage telemetry. This helps us
         # shape the future development of `tbot`. You can disable this by
         # omitting this.
@@ -584,8 +601,8 @@ Navigate to the **Actions** tab of your GitHub repository in your web browser.
 Select the **Workflow** that has now been created and triggered by the change,
 and select the `example` job.
 
-Expand the **List pods** step of the action, where you can then confirm that the
-output shows a list of all the pods within your Kubernetes cluster.
+Expand the **Access the app** step of the action and confirm that the output
+shows a valid response from your application.
 
 ### Example: `teleport-actions/application-proxy`
 
@@ -601,6 +618,23 @@ While this action only supports HTTP applications, you can access arbitrary apps
 so long as your bot has been granted appropriate RBAC permissions, so long as
 your client app can use HTTP proxies (e.g. the `$HTTP_PROXY` environment
 variable).
+
+Use `tctl edit role/example-bot` to add the following to the role:
+
+```yaml
+spec:
+  allow:
+    # Grants access to all applications.
+    app_labels:
+      '*': '*'
+```
+
+If desired, adjust the label selector in the role to restrict which applications
+the bot will be allowed to access. For more information, refer to our
+[dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
+
+Once privileges have been granted, you can now create the GitHub Actions
+workflow. Create `.github/workflows/example.yaml`:
 
 ```yaml
 # This is a basic workflow to help you get started, modify it for your needs.
@@ -639,7 +673,7 @@ jobs:
         # with the bot in the background. If running multiple background bots
         # (app tunnel/proxy, database tunnel, etc), make sure to give each a
         # unique port. If unset, the default shown below is used.
-        diagPort: 57263
+        diag-port: 57263
         # Enable the submission of anonymous usage telemetry. This helps us
         # shape the future development of `tbot`. You can disable this by
         # omitting this.
@@ -822,7 +856,7 @@ jobs:
         TELEPORT_ANONYMOUS_TELEMETRY: 1
       run: nohup tbot start -c ./tbot.yaml --diag-addr localhost:57264 > ./tbot.log 2>&1 &
     - name: Wait for tbot to become ready
-      run: tbot wait --diag-addr localhost:57264
+      run: tbot wait --timeout=30s --diag-addr localhost:57264
 
     # Insert other steps that use tbot credentials or services here.
 

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -527,14 +527,14 @@ Use `tctl edit role/example-bot` to add the following to the role:
 ```yaml
 spec:
   allow:
-    # Grants access to all applications.
+    # Grants access to apps with the `env=dev` label.
     app_labels:
-      '*': '*'
+      env: dev
 ```
 
-If desired, adjust the label selector in the role to restrict which applications
-the bot will be allowed to access. For more information, refer to our
-[dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
+Make sure to adjust the label selector in the role to restrict which
+applications the bot will be allowed to access. For more information, refer to
+our [dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
 
 Once privileges have been granted, you can now create the GitHub Actions
 workflow. Create `.github/workflows/example.yaml`:
@@ -624,14 +624,14 @@ Use `tctl edit role/example-bot` to add the following to the role:
 ```yaml
 spec:
   allow:
-    # Grants access to all applications.
+    # Grants access to apps with the `env=dev` label.
     app_labels:
-      '*': '*'
+      env: dev
 ```
 
-If desired, adjust the label selector in the role to restrict which applications
-the bot will be allowed to access. For more information, refer to our
-[dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
+Make sure to adjust the label selector in the role to restrict which
+applications the bot will be allowed to access. For more information, refer to
+our [dedicated application access guide](../../machine-workload-identity/access-guides/applications.mdx).
 
 Once privileges have been granted, you can now create the GitHub Actions
 workflow. Create `.github/workflows/example.yaml`:

--- a/docs/pages/machine-workload-identity/deployment/github-actions.mdx
+++ b/docs/pages/machine-workload-identity/deployment/github-actions.mdx
@@ -164,7 +164,7 @@ configure `tsh` and `tctl` to use this identity.
 <Admonition type="info" title="Guided integration available">
     You can use the GitHub Action + SSH integration guide via the
     Teleport Web UI?
-    
+
     The guide walks you through connecting your GitHub Actions
     workflow to Teleport and giving it the permissions it needs to access your
     enrolled SSH nodes.
@@ -295,7 +295,7 @@ modified to deploy to a Kubernetes cluster with `kubectl` or `helm`.
 <Admonition type="info" title="Guided integration available">
     You can use the GitHub Action + Kubernetes integration guide via the
     Teleport Web UI?
-    
+
     The guide walks you through connecting your GitHub Actions
     workflow to Teleport and giving it the permissions it needs to access your
     enrolled Kubernetes clusters.
@@ -398,11 +398,290 @@ and select the `example` job.
 Expand the **List pods** step of the action, where you can then confirm that the
 output shows a list of all the pods within your Kubernetes cluster.
 
+### Example: `teleport-actions/database-tunnel`
+
+<Admonition type="warning" title="Required version">
+  This requires use of version 18.6.4 or later of the `tbot` client.
+</Admonition>
+
+The `teleport-actions/database-tunnel` action runs a background `tbot` client
+that provides a tunnel to a database protected by Teleport using Machine &
+Workload ID's [`database-tunnel` service](../../reference/machine-workload-identity/configuration.mdx#database-tunnel).
+
+In this example, the `psql` client will be used to run a simple query on a
+Postgres database, but you may use any supported database type with any
+compatible client. Refer to our [generic database guide](../access-guides/databases.mdx)
+for more information on accessing databases protected by Teleport in your apps.
+
+Use `tctl edit role/example-bot` to add the following to the role:
+
+```yaml
+spec:
+  allow:
+    # TODO: database rules
+```
+
+With that privileges granted, you can now create the GitHub Actions workflow.
+Create `.github/workflows/example.yaml`:
+
+```yaml
+# This is a basic workflow to help you get started, modify it for your needs.
+on:
+  push:
+    branches:
+    - main
+jobs:
+  demo:
+    permissions:
+      # The "id-token: write" permission is required or tbot will not be able to
+      # authenticate with the cluster.
+      id-token: write
+      contents: read
+    name: example
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Fetch Teleport binaries
+      uses: teleport-actions/setup@v1
+      with:
+        version: auto
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+    - name: Fetch credentials using Machine ID
+      uses: teleport-actions/database-tunnel@v1
+      with:
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+        # Use the name of the join token resource you created in step 1.
+        token: example-bot
+        # Configure the listener address for the tunnel. Your native database
+        # client (e.g. `psql`) will connect using this socket address.
+        listen: tcp://localhost:5432
+        # The database service name, usually the name of the database server as
+        # shown in `tsh db ls`
+        service: postgres
+        # The name of the specific database to connect to.
+        database: demo
+        # The username of the database user to connect as.
+        username: demo
+        # Configure the port for tbot's diagnostics service, used to coordinate
+        # with the bot in the background. If running multiple background bots
+        # (app tunnel/proxy, database tunnel, etc), make sure to give each a
+        # unique port. If unset, the default shown below is used.
+        diagPort: 57263
+        # Enable the submission of anonymous usage telemetry. This helps us
+        # shape the future development of `tbot`. You can disable this by
+        # omitting this.
+        anonymous-telemetry: 1
+
+    - name: Run a database command
+      run: |
+        psql postgres://demo@localhost:5432/demo -c 'select 1;'
+```
+
+Replace:
+
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+- `example-bot` with the name of the token you created in a previous step.
+- `service` with the name of your database server as configured in Teleport.
+- `database` with the database name to access.
+- `username` with the database username to connect as.
+
+Once the `teleport-actions/database-tunnel` action completes, a database tunnel
+will be running at the configured port (in this case, `localhost:5432`). You may
+then access that using `psql` or any other compatible client, depending on your
+database.
+
+Add, commit, and push this new workflow file to the default branch of your
+repository.
+
+Navigate to the **Actions** tab of your GitHub repository in your web browser.
+Select the **Workflow** that has now been created and triggered by the change,
+and select the `example` job.
+
+Expand the **Run a database command** step of the action, where you can then
+confirm that the database command was run successfully.
+
+### Example: `teleport-actions/application-tunnel`
+
+<Admonition type="warning" title="Required version">
+  This requires use of version 18.6.4 or later of the `tbot` client.
+</Admonition>
+
+The `teleport-actions/application-tunnel` action runs a background `tbot` client
+that provides a tunnel to an HTTP or TCP app protected by Teleport using Machine
+& Workload ID's [`application-tunnel` service](../../reference/machine-workload-identity/configuration.mdx#application-tunnel).
+
+Use `tctl edit role/example-bot` to add the following to the role:
+
+```yaml
+spec:
+  allow:
+    # TODO: app rules
+```
+
+With that privileges granted, you can now create the GitHub Actions workflow.
+Create `.github/workflows/example.yaml`:
+
+```yaml
+# This is a basic workflow to help you get started, modify it for your needs.
+on:
+  push:
+    branches:
+    - main
+jobs:
+  demo:
+    permissions:
+      # The "id-token: write" permission is required or tbot will not be able to
+      # authenticate with the cluster.
+      id-token: write
+      contents: read
+    name: example
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Fetch kubectl
+      uses: azure/setup-kubectl@v3
+    - name: Fetch Teleport binaries
+      uses: teleport-actions/setup@v1
+      with:
+        version: auto
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+    - name: Fetch credentials using Machine ID
+      uses: teleport-actions/application-tunnel@v1
+      with:
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+        # Use the name of the join token resource you created in step 1.
+        token: example-bot
+        # The name of the app to access.
+        app: my-application
+        # Enable the submission of anonymous usage telemetry. This helps us
+        # shape the future development of `tbot`. You can disable this by
+        # omitting this.
+        anonymous-telemetry: 1
+
+    - name: Access the app
+      run: curl http://localhost:1234
+```
+
+Replace:
+
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+- `example-bot` with the name of the token you created in a previous step.
+- `my-application` with the name of your app as configured in Teleport.
+
+Once run, the `application-tunnel` action opens a tunnel to the selected
+application on the configured host and port (in this case, `localhost:1234`).
+
+Add, commit, and push this new workflow file to the default branch of your
+repository.
+
+Navigate to the **Actions** tab of your GitHub repository in your web browser.
+Select the **Workflow** that has now been created and triggered by the change,
+and select the `example` job.
+
+Expand the **List pods** step of the action, where you can then confirm that the
+output shows a list of all the pods within your Kubernetes cluster.
+
+### Example: `teleport-actions/application-proxy`
+
+<Admonition type="warning" title="Required version">
+  This requires use of version 18.6.4 or later of the `tbot` client.
+</Admonition>
+
+The `teleport-actions/application-proxy` action runs a background `tbot` client
+that provides a local HTTP proxy server that can be used to access to arbitrary
+HTTP apps protected by Teleport using Machine & Workload ID's [`application-proxy` service](../../reference/machine-workload-identity/configuration.mdx#application-proxy).
+
+While this action only supports HTTP applications, you can access arbitrary apps
+so long as your bot has been granted appropriate RBAC permissions, so long as
+your client app can use HTTP proxies (e.g. the `$HTTP_PROXY` environment
+variable).
+
+```yaml
+# This is a basic workflow to help you get started, modify it for your needs.
+on:
+  push:
+    branches:
+    - main
+jobs:
+  demo:
+    permissions:
+      # The "id-token: write" permission is required or tbot will not be able to
+      # authenticate with the cluster.
+      id-token: write
+      contents: read
+    name: example
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Fetch Teleport binaries
+      uses: teleport-actions/setup@v1
+      with:
+        version: auto
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+    - name: Fetch credentials using Machine ID
+      uses: teleport-actions/application-proxy@v1
+      with:
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+        # Use the name of the join token resource you created in step 1.
+        token: example-bot
+        # Configure the listener address for the HTTP proxy server.
+        listen: tcp://localhost:1235
+        # Configure the port for tbot's diagnostics service, used to coordinate
+        # with the bot in the background. If running multiple background bots
+        # (app tunnel/proxy, database tunnel, etc), make sure to give each a
+        # unique port. If unset, the default shown below is used.
+        diagPort: 57263
+        # Enable the submission of anonymous usage telemetry. This helps us
+        # shape the future development of `tbot`. You can disable this by
+        # omitting this.
+        anonymous-telemetry: 1
+
+    - name: Perform a request over the application tunnel
+      run: |
+        http_proxy=http://localhost:1235 curl http://httpbin/get
+```
+
+Replace:
+
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+- `example-bot` with the name of the token you created in a previous step.
+
+No specific app name needs to be configured for the application proxy.
+
+Once the action completes, an HTTP proxy server will be running on the
+configured port (in this case, `http://localhost:1235`). Any application that
+can use HTTP proxies can then access any app granted to the bot via its role,
+at `http://APP_NAME/`.
+
+Add, commit, and push this new workflow file to the default branch of your
+repository.
+
+Navigate to the **Actions** tab of your GitHub repository in your web browser.
+Select the **Workflow** that has now been created and triggered by the change,
+and select the `example` job.
+
+Expand the **Perform a request...** step of the action, where you can then
+confirm that the output shows a successful `curl` request via the proxy.
+
 ### Example: Manual configuration
 
 To configure `tbot` manually, a YAML file will be used. In this example we'll
 commit this to the repository, but this could be generated or created by the
 CI pipeline itself.
+
+Note that this example uses `tbot`'s "oneshot" mode to output credentials and
+exit immediately. If you need to use a long running background service,
+[see below](#example-manual-configuration-with-a-background-service) for a
+tailored example.
 
 Create `tbot.yaml` within your repository:
 
@@ -470,6 +749,101 @@ Actions UI to ensure that the workflow has succeeded.
 
 (!docs/pages/includes/machine-id/configure-services.mdx!)
 
+### Example: Manual configuration with a background service
+
+<Admonition type="warning" title="Required version">
+  This requires use of version 18.6.4 or later of the `tbot` client.
+</Admonition>
+
+If you need to have a `tbot` client running in the background to provide a
+service not directly supported by a dedicated action, like the
+[`ssh-multiplexer`](../../reference/machine-workload-identity/configuration.mdx#ssh-multiplexer)
+or [`workload-identity-api`](../../reference/machine-workload-identity/configuration.mdx#workload-identity-api)
+services, or just to continually renew certificates for long-running jobs, it is
+possible to safely run `tbot` in the background with some additional steps.
+
+As in the standard manual configuration steps, create `tbot.yaml` within your
+repository:
+
+```yaml
+version: v2
+proxy_server: example.teleport.sh:443
+onboarding:
+  join_method: github
+  token: example-bot
+storage:
+  type: memory
+# services will be filled in during the completion of an access guide.
+services: []
+```
+
+Replace:
+
+- `example.teleport.sh:443` with the address of your Teleport Proxy Service.
+- `example-bot` with the name of the token you created in the first step.
+
+Now you can define a GitHub Actions workflow that will start `tbot` with this
+configuration.
+
+Create `.github/workflows/example-action.yaml`:
+
+```yaml
+# This is a basic workflow to help you get started.
+# It will take the following action whenever a push is made to the "main" branch.
+on:
+  push:
+    branches:
+    - main
+jobs:
+  demo:
+    permissions:
+      # The "id-token: write" permission is required or tbot will not be able to
+      # authenticate with the cluster.
+      id-token: write
+      contents: read
+    # The name of the workflow, and the Linux distro to be used to perform the
+    # required steps.
+    name: guide-demo
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Fetch Teleport binaries
+      uses: teleport-actions/setup@v1
+      with:
+        version: auto
+        # Replace with the address of your Teleport Proxy Service.
+        proxy: example.teleport.sh:443
+    - name: Start tbot in the background
+      env:
+        # TELEPORT_ANONYMOUS_TELEMETRY enables the submission of anonymous
+        # usage telemetry. This helps us shape the future development of
+        # tbot. You can disable this by omitting this.
+        TELEPORT_ANONYMOUS_TELEMETRY: 1
+      run: nohup tbot start -c ./tbot.yaml --diag-addr localhost:57264 > ./tbot.log 2>&1 &
+    - name: Wait for tbot to become ready
+      run: tbot wait --diag-addr localhost:57264
+
+    # Insert other steps that use tbot credentials or services here.
+
+    # At the end of the job, this step prints recorded tbot logs for debugging
+    # purposes (stored in tbot.log).
+    - name: Print tbot logs
+      # Logs should be printed regardless of whether or not other job steps fail.
+      if: always()
+      run: |
+        if [ -f ./tbot.log ]; then
+          cat ./tbot.log
+        else
+          echo "No tbot logs found"
+        fi
+```
+
+Add, commit, and push these two files to the repository. Check the GitHub
+Actions UI to ensure that the workflow has succeeded.
+
+(!docs/pages/includes/machine-id/configure-services.mdx!)
+
 ## A note on security implications and risk
 
 Once `teleport-actions/auth` has been used in a workflow job, all successive
@@ -490,6 +864,9 @@ interact with.
   - [teleport-actions/auth](https://github.com/teleport-actions/auth)
   - [teleport-actions/auth-k8s](https://github.com/teleport-actions/auth-k8s)
   - [teleport-actions/auth-application](https://github.com/teleport-actions/auth-application)
+  - [teleport-actions/database-tunnel](https://github.com/teleport-actions/database-tunnel)
+  - [teleport-actions/application-tunnel](https://github.com/teleport-actions/application-tunnel)
+  - [teleport-actions/application-proxy](https://github.com/teleport-actions/application-proxy)
 - For more information about the `github` join method, read the
   [join token reference page](../../reference/deployment/join-methods.mdx#github-actions-github)
 - Find out more about GitHub Actions itself, read


### PR DESCRIPTION
This adds new docs examples for background-friendly GitHub Actions, including `database-tunnel`, `application-tunnel`, and `application-proxy`. It additionally adds a new manual example for using a generic background bot with the new `tbot wait` feature.