### PR TITLE
Remove `mediation: 'silent'` when logging in with Webauthn

### DIFF
--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -139,7 +139,6 @@ const auth = {
       .then(res =>
         navigator.credentials.get({
           publicKey: res.webauthnPublicKey,
-          mediation: 'silent',
         })
       )
       .then(res => {


### PR DESCRIPTION
Closes #63231

changelog: Fixed a `CredentialContainer` error when attempting to log in to the Web UI with a hardware key using Firefox >=147.0.2

Firefox 147.0.2 seems to have [removed support for `mediation: 'silent'`](https://github.com/gravitational/teleport/blob/66e3a37f6a6610284897b55859ed3613fc7421a1/web/packages/teleport/src/services/auth/auth.ts#L142) and now returns a hard error when our code tries to use Webauthn ("CredentialContainer request is not supported").

It's unclear why we had this option in the first place. It was added in a PR that was not strictly related to Webauthn, https://github.com/gravitational/webapps/pull/1172, specifically commit [`51de7add`](https://github.com/gravitational/webapps/pull/1172/commits/51de7add4009e57f87ea60f7ccde2ec72379bd20#diff-a6634d95eebe19bc837e266ecf8ecb5433033f75aef84ce069b32ec265935159). Removing the option makes it possible to log in again.

The docs for the silent option say:

> The user will not be asked to authenticate. The user agent will automatically reauthenticate the user and log them in if possible. If consent is required, the promise will fulfill with `null`. This value is intended for situations where you would want to automatically sign a user in upon visiting a web app if possible, but if not, you don't want to present them with a confusing login dialog box. Instead, you'd want to wait for them to explicitly click a "Login/Signup" button.

It doesn't seem like it's warranted in our case because the call to `navigator.credentials.get` is always gated behind a button click, so it's not like we call this API on page load.