### PR TITLE
Connect: Remove dialog asking about background mode

### DIFF
--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -49,10 +49,6 @@ import { darkTheme, lightTheme } from 'teleterm/ui/ThemeProvider/theme';
 
 type WindowState = Rectangle;
 
-interface RunInBackgroundState {
-  notified?: boolean;
-}
-
 export class WindowsManager {
   private storageKey = 'windowState';
   private logger = new Logger('WindowsManager');
@@ -167,7 +163,10 @@ export class WindowsManager {
     window.on('close', async e => {
       this.saveWindowState(window);
 
-      if (isAppQuitting || !this.configService.get('runInBackground').value) {
+      const shouldRunInBackground =
+        this.configService.get('runInBackground').value;
+
+      if (isAppQuitting || !shouldRunInBackground) {
         this.frontendAppInit.reject(
           new Error('Window was closed before frontend app got initialized')
         );
@@ -176,8 +175,7 @@ export class WindowsManager {
 
       e.preventDefault();
 
-      const shouldRun = await this.confirmIfShouldRunInBackgroundOnce();
-      if (shouldRun) {
+      if (shouldRunInBackground) {
         this.enterBackgroundMode();
         return;
       }
@@ -484,42 +482,6 @@ export class WindowsManager {
       ...getDefaults(),
       ...getPositionAndSize(),
     };
-  }
-
-  private async confirmIfShouldRunInBackgroundOnce(): Promise<boolean> {
-    const runInBackgroundState = this.fileStorage.get(
-      'runInBackground'
-    ) as RunInBackgroundState;
-    if (
-      runInBackgroundState?.notified ||
-      // If the value is set in the config file, do not notify too.
-      this.configService.get('runInBackground').metadata.isStored
-    ) {
-      return true;
-    }
-
-    const isMac = this.settings.platform === 'darwin';
-
-    const { response } = await dialog.showMessageBox(this.window, {
-      type: 'question',
-      message: isMac
-        ? 'Keep Teleport Connect running in the menu bar?'
-        : 'Keep Teleport Connect running in the system tray?',
-      detail:
-        'VNet and connections to databases, Kubernetes clusters, and apps will remain active.',
-      buttons: ['Keep Running', 'Quit'],
-      noLink: true,
-      defaultId: 0,
-    });
-
-    const state: RunInBackgroundState = { notified: true };
-    this.fileStorage.put('runInBackground', state);
-
-    const keepRunning = response === 0;
-    if (!keepRunning) {
-      this.configService.set('runInBackground', false);
-    }
-    return keepRunning;
   }
 
   /**

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -167,6 +167,9 @@ export class WindowsManager {
         this.configService.get('runInBackground').value;
 
       if (isAppQuitting || !shouldRunInBackground) {
+        // If frontendAppInit wasn't resolved yet, reject it with an error since the app is about to
+        // quit. Electron apps by default quit after the last window is closed.
+        // https://www.electronjs.org/docs/latest/api/app#event-window-all-closed
         this.frontendAppInit.reject(
           new Error('Window was closed before frontend app got initialized')
         );
@@ -174,13 +177,7 @@ export class WindowsManager {
       }
 
       e.preventDefault();
-
-      if (shouldRunInBackground) {
-        this.enterBackgroundMode();
-        return;
-      }
-      // Retry closing.
-      window.close();
+      this.enterBackgroundMode();
     });
 
     // shows the window when the DOM is ready, so we don't have a brief flash of a blank screen


### PR DESCRIPTION
Before 18.2.1, Connect would quit the moment you closed the app window, which is not that common in macOS applications.

In 18.2.1 and #58575 specifically, we made it so that by default on Windows and macOS closing the window does not close the whole app. However, since we considered it to be a breaking change in terms of UX, we added a dialog that showed up when you first closed the window after updating the app to 18.2.1:

<img width="280" height="224" alt="Background mode dialog" src="https://github.com/user-attachments/assets/58d167a2-b9de-4fc5-972c-15c51033fe36" />

We no longer think the dialog is necessary. Old users had quite a bit of time to see the dialog and new users are likely to expect the app to keep running when closing the window and might be confused by the dialog itself.