### PR TITLE
fix agentless joining default restart command

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2911,10 +2911,15 @@ func ConfigureOpenSSH(clf *CommandLineFlags, cfg *servicecfg.Config) error {
 	lib.SetInsecureDevMode(clf.InsecureMode)
 
 	// Apply command line --debug flag to override logger severity.
+	level := slog.LevelError
 	if clf.Debug {
 		cfg.SetLogLevel(slog.LevelDebug)
+		level = slog.LevelDebug
 		cfg.Debug = clf.Debug
 	}
+
+	// Ensure that the logging level is respected by the logger.
+	utils.InitLogger(utils.LoggingForDaemon, level)
 
 	if clf.AuthToken != "" {
 		// store the value of the --token flag:

--- a/lib/openssh/sshd.go
+++ b/lib/openssh/sshd.go
@@ -284,7 +284,7 @@ func defaultRestart() error {
 		}
 
 		const activeService = "ActiveState=active"
-		if !bytes.Equal([]byte(activeService), out) {
+		if !bytes.Equal([]byte(activeService), bytes.TrimSpace(out)) {
 			slog.DebugContext(context.Background(), "skipping inactive OpenSSH service", "service", service)
 			continue
 		}


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/63011 missed that the output from systemctl show includes a trailing \n. Additionally, the teleport join openssh command now respects the -d flag and will produce debug logging if requested.