### PR TITLE
[v18] Remove `mediation: 'silent'` when logging in with Webauthn

### DIFF
--- a/web/packages/teleport/src/services/auth/auth.ts
+++ b/web/packages/teleport/src/services/auth/auth.ts
@@ -132,7 +132,6 @@ const auth = {
       .then(res =>
         navigator.credentials.get({
           publicKey: res.webauthnPublicKey,
-          mediation: 'silent',
         })
       )
       .then(res => {


### PR DESCRIPTION
Backport #63230 to branch/v18

changelog: Fixed a `CredentialContainer` error when attempting to log in to the Web UI with a hardware key using Firefox >=147.0.2
