### PR TITLE
Add "scanning" status to IaCOverview page

### DIFF
--- a/web/packages/teleport/src/Integrations/helpers.ts
+++ b/web/packages/teleport/src/Integrations/helpers.ts
@@ -22,10 +22,11 @@ import { Status } from './types';
 
 const StatusRank: Record<Status, number> = {
   [Status.Draft]: 1,
-  [Status.Healthy]: 2,
-  [Status.Issues]: 3,
-  [Status.Failed]: 4,
-  [Status.Unknown]: 5,
+  [Status.Scanning]: 2,
+  [Status.Healthy]: 3,
+  [Status.Issues]: 4,
+  [Status.Failed]: 5,
+  [Status.Unknown]: 6,
 };
 
 export const sortByStatus = (a, b) => {

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from 'design/utils/testing';
+
+import {
+  IntegrationKind,
+  IntegrationWithSummary,
+} from 'teleport/services/integrations';
+
+import { SummaryStatusLabel } from './StatusLabel';
+
+test('SummaryStatusLabel shows scanning when no sync timestamps exist', () => {
+  const stats: IntegrationWithSummary = {
+    name: 'integration-name',
+    subKind: IntegrationKind.AwsOidc,
+    unresolvedUserTasks: 0,
+    userTasks: [],
+    awsra: undefined,
+    awsoidc: {
+      roleArn: 'arn:aws:iam::123456789012:role/example',
+    },
+    awsec2: {
+      rulesCount: 0,
+      resourcesFound: 0,
+      resourcesEnrollmentFailed: 0,
+      resourcesEnrollmentSuccess: 0,
+      discoverLastSync: 0,
+      ecsDatabaseServiceCount: 0,
+      unresolvedUserTasks: 0,
+    },
+    awsrds: {
+      rulesCount: 0,
+      resourcesFound: 0,
+      resourcesEnrollmentFailed: 0,
+      resourcesEnrollmentSuccess: 0,
+      discoverLastSync: 0,
+      ecsDatabaseServiceCount: 0,
+      unresolvedUserTasks: 0,
+    },
+    awseks: {
+      rulesCount: 0,
+      resourcesFound: 0,
+      resourcesEnrollmentFailed: 0,
+      resourcesEnrollmentSuccess: 0,
+      discoverLastSync: 0,
+      ecsDatabaseServiceCount: 0,
+      unresolvedUserTasks: 0,
+    },
+    rolesAnywhereProfileSync: undefined,
+  };
+
+  render(<SummaryStatusLabel summary={stats} />);
+
+  expect(screen.getByText('Scanning')).toBeInTheDocument();
+  expect(screen.getByText('(scanning in progress)')).toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Integrations/types.ts
+++ b/web/packages/teleport/src/Integrations/types.ts
@@ -19,6 +19,7 @@
 export const Status = {
   Healthy: 'Healthy',
   Issues: 'Issues',
+  Scanning: 'Scanning',
   Failed: 'Failed',
   Draft: 'Draft',
   Unknown: 'Unknown',


### PR DESCRIPTION
If no last sync time has happened yet (i.e., the first time syncing), we can show a "scanning" status so the users know that something is going on rather than leaving the page blank/bare. 
<img width="1058" height="525" alt="Screenshot 2026-01-28 at 11 28 15 AM" src="https://github.com/user-attachments/assets/0c34bcce-8968-48be-94e9-f9670961df87" />
