### PR TITLE
[dynamodb] implement export event chunks

### DIFF
--- a/lib/events/dynamoevents/chunk.go
+++ b/lib/events/dynamoevents/chunk.go
@@ -1,0 +1,379 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dynamoevents
+
+import (
+	"context"
+	"log/slog"
+	"maps"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	dynamodbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+)
+
+const (
+	// chunkPrefix defines the chunk id prefix.
+	chunkPrefix = "CHUNK#"
+	// chunkStatusOpen defines the OPEN status.
+	chunkStatusOpen = "OPEN"
+	// chunkStatusClosed defines the CLOSED status.
+	chunkStatusClosed = "CLOSED"
+
+	// TODO: Tune chunk ttl and capcity with load tests.
+
+	// chunkTTL defines the TTL of an OPEN chunk.
+	chunkTTL = time.Minute * 3
+	// chunkCapacity defines the maximum size of a chunk.
+	chunkCapacity = 1000
+)
+
+// chunk identifies a chunk of events.
+type chunk struct {
+	// ID identifies a chunk.
+	// The ID is written as SessionID in DynamoDB to satisfy the primary key
+	// constraint. ID must always be set.
+	ID string `dynamodbav:"SessionID"`
+	// EventIndex is not used for chunks, but it is a required in DynamoDB to
+	// satisfy the sort key constraint. EventIndex will always be 0.
+	EventIndex int64
+	// ChunkStatus indicates the status of the chunk.
+	// This can be either "OPEN" or "CLOSED".
+	ChunkStatus string
+	// CreatedAt is the timestamp in unix format specifying when the chunk was
+	// created. This is used to used to identify and close chunks that have passed
+	// their OPEN status TTL. This is also used as a secondary DynamoDB index.
+	CreatedAt int64 `json:",omitempty" dynamodbav:",omitempty"`
+	// CreatedAtDate is used to identify the chunk partition.
+	CreatedAtDate string `json:",omitempty" dynamodbav:",omitempty"`
+}
+
+// ChunkService is responsible for managing chunks.
+type ChunkService struct {
+	// dynamo is the dynamoDB API client.
+	dynamo *dynamodb.Client
+	// tableName is the dynamoDB chunk table name.
+	tableName string
+	// logger is emits log messages.
+	logger *slog.Logger
+
+	// chunkLock locks access to chunk status.
+	chunkLock sync.Mutex
+	// chunkID is the current open chunkID.
+	chunkID string
+	// chunkCount is the current number of events added to the open chunk.
+	chunkCount int
+	// chunkCreatedAt specifies the created at timestamp for the current open chunk.
+	chunkCreatedAt time.Time
+
+	// TODO: Figure out lease mechanism
+
+	// chunkLeases keeps track of chunk leases.
+	// A chunk lease must be acquired before writing the chunk, and it must
+	// be released once done writing the chunk. This is required to ensure chunks
+	// are closed after there are no more writers of a chunk.
+	chunkLeases map[string]*chunkLease
+	// staleChunks is the set of stale chunks that are pending closure.
+	staleChunks map[string]struct{}
+	// triggerReconcile triggers a reconcile to close stale chunks.
+	triggerReconcile chan struct{}
+}
+
+// NewChunkService returns a new ChunkService.
+func NewChunkService(
+	dynamodbClient *dynamodb.Client,
+	tableName string,
+	logger *slog.Logger,
+) *ChunkService {
+	return &ChunkService{
+		dynamo:           dynamodbClient,
+		tableName:        tableName,
+		logger:           logger,
+		chunkLeases:      make(map[string]*chunkLease),
+		staleChunks:      make(map[string]struct{}),
+		triggerReconcile: make(chan struct{}, 1),
+	}
+}
+
+// Run runs the ChunkService.
+func (svc *ChunkService) Run(ctx context.Context) {
+	svc.reconcileChunks(ctx)
+}
+
+// AcquireChunk acquires an open chunk lease.
+func (svc *ChunkService) AcquireChunk(ctx context.Context) (string, error) {
+	now := time.Now()
+
+	svc.chunkLock.Lock()
+	defer svc.chunkLock.Unlock()
+
+	// Rotate if chunk is at capacity or ttl is expired.
+	if svc.chunkID == "" ||
+		svc.chunkCount >= chunkCapacity ||
+		now.After(svc.chunkCreatedAt.Add(chunkTTL)) {
+
+		if svc.chunkID != "" {
+			// Defer chunk closure
+			svc.staleChunks[svc.chunkID] = struct{}{}
+
+			select {
+			case svc.triggerReconcile <- struct{}{}:
+			default:
+			}
+
+			svc.chunkID = ""
+		}
+
+		id, err := uuid.NewV7()
+		if err != nil {
+			return "", trace.Wrap(err, "failed to generate uuid")
+		}
+
+		chunkID := chunkPrefix + id.String()
+
+		if err := svc.openChunk(ctx, chunkID, now); err != nil {
+			return "", trace.Wrap(err, " failed to open chunk")
+		}
+
+		svc.chunkID = chunkID
+		svc.chunkCreatedAt = now
+		svc.chunkCount = 0
+	}
+
+	lease, ok := svc.chunkLeases[svc.chunkID]
+	if !ok {
+		lease = NewChunkLease()
+		svc.chunkLeases[svc.chunkID] = lease
+	}
+	lease.Acquire()
+
+	// Reserve capacity
+	svc.chunkCount++
+
+	return svc.chunkID, nil
+}
+
+// ReleaseChunk releases the chunk lease.
+func (svc *ChunkService) ReleaseChunk(ctx context.Context, chunkID string) {
+	svc.chunkLock.Lock()
+	lease := svc.chunkLeases[chunkID]
+	svc.chunkLock.Unlock()
+
+	if lease == nil {
+		svc.logger.DebugContext(ctx, "failed to release chunk; chunk lease not found",
+			"chunk", chunkID)
+		return
+	}
+
+	lease.Release()
+}
+
+func (svc *ChunkService) openChunk(ctx context.Context, chunkID string, createdAt time.Time) error {
+	item, err := attributevalue.MarshalMap(chunk{
+		ID:            chunkID,
+		EventIndex:    0,
+		CreatedAt:     createdAt.Unix(),
+		CreatedAtDate: createdAt.Format(time.DateOnly),
+		ChunkStatus:   chunkStatusOpen,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = svc.dynamo.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(svc.tableName),
+		Item:                item,
+		ConditionExpression: aws.String("attribute_not_exists(SessionID)"),
+	})
+
+	return trace.Wrap(err)
+}
+
+func (svc *ChunkService) closeChunk(ctx context.Context, chunkID string) error {
+	_, err := svc.dynamo.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(svc.tableName),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			keySessionID:  &dynamodbtypes.AttributeValueMemberS{Value: chunkID},
+			keyEventIndex: &dynamodbtypes.AttributeValueMemberN{Value: "0"},
+		},
+		UpdateExpression:    aws.String("SET #status = :closed"),
+		ConditionExpression: aws.String("#status = :open"),
+		ExpressionAttributeNames: map[string]string{
+			"#status": keyChunkStatus,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":closed": &dynamodbtypes.AttributeValueMemberS{Value: chunkStatusClosed},
+			":open":   &dynamodbtypes.AttributeValueMemberS{Value: chunkStatusOpen},
+		},
+	})
+
+	if trace.IsAlreadyExists(convertError(err)) {
+		svc.logger.DebugContext(ctx, "chunk is already closed", "chunk", chunkID)
+		return nil
+	}
+
+	return trace.Wrap(err)
+}
+
+// reconcileChunks periodically attempts to close expired chunks.
+func (svc *ChunkService) reconcileChunks(ctx context.Context) {
+	const interval = time.Minute * 3
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			svc.logger.DebugContext(ctx, "reconcileChunks stopped")
+			return
+		case <-ticker.C:
+			if err := svc.closeExpiredChunks(ctx); err != nil {
+				svc.logger.WarnContext(ctx, "failed to close expired chunks", "error", err)
+			}
+		case <-svc.triggerReconcile:
+			if err := svc.closeStaleChunks(ctx); err != nil {
+				svc.logger.WarnContext(ctx, "failed to close stale chunks", "error", err)
+			}
+		}
+	}
+}
+
+// closeExpiredChunks closes expired chunks that have been orphaned.
+func (svc *ChunkService) closeExpiredChunks(ctx context.Context) error {
+	expiredThreshold := time.Now().Add(-chunkTTL * 2).Unix()
+	input := dynamodb.QueryInput{
+		TableName:              aws.String(svc.tableName),
+		IndexName:              aws.String(indexChunkStatusSearch),
+		KeyConditionExpression: aws.String("#status = :status AND #createdAt <= :threshold"),
+		ExpressionAttributeNames: map[string]string{
+			"#status":    keyChunkStatus,
+			"#createdAt": keyCreatedAt,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":status":    &dynamodbtypes.AttributeValueMemberS{Value: chunkStatusOpen},
+			":threshold": &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(expiredThreshold, 10)},
+		},
+		// TODO: Handle pagination
+		Limit: aws.Int32(1000),
+	}
+
+	start := time.Now()
+	out, err := svc.dynamo.Query(ctx, &input)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO: Remove debug logs
+	svc.logger.DebugContext(ctx, "Successfully queried OPEN chunk IDs",
+		"duration", time.Since(start),
+		"items", len(out.Items),
+	)
+
+	for _, item := range out.Items {
+		var result chunk
+		if err := attributevalue.UnmarshalMap(item, &result); err != nil {
+			return trace.Wrap(err, "failed to unmarshal chunk")
+		}
+
+		if err := svc.closeChunk(ctx, result.ID); err != nil {
+			svc.logger.WarnContext(ctx, "failed to close chunk",
+				"error", err,
+				"chunk", result.ID)
+			continue
+		}
+
+		// Clean up stale chunks in case callers never released chunk lease
+		svc.chunkLock.Lock()
+		delete(svc.chunkLeases, result.ID)
+		delete(svc.staleChunks, result.ID)
+		svc.chunkLock.Unlock()
+	}
+	return nil
+}
+
+// closeStaleChunks attempts to close stale chunks that are at capacity or have
+// an expired ttl.
+func (svc *ChunkService) closeStaleChunks(ctx context.Context) error {
+	svc.chunkLock.Lock()
+	staleChunks := maps.Keys(svc.staleChunks)
+	svc.chunkLock.Unlock()
+
+	for staleChunk := range staleChunks {
+		svc.chunkLock.Lock()
+		lease := svc.chunkLeases[staleChunk]
+		svc.chunkLock.Unlock()
+
+		// stale chunk has already been deleted
+		if lease == nil {
+			continue
+		}
+
+		if lease.Count() == 0 {
+			// All leases have been released.
+			if err := svc.closeChunk(ctx, staleChunk); err != nil {
+				svc.logger.WarnContext(ctx, "failed to close chunk",
+					"chunk", staleChunk,
+					"error", err)
+			}
+
+			svc.chunkLock.Lock()
+			delete(svc.chunkLeases, staleChunk)
+			delete(svc.staleChunks, staleChunk)
+			svc.chunkLock.Unlock()
+		}
+	}
+
+	return nil
+}
+
+type chunkLease struct {
+	mu    sync.Mutex
+	count int
+}
+
+func NewChunkLease() *chunkLease {
+	lease := &chunkLease{}
+	return lease
+}
+
+func (l *chunkLease) Acquire() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.count++
+}
+
+func (l *chunkLease) Release() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.count > 0 {
+		l.count--
+	}
+}
+
+func (l *chunkLease) Count() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.count
+}

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"maps"
 	"math"
@@ -95,6 +96,15 @@ var tableSchema = []dynamodbtypes.AttributeDefinition{
 	// New attribute in RFD 24.
 	{
 		AttributeName: aws.String(keyDate),
+		AttributeType: dynamodbtypes.ScalarAttributeTypeS,
+	},
+	// New attributes to support chunks in Teleport v19.
+	{
+		AttributeName: aws.String(keyChunkID),
+		AttributeType: dynamodbtypes.ScalarAttributeTypeS,
+	},
+	{
+		AttributeName: aws.String(keyChunkStatus),
 		AttributeType: dynamodbtypes.ScalarAttributeTypeS,
 	},
 }
@@ -221,6 +231,13 @@ type Log struct {
 	// Config is a backend configuration
 	Config
 	svc *dynamodb.Client
+
+	// chunkID is the current open chunkID.
+	chunkID string
+	// chunkCount is the current number of events added to the open chunk.
+	chunkCount int
+	// chunkCreatedAt specifies the created at timestamp for the current open chunk.
+	chunkCreatedAt time.Time
 }
 
 // EventKey contains the subset of event fields used as a dynamo primary key,
@@ -262,6 +279,7 @@ type event struct {
 	Expires        *int64 `json:"Expires,omitempty" dynamodbav:",omitempty"`
 	FieldsMap      events.EventFields
 	EventNamespace string
+	ChunkID        string
 }
 
 // toIterator marshals an event's EventKey, to be used in checkpointKey.
@@ -291,9 +309,23 @@ const (
 	// Specified in RFD 24.
 	keyDate = "CreatedAtDate"
 
+	// keyChunkID identifies the chunk id of an event.
+	keyChunkID = "ChunkID"
+
+	// keyChunkStatus identifies the status of a chunk.
+	keyChunkStatus = "ChunkStatus"
+
 	// indexTimeSearchV2 is the new secondary global index proposed in RFD 24.
 	// Allows searching events by time.
 	indexTimeSearchV2 = "timesearchV2"
+
+	// indexChunkIDSearch is a secondary global index for events.
+	// Allows searching events by chunk id.
+	indexChunkIDSearch = "chunkIDSearch"
+
+	// indexChunkStatusSearch is a secondary global index for chunks.
+	// Allows searching chunks by status.
+	indexChunkStatusSearch = "chunkStatusSearch"
 
 	// DefaultReadCapacityUnits specifies default value for read capacity units
 	DefaultReadCapacityUnits = 10
@@ -304,6 +336,12 @@ const (
 	// DefaultRetentionPeriod is a default data retention period in events table.
 	// The default is 1 year.
 	DefaultRetentionPeriod = types.Duration(365 * 24 * time.Hour)
+
+	// chunkTTL defines the TTL of an OPEN chunk.
+	chunkTTL = time.Minute * 3
+
+	// maxChunkSize defines the maximum size of a chunk.
+	maxChunkSize = 1000
 )
 
 // New returns new instance of DynamoDB backend.
@@ -392,6 +430,8 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 		"table", cfg.Tablename,
 		"region", cfg.Region,
 	)
+
+	go b.reconcileChunks(ctx)
 
 	return b, nil
 }
@@ -639,8 +679,165 @@ const (
 	largeEventHandledContextKey
 )
 
+// chunk identifies a chunk of events.
+type chunk struct {
+	// ID identifies a chunk.
+	// The ID is written as SessionID in DynamoDB to satisfy the primary key
+	// constraint. ID must always be set.
+	ID string `dynamodbav:"SessionID"`
+	// EventIndex is not used for chunks, but it is a required in DynamoDB to
+	// satisfy the sort key constraint. EventIndex will always be 0.
+	EventIndex int64
+	// ChunkStatus indicates the status of the chunk.
+	// This can be either "OPEN" or "CLOSED".
+	ChunkStatus string
+	// CreatedAt is the timestamp in unix format specifying when the chunk was
+	// created. This is used to used to identify and close chunks that have passed
+	// their OPEN status TTL. This is also used as a secondary DynamoDB index.
+	CreatedAt int64 `json:",omitempty" dynamodbav:",omitempty"`
+	// CreatedAtDate is used to idnetify the chunk partition.
+	CreatedAtDate string `json:",omitempty" dynamodbav:",omitempty"`
+}
+
+// reconcileChunks periodically attempts to close expired chunks.
+func (l *Log) reconcileChunks(ctx context.Context) {
+	const interval = time.Minute * 3
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			l.logger.DebugContext(ctx, "reconcileChunks stopped")
+			return
+		case <-ticker.C:
+			if err := l.closeExpiredChunks(ctx); err != nil {
+				l.logger.WarnContext(ctx, "failed to close expired chunks", "error", err)
+			}
+		}
+	}
+}
+
+func (l *Log) closeExpiredChunks(ctx context.Context) error {
+	expiredThreshold := time.Now().Add(-chunkTTL * 2).Unix()
+	input := dynamodb.QueryInput{
+		TableName:              aws.String(l.Tablename),
+		IndexName:              aws.String(indexChunkStatusSearch),
+		KeyConditionExpression: aws.String("#date = :date AND #status = :status AND #createdAt <= :threshold"),
+		ExpressionAttributeNames: map[string]string{
+			"#date":      keyDate,
+			"#status":    keyChunkStatus,
+			"#createdAt": keyCreatedAt,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":date":      &dynamodbtypes.AttributeValueMemberS{Value: time.Now().Format(time.DateOnly)},
+			":status":    &dynamodbtypes.AttributeValueMemberS{Value: "OPEN"},
+			":threshold": &dynamodbtypes.AttributeValueMemberN{Value: strconv.FormatInt(expiredThreshold, 10)},
+		},
+		// TODO: Handle pagination
+		Limit: aws.Int32(1000),
+	}
+
+	start := time.Now()
+	out, err := l.svc.Query(ctx, &input)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	// TODO: Remove debug logs
+	l.logger.DebugContext(ctx, "Successfully queried OPEN chunk IDs",
+		"duration", time.Since(start),
+		"items", len(out.Items),
+		"date", time.Now().Format(time.DateOnly),
+	)
+
+	for _, item := range out.Items {
+		var result chunk
+		if err := attributevalue.UnmarshalMap(item, &result); err != nil {
+			return trace.Wrap(err, "failed to unmarshal chunk")
+		}
+		if err := l.closeChunk(ctx, result.ID); err != nil {
+			return trace.Wrap(err, "unable to close chunk")
+		}
+	}
+	return nil
+}
+
+func (l *Log) getChunkID(ctx context.Context) (string, error) {
+	chunkFull := l.chunkCount >= maxChunkSize
+	chunkExpired := time.Now().After(l.chunkCreatedAt.Add(chunkTTL))
+	if chunkFull || chunkExpired {
+		if err := l.closeChunk(ctx, l.chunkID); err != nil {
+			l.logger.WarnContext(ctx, "unable to close chunk", "chunk", l.chunkID)
+		}
+		l.chunkID = ""
+	}
+
+	if l.chunkID == "" {
+		l.chunkID = "CHUNK#" + uuid.New().String()
+		l.chunkCount = 0
+		l.chunkCreatedAt = time.Now()
+
+		if err := l.openChunk(ctx, l.chunkID, l.chunkCreatedAt); err != nil {
+			return "", trace.Wrap(err, "unable to open new chunk")
+		}
+	}
+
+	return l.chunkID, nil
+}
+
+func (l *Log) incChunk() {
+	l.chunkCount++
+}
+
+func (l *Log) openChunk(ctx context.Context, chunkID string, createdAt time.Time) error {
+	item, err := attributevalue.MarshalMap(chunk{
+		ID:            chunkID,
+		EventIndex:    0,
+		CreatedAt:     createdAt.Unix(),
+		CreatedAtDate: createdAt.Format(time.DateOnly),
+		ChunkStatus:   "OPEN",
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = l.svc.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName:           aws.String(l.Tablename),
+		Item:                item,
+		ConditionExpression: aws.String("attribute_not_exists(SessionID)"),
+	})
+	return trace.Wrap(err)
+}
+
+func (l *Log) closeChunk(ctx context.Context, chunkID string) error {
+	_, err := l.svc.UpdateItem(ctx, &dynamodb.UpdateItemInput{
+		TableName: aws.String(l.Tablename),
+		Key: map[string]dynamodbtypes.AttributeValue{
+			keySessionID:  &dynamodbtypes.AttributeValueMemberS{Value: chunkID},
+			keyEventIndex: &dynamodbtypes.AttributeValueMemberN{Value: "0"},
+		},
+		UpdateExpression:    aws.String("SET #status = :closed"),
+		ConditionExpression: aws.String("#status = :open"),
+		ExpressionAttributeNames: map[string]string{
+			"#status": keyChunkStatus,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":closed": &dynamodbtypes.AttributeValueMemberS{Value: "CLOSED"},
+			":open":   &dynamodbtypes.AttributeValueMemberS{Value: "OPEN"},
+		},
+	})
+	return trace.Wrap(err)
+}
+
 func (l *Log) putAuditEvent(ctx context.Context, sessionID string, in apievents.AuditEvent) error {
-	input, err := l.createPutItem(sessionID, in)
+	chunkID, err := l.getChunkID(ctx)
+	if err != nil {
+		return trace.Wrap(err, "unable to get chunk ID")
+	}
+
+	input, err := l.createPutItem(sessionID, chunkID, in)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -675,10 +872,13 @@ func (l *Log) putAuditEvent(ctx context.Context, sessionID string, in apievents.
 		return err
 	}
 
+	// Increment chunk counter on success
+	l.incChunk()
+
 	return nil
 }
 
-func (l *Log) createPutItem(sessionID string, in apievents.AuditEvent) (*dynamodb.PutItemInput, error) {
+func (l *Log) createPutItem(sessionID, chunkID string, in apievents.AuditEvent) (*dynamodb.PutItemInput, error) {
 	fieldsMap, err := events.ToEventFields(in)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -693,6 +893,7 @@ func (l *Log) createPutItem(sessionID string, in apievents.AuditEvent) (*dynamod
 		EventType:      in.GetType(),
 		EventNamespace: apidefaults.Namespace,
 		FieldsMap:      fieldsMap,
+		ChunkID:        chunkID,
 	}
 	l.setExpiry(&e)
 	av, err := attributevalue.MarshalMap(e)
@@ -824,11 +1025,153 @@ func (l *Log) searchEventsWithFilter(ctx context.Context, fromUTC, toUTC time.Ti
 }
 
 func (l *Log) ExportUnstructuredEvents(ctx context.Context, req *auditlogpb.ExportUnstructuredEventsRequest) stream.Stream[*auditlogpb.ExportEventUnstructured] {
-	return stream.Fail[*auditlogpb.ExportEventUnstructured](trace.NotImplemented("dynamoevents backend does not support streaming export"))
+	if req.Chunk == "" {
+		return stream.Fail[*auditlogpb.ExportEventUnstructured](trace.BadParameter("missing required parameter 'chunk'"))
+	}
+
+	var cursor int
+	var err error
+	if req.GetCursor() != "" {
+		cursor, err = strconv.Atoi(req.GetCursor())
+		if err != nil {
+			return stream.Fail[*auditlogpb.ExportEventUnstructured](trace.Wrap(err, "failed to parse cursor"))
+		}
+	}
+
+	// Skip to cursor
+	evts := stream.Skip(l.streamEventsFromChunk(ctx, req.Chunk), cursor)
+
+	return stream.FilterMap(evts, func(e events.EventFields) (*auditlogpb.ExportEventUnstructured, bool) {
+		// Increment cursor position
+		cursor++
+
+		unstructuredEvent, err := events.EventFieldsToUnstructured(e)
+		if err != nil {
+			l.logger.WarnContext(ctx, "skipping export of audit event due to failed conversion to unstructured event",
+				"error", err,
+				"chunk", req.Chunk,
+			)
+			return nil, false
+		}
+
+		return &auditlogpb.ExportEventUnstructured{
+			Event:  unstructuredEvent,
+			Cursor: strconv.Itoa(cursor),
+		}, true
+	})
+}
+
+func (l *Log) streamEventsFromChunk(ctx context.Context, chunkID string) stream.Stream[events.EventFields] {
+	input := dynamodb.QueryInput{
+		TableName:              aws.String(l.Tablename),
+		IndexName:              aws.String(indexChunkIDSearch),
+		KeyConditionExpression: aws.String("#id = :chunk_id"),
+		ExpressionAttributeNames: map[string]string{
+			"#id": keyChunkID,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":chunk_id": &dynamodbtypes.AttributeValueMemberS{Value: chunkID},
+		},
+		// TODO: Handle pagination
+		Limit: aws.Int32(1000),
+	}
+
+	start := time.Now()
+	out, err := l.svc.Query(ctx, &input)
+	if err != nil {
+		return stream.Fail[events.EventFields](err)
+	}
+
+	// TODO: Remove debug logs
+	l.logger.DebugContext(ctx, "Successfully queried events",
+		"duration", time.Since(start),
+		"items", len(out.Items),
+		"chunk_id", chunkID,
+	)
+
+	// Return empty stream if query returned 0 events
+	if out.Count == 0 {
+		return stream.Empty[events.EventFields]()
+	}
+
+	var index = 0
+	return stream.Func(func() (events.EventFields, error) {
+		if index >= int(out.Count) {
+			return events.EventFields{}, io.EOF
+		}
+
+		item := out.Items[index]
+		index++
+
+		var result event
+		if err := attributevalue.UnmarshalMap(item, &result); err != nil {
+			return nil, trace.Wrap(err, "failed to unmarshal event")
+		}
+
+		return result.FieldsMap, nil
+	})
 }
 
 func (l *Log) GetEventExportChunks(ctx context.Context, req *auditlogpb.GetEventExportChunksRequest) stream.Stream[*auditlogpb.EventExportChunk] {
-	return stream.Fail[*auditlogpb.EventExportChunk](trace.NotImplemented("dynamoevents backend does not support streaming export"))
+	// TODO: May need to return NotImplemented error stream if chunk indexes have not been initialized.
+
+	date := req.Date.AsTime()
+	if date.IsZero() {
+		return stream.Fail[*auditlogpb.EventExportChunk](trace.BadParameter("missing required parameter 'date'"))
+	}
+
+	input := dynamodb.QueryInput{
+		TableName:              aws.String(l.Tablename),
+		IndexName:              aws.String(indexChunkStatusSearch),
+		KeyConditionExpression: aws.String("#date = :date AND #status = :status"),
+		ExpressionAttributeNames: map[string]string{
+			"#date":   keyDate,
+			"#status": keyChunkStatus,
+		},
+		ExpressionAttributeValues: map[string]dynamodbtypes.AttributeValue{
+			":date":   &dynamodbtypes.AttributeValueMemberS{Value: date.Format(time.DateOnly)},
+			":status": &dynamodbtypes.AttributeValueMemberS{Value: "CLOSED"},
+		},
+		// TODO: Handle pagination
+		Limit: aws.Int32(1000),
+	}
+
+	start := time.Now()
+	out, err := l.svc.Query(ctx, &input)
+	if err != nil {
+		return stream.Fail[*auditlogpb.EventExportChunk](trace.Wrap(err, "failed to query chunks"))
+	}
+
+	// TODO: Remove debug logs
+	l.logger.DebugContext(ctx, "Successfully queried CLOSED chunk IDs",
+		"duration", time.Since(start),
+		"items", len(out.Items),
+		"date", date,
+	)
+
+	// Return empty stream if query returned 0 chunks
+	if out.Count == 0 {
+		return stream.Empty[*auditlogpb.EventExportChunk]()
+	}
+
+	index := 0
+	return stream.Func(func() (*auditlogpb.EventExportChunk, error) {
+		if index >= int(out.Count) {
+			return nil, io.EOF
+		}
+
+		item := out.Items[index]
+		index++
+
+		var result chunk
+		if err := attributevalue.UnmarshalMap(item, &result); err != nil {
+			return nil, trace.Wrap(err, "failed to unmarshal chunk")
+		}
+
+		return &auditlogpb.EventExportChunk{
+			Chunk: result.ID,
+		}, nil
+	})
 }
 
 // eventFilterList constructs a string of the form
@@ -1435,6 +1778,44 @@ func (l *Log) createTable(ctx context.Context, tableName string) error {
 				},
 				Projection: &dynamodbtypes.Projection{
 					ProjectionType: dynamodbtypes.ProjectionTypeAll,
+				},
+				ProvisionedThroughput: &provisionedThroughput,
+			},
+			{
+				IndexName: aws.String(indexChunkIDSearch),
+				KeySchema: []dynamodbtypes.KeySchemaElement{
+					{
+						AttributeName: aws.String(keyChunkID),
+						KeyType:       dynamodbtypes.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String(keyCreatedAt),
+						KeyType:       dynamodbtypes.KeyTypeRange,
+					},
+				},
+				Projection: &dynamodbtypes.Projection{
+					ProjectionType: dynamodbtypes.ProjectionTypeAll,
+				},
+				ProvisionedThroughput: &provisionedThroughput,
+			},
+			{
+				IndexName: aws.String(indexChunkStatusSearch),
+				KeySchema: []dynamodbtypes.KeySchemaElement{
+					{
+						AttributeName: aws.String(keyChunkStatus),
+						KeyType:       dynamodbtypes.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String(keyDate),
+						KeyType:       dynamodbtypes.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String(keyCreatedAt),
+						KeyType:       dynamodbtypes.KeyTypeRange,
+					},
+				},
+				Projection: &dynamodbtypes.Projection{
+					ProjectionType: dynamodbtypes.ProjectionTypeKeysOnly,
 				},
 				ProvisionedThroughput: &provisionedThroughput,
 			},


### PR DESCRIPTION
This PR implements the chunk export api for audit events.

### Details

There are a couple requirements that must be met to implement the chunk export api. First, the chunk export api requires the select backend service to support two functions: `GetEventExportChunks`, which returns a stream of chunk_ids and `ExportUnstructuredEvents`, which returns a stream of events for a given chunk_id. Additionally, to ensure events do not get skipped, chunks must be in an immutable state before they are exported.

The idea for this approach is to generate a UUID as a chunk_id on each Auth server, and store it in dynamodb as chunk metadata. The metadata also includes the TTL and OPEN/CLOSED status. Now when new events are ingested, the currently OPEN chunk_id will be appended to the event entry, and once the chunk has reached it max capacity, or the chunk TTL has expired, the chunk_id will be rotated.

A separate goroutine will be running to ensure that orphaned chunks in dynamodb are transitioned to a CLOSED status once the chunk TTL has expired. A bit of delay is introduced here to account for a reasonable amount of time-drift between Auth servers.

Two new dynamodb secondary indexes must be created. `chunkStatusSearch` is used to search for chunks by status. `chunkIDSearch` index is used to search for events by chunk_id.

With all the above in place, `GetEventExportChunks` now queries dynamodb for chunks in a CLOSED state and returns a stream of the chunk_ids. `ExportUnstructuredEvents` queries and streams events with the provided chunk_id.