### PR TITLE
Detect outdated tctl callers on GetCertAuthority

### DIFF
--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -20,9 +20,7 @@ package trustv1
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"time"
 
@@ -31,7 +29,6 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
@@ -205,16 +202,8 @@ func failPreWindowsTctlUserCAQuery(ctx context.Context, caType string) error {
 		return nil
 	}
 
-	var minVer string
-	if api.VersionMajor == 18 {
-		minVer = fmt.Sprintf("18.%v", api.VersionMinor)
-	} else {
-		minVer = strconv.Itoa(api.VersionMajor)
-	}
 	return trace.BadParameter(
-		"outdated client is attempting to query the %q CA, please update your client to Teleport version %v",
-		caType, minVer,
-	)
+		"in order to query the User CA, tctl must be upgraded to version %v or newer", minGetUserCASemver)
 }
 
 // GetCertAuthorities retrieves the cert authorities with the specified type.

--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -42,7 +42,7 @@ import (
 )
 
 // TODO(codingllama): DELETE IN 20. All valid clients support WindowsCA by then.
-var minGetUserCASemver = semver.New("18.7.0")
+var minGetUserCASemver = semver.New("18.8.0")
 
 type authServer interface {
 	// GetClusterName returns cluster name

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +34,7 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/testing/protocmp"
 
+	"github.com/gravitational/teleport"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
 	apimetadata "github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -26,11 +26,16 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	apimetadata "github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -568,6 +573,172 @@ func TestGetCertAuthority(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ca, err := service.GetCertAuthority(ctx, test.request)
 			test.assertion(t, ca, err)
+		})
+	}
+}
+
+func TestGetCertAuthority_outdatedTctl(t *testing.T) {
+	t.Parallel()
+
+	pack := newTestPack(t)
+
+	authorizer := &fakeAuthorizer{
+		checker: &fakeChecker{
+			allow: map[check]bool{
+				{types.KindCertAuthority, types.VerbRead}:          true,
+				{types.KindCertAuthority, types.VerbReadNoSecrets}: true,
+			},
+		},
+	}
+
+	trust := local.NewCAService(pack.mem)
+
+	// Prepare an SSH key pair for test CAs.
+	sshPriv, sshPub, err := testauthority.GenerateKeyPair()
+	require.NoError(t, err)
+
+	// Prepare a TLS key/cert pair for test CAs.
+	const clusterName = "zarq"
+	keyPEM, certPEM, err := tlsca.GenerateSelfSignedCA(pkix.Name{
+		Organization: []string{clusterName},
+		CommonName:   clusterName,
+	}, nil /* dnsNames */, 1*time.Hour /* ttl */)
+	require.NoError(t, err)
+
+	// Prepare a couple of test CAs.
+	userCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.UserCA,
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{
+				{
+					PublicKey:      sshPub,
+					PrivateKey:     sshPriv,
+					PrivateKeyType: types.PrivateKeyType_RAW,
+				},
+			},
+			TLS: []*types.TLSKeyPair{
+				{
+					Cert:    certPEM,
+					Key:     keyPEM,
+					KeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	otherCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        types.DatabaseCA, // Any non-UserCA type works.
+		ClusterName: clusterName,
+		ActiveKeys: types.CAKeySet{
+			TLS: []*types.TLSKeyPair{
+				{
+					Cert:    certPEM,
+					Key:     keyPEM,
+					KeyType: types.PrivateKeyType_RAW,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	cfg := &ServiceConfig{
+		Cache:            trust,
+		Backend:          trust,
+		Authorizer:       authorizer,
+		ScopedAuthorizer: authorizer,
+		AuthServer:       &fakeAuthServer{}, // unused, only needs to be non-nil
+	}
+	service, err := NewService(cfg)
+	require.NoError(t, err)
+
+	ctx := t.Context()
+	_, err = trust.CreateCertAuthorities(ctx, userCA, otherCA)
+	require.NoError(t, err, "CreateCertAuthorities errored")
+
+	requestForCA := func(ca types.CertAuthority) *trustpb.GetCertAuthorityRequest {
+		return &trustpb.GetCertAuthorityRequest{
+			Type:       string(ca.GetType()),
+			Domain:     ca.GetClusterName(),
+			IncludeKey: true, // Makes for simpler assertions. Not necessary.
+		}
+	}
+
+	makeClientContext := func(ctx context.Context, component, version string) context.Context {
+		// We cheat a little here because a client context is usually an outgoing
+		// context, and also "apimetadata" doesn't provide the APIs to set these
+		// keys transparently.
+		return metadata.NewIncomingContext(ctx, metadata.MD{
+			apimetadata.VersionKey: []string{version},
+			"user-agent":           []string{component + "/" + version},
+		})
+	}
+
+	const oldVer, newVer = "18.6.4", "18.7.0"
+	oldTlctContext := func(ctx context.Context) context.Context {
+		return makeClientContext(ctx, teleport.ComponentTCTL, oldVer)
+	}
+	newTlctContext := func(ctx context.Context) context.Context {
+		return makeClientContext(ctx, teleport.ComponentTCTL, newVer)
+	}
+
+	tests := []struct {
+		name    string
+		makeCtx func(context.Context) context.Context
+		req     *trustpb.GetCertAuthorityRequest
+		wantErr string // takes precedence over want
+		want    types.CertAuthority
+	}{
+		{
+			name: "ok: client without metadata",
+			req:  requestForCA(userCA),
+			want: userCA,
+		},
+		{
+			name:    "ok: new tctl",
+			req:     requestForCA(userCA),
+			makeCtx: newTlctContext,
+			want:    userCA,
+		},
+		{
+			name:    "ok: old tctl queries otherCA",
+			req:     requestForCA(otherCA),
+			makeCtx: oldTlctContext,
+			want:    otherCA,
+		},
+		{
+			name: "ok: old non-tctl client queries UserCA",
+			req:  requestForCA(userCA),
+			makeCtx: func(ctx context.Context) context.Context {
+				return makeClientContext(ctx, "llama" /* component */, oldVer)
+			},
+			want: userCA,
+		},
+		{
+			name:    "nok: old tctl",
+			req:     requestForCA(userCA),
+			makeCtx: oldTlctContext,
+			wantErr: "outdated client",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			if test.makeCtx != nil {
+				ctx = test.makeCtx(ctx)
+			}
+
+			got, err := service.GetCertAuthority(ctx, test.req)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "GetCertAuthority error mismatch")
+				return
+			}
+
+			got.Metadata.Revision = "" // ignore the revision
+			if diff := cmp.Diff(test.want, got, protocmp.Transform()); diff != "" {
+				t.Errorf("GetCertAuthority mismatch (-want +got)\n%s", diff)
+			}
 		})
 	}
 }

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -680,7 +680,7 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 		})
 	}
 
-	const oldVer, newVer = "18.6.4", "18.7.0"
+	const oldVer, newVer = "18.6.4", "18.8.0"
 	oldTlctContext := func(ctx context.Context) context.Context {
 		return makeClientContext(ctx, teleport.ComponentTCTL, oldVer)
 	}

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -681,10 +681,10 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 	}
 
 	const oldVer, newVer = "18.6.4", "18.8.0"
-	oldTlctContext := func(ctx context.Context) context.Context {
+	oldTctlContext := func(ctx context.Context) context.Context {
 		return makeClientContext(ctx, teleport.ComponentTCTL, oldVer)
 	}
-	newTlctContext := func(ctx context.Context) context.Context {
+	newTctlContext := func(ctx context.Context) context.Context {
 		return makeClientContext(ctx, teleport.ComponentTCTL, newVer)
 	}
 
@@ -703,13 +703,13 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 		{
 			name:    "ok: new tctl",
 			req:     requestForCA(userCA),
-			makeCtx: newTlctContext,
+			makeCtx: newTctlContext,
 			want:    userCA,
 		},
 		{
 			name:    "ok: old tctl queries otherCA",
 			req:     requestForCA(otherCA),
-			makeCtx: oldTlctContext,
+			makeCtx: oldTctlContext,
 			want:    otherCA,
 		},
 		{
@@ -723,7 +723,7 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 		{
 			name:    "nok: old tctl",
 			req:     requestForCA(userCA),
-			makeCtx: oldTlctContext,
+			makeCtx: oldTctlContext,
 			wantErr: "tctl must be upgraded",
 		},
 	}

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -724,7 +724,7 @@ func TestGetCertAuthority_outdatedTctl(t *testing.T) {
 			name:    "nok: old tctl",
 			req:     requestForCA(userCA),
 			makeCtx: oldTlctContext,
-			wantErr: "outdated client",
+			wantErr: "tctl must be upgraded",
 		},
 	}
 	for _, test := range tests {

--- a/lib/auth/trust/trustv1/service_test.go
+++ b/lib/auth/trust/trustv1/service_test.go
@@ -21,6 +21,7 @@ package trustv1
 import (
 	"context"
 	"crypto/x509/pkix"
+	"sync"
 	"testing"
 	"time"
 
@@ -133,11 +134,16 @@ func (f *fakeAuthServer) ListTrustedClusters(ctx context.Context, limit int, sta
 
 type fakeChecker struct {
 	services.AccessChecker
+
+	mu     sync.Mutex
 	allow  map[check]bool
 	checks []check
 }
 
 func (f *fakeChecker) CheckAccessToRule(context services.RuleContext, namespace string, rule string, verb string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	c := check{rule, verb}
 	f.checks = append(f.checks, c)
 	if f.allow[c] {


### PR DESCRIPTION
Detect tctl binaries pre introduction of WindowsCA and denies "GetCertAuthority(UserCA)" requests from those binaries. That is because those binaries use the UserCA for Windows-related operations and we can't distinguish their intent from the queries.

This avoids incorrect results when running "tctl auth export --type=windows".

The workaround is not perfect, as it also stops would-be legitimate requests like "tctl get cas/user/clustername", and fails attempts to interactively rotate the user CA.

Actions that call specialized RPCs directly, without calls to GetCertAuthority, still work. This includes signing ("tctl auth sign"), CRLs ("tctl auth crl") and manual rotation ("tctl auth rotate --type=user --phase=init").

UX (old tctl):

```shell
$ tctl version
Teleport v18.6.3 git:v18.6.3-0-g1a83bb5 go1.24.11
# Note: any version prior to 18.7.0 behaves the same.

$ tctl auth export --type=windows
ERROR: outdated client is attempting to query the "user" CA, please update your client to Teleport version 19
# Note: the server is running v19.0.0-dev.

$ tctl auth rotate
# interactive, pick "user"
Rotating the user CA.
⣽ Fetching current CA rotation phase
# Binary suddenly dies, exit code zero.
```

#10111