### PR TITLE
[Access Requests] Add KindWindowsDesktop to ListResources

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -7480,9 +7480,9 @@ func (a *Server) DeleteDatabase(ctx context.Context, name string) error {
 
 // ListResources returns paginated resources depending on the resource type..
 func (a *Server) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
-	// Because WindowsDesktopService does not contain the desktop resources,
-	// this is not implemented at the cache level and requires the workaround
-	// here in order to support KindWindowsDesktop for ListResources.
+	// WindowsDesktop resources are handled specially here to call ListWindowsDesktops
+	// which applies the WindowsDesktopFilter. Cache's ListResources also supports
+	// KindWindowsDesktop directly but without filter support.
 	if req.ResourceType == types.KindWindowsDesktop {
 		wResp, err := a.ListWindowsDesktops(ctx, types.ListWindowsDesktopsRequest{
 			WindowsDesktopFilter: req.WindowsDesktopFilter,

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -1755,6 +1755,14 @@ func (c *Cache) listResources(ctx context.Context, req authproto.ListResourcesRe
 			},
 		)
 		return resp, trace.Wrap(err)
+	case types.KindWindowsDesktop:
+		resp, err := buildListResourcesResponse(
+			c.collections.windowsDesktops.store.resources(windowsDesktopNameIndex, req.StartKey, ""),
+			limit,
+			filter,
+			types.WindowsDesktop.CloneResource,
+		)
+		return resp, trace.Wrap(err)
 	case types.KindKubeServer:
 		resp, err := buildListResourcesResponse(
 			c.collections.kubeServers.store.resources(kubeServerNameIndex, req.StartKey, ""),


### PR DESCRIPTION
Add KindWindowsDesktop to Cache's ListResources, allowing Windows Desktop resources to be included in long-term Access Request resource grouping.

- Related to https://github.com/gravitational/teleport/issues/61380
- Related to https://github.com/gravitational/teleport/issues/58184