### PR TITLE
Connect: read automatic updates configuration from Windows registry 

### DIFF
--- a/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
@@ -42,27 +42,27 @@ type ConfigSource int32
 
 const (
 	ConfigSource_CONFIG_SOURCE_UNSPECIFIED ConfigSource = 0
-	// Configuration comes from environment variable.
-	ConfigSource_CONFIG_SOURCE_ENV_VAR ConfigSource = 2
+	// Configuration comes from an environment variable.
+	ConfigSource_CONFIG_SOURCE_ENV_VAR ConfigSource = 1
 	// Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
-	ConfigSource_CONFIG_SOURCE_POLICY ConfigSource = 3
-	// Configuration comes from hardcoded default.
-	ConfigSource_CONFIG_SOURCE_DEFAULT ConfigSource = 4
+	ConfigSource_CONFIG_SOURCE_POLICY ConfigSource = 2
+	// Configuration comes from a hardcoded default.
+	ConfigSource_CONFIG_SOURCE_DEFAULT ConfigSource = 3
 )
 
 // Enum value maps for ConfigSource.
 var (
 	ConfigSource_name = map[int32]string{
 		0: "CONFIG_SOURCE_UNSPECIFIED",
-		2: "CONFIG_SOURCE_ENV_VAR",
-		3: "CONFIG_SOURCE_POLICY",
-		4: "CONFIG_SOURCE_DEFAULT",
+		1: "CONFIG_SOURCE_ENV_VAR",
+		2: "CONFIG_SOURCE_POLICY",
+		3: "CONFIG_SOURCE_DEFAULT",
 	}
 	ConfigSource_value = map[string]int32{
 		"CONFIG_SOURCE_UNSPECIFIED": 0,
-		"CONFIG_SOURCE_ENV_VAR":     2,
-		"CONFIG_SOURCE_POLICY":      3,
-		"CONFIG_SOURCE_DEFAULT":     4,
+		"CONFIG_SOURCE_ENV_VAR":     1,
+		"CONFIG_SOURCE_POLICY":      2,
+		"CONFIG_SOURCE_DEFAULT":     3,
 	}
 )
 
@@ -586,9 +586,9 @@ const file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDes
 	"\x16is_per_machine_install\x18\x01 \x01(\bR\x13isPerMachineInstall*}\n" +
 	"\fConfigSource\x12\x1d\n" +
 	"\x19CONFIG_SOURCE_UNSPECIFIED\x10\x00\x12\x19\n" +
-	"\x15CONFIG_SOURCE_ENV_VAR\x10\x02\x12\x18\n" +
-	"\x14CONFIG_SOURCE_POLICY\x10\x03\x12\x19\n" +
-	"\x15CONFIG_SOURCE_DEFAULT\x10\x042\xd4\x03\n" +
+	"\x15CONFIG_SOURCE_ENV_VAR\x10\x01\x12\x18\n" +
+	"\x14CONFIG_SOURCE_POLICY\x10\x02\x12\x19\n" +
+	"\x15CONFIG_SOURCE_DEFAULT\x10\x032\xd4\x03\n" +
 	"\x11AutoUpdateService\x12\x97\x01\n" +
 	"\x12GetClusterVersions\x12?.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest\x1a@.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse\x12|\n" +
 	"\tGetConfig\x126.teleport.lib.teleterm.auto_update.v1.GetConfigRequest\x1a7.teleport.lib.teleterm.auto_update.v1.GetConfigResponse\x12\xa6\x01\n" +

--- a/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
@@ -37,6 +37,62 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Source of the config.
+type ConfigSource int32
+
+const (
+	ConfigSource_CONFIG_SOURCE_UNSPECIFIED ConfigSource = 0
+	// Configuration comes from environment variable.
+	ConfigSource_CONFIG_SOURCE_ENV_VAR ConfigSource = 2
+	// Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
+	ConfigSource_CONFIG_SOURCE_POLICY ConfigSource = 3
+	// Configuration comes from hardcoded default.
+	ConfigSource_CONFIG_SOURCE_DEFAULT ConfigSource = 4
+)
+
+// Enum value maps for ConfigSource.
+var (
+	ConfigSource_name = map[int32]string{
+		0: "CONFIG_SOURCE_UNSPECIFIED",
+		2: "CONFIG_SOURCE_ENV_VAR",
+		3: "CONFIG_SOURCE_POLICY",
+		4: "CONFIG_SOURCE_DEFAULT",
+	}
+	ConfigSource_value = map[string]int32{
+		"CONFIG_SOURCE_UNSPECIFIED": 0,
+		"CONFIG_SOURCE_ENV_VAR":     2,
+		"CONFIG_SOURCE_POLICY":      3,
+		"CONFIG_SOURCE_DEFAULT":     4,
+	}
+)
+
+func (x ConfigSource) Enum() *ConfigSource {
+	p := new(ConfigSource)
+	*p = x
+	return p
+}
+
+func (x ConfigSource) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ConfigSource) Descriptor() protoreflect.EnumDescriptor {
+	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_enumTypes[0].Descriptor()
+}
+
+func (ConfigSource) Type() protoreflect.EnumType {
+	return &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_enumTypes[0]
+}
+
+func (x ConfigSource) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ConfigSource.Descriptor instead.
+func (ConfigSource) EnumDescriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{0}
+}
+
 // Request for GetClusterVersions.
 type GetClusterVersionsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -301,16 +357,18 @@ type GetConfigResponse struct {
 	// * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
 	//   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
 	//   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+	//   - If policy values are missing, falls back to `TELEPORT_CDN_BASE_URL` (deprecated).
 	//
 	// Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
-	CdnBaseUrl string `protobuf:"bytes,1,opt,name=cdn_base_url,json=cdnBaseUrl,proto3" json:"cdn_base_url,omitempty"`
+	CdnBaseUrl *ConfigValue `protobuf:"bytes,1,opt,name=cdn_base_url,json=cdnBaseUrl,proto3" json:"cdn_base_url,omitempty"`
 	// The specific client tools version to use. The 'off' value disables automatic updates.
 	// Sources resolved by platform:
 	// * macOS/Linux: The `TELEPORT_TOOLS_VERSION` environment variable.
 	// * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
 	//   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
 	//   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
-	ToolsVersion  string `protobuf:"bytes,2,opt,name=tools_version,json=toolsVersion,proto3" json:"tools_version,omitempty"`
+	//   - If policy values are missing, falls back to `TELEPORT_TOOLS_VERSION` (deprecated).
+	ToolsVersion  *ConfigValue `protobuf:"bytes,2,opt,name=tools_version,json=toolsVersion,proto3" json:"tools_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -345,18 +403,72 @@ func (*GetConfigResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *GetConfigResponse) GetCdnBaseUrl() string {
+func (x *GetConfigResponse) GetCdnBaseUrl() *ConfigValue {
 	if x != nil {
 		return x.CdnBaseUrl
+	}
+	return nil
+}
+
+func (x *GetConfigResponse) GetToolsVersion() *ConfigValue {
+	if x != nil {
+		return x.ToolsVersion
+	}
+	return nil
+}
+
+// Contains the config value and its source.
+type ConfigValue struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Value string                 `protobuf:"bytes,1,opt,name=value,proto3" json:"value,omitempty"`
+	// Source of the config.
+	Source        ConfigSource `protobuf:"varint,2,opt,name=source,proto3,enum=teleport.lib.teleterm.auto_update.v1.ConfigSource" json:"source,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ConfigValue) Reset() {
+	*x = ConfigValue{}
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ConfigValue) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ConfigValue) ProtoMessage() {}
+
+func (x *ConfigValue) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ConfigValue.ProtoReflect.Descriptor instead.
+func (*ConfigValue) Descriptor() ([]byte, []int) {
+	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ConfigValue) GetValue() string {
+	if x != nil {
+		return x.Value
 	}
 	return ""
 }
 
-func (x *GetConfigResponse) GetToolsVersion() string {
+func (x *ConfigValue) GetSource() ConfigSource {
 	if x != nil {
-		return x.ToolsVersion
+		return x.Source
 	}
-	return ""
+	return ConfigSource_CONFIG_SOURCE_UNSPECIFIED
 }
 
 // Request for GetInstallationMetadata.
@@ -368,7 +480,7 @@ type GetInstallationMetadataRequest struct {
 
 func (x *GetInstallationMetadataRequest) Reset() {
 	*x = GetInstallationMetadataRequest{}
-	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[6]
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -380,7 +492,7 @@ func (x *GetInstallationMetadataRequest) String() string {
 func (*GetInstallationMetadataRequest) ProtoMessage() {}
 
 func (x *GetInstallationMetadataRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[6]
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -393,7 +505,7 @@ func (x *GetInstallationMetadataRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInstallationMetadataRequest.ProtoReflect.Descriptor instead.
 func (*GetInstallationMetadataRequest) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{6}
+	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{7}
 }
 
 // Response for GetInstallationMetadata.
@@ -407,7 +519,7 @@ type GetInstallationMetadataResponse struct {
 
 func (x *GetInstallationMetadataResponse) Reset() {
 	*x = GetInstallationMetadataResponse{}
-	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[7]
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -419,7 +531,7 @@ func (x *GetInstallationMetadataResponse) String() string {
 func (*GetInstallationMetadataResponse) ProtoMessage() {}
 
 func (x *GetInstallationMetadataResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[7]
+	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -432,7 +544,7 @@ func (x *GetInstallationMetadataResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetInstallationMetadataResponse.ProtoReflect.Descriptor instead.
 func (*GetInstallationMetadataResponse) Descriptor() ([]byte, []int) {
-	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{7}
+	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetInstallationMetadataResponse) GetIsPerMachineInstall() bool {
@@ -461,14 +573,22 @@ const file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDes
 	"\vcluster_uri\x18\x01 \x01(\tR\n" +
 	"clusterUri\x12#\n" +
 	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"\x12\n" +
-	"\x10GetConfigRequest\"Z\n" +
-	"\x11GetConfigResponse\x12 \n" +
-	"\fcdn_base_url\x18\x01 \x01(\tR\n" +
-	"cdnBaseUrl\x12#\n" +
-	"\rtools_version\x18\x02 \x01(\tR\ftoolsVersion\" \n" +
+	"\x10GetConfigRequest\"\xc0\x01\n" +
+	"\x11GetConfigResponse\x12S\n" +
+	"\fcdn_base_url\x18\x01 \x01(\v21.teleport.lib.teleterm.auto_update.v1.ConfigValueR\n" +
+	"cdnBaseUrl\x12V\n" +
+	"\rtools_version\x18\x02 \x01(\v21.teleport.lib.teleterm.auto_update.v1.ConfigValueR\ftoolsVersion\"o\n" +
+	"\vConfigValue\x12\x14\n" +
+	"\x05value\x18\x01 \x01(\tR\x05value\x12J\n" +
+	"\x06source\x18\x02 \x01(\x0e22.teleport.lib.teleterm.auto_update.v1.ConfigSourceR\x06source\" \n" +
 	"\x1eGetInstallationMetadataRequest\"V\n" +
 	"\x1fGetInstallationMetadataResponse\x123\n" +
-	"\x16is_per_machine_install\x18\x01 \x01(\bR\x13isPerMachineInstall2\xd4\x03\n" +
+	"\x16is_per_machine_install\x18\x01 \x01(\bR\x13isPerMachineInstall*}\n" +
+	"\fConfigSource\x12\x1d\n" +
+	"\x19CONFIG_SOURCE_UNSPECIFIED\x10\x00\x12\x19\n" +
+	"\x15CONFIG_SOURCE_ENV_VAR\x10\x02\x12\x18\n" +
+	"\x14CONFIG_SOURCE_POLICY\x10\x03\x12\x19\n" +
+	"\x15CONFIG_SOURCE_DEFAULT\x10\x042\xd4\x03\n" +
 	"\x11AutoUpdateService\x12\x97\x01\n" +
 	"\x12GetClusterVersions\x12?.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest\x1a@.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse\x12|\n" +
 	"\tGetConfig\x126.teleport.lib.teleterm.auto_update.v1.GetConfigRequest\x1a7.teleport.lib.teleterm.auto_update.v1.GetConfigResponse\x12\xa6\x01\n" +
@@ -486,31 +606,37 @@ func file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDesc
 	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescData
 }
 
-var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
 var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_goTypes = []any{
-	(*GetClusterVersionsRequest)(nil),       // 0: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest
-	(*GetClusterVersionsResponse)(nil),      // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
-	(*ClusterVersionInfo)(nil),              // 2: teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
-	(*UnreachableCluster)(nil),              // 3: teleport.lib.teleterm.auto_update.v1.UnreachableCluster
-	(*GetConfigRequest)(nil),                // 4: teleport.lib.teleterm.auto_update.v1.GetConfigRequest
-	(*GetConfigResponse)(nil),               // 5: teleport.lib.teleterm.auto_update.v1.GetConfigResponse
-	(*GetInstallationMetadataRequest)(nil),  // 6: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
-	(*GetInstallationMetadataResponse)(nil), // 7: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
+	(ConfigSource)(0),                       // 0: teleport.lib.teleterm.auto_update.v1.ConfigSource
+	(*GetClusterVersionsRequest)(nil),       // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest
+	(*GetClusterVersionsResponse)(nil),      // 2: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
+	(*ClusterVersionInfo)(nil),              // 3: teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
+	(*UnreachableCluster)(nil),              // 4: teleport.lib.teleterm.auto_update.v1.UnreachableCluster
+	(*GetConfigRequest)(nil),                // 5: teleport.lib.teleterm.auto_update.v1.GetConfigRequest
+	(*GetConfigResponse)(nil),               // 6: teleport.lib.teleterm.auto_update.v1.GetConfigResponse
+	(*ConfigValue)(nil),                     // 7: teleport.lib.teleterm.auto_update.v1.ConfigValue
+	(*GetInstallationMetadataRequest)(nil),  // 8: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
+	(*GetInstallationMetadataResponse)(nil), // 9: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
 }
 var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_depIdxs = []int32{
-	2, // 0: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.reachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
-	3, // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.unreachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.UnreachableCluster
-	0, // 2: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:input_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest
-	4, // 3: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:input_type -> teleport.lib.teleterm.auto_update.v1.GetConfigRequest
-	6, // 4: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:input_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
-	1, // 5: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:output_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
-	5, // 6: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:output_type -> teleport.lib.teleterm.auto_update.v1.GetConfigResponse
-	7, // 7: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:output_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
-	5, // [5:8] is the sub-list for method output_type
-	2, // [2:5] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	3, // 0: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.reachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
+	4, // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.unreachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.UnreachableCluster
+	7, // 2: teleport.lib.teleterm.auto_update.v1.GetConfigResponse.cdn_base_url:type_name -> teleport.lib.teleterm.auto_update.v1.ConfigValue
+	7, // 3: teleport.lib.teleterm.auto_update.v1.GetConfigResponse.tools_version:type_name -> teleport.lib.teleterm.auto_update.v1.ConfigValue
+	0, // 4: teleport.lib.teleterm.auto_update.v1.ConfigValue.source:type_name -> teleport.lib.teleterm.auto_update.v1.ConfigSource
+	1, // 5: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:input_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest
+	5, // 6: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:input_type -> teleport.lib.teleterm.auto_update.v1.GetConfigRequest
+	8, // 7: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:input_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
+	2, // 8: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:output_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
+	6, // 9: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:output_type -> teleport.lib.teleterm.auto_update.v1.GetConfigResponse
+	9, // 10: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:output_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
+	8, // [8:11] is the sub-list for method output_type
+	5, // [5:8] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_init() }
@@ -523,13 +649,14 @@ func file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_init() 
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDesc), len(file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   8,
+			NumEnums:      1,
+			NumMessages:   9,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_goTypes,
 		DependencyIndexes: file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_depIdxs,
+		EnumInfos:         file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_enumTypes,
 		MessageInfos:      file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes,
 	}.Build()
 	File_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto = out.File

--- a/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service.pb.go
@@ -255,27 +255,27 @@ func (x *UnreachableCluster) GetErrorMessage() string {
 	return ""
 }
 
-// Request for GetDownloadBaseUrl.
-type GetDownloadBaseUrlRequest struct {
+// Request for GetConfig.
+type GetConfigRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetDownloadBaseUrlRequest) Reset() {
-	*x = GetDownloadBaseUrlRequest{}
+func (x *GetConfigRequest) Reset() {
+	*x = GetConfigRequest{}
 	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetDownloadBaseUrlRequest) String() string {
+func (x *GetConfigRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetDownloadBaseUrlRequest) ProtoMessage() {}
+func (*GetConfigRequest) ProtoMessage() {}
 
-func (x *GetDownloadBaseUrlRequest) ProtoReflect() protoreflect.Message {
+func (x *GetConfigRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -287,33 +287,48 @@ func (x *GetDownloadBaseUrlRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetDownloadBaseUrlRequest.ProtoReflect.Descriptor instead.
-func (*GetDownloadBaseUrlRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetConfigRequest.ProtoReflect.Descriptor instead.
+func (*GetConfigRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{4}
 }
 
-// Response for GetDownloadBaseUrl.
-type GetDownloadBaseUrlResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	BaseUrl       string                 `protobuf:"bytes,1,opt,name=base_url,json=baseUrl,proto3" json:"base_url,omitempty"`
+// Response for GetConfig.
+type GetConfigResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A base URL (e.g. cdn.teleport.dev) for downloading packages.
+	// Sources resolved by platform:
+	// * macOS/Linux: The `TELEPORT_CDN_BASE_URL` environment variable.
+	// * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+	//   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+	//   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+	//
+	// Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
+	CdnBaseUrl string `protobuf:"bytes,1,opt,name=cdn_base_url,json=cdnBaseUrl,proto3" json:"cdn_base_url,omitempty"`
+	// The specific client tools version to use. The 'off' value disables automatic updates.
+	// Sources resolved by platform:
+	// * macOS/Linux: The `TELEPORT_TOOLS_VERSION` environment variable.
+	// * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+	//   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+	//   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+	ToolsVersion  string `protobuf:"bytes,2,opt,name=tools_version,json=toolsVersion,proto3" json:"tools_version,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetDownloadBaseUrlResponse) Reset() {
-	*x = GetDownloadBaseUrlResponse{}
+func (x *GetConfigResponse) Reset() {
+	*x = GetConfigResponse{}
 	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetDownloadBaseUrlResponse) String() string {
+func (x *GetConfigResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetDownloadBaseUrlResponse) ProtoMessage() {}
+func (*GetConfigResponse) ProtoMessage() {}
 
-func (x *GetDownloadBaseUrlResponse) ProtoReflect() protoreflect.Message {
+func (x *GetConfigResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -325,14 +340,21 @@ func (x *GetDownloadBaseUrlResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetDownloadBaseUrlResponse.ProtoReflect.Descriptor instead.
-func (*GetDownloadBaseUrlResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use GetConfigResponse.ProtoReflect.Descriptor instead.
+func (*GetConfigResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *GetDownloadBaseUrlResponse) GetBaseUrl() string {
+func (x *GetConfigResponse) GetCdnBaseUrl() string {
 	if x != nil {
-		return x.BaseUrl
+		return x.CdnBaseUrl
+	}
+	return ""
+}
+
+func (x *GetConfigResponse) GetToolsVersion() string {
+	if x != nil {
+		return x.ToolsVersion
 	}
 	return ""
 }
@@ -438,16 +460,18 @@ const file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_rawDes
 	"\x12UnreachableCluster\x12\x1f\n" +
 	"\vcluster_uri\x18\x01 \x01(\tR\n" +
 	"clusterUri\x12#\n" +
-	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"\x1b\n" +
-	"\x19GetDownloadBaseUrlRequest\"7\n" +
-	"\x1aGetDownloadBaseUrlResponse\x12\x19\n" +
-	"\bbase_url\x18\x01 \x01(\tR\abaseUrl\" \n" +
+	"\rerror_message\x18\x02 \x01(\tR\ferrorMessage\"\x12\n" +
+	"\x10GetConfigRequest\"Z\n" +
+	"\x11GetConfigResponse\x12 \n" +
+	"\fcdn_base_url\x18\x01 \x01(\tR\n" +
+	"cdnBaseUrl\x12#\n" +
+	"\rtools_version\x18\x02 \x01(\tR\ftoolsVersion\" \n" +
 	"\x1eGetInstallationMetadataRequest\"V\n" +
 	"\x1fGetInstallationMetadataResponse\x123\n" +
-	"\x16is_per_machine_install\x18\x01 \x01(\bR\x13isPerMachineInstall2\xf0\x03\n" +
+	"\x16is_per_machine_install\x18\x01 \x01(\bR\x13isPerMachineInstall2\xd4\x03\n" +
 	"\x11AutoUpdateService\x12\x97\x01\n" +
-	"\x12GetClusterVersions\x12?.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest\x1a@.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse\x12\x97\x01\n" +
-	"\x12GetDownloadBaseUrl\x12?.teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest\x1a@.teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse\x12\xa6\x01\n" +
+	"\x12GetClusterVersions\x12?.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest\x1a@.teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse\x12|\n" +
+	"\tGetConfig\x126.teleport.lib.teleterm.auto_update.v1.GetConfigRequest\x1a7.teleport.lib.teleterm.auto_update.v1.GetConfigResponse\x12\xa6\x01\n" +
 	"\x17GetInstallationMetadata\x12D.teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest\x1aE.teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponseBcZagithub.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1;auto_updatev1b\x06proto3"
 
 var (
@@ -468,8 +492,8 @@ var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_goTypes 
 	(*GetClusterVersionsResponse)(nil),      // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
 	(*ClusterVersionInfo)(nil),              // 2: teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
 	(*UnreachableCluster)(nil),              // 3: teleport.lib.teleterm.auto_update.v1.UnreachableCluster
-	(*GetDownloadBaseUrlRequest)(nil),       // 4: teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest
-	(*GetDownloadBaseUrlResponse)(nil),      // 5: teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse
+	(*GetConfigRequest)(nil),                // 4: teleport.lib.teleterm.auto_update.v1.GetConfigRequest
+	(*GetConfigResponse)(nil),               // 5: teleport.lib.teleterm.auto_update.v1.GetConfigResponse
 	(*GetInstallationMetadataRequest)(nil),  // 6: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
 	(*GetInstallationMetadataResponse)(nil), // 7: teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
 }
@@ -477,10 +501,10 @@ var file_teleport_lib_teleterm_auto_update_v1_auto_update_service_proto_depIdxs 
 	2, // 0: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.reachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.ClusterVersionInfo
 	3, // 1: teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse.unreachable_clusters:type_name -> teleport.lib.teleterm.auto_update.v1.UnreachableCluster
 	0, // 2: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:input_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsRequest
-	4, // 3: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetDownloadBaseUrl:input_type -> teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest
+	4, // 3: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:input_type -> teleport.lib.teleterm.auto_update.v1.GetConfigRequest
 	6, // 4: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:input_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataRequest
 	1, // 5: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetClusterVersions:output_type -> teleport.lib.teleterm.auto_update.v1.GetClusterVersionsResponse
-	5, // 6: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetDownloadBaseUrl:output_type -> teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse
+	5, // 6: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetConfig:output_type -> teleport.lib.teleterm.auto_update.v1.GetConfigResponse
 	7, // 7: teleport.lib.teleterm.auto_update.v1.AutoUpdateService.GetInstallationMetadata:output_type -> teleport.lib.teleterm.auto_update.v1.GetInstallationMetadataResponse
 	5, // [5:8] is the sub-list for method output_type
 	2, // [2:5] is the sub-list for method input_type

--- a/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service_grpc.pb.go
+++ b/gen/proto/go/teleport/lib/teleterm/auto_update/v1/auto_update_service_grpc.pb.go
@@ -50,8 +50,9 @@ type AutoUpdateServiceClient interface {
 	GetClusterVersions(ctx context.Context, in *GetClusterVersionsRequest, opts ...grpc.CallOption) (*GetClusterVersionsResponse, error)
 	// GetConfigRequest retrieves the local auto updates configuration.
 	// It resolves settings using platform-specific mechanisms:
-	// * macOS/Linux: Environment variables.
-	// * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+	//   - macOS/Linux: Environment variables.
+	//   - Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+	//     with a fallback to the deprecated environment variables when policy values are not set.
 	GetConfig(ctx context.Context, in *GetConfigRequest, opts ...grpc.CallOption) (*GetConfigResponse, error)
 	// GetInstallationMetadata returns installation metadata of the currently running app instance.
 	// Implemented only on Windows.
@@ -106,8 +107,9 @@ type AutoUpdateServiceServer interface {
 	GetClusterVersions(context.Context, *GetClusterVersionsRequest) (*GetClusterVersionsResponse, error)
 	// GetConfigRequest retrieves the local auto updates configuration.
 	// It resolves settings using platform-specific mechanisms:
-	// * macOS/Linux: Environment variables.
-	// * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+	//   - macOS/Linux: Environment variables.
+	//   - Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+	//     with a fallback to the deprecated environment variables when policy values are not set.
 	GetConfig(context.Context, *GetConfigRequest) (*GetConfigResponse, error)
 	// GetInstallationMetadata returns installation metadata of the currently running app instance.
 	// Implemented only on Windows.

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.client.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.client.ts
@@ -25,8 +25,8 @@ import type { ServiceInfo } from "@protobuf-ts/runtime-rpc";
 import { AutoUpdateService } from "./auto_update_service_pb";
 import type { GetInstallationMetadataResponse } from "./auto_update_service_pb";
 import type { GetInstallationMetadataRequest } from "./auto_update_service_pb";
-import type { GetDownloadBaseUrlResponse } from "./auto_update_service_pb";
-import type { GetDownloadBaseUrlRequest } from "./auto_update_service_pb";
+import type { GetConfigResponse } from "./auto_update_service_pb";
+import type { GetConfigRequest } from "./auto_update_service_pb";
 import { stackIntercept } from "@protobuf-ts/runtime-rpc";
 import type { GetClusterVersionsResponse } from "./auto_update_service_pb";
 import type { GetClusterVersionsRequest } from "./auto_update_service_pb";
@@ -45,13 +45,14 @@ export interface IAutoUpdateServiceClient {
      */
     getClusterVersions(input: GetClusterVersionsRequest, options?: RpcOptions): UnaryCall<GetClusterVersionsRequest, GetClusterVersionsResponse>;
     /**
-     * GetDownloadBaseUrl returns a base URL (e.g. cdn.teleport.dev) for downloading packages.
-     * Can be overridden with TELEPORT_CDN_BASE_URL env var.
-     * OSS builds require this env var to be set, otherwise an error is returned.
+     * GetConfigRequest retrieves the local auto updates configuration.
+     * It resolves settings using platform-specific mechanisms:
+     * * macOS/Linux: Environment variables.
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
      *
-     * @generated from protobuf rpc: GetDownloadBaseUrl(teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest) returns (teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse);
+     * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */
-    getDownloadBaseUrl(input: GetDownloadBaseUrlRequest, options?: RpcOptions): UnaryCall<GetDownloadBaseUrlRequest, GetDownloadBaseUrlResponse>;
+    getConfig(input: GetConfigRequest, options?: RpcOptions): UnaryCall<GetConfigRequest, GetConfigResponse>;
     /**
      * GetInstallationMetadata returns installation metadata of the currently running app instance.
      * Implemented only on Windows.
@@ -81,15 +82,16 @@ export class AutoUpdateServiceClient implements IAutoUpdateServiceClient, Servic
         return stackIntercept<GetClusterVersionsRequest, GetClusterVersionsResponse>("unary", this._transport, method, opt, input);
     }
     /**
-     * GetDownloadBaseUrl returns a base URL (e.g. cdn.teleport.dev) for downloading packages.
-     * Can be overridden with TELEPORT_CDN_BASE_URL env var.
-     * OSS builds require this env var to be set, otherwise an error is returned.
+     * GetConfigRequest retrieves the local auto updates configuration.
+     * It resolves settings using platform-specific mechanisms:
+     * * macOS/Linux: Environment variables.
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
      *
-     * @generated from protobuf rpc: GetDownloadBaseUrl(teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest) returns (teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse);
+     * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */
-    getDownloadBaseUrl(input: GetDownloadBaseUrlRequest, options?: RpcOptions): UnaryCall<GetDownloadBaseUrlRequest, GetDownloadBaseUrlResponse> {
+    getConfig(input: GetConfigRequest, options?: RpcOptions): UnaryCall<GetConfigRequest, GetConfigResponse> {
         const method = this.methods[1], opt = this._transport.mergeOptions(options);
-        return stackIntercept<GetDownloadBaseUrlRequest, GetDownloadBaseUrlResponse>("unary", this._transport, method, opt, input);
+        return stackIntercept<GetConfigRequest, GetConfigResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * GetInstallationMetadata returns installation metadata of the currently running app instance.

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.client.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.client.ts
@@ -48,7 +48,8 @@ export interface IAutoUpdateServiceClient {
      * GetConfigRequest retrieves the local auto updates configuration.
      * It resolves settings using platform-specific mechanisms:
      * * macOS/Linux: Environment variables.
-     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+     *   with a fallback to the deprecated environment variables when policy values are not set.
      *
      * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */
@@ -85,7 +86,8 @@ export class AutoUpdateServiceClient implements IAutoUpdateServiceClient, Servic
      * GetConfigRequest retrieves the local auto updates configuration.
      * It resolves settings using platform-specific mechanisms:
      * * macOS/Linux: Environment variables.
-     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+     *   with a fallback to the deprecated environment variables when policy values are not set.
      *
      * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.grpc-server.ts
@@ -43,7 +43,8 @@ export interface IAutoUpdateService extends grpc.UntypedServiceImplementation {
      * GetConfigRequest retrieves the local auto updates configuration.
      * It resolves settings using platform-specific mechanisms:
      * * macOS/Linux: Environment variables.
-     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+     *   with a fallback to the deprecated environment variables when policy values are not set.
      *
      * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.grpc-server.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.grpc-server.ts
@@ -22,8 +22,8 @@
 //
 import { GetInstallationMetadataResponse } from "./auto_update_service_pb";
 import { GetInstallationMetadataRequest } from "./auto_update_service_pb";
-import { GetDownloadBaseUrlResponse } from "./auto_update_service_pb";
-import { GetDownloadBaseUrlRequest } from "./auto_update_service_pb";
+import { GetConfigResponse } from "./auto_update_service_pb";
+import { GetConfigRequest } from "./auto_update_service_pb";
 import { GetClusterVersionsResponse } from "./auto_update_service_pb";
 import { GetClusterVersionsRequest } from "./auto_update_service_pb";
 import type * as grpc from "@grpc/grpc-js";
@@ -40,13 +40,14 @@ export interface IAutoUpdateService extends grpc.UntypedServiceImplementation {
      */
     getClusterVersions: grpc.handleUnaryCall<GetClusterVersionsRequest, GetClusterVersionsResponse>;
     /**
-     * GetDownloadBaseUrl returns a base URL (e.g. cdn.teleport.dev) for downloading packages.
-     * Can be overridden with TELEPORT_CDN_BASE_URL env var.
-     * OSS builds require this env var to be set, otherwise an error is returned.
+     * GetConfigRequest retrieves the local auto updates configuration.
+     * It resolves settings using platform-specific mechanisms:
+     * * macOS/Linux: Environment variables.
+     * * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
      *
-     * @generated from protobuf rpc: GetDownloadBaseUrl(teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest) returns (teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse);
+     * @generated from protobuf rpc: GetConfig(teleport.lib.teleterm.auto_update.v1.GetConfigRequest) returns (teleport.lib.teleterm.auto_update.v1.GetConfigResponse);
      */
-    getDownloadBaseUrl: grpc.handleUnaryCall<GetDownloadBaseUrlRequest, GetDownloadBaseUrlResponse>;
+    getConfig: grpc.handleUnaryCall<GetConfigRequest, GetConfigResponse>;
     /**
      * GetInstallationMetadata returns installation metadata of the currently running app instance.
      * Implemented only on Windows.
@@ -77,15 +78,15 @@ export const autoUpdateServiceDefinition: grpc.ServiceDefinition<IAutoUpdateServ
         responseSerialize: value => Buffer.from(GetClusterVersionsResponse.toBinary(value)),
         requestSerialize: value => Buffer.from(GetClusterVersionsRequest.toBinary(value))
     },
-    getDownloadBaseUrl: {
-        path: "/teleport.lib.teleterm.auto_update.v1.AutoUpdateService/GetDownloadBaseUrl",
-        originalName: "GetDownloadBaseUrl",
+    getConfig: {
+        path: "/teleport.lib.teleterm.auto_update.v1.AutoUpdateService/GetConfig",
+        originalName: "GetConfig",
         requestStream: false,
         responseStream: false,
-        responseDeserialize: bytes => GetDownloadBaseUrlResponse.fromBinary(bytes),
-        requestDeserialize: bytes => GetDownloadBaseUrlRequest.fromBinary(bytes),
-        responseSerialize: value => Buffer.from(GetDownloadBaseUrlResponse.toBinary(value)),
-        requestSerialize: value => Buffer.from(GetDownloadBaseUrlRequest.toBinary(value))
+        responseDeserialize: bytes => GetConfigResponse.fromBinary(bytes),
+        requestDeserialize: bytes => GetConfigRequest.fromBinary(bytes),
+        responseSerialize: value => Buffer.from(GetConfigResponse.toBinary(value)),
+        requestSerialize: value => Buffer.from(GetConfigRequest.toBinary(value))
     },
     getInstallationMetadata: {
         path: "/teleport.lib.teleterm.auto_update.v1.AutoUpdateService/GetInstallationMetadata",

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
@@ -190,23 +190,23 @@ export enum ConfigSource {
      */
     UNSPECIFIED = 0,
     /**
-     * Configuration comes from environment variable.
+     * Configuration comes from an environment variable.
      *
-     * @generated from protobuf enum value: CONFIG_SOURCE_ENV_VAR = 2;
+     * @generated from protobuf enum value: CONFIG_SOURCE_ENV_VAR = 1;
      */
-    ENV_VAR = 2,
+    ENV_VAR = 1,
     /**
      * Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
      *
-     * @generated from protobuf enum value: CONFIG_SOURCE_POLICY = 3;
+     * @generated from protobuf enum value: CONFIG_SOURCE_POLICY = 2;
      */
-    POLICY = 3,
+    POLICY = 2,
     /**
-     * Configuration comes from hardcoded default.
+     * Configuration comes from a hardcoded default.
      *
-     * @generated from protobuf enum value: CONFIG_SOURCE_DEFAULT = 4;
+     * @generated from protobuf enum value: CONFIG_SOURCE_DEFAULT = 3;
      */
-    DEFAULT = 4
+    DEFAULT = 3
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class GetClusterVersionsRequest$Type extends MessageType<GetClusterVersionsRequest> {

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
@@ -103,22 +103,42 @@ export interface UnreachableCluster {
     errorMessage: string;
 }
 /**
- * Request for GetDownloadBaseUrl.
+ * Request for GetConfig.
  *
- * @generated from protobuf message teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest
+ * @generated from protobuf message teleport.lib.teleterm.auto_update.v1.GetConfigRequest
  */
-export interface GetDownloadBaseUrlRequest {
+export interface GetConfigRequest {
 }
 /**
- * Response for GetDownloadBaseUrl.
+ * Response for GetConfig.
  *
- * @generated from protobuf message teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse
+ * @generated from protobuf message teleport.lib.teleterm.auto_update.v1.GetConfigResponse
  */
-export interface GetDownloadBaseUrlResponse {
+export interface GetConfigResponse {
     /**
-     * @generated from protobuf field: string base_url = 1;
+     * A base URL (e.g. cdn.teleport.dev) for downloading packages.
+     * Sources resolved by platform:
+     * * macOS/Linux: The `TELEPORT_CDN_BASE_URL` environment variable.
+     * * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+     *   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+     *   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+     *
+     * Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
+     *
+     * @generated from protobuf field: string cdn_base_url = 1;
      */
-    baseUrl: string;
+    cdnBaseUrl: string;
+    /**
+     * The specific client tools version to use. The 'off' value disables automatic updates.
+     * Sources resolved by platform:
+     * * macOS/Linux: The `TELEPORT_TOOLS_VERSION` environment variable.
+     * * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+     *   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+     *   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+     *
+     * @generated from protobuf field: string tools_version = 2;
+     */
+    toolsVersion: string;
 }
 /**
  * Request for GetInstallationMetadata.
@@ -347,20 +367,20 @@ class UnreachableCluster$Type extends MessageType<UnreachableCluster> {
  */
 export const UnreachableCluster = new UnreachableCluster$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class GetDownloadBaseUrlRequest$Type extends MessageType<GetDownloadBaseUrlRequest> {
+class GetConfigRequest$Type extends MessageType<GetConfigRequest> {
     constructor() {
-        super("teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest", []);
+        super("teleport.lib.teleterm.auto_update.v1.GetConfigRequest", []);
     }
-    create(value?: PartialMessage<GetDownloadBaseUrlRequest>): GetDownloadBaseUrlRequest {
+    create(value?: PartialMessage<GetConfigRequest>): GetConfigRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<GetDownloadBaseUrlRequest>(this, message, value);
+            reflectionMergePartial<GetConfigRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetDownloadBaseUrlRequest): GetDownloadBaseUrlRequest {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetConfigRequest): GetConfigRequest {
         return target ?? this.create();
     }
-    internalBinaryWrite(message: GetDownloadBaseUrlRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+    internalBinaryWrite(message: GetConfigRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -368,30 +388,35 @@ class GetDownloadBaseUrlRequest$Type extends MessageType<GetDownloadBaseUrlReque
     }
 }
 /**
- * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlRequest
+ * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.GetConfigRequest
  */
-export const GetDownloadBaseUrlRequest = new GetDownloadBaseUrlRequest$Type();
+export const GetConfigRequest = new GetConfigRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class GetDownloadBaseUrlResponse$Type extends MessageType<GetDownloadBaseUrlResponse> {
+class GetConfigResponse$Type extends MessageType<GetConfigResponse> {
     constructor() {
-        super("teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse", [
-            { no: 1, name: "base_url", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+        super("teleport.lib.teleterm.auto_update.v1.GetConfigResponse", [
+            { no: 1, name: "cdn_base_url", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "tools_version", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
         ]);
     }
-    create(value?: PartialMessage<GetDownloadBaseUrlResponse>): GetDownloadBaseUrlResponse {
+    create(value?: PartialMessage<GetConfigResponse>): GetConfigResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.baseUrl = "";
+        message.cdnBaseUrl = "";
+        message.toolsVersion = "";
         if (value !== undefined)
-            reflectionMergePartial<GetDownloadBaseUrlResponse>(this, message, value);
+            reflectionMergePartial<GetConfigResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetDownloadBaseUrlResponse): GetDownloadBaseUrlResponse {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: GetConfigResponse): GetConfigResponse {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string base_url */ 1:
-                    message.baseUrl = reader.string();
+                case /* string cdn_base_url */ 1:
+                    message.cdnBaseUrl = reader.string();
+                    break;
+                case /* string tools_version */ 2:
+                    message.toolsVersion = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -404,10 +429,13 @@ class GetDownloadBaseUrlResponse$Type extends MessageType<GetDownloadBaseUrlResp
         }
         return message;
     }
-    internalBinaryWrite(message: GetDownloadBaseUrlResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string base_url = 1; */
-        if (message.baseUrl !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.baseUrl);
+    internalBinaryWrite(message: GetConfigResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string cdn_base_url = 1; */
+        if (message.cdnBaseUrl !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.cdnBaseUrl);
+        /* string tools_version = 2; */
+        if (message.toolsVersion !== "")
+            writer.tag(2, WireType.LengthDelimited).string(message.toolsVersion);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -415,9 +443,9 @@ class GetDownloadBaseUrlResponse$Type extends MessageType<GetDownloadBaseUrlResp
     }
 }
 /**
- * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.GetDownloadBaseUrlResponse
+ * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.GetConfigResponse
  */
-export const GetDownloadBaseUrlResponse = new GetDownloadBaseUrlResponse$Type();
+export const GetConfigResponse = new GetConfigResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class GetInstallationMetadataRequest$Type extends MessageType<GetInstallationMetadataRequest> {
     constructor() {
@@ -495,6 +523,6 @@ export const GetInstallationMetadataResponse = new GetInstallationMetadataRespon
  */
 export const AutoUpdateService = new ServiceType("teleport.lib.teleterm.auto_update.v1.AutoUpdateService", [
     { name: "GetClusterVersions", options: {}, I: GetClusterVersionsRequest, O: GetClusterVersionsResponse },
-    { name: "GetDownloadBaseUrl", options: {}, I: GetDownloadBaseUrlRequest, O: GetDownloadBaseUrlResponse },
+    { name: "GetConfig", options: {}, I: GetConfigRequest, O: GetConfigResponse },
     { name: "GetInstallationMetadata", options: {}, I: GetInstallationMetadataRequest, O: GetInstallationMetadataResponse }
 ]);

--- a/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
+++ b/gen/proto/ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb.ts
@@ -122,12 +122,13 @@ export interface GetConfigResponse {
      * * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
      *   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
      *   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+     *   - If policy values are missing, falls back to `TELEPORT_CDN_BASE_URL` (deprecated).
      *
      * Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
      *
-     * @generated from protobuf field: string cdn_base_url = 1;
+     * @generated from protobuf field: teleport.lib.teleterm.auto_update.v1.ConfigValue cdn_base_url = 1;
      */
-    cdnBaseUrl: string;
+    cdnBaseUrl?: ConfigValue;
     /**
      * The specific client tools version to use. The 'off' value disables automatic updates.
      * Sources resolved by platform:
@@ -135,10 +136,28 @@ export interface GetConfigResponse {
      * * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
      *   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
      *   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+     *   - If policy values are missing, falls back to `TELEPORT_TOOLS_VERSION` (deprecated).
      *
-     * @generated from protobuf field: string tools_version = 2;
+     * @generated from protobuf field: teleport.lib.teleterm.auto_update.v1.ConfigValue tools_version = 2;
      */
-    toolsVersion: string;
+    toolsVersion?: ConfigValue;
+}
+/**
+ * Contains the config value and its source.
+ *
+ * @generated from protobuf message teleport.lib.teleterm.auto_update.v1.ConfigValue
+ */
+export interface ConfigValue {
+    /**
+     * @generated from protobuf field: string value = 1;
+     */
+    value: string;
+    /**
+     * Source of the config.
+     *
+     * @generated from protobuf field: teleport.lib.teleterm.auto_update.v1.ConfigSource source = 2;
+     */
+    source: ConfigSource;
 }
 /**
  * Request for GetInstallationMetadata.
@@ -159,6 +178,35 @@ export interface GetInstallationMetadataResponse {
      * @generated from protobuf field: bool is_per_machine_install = 1;
      */
     isPerMachineInstall: boolean;
+}
+/**
+ * Source of the config.
+ *
+ * @generated from protobuf enum teleport.lib.teleterm.auto_update.v1.ConfigSource
+ */
+export enum ConfigSource {
+    /**
+     * @generated from protobuf enum value: CONFIG_SOURCE_UNSPECIFIED = 0;
+     */
+    UNSPECIFIED = 0,
+    /**
+     * Configuration comes from environment variable.
+     *
+     * @generated from protobuf enum value: CONFIG_SOURCE_ENV_VAR = 2;
+     */
+    ENV_VAR = 2,
+    /**
+     * Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
+     *
+     * @generated from protobuf enum value: CONFIG_SOURCE_POLICY = 3;
+     */
+    POLICY = 3,
+    /**
+     * Configuration comes from hardcoded default.
+     *
+     * @generated from protobuf enum value: CONFIG_SOURCE_DEFAULT = 4;
+     */
+    DEFAULT = 4
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class GetClusterVersionsRequest$Type extends MessageType<GetClusterVersionsRequest> {
@@ -395,14 +443,12 @@ export const GetConfigRequest = new GetConfigRequest$Type();
 class GetConfigResponse$Type extends MessageType<GetConfigResponse> {
     constructor() {
         super("teleport.lib.teleterm.auto_update.v1.GetConfigResponse", [
-            { no: 1, name: "cdn_base_url", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
-            { no: 2, name: "tools_version", kind: "scalar", T: 9 /*ScalarType.STRING*/ }
+            { no: 1, name: "cdn_base_url", kind: "message", T: () => ConfigValue },
+            { no: 2, name: "tools_version", kind: "message", T: () => ConfigValue }
         ]);
     }
     create(value?: PartialMessage<GetConfigResponse>): GetConfigResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.cdnBaseUrl = "";
-        message.toolsVersion = "";
         if (value !== undefined)
             reflectionMergePartial<GetConfigResponse>(this, message, value);
         return message;
@@ -412,11 +458,11 @@ class GetConfigResponse$Type extends MessageType<GetConfigResponse> {
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* string cdn_base_url */ 1:
-                    message.cdnBaseUrl = reader.string();
+                case /* teleport.lib.teleterm.auto_update.v1.ConfigValue cdn_base_url */ 1:
+                    message.cdnBaseUrl = ConfigValue.internalBinaryRead(reader, reader.uint32(), options, message.cdnBaseUrl);
                     break;
-                case /* string tools_version */ 2:
-                    message.toolsVersion = reader.string();
+                case /* teleport.lib.teleterm.auto_update.v1.ConfigValue tools_version */ 2:
+                    message.toolsVersion = ConfigValue.internalBinaryRead(reader, reader.uint32(), options, message.toolsVersion);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -430,12 +476,12 @@ class GetConfigResponse$Type extends MessageType<GetConfigResponse> {
         return message;
     }
     internalBinaryWrite(message: GetConfigResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* string cdn_base_url = 1; */
-        if (message.cdnBaseUrl !== "")
-            writer.tag(1, WireType.LengthDelimited).string(message.cdnBaseUrl);
-        /* string tools_version = 2; */
-        if (message.toolsVersion !== "")
-            writer.tag(2, WireType.LengthDelimited).string(message.toolsVersion);
+        /* teleport.lib.teleterm.auto_update.v1.ConfigValue cdn_base_url = 1; */
+        if (message.cdnBaseUrl)
+            ConfigValue.internalBinaryWrite(message.cdnBaseUrl, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* teleport.lib.teleterm.auto_update.v1.ConfigValue tools_version = 2; */
+        if (message.toolsVersion)
+            ConfigValue.internalBinaryWrite(message.toolsVersion, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -446,6 +492,61 @@ class GetConfigResponse$Type extends MessageType<GetConfigResponse> {
  * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.GetConfigResponse
  */
 export const GetConfigResponse = new GetConfigResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ConfigValue$Type extends MessageType<ConfigValue> {
+    constructor() {
+        super("teleport.lib.teleterm.auto_update.v1.ConfigValue", [
+            { no: 1, name: "value", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "source", kind: "enum", T: () => ["teleport.lib.teleterm.auto_update.v1.ConfigSource", ConfigSource, "CONFIG_SOURCE_"] }
+        ]);
+    }
+    create(value?: PartialMessage<ConfigValue>): ConfigValue {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.value = "";
+        message.source = 0;
+        if (value !== undefined)
+            reflectionMergePartial<ConfigValue>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ConfigValue): ConfigValue {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string value */ 1:
+                    message.value = reader.string();
+                    break;
+                case /* teleport.lib.teleterm.auto_update.v1.ConfigSource source */ 2:
+                    message.source = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ConfigValue, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string value = 1; */
+        if (message.value !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.value);
+        /* teleport.lib.teleterm.auto_update.v1.ConfigSource source = 2; */
+        if (message.source !== 0)
+            writer.tag(2, WireType.Varint).int32(message.source);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message teleport.lib.teleterm.auto_update.v1.ConfigValue
+ */
+export const ConfigValue = new ConfigValue$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class GetInstallationMetadataRequest$Type extends MessageType<GetInstallationMetadataRequest> {
     constructor() {

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -42,6 +42,7 @@ const (
 	// launching tsh with TELEPORT_TOOLS_VERSION=off, and forwards the real value via
 	// FORWARDED_TELEPORT_TOOLS_VERSION.
 	forwardedTeleportToolsEnvVar = "FORWARDED_TELEPORT_TOOLS_VERSION"
+	teleportToolsVersionOff      = "off"
 )
 
 // Service implements gRPC service for autoupdate.
@@ -152,7 +153,7 @@ func (s *Service) GetConfig(_ context.Context, _ *api.GetConfigRequest) (*api.Ge
 	toolsVersionSource := config.GetToolsVersion().Source
 	if toolsVersionValue == "" {
 		toolsVersionSource = api.ConfigSource_CONFIG_SOURCE_UNSPECIFIED
-	} else {
+	} else if toolsVersionValue != teleportToolsVersionOff {
 		if _, err = semver.NewVersion(toolsVersionValue); err != nil {
 			return nil, trace.BadParameter("invalid version %v for tools version", toolsVersionValue)
 		}

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -164,10 +164,9 @@ func (s *Service) GetConfig(_ context.Context, _ *api.GetConfigRequest) (*api.Ge
 
 	cdnBaseUrlValue := strings.TrimSpace(config.GetCdnBaseUrl().Value)
 	cdnBaseUrlSource := config.GetCdnBaseUrl().Source
-	switch cdnBaseUrlValue {
-	case "":
+	if cdnBaseUrlValue == "" {
 		cdnBaseUrlSource = api.ConfigSource_CONFIG_SOURCE_UNSPECIFIED
-	default:
+	} else {
 		if err = validateURL(cdnBaseUrlValue); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/teleterm/autoupdate/service.go
+++ b/lib/teleterm/autoupdate/service.go
@@ -151,9 +151,12 @@ func (s *Service) GetConfig(_ context.Context, _ *api.GetConfigRequest) (*api.Ge
 
 	toolsVersionValue := strings.TrimSpace(config.GetToolsVersion().Value)
 	toolsVersionSource := config.GetToolsVersion().Source
-	if toolsVersionValue == "" {
+	switch toolsVersionValue {
+	case "":
 		toolsVersionSource = api.ConfigSource_CONFIG_SOURCE_UNSPECIFIED
-	} else if toolsVersionValue != teleportToolsVersionOff {
+	case teleportToolsVersionOff:
+		break
+	default:
 		if _, err = semver.NewVersion(toolsVersionValue); err != nil {
 			return nil, trace.BadParameter("invalid version %v for tools version", toolsVersionValue)
 		}
@@ -161,9 +164,10 @@ func (s *Service) GetConfig(_ context.Context, _ *api.GetConfigRequest) (*api.Ge
 
 	cdnBaseUrlValue := strings.TrimSpace(config.GetCdnBaseUrl().Value)
 	cdnBaseUrlSource := config.GetCdnBaseUrl().Source
-	if cdnBaseUrlValue == "" {
+	switch cdnBaseUrlValue {
+	case "":
 		cdnBaseUrlSource = api.ConfigSource_CONFIG_SOURCE_UNSPECIFIED
-	} else {
+	default:
 		if err = validateURL(cdnBaseUrlValue); err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/teleterm/autoupdate/service_other.go
+++ b/lib/teleterm/autoupdate/service_other.go
@@ -1,0 +1,42 @@
+//go:build !windows
+
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package autoupdate
+
+import (
+	"os"
+
+	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1"
+	"github.com/gravitational/teleport/lib/autoupdate"
+)
+
+// When tsh runs as a daemon, auto-updates must be disabled. Connect enforces this by
+// launching tsh with TELEPORT_TOOLS_VERSION=off, and forwards the real value via
+// FORWARDED_TELEPORT_TOOLS_VERSION.
+const forwardedTeleportToolsEnvVar = "FORWARDED_TELEPORT_TOOLS_VERSION"
+
+// platformGetConfig retrieves the local auto updates configuration.
+func platformGetConfig() (*api.GetConfigResponse, error) {
+	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
+	envTeleportToolsVersion := os.Getenv(forwardedTeleportToolsEnvVar)
+
+	return &api.GetConfigResponse{
+		CdnBaseUrl:   envBaseURL,
+		ToolsVersion: envTeleportToolsVersion,
+	}, nil
+}

--- a/lib/teleterm/autoupdate/service_other.go
+++ b/lib/teleterm/autoupdate/service_other.go
@@ -19,24 +19,13 @@
 package autoupdate
 
 import (
-	"os"
+	"github.com/gravitational/trace"
 
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/auto_update/v1"
-	"github.com/gravitational/teleport/lib/autoupdate"
 )
-
-// When tsh runs as a daemon, auto-updates must be disabled. Connect enforces this by
-// launching tsh with TELEPORT_TOOLS_VERSION=off, and forwards the real value via
-// FORWARDED_TELEPORT_TOOLS_VERSION.
-const forwardedTeleportToolsEnvVar = "FORWARDED_TELEPORT_TOOLS_VERSION"
 
 // platformGetConfig retrieves the local auto updates configuration.
 func platformGetConfig() (*api.GetConfigResponse, error) {
-	envBaseURL := os.Getenv(autoupdate.BaseURLEnvVar)
-	envTeleportToolsVersion := os.Getenv(forwardedTeleportToolsEnvVar)
-
-	return &api.GetConfigResponse{
-		CdnBaseUrl:   envBaseURL,
-		ToolsVersion: envTeleportToolsVersion,
-	}, nil
+	config, err := readConfigFromEnvVars()
+	return config, trace.Wrap(err)
 }

--- a/lib/teleterm/autoupdate/service_windows.go
+++ b/lib/teleterm/autoupdate/service_windows.go
@@ -111,7 +111,7 @@ func platformGetConfig() (*api.GetConfigResponse, error) {
 }
 
 func isPerMachineInstall() (bool, error) {
-	perMachineLocation, err := readyRegistryValue(registry.LOCAL_MACHINE, teleportConnectKeyPath, registryValueInstallLocation)
+	perMachineLocation, err := readRegistryValue(registry.LOCAL_MACHINE, teleportConnectKeyPath, registryValueInstallLocation)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return false, nil
@@ -125,9 +125,9 @@ func isPerMachineInstall() (bool, error) {
 	}
 
 	// tsh is placed in <installation directory>/resources/bin/tsh.exe.
-	exePathImperMachineLocation := filepath.Join(perMachineLocation, "resources", "bin", "tsh.exe")
+	exePathInPerMachineLocation := filepath.Join(perMachineLocation, "resources", "bin", "tsh.exe")
 
-	return exePath == exePathImperMachineLocation, nil
+	return exePath == exePathInPerMachineLocation, nil
 }
 
 type policyValue struct {
@@ -136,12 +136,12 @@ type policyValue struct {
 }
 
 func readRegistryPolicyValues(key registry.Key) (*policyValue, error) {
-	version, err := readyRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueToolsVersion)
+	version, err := readRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueToolsVersion)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
 
-	url, err := readyRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueCDNBaseURL)
+	url, err := readRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueCDNBaseURL)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -152,7 +152,7 @@ func readRegistryPolicyValues(key registry.Key) (*policyValue, error) {
 	}, nil
 }
 
-func readyRegistryValue(hive registry.Key, pathName string, valueName string) (path string, err error) {
+func readRegistryValue(hive registry.Key, pathName string, valueName string) (path string, err error) {
 	key, err := registry.OpenKey(hive, pathName, registry.READ)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotExist) {

--- a/lib/teleterm/autoupdate/service_windows.go
+++ b/lib/teleterm/autoupdate/service_windows.go
@@ -30,9 +30,13 @@ import (
 
 const (
 	// Defined in electron-builder-config.js
-	teleportConnectGUID    = "22539266-67e8-54a3-83b9-dfdca7b33ee1"
-	teleportConnectKeyPath = `SOFTWARE\` + teleportConnectGUID
-	installLocationKey     = "InstallLocation"
+	teleportConnectGUID          = "22539266-67e8-54a3-83b9-dfdca7b33ee1"
+	teleportConnectKeyPath       = `SOFTWARE\` + teleportConnectGUID
+	registryValueInstallLocation = "InstallLocation"
+
+	teleportConnectPoliciesKeyPath = `SOFTWARE\Policies\Teleport\TeleportConnect`
+	registryValueToolsVersion      = "ToolsVersion"
+	registryValueCDNBaseURL        = "CdnBaseUrl"
 )
 
 // GetInstallationMetadata returns installation metadata of the currently running app instance.
@@ -45,8 +49,48 @@ func (s *Service) GetInstallationMetadata(_ context.Context, _ *api.GetInstallat
 	return &api.GetInstallationMetadataResponse{IsPerMachineInstall: perMachine}, nil
 }
 
+// platformGetConfig retrieves the local auto updates configuration.
+func platformGetConfig() (*api.GetConfigResponse, error) {
+	perMachine, err := isPerMachineInstall()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	machineValues, err := readRegistryPolicyValues(registry.LOCAL_MACHINE)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config := &api.GetConfigResponse{
+		CdnBaseUrl:   machineValues.cdnBaseURL,
+		ToolsVersion: machineValues.version,
+	}
+
+	// If per-machine config is fully set, there's no need to check if there are values in the per-user hive.
+	perMachineConfigFullySet := machineValues.cdnBaseURL != "" && machineValues.version != ""
+
+	if perMachine || perMachineConfigFullySet {
+		return config, nil
+	}
+
+	userValues, err := readRegistryPolicyValues(registry.CURRENT_USER)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if machineValues.cdnBaseURL == "" {
+		config.CdnBaseUrl = userValues.cdnBaseURL
+	}
+
+	if machineValues.version == "" {
+		config.ToolsVersion = userValues.version
+	}
+
+	return config, nil
+}
+
 func isPerMachineInstall() (bool, error) {
-	perMachineLocation, err := readPerMachineInstallLocation()
+	perMachineLocation, err := readyRegistryValue(registry.LOCAL_MACHINE, teleportConnectKeyPath, registryValueInstallLocation)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			return false, nil
@@ -65,24 +109,49 @@ func isPerMachineInstall() (bool, error) {
 	return exePath == exePathImperMachineLocation, nil
 }
 
-func readPerMachineInstallLocation() (path string, err error) {
-	key, err := registry.OpenKey(registry.LOCAL_MACHINE, teleportConnectKeyPath, registry.READ)
+type policyValue struct {
+	cdnBaseURL string
+	version    string
+}
+
+func readRegistryPolicyValues(key registry.Key) (*policyValue, error) {
+	version, err := readyRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueToolsVersion)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	url, err := readyRegistryValue(key, teleportConnectPoliciesKeyPath, registryValueCDNBaseURL)
+	if err != nil && !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	return &policyValue{
+		cdnBaseURL: url,
+		version:    version,
+	}, nil
+}
+
+func readyRegistryValue(hive registry.Key, pathName string, valueName string) (path string, err error) {
+	key, err := registry.OpenKey(hive, pathName, registry.READ)
 	if err != nil {
 		if errors.Is(err, registry.ErrNotExist) {
-			return "", trace.NotFound("registry key %s not found", teleportConnectKeyPath)
+			return "", trace.NotFound("registry key %s not found", pathName)
 		}
-		return "", trace.Wrap(err, "opening registry key %s", teleportConnectKeyPath)
+		return "", trace.Wrap(err, "opening registry key %s", pathName)
 	}
 
 	defer func() {
 		if closeErr := key.Close(); closeErr != nil && err == nil {
-			err = trace.Wrap(closeErr, "closing registry key %s", teleportConnectKeyPath)
+			err = trace.Wrap(closeErr, "closing registry key %s", pathName)
 		}
 	}()
 
-	path, _, err = key.GetStringValue(installLocationKey)
+	path, _, err = key.GetStringValue(valueName)
 	if err != nil {
-		return "", trace.Wrap(err, "reading registry value %s from %s", installLocationKey, teleportConnectKeyPath)
+		if errors.Is(err, registry.ErrNotExist) {
+			return "", trace.NotFound("registry value %s not found in %s", valueName, pathName)
+		}
+		return "", trace.Wrap(err, "reading registry value %s from %s", valueName, pathName)
 	}
 
 	return path, nil

--- a/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
+++ b/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
@@ -100,12 +100,12 @@ message ConfigValue {
 // Source of the config.
 enum ConfigSource {
   CONFIG_SOURCE_UNSPECIFIED = 0;
-  // Configuration comes from environment variable.
-  CONFIG_SOURCE_ENV_VAR = 2;
+  // Configuration comes from an environment variable.
+  CONFIG_SOURCE_ENV_VAR = 1;
   // Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
-  CONFIG_SOURCE_POLICY = 3;
-  // Configuration comes from hardcoded default.
-  CONFIG_SOURCE_DEFAULT = 4;
+  CONFIG_SOURCE_POLICY = 2;
+  // Configuration comes from a hardcoded default.
+  CONFIG_SOURCE_DEFAULT = 3;
 }
 
 // Request for GetInstallationMetadata.

--- a/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
+++ b/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
@@ -24,10 +24,11 @@ option go_package = "github.com/gravitational/teleport/gen/proto/go/teleport/lib
 service AutoUpdateService {
   // GetClusterVersions returns client tools versions for all clusters.
   rpc GetClusterVersions(GetClusterVersionsRequest) returns (GetClusterVersionsResponse);
-  // GetDownloadBaseUrl returns a base URL (e.g. cdn.teleport.dev) for downloading packages.
-  // Can be overridden with TELEPORT_CDN_BASE_URL env var.
-  // OSS builds require this env var to be set, otherwise an error is returned.
-  rpc GetDownloadBaseUrl(GetDownloadBaseUrlRequest) returns (GetDownloadBaseUrlResponse);
+  // GetConfigRequest retrieves the local auto updates configuration.
+  // It resolves settings using platform-specific mechanisms:
+  // * macOS/Linux: Environment variables.
+  // * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+  rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
   // GetInstallationMetadata returns installation metadata of the currently running app instance.
   // Implemented only on Windows.
   rpc GetInstallationMetadata(GetInstallationMetadataRequest) returns (GetInstallationMetadataResponse);
@@ -62,12 +63,28 @@ message UnreachableCluster {
   string error_message = 2;
 }
 
-// Request for GetDownloadBaseUrl.
-message GetDownloadBaseUrlRequest {}
+// Request for GetConfig.
+message GetConfigRequest {}
 
-// Response for GetDownloadBaseUrl.
-message GetDownloadBaseUrlResponse {
-  string base_url = 1;
+// Response for GetConfig.
+message GetConfigResponse {
+  // A base URL (e.g. cdn.teleport.dev) for downloading packages.
+  // Sources resolved by platform:
+  // * macOS/Linux: The `TELEPORT_CDN_BASE_URL` environment variable.
+  // * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+  //   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+  //   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+  //
+  // Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
+  string cdn_base_url = 1;
+
+  // The specific client tools version to use. The 'off' value disables automatic updates.
+  // Sources resolved by platform:
+  // * macOS/Linux: The `TELEPORT_TOOLS_VERSION` environment variable.
+  // * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
+  //   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
+  //   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+  string tools_version = 2;
 }
 
 // Request for GetInstallationMetadata.

--- a/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
+++ b/proto/teleport/lib/teleterm/auto_update/v1/auto_update_service.proto
@@ -27,7 +27,8 @@ service AutoUpdateService {
   // GetConfigRequest retrieves the local auto updates configuration.
   // It resolves settings using platform-specific mechanisms:
   // * macOS/Linux: Environment variables.
-  // * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes).
+  // * Windows: System Registry policies (respecting per-machine vs. per-user installation scopes),
+  //   with a fallback to the deprecated environment variables when policy values are not set.
   rpc GetConfig(GetConfigRequest) returns (GetConfigResponse);
   // GetInstallationMetadata returns installation metadata of the currently running app instance.
   // Implemented only on Windows.
@@ -74,9 +75,10 @@ message GetConfigResponse {
   // * Windows: The `CdnBaseUrl` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
   //   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
   //   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
+  //   - If policy values are missing, falls back to `TELEPORT_CDN_BASE_URL` (deprecated).
   //
   // Note: OSS builds require this to be set (via env var or registry), otherwise an empty value is returned.
-  string cdn_base_url = 1;
+  ConfigValue cdn_base_url = 1;
 
   // The specific client tools version to use. The 'off' value disables automatic updates.
   // Sources resolved by platform:
@@ -84,7 +86,26 @@ message GetConfigResponse {
   // * Windows: The `ToolsVersion` value in the system registry (SOFTWARE\Policies\Teleport\TeleportConnect).
   //   - HKEY_LOCAL_MACHINE (Machine Policy): Takes precedence over user policies.
   //   - HKEY_CURRENT_USER (User Policy): Used only for per-user installations if no machine policy is defined.
-  string tools_version = 2;
+  //   - If policy values are missing, falls back to `TELEPORT_TOOLS_VERSION` (deprecated).
+  ConfigValue tools_version = 2;
+}
+
+// Contains the config value and its source.
+message ConfigValue {
+  string value = 1;
+  // Source of the config.
+  ConfigSource source = 2;
+}
+
+// Source of the config.
+enum ConfigSource {
+  CONFIG_SOURCE_UNSPECIFIED = 0;
+  // Configuration comes from environment variable.
+  CONFIG_SOURCE_ENV_VAR = 2;
+  // Configuration comes from SOFTWARE\Policies\Teleport\TeleportConnect.
+  CONFIG_SOURCE_POLICY = 3;
+  // Configuration comes from hardcoded default.
+  CONFIG_SOURCE_DEFAULT = 4;
 }
 
 // Request for GetInstallationMetadata.

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -52,11 +52,7 @@ import {
   TSH_AUTOUPDATE_ENV_VAR,
   TSH_AUTOUPDATE_OFF,
 } from 'teleterm/node/tshAutoupdate';
-import {
-  AppUpdater,
-  AppUpdaterStorage,
-  TELEPORT_TOOLS_VERSION_ENV_VAR,
-} from 'teleterm/services/appUpdater';
+import { AppUpdater, AppUpdaterStorage } from 'teleterm/services/appUpdater';
 import { subscribeToFileStorageEvents } from 'teleterm/services/fileStorage';
 import * as grpcCreds from 'teleterm/services/grpcCredentials';
 import {
@@ -196,10 +192,10 @@ export default class MainProcess {
     this.appUpdater = new AppUpdater(
       makeAppUpdaterStorage(this.appStateFileStorage),
       {
-        getDownloadBaseUrl: async () => {
+        getConfig: async () => {
           const { autoUpdateService } = await this.tshdClients;
-          const { response } = await autoUpdateService.getDownloadBaseUrl({});
-          return response.baseUrl;
+          const { response } = await autoUpdateService.getConfig({});
+          return response;
         },
         getClusterVersions: async () => {
           const { autoUpdateService } = await this.tshdClients;
@@ -221,8 +217,7 @@ export default class MainProcess {
         this.windowsManager
           .getWindow()
           .webContents.send(RendererIpc.AppUpdateEvent, event);
-      },
-      process.env[TELEPORT_TOOLS_VERSION_ENV_VAR]
+      }
     );
     this.clusterStore = new ClusterStore(
       () => this.tshdClients.then(c => c.terminalService),

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -290,6 +290,7 @@ export default class MainProcess {
           ...process.env,
           TELEPORT_HOME: this.configService.get('tshHome').value,
           [TSH_AUTOUPDATE_ENV_VAR]: TSH_AUTOUPDATE_OFF,
+          FORWARDED_TELEPORT_TOOLS_VERSION: process.env[TSH_AUTOUPDATE_ENV_VAR],
         },
       }
     );

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.test.ts
@@ -100,7 +100,7 @@ class MockedMacUpdater extends MacUpdater {
 function setUpAppUpdater(options: {
   clusters: GetClusterVersionsResponse;
   storage?: AppUpdaterStorage;
-  processEnvVar?: string;
+  configToolsVersion?: string;
 }) {
   const nativeUpdater = new MockedMacUpdater();
 
@@ -111,13 +111,15 @@ function setUpAppUpdater(options: {
     options.storage || makeUpdaterStorage(),
     {
       getClusterVersions: async () => options.clusters,
-      getDownloadBaseUrl: async () => 'https://cdn.teleport.dev',
+      getConfig: async () => ({
+        cdnBaseUrl: 'https://cdn.teleport.dev',
+        toolsVersion: options.configToolsVersion,
+      }),
       getInstallationMetadata: async () => ({ isPerMachineInstall: false }),
     },
     event => {
       lastEvent.value = event;
     },
-    options.processEnvVar,
     nativeUpdater
   );
 
@@ -192,9 +194,9 @@ test('does not auto-download update when there are unreachable clusters', async 
   expect(setup.downloadUpdateSpy).toHaveBeenCalledTimes(0);
 });
 
-test('does not auto-download update when env var is set to off', async () => {
+test('does not auto-download update when local config tools version is set to off', async () => {
   const setup = setUpAppUpdater({
-    processEnvVar: 'off',
+    configToolsVersion: 'off',
     clusters: {
       reachableClusters: [
         {
@@ -213,7 +215,7 @@ test('does not auto-download update when env var is set to off', async () => {
     expect.objectContaining({
       kind: 'update-not-available',
       autoUpdatesStatus: expect.objectContaining({
-        reason: 'disabled-by-env-var',
+        reason: 'disabled-by-env-config',
       }),
     })
   );

--- a/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
+++ b/web/packages/teleterm/src/services/appUpdater/appUpdater.ts
@@ -88,9 +88,10 @@ export class AppUpdater {
     const getClientToolsVersion: ClientToolsVersionGetter = async () => {
       const config = await this.client.getConfig();
 
+      const cdnBaseUrl = config.cdnBaseUrl?.value || '';
       await this.refreshAutoUpdatesStatus({
-        toolsVersion: config.toolsVersion.value,
-        cdnBaseUrl: config.cdnBaseUrl.value,
+        toolsVersion: config.toolsVersion?.value || '',
+        cdnBaseUrl,
       });
 
       if (this.autoUpdatesStatus.enabled) {
@@ -107,13 +108,13 @@ export class AppUpdater {
 
         if (isPerMachineInstall) {
           this.nsisUpdaterSettings.privilegedUpdaterCannotBeUsed =
-            config.toolsVersion.source === ConfigSource.ENV_VAR ||
-            config.cdnBaseUrl.source === ConfigSource.ENV_VAR;
+            config.toolsVersion?.source === ConfigSource.ENV_VAR ||
+            config.cdnBaseUrl?.source === ConfigSource.ENV_VAR;
         }
 
         return {
           version: this.autoUpdatesStatus.version,
-          baseUrl: config.cdnBaseUrl.value,
+          baseUrl: cdnBaseUrl,
           isPerMachineInstall,
         };
       }

--- a/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
+++ b/web/packages/teleterm/src/services/appUpdater/autoUpdatesStatus.test.ts
@@ -30,19 +30,23 @@ beforeAll(() => {
   Logger.init(new NullService());
 });
 
+const cdnBaseUrl = 'https://cdn.teleport.dev';
+
 test.each<{
   title: string;
   input: {
-    versionEnvVar: string;
+    configToolsVersion: string;
+    cdnBaseUrl: string;
     managingClusterUri: string;
     getClusterVersions: () => Promise<GetClusterVersionsResponse>;
   };
   expected: AutoUpdatesStatus;
 }>([
   {
-    title: 'disabled when env var is "off"',
+    title: 'disabled when tools version is "off"',
     input: {
-      versionEnvVar: 'off',
+      configToolsVersion: 'off',
+      cdnBaseUrl: '',
       managingClusterUri: '',
       getClusterVersions: async () => ({
         reachableClusters: [],
@@ -51,7 +55,7 @@ test.each<{
     },
     expected: {
       enabled: false,
-      reason: 'disabled-by-env-var',
+      reason: 'disabled-by-env-config',
       options: {
         managingClusterUri: '',
         highestCompatibleVersion: '',
@@ -61,9 +65,32 @@ test.each<{
     },
   },
   {
-    title: 'resolving with env var when set to version',
+    title: 'disabled when there is no download base URL defined',
     input: {
-      versionEnvVar: '14.0.0',
+      cdnBaseUrl: '',
+      configToolsVersion: '',
+      managingClusterUri: '',
+      getClusterVersions: async () => ({
+        reachableClusters: [],
+        unreachableClusters: [],
+      }),
+    },
+    expected: {
+      enabled: false,
+      reason: 'no-base-url',
+      options: {
+        managingClusterUri: '',
+        highestCompatibleVersion: '',
+        unreachableClusters: [],
+        clusters: [],
+      },
+    },
+  },
+  {
+    title: 'resolving with tools version when set to version',
+    input: {
+      cdnBaseUrl,
+      configToolsVersion: '14.0.0',
       managingClusterUri: '',
       getClusterVersions: async () => ({
         reachableClusters: [],
@@ -73,7 +100,7 @@ test.each<{
     expected: {
       enabled: true,
       version: '14.0.0',
-      source: 'env-var',
+      source: 'env-config',
       options: {
         managingClusterUri: '',
         highestCompatibleVersion: '',
@@ -85,7 +112,8 @@ test.each<{
   {
     title: 'disabled when no versions with auto-update enabled',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       managingClusterUri: undefined,
       getClusterVersions: async () => ({
         reachableClusters: [
@@ -121,7 +149,8 @@ test.each<{
   {
     title: 'resolving with managing cluster if specified',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -159,7 +188,8 @@ test.each<{
     title:
       'resolving using most compatible version when clusters are on the same version',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -210,7 +240,8 @@ test.each<{
     title:
       'resolving using most compatible version when clusters are on the same major version',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -261,7 +292,8 @@ test.each<{
     title:
       'resolving to stable version when both stable and pre-release are available',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -312,7 +344,8 @@ test.each<{
     title:
       'resolving using most compatible version when clusters are on different major version',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -363,7 +396,8 @@ test.each<{
     title:
       'disabled when cluster managing updates no longer has `toolsAutoUpdate` set to true',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -412,7 +446,8 @@ test.each<{
   {
     title: 'disabled when cluster managing updates is unreachable',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {
@@ -459,7 +494,8 @@ test.each<{
     title:
       'resolving with no compatible version when clusters are on incompatibles versions',
     input: {
-      versionEnvVar: '',
+      cdnBaseUrl,
+      configToolsVersion: '',
       getClusterVersions: async () => ({
         reachableClusters: [
           {

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -17,6 +17,7 @@
  */
 
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+import { ConfigSource } from 'gen-proto-ts/teleport/lib/teleterm/auto_update/v1/auto_update_service_pb';
 import { ClientVersionStatus } from 'gen-proto-ts/teleport/lib/teleterm/v1/auth_settings_pb';
 
 import {
@@ -148,7 +149,11 @@ export class MockAutoUpdateClient implements AutoUpdateClient {
       reachableClusters: [],
       unreachableClusters: [],
     });
-  getConfig = () => new MockedUnaryCall({ cdnBaseUrl: '', toolsVersion: '' });
+  getConfig = () =>
+    new MockedUnaryCall({
+      cdnBaseUrl: { value: '', source: ConfigSource.UNSPECIFIED },
+      toolsVersion: { value: '', source: ConfigSource.UNSPECIFIED },
+    });
   getInstallationMetadata = () =>
     new MockedUnaryCall({ isPerMachineInstall: false });
 }

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -148,7 +148,7 @@ export class MockAutoUpdateClient implements AutoUpdateClient {
       reachableClusters: [],
       unreachableClusters: [],
     });
-  getDownloadBaseUrl = () => new MockedUnaryCall({ baseUrl: '' });
+  getConfig = () => new MockedUnaryCall({ cdnBaseUrl: '', toolsVersion: '' });
   getInstallationMetadata = () =>
     new MockedUnaryCall({ isPerMachineInstall: false });
 }

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -52,7 +52,7 @@ export interface StoryProps {
     | 'Error'
     | 'Update downloaded';
   updateSource: string;
-  envVar: 'Set to "off"' | 'Set to version - v15' | 'Unset';
+  configToolsVersion: 'Set to "off"' | 'Set to version - v15' | 'Unset';
   platform: Platform;
   clusterFoo:
     | 'Does not exist'
@@ -68,17 +68,18 @@ export interface StoryProps {
     | 'Disabled client updates - v17 cluster';
   clusterBarSetToManageUpdates: boolean;
   updateKind: 'Upgrade' | 'Downgrade';
-  nonTeleportCdn: boolean;
+  cdnBaseUrl: 'Unset (OSS build)' | 'Official' | 'Non-official';
 }
 
 const meta: Meta<StoryProps> = {
   title: 'Teleterm/AppUpdater',
   component: WidgetAndDetails,
   argTypes: {
-    envVar: {
+    configToolsVersion: {
       control: { type: 'radio' },
       options: ['Off', 'Set to version - v15', 'Unset'],
-      description: '`TELEPORT_TOOLS_VERSION` value',
+      description:
+        'Tools version from the local config (env var/system registry value)',
     },
     clusterFoo: {
       control: { type: 'select' },
@@ -129,21 +130,21 @@ const meta: Meta<StoryProps> = {
       options: ['win32', 'darwin', 'linux'],
       description: 'Operating system',
     },
-    nonTeleportCdn: {
-      control: { type: 'boolean' },
-      description:
-        'Whether `TELEPORT_CDN_BASE_URL` is set to non-Teleport CDN URL',
+    cdnBaseUrl: {
+      control: { type: 'radio' },
+      description: 'CDN Base URL',
+      options: ['Unset (OSS build)', 'Official', 'Non-official'],
     },
   },
   args: {
-    envVar: 'Unset',
+    configToolsVersion: 'Unset',
     clusterFoo: 'Enabled client updates - v18 cluster',
     clusterBar: 'Does not exist',
     clusterBarSetToManageUpdates: false,
     updateKind: 'Upgrade',
     step: 'Update available',
     platform: 'darwin',
-    nonTeleportCdn: false,
+    cdnBaseUrl: 'Official',
   },
 };
 
@@ -155,10 +156,16 @@ context.addRootCluster(makeRootCluster({ uri: '/clusters/bar', name: 'bar' }));
 
 async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
   const status = await resolveAutoUpdatesStatus({
-    versionEnvVar:
-      storyProps.envVar === 'Set to version - v15'
+    cdnBaseUrl:
+      storyProps.cdnBaseUrl === 'Unset (OSS build)'
+        ? ''
+        : storyProps.cdnBaseUrl === 'Official'
+          ? 'https://cdn.teleport.dev'
+          : 'https://custom-hosting.local',
+    configToolsVersion:
+      storyProps.configToolsVersion === 'Set to version - v15'
         ? '15.0.0'
-        : storyProps.envVar === 'Unset'
+        : storyProps.configToolsVersion === 'Unset'
           ? undefined
           : 'off',
     managingClusterUri: storyProps.clusterBarSetToManageUpdates
@@ -242,8 +249,9 @@ async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
     },
   });
 
+  const nonTeleportCdn = storyProps.cdnBaseUrl === 'Non-official';
   const updateInfo = makeUpdateInfo(
-    storyProps.nonTeleportCdn,
+    nonTeleportCdn,
     status.enabled ? status.version : '',
     storyProps.updateKind === 'Upgrade' ? 'upgrade' : 'downgrade'
   );
@@ -340,9 +348,9 @@ function WidgetAndDetails(storyProps: StoryProps) {
   );
 }
 
-export const EnabledWithEnvVar: StoryObj<StoryProps> = {
+export const EnabledWithLocalConfigToolsVersion: StoryObj<StoryProps> = {
   args: {
-    envVar: 'Set to version - v15',
+    configToolsVersion: 'Set to version - v15',
   },
 };
 
@@ -428,3 +436,9 @@ export const DisabledBecauseClustersRequireIncompatibleVersions: StoryObj<StoryP
       step: 'Update not available',
     },
   };
+
+export const DisabledNoCdnBaseUrl: StoryObj<StoryProps> = {
+  args: {
+    cdnBaseUrl: 'Unset (OSS build)',
+  },
+};

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -69,6 +69,7 @@ export interface StoryProps {
   clusterBarSetToManageUpdates: boolean;
   updateKind: 'Upgrade' | 'Downgrade';
   cdnBaseUrl: 'Unset (OSS build)' | 'Official' | 'Non-official';
+  updateRequiresUacPrompt: boolean;
 }
 
 const meta: Meta<StoryProps> = {
@@ -135,6 +136,11 @@ const meta: Meta<StoryProps> = {
       description: 'CDN Base URL',
       options: ['Unset (OSS build)', 'Official', 'Non-official'],
     },
+    updateRequiresUacPrompt: {
+      control: { type: 'boolean' },
+      description:
+        'Deprecated per‑machine env‑var configuration requires a UAC prompt and prevents use of the privileged updater. Windows only.',
+    },
   },
   args: {
     configToolsVersion: 'Unset',
@@ -145,6 +151,7 @@ const meta: Meta<StoryProps> = {
     step: 'Update available',
     platform: 'darwin',
     cdnBaseUrl: 'Official',
+    updateRequiresUacPrompt: false,
   },
 };
 
@@ -253,8 +260,13 @@ async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
   const updateInfo = makeUpdateInfo(
     nonTeleportCdn,
     status.enabled ? status.version : '',
-    storyProps.updateKind === 'Upgrade' ? 'upgrade' : 'downgrade'
+    storyProps.updateKind === 'Upgrade' ? 'upgrade' : 'downgrade',
+    storyProps.updateRequiresUacPrompt
   );
+
+  if (storyProps.platform !== 'win32' && storyProps.updateRequiresUacPrompt) {
+    return;
+  }
 
   switch (storyProps.step) {
     case 'Checking for update':

--- a/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AppUpdater.story.tsx
@@ -68,7 +68,7 @@ export interface StoryProps {
     | 'Disabled client updates - v17 cluster';
   clusterBarSetToManageUpdates: boolean;
   updateKind: 'Upgrade' | 'Downgrade';
-  cdnBaseUrl: 'Unset (OSS build)' | 'Official' | 'Non-official';
+  cdnBaseUrl: 'Unset (OSS build)' | 'Official' | 'Unofficial';
   updateRequiresUacPrompt: boolean;
 }
 
@@ -134,7 +134,7 @@ const meta: Meta<StoryProps> = {
     cdnBaseUrl: {
       control: { type: 'radio' },
       description: 'CDN Base URL',
-      options: ['Unset (OSS build)', 'Official', 'Non-official'],
+      options: ['Unset (OSS build)', 'Official', 'Unofficial'],
     },
     updateRequiresUacPrompt: {
       control: { type: 'boolean' },
@@ -256,7 +256,7 @@ async function resolveEvent(storyProps: StoryProps): Promise<AppUpdateEvent> {
     },
   });
 
-  const nonTeleportCdn = storyProps.cdnBaseUrl === 'Non-official';
+  const nonTeleportCdn = storyProps.cdnBaseUrl === 'Unofficial';
   const updateInfo = makeUpdateInfo(
     nonTeleportCdn,
     status.enabled ? status.version : '',

--- a/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
@@ -26,6 +26,7 @@ import { RadioGroup } from 'design/RadioGroup';
 import { H3, P3 } from 'design/Text';
 import { pluralize } from 'shared/utils/text';
 
+import type { Platform } from 'teleterm/mainProcess/types';
 import {
   AppUpdateEvent,
   AutoUpdatesDisabled,
@@ -40,6 +41,7 @@ const listFormatter = new Intl.ListFormat('en', {
 });
 
 export function AutoUpdatesManagement(props: {
+  platform: Platform;
   status: AutoUpdatesStatus;
   updateEventKind: AppUpdateEvent['kind'];
   changeManagingCluster(clusterUri: RootClusterUri | undefined): void;
@@ -50,7 +52,7 @@ export function AutoUpdatesManagement(props: {
   const content =
     status.enabled === true
       ? makeContentForEnabledAutoUpdates(status)
-      : makeContentForDisabledAutoUpdates(status);
+      : makeContentForDisabledAutoUpdates(status, props.platform);
   const retryButton = {
     content: 'Retry',
     onClick: props.onCheckForUpdates,
@@ -284,7 +286,7 @@ function makeContentForEnabledAutoUpdates(status: AutoUpdatesEnabled): {
   showRetry?: boolean;
 } {
   switch (status.source) {
-    case 'env-var':
+    case 'env-config':
       return {
         kind: 'neutral',
         description: `The app is set to stay on version ${status.version} by your device settings.`,
@@ -308,14 +310,41 @@ function makeContentForEnabledAutoUpdates(status: AutoUpdatesEnabled): {
   }
 }
 
-function makeContentForDisabledAutoUpdates(updateSource: AutoUpdatesDisabled): {
+function makeContentForDisabledAutoUpdates(
+  updateSource: AutoUpdatesDisabled,
+  platform: Platform
+): {
   title?: string;
   description?: ReactNode;
   kind: 'danger' | 'neutral';
   showRetry?: boolean;
 } {
   switch (updateSource.reason) {
-    case 'disabled-by-env-var':
+    case 'no-base-url':
+      return {
+        kind: 'danger',
+        description: (
+          <>
+            Client tools updates are disabled because the download base URL is
+            not configured. To use Community Edition builds or custom binaries,
+            set{' '}
+            {platform === 'win32' ? (
+              <>
+                <code>CdnBaseUrl</code> in{' '}
+                <code>
+                  HKEY_LOCAL_MACHINE|HKEY_CURRENT_USER\SOFTWARE\Policies\Teleport\TeleportConnect
+                </code>{' '}
+                in the system registry.
+              </>
+            ) : (
+              <>
+                the <code>TELEPORT_CDN_BASE_URL</code> environment variable.
+              </>
+            )}
+          </>
+        ),
+      };
+    case 'disabled-by-env-config':
       return {
         kind: 'neutral',
         description: 'App updates are disabled by your device settings.',

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -73,6 +73,7 @@ export function DetailsView({
     <Stack gap={3} width="100%">
       {updateEvent.autoUpdatesStatus && (
         <AutoUpdatesManagement
+          platform={platform}
           status={updateEvent.autoUpdatesStatus}
           updateEventKind={updateEvent.kind}
           onCheckForUpdates={onCheckForUpdates}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -272,6 +272,7 @@ function AvailableUpdate(props: { update: UpdateInfo; platform: Platform }) {
               without requiring UAC prompts, migrate these settings to the
               system policy registry keys:{' '}
               <code>HKLM\SOFTWARE\Policies\Teleport\TeleportConnect</code>.
+              {/*TODO(gzdunek): Link to docs.*/}
             </Text>
           </Flex>
         )}

--- a/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/DetailsView.tsx
@@ -261,6 +261,21 @@ function AvailableUpdate(props: { update: UpdateInfo; platform: Platform }) {
           </Flex>
         )}
       </P3>
+      <P3 m={0} color="text.slightlyMuted">
+        {props.update.requiresUacPrompt && (
+          <Flex gap={1} mt={1}>
+            <Info size="small" />
+            <Text>
+              Teleport Connect updates are currently configured using deprecated
+              environment variables (<code>TELEPORT_TOOLS_VERSION</code> or{' '}
+              <code>TELEPORT_CDN_BASE_URL</code>). To continue receiving updates
+              without requiring UAC prompts, migrate these settings to the
+              system policy registry keys:{' '}
+              <code>HKLM\SOFTWARE\Policies\Teleport\TeleportConnect</code>.
+            </Text>
+          </Flex>
+        )}
+      </P3>
     </Stack>
   );
 }

--- a/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/WidgetView.tsx
@@ -137,11 +137,13 @@ export function WidgetView({
       ? updateEvent.autoUpdatesStatus.options.unreachableClusters
       : [];
   const downloadBaseUrl = getDownloadHost(updateEvent);
+  const requiresUacPrompt = updateEvent.update.requiresUacPrompt;
 
   return (
     <AvailableUpdate
       version={updateEvent.update.version}
       platform={platform}
+      requiresUacPrompt={requiresUacPrompt}
       description={description}
       unreachableClusters={unreachableClusters}
       downloadHost={downloadBaseUrl}
@@ -159,6 +161,7 @@ function AvailableUpdate({
   downloadHost,
   onMore,
   platform,
+  requiresUacPrompt,
   primaryButton,
   unreachableClusters,
   version,
@@ -169,6 +172,7 @@ function AvailableUpdate({
   unreachableClusters: UnreachableCluster[];
   downloadHost: string;
   platform: Platform;
+  requiresUacPrompt: boolean;
   onMore(): void;
   primaryButton?: {
     name: string;
@@ -221,7 +225,7 @@ function AvailableUpdate({
           </ButtonSecondary>
         </Flex>
       </Flex>
-      {(hasUnreachableClusters || isNonTeleportServer) && (
+      {(hasUnreachableClusters || isNonTeleportServer || requiresUacPrompt) && (
         <Stack ml={1}>
           {hasUnreachableClusters && (
             <IconAndText
@@ -233,6 +237,12 @@ function AvailableUpdate({
             <IconAndText
               Icon={Info}
               text={`Using ${downloadHost} as the update server.`}
+            />
+          )}
+          {requiresUacPrompt && (
+            <IconAndText
+              Icon={Info}
+              text="Update your configuration to enable UAC-free updates."
             />
           )}
         </Stack>

--- a/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
+++ b/web/packages/teleterm/src/ui/AppUpdater/testHelpers.ts
@@ -27,7 +27,8 @@ import { shouldAutoDownload } from 'teleterm/services/appUpdater/autoUpdatesStat
 export function makeUpdateInfo(
   nonTeleportCdn: boolean,
   version: string,
-  updateKind: 'upgrade' | 'downgrade'
+  updateKind: 'upgrade' | 'downgrade',
+  requiresUacPrompt?: boolean
 ): UpdateInfo {
   return {
     files: [
@@ -39,6 +40,7 @@ export function makeUpdateInfo(
         size: 123214312,
       },
     ],
+    requiresUacPrompt,
     releaseDate: '',
     updateKind,
     version,

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/storyHelpers.tsx
@@ -137,6 +137,7 @@ export function makeProps(
         path: '',
         releaseDate: '',
         sha512: '',
+        requiresUacPrompt: false,
       },
       autoDownload: true,
       autoUpdatesStatus: {


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/59295
RFD https://github.com/gravitational/teleport/pull/62545

This PR moves Windows configuration from the `TELEPORT_CDN_BASE_URL` and `TELEPORT_TOOLS_VERSION` environment variables to registry policies:
* `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Teleport\TeleportConnect` (Machine Policy): Takes precedence over any user-level policy.
* `HKEY_CURRENT_USER\SOFTWARE\Policies\Teleport\TeleportConnect` (User Policy): Applies only to per-user installations when no machine policy is defined. Ignored in per-machine installations.

> [!NOTE]
>The registry keys differ slightly from what was described in the RFD. Previously, the path was `Policies\TeleportConnect`, but it is now `Policies\Teleport\TeleportConnect`. I made this adjustment because registry policies are typically structured as `<company-name>\<app-name>`. 

To do this, I replaced the `GetDownloadBaseUrl` RPC with a new `GetConfig` RPC that returns both the CDN base URL and the tools version. This required some other, minor changes:

* Previously, `GetDownloadBaseUrl` would throw an error in OSS builds when `TELEPORT_CDN_BASE_URL` was not set. Since auto-updates may be disabled in this case (`TELEPORT_TOOLS_VERSION=off`), we should first check whether updates are enabled and only require the CDN base URL if they are. However, since `GetConfig` must return both values together, I chose to return an empty `cdnBaseUrl` and let the client infer the cause (OSS build). This also improves local development: Connect no longer shows an auto-update error when `cdnBaseUrl` is missing, auto-updates are now disabled instead.

* After finishing the implementation, I noticed that `GetConfig` always returned `toolsVersion: 'off'`. This happens because when `tsh` runs as a daemon, auto-updates must be disabled, and we enforce that by launching it with `TELEPORT_TOOLS_VERSION=off`. To work around this (and ensure consistent behavior for `GetConfig` across platforms), I introduced `FORWARDED_TELEPORT_TOOLS_VERSION`, which passes through the real `TELEPORT_TOOLS_VERSION` value to `tsh`.

changelog: The `TELEPORT_CDN_BASE_URL` and `TELEPORT_TOOLS_VERSION` environment variables are deprecated for configuring Teleport Connect automatic updates on Windows. These settings must now be managed via the system policy registry keys under `HKEY_LOCAL_MACHINE` or `HKEY_CURRENT_USER\SOFTWARE\Policies\Teleport\TeleportConnect`. Legacy environment variables will prevent per-machine updates from installing silently.

Docs will be updated in a separate PR.