### PR TITLE
Release 18.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 18.6.5 (01/29/26)
+
+* Fixed a `CredentialContainer` error when attempting to log in to the Web UI with a hardware key using Firefox >=147.0.2. [#63245](https://github.com/gravitational/teleport/pull/63245)
+* Added support for deleting cluster alerts via `tctl alerts rm <alertID>` command. [#63211](https://github.com/gravitational/teleport/pull/63211)
+* Updated OpenSSL to 3.0.19. [#63202](https://github.com/gravitational/teleport/pull/63202)
+* Added support for injecting Teleport-issued ID tokens into outgoing MCP requests, enabling integrations with MCP servers such as the AWS Bedrock AgentCore MCP Gateway that can validate tokens via OIDC discovery URL. [#63156](https://github.com/gravitational/teleport/pull/63156)
+* Export "additional_trusted_keys" when exporting TLS CAs, which includes new certificates generated in the "init" rotation phase. Reflected in "tctl auth export" and the "/webapi/auth/export" endpoint. [#63134](https://github.com/gravitational/teleport/pull/63134)
+* Updated indirect dependency go-chi/chi/v5 (addresses GO-2026-4316). [#63092](https://github.com/gravitational/teleport/pull/63092)
+* The `tbot systemd install` command now supports a `--pid-file` flag for setting the path to the PID file. [#63039](https://github.com/gravitational/teleport/pull/63039)
+* Allow kubeconfig and context to be explicitly configured for `tbot` `kubernetes_secret` destination. [#63037](https://github.com/gravitational/teleport/pull/63037)
+* Implemented "tctl get cert_authority/catype", in addition to the already existing "tctl get cert_authority" and "tctl get cert_authority/catype/domain". [#63027](https://github.com/gravitational/teleport/pull/63027)
+* Added a Terraform module to configure Teleport and AWS for EC2 discovery in an AWS account. [#63004](https://github.com/gravitational/teleport/pull/63004)
+* Added opt-in support to bootstrap the `teleport-plugin-event-handler` helm chart with MWI to auto-join Teleport clusters when Operator is enabled. [#63001](https://github.com/gravitational/teleport/pull/63001)
+* Added permissions to the `editor` role allowing users to view autoupdate agent reports. [#62973](https://github.com/gravitational/teleport/pull/62973)
+* Improved performance of large search queries for DynamoDB event backend. [#62890](https://github.com/gravitational/teleport/pull/62890)
+* Introduced tbot-spiffe-daemon-set helm chart for deploying a Daemon Set of tbot agents which serve SPIFFE SVIDs to Kubernetes pods via the SPIFFE Workload API. [#62583](https://github.com/gravitational/teleport/pull/62583)
+
+Enterprise:
+* Fixed an issue with the legacy Azure OIDC IdP SSO `issuer=sts.windows.net` where Teleport was unable to map Teleport roles from the groups claim available in the `id_token`.
+* Added updated resources to SCIM audit events that create or change SCIM resources.
+* Support multi-arch lock file population for the terraform provider.
+* Added audit events to SCIM PATCH operations.
+* Updated Entra ID plugin to support importing Entra ID group owners as Access List owners.
+* Replaced enterprise downloads list view in Web UI with links to Public Downloads page.
+
 ## 18.6.4 (01/20/26)
 
 * Fixed GCS session recording backend not respecting rate limits. [#62986](https://github.com/gravitational/teleport/pull/62986)
@@ -1175,4 +1200,3 @@ or `alpn-ping` as upgrade types was left as a fallback until v17.
 
 Teleport v18 removes the legacy upgrade mode entirely including the use of the
 `TELEPORT_TLS_ROUTING_CONN_UPGRADE_MODE` environment variable.
-

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=18.6.4
+VERSION=18.6.5
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -2,10 +2,10 @@
 
 package api
 
-const Version = "18.6.4"
+const Version = "18.6.5"
 
 const VersionMajor = 18
 const VersionMinor = 6
-const VersionPatch = 4
+const VersionPatch = 5
 const VersionPreRelease = ""
 const VersionMetadata = ""

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>18.6.4</string>
+		<string>18.6.5</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>18.6.4</string>
+		<string>18.6.5</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>18.6.4</string>
+		<string>18.6.5</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>18.6.4</string>
+		<string>18.6.5</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -392,6 +392,7 @@
     "caddef",
     "canonicalize",
     "categorisation",
+    "catype",
     "cavium",
     "centralus",
     "certificatekey",

--- a/examples/chart/access/datadog/Chart.yaml
+++ b/examples/chart/access/datadog/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,6 +26,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-datadog-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-datadog-18.6.5
       name: RELEASE-NAME-teleport-plugin-datadog

--- a/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/datadog/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-datadog
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-datadog-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-datadog-18.6.5
       name: RELEASE-NAME-teleport-plugin-datadog
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-datadog
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-datadog-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-datadog-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/access/discord/Chart.yaml
+++ b/examples/chart/access/discord/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-discord-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-discord-18.6.5
       name: RELEASE-NAME-teleport-plugin-discord

--- a/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-discord
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-discord-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-discord-18.6.5
       name: RELEASE-NAME-teleport-plugin-discord
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-discord
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-discord-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-discord-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/access/email/Chart.yaml
+++ b/examples/chart/access/email/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/configmap_test.yaml.snap
@@ -26,8 +26,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on):
   1: |
@@ -59,8 +59,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, no starttls):
   1: |
@@ -92,8 +92,8 @@ should match the snapshot (smtp on, no starttls):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, password file):
   1: |
@@ -125,8 +125,8 @@ should match the snapshot (smtp on, password file):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, roleToRecipients set):
   1: |
@@ -161,8 +161,8 @@ should match the snapshot (smtp on, roleToRecipients set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
 should match the snapshot (smtp on, starttls disabled):
   1: |
@@ -194,6 +194,6 @@ should match the snapshot (smtp on, starttls disabled):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email

--- a/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/email/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should be possible to override volume name (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should be possible to override volume name (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -34,7 +34,7 @@ should be possible to override volume name (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -75,8 +75,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -136,8 +136,8 @@ should match the snapshot (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -151,8 +151,8 @@ should match the snapshot (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -163,7 +163,7 @@ should match the snapshot (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -204,8 +204,8 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -219,8 +219,8 @@ should match the snapshot (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -231,7 +231,7 @@ should match the snapshot (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -272,8 +272,8 @@ should mount external secret (mailgun on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -287,8 +287,8 @@ should mount external secret (mailgun on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -299,7 +299,7 @@ should mount external secret (mailgun on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:
@@ -340,8 +340,8 @@ should mount external secret (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-email
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-email-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-email-18.6.5
       name: RELEASE-NAME-teleport-plugin-email
     spec:
       replicas: 1
@@ -355,8 +355,8 @@ should mount external secret (smtp on):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-email
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-email-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-email-18.6.5
         spec:
           containers:
           - command:
@@ -367,7 +367,7 @@ should mount external secret (smtp on):
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-email:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-email
             ports:

--- a/examples/chart/access/jira/Chart.yaml
+++ b/examples/chart/access/jira/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/configmap_test.yaml.snap
@@ -32,6 +32,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-jira-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-jira-18.6.5
       name: RELEASE-NAME-teleport-plugin-jira

--- a/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/jira/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-jira
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-jira-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-jira-18.6.5
       name: RELEASE-NAME-teleport-plugin-jira
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-jira
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-jira-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-jira-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/access/mattermost/Chart.yaml
+++ b/examples/chart/access/mattermost/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/configmap_test.yaml.snap
@@ -22,6 +22,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-mattermost-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-mattermost-18.6.5
       name: RELEASE-NAME-teleport-plugin-mattermost

--- a/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/mattermost/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-mattermost-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-mattermost-18.6.5
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-mattermost-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-mattermost-18.6.5
         spec:
           containers:
           - command:
@@ -75,8 +75,8 @@ should mount external secret:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-mattermost-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-mattermost-18.6.5
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -90,8 +90,8 @@ should mount external secret:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-mattermost-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-mattermost-18.6.5
         spec:
           containers:
           - command:
@@ -102,7 +102,7 @@ should mount external secret:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:
@@ -143,8 +143,8 @@ should override volume name:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-mattermost
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-mattermost-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-mattermost-18.6.5
       name: RELEASE-NAME-teleport-plugin-mattermost
     spec:
       replicas: 1
@@ -158,8 +158,8 @@ should override volume name:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-mattermost
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-mattermost-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-mattermost-18.6.5
         spec:
           containers:
           - command:
@@ -170,7 +170,7 @@ should override volume name:
             env:
             - name: TELEPORT_PLUGIN_FAIL_FAST
               value: "true"
-            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.6.4
+            image: public.ecr.aws/gravitational/teleport-plugin-mattermost:18.6.5
             imagePullPolicy: IfNotPresent
             name: teleport-plugin-mattermost
             ports:

--- a/examples/chart/access/msteams/Chart.yaml
+++ b/examples/chart/access/msteams/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/configmap_test.yaml.snap
@@ -29,6 +29,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-msteams-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-msteams-18.6.5
       name: RELEASE-NAME-teleport-plugin-msteams

--- a/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/msteams/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-msteams
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-msteams-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-msteams-18.6.5
       name: RELEASE-NAME-teleport-plugin-msteams
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-msteams
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-msteams-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-msteams-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/access/pagerduty/Chart.yaml
+++ b/examples/chart/access/pagerduty/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/configmap_test.yaml.snap
@@ -21,6 +21,6 @@ should match the snapshot (smtp on):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-pagerduty-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-pagerduty-18.6.5
       name: RELEASE-NAME-teleport-plugin-pagerduty

--- a/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/pagerduty/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-pagerduty
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-pagerduty-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-pagerduty-18.6.5
       name: RELEASE-NAME-teleport-plugin-pagerduty
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-pagerduty
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-pagerduty-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-pagerduty-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/access/slack/Chart.yaml
+++ b/examples/chart/access/slack/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/configmap_test.yaml.snap
@@ -24,6 +24,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-slack-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-slack-18.6.5
       name: RELEASE-NAME-teleport-plugin-slack

--- a/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/access/slack/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-slack
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-slack-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-slack-18.6.5
       name: RELEASE-NAME-teleport-plugin-slack
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-slack
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-slack-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-slack-18.6.5
         spec:
           containers:
           - command:

--- a/examples/chart/event-handler/Chart.yaml
+++ b/examples/chart/event-handler/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 apiVersion: v2
 name: teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/configmap_test.yaml.snap
@@ -33,6 +33,6 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-event-handler-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-event-handler-18.6.5
       name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/deployment_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-event-handler-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-event-handler-18.6.5
       name: RELEASE-NAME-teleport-plugin-event-handler
     spec:
       replicas: 1
@@ -22,8 +22,8 @@ should match the snapshot:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-plugin-event-handler
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-plugin-event-handler-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-plugin-event-handler-18.6.5
         spec:
           containers:
           - args:
@@ -87,7 +87,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.6.4
+      image: public.ecr.aws/gravitational/teleport-plugin-event-handler:18.6.5
       imagePullPolicy: IfNotPresent
       name: teleport-plugin-event-handler
       ports:

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -7,8 +7,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-event-handler-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-event-handler-18.6.5
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -28,8 +28,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-event-handler-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-event-handler-18.6.5
       name: RELEASE-NAME-teleport-plugin-event-handler
       namespace: NAMESPACE
     spec:
@@ -43,8 +43,8 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-plugin-event-handler
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-plugin-event-handler-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-plugin-event-handler-18.6.5
       name: test-token
       namespace: NAMESPACE
     spec:

--- a/examples/chart/tbot/Chart.yaml
+++ b/examples/chart/tbot/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 name: tbot
 apiVersion: v2

--- a/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/deployment_test.yaml.snap
@@ -29,7 +29,7 @@ should match the snapshot (full):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.6.4
+            helm.sh/chart: tbot-18.6.5
             test-key: test-label-pod
         spec:
           affinity:
@@ -68,7 +68,7 @@ should match the snapshot (full):
               value: "1"
             - name: TEST_ENV
               value: test-value
-            image: public.ecr.aws/gravitational/tbot-distroless:18.6.4
+            image: public.ecr.aws/gravitational/tbot-distroless:18.6.5
             imagePullPolicy: Always
             livenessProbe:
               failureThreshold: 6
@@ -167,7 +167,7 @@ should match the snapshot (simple):
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: tbot
-            helm.sh/chart: tbot-18.6.4
+            helm.sh/chart: tbot-18.6.5
         spec:
           containers:
           - args:
@@ -189,7 +189,7 @@ should match the snapshot (simple):
                   fieldPath: spec.nodeName
             - name: KUBERNETES_TOKEN_PATH
               value: /var/run/secrets/tokens/join-sa-token
-            image: public.ecr.aws/gravitational/tbot-distroless:18.6.4
+            image: public.ecr.aws/gravitational/tbot-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_clusterrole_test.yaml.snap
@@ -8,8 +8,8 @@ adds operator permissions to ClusterRole:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-cluster-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-cluster-18.6.5
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME
     rules:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -2040,8 +2040,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-cluster-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-cluster-18.6.5
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-auth
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -8,7 +8,7 @@
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -159,7 +159,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -277,7 +277,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -381,7 +381,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_config_test.yaml.snap
@@ -567,8 +567,8 @@ sets clusterDomain on Configmap:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-cluster-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-cluster-18.6.5
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -11,8 +11,8 @@ sets clusterDomain on Deployment Pods:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: teleport-cluster
-        app.kubernetes.io/version: 18.6.4
-        helm.sh/chart: teleport-cluster-18.6.4
+        app.kubernetes.io/version: 18.6.5
+        helm.sh/chart: teleport-cluster-18.6.5
         teleport.dev/majorVersion: "18"
       name: RELEASE-NAME-proxy
       namespace: NAMESPACE
@@ -26,7 +26,7 @@ sets clusterDomain on Deployment Pods:
       template:
         metadata:
           annotations:
-            checksum/config: 713ce483f4fc0cca1b8fbd055603f371c745ab6701512da1a6d00386c4c65147
+            checksum/config: 41f1e2a1778cb9faf4c5da667f8bf2c4df3d44a08b66ff869d16f1f7e299bb3c
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -34,8 +34,8 @@ sets clusterDomain on Deployment Pods:
             app.kubernetes.io/instance: RELEASE-NAME
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: teleport-cluster
-            app.kubernetes.io/version: 18.6.4
-            helm.sh/chart: teleport-cluster-18.6.4
+            app.kubernetes.io/version: 18.6.5
+            helm.sh/chart: teleport-cluster-18.6.5
             teleport.dev/majorVersion: "18"
         spec:
           affinity:
@@ -44,7 +44,7 @@ sets clusterDomain on Deployment Pods:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             lifecycle:
               preStop:
@@ -106,7 +106,7 @@ sets clusterDomain on Deployment Pods:
             - wait
             - no-resolve
             - RELEASE-NAME-auth-v17.NAMESPACE.svc.test.com
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             name: wait-auth-update
           serviceAccountName: RELEASE-NAME-proxy
           terminationGracePeriodSeconds: 60
@@ -155,7 +155,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
       resources:
         limits:
@@ -219,7 +219,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -281,7 +281,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -352,7 +352,7 @@ should set resources for wait-auth-update initContainer when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -421,7 +421,7 @@ should set resources for wait-auth-update initContainer when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
       resources:
         limits:
@@ -481,7 +481,7 @@ should set resources when set in values:
       env:
       - name: GOMEMLIMIT
         value: "3865470567"
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -550,7 +550,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
       resources:
         limits:
@@ -607,7 +607,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -676,7 +676,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -733,7 +733,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -802,7 +802,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v17.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -32,7 +32,7 @@ sets Deployment annotations when specified if action is Upgrade:
               value: "true"
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -109,7 +109,7 @@ sets Deployment labels when specified if action is Upgrade:
             value: "true"
           - name: TELEPORT_KUBE_CLUSTER_DOMAIN
             value: cluster.local
-          image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+          image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -173,7 +173,7 @@ sets Pod annotations when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -237,7 +237,7 @@ sets Pod labels when specified if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -322,7 +322,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -387,7 +387,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -451,7 +451,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -513,7 +513,7 @@ should expose diag port if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -589,7 +589,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -665,7 +665,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -729,7 +729,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -793,7 +793,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -862,7 +862,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf an
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -932,7 +932,7 @@ should mount jamfCredentialsSecret.name when role is jamf and action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1004,7 +1004,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1078,7 +1078,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should provision initContainer correctly when set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1270,7 +1270,7 @@ should set affinity when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1334,7 +1334,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1411,7 +1411,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1539,7 +1539,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1603,7 +1603,7 @@ should set nodeSelector if set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1669,7 +1669,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1745,7 +1745,7 @@ should set preferred affinity when more than one replica is used if action is Up
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1809,7 +1809,7 @@ should set priorityClassName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1874,7 +1874,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1948,7 +1948,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2012,7 +2012,7 @@ should set resources when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2083,7 +2083,7 @@ should set serviceAccountName when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2147,7 +2147,7 @@ should set tolerations when set in values if action is Upgrade:
         value: "true"
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -25,7 +25,7 @@ should create ServiceAccount for post-delete hook by default:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -108,7 +108,7 @@ should not create ServiceAccount for post-delete hook if serviceAccount.create i
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             name: post-delete-job
             securityContext:
@@ -138,7 +138,7 @@ should not create ServiceAccount, Role or RoleBinding for post-delete hook if se
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -168,7 +168,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -200,7 +200,7 @@ should set resources in the Job's pod spec if resources is set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -18,7 +18,7 @@ sets Pod annotations when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -104,7 +104,7 @@ sets Pod labels when specified:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -214,7 +214,7 @@ sets StatefulSet labels when specified:
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -332,7 +332,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -418,7 +418,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -524,7 +524,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
               value: RELEASE-NAME
             - name: TELEPORT_KUBE_CLUSTER_DOMAIN
               value: cluster.local
-            image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+            image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -620,7 +620,7 @@ should add volumeMount for data volume when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -706,7 +706,7 @@ should expose diag port:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -792,7 +792,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -892,7 +892,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -990,7 +990,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1076,7 +1076,7 @@ should have one replica when replicaCount is not set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1162,7 +1162,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1250,7 +1250,7 @@ should mount extraVolumes and extraVolumeMounts:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1341,7 +1341,7 @@ should mount jamfCredentialsSecret if it already exists and when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1435,7 +1435,7 @@ should mount jamfCredentialsSecret.name when role is jamf:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1531,7 +1531,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: cluster.local
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1629,7 +1629,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/helm-lint-existing-tls-secret-key-name
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1723,7 +1723,7 @@ should not add emptyDir for data when using StatefulSet:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1811,7 +1811,7 @@ should provision initContainer correctly when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1955,7 +1955,7 @@ should set affinity when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2041,7 +2041,7 @@ should set default serviceAccountName when not set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2140,7 +2140,7 @@ should set environment when extraEnv set in values:
         value: cluster.local
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2312,7 +2312,7 @@ should set imagePullPolicy when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2398,7 +2398,7 @@ should set nodeSelector if set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2498,7 +2498,7 @@ should set preferred affinity when more than one replica is used:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2584,7 +2584,7 @@ should set probeTimeoutSeconds when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2680,7 +2680,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2768,7 +2768,7 @@ should set resources when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2861,7 +2861,7 @@ should set serviceAccountName when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2947,7 +2947,7 @@ should set storage.requests when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3033,7 +3033,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -3119,7 +3119,7 @@ should set tolerations when set in values:
         value: RELEASE-NAME
       - name: TELEPORT_KUBE_CLUSTER_DOMAIN
         value: cluster.local
-      image: public.ecr.aws/gravitational/teleport-distroless:18.6.4
+      image: public.ecr.aws/gravitational/teleport-distroless:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -27,7 +27,7 @@ sets the affinity:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.6.4
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -73,7 +73,7 @@ sets the tolerations:
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --version-channel=custom/preview
-      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.6.4
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:18.6.5
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-relay/Chart.yaml
+++ b/examples/chart/teleport-relay/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "18.6.4"
+.version: &version "18.6.5"
 
 name: teleport-relay
 apiVersion: v2


### PR DESCRIPTION
* Fixed a `CredentialContainer` error when attempting to log in to the Web UI with a hardware key using Firefox >=147.0.2. [#63245](https://github.com/gravitational/teleport/pull/63245)
* Added support for deleting cluster alerts via `tctl alerts rm <alertID>` command. [#63211](https://github.com/gravitational/teleport/pull/63211)
* Updated OpenSSL to 3.0.19. [#63202](https://github.com/gravitational/teleport/pull/63202)
* Added support for injecting Teleport-issued ID tokens into outgoing MCP requests, enabling integrations with MCP servers such as the AWS Bedrock AgentCore MCP Gateway that can validate tokens via OIDC discovery URL. [#63156](https://github.com/gravitational/teleport/pull/63156)
* Export "additional_trusted_keys" when exporting TLS CAs, which includes new certificates generated in the "init" rotation phase. Reflected in "tctl auth export" and the "/webapi/auth/export" endpoint. [#63134](https://github.com/gravitational/teleport/pull/63134)
* Updated indirect dependency go-chi/chi/v5 (addresses GO-2026-4316). [#63092](https://github.com/gravitational/teleport/pull/63092)
* The `tbot systemd install` command now supports a `--pid-file` flag for setting the path to the PID file. [#63039](https://github.com/gravitational/teleport/pull/63039)
* Allow kubeconfig and context to be explicitly configured for `tbot` `kubernetes_secret` destination. [#63037](https://github.com/gravitational/teleport/pull/63037)
* Implemented "tctl get cert_authority/catype", in addition to the already existing "tctl get cert_authority" and "tctl get cert_authority/catype/domain". [#63027](https://github.com/gravitational/teleport/pull/63027)
* Added a Terraform module to configure Teleport and AWS for EC2 discovery in an AWS account. [#63004](https://github.com/gravitational/teleport/pull/63004)
* Added opt-in support to bootstrap the `teleport-plugin-event-handler` helm chart with MWI to auto-join Teleport clusters when Operator is enabled. [#63001](https://github.com/gravitational/teleport/pull/63001)
* Added permissions to the `editor` role allowing users to view autoupdate agent reports. [#62973](https://github.com/gravitational/teleport/pull/62973)
* Improved performance of large search queries for DynamoDB event backend. [#62890](https://github.com/gravitational/teleport/pull/62890)
* Introduced tbot-spiffe-daemon-set helm chart for deploying a Daemon Set of tbot agents which serve SPIFFE SVIDs to Kubernetes pods via the SPIFFE Workload API. [#62583](https://github.com/gravitational/teleport/pull/62583)

Enterprise:
* Fixed an issue with the legacy Azure OIDC IdP SSO `issuer=sts.windows.net` where Teleport was unable to map Teleport roles from the groups claim available in the `id_token`.
* Added updated resources to SCIM audit events that create or change SCIM resources.
* Support multi-arch lock file population for the terraform provider.
* Added audit events to SCIM PATCH operations.
* Updated Entra ID plugin to support importing Entra ID group owners as Access List owners.
* Replaced enterprise downloads list view in Web UI with links to Public Downloads page.