### PR TITLE
[v17] Fix TestConnectorSelection flakiness by refactoring connector selection

### DIFF
--- a/lib/srv/db/sqlserver/connect.go
+++ b/lib/srv/db/sqlserver/connect.go
@@ -55,23 +55,60 @@ type connector struct {
 	DBAuth common.Auth
 
 	kerberos kerberos.ClientProvider
+
+	// Connector creation functions - can be mocked in tests
+	newAzureConnector         func(config msdsn.Config) (*mssql.Connector, error)
+	newSecurityTokenConnector func(config msdsn.Config, tokenProvider func(ctx context.Context) (token string, err error)) (*mssql.Connector, error)
+}
+
+// newConnector creates a new connector with default connector creation functions.
+func newConnector(dbAuth common.Auth, kerbProvider kerberos.ClientProvider) *connector {
+	return &connector{
+		DBAuth:                    dbAuth,
+		kerberos:                  kerbProvider,
+		newAzureConnector:         azuread.NewConnectorFromConfig,
+		newSecurityTokenConnector: mssql.NewSecurityTokenConnector,
+	}
 }
 
 // Connect connects to the target SQL Server with Kerberos authentication.
 func (c *connector) Connect(ctx context.Context, sessionCtx *common.Session, loginPacket *protocol.Login7Packet) (io.ReadWriteCloser, []mssql.Token, error) {
-	host, port, err := net.SplitHostPort(sessionCtx.Database.GetURI())
+	connector, err := c.selectConnector(ctx, sessionCtx, loginPacket)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
+	}
+
+	conn, err := connector.Connect(ctx)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	mssqlConn, ok := conn.(*mssql.Conn)
+	if !ok {
+		return nil, nil, trace.BadParameter("expected *mssql.Conn, got: %T", conn)
+	}
+
+	// Return all login flags returned by the server so that they can be passed
+	// back to the client.
+	return mssqlConn.GetUnderlyingConn(), mssqlConn.GetLoginFlags(), nil
+}
+
+// selectConnector selects the appropriate mssql.Connector based on the database
+// configuration without establishing a connection.
+func (c *connector) selectConnector(ctx context.Context, sessionCtx *common.Session, loginPacket *protocol.Login7Packet) (*mssql.Connector, error) {
+	host, port, err := getHostPort(sessionCtx.Database)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	portI, err := strconv.ParseUint(port, 10, 64)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	tlsConfig, err := c.DBAuth.GetTLSConfig(ctx, sessionCtx.GetExpiry(), sessionCtx.Database, sessionCtx.DatabaseUser)
 	if err != nil {
-		return nil, nil, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Pass all login options from the client to the server.
@@ -92,35 +129,17 @@ func (c *connector) Connect(ctx context.Context, sessionCtx *common.Session, log
 		Protocols:    []string{"tcp"},
 	}
 
-	var connector *mssql.Connector
 	switch {
 	case sessionCtx.Database.IsAzure() && sessionCtx.Database.GetAD().Domain == "":
 		// If the client is connecting to Azure SQL, and no AD configuration is
 		// provided, authenticate using the Azure AD Integrated authentication
 		// method.
-		connector, err = c.getAzureConnector(ctx, sessionCtx, dsnConfig)
+		return c.getAzureConnector(ctx, sessionCtx, dsnConfig)
 	case sessionCtx.Database.GetType() == types.DatabaseTypeRDSProxy:
-		connector, err = c.getAccessTokenConnector(ctx, sessionCtx, dsnConfig)
+		return c.getAccessTokenConnector(ctx, sessionCtx, dsnConfig)
 	default:
-		connector, err = c.getKerberosConnector(ctx, sessionCtx, dsnConfig)
+		return c.getKerberosConnector(ctx, sessionCtx, dsnConfig)
 	}
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	conn, err := connector.Connect(ctx)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
-	mssqlConn, ok := conn.(*mssql.Conn)
-	if !ok {
-		return nil, nil, trace.BadParameter("expected *mssql.Conn, got: %T", conn)
-	}
-
-	// Return all login flags returned by the server so that they can be passed
-	// back to the client.
-	return mssqlConn.GetUnderlyingConn(), mssqlConn.GetLoginFlags(), nil
 }
 
 // getKerberosConnector generates a Kerberos connector using proper Kerberos
@@ -150,7 +169,7 @@ func (c *connector) getAzureConnector(ctx context.Context, sessionCtx *common.Se
 		ResourceIDDSNKey:    managedIdentityID,
 	}
 
-	connector, err := azuread.NewConnectorFromConfig(dsnConfig)
+	connector, err := c.newAzureConnector(dsnConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -161,7 +180,17 @@ func (c *connector) getAzureConnector(ctx context.Context, sessionCtx *common.Se
 // getAccessTokenConnector generates a connector that uses a token to
 // authenticate.
 func (c *connector) getAccessTokenConnector(ctx context.Context, sessionCtx *common.Session, dsnConfig msdsn.Config) (*mssql.Connector, error) {
-	return mssql.NewSecurityTokenConnector(dsnConfig, func(ctx context.Context) (string, error) {
+	return c.newSecurityTokenConnector(dsnConfig, func(ctx context.Context) (string, error) {
 		return c.DBAuth.GetRDSAuthToken(ctx, sessionCtx.Database, sessionCtx.DatabaseUser)
 	})
+}
+
+// getHostPort returns the host and port of the database URI.
+// The URI must specify a port.
+func getHostPort(db types.Database) (string, string, error) {
+	host, port, err := net.SplitHostPort(db.GetURI())
+	if err != nil {
+		return "", "", trace.Wrap(err, "failed to parse database URI")
+	}
+	return host, port, nil
 }

--- a/lib/srv/db/sqlserver/connect_test.go
+++ b/lib/srv/db/sqlserver/connect_test.go
@@ -23,10 +23,11 @@ import (
 	_ "embed"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jcmturner/gokrb5/v8/client"
+	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/microsoft/go-mssqldb/msdsn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -40,18 +41,13 @@ import (
 // selection logic.
 func TestConnectorSelection(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	connector := &connector{
-		DBAuth:   &mockDBAuth{},
-		kerberos: &mockKerberos{},
-	}
 
 	for i, tt := range []struct {
-		desc         string
-		databaseSpec types.DatabaseSpecV3
-		errAssertion require.ErrorAssertionFunc
+		desc                 string
+		databaseSpec         types.DatabaseSpecV3
+		expectAzureConnector bool
+		expectTokenConnector bool
+		errAssertion         require.ErrorAssertionFunc
 	}{
 		{
 			desc: "Non-Azure database",
@@ -61,9 +57,7 @@ func TestConnectorSelection(t *testing.T) {
 			},
 			// When using a non-Azure database, the connector should fail
 			// loading Kerberos credentials.
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.ErrorContains(t, err, unimplementedMessage)
-			},
+			errAssertion: requireKerberosClientError,
 		},
 		{
 			desc: "Azure database with AD configured",
@@ -71,29 +65,23 @@ func TestConnectorSelection(t *testing.T) {
 				Protocol: defaults.ProtocolSQLServer,
 				URI:      "name.database.windows.net:1443",
 				AD: types.AD{
-					// Domain is required for AD authentication.
 					Domain: "EXAMPLE.COM",
 				},
 			},
-			// When using a Azure database with AD configuration, the connector
+			// When using an Azure database with AD configuration, the connector
 			// should fail loading Kerberos credentials.
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.ErrorContains(t, err, unimplementedMessage)
-			},
+			errAssertion: requireKerberosClientError,
 		},
 		{
 			desc: "Azure database without AD configured",
 			databaseSpec: types.DatabaseSpecV3{
 				Protocol: defaults.ProtocolSQLServer,
-				URI:      "random.database.windows.net:1443",
+				URI:      "azure-db.database.windows.net:1443",
 			},
-			// When using a Azure database without AD configuration, the
-			// connector should fail because it could not connect to the
-			// database.
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "unable to open tcp connection with host")
-			},
+			// When using an Azure database without AD configuration, the
+			// connector should succeed in selecting the Azure connector.
+			expectAzureConnector: true,
+			errAssertion:         require.NoError,
 		},
 		{
 			desc: "RDS Proxied database",
@@ -106,38 +94,38 @@ func TestConnectorSelection(t *testing.T) {
 					},
 				},
 			},
-			// RDS proxies cannot be accessed outside their VPC. So, this test
-			// case should not resolve their host.
-			errAssertion: func(t require.TestingT, err error, _ ...interface{}) {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "no such host")
-			},
+			// When using an RDS proxy database, the connector should succeed
+			// in selecting the access token connector.
+			expectTokenConnector: true,
+			errAssertion:         require.NoError,
 		},
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
+			var azureCalled, tokenCalled bool
+
+			connector := &connector{
+				DBAuth:   &mockDBAuth{},
+				kerberos: &mockKerberos{},
+				newAzureConnector: func(msdsn.Config) (*mssql.Connector, error) {
+					azureCalled = true
+					return &mssql.Connector{}, nil
+				},
+				newSecurityTokenConnector: func(msdsn.Config, func(context.Context) (string, error)) (*mssql.Connector, error) {
+					tokenCalled = true
+					return &mssql.Connector{}, nil
+				},
+			}
+
 			database, err := types.NewDatabaseV3(types.Metadata{
 				Name: fmt.Sprintf("db-%v", i),
 			}, tt.databaseSpec)
 			require.NoError(t, err)
 
-			connectorCtx, cancel := context.WithCancel(ctx)
-			defer cancel()
+			_, err = connector.selectConnector(t.Context(), &common.Session{Database: database}, &protocol.Login7Packet{})
+			tt.errAssertion(t, err)
 
-			resChan := make(chan error, 1)
-			go func() {
-				_, _, err = connector.Connect(connectorCtx, &common.Session{Database: database}, &protocol.Login7Packet{})
-				resChan <- err
-			}()
-
-			// Cancel the context to avoid dialing databases.
-			cancel()
-
-			select {
-			case err := <-resChan:
-				tt.errAssertion(t, err)
-			case <-ctx.Done():
-				require.Fail(t, "timed out waiting for connector to return")
-			}
+			require.Equal(t, tt.expectAzureConnector, azureCalled, "Azure connector call mismatch")
+			require.Equal(t, tt.expectTokenConnector, tokenCalled, "Token connector call mismatch")
 		})
 	}
 }
@@ -148,4 +136,8 @@ const unimplementedMessage = "intentionally left unimplemented"
 
 func (m *mockKerberos) GetKerberosClient(ctx context.Context, ad types.AD, username string) (*client.Client, error) {
 	return nil, trace.BadParameter(unimplementedMessage)
+}
+
+func requireKerberosClientError(t require.TestingT, err error, msgAndArgs ...any) {
+	require.ErrorContains(t, err, unimplementedMessage, msgAndArgs...)
 }

--- a/lib/srv/db/sqlserver/engine.go
+++ b/lib/srv/db/sqlserver/engine.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"io"
 	"net"
+	"runtime/debug"
 
 	"github.com/gravitational/trace"
 
@@ -39,11 +40,7 @@ import (
 func NewEngine(ec common.EngineConfig) common.Engine {
 	return &Engine{
 		EngineConfig: ec,
-		Connector: &connector{
-			DBAuth: ec.Auth,
-
-			kerberos: kerberos.NewClientProvider(ec.AuthClient, ec.Log),
-		},
+		Connector:    newConnector(ec.Auth, kerberos.NewClientProvider(ec.AuthClient, ec.Log)),
 	}
 }
 
@@ -132,7 +129,7 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 func (e *Engine) receiveFromClient(clientConn, serverConn io.ReadWriteCloser, clientErrCh chan<- error, sessionCtx *common.Session) {
 	defer func() {
 		if r := recover(); r != nil {
-			e.Log.ErrorContext(e.Context, "Recovered while handling DB connection", "recover", r)
+			e.Log.WarnContext(e.Context, "Recovered while handling DB connection", "problem", r, "stack", debug.Stack())
 			err := trace.BadParameter("failed to handle client connection")
 			e.SendError(err)
 		}
@@ -167,7 +164,7 @@ func (e *Engine) receiveFromClient(clientConn, serverConn io.ReadWriteCloser, cl
 			sqlPacket, err := e.toSQLPacket(initialPacketHeader, p, &chunkData)
 			switch {
 			case err != nil:
-				e.Log.ErrorContext(e.Context, "Failed to parse SQLServer packet.", "error", err)
+				e.Log.WarnContext(e.Context, "Failed to parse SQLServer packet.", "error", err)
 				e.emitMalformedPacket(e.Context, sessionCtx, p)
 			default:
 				e.auditPacket(e.Context, sessionCtx, sqlPacket)


### PR DESCRIPTION
Backport #63242 to branch/v17

Note: Adapted to use `mssql.NewConnectorConfig` instead of `mssql.NewConnectorConfigCustomAuth` to match v17's older go-mssqldb library version.