### PR TITLE
Slack plugin hardening

### DIFF
--- a/integrations/access/common/auth/token_provider.go
+++ b/integrations/access/common/auth/token_provider.go
@@ -163,8 +163,8 @@ func (r *RotatedAccessTokenProvider) RefreshLoop(ctx context.Context) {
 			creds, err := r.store.GetCredentials(ctx)
 			if err != nil {
 				r.lock.RLock()
-				defer r.lock.RUnlock()
 				r.log.WarnContext(ctx, "Error getting credentials, not attempting to refresh credentials", "error", err, "creds_expiry", r.creds.ExpiresAt)
+				r.lock.RUnlock()
 				// We cannot get the credentials from the backend, something is going on.
 				// If we don't have backend access, or we are in an unknown state, we should not attempt to refresh
 				// credentials. This will lower the probability of ending up in an awkward state where we refreshed the

--- a/integrations/access/common/auth/token_provider.go
+++ b/integrations/access/common/auth/token_provider.go
@@ -165,7 +165,7 @@ func (r *RotatedAccessTokenProvider) RefreshLoop(ctx context.Context) {
 			if err != nil {
 				r.lock.RLock()
 				credsExpiry := r.creds.ExpiresAt
-				r.log.RUnlock()
+				r.lock.RUnlock()
 				r.log.WarnContext(ctx, "Error getting credentials, not attempting to refresh credentials", "error", err, "creds_expiry", credsExpiry)
 				// We cannot get the credentials from the backend, something is going on.
 				// If we don't have backend access, or we are in an unknown state, we should not attempt to refresh

--- a/integrations/access/slack/oauth.go
+++ b/integrations/access/slack/oauth.go
@@ -20,6 +20,7 @@ package slack
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -29,19 +30,25 @@ import (
 	"github.com/gravitational/teleport/integrations/access/common/auth/storage"
 )
 
+const (
+	requestTimeout = 30 * time.Second
+)
+
 // Authorizer implements oauth2.Authorizer for Slack API.
 type Authorizer struct {
 	client *resty.Client
 
 	clientID     string
 	clientSecret string
+	log          *slog.Logger
 }
 
-func newAuthorizer(client *resty.Client, clientID string, clientSecret string) *Authorizer {
+func newAuthorizer(client *resty.Client, clientID string, clientSecret string, log *slog.Logger) *Authorizer {
 	return &Authorizer{
 		client:       client,
 		clientID:     clientID,
 		clientSecret: clientSecret,
+		log:          log,
 	}
 }
 
@@ -49,16 +56,20 @@ func newAuthorizer(client *resty.Client, clientID string, clientSecret string) *
 //
 // clientID is the Client ID for this Slack app as specified by OAuth2.
 // clientSecret is the Client Secret for this Slack app as specified by OAuth2.
-func NewAuthorizer(clientID string, clientSecret string) *Authorizer {
+func NewAuthorizer(clientID string, clientSecret string, log *slog.Logger) *Authorizer {
 	client := makeSlackClient(slackAPIURL)
-	return newAuthorizer(client, clientID, clientSecret)
+	return newAuthorizer(client, clientID, clientSecret, log.With("authorizer", "slack"))
 }
 
 // Exchange implements oauth.Exchanger
 func (a *Authorizer) Exchange(ctx context.Context, authorizationCode string, redirectURI string) (*storage.Credentials, error) {
 	var result AccessResponse
 
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
 	_, err := a.client.R().
+		SetContext(ctx).
 		SetQueryParam("client_id", a.clientID).
 		SetQueryParam("client_secret", a.clientSecret).
 		SetQueryParam("code", authorizationCode).
@@ -67,6 +78,7 @@ func (a *Authorizer) Exchange(ctx context.Context, authorizationCode string, red
 		Post("oauth.v2.access")
 
 	if err != nil {
+		a.log.WarnContext(ctx, "Failed to exchange access token.", "error", err)
 		return nil, trace.Wrap(err)
 	}
 
@@ -84,7 +96,15 @@ func (a *Authorizer) Exchange(ctx context.Context, authorizationCode string, red
 // Refresh implements oauth.Refresher
 func (a *Authorizer) Refresh(ctx context.Context, refreshToken string) (*storage.Credentials, error) {
 	var result AccessResponse
+
+	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	a.log.DebugContext(ctx, "Refreshing access token",
+		"refresh_token", refreshToken,
+		"client_id", a.clientID)
 	_, err := a.client.R().
+		SetContext(ctx).
 		SetQueryParam("client_id", a.clientID).
 		SetQueryParam("client_secret", a.clientSecret).
 		SetQueryParam("grant_type", "refresh_token").
@@ -93,6 +113,7 @@ func (a *Authorizer) Refresh(ctx context.Context, refreshToken string) (*storage
 		Post("oauth.v2.access")
 
 	if err != nil {
+		a.log.WarnContext(ctx, "Failed to refresh access token.", "error", err)
 		return nil, trace.Wrap(err)
 	}
 

--- a/integrations/access/slack/oauth.go
+++ b/integrations/access/slack/oauth.go
@@ -100,9 +100,6 @@ func (a *Authorizer) Refresh(ctx context.Context, refreshToken string) (*storage
 	ctx, cancel := context.WithTimeout(ctx, requestTimeout)
 	defer cancel()
 
-	a.log.DebugContext(ctx, "Refreshing access token",
-		"refresh_token", refreshToken,
-		"client_id", a.clientID)
 	_, err := a.client.R().
 		SetContext(ctx).
 		SetQueryParam("client_id", a.clientID).


### PR DESCRIPTION
This PR improves how we handle issues during Slack token renewal, or renewal during shutdown. It makes sure we try everything possible to finish the renewal. The server can still crash/be ungracefully terminated, but at least we support graceful termination better.

Twin `e` PR: https://github.com/gravitational/teleport.e/pull/7951

This PR does the following changes:
- Do not cancel ongoing refresh
- Better logging in case of error

More context in Slack: 
- https://gravitational.slack.com/archives/C0AB4LP82MA/p1769631950162209?thread_ts=1769631646.667399&cid=C0AB4LP82MA
- https://gravitational.slack.com/archives/C0AB4LP82MA/p1769648282761929?thread_ts=1769647992.734989&cid=C0AB4LP82MA

Changelog: Improved robustness of the Slack hosted plugin to reduce the likeliness of failed token refresh when experiencing external disruption.