### PR TITLE
Improve UX and performance of teleport backend clone

### DIFF
--- a/lib/backend/clone.go
+++ b/lib/backend/clone.go
@@ -27,10 +27,8 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
-
-// bufferSize is the number of backend items that are queried at a time.
-const bufferSize = 10000
 
 // CloneConfig contains the configuration for cloning a [Backend].
 // All items from the source are copied to the destination. All Teleport Auth
@@ -50,17 +48,16 @@ type CloneConfig struct {
 
 // Clone copies all items from a source to a destination [Backend].
 func Clone(ctx context.Context, src, dst Backend, parallel int, force bool) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	log := slog.With(teleport.ComponentKey, "clone")
-	itemC := make(chan Item, bufferSize)
+
 	start := NewKey("")
-	migrated := &atomic.Int32{}
+	cloned, failed := &atomic.Int64{}, &atomic.Int64{}
 
 	if parallel <= 0 {
 		parallel = 1
 	}
-
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	if !force {
 		result, err := dst.GetRange(ctx, start, RangeEnd(start), 1)
@@ -70,105 +67,138 @@ func Clone(ctx context.Context, src, dst Backend, parallel int, force bool) erro
 		if len(result.Items) > 0 {
 			return trace.Errorf("unable to clone data to destination with existing data; this may be overridden by configuring 'force: true'")
 		}
-	} else {
-		log.WarnContext(ctx, "Skipping check for existing data in destination.")
 	}
 
 	group, ctx := errgroup.WithContext(ctx)
-	// Add 1 to ensure a goroutine exists for getting items.
-	group.SetLimit(parallel + 1)
+	group.SetLimit(parallel)
 
-	group.Go(func() error {
-		var result *GetResult
-		pageKey := start
-		defer close(itemC)
-		for {
-			err := retry(ctx, 3, func() error {
-				var err error
-				result, err = src.GetRange(ctx, pageKey, RangeEnd(start), bufferSize)
-				if err != nil {
-					return trace.Wrap(err)
-				}
-				return nil
-			})
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			for _, item := range result.Items {
-				select {
-				case itemC <- item:
-				case <-ctx.Done():
-					return trace.Wrap(ctx.Err())
-				}
-			}
-			if len(result.Items) < bufferSize {
-				return nil
-			}
-			pageKey = RangeEnd(result.Items[len(result.Items)-1].Key)
-		}
-	})
-
-	logProgress := func() {
-		log.InfoContext(ctx, "Backend clone still in progress", "items_copied", migrated.Load())
-	}
-	defer logProgress()
 	go func() {
-		ticker := time.NewTicker(time.Second)
+		ticker := time.NewTicker(250 * time.Millisecond)
 		defer ticker.Stop()
-		select {
-		case <-ticker.C:
-			logProgress()
-		case <-ctx.Done():
-			return
+
+		for {
+			select {
+			case <-ticker.C:
+				log.InfoContext(ctx, "Backend clone in progress", "cloned_items", cloned.Load(), "failed_items", failed.Load())
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 
-	for item := range itemC {
-		group.Go(func() error {
-			if err := retry(ctx, 3, func() error {
-				if _, err := dst.Put(ctx, item); err != nil {
-					return trace.Wrap(err)
-				}
-				return nil
-			}); err != nil {
-				return trace.Wrap(err)
-			}
-			migrated.Add(1)
-			return nil
-		})
-		if err := ctx.Err(); err != nil {
+	const maxAttempts = 3
+	end := RangeEnd(start)
+	for i := range maxAttempts {
+		lastRead, err := cloneItems(ctx, src, dst, start, end, log, cloned, failed, group, maxAttempts)
+		if err == nil {
 			break
 		}
+
+		if i == maxAttempts-1 {
+			log.ErrorContext(ctx, "Cloning backend failed. Encountered too many errors reading from the source backend.",
+				"error", trace.Unwrap(err),
+				"cloned_items", cloned.Load(),
+				"failed_items", failed.Load(),
+				"last_cloned_item", logutils.StringerAttr(lastRead),
+			)
+			groupError := group.Wait()
+			return trace.NewAggregate(groupError, trace.Wrap(err, "retrieving backend items for cloning"))
+		}
+
+		if lastRead.Compare(end) < 0 {
+			start = lastRead
+		}
 	}
-	if err := group.Wait(); err != nil {
+
+	err := group.Wait()
+	cloneCount := cloned.Load()
+	failCount := failed.Load()
+
+	logger := log.With("cloned_items", cloneCount, "failed_items", failed.Load())
+	switch {
+	case err == nil && cloneCount == 0 && failCount == 0:
+		logger.WarnContext(ctx, "No data was found in the source backend, ensure the backend configuration is correct")
+	case err != nil && cloneCount > 0 && failCount > 0:
+		logger.InfoContext(ctx, "Cloning backend failed: some backend items were unable to be copied", "err", err)
 		return trace.Wrap(err)
+	case err != nil && cloneCount == 0 && failCount > 0:
+		logger.InfoContext(ctx, "Cloning backend failed: no backend items were able to be copied", "err", err)
+		return trace.Wrap(err)
+	default:
+		logger.InfoContext(ctx, "Cloning backend completed successfully")
 	}
+
 	return nil
 }
 
-func retry(ctx context.Context, attempts int, fn func() error) error {
-	retry, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
-		Driver: retryutils.NewExponentialDriver(time.Millisecond * 100),
-		Max:    time.Second * 2,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if attempts <= 0 {
-		return trace.Errorf("retry attempts must be > 0")
+func cloneItems(ctx context.Context, src, dst Backend, start, end Key, log *slog.Logger, cloned, failed *atomic.Int64, group *errgroup.Group, maxAttempts int) (Key, error) {
+	lastRead := start
+	for item, err := range src.Items(ctx, ItemsParams{StartKey: start, EndKey: end}) {
+		if err != nil {
+			log.WarnContext(ctx, "Failed reading backend item",
+				"error", trace.Unwrap(err),
+				"cloned_items", cloned.Load(),
+				"failed_items", failed.Load(),
+			)
+
+			return lastRead, trace.Wrap(err)
+		}
+
+		// Prevent processing the same key twice. If reading from
+		// the destination has previously failed, then start will be
+		// the last item that was previously processed. Since there
+		// is no way to exclude the start key from the Items range, it
+		// has to be skipped manually instead.
+		if item.Key.Compare(start) == 0 {
+			continue
+		}
+
+		lastRead = item.Key
+		group.Go(func() error {
+			if err := retryPut(ctx, maxAttempts, dst, item); err != nil {
+				failed.Add(1)
+				return trace.Wrap(err)
+			}
+			cloned.Add(1)
+			return nil
+		})
 	}
 
-	for range attempts {
-		err = fn()
-		if err == nil {
+	return lastRead, nil
+}
+
+func retryPut(ctx context.Context, attempts int, b Backend, item Item) error {
+	if attempts <= 0 {
+		return trace.BadParameter("retry attempts must be greater than 0")
+	}
+
+	var retry retryutils.Retry
+	for i := range attempts {
+		if _, err := b.Put(ctx, item); err == nil {
 			return nil
+		} else if i >= attempts-1 {
+			return trace.LimitExceeded("Failed to clone item %d times: %s", attempts, err)
 		}
+
+		if retry == nil {
+			r, err := retryutils.NewRetryV2(retryutils.RetryV2Config{
+				Driver: retryutils.NewExponentialDriver(time.Millisecond * 100),
+				Max:    time.Second * 2,
+			})
+			if err != nil {
+				return trace.Wrap(err, "creating retry driver")
+			}
+
+			retry = r
+		}
+
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return trace.Wrap(ctx.Err())
 		case <-retry.After():
 			retry.Inc()
 		}
 	}
-	return trace.Wrap(err)
+
+	return nil
 }

--- a/lib/backend/clone_test.go
+++ b/lib/backend/clone_test.go
@@ -17,20 +17,31 @@
 package backend_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"iter"
+	"log/slog"
+	"strconv"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/itertools/stream"
 )
 
 func TestClone(t *testing.T) {
-	ctx := context.Background()
+	t.Parallel()
+
+	ctx := t.Context()
 	src, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 	defer src.Close()
@@ -39,7 +50,7 @@ func TestClone(t *testing.T) {
 	require.NoError(t, err)
 	defer dst.Close()
 
-	itemCount := 11111
+	const itemCount = 11111
 	items := make([]backend.Item, itemCount)
 
 	for i := range itemCount {
@@ -56,17 +67,245 @@ func TestClone(t *testing.T) {
 	require.NoError(t, err)
 
 	start := backend.NewKey("")
-	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
+	result, err := stream.Collect(dst.Items(ctx, backend.ItemsParams{StartKey: start, EndKey: backend.RangeEnd(start)}))
 	require.NoError(t, err)
 
-	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+	assert.Len(t, result, itemCount)
+	diff := cmp.Diff(items, result, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
 	require.Empty(t, diff)
+}
+
+type failingBackendConfig struct {
+	failedItemsAttempts     int
+	failAfterItemNumber     int
+	failAfterItemNumberOnce bool
+	failedPutAttempts       map[string]*atomic.Int32
+	b                       *memory.Memory
+}
+
+type failingBackend struct {
+	failedItemsAttempts     int32
+	failAfterItemNumber     int
+	failAfterItemNumberOnce bool
+	itemsAttempts           atomic.Int32
+	failedPutAttempts       map[string]*atomic.Int32
+	*memory.Memory
+}
+
+func newFailingBackend(cfg failingBackendConfig) (*failingBackend, error) {
+	bk := cfg.b
+	if cfg.b == nil {
+		mem, err := memory.New(memory.Config{})
+		if err != nil {
+			return nil, err
+		}
+		bk = mem
+	}
+
+	return &failingBackend{
+		failedItemsAttempts:     int32(cfg.failedItemsAttempts),
+		failAfterItemNumber:     cfg.failAfterItemNumber,
+		failAfterItemNumberOnce: cfg.failAfterItemNumberOnce,
+		failedPutAttempts:       cfg.failedPutAttempts,
+		Memory:                  bk,
+	}, nil
+}
+
+func (f *failingBackend) Put(ctx context.Context, i backend.Item) (*backend.Lease, error) {
+	counter, ok := f.failedPutAttempts[i.Key.String()]
+	if ok && counter.Add(-1) >= 0 {
+		return nil, fmt.Errorf("failed to put item %s", i.Key)
+	}
+
+	return f.Memory.Put(ctx, i)
+}
+
+func (f *failingBackend) Items(ctx context.Context, params backend.ItemsParams) iter.Seq2[backend.Item, error] {
+	return func(yield func(backend.Item, error) bool) {
+		attempts := f.itemsAttempts.Add(1)
+		if f.failedItemsAttempts > 0 && attempts <= f.failedItemsAttempts {
+			yield(backend.Item{}, errors.New("failed to get items"))
+			return
+		}
+
+		count := f.failAfterItemNumber
+		for i, err := range f.Memory.Items(ctx, params) {
+			if err != nil {
+				yield(backend.Item{}, err)
+				return
+			}
+
+			if f.failAfterItemNumber > 0 && count == 0 {
+				if !f.failAfterItemNumberOnce || (f.failAfterItemNumberOnce && attempts == 1) {
+					yield(backend.Item{}, fmt.Errorf("failed to get item %s", i.Key))
+					return
+				}
+			}
+
+			if !yield(i, nil) {
+				return
+			}
+			count--
+		}
+	}
+}
+
+func TestCloneResiliency(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	const itemCount = 11111
+
+	newAtomic := func(value int32) *atomic.Int32 {
+		i := &atomic.Int32{}
+		i.Add(value)
+		return i
+	}
+
+	populatedBackend, err := memory.New(memory.Config{})
 	require.NoError(t, err)
-	require.Len(t, result.Items, itemCount)
+	defer populatedBackend.Close()
+
+	items := make([]backend.Item, itemCount)
+
+	for i := range itemCount {
+		item := backend.Item{
+			Key:   backend.NewKey(fmt.Sprintf("key-%05d", i)),
+			Value: fmt.Appendf(nil, "value-%d", i),
+		}
+		_, err := populatedBackend.Put(ctx, item)
+		require.NoError(t, err)
+		items[i] = item
+	}
+
+	tests := []struct {
+		name      string
+		dstConfig failingBackendConfig
+		srcConfig failingBackendConfig
+		assertion func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item)
+	}{
+		{
+			name: "cloning completes with transient destination errors",
+			srcConfig: failingBackendConfig{
+				b: populatedBackend,
+			},
+			dstConfig: failingBackendConfig{
+				failedItemsAttempts: 1,
+				failAfterItemNumber: 133,
+				failedPutAttempts: map[string]*atomic.Int32{
+					"/key-00000": newAtomic(2),
+				},
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				require.NoError(t, cloneError)
+				assert.Len(t, destinationItems, itemCount)
+				diff := cmp.Diff(sourceItems, destinationItems, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+				require.Empty(t, diff)
+			},
+		},
+		{
+			name: "cloning fails with persistent destination errors",
+			srcConfig: failingBackendConfig{
+				b: populatedBackend,
+			},
+			dstConfig: failingBackendConfig{
+				failedPutAttempts: map[string]*atomic.Int32{
+					"/key-00000": newAtomic(3),
+				},
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				assert.Error(t, cloneError)
+				assert.True(t, trace.IsLimitExceeded(cloneError))
+				require.Len(t, destinationItems, itemCount-1)
+				diff := cmp.Diff(sourceItems[1:], destinationItems, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+				require.Empty(t, diff)
+			},
+		},
+		{
+			name: "cloning completes with transient source errors",
+			srcConfig: failingBackendConfig{
+				failAfterItemNumber: itemCount / 2,
+				b:                   populatedBackend,
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				require.NoError(t, cloneError)
+				assert.Len(t, destinationItems, itemCount)
+				diff := cmp.Diff(sourceItems, destinationItems, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+				require.Empty(t, diff)
+			},
+		},
+		{
+			name: "cloning completes with transient source and destination errors",
+			dstConfig: failingBackendConfig{
+				failedPutAttempts: map[string]*atomic.Int32{
+					"/key-00000": newAtomic(2),
+				},
+			},
+			srcConfig: failingBackendConfig{
+				failedItemsAttempts: 2,
+				b:                   populatedBackend,
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				require.NoError(t, cloneError)
+				assert.Len(t, destinationItems, itemCount)
+				diff := cmp.Diff(sourceItems, destinationItems, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+				require.Empty(t, diff)
+			},
+		},
+		{
+			name: "cloning fails with persistent source errors",
+			srcConfig: failingBackendConfig{
+				failAfterItemNumber: 10,
+				failedItemsAttempts: 2,
+				b:                   populatedBackend,
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				assert.Error(t, cloneError)
+				assert.ErrorContains(t, cloneError, "failed to get item /key-00010")
+				require.Len(t, destinationItems, 10)
+				diff := cmp.Diff(sourceItems[:10], destinationItems, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+				require.Empty(t, diff)
+			},
+		},
+		{
+			name: "cloning fails with unavailable source",
+			srcConfig: failingBackendConfig{
+				failedItemsAttempts: 10,
+				b:                   populatedBackend,
+			},
+			assertion: func(t *testing.T, cloneError error, sourceItems, destinationItems []backend.Item) {
+				assert.Error(t, cloneError)
+				assert.ErrorContains(t, cloneError, "failed to get items")
+				assert.Empty(t, destinationItems)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			dst, err := newFailingBackend(test.dstConfig)
+			require.NoError(t, err)
+
+			defer dst.Close()
+
+			src, err := newFailingBackend(test.srcConfig)
+			require.NoError(t, err)
+
+			cloneError := backend.Clone(ctx, src, dst, 1, false)
+
+			start := backend.NewKey("")
+			result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
+			require.NoError(t, err)
+
+			test.assertion(t, cloneError, items, result.Items)
+		})
+	}
 }
 
 func TestCloneForce(t *testing.T) {
-	ctx := context.Background()
+	t.Parallel()
+
+	ctx := t.Context()
 	src, err := memory.New(memory.Config{})
 	require.NoError(t, err)
 	defer src.Close()
@@ -75,7 +314,7 @@ func TestCloneForce(t *testing.T) {
 	require.NoError(t, err)
 	defer dst.Close()
 
-	itemCount := 100
+	const itemCount = 100
 	items := make([]backend.Item, itemCount)
 
 	for i := range itemCount {
@@ -98,10 +337,119 @@ func TestCloneForce(t *testing.T) {
 	require.NoError(t, err)
 
 	start := backend.NewKey("")
-	result, err := dst.GetRange(ctx, start, backend.RangeEnd(start), 0)
+	result, err := stream.Collect(dst.Items(ctx, backend.ItemsParams{StartKey: start, EndKey: backend.RangeEnd(start)}))
 	require.NoError(t, err)
 
-	diff := cmp.Diff(items, result.Items, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+	assert.Len(t, result, itemCount)
+	diff := cmp.Diff(items, result, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
 	require.Empty(t, diff)
-	require.Len(t, result.Items, itemCount)
+}
+
+func BenchmarkClone(b *testing.B) {
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+
+	ctx := b.Context()
+	src, err := memory.New(memory.Config{})
+	require.NoError(b, err)
+	defer src.Close()
+
+	itemCount := 11111
+	items := make([]backend.Item, itemCount)
+
+	for i := range itemCount {
+		item := backend.Item{
+			Key:   backend.NewKey("key-" + strconv.Itoa(i)),
+			Value: bytes.Repeat([]byte{1}, 100),
+		}
+		_, err := src.Put(ctx, item)
+		require.NoError(b, err)
+		items[i] = item
+	}
+
+	benchmarkClone := func() {
+		dst, err := memory.New(memory.Config{})
+		require.NoError(b, err)
+		defer dst.Close()
+
+		err = backend.Clone(ctx, src, dst, 500, false)
+		require.NoError(b, err)
+
+		start := backend.NewKey("")
+		var clonedItems int
+		for _, err := range dst.Items(ctx, backend.ItemsParams{StartKey: start, EndKey: backend.RangeEnd(start)}) {
+			require.NoError(b, err)
+			clonedItems++
+		}
+		require.Equal(b, itemCount, clonedItems)
+	}
+
+	for b.Loop() {
+		benchmarkClone()
+	}
+}
+
+func TestCloneReadResumption(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	populated, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	defer populated.Close()
+
+	const itemCount = 4
+	items := make([]backend.Item, 0, itemCount)
+
+	fooBar1 := backend.Item{
+		Key:   backend.NewKey("foo", "bar-"),
+		Value: []byte{0, 1, 2, 3},
+	}
+	_, err = populated.Put(ctx, fooBar1)
+	require.NoError(t, err)
+	items = append(items, fooBar1)
+
+	fooBar2 := backend.Item{
+		Key:   backend.NewKey("foo", "bar--"),
+		Value: []byte{0, 1, 2, 3},
+	}
+	_, err = populated.Put(ctx, fooBar2)
+	require.NoError(t, err)
+	items = append(items, fooBar2)
+
+	fooBar3 := backend.Item{
+		Key:   backend.NewKey("foo", "bar-0"),
+		Value: []byte{0, 1, 2, 3},
+	}
+	_, err = populated.Put(ctx, fooBar3)
+	require.NoError(t, err)
+	items = append(items, fooBar3)
+
+	fooBar4 := backend.Item{
+		Key:   backend.NewKey("foo", "bar."),
+		Value: []byte{0, 1, 2, 3},
+	}
+	_, err = populated.Put(ctx, fooBar4)
+	require.NoError(t, err)
+	items = append(items, fooBar4)
+
+	src, err := newFailingBackend(failingBackendConfig{
+		failAfterItemNumber:     1,
+		failAfterItemNumberOnce: true,
+		b:                       populated,
+	})
+	require.NoError(t, err)
+
+	dst, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	defer dst.Close()
+
+	err = backend.Clone(ctx, src, dst, 10, false)
+	require.NoError(t, err)
+
+	start := backend.NewKey("")
+	result, err := stream.Collect(dst.Items(ctx, backend.ItemsParams{StartKey: start, EndKey: backend.RangeEnd(start)}))
+	require.NoError(t, err)
+
+	assert.Len(t, result, itemCount)
+	diff := cmp.Diff(items, result, cmpopts.IgnoreFields(backend.Item{}, "Revision"), cmp.AllowUnexported(backend.Key{}))
+	require.Empty(t, diff)
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -846,6 +846,13 @@ Examples:
 		}
 		err = onSELinuxDirs(ccf.ConfigFile)
 	case backendCloneCmd.FullCommand():
+		// Ensure that the logging level is respected by the logger.
+		level := slog.LevelInfo
+		if ccf.Debug {
+			level = slog.LevelDebug
+		}
+		utils.InitLogger(utils.LoggingForDaemon, level)
+
 		err = onBackendClone(ctx, ccf.ConfigFile)
 	case backendGetCmd.FullCommand():
 		// configuration merge: defaults -> file-based conf -> CLI conf


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/63140.


## UX improvements

While backend.Clone did have some logging the default slog.Logger was never initialized by `teleport backend clone`. This prevented any of the commands output from being seen by users. The `teleport backend clone` command now creates the default logger at Info level - and will respect the -d flag.

backend.Clone also seemingly meant to output a progress message once per second. Though this operation was not in a loop so it only emitted a single progress message after the command had been running for one second. The status output is now emitted once every 250ms for the duration of `teleport backend clone` and once after the clone has completed with an overall status.

Friendly messages are emitted at the conclusion of the command to let users know if there is any action on their part.


## Performance improvements

backend.Clone now makes use of backend.Backend.Items instead of backend.Backend.GetRange. This helps reduce allocations since each page doesn't need to be provided one slice at a time. Instead of broadcasting each item from the GetRange result to a channel, we now spawn new work directly while processing each item when iterating the backend.Items.

The number of allocations required to process each item has also been reduced by holding off on creating a retry object until an error is encountered pushing an item to the new backend.

Comparison of BenchmarkClone before and after this change below.

```bash
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/lib/backend
cpu: Apple M2 Pro
         │   old.txt   │            new.txt            │
         │   sec/op    │   sec/op     vs base          │
Clone-12   146.2m ± 2%   148.5m ± 1%  ~ (p=0.165 n=10)

         │    old.txt    │               new.txt                │
         │     B/op      │     B/op      vs base                │
Clone-12   12.380Mi ± 0%   5.489Mi ± 0%  -55.66% (p=0.000 n=10)

         │   old.txt   │               new.txt               │
         │  allocs/op  │  allocs/op   vs base                │
Clone-12   94.39k ± 0%   72.06k ± 0%  -23.66% (p=0.000 n=10)
```

Changelog: Improve `teleport backend clone` performance and user experience. The command now outputs progress and provides a concise summary when the command completes.
