### PR TITLE
Add Access Request permission troubleshooting note

### DIFF
--- a/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/datadog-hosted.mdx
@@ -261,6 +261,10 @@ To trigger an auto-approval, login to Teleport as the current on-call user in Da
 and create an Access Request for the `editor` role. Automatic approvals requires
 that the Teleport username matches the Datadog on-call user email.
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
 ## Next steps
 
 - Read our guide on [Routing Access Request notifications](../notification-routing-rules.mdx)

--- a/docs/pages/identity-governance/access-requests/plugins/discord.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/discord.mdx
@@ -402,6 +402,10 @@ $ sudo systemctl enable teleport-discord
 $ sudo systemctl start teleport-discord
 ```
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
 ## Next steps
 
 - Read our guides to configuring [Resource Access

--- a/docs/pages/identity-governance/access-requests/plugins/email.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/email.mdx
@@ -526,3 +526,8 @@ $ sudo systemctl enable teleport-email
 $ sudo systemctl start teleport-email
 ```
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
+

--- a/docs/pages/identity-governance/access-requests/plugins/jira.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/jira.mdx
@@ -450,3 +450,8 @@ supported by systemd.
 $ sudo systemctl enable teleport-jira
 $ sudo systemctl start teleport-jira
 ```
+
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+

--- a/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/mattermost.mdx
@@ -380,3 +380,8 @@ $ sudo systemctl enable teleport-mattermost
 $ sudo systemctl start teleport-mattermost
 ```
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
+

--- a/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/msteams.mdx
@@ -576,6 +576,10 @@ $ sudo systemctl enable teleport-msteams
 $ sudo systemctl start teleport-msteams
 ```
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
 ## Next steps
 
 - Read our guides to configuring [Resource Access

--- a/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/opsgenie.mdx
@@ -128,3 +128,9 @@ When auditing Access Request reviews, check for events with the type `Access
 Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
+
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
+

--- a/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/pagerduty.mdx
@@ -634,3 +634,9 @@ Enable and start the plugin:
 $ sudo systemctl enable teleport-pagerduty
 $ sudo systemctl start teleport-pagerduty
 ```
+
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
+

--- a/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/servicenow.mdx
@@ -109,3 +109,9 @@ ServiceNow user currently on-call in that rotation and approve the Access Reques
 ### Resolve the request
 
 (!docs/pages/includes/plugins/resolve-request.mdx!)
+
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
+

--- a/docs/pages/identity-governance/access-requests/plugins/slack.mdx
+++ b/docs/pages/identity-governance/access-requests/plugins/slack.mdx
@@ -427,6 +427,10 @@ $ sudo systemctl enable teleport-slack
 $ sudo systemctl start teleport-slack
 ```
 
+## Troubleshooting
+
+(!docs/pages/includes/plugins/access-plugin-troubleshooting.mdx!)
+
 ## Next steps
 
 - Read our guides to configuring [Resource Access

--- a/docs/pages/includes/plugins/access-plugin-troubleshooting.mdx
+++ b/docs/pages/includes/plugins/access-plugin-troubleshooting.mdx
@@ -3,12 +3,31 @@ types included in a request. This is because, when the plugin receives a
 resource request, it queries the Teleport Auth Service API for data about the
 requested resources. 
 
-If you receive an error message similar to the following, make sure the Teleport
-roles for the Access Request plugin's identity include permissions to list
-requested resources:
+If you receive an error message similar to the following, the Teleport roles for
+the Access Request plugin's identity do not have permissions to perform one or
+more operations against the Teleport API. In the example below, the Access
+Request plugin needs `list` and `read` permissions on the `user_group` resource:
 
 ```
 ERRO   Failed to process request error:[
 ERROR REPORT:
 Original Error: *interceptors.RemoteError access denied to perform action "list" on "user_group", access denied to perform action "read" on "user_group"
 ```
+
+Make sure the Teleport roles for the Access Request plugin's identity include
+permissions to list requested resources. To resolve the error above, for
+example, you could grant the following role to the Access Request plugin's
+identity:
+
+```yaml
+kind: role
+version: v7
+metadata:
+  name: read-user-groups
+spec:
+  allow:
+    rules:
+      - resources: [user_group]
+        verbs: [list, read]
+```
+

--- a/docs/pages/includes/plugins/access-plugin-troubleshooting.mdx
+++ b/docs/pages/includes/plugins/access-plugin-troubleshooting.mdx
@@ -1,0 +1,14 @@
+Access Request plugins need permissions to list and read any Teleport resource
+types included in a request. This is because, when the plugin receives a
+resource request, it queries the Teleport Auth Service API for data about the
+requested resources. 
+
+If you receive an error message similar to the following, make sure the Teleport
+roles for the Access Request plugin's identity include permissions to list
+requested resources:
+
+```
+ERRO   Failed to process request error:[
+ERROR REPORT:
+Original Error: *interceptors.RemoteError access denied to perform action "list" on "user_group", access denied to perform action "read" on "user_group"
+```


### PR DESCRIPTION
Closes #48955

Add a note that Access Request plugin identities need permissions to list and read the resources included in an Access Request. Include this information in a standard Troubleshooting section at the end of each Access Request plugin guide.