### PR TITLE
Rename billing to usage

### DIFF
--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -98,7 +98,11 @@ export enum NavTitle {
   AuditLog = 'Audit Log',
 
   // Billing
+  // Deprecated, safe to remove after https://github.com/gravitational/teleport.e/pull/7952 merges
   BillingSummary = 'Billing Summary',
+
+  // Usage
+  UsageReporting = 'Usage Reporting',
 
   // Clusters
   ManageClusters = 'Manage Clusters',


### PR DESCRIPTION
Removes 'billing' from usage views/context

Leveraged in https://github.com/gravitational/teleport.e/pull/7952
Supports https://github.com/gravitational/cloud/issues/13465