### PR TITLE
Bring `require_session_mfa` reference docs up to date

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -152,8 +152,13 @@ auth_service:
     #local_auth: true
 
     # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
-    # Possible values: true, false, "hardware_key", "hardware_key_touch".
-    # Defaults to false.
+    # Defaults to false. Possible values:
+    # - "false" to disable per-session MFA
+    # - "true" to require MFA of any type on each session
+    # - "hardware_key" to require MFA of any type on each session AND hardware-key-backed private keys
+    # - "hardware_key_touch" to require a hardware key touch on each session
+    # - "hardware_key_pin" to require entering a hardware key PIN on each session
+    # - "hardware_key_touch_and_pin" to require a hardware key touch and PIN on each session
     require_session_mfa: false
 
     # second_factors is the list of allowed second factors for the cluster.


### PR DESCRIPTION
While going about my work, I noticed that the [reference docs for the `require_session_mfa` field](https://goteleport.com/docs/reference/deployment/config/#auth-service) are out of date. This PR brings it up to date.