### PR TITLE
Adding `azure` and `azure_devops` join methods to scoped tokens 

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -162,7 +162,11 @@ type ScopedTokenSpec struct {
 	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
 	Aws *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
 	// The GCP-specific configuration used with the "gcp" join method.
-	Gcp           *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
+	Gcp *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
+	// The Azure-specific configuration used with the "azure" join method.
+	Azure *Azure `protobuf:"bytes,8,opt,name=azure,proto3" json:"azure,omitempty"`
+	// The Azure Devops-specific configuration used with the "azure_devops" join method.
+	AzureDevops   *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -242,6 +246,20 @@ func (x *ScopedTokenSpec) GetAws() *AWS {
 func (x *ScopedTokenSpec) GetGcp() *GCP {
 	if x != nil {
 		return x.Gcp
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzure() *Azure {
+	if x != nil {
+		return x.Azure
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
+	if x != nil {
+		return x.AzureDevops
 	}
 	return nil
 }
@@ -830,6 +848,111 @@ func (x *GCP) GetAllow() []*GCP_Rule {
 	return nil
 }
 
+// The Azure-specific configuration used with the "azure" join method.
+type Azure struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*Azure_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Azure) Reset() {
+	*x = Azure{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure) ProtoMessage() {}
+
+func (x *Azure) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure.ProtoReflect.Descriptor instead.
+func (*Azure) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *Azure) GetAllow() []*Azure_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+type AzureDevops struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AzureDevops_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The UUID of the Azure DevOps organization that this join token will grant access to.
+	// This is used to identify the correct issuer verification of the ID token.
+	// This is a required field.
+	OrganizationId string `protobuf:"bytes,2,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AzureDevops) Reset() {
+	*x = AzureDevops{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops) ProtoMessage() {}
+
+func (x *AzureDevops) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops.ProtoReflect.Descriptor instead.
+func (*AzureDevops) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *AzureDevops) GetAllow() []*AzureDevops_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AzureDevops) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -854,7 +977,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -866,7 +989,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -933,7 +1056,7 @@ type GCP_Rule struct {
 
 func (x *GCP_Rule) Reset() {
 	*x = GCP_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -945,7 +1068,7 @@ func (x *GCP_Rule) String() string {
 func (*GCP_Rule) ProtoMessage() {}
 
 func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -982,6 +1105,188 @@ func (x *GCP_Rule) GetServiceAccounts() []string {
 	return nil
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "azure" join method.
+type Azure_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The Azure subscription.
+	Subscription string `protobuf:"bytes,1,opt,name=subscription,proto3" json:"subscription,omitempty"`
+	// A list of Azure resource groups the node is allowed to join from.
+	ResourceGroups []string `protobuf:"bytes,2,rep,name=resource_groups,json=resourceGroups,proto3" json:"resource_groups,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Azure_Rule) Reset() {
+	*x = Azure_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure_Rule) ProtoMessage() {}
+
+func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure_Rule.ProtoReflect.Descriptor instead.
+func (*Azure_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11, 0}
+}
+
+func (x *Azure_Rule) GetSubscription() string {
+	if x != nil {
+		return x.Subscription
+	}
+	return ""
+}
+
+func (x *Azure_Rule) GetResourceGroups() []string {
+	if x != nil {
+		return x.ResourceGroups
+	}
+	return nil
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "azure_devops" join method.
+type AzureDevops_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The subject string that roughly uniquely identifies the workload. Example:
+	// `p://my-organization/my-project/my-pipeline`
+	// Mapped from the `sub` claim.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// The name of the AZDO project. Example:
+	// `my-project`.
+	// Mapped out of the `sub` claim.
+	ProjectName string `protobuf:"bytes,2,opt,name=project_name,json=projectName,proto3" json:"project_name,omitempty"`
+	// The name of the AZDO pipeline. Example:
+	// `my-pipeline`.
+	// Mapped out of the `sub` claim.
+	PipelineName string `protobuf:"bytes,3,opt,name=pipeline_name,json=pipelineName,proto3" json:"pipeline_name,omitempty"`
+	// The ID of the AZDO pipeline. Example:
+	// `271ef6f7-0000-0000-0000-4b54d9129990`
+	// Mapped from the `prj_id` claim.
+	ProjectId string `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// The ID of the AZDO pipeline definition. Example:
+	// `1`
+	// Mapped from the `def_id` claim.
+	DefinitionId string `protobuf:"bytes,5,opt,name=definition_id,json=definitionId,proto3" json:"definition_id,omitempty"`
+	// The URI of the repository the pipeline is using. Example:
+	// `https://github.com/gravitational/teleport.git`.
+	// Mapped from the `rpo_uri` claim.
+	RepositoryUri string `protobuf:"bytes,6,opt,name=repository_uri,json=repositoryUri,proto3" json:"repository_uri,omitempty"`
+	// The individual commit of the repository the pipeline is using. Example:
+	// `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+	// Mapped from the `rpo_ver` claim.
+	RepositoryVersion string `protobuf:"bytes,7,opt,name=repository_version,json=repositoryVersion,proto3" json:"repository_version,omitempty"`
+	// The reference of the repository the pipeline is using. Example:
+	// `refs/heads/main`.
+	// Mapped from the `rpo_ref` claim.
+	RepositoryRef string `protobuf:"bytes,8,opt,name=repository_ref,json=repositoryRef,proto3" json:"repository_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AzureDevops_Rule) Reset() {
+	*x = AzureDevops_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops_Rule) ProtoMessage() {}
+
+func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops_Rule.ProtoReflect.Descriptor instead.
+func (*AzureDevops_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12, 0}
+}
+
+func (x *AzureDevops_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectName() string {
+	if x != nil {
+		return x.ProjectName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetPipelineName() string {
+	if x != nil {
+		return x.PipelineName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetDefinitionId() string {
+	if x != nil {
+		return x.DefinitionId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryUri() string {
+	if x != nil {
+		return x.RepositoryUri
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryVersion() string {
+	if x != nil {
+		return x.RepositoryVersion
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryRef() string {
+	if x != nil {
+		return x.RepositoryRef
+	}
+	return ""
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -994,7 +1299,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xcc\x02\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xd1\x03\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -1004,7 +1309,9 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
 	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
 	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
-	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\"\xb6\x01\n" +
+	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\x127\n" +
+	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
+	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -1055,7 +1362,25 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\vproject_ids\x18\x01 \x03(\tR\n" +
 	"projectIds\x12\x1c\n" +
 	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
-	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccountsBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccounts\"\x9a\x01\n" +
+	"\x05Azure\x12<\n" +
+	"\x05allow\x18\x01 \x03(\v2&.teleport.scopes.joining.v1.Azure.RuleR\x05allow\x1aS\n" +
+	"\x04Rule\x12\"\n" +
+	"\fsubscription\x18\x01 \x01(\tR\fsubscription\x12'\n" +
+	"\x0fresource_groups\x18\x02 \x03(\tR\x0eresourceGroups\"\x9e\x03\n" +
+	"\vAzureDevops\x12B\n" +
+	"\x05allow\x18\x01 \x03(\v2,.teleport.scopes.joining.v1.AzureDevops.RuleR\x05allow\x12'\n" +
+	"\x0forganization_id\x18\x02 \x01(\tR\x0eorganizationId\x1a\xa1\x02\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12!\n" +
+	"\fproject_name\x18\x02 \x01(\tR\vprojectName\x12#\n" +
+	"\rpipeline_name\x18\x03 \x01(\tR\fpipelineName\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x04 \x01(\tR\tprojectId\x12#\n" +
+	"\rdefinition_id\x18\x05 \x01(\tR\fdefinitionId\x12%\n" +
+	"\x0erepository_uri\x18\x06 \x01(\tR\rrepositoryUri\x12-\n" +
+	"\x12repository_version\x18\a \x01(\tR\x11repositoryVersion\x12%\n" +
+	"\x0erepository_ref\x18\b \x01(\tR\rrepositoryRefBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -1069,7 +1394,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -1082,35 +1407,43 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*StaticScopedTokensSpec)(nil), // 8: teleport.scopes.joining.v1.StaticScopedTokensSpec
 	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
 	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
-	nil,                            // 11: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 12: teleport.scopes.joining.v1.AWS.Rule
-	(*GCP_Rule)(nil),               // 13: teleport.scopes.joining.v1.GCP.Rule
-	(*v1.Metadata)(nil),            // 14: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
+	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
+	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
+	nil,                            // 13: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 14: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 15: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 16: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 17: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*v1.Metadata)(nil),            // 18: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 19: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	14, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	18, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	6,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
 	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
 	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
-	15, // 6: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	15, // 7: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 8: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 9: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 10: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	11, // 11: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	14, // 12: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	8,  // 13: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 14: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	12, // 15: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	13, // 16: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
-	17, // [17:17] is the sub-list for method output_type
-	17, // [17:17] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
+	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
+	19, // 8: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	19, // 9: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 10: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 11: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 12: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	13, // 13: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	18, // 14: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	8,  // 15: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 16: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	14, // 17: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	15, // 18: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	16, // 19: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	17, // 20: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -1127,7 +1460,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -76,6 +76,12 @@ message ScopedTokenSpec {
 
   // The GCP-specific configuration used with the "gcp" join method.
   GCP gcp = 7;
+
+  // The Azure-specific configuration used with the "azure" join method.
+  Azure azure = 8;
+
+  // The Azure Devops-specific configuration used with the "azure_devops" join method.
+  AzureDevops azure_devops = 9;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -210,4 +216,66 @@ message GCP {
   // A list of Rules for allowing use of this token. A node must match at least one
   // allow rule in order to use this token.
   repeated Rule allow = 1;
+}
+
+// The Azure-specific configuration used with the "azure" join method.
+message Azure {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure" join method.
+  message Rule {
+    // The Azure subscription.
+    string subscription = 1;
+    // A list of Azure resource groups the node is allowed to join from.
+    repeated string resource_groups = 2;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+message AzureDevops {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure_devops" join method.
+  message Rule {
+    // The subject string that roughly uniquely identifies the workload. Example:
+    // `p://my-organization/my-project/my-pipeline`
+    // Mapped from the `sub` claim.
+    string sub = 1;
+    // The name of the AZDO project. Example:
+    // `my-project`.
+    // Mapped out of the `sub` claim.
+    string project_name = 2;
+    // The name of the AZDO pipeline. Example:
+    // `my-pipeline`.
+    // Mapped out of the `sub` claim.
+    string pipeline_name = 3;
+    // The ID of the AZDO pipeline. Example:
+    // `271ef6f7-0000-0000-0000-4b54d9129990`
+    // Mapped from the `prj_id` claim.
+    string project_id = 4;
+    // The ID of the AZDO pipeline definition. Example:
+    // `1`
+    // Mapped from the `def_id` claim.
+    string definition_id = 5;
+    // The URI of the repository the pipeline is using. Example:
+    // `https://github.com/gravitational/teleport.git`.
+    // Mapped from the `rpo_uri` claim.
+    string repository_uri = 6;
+    // The individual commit of the repository the pipeline is using. Example:
+    // `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+    // Mapped from the `rpo_ver` claim.
+    string repository_version = 7;
+    // The reference of the repository the pipeline is using. Example:
+    // `refs/heads/main`.
+    // Mapped from the `rpo_ref` claim.
+    string repository_ref = 8;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+  // The UUID of the Azure DevOps organization that this join token will grant access to.
+  // This is used to identify the correct issuer verification of the ID token.
+  // This is a required field.
+  string organization_id = 2;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -159,6 +159,8 @@ type ProvisionToken interface {
 	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetGitlabRules will return the GitLab rules within this token.
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
+	// GetAzure will return the Azure specific configuration for this token.
+	GetAzure() *ProvisionTokenSpecV2Azure
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -548,6 +550,11 @@ func (p *ProvisionTokenV2) GetGitlabRules() *ProvisionTokenSpecV2GitLab {
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (p *ProvisionTokenV2) GetAWSIIDTTL() Duration {
 	return p.Spec.AWSIIDTTL
+}
+
+// GetAzure the Azure specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
+	return p.Spec.Azure
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -161,6 +161,8 @@ type ProvisionToken interface {
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
 	// GetAzure will return the Azure specific configuration for this token.
 	GetAzure() *ProvisionTokenSpecV2Azure
+	// GetAzureDevops will return the AzureDevops specific configuration for this token.
+	GetAzureDevops() *ProvisionTokenSpecV2AzureDevops
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -555,6 +557,11 @@ func (p *ProvisionTokenV2) GetAWSIIDTTL() Duration {
 // GetAzure the Azure specific configuration for this token.
 func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
 	return p.Spec.Azure
+}
+
+// GetAzureDevops will return the AzureDevops specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzureDevops() *ProvisionTokenSpecV2AzureDevops {
+	return p.Spec.AzureDevops
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -38,10 +38,10 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/provision"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -404,8 +404,8 @@ func claimsToIdentifiers(tokenClaims *AccessTokenClaims) (subscriptionID, resour
 	return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
 }
 
-func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token *types.ProvisionTokenV2) error {
-	for _, rule := range token.Spec.Azure.Allow {
+func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token provision.Token) error {
+	for _, rule := range token.GetAzure().Allow {
 		if rule.Subscription != attrs.Subscription {
 			continue
 		}
@@ -448,7 +448,7 @@ type CheckAzureRequestParams struct {
 	// AzureJoinConfig holds configurable options for Azure joining.
 	AzureJoinConfig *AzureJoinConfig
 	// Token is the token used for the incoming request.
-	Token *types.ProvisionTokenV2
+	Token provision.Token
 	// Challenge is the challenge that was issued.
 	Challenge string
 	// AttestedData is the Azure attested data that was returned by the joining

--- a/lib/join/azurejoin/join_azure_test.go
+++ b/lib/join/azurejoin/join_azure_test.go
@@ -493,7 +493,7 @@ func TestJoinAzure(t *testing.T) {
 				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
 			})
 
-			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
 				Scope: "/test",
 				Metadata: &headerv1.Metadata{
 					Name: "scoped_" + token.GetName(),
@@ -859,7 +859,7 @@ func TestJoinAzureClaims(t *testing.T) {
 				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
 			})
 
-			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
 				Scope: "/test",
 				Metadata: &headerv1.Metadata{
 					Name: "scoped_" + token.GetName(),

--- a/lib/join/join_azuredevops_test.go
+++ b/lib/join/join_azuredevops_test.go
@@ -27,11 +27,15 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockAzureDevopsTokenValidator struct {
@@ -325,9 +329,44 @@ func TestJoinAzureDevops(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, auth.UpsertToken(ctx, token))
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = auth.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := auth.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			t.Run("new", func(t *testing.T) {
 				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
 					Token: token.GetName(),
+					ID: state.IdentityID{
+						Role:     types.RoleInstance,
+						NodeName: "testnode",
+					},
+					IDToken:    tt.idToken,
+					AuthClient: nopClient,
+				})
+				tt.assertError(t, err)
+			})
+			t.Run("scoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: "scoped_" + token.GetName(),
 					ID: state.IdentityID{
 						Role:     types.RoleInstance,
 						NodeName: "testnode",

--- a/lib/join/join_azuredevops_test.go
+++ b/lib/join/join_azuredevops_test.go
@@ -329,7 +329,7 @@ func TestJoinAzureDevops(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, auth.UpsertToken(ctx, token))
 
-			scopedToken, err := jointest.ScopedTokenFromProvisionToken(token, &joiningv1.ScopedToken{
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tt.tokenSpec, &joiningv1.ScopedToken{
 				Scope: "/test",
 				Metadata: &headerv1.Metadata{
 					Name: "scoped_" + token.GetName(),

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -110,6 +110,24 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 		scopedToken.Spec.Azure = &joiningv1.Azure{
 			Allow: allow,
 		}
+	case types.JoinMethodAzureDevops:
+		allow := make([]*joiningv1.AzureDevops_Rule, len(base.GetAzureDevops().Allow))
+		for i, rule := range base.GetAzureDevops().Allow {
+			allow[i] = &joiningv1.AzureDevops_Rule{
+				Sub:               rule.Sub,
+				ProjectName:       rule.ProjectName,
+				PipelineName:      rule.PipelineName,
+				ProjectId:         rule.ProjectID,
+				DefinitionId:      rule.DefinitionID,
+				RepositoryUri:     rule.RepositoryURI,
+				RepositoryVersion: rule.RepositoryVersion,
+				RepositoryRef:     rule.RepositoryRef,
+			}
+		}
+		scopedToken.Spec.AzureDevops = &joiningv1.AzureDevops{
+			Allow:          allow,
+			OrganizationId: base.GetAzureDevops().OrganizationID,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
 	}

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -100,8 +100,8 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 			Allow: allow,
 		}
 	case types.JoinMethodAzure:
-		allow := make([]*joiningv1.Azure_Rule, len(base.GetAzure().Allow))
-		for i, rule := range base.GetAzure().Allow {
+		allow := make([]*joiningv1.Azure_Rule, len(base.Azure.Allow))
+		for i, rule := range base.Azure.Allow {
 			allow[i] = &joiningv1.Azure_Rule{
 				Subscription:   rule.Subscription,
 				ResourceGroups: rule.ResourceGroups,
@@ -111,8 +111,8 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 			Allow: allow,
 		}
 	case types.JoinMethodAzureDevops:
-		allow := make([]*joiningv1.AzureDevops_Rule, len(base.GetAzureDevops().Allow))
-		for i, rule := range base.GetAzureDevops().Allow {
+		allow := make([]*joiningv1.AzureDevops_Rule, len(base.AzureDevops.Allow))
+		for i, rule := range base.AzureDevops.Allow {
 			allow[i] = &joiningv1.AzureDevops_Rule{
 				Sub:               rule.Sub,
 				ProjectName:       rule.ProjectName,
@@ -126,7 +126,7 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 		}
 		scopedToken.Spec.AzureDevops = &joiningv1.AzureDevops{
 			Allow:          allow,
-			OrganizationId: base.GetAzureDevops().OrganizationID,
+			OrganizationId: base.AzureDevops.OrganizationID,
 		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -99,6 +99,17 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 		scopedToken.Spec.Gcp = &joiningv1.GCP{
 			Allow: allow,
 		}
+	case types.JoinMethodAzure:
+		allow := make([]*joiningv1.Azure_Rule, len(base.GetAzure().Allow))
+		for i, rule := range base.GetAzure().Allow {
+			allow[i] = &joiningv1.Azure_Rule{
+				Subscription:   rule.Subscription,
+				ResourceGroups: rule.ResourceGroups,
+			}
+		}
+		scopedToken.Spec.Azure = &joiningv1.Azure{
+			Allow: allow,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
 	}

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -62,4 +62,6 @@ type Token interface {
 	GetGCPRules() *types.ProvisionTokenSpecV2GCP
 	// GetAzure returns the Azure-specific configuration for this token.
 	GetAzure() *types.ProvisionTokenSpecV2Azure
+	// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
 }

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -60,4 +60,6 @@ type Token interface {
 	GetIntegration() string
 	// GetGCPRules returns the GCP-specific configuration for this token.
 	GetGCPRules() *types.ProvisionTokenSpecV2GCP
+	// GetAzure returns the Azure-specific configuration for this token.
+	GetAzure() *types.ProvisionTokenSpecV2Azure
 }

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -81,15 +80,10 @@ func (s *Server) handleAzureJoin(
 		return nil, trace.BadParameter("client did not send access token")
 	}
 
-	ptv2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
-	}
-
 	// Verify the client's identity and make sure it matches an allow rule in the provision token.
 	claims, err := azurejoin.CheckAzureRequest(stream.Context(), azurejoin.CheckAzureRequestParams{
 		AzureJoinConfig: s.cfg.AuthService.GetAzureJoinConfig(),
-		Token:           ptv2,
+		Token:           token,
 		Challenge:       challenge,
 		AttestedData:    solution.AttestedData,
 		Intermediate:    solution.Intermediate,

--- a/lib/join/server_azuredevops.go
+++ b/lib/join/server_azuredevops.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/provision"
 )
@@ -32,13 +31,8 @@ func (s *Server) validateAzureDevopsToken(
 	pt provision.Token,
 	idToken []byte,
 ) (any, *workloadidentityv1.JoinAttrs, error) {
-	ptv2, ok := pt.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, nil, trace.BadParameter("Azure Devops joining only supports ProvisionTokenV2, got %T", pt)
-	}
-
 	claims, err := azuredevops.CheckIDToken(ctx, &azuredevops.CheckIDTokenParams{
-		ProvisionToken: ptv2,
+		ProvisionToken: pt,
 		IDToken:        string(idToken),
 		Validator:      s.cfg.AuthService.GetAzureDevopsIDTokenValidator(),
 	})

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -60,6 +60,10 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 		if len(token.GetSpec().GetGcp().GetAllow()) == 0 {
 			return trace.BadParameter("gcp configuration must be defined for a scoped token when using the gcp join method")
 		}
+	case types.JoinMethodAzure:
+		if len(token.GetSpec().GetAzure().GetAllow()) == 0 {
+			return trace.BadParameter("azure configuration must be defined for a scoped token when using the azure join method")
+		}
 	default:
 		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
 	}
@@ -331,6 +335,21 @@ func (t *Token) GetGCPRules() *types.ProvisionTokenSpecV2GCP {
 	}
 
 	return &types.ProvisionTokenSpecV2GCP{
+		Allow: allow,
+	}
+}
+
+// GetAzure returns the Azure-specific configuration for this token.
+func (t *Token) GetAzure() *types.ProvisionTokenSpecV2Azure {
+	allow := make([]*types.ProvisionTokenSpecV2Azure_Rule, len(t.scoped.GetSpec().GetAzure().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzure().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Azure_Rule{
+			Subscription:   rule.GetSubscription(),
+			ResourceGroups: rule.GetResourceGroups(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Azure{
 		Allow: allow,
 	}
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -64,6 +64,10 @@ func validateJoinMethod(token *joiningv1.ScopedToken) error {
 		if len(token.GetSpec().GetAzure().GetAllow()) == 0 {
 			return trace.BadParameter("azure configuration must be defined for a scoped token when using the azure join method")
 		}
+	case types.JoinMethodAzureDevops:
+		if len(token.GetSpec().GetAzureDevops().GetAllow()) == 0 {
+			return trace.BadParameter("azure_devops configuration must be defined for a scoped token when using the azure_devops join method")
+		}
 	default:
 		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
 	}
@@ -351,6 +355,28 @@ func (t *Token) GetAzure() *types.ProvisionTokenSpecV2Azure {
 
 	return &types.ProvisionTokenSpecV2Azure{
 		Allow: allow,
+	}
+}
+
+// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+func (t *Token) GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops {
+	allow := make([]*types.ProvisionTokenSpecV2AzureDevops_Rule, len(t.scoped.GetSpec().GetAzureDevops().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzureDevops().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2AzureDevops_Rule{
+			Sub:               rule.GetSub(),
+			ProjectName:       rule.GetProjectName(),
+			PipelineName:      rule.GetPipelineName(),
+			ProjectID:         rule.GetProjectId(),
+			DefinitionID:      rule.GetDefinitionId(),
+			RepositoryURI:     rule.GetRepositoryUri(),
+			RepositoryVersion: rule.GetRepositoryVersion(),
+			RepositoryRef:     rule.GetRepositoryRef(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2AzureDevops{
+		Allow:          allow,
+		OrganizationID: t.scoped.GetSpec().GetAzureDevops().GetOrganizationId(),
 	}
 }
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -462,6 +462,25 @@ func TestValidateScopedToken(t *testing.T) {
 			expectedWeakErr:   "azure configuration must be defined for a scoped token when using the azure join method",
 		},
 		{
+			name: "azure_devops token without azure configuration",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodAzureDevops),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			},
+			expectedStrongErr: "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
+			expectedWeakErr:   "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
+		},
+		{
 			name: "invalid usage mode",
 			token: &joiningv1.ScopedToken{
 				Kind:    types.KindScopedToken,
@@ -684,6 +703,37 @@ func TestValidateScopedToken(t *testing.T) {
 						Allow: []*joiningv1.Azure_Rule{
 							{
 								Subscription: "1234567890",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid azure_devops scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodAzureDevops),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+					ImmutableLabels: &joiningv1.ImmutableLabels{
+						Ssh: map[string]string{
+							"one":   "1",
+							"two":   "2",
+							"three": "3",
+						},
+					},
+					AzureDevops: &joiningv1.AzureDevops{
+						Allow: []*joiningv1.AzureDevops_Rule{
+							{
+								Sub: "1234567890",
 							},
 						},
 					},

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -443,6 +443,25 @@ func TestValidateScopedToken(t *testing.T) {
 			expectedWeakErr:   "gcp configuration must be defined for a scoped token when using the gcp join method",
 		},
 		{
+			name: "azure token without azure configuration",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodAzure),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			},
+			expectedStrongErr: "azure configuration must be defined for a scoped token when using the azure join method",
+			expectedWeakErr:   "azure configuration must be defined for a scoped token when using the azure join method",
+		},
+		{
 			name: "invalid usage mode",
 			token: &joiningv1.ScopedToken{
 				Kind:    types.KindScopedToken,
@@ -634,6 +653,37 @@ func TestValidateScopedToken(t *testing.T) {
 						Allow: []*joiningv1.GCP_Rule{
 							{
 								ProjectIds: []string{"1234567890"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid azure scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodAzure),
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+					ImmutableLabels: &joiningv1.ImmutableLabels{
+						Ssh: map[string]string{
+							"one":   "1",
+							"two":   "2",
+							"three": "3",
+						},
+					},
+					Azure: &joiningv1.Azure{
+						Allow: []*joiningv1.Azure_Rule{
+							{
+								Subscription: "1234567890",
 							},
 						},
 					},


### PR DESCRIPTION
This PR adds support for the `azure` and `azure_devops` join methods when using scoped tokens.

# Manual testing
- [x] Create a scoped token that uses the `azure` join method `tctl scoped tokens add --type node --join-method azure --scope /local --assign-scope /local`
- [ ] ~Create a scoped token that uses the `azure_devops` join method `tctl scoped tokens add --type node --join-method azure_devops --scope /local --assign-scope /local`~
- [x] Provision an Azure node
- [ ] ~Provision a node using Azure DevOps~

The `azure_devops` method is used to provision bots (which aren't yet supported by scoped tokens) so I've skipped the manual testing for now. Since I've already made the changes to support it and automated tests are passing I opted to leave it in the PR rather than removing it, but I can also split it into its own branch if we'd rather wait until bots are supported