### PR TITLE
update terraform-docs settings

### DIFF
--- a/integrations/terraform-modules/.terraform-docs.yml
+++ b/integrations/terraform-modules/.terraform-docs.yml
@@ -16,13 +16,13 @@ sections:
   hide: []
   show: []
 settings:
-  anchor: true
+  anchor: false
   color: true
   default: true
   description: false
   escape: true
   hide-empty: false
-  html: true
+  html: false
   indent: 2
   lockfile: false # avoid pinning provider version in README
   read-comments: true

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -30,20 +30,20 @@ For bugs related to this code, please [open an issue](https://github.com/gravita
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | >= 3.0 |
-| <a name="requirement_teleport"></a> [teleport](#requirement\_teleport) | >= 18.5.1 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+| terraform | >= 1.5.7 |
+| aws | >= 5.0 |
+| http | >= 3.0 |
+| teleport | >= 18.5.1 |
+| tls | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | >= 3.0 |
-| <a name="provider_teleport"></a> [teleport](#provider\_teleport) | >= 18.5.1 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
+| aws | >= 5.0 |
+| http | >= 3.0 |
+| teleport | >= 18.5.1 |
+| tls | >= 4.0 |
 
 ## Modules
 
@@ -71,36 +71,36 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apply_aws_tags"></a> [apply\_aws\_tags](#input\_apply\_aws\_tags) | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
-| <a name="input_apply_teleport_resource_labels"></a> [apply\_teleport\_resource\_labels](#input\_apply\_teleport\_resource\_labels) | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
-| <a name="input_aws_iam_policy_document"></a> [aws\_iam\_policy\_document](#input\_aws\_iam\_policy\_document) | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
-| <a name="input_aws_iam_policy_name"></a> [aws\_iam\_policy\_name](#input\_aws\_iam\_policy\_name) | Name for the AWS IAM policy for discovery. | `string` | `"teleport-discovery"` | no |
-| <a name="input_aws_iam_policy_use_name_prefix"></a> [aws\_iam\_policy\_use\_name\_prefix](#input\_aws\_iam\_policy\_use\_name\_prefix) | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
-| <a name="input_aws_iam_role_name"></a> [aws\_iam\_role\_name](#input\_aws\_iam\_role\_name) | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
-| <a name="input_aws_iam_role_use_name_prefix"></a> [aws\_iam\_role\_use\_name\_prefix](#input\_aws\_iam\_role\_use\_name\_prefix) | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
-| <a name="input_create"></a> [create](#input\_create) | Toggle creation of all resources. | `bool` | `true` | no |
-| <a name="input_create_aws_iam_openid_connect_provider"></a> [create\_aws\_iam\_openid\_connect\_provider](#input\_create\_aws\_iam\_openid\_connect\_provider) | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
-| <a name="input_discovery_service_iam_credential_source"></a> [discovery\_service\_iam\_credential\_source](#input\_discovery\_service\_iam\_credential\_source) | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | <pre>object({<br/>    use_oidc_integration = optional(bool)<br/>    trust_role = optional(object({<br/>      role_arn    = string<br/>      external_id = optional(string, "")<br/>    }))<br/>  })</pre> | <pre>{<br/>  "trust_role": null,<br/>  "use_oidc_integration": true<br/>}</pre> | no |
-| <a name="input_match_aws_regions"></a> [match\_aws\_regions](#input\_match\_aws\_regions) | AWS regions to discover. The default matches all AWS regions. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
-| <a name="input_match_aws_resource_types"></a> [match\_aws\_resource\_types](#input\_match\_aws\_resource\_types) | AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`. | `list(string)` | n/a | yes |
-| <a name="input_match_aws_tags"></a> [match\_aws\_tags](#input\_match\_aws\_tags) | AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | <pre>{<br/>  "*": [<br/>    "*"<br/>  ]<br/>}</pre> | no |
-| <a name="input_teleport_discovery_config_name"></a> [teleport\_discovery\_config\_name](#input\_teleport\_discovery\_config\_name) | Name for the `teleport_discovery_config` resource. | `string` | `"discovery"` | no |
-| <a name="input_teleport_discovery_config_use_name_prefix"></a> [teleport\_discovery\_config\_use\_name\_prefix](#input\_teleport\_discovery\_config\_use\_name\_prefix) | Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix. | `bool` | `true` | no |
-| <a name="input_teleport_discovery_group_name"></a> [teleport\_discovery\_group\_name](#input\_teleport\_discovery\_group\_name) | Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use "cloud-discovery-group". | `string` | n/a | yes |
-| <a name="input_teleport_integration_name"></a> [teleport\_integration\_name](#input\_teleport\_integration\_name) | Name for the `teleport_integration` resource. | `string` | `"discovery"` | no |
-| <a name="input_teleport_integration_use_name_prefix"></a> [teleport\_integration\_use\_name\_prefix](#input\_teleport\_integration\_use\_name\_prefix) | Determines whether the name of the Teleport integration (`teleport_integration_name`) is used as a prefix. | `bool` | `true` | no |
-| <a name="input_teleport_provision_token_name"></a> [teleport\_provision\_token\_name](#input\_teleport\_provision\_token\_name) | Name for the `teleport_provision_token` resource. | `string` | `"discovery"` | no |
-| <a name="input_teleport_provision_token_use_name_prefix"></a> [teleport\_provision\_token\_use\_name\_prefix](#input\_teleport\_provision\_token\_use\_name\_prefix) | Determines whether the name of the Teleport provision token (`teleport_provision_token_name`) is used as a prefix. | `bool` | `true` | no |
-| <a name="input_teleport_proxy_public_addr"></a> [teleport\_proxy\_public\_addr](#input\_teleport\_proxy\_public\_addr) | Teleport cluster proxy public address `host:port`. | `string` | n/a | yes |
+| apply\_aws\_tags | Additional AWS tags to apply to all created AWS resources. | `map(string)` | `{}` | no |
+| apply\_teleport\_resource\_labels | Additional Teleport resource labels to apply to all created Teleport resources. | `map(string)` | `{}` | no |
+| aws\_iam\_policy\_document | Override the AWS IAM policy document attached to the AWS IAM role for resource discovery. | `string` | `""` | no |
+| aws\_iam\_policy\_name | Name for the AWS IAM policy for discovery. | `string` | `"teleport-discovery"` | no |
+| aws\_iam\_policy\_use\_name\_prefix | Determines whether the name of the AWS IAM policy (`aws_iam_policy_name`) is used as a prefix. | `bool` | `true` | no |
+| aws\_iam\_role\_name | Name for the AWS IAM role for discovery. | `string` | `"teleport-discovery"` | no |
+| aws\_iam\_role\_use\_name\_prefix | Determines whether the name of the AWS IAM role (`aws_iam_role_name`) is used as a prefix. | `bool` | `true` | no |
+| create | Toggle creation of all resources. | `bool` | `true` | no |
+| create\_aws\_iam\_openid\_connect\_provider | Toggle AWS IAM OIDC provider creation. If false and using OIDC, then the AWS IAM OIDC provider must already exist. | `bool` | `true` | no |
+| discovery\_service\_iam\_credential\_source | Configure the AWS credential source for Teleport Discovery Service instances. The default uses AWS OIDC integration. | ```object({ use_oidc_integration = optional(bool) trust_role = optional(object({ role_arn = string external_id = optional(string, "") })) })``` | ```{ "trust_role": null, "use_oidc_integration": true }``` | no |
+| match\_aws\_regions | AWS regions to discover. The default matches all AWS regions. | `list(string)` | ```[ "*" ]``` | no |
+| match\_aws\_resource\_types | AWS resource types to match when discovering resources with Teleport. Valid values are: `ec2`. | `list(string)` | n/a | yes |
+| match\_aws\_tags | AWS resource tags to match when discovering resources with Teleport. The default matches all discovered AWS resources. | `map(list(string))` | ```{ "*": [ "*" ] }``` | no |
+| teleport\_discovery\_config\_name | Name for the `teleport_discovery_config` resource. | `string` | `"discovery"` | no |
+| teleport\_discovery\_config\_use\_name\_prefix | Determines whether the name of the Teleport discovery config (`teleport_discovery_config_name`) is used as a prefix. | `bool` | `true` | no |
+| teleport\_discovery\_group\_name | Teleport discovery group to use. For discovery configuration to apply, this name must match at least one Teleport Discovery Service instance's configured `discovery_group`. For Teleport Cloud clusters, use "cloud-discovery-group". | `string` | n/a | yes |
+| teleport\_integration\_name | Name for the `teleport_integration` resource. | `string` | `"discovery"` | no |
+| teleport\_integration\_use\_name\_prefix | Determines whether the name of the Teleport integration (`teleport_integration_name`) is used as a prefix. | `bool` | `true` | no |
+| teleport\_provision\_token\_name | Name for the `teleport_provision_token` resource. | `string` | `"discovery"` | no |
+| teleport\_provision\_token\_use\_name\_prefix | Determines whether the name of the Teleport provision token (`teleport_provision_token_name`) is used as a prefix. | `bool` | `true` | no |
+| teleport\_proxy\_public\_addr | Teleport cluster proxy public address `host:port`. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_oidc_provider_arn"></a> [aws\_oidc\_provider\_arn](#output\_aws\_oidc\_provider\_arn) | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
-| <a name="output_teleport_discovery_config_name"></a> [teleport\_discovery\_config\_name](#output\_teleport\_discovery\_config\_name) | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
-| <a name="output_teleport_discovery_service_iam_policy_arn"></a> [teleport\_discovery\_service\_iam\_policy\_arn](#output\_teleport\_discovery\_service\_iam\_policy\_arn) | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |
-| <a name="output_teleport_discovery_service_iam_role_arn"></a> [teleport\_discovery\_service\_iam\_role\_arn](#output\_teleport\_discovery\_service\_iam\_role\_arn) | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
-| <a name="output_teleport_integration_name"></a> [teleport\_integration\_name](#output\_teleport\_integration\_name) | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
-| <a name="output_teleport_provision_token_name"></a> [teleport\_provision\_token\_name](#output\_teleport\_provision\_token\_name) | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
+| aws\_oidc\_provider\_arn | AWS resource name (ARN) of the AWS OpenID Connect (OIDC) provider that allows Teleport Discovery Service to assume an AWS IAM role using OIDC. |
+| teleport\_discovery\_config\_name | Name of the Teleport dynamic `discovery_config`. Configuration details can be viewed with `tctl get discovery_config/<name>`. Teleport Discovery Service instances will use this `discovery_config` if they are in the same discovery group as the `discovery_config`. |
+| teleport\_discovery\_service\_iam\_policy\_arn | AWS resource name (ARN) of the AWS IAM policy that grants the permissions needed for Teleport to discover resources in AWS. |
+| teleport\_discovery\_service\_iam\_role\_arn | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
+| teleport\_integration\_name | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
+| teleport\_provision\_token\_name | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
 <!-- END_TF_DOCS -->

--- a/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/examples/single-account/README.md
@@ -7,22 +7,22 @@ Configuration in this directory creates AWS and Teleport resources necessary for
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
-| <a name="requirement_teleport"></a> [teleport](#requirement\_teleport) | >= 18.5.1 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
+| terraform | >= 1.0 |
+| aws | >= 5.0 |
+| teleport | >= 18.5.1 |
+| tls | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| aws | >= 5.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_discovery"></a> [aws\_discovery](#module\_aws\_discovery) | ../.. | n/a |
+| aws\_discovery | ../.. | n/a |
 
 ## Resources
 
@@ -38,5 +38,5 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_aws_discovery"></a> [aws\_discovery](#output\_aws\_discovery) | n/a |
+| aws\_discovery | n/a |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
Related issue:
- https://github.com/gravitational/teleport/issues/62276

This PR updates the settings used for generating the README markdown files for our terraform modules.

I decided to split this change out of another larger branch that uses the README markdown files to generate docs on our docs website.

The HTML tags were breaking rendering when I tried to use the README files as .mdx files.
