### PR TITLE
Generate reference docs for Terraform modules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -66,10 +66,16 @@ jobs:
               - 'integrations/terraform/examples/**'
               - 'integrations/terraform/templates/**'
               - 'integrations/terraform/provider/**'
+              # terraform modules generator changes
+              - 'integrations/terraform-modules/.terraform-docs.yml'
+              - 'integrations/terraform-modules/Makefile'
+              - 'integrations/terraform-modules/teleport/**'
+              - 'integrations/terraform-modules/gen/docs.sh'
               # rendered doc changes
               - 'docs/pages/reference/infrastructure-as-code/operator-resources/**'
               - 'docs/pages/reference/infrastructure-as-code/terraform-provider/**'
               - 'docs/pages/reference/infrastructure-as-code/teleport-resources/**'
+              - 'docs/pages/reference/infrastructure-as-code/terraform-modules/**'
               - 'examples/chart/teleport-cluster/charts/teleport-operator/operator-crds'
               - 'build.assets/tooling/cmd/resource-ref-generator/**'
             has_ui:
@@ -277,6 +283,14 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         # The protoc-gen-terraform version must match the version in integrations/terraform/Makefile
         run: git config --global --add safe.directory $(realpath .) && go install github.com/gravitational/protoc-gen-terraform/v3@v3.0.3 && make terraform-resources-up-to-date
+
+      - name: Check if Terraform module reference docs are up to date
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        # terraform-docs version must match the version in integrations/terraform-modules/.terraform-docs.yml
+        run: |
+          git config --global --add safe.directory $(realpath .)
+          go install github.com/terraform-docs/terraform-docs@v0.21.0
+          make terraform-module-docs-up-to-date
 
       - name: Check if the Access Monitoring reference is up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.

--- a/Makefile
+++ b/Makefile
@@ -1699,6 +1699,15 @@ terraform-resources-up-to-date: must-start-clean/host
 		exit 1; \
 	fi
 
+# terraform-module-docs-up-to-date checks if the generated Terraform module documentation is up to date.
+.PHONY: terraform-module-docs-up-to-date
+terraform-module-docs-up-to-date: must-start-clean/host
+	$(MAKE) -C integrations/terraform-modules docs
+	@if ! git diff --quiet; then \
+		./build.assets/please-run.sh "TF module docs" "make -C integrations/terraform-modules docs"; \
+		exit 1; \
+	fi
+
 # icons-up-to-date checks if icons were pre-processed before being added to the repo.
 .PHONY: icons-up-to-date
 icons-up-to-date: must-start-clean/host

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/examples.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/examples.mdx
@@ -1,0 +1,15 @@
+---
+title: Teleport AWS discovery examples
+sidebar_label: examples
+description: Index of all the examples for the teleport-discovery-aws Terraform module.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit integrations/terraform-modules/gen/docs.sh
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+*/}
+
+<DocCardList />
+

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
@@ -1,3 +1,17 @@
+---
+title: Example for discovering AWS resources in a single account
+sidebar_label: single-account
+description: Configure Teleport to discover resources in a AWS account.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit teleport/discovery/aws/examples/single-account/README.md
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+*/}
+
+Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws/examples/single-account)
 ## Teleport AWS Account Discovery Example
 
 Configuration in this directory creates AWS and Teleport resources necessary for Teleport to discover resources in a single AWS account.

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/examples/single-account.mdx
@@ -18,7 +18,7 @@ Configuration in this directory creates AWS and Teleport resources necessary for
 
 In addition, the example uses a custom AWS IAM policy to narrow the scope of permissions for Teleport Discovery Service instances.
 
-<!-- BEGIN_TF_DOCS -->
+{/* BEGIN_TF_DOCS */}
 ## Requirements
 
 | Name | Version |
@@ -55,4 +55,4 @@ No inputs.
 | Name | Description |
 |------|-------------|
 | aws\_discovery | n/a |
-<!-- END_TF_DOCS -->
+{/* END_TF_DOCS */}

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -27,6 +27,7 @@ This Terraform module creates the AWS and Teleport cluster resources necessary f
 
 ## Prerequisites
 
+{/* lint ignore absolute-docs-links */}
 - [Configure Teleport Terraform Provider](https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/)
 - [Configure AWS Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 
@@ -55,17 +56,13 @@ module "aws_discovery" {
 }
 ```
 
-## Examples
-
-- [Discover resources in a single AWS account](./examples/single-account)
-
 ## How to get help
 
 If you're having trouble, check out our [GitHub Discussions](https://github.com/gravitational/teleport/discussions).
 
 For bugs related to this code, please [open an issue](https://github.com/gravitational/teleport/issues/new/choose).
 
-<!-- BEGIN_TF_DOCS -->
+{/* BEGIN_TF_DOCS */}
 ## Requirements
 
 | Name | Version |
@@ -143,4 +140,4 @@ No modules.
 | teleport\_discovery\_service\_iam\_role\_arn | AWS resource name (ARN) of the AWS IAM role that Teleport Discovery Service will assume. |
 | teleport\_integration\_name | Name of the Teleport `integration` resource. The integration resource configures Teleport Discovery Service instances to assume an AWS IAM role for discovery using AWS OIDC federation. Integration details can be viewed with `tctl get integrations/<name>` or by visiting the Teleport web UI under 'Zero Trust Access' > 'Integrations'. |
 | teleport\_provision\_token\_name | Name of the Teleport provision `token` that allows Teleport nodes to join the Teleport cluster using AWS IAM credentials. Token details can be viewed with `tctl get token/<name>`. |
-<!-- END_TF_DOCS -->
+{/* END_TF_DOCS */}

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/teleport-discovery-aws/teleport-discovery-aws.mdx
@@ -1,3 +1,17 @@
+---
+title: Reference for the teleport-discovery-aws Terraform module
+sidebar_label: teleport-discovery-aws
+description: This page describes the Terraform module for discovering resources in AWS.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit integrations/terraform-modules/teleport/discovery/aws/README.md
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+*/}
+
+Source Code: [github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws](https://github.com/gravitational/teleport/tree/master/integrations/terraform-modules/teleport/discovery/aws)
 ## AWS Discovery Terraform module
 
 This Terraform module creates the AWS and Teleport cluster resources necessary for a Teleport cluster to discover resources in AWS.

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
@@ -8,12 +8,12 @@ tags:
  - platform-wide
 ---
 
-<!--
+{/*
     Auto-generated file.
     Do not edit this directly in the docs/pages tree.
     Instead, edit integrations/terraform-modules/gen/docs.sh
     Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
--->
+*/}
 
 Teleport publishes the following Terraform modules:
 

--- a/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
+++ b/docs/pages/reference/infrastructure-as-code/terraform-modules/terraform-modules.mdx
@@ -1,0 +1,20 @@
+---
+title: "Teleport Terraform Modules Reference"
+sidebar_label: Terraform Modules
+description: Reference documentation for the Teleport Terraform modules.
+tags:
+ - infrastructure-as-code
+ - reference
+ - platform-wide
+---
+
+<!--
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit integrations/terraform-modules/gen/docs.sh
+    Then, regenerate the docs with `make -C integrations/terraform-modules docs`.
+-->
+
+Teleport publishes the following Terraform modules:
+
+- [`teleport-discovery-aws`](./teleport-discovery-aws/teleport-discovery-aws.mdx)

--- a/integrations/terraform-modules/.terraform-docs.yml
+++ b/integrations/terraform-modules/.terraform-docs.yml
@@ -32,4 +32,4 @@ settings:
 sort:
   enabled: true
   by: name
-version: ''
+version: '0.21.0'

--- a/integrations/terraform-modules/Makefile
+++ b/integrations/terraform-modules/Makefile
@@ -15,7 +15,8 @@ MODULE_DIRS := $(shell find . -type f -name '*.tf' -exec dirname {} \; 2>/dev/nu
 README_FILES := $(addsuffix /README.md,$(MODULE_DIRS))
 
 .PHONY: docs
-docs: $(README_FILES) ;
+docs: $(README_FILES)
+	./gen/docs.sh $(VERSION) $(PUBLISHED_TF_MODULES)
 
 %/README.md: force
 	terraform-docs markdown table --config .terraform-docs.yml $*
@@ -53,10 +54,10 @@ release: build
 
 PLUGIN_TYPE := terraform-module
 # This list controls which modules are actually published.
-PUBLISHED_TF_MODULES := $(subst /,_, \
+PUBLISHED_TF_MODULES := \
 	teleport/discovery/aws \
-)
-MODULE_TARBALLS:=$(addsuffix .tar.gz, $(PUBLISHED_TF_MODULES))
+
+MODULE_TARBALLS:=$(addsuffix .tar.gz, $(subst /,_,$(PUBLISHED_TF_MODULES)))
 BUILD_TARGETS:=$(addprefix $(BUILD_DIR)/$(PLUGIN_TYPE)_, $(MODULE_TARBALLS))
 
 .PHONY: build

--- a/integrations/terraform-modules/gen/docs.sh
+++ b/integrations/terraform-modules/gen/docs.sh
@@ -14,6 +14,10 @@ error() {
     printf "\e[1;31m%s\e[0m\n" "$1"
     exit 1
 }
+# convert_tf_docs_comment converts comments like <!-- BEGIN_TF_DOCS --> to an mdx comment like {/* BEGIN_TF_DOCS */}
+convert_tf_docs_comment() {
+  sed 's#<!-- \(.*\) -->#{/\* \1 \*/}#'
+}
 
 VERSION="$1"; shift
 
@@ -46,12 +50,12 @@ tags:
  - platform-wide
 ---
 
-<!--
+{/*
     Auto-generated file.
     Do not edit this directly in the docs/pages tree.
     Instead, edit ${MODULES_ROOT_DIR}/gen/docs.sh
     Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
--->
+*/}
 
 Teleport publishes the following Terraform modules:
 
@@ -91,7 +95,7 @@ description: This page describes the Terraform module for discovering resources 
 
 Source Code: [${SOURCE_URI}/${module}](https://${SOURCE_URI}/${module})
 EOF
-    cat "${module}/README.md" >> "${module_index_doc}"
+    convert_tf_docs_comment < "${module}/README.md" >> "${module_index_doc}"
 
     # handle examples
     module_examples_docs_dir="${module_docs_dir}/examples"
@@ -137,7 +141,7 @@ description: Configure Teleport to discover resources in a ${remote_system} acco
 
 Source Code: [${SOURCE_URI}/${example}](https://${SOURCE_URI}/${example})
 EOF
-        cat "${example}/README.md" >> "${example_doc}"
+        convert_tf_docs_comment < "${example}/README.md" >> "${example_doc}"
     done
 done
 

--- a/integrations/terraform-modules/gen/docs.sh
+++ b/integrations/terraform-modules/gen/docs.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+# If someone runs a debug GitHub Actions task
+if [ -n "$RUNNER_DEBUG" ]; then
+  set -x
+fi
+
+set -euo pipefail
+
+info() {
+    printf "\e[1;32m%s\e[0m\n" "$1"
+}
+error() {
+    printf "\e[1;31m%s\e[0m\n" "$1"
+    exit 1
+}
+
+VERSION="$1"; shift
+
+if [ -z "$VERSION" ]; then
+  error "Version arg is required"
+fi
+
+PUBLISHED_TF_MODULES=( "$@" )
+
+if [[ ${#PUBLISHED_TF_MODULES[@]} -eq 0 ]]; then
+  error "Published modules args are required"
+fi
+
+DOCSDIR="$(pwd)/../../docs/pages/reference/infrastructure-as-code/terraform-modules"
+TMPDIR="$(mktemp -d)"
+MODULES_DOC_INDEX="${TMPDIR}/terraform-modules.mdx"
+MODULES_ROOT_DIR="$(git rev-parse --show-prefix)" # the relative path from the git repo to the modules dir, e.g., "integrations/terraform-modules" at time of writing.
+MODULES_ROOT_DIR="${MODULES_ROOT_DIR%%/}" # trim trailing slash
+SOURCE_URI="github.com/gravitational/teleport/tree/master/${MODULES_ROOT_DIR}"
+
+info "Rendering modules reference index"
+cat <<EOF > "${MODULES_DOC_INDEX}"
+---
+title: "Teleport Terraform Modules Reference"
+sidebar_label: Terraform Modules
+description: Reference documentation for the Teleport Terraform modules.
+tags:
+ - infrastructure-as-code
+ - reference
+ - platform-wide
+---
+
+<!--
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit ${MODULES_ROOT_DIR}/gen/docs.sh
+    Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
+-->
+
+Teleport publishes the following Terraform modules:
+
+EOF
+
+for module in "${PUBLISHED_TF_MODULES[@]}"; do
+    module_name="${module//\//-}"
+
+    # inject a link to the module into the modules index page
+    info "Adding ${module_name} to modules reference index"
+    cat <<EOF >> "${MODULES_DOC_INDEX}"
+- [\`${module_name}\`](./${module_name}/${module_name}.mdx)
+EOF
+
+    info "Rendering module ${module_name} reference doc"
+    module_docs_dir=${TMPDIR}/${module_name}
+    mkdir -p "${module_docs_dir}"
+    module_index_doc="${module_docs_dir}/${module_name}.mdx"
+
+    remote_system="${module_name##*-}" # trim everything up to the last dash, which is the "system" component, e.g., "aws".
+    remote_system=$(echo "${remote_system}" | tr '[:lower:]' '[:upper:]') # uppercase it, e.g., "aws" -> "AWS".
+
+    # inject a generated docs header
+    cat <<EOF > "${module_index_doc}"
+---
+title: Reference for the ${module_name} Terraform module
+sidebar_label: ${module_name}
+description: This page describes the Terraform module for discovering resources in ${remote_system}.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit ${MODULES_ROOT_DIR}/${module}/README.md
+    Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
+*/}
+
+Source Code: [${SOURCE_URI}/${module}](https://${SOURCE_URI}/${module})
+EOF
+    cat "${module}/README.md" >> "${module_index_doc}"
+
+    # handle examples
+    module_examples_docs_dir="${module_docs_dir}/examples"
+    mkdir -p "${module_examples_docs_dir}"
+    module_examples_index="${module_examples_docs_dir}/examples.mdx"
+    info "Rendering module ${module_name} examples index"
+    cat <<EOF > "${module_examples_index}"
+---
+title: Teleport ${remote_system} discovery examples
+sidebar_label: examples
+description: Index of all the examples for the ${module_name} Terraform module.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit ${MODULES_ROOT_DIR}/gen/docs.sh
+    Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
+*/}
+
+<DocCardList />
+
+EOF
+    examples="$(find "${module}/examples" -maxdepth 1 -mindepth 1 -type d)"
+    for example in ${examples}; do
+        example_name="$(basename "${example}")"
+        info "Rendering module ${module_name} example ${example_name} reference doc"
+        example_doc="${module_examples_docs_dir}/${example_name}.mdx"
+        # inject header
+        cat <<EOF > "${example_doc}"
+---
+title: Example for discovering ${remote_system} resources in a single account
+sidebar_label: ${example_name}
+description: Configure Teleport to discover resources in a ${remote_system} account.
+---
+
+{/*
+    Auto-generated file.
+    Do not edit this directly in the docs/pages tree.
+    Instead, edit ${example}/README.md
+    Then, regenerate the docs with \`make -C ${MODULES_ROOT_DIR} docs\`.
+*/}
+
+Source Code: [${SOURCE_URI}/${example}](https://${SOURCE_URI}/${example})
+EOF
+        cat "${example}/README.md" >> "${example_doc}"
+    done
+done
+
+rm -rf "${DOCSDIR}"
+cp -r "${TMPDIR}" "${DOCSDIR}"

--- a/integrations/terraform-modules/teleport/discovery/aws/README.md
+++ b/integrations/terraform-modules/teleport/discovery/aws/README.md
@@ -13,6 +13,7 @@ This Terraform module creates the AWS and Teleport cluster resources necessary f
 
 ## Prerequisites
 
+<!-- lint ignore absolute-docs-links -->
 - [Configure Teleport Terraform Provider](https://goteleport.com/docs/zero-trust-access/infrastructure-as-code/terraform-provider/)
 - [Configure AWS Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs)
 
@@ -40,10 +41,6 @@ module "aws_discovery" {
   }
 }
 ```
-
-## Examples
-
-- [Discover resources in a single AWS account](./examples/single-account)
 
 ## How to get help
 


### PR DESCRIPTION
Related issue:
- https://github.com/gravitational/teleport/issues/62276

This PR is stacked on top of another PR and will rebase automatically after that PR merges:
- https://github.com/gravitational/teleport/pull/63313

Relevant section of the docs site that this generates:
<img width="284" height="1089" alt="image" src="https://github.com/user-attachments/assets/60de6c60-621e-46b0-a895-6b7518ca1e49" />

