### PR TITLE
Fix test-time fake clock race condition

### DIFF
--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -309,16 +309,20 @@ func StartMonitor(cfg MonitorConfig) error {
 		return nil
 	}
 
+	// Wait for the monitor goroutine to register its idle timeout timer before
+	// returning, so callers can safely advance fake clocks after StartMonitor.
+	ready := make(chan struct{})
 	go func() {
-		w.start(lockWatch)
+		w.start(lockWatch, ready)
 		if w.MonitorCloseChannel != nil {
-			// Non blocking send to the close channel.
+			// Non-blocking send to the close channel.
 			select {
 			case w.MonitorCloseChannel <- struct{}{}:
 			default:
 			}
 		}
 	}()
+	<-ready
 	return nil
 }
 
@@ -331,13 +335,19 @@ type Monitor struct {
 }
 
 // start starts monitoring connection.
-func (w *Monitor) start(lockWatch types.Watcher) {
+func (w *Monitor) start(lockWatch types.Watcher, ready chan struct{}) {
 	lockWatchDoneC := lockWatch.Done()
 	defer func() {
 		if err := lockWatch.Close(); err != nil {
 			w.Logger.WarnContext(w.Context, "Failed to close lock watcher subscription", "error", err)
 		}
 	}()
+
+	var idleTime <-chan time.Time
+	if w.ClientIdleTimeout != 0 {
+		idleTime = w.Clock.After(w.ClientIdleTimeout)
+	}
+	close(ready)
 
 	var certTime <-chan time.Time
 	if !w.DisconnectExpiredCert.IsZero() {
@@ -351,11 +361,6 @@ func (w *Monitor) start(lockWatch types.Watcher) {
 		t := w.Clock.NewTicker(discTime)
 		defer t.Stop()
 		certTime = t.Chan()
-	}
-
-	var idleTime <-chan time.Time
-	if w.ClientIdleTimeout != 0 {
-		idleTime = w.Clock.After(w.ClientIdleTimeout)
 	}
 
 	for {

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -332,6 +332,35 @@ func TestMonitorDisconnectExpiredCertBeforeTimeNow(t *testing.T) {
 	}
 }
 
+// TestFakeClockCanSafelyAdvance verifies that advancing a fake clock immediately
+// after StartMonitor returns correctly triggers the idle timeout.
+func TestFakeClockCanSafelyAdvance(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+
+	asrv, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, asrv.Close()) })
+
+	conn, _, _ := newTestMonitor(t.Context(), t, asrv, func(config *MonitorConfig) {
+		config.ClientIdleTimeout = 1 * time.Minute
+		// default activity tracker appears always active due to clock moving forward.
+		// replace it with inactive one.
+		config.Tracker = &mockActivityTracker{clock: clockwork.NewFakeClock()}
+	})
+	clock.Advance(2 * time.Minute)
+
+	select {
+	case <-conn.closedC:
+	case <-time.After(1 * time.Second):
+		t.Fatal("Client is still connected.")
+	}
+}
+
 func TestTrackingReadConn(t *testing.T) {
 	server, client := net.Pipe()
 	defer client.Close()


### PR DESCRIPTION
Fix the test-specific race condition in `StartMonitor()` where tests using fake clocks could fail intermittently. 

The issue occurred when `clock.Advance()` was called immediately after `StartMonitor()` returned - the monitor goroutine might not have registered its idle timeout timer yet, causing the clock advance to have no effect.

`StartMonitor()` now waits for the idle timeout timer to be registered before returning.

To reproduce, run `TestFakeClockCanSafelyAdvance` with commented out `<-ready` line.

Fixes #60796.