### PR TITLE
Inject tbot's slog.Logger into Join client

### DIFF
--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -216,11 +216,18 @@ type RegisterParams struct {
 	OracleIMDSClient utils.HTTPDoClient
 	// AttestTPM overrides the function used to attest the host TPM for the TPM join method.
 	AttestTPM func(context.Context, *slog.Logger) (*tpm.Attestation, func() error, error)
+	// Log is the logger to use for emitting log messages.
+	// If not specified, this defaults to the global logger.
+	Log *slog.Logger
 }
 
 func (r *RegisterParams) CheckAndSetDefaults() error {
 	if r.Clock == nil {
 		r.Clock = clockwork.NewRealClock()
+	}
+
+	if r.Log == nil {
+		r.Log = slog.Default()
 	}
 
 	if r.KubernetesReadFileFunc == nil {

--- a/lib/auth/join/join.go
+++ b/lib/auth/join/join.go
@@ -325,6 +325,7 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	if err := params.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	log := params.Log
 	// Read in the token. The token can either be passed in or come from a file
 	// on disk.
 	token, err := utils.TryReadValueAsFile(params.Token)
@@ -421,13 +422,13 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	// If an explicit AuthClient has been provided, we want to go straight to
 	// using that rather than trying both proxy and auth dialing.
 	if params.AuthClient != nil {
-		slog.InfoContext(ctx, "Attempting registration with existing auth client.")
+		log.InfoContext(ctx, "Attempting registration with existing auth client.")
 		result, err := registerThroughAuthClient(ctx, token, params, params.AuthClient)
 		if err != nil {
-			slog.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
+			log.ErrorContext(ctx, "Registration with existing auth client failed.", "error", err)
 			return nil, trace.Wrap(err)
 		}
-		slog.InfoContext(ctx, "Successfully registered with existing auth client.")
+		log.InfoContext(ctx, "Successfully registered with existing auth client.")
 		return result, nil
 	}
 
@@ -442,35 +443,35 @@ func Register(ctx context.Context, params RegisterParams) (result *RegisterResul
 	registerMethods := []registerMethod{registerThroughAuth, registerThroughProxy}
 
 	if !params.ProxyServer.IsEmpty() {
-		slog.DebugContext(ctx, "Registering node to the cluster.", "proxy_server", params.ProxyServer)
+		log.DebugContext(ctx, "Registering node to the cluster.", "proxy_server", params.ProxyServer)
 
 		registerMethods = []registerMethod{registerThroughProxy}
 
 		if proxyServerIsAuth(params.ProxyServer) {
-			slog.DebugContext(ctx, "The specified proxy server appears to be an auth server.")
+			log.DebugContext(ctx, "The specified proxy server appears to be an auth server.")
 		}
 	} else {
-		slog.DebugContext(ctx, "Registering node to the cluster.", "auth_servers", params.AuthServers)
+		log.DebugContext(ctx, "Registering node to the cluster.", "auth_servers", params.AuthServers)
 
 		if params.GetHostCredentials == nil {
-			slog.DebugContext(ctx, "Missing client, it is not possible to register through proxy.")
+			log.DebugContext(ctx, "Missing client, it is not possible to register through proxy.")
 			registerMethods = []registerMethod{registerThroughAuth}
 		} else if LooksLikeProxy(params.AuthServers) {
-			slog.DebugContext(ctx, "The first specified auth server appears to be a proxy.")
+			log.DebugContext(ctx, "The first specified auth server appears to be a proxy.")
 			registerMethods = []registerMethod{registerThroughProxy, registerThroughAuth}
 		}
 	}
 
 	var collectedErrs []error
 	for _, method := range registerMethods {
-		slog.InfoContext(ctx, "Attempting registration.", "method", method.desc)
+		log.InfoContext(ctx, "Attempting registration.", "method", method.desc)
 		result, err := method.call(ctx, token, params)
 		if err != nil {
 			collectedErrs = append(collectedErrs, err)
-			slog.DebugContext(ctx, "Registration failed.", "method", method.desc, "error", err)
+			log.DebugContext(ctx, "Registration failed.", "method", method.desc, "error", err)
 			continue
 		}
-		slog.InfoContext(ctx, "Successfully registered.", "method", method.desc)
+		log.InfoContext(ctx, "Successfully registered.", "method", method.desc)
 		return result, nil
 	}
 	return nil, trace.NewAggregate(collectedErrs...)
@@ -524,7 +525,7 @@ func registerThroughProxy(
 				CipherSuites: params.CipherSuites,
 				Clock:        params.Clock,
 				Insecure:     params.Insecure,
-				Log:          slog.Default(),
+				Log:          params.Log,
 			},
 		)
 		if err != nil {
@@ -659,7 +660,7 @@ func getHostAddresses(params RegisterParams) []string {
 func NewAuthClient(ctx context.Context, params RegisterParams) (*authclient.Client, error) {
 	switch {
 	case params.Insecure:
-		slog.WarnContext(ctx, "Insecure mode enabled. Auth Server cert will not be validated and CAPins and CAPath value will be ignored.")
+		params.Log.WarnContext(ctx, "Insecure mode enabled. Auth Server cert will not be validated and CAPins and CAPath value will be ignored.")
 		return insecureRegisterClient(ctx, params)
 	case len(params.CAPins) != 0:
 		// CAPins takes precedence over CAPath
@@ -684,7 +685,7 @@ func insecureRegisterClient(ctx context.Context, params RegisterParams) (*authcl
 		"attacker can gain privileged network access. To remedy this, use the CA pin " +
 		"value provided when join token was generated to validate the identity of " +
 		"the Auth Server or point to a valid Certificate via the CA Path option."
-	slog.WarnContext(ctx, msg)
+	params.Log.WarnContext(ctx, msg)
 
 	tlsConfig := utils.TLSConfig(params.CipherSuites)
 	tlsConfig.Time = params.Clock.Now
@@ -758,7 +759,7 @@ func pinRegisterClient(
 		}
 
 	}
-	slog.InfoContext(ctx, "Joining remote cluster with CA pin.", "cluster", certs[0].Subject.CommonName)
+	params.Log.InfoContext(ctx, "Joining remote cluster with CA pin.", "cluster", certs[0].Subject.CommonName)
 
 	// Create another client, but this time with the CA provided to validate
 	// that the Auth Server was issued a certificate by the same CA.
@@ -799,7 +800,7 @@ func caPathRegisterClient(ctx context.Context, params RegisterParams) (*authclie
 	// we may wish to consider changing this to return an error - but this is a
 	// breaking change.
 	if trace.IsNotFound(err) {
-		slog.WarnContext(ctx, "Falling back to insecurely joining because a missing or empty CA Path was provided.")
+		params.Log.WarnContext(ctx, "Falling back to insecurely joining because a missing or empty CA Path was provided.")
 		return insecureRegisterClient(ctx, params)
 	}
 
@@ -807,7 +808,7 @@ func caPathRegisterClient(ctx context.Context, params RegisterParams) (*authclie
 	certPool.AddCert(cert)
 	tlsConfig.RootCAs = certPool
 
-	slog.InfoContext(ctx, "Joining remote cluster, validating connection with certificate on disk.", "cluster", cert.Subject.CommonName)
+	params.Log.InfoContext(ctx, "Joining remote cluster, validating connection with certificate on disk.", "cluster", cert.Subject.CommonName)
 
 	client, err := authclient.NewClient(client.Config{
 		Addrs: getHostAddresses(params),
@@ -865,7 +866,8 @@ func registerUsingTokenRequestForParams(token string, hostKeys *newHostKeys, par
 func registerUsingIAMMethod(
 	ctx context.Context, joinServiceClient joinServiceClient, token string, hostKeys *newHostKeys, params RegisterParams,
 ) (*proto.Certs, error) {
-	slog.InfoContext(ctx, "Attempting to register with IAM method using region STS endpoint.", "role", params.ID.Role)
+	log := params.Log
+	log.InfoContext(ctx, "Attempting to register with IAM method using region STS endpoint.", "role", params.ID.Role)
 	// Call RegisterUsingIAMMethod and pass a callback to respond to the challenge with a signed join request.
 	certs, err := joinServiceClient.RegisterUsingIAMMethod(ctx, func(challenge string) (*proto.RegisterUsingIAMMethodRequest, error) {
 		// create the signed sts:GetCallerIdentity request and include the challenge
@@ -883,11 +885,11 @@ func registerUsingIAMMethod(
 		}, nil
 	})
 	if err != nil {
-		slog.InfoContext(ctx, "Failed to register using regional STS endpoint", "role", params.ID.Role, "error", err)
+		log.InfoContext(ctx, "Failed to register using regional STS endpoint", "role", params.ID.Role, "error", err)
 		return nil, trace.Wrap(err, "registering via IAM method streaming RPC")
 	}
 
-	slog.InfoContext(ctx, "Successfully registered with IAM method using regional STS endpoint.", "role", params.ID.Role)
+	log.InfoContext(ctx, "Successfully registered with IAM method using regional STS endpoint.", "role", params.ID.Role)
 	return certs, nil
 }
 
@@ -931,7 +933,7 @@ func registerUsingTPMMethod(
 	hostKeys *newHostKeys,
 	params RegisterParams,
 ) (*proto.Certs, error) {
-	log := slog.Default()
+	log := params.Log
 
 	initReq := &proto.RegisterUsingTPMMethodInitialRequest{
 		JoinRequest: registerUsingTokenRequestForParams(token, hostKeys, params),
@@ -1046,6 +1048,7 @@ func registerUsingBoundKeypairMethod(
 	params RegisterParams,
 ) (*RegisterResult, error) {
 	bkParams := params.BoundKeypairParams
+	log := params.Log
 
 	initReq := &proto.RegisterUsingBoundKeypairInitialRequest{
 		JoinRequest:       registerUsingTokenRequestForParams(token, hostKeys, params),
@@ -1102,7 +1105,7 @@ func registerUsingBoundKeypairMethod(
 					return nil, trace.BadParameter("RequestNewKeypair is required")
 				}
 
-				slog.InfoContext(ctx, "Server has requested keypair rotation", "suite", kind.Rotation.SignatureAlgorithmSuite)
+				log.InfoContext(ctx, "Server has requested keypair rotation", "suite", kind.Rotation.SignatureAlgorithmSuite)
 
 				newSigner, err := bkParams.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(kind.Rotation.SignatureAlgorithmSuite))
 				if err != nil {

--- a/lib/join/joinclient/join.go
+++ b/lib/join/joinclient/join.go
@@ -22,7 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"log/slog"
 	"os"
 
 	"github.com/gravitational/trace"
@@ -61,6 +60,7 @@ func Join(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	if err := params.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	log := params.Log
 	if params.AuthClient == nil && params.ID.HostUUID != "" {
 		// This check is skipped if AuthClient is provided because this is a
 		// re-join with an existing identity and the HostUUID will be
@@ -70,18 +70,18 @@ func Join(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	if params.ID.Role != types.RoleInstance && params.ID.Role != types.RoleBot {
 		return nil, trace.BadParameter("Only Instance and Bot roles may be used for direct join attempts")
 	}
-	slog.InfoContext(ctx, "Trying to join with the new join service")
+	log.InfoContext(ctx, "Trying to join with the new join service")
 	result, err := joinNew(ctx, params)
 	if trace.IsNotImplemented(err) || isConnectionError(err) {
 		// Fall back to joining via legacy service.
-		slog.InfoContext(ctx, "Joining via new join service failed, falling back to joining via the legacy join service", "error", err)
+		log.InfoContext(ctx, "Joining via new join service failed, falling back to joining via the legacy join service", "error", err)
 		// Non-bots must provide their own host UUID when joining via legacy service.
 		if params.ID.HostUUID == "" && params.ID.Role != types.RoleBot {
 			hostID, err := hostid.Generate(ctx, params.JoinMethod)
 			if err != nil {
 				return nil, trace.Wrap(err, "generating host ID")
 			}
-			slog.InfoContext(ctx, "Generated host UUID for legacy join attempt", "host_uuid", hostID)
+			log.InfoContext(ctx, "Generated host UUID for legacy join attempt", "host_uuid", hostID)
 			params.ID.HostUUID = hostID
 		}
 		result, err := LegacyJoin(ctx, params)
@@ -104,12 +104,13 @@ func LegacyJoin(ctx context.Context, params JoinParams) (*JoinResult, error) {
 }
 
 func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
+	log := params.Log
 	if params.AuthClient != nil {
-		slog.InfoContext(ctx, "Attempting to join cluster with existing Auth client")
+		log.InfoContext(ctx, "Attempting to join cluster with existing Auth client")
 		return joinViaAuthClient(ctx, params, params.AuthClient)
 	}
 	if !params.ProxyServer.IsEmpty() {
-		slog.InfoContext(ctx, "Attempting to join cluster via Proxy")
+		log.InfoContext(ctx, "Attempting to join cluster via Proxy")
 		return joinViaProxy(ctx, params, params.ProxyServer.String())
 	}
 
@@ -117,7 +118,7 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	// params.CheckAndSetDefaults() asserts that this list is not empty when
 	// AuthClient and ProxyServer are both unset.
 	addr := params.AuthServers[0].String()
-	slog := slog.With("addr", addr)
+	log = log.With("addr", addr)
 
 	type strategy struct {
 		name string
@@ -137,10 +138,10 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 	}
 	var strategies []strategy
 	if authjoin.LooksLikeProxy(params.AuthServers) {
-		slog.InfoContext(ctx, "Attempting to join cluster, address looks like a Proxy")
+		log.InfoContext(ctx, "Attempting to join cluster, address looks like a Proxy")
 		strategies = []strategy{proxyStrategy, authStrategy}
 	} else {
-		slog.InfoContext(ctx, "Attempting to join cluster, address looks like an Auth server")
+		log.InfoContext(ctx, "Attempting to join cluster, address looks like an Auth server")
 		strategies = []strategy{authStrategy, proxyStrategy}
 	}
 
@@ -157,7 +158,7 @@ func joinNew(ctx context.Context, params JoinParams) (*JoinResult, error) {
 		// Connection error: keep for aggregate and try next strategy (if any).
 		errs = append(errs, trace.Wrap(err, "joining via %s", strat.name))
 		if i+1 < len(strategies) {
-			slog.InfoContext(ctx, "Failed to join cluster with a connection error, will try next method",
+			log.InfoContext(ctx, "Failed to join cluster with a connection error, will try next method",
 				"method", strat.name, "next_method", strategies[i+1].name)
 		}
 	}
@@ -173,7 +174,7 @@ func joinViaProxy(ctx context.Context, params JoinParams, proxyAddr string) (*Jo
 			CipherSuites: params.CipherSuites,
 			Clock:        params.Clock,
 			Insecure:     params.Insecure,
-			Log:          slog.Default(),
+			Log:          params.Log,
 		},
 	)
 	if err != nil {

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -103,7 +103,7 @@ func boundKeypairJoin(
 		case *messages.BoundKeypairRotationRequest:
 			newPubkey, err := handleBoundKeypairRotationRequest(
 				ctx, joinParams.Log, bkParams, kind,
-				)
+			)
 			if err != nil {
 				sendGivingUpErr := stream.Send(&messages.GivingUp{
 					Reason: messages.GivingUpReasonChallengeSolutionFailed,

--- a/lib/join/joinclient/join_boundkeypair.go
+++ b/lib/join/joinclient/join_boundkeypair.go
@@ -101,7 +101,9 @@ func boundKeypairJoin(
 				return nil, trace.Wrap(err)
 			}
 		case *messages.BoundKeypairRotationRequest:
-			newPubkey, err := handleBoundKeypairRotationRequest(ctx, bkParams, kind)
+			newPubkey, err := handleBoundKeypairRotationRequest(
+				ctx, joinParams.Log, bkParams, kind,
+				)
 			if err != nil {
 				sendGivingUpErr := stream.Send(&messages.GivingUp{
 					Reason: messages.GivingUpReasonChallengeSolutionFailed,
@@ -157,12 +159,17 @@ func solveBoundKeypairChallenge(bkParams *BoundKeypairParams, challengeMsg *mess
 	return []byte(serialized), nil
 }
 
-func handleBoundKeypairRotationRequest(ctx context.Context, bkParams *BoundKeypairParams, rotationRequest *messages.BoundKeypairRotationRequest) ([]byte, error) {
+func handleBoundKeypairRotationRequest(
+	ctx context.Context,
+	log *slog.Logger,
+	bkParams *BoundKeypairParams,
+	rotationRequest *messages.BoundKeypairRotationRequest,
+) ([]byte, error) {
 	if bkParams.RequestNewKeypair == nil {
 		return nil, trace.BadParameter("RequestNewKeypair is required")
 	}
 
-	slog.InfoContext(ctx, "Server has requested keypair rotation", "suite", rotationRequest.SignatureAlgorithmSuite)
+	log.InfoContext(ctx, "Server has requested keypair rotation", "suite", rotationRequest.SignatureAlgorithmSuite)
 
 	suite, err := types.SignatureAlgorithmSuiteFromString(rotationRequest.SignatureAlgorithmSuite)
 	if err != nil {

--- a/lib/join/joinclient/join_tpm.go
+++ b/lib/join/joinclient/join_tpm.go
@@ -18,7 +18,6 @@ package joinclient
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/google/go-attestation/attest"
 	"github.com/gravitational/trace"
@@ -46,7 +45,7 @@ func tpmJoin(
 	// TPMEncryptedCredential->TPMSolution flow, and receive and return the
 	// final result.
 
-	log := slog.Default()
+	log := joinParams.Log
 
 	attestation, close, err := joinParams.AttestTPM(ctx, log)
 	if err != nil {

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -717,7 +717,7 @@ func botIdentityFromToken(
 		},
 		JoinMethod: cfg.Onboarding.JoinMethod,
 		Expires:    &expires,
-		Log: log,
+		Log:        log,
 
 		// Below options are effectively ignored if AuthClient is not-nil
 		Insecure:           cfg.Connection.Insecure,

--- a/lib/tbot/internal/identity/service.go
+++ b/lib/tbot/internal/identity/service.go
@@ -717,6 +717,7 @@ func botIdentityFromToken(
 		},
 		JoinMethod: cfg.Onboarding.JoinMethod,
 		Expires:    &expires,
+		Log: log,
 
 		// Below options are effectively ignored if AuthClient is not-nil
 		Insecure:           cfg.Connection.Insecure,


### PR DESCRIPTION
Modifies the join client to leverage an injected `slog.Logger` instance rather than the global one. If no `slog.Logger` is provided in params, it falls back to the global one - preserving prior behaviour.

`tbot` now injects its own logger down the join client. This should make it possible to reduce the amount of logs emitted when using `embeddedtbot` in CLI applications.