### PR TITLE
[v18] Fix proxy cache missing services due to lack of permissions

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -1307,6 +1307,7 @@ func definitionForBuiltinRole(clusterName string, recConfig readonly.SessionReco
 						types.NewRule(types.KindLock, services.RW()),
 						types.NewRule(types.KindSAML, services.ReadNoSecrets()),
 						types.NewRule(types.KindAccessList, services.RO()),
+						types.NewRule(types.KindAccessListMember, services.RO()),
 						// Okta can read/write access lists and roles it creates.
 						{
 							Resources: []string{types.KindRole},


### PR DESCRIPTION
Partial backport of #62994 (without app auth config, since it wasn't backported yet) to `branch/v18`.