### PR TITLE
Remove unused argument from httplib.SetIndexContentSecurityPolicy

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/utils"
 )
 
@@ -194,8 +193,8 @@ var sshSessionRe = regexp.MustCompile(`^/web/cluster/[^/]+/console/node/[^/]+/[^
 
 var indexCSPStringCache *cspCache = newCSPCache()
 
-func getIndexContentSecurityPolicyString(cfg proto.Features, urlPath string) string {
-	// Check for result with this cfg and urlPath in cache
+func getIndexContentSecurityPolicyString(urlPath string) string {
+	// Check for result with this urlPath in cache
 	if cspString, ok := indexCSPStringCache.get(urlPath); ok {
 		return cspString
 	}
@@ -212,8 +211,8 @@ func getIndexContentSecurityPolicyString(cfg proto.Features, urlPath string) str
 }
 
 // SetIndexContentSecurityPolicy sets the Content-Security-Policy header for main index.html page
-func SetIndexContentSecurityPolicy(h http.Header, cfg proto.Features, urlPath string) {
-	cspString := getIndexContentSecurityPolicyString(cfg, urlPath)
+func SetIndexContentSecurityPolicy(h http.Header, urlPath string) {
+	cspString := getIndexContentSecurityPolicyString(urlPath)
 	h.Set("Content-Security-Policy", cspString)
 }
 

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
-	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/observability/tracing"
 )
 
@@ -273,14 +272,12 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 
 	for _, tt := range []struct {
 		name            string
-		features        proto.Features
 		urlPath         string
 		expectedCspVals map[string]string
 	}{
 		{
-			name:     "default (no wasm)",
-			features: proto.Features{},
-			urlPath:  "/web/index.js",
+			name:    "default (no wasm)",
+			urlPath: "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
 				"base-uri":        "'self'",
@@ -295,9 +292,8 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for cloud based usage, EUB product (no wasm)",
-			features: proto.Features{Cloud: true, IsUsageBased: true, IsStripeManaged: false},
-			urlPath:  "/web/index.js",
+			name:    "for cloud based usage, EUB product (no wasm)",
+			urlPath: "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
 				"base-uri":        "'self'",
@@ -311,26 +307,8 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for desktop session (with wasm)",
-			features: proto.Features{},
-			urlPath:  "/web/cluster/:clusterId/desktops/:desktopName/:username",
-			expectedCspVals: map[string]string{
-				"default-src":     "'self'",
-				"base-uri":        "'self'",
-				"form-action":     "'self'",
-				"frame-ancestors": "'none'",
-				"object-src":      "'none'",
-				"script-src":      "'self' 'wasm-unsafe-eval'",
-				"style-src":       "'self' 'unsafe-inline'",
-				"img-src":         "'self' data: blob:",
-				"font-src":        "'self' data:",
-				"connect-src":     "'self' wss:",
-			},
-		},
-		{
-			name:     "for web ssh session (with wasm)",
-			features: proto.Features{},
-			urlPath:  "/web/cluster/:clusterId/console/node/:sessionId/:username",
+			name:    "for desktop session (with wasm)",
+			urlPath: "/web/cluster/:clusterId/desktops/:desktopName/:username",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
 				"base-uri":        "'self'",
@@ -345,9 +323,24 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
-			name:     "for cloud based usage & desktop session, with wasm",
-			features: proto.Features{Cloud: true, IsUsageBased: true, IsStripeManaged: true},
-			urlPath:  "/web/cluster/:clusterId/desktops/:desktopName/:username",
+			name:    "for web ssh session (with wasm)",
+			urlPath: "/web/cluster/:clusterId/console/node/:sessionId/:username",
+			expectedCspVals: map[string]string{
+				"default-src":     "'self'",
+				"base-uri":        "'self'",
+				"form-action":     "'self'",
+				"frame-ancestors": "'none'",
+				"object-src":      "'none'",
+				"script-src":      "'self' 'wasm-unsafe-eval'",
+				"style-src":       "'self' 'unsafe-inline'",
+				"img-src":         "'self' data: blob:",
+				"font-src":        "'self' data:",
+				"connect-src":     "'self' wss:",
+			},
+		},
+		{
+			name:    "for cloud based usage & desktop session, with wasm",
+			urlPath: "/web/cluster/:clusterId/desktops/:desktopName/:username",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
 				"base-uri":        "'self'",
@@ -364,7 +357,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			h := make(http.Header)
-			SetIndexContentSecurityPolicy(h, tt.features, tt.urlPath)
+			SetIndexContentSecurityPolicy(h, tt.urlPath)
 			actualCsp := h.Get("Content-Security-Policy")
 			for k, v := range tt.expectedCspVals {
 				expectedCspSubString := fmt.Sprintf("%s %s;", k, v)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -710,7 +710,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			session.XCSRF = csrfToken
 
 			httplib.SetNoCacheHeaders(w.Header())
-			httplib.SetIndexContentSecurityPolicy(w.Header(), cfg.ClusterFeatures, r.URL.Path)
+			httplib.SetIndexContentSecurityPolicy(w.Header(), r.URL.Path)
 
 			if err := indexPage.Execute(w, session); err != nil {
 				h.logger.ErrorContext(r.Context(), "Failed to execute index page template", "error", err)


### PR DESCRIPTION
The CSP used to conditionally include Stripe for the stripe-js SDK. When the team plan was retired we forgot to clean up the features references in the API.