### PR TITLE
Prevent panic in impersonation code path where user no longer exists

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -571,7 +571,7 @@ func (a *authorizer) isAdminActionAuthorizationRequired(ctx context.Context, aut
 		// Check that the impersonator matches a host service FQDN - <host-id>.<clustername>
 		if trace.IsNotFound(err) {
 			hostFQDNParts := strings.SplitN(impersonator, ".", 2)
-			if hostFQDNParts[1] == a.clusterName {
+			if len(hostFQDNParts) > 1 && hostFQDNParts[1] == a.clusterName {
 				if _, err := uuid.Parse(hostFQDNParts[0]); err == nil {
 					a.logger.DebugContext(ctx, "Skipping admin action MFA check for admin-impersonated identity", "identity", ident)
 					return false, nil

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -706,6 +706,17 @@ func TestAuthorizer_AuthorizeAdminAction(t *testing.T) {
 			withMFA:                   validMFAWithReuse,
 			wantAdminActionAuthorized: false,
 		}, {
+			name: "NOK edge case impersonator no longer exists",
+			user: authz.LocalUser{
+				Username: localUser.GetName(),
+				Identity: tlsca.Identity{
+					Username:     localUser.GetName(),
+					Groups:       localUser.GetRoles(),
+					Impersonator: "impersonator",
+				},
+			},
+			wantAdminActionAuthorized: false,
+		}, {
 			name: "OK local user valid mfa",
 			user: authz.LocalUser{
 				Username: localUser.GetName(),


### PR DESCRIPTION
This is a pretty obscure edge case where an admin action attempt can cause the admin server to crash.

The following have to be true:

- The request is coming from an impersonator
- The impersonating user no longer exists, but has a valid cert
- They are impersonating a user who does still exist (not a role)
- The impersonator username does not have a dot ('.') in it
- Admin action MFA is required

If all of those are true, then the request will cause a panic. I confirmed in my own testing cluster, and was able to crash my auth server.

This may be considered a security issue (denial of service) but I'd classify it more of a weakness / hardening opportunity than a real vulnerability. The impact is low, and the complexity is extremely high.