### PR TITLE
[v18] fix: tighten access list review range bounds

### DIFF
--- a/lib/cache/access_list.go
+++ b/lib/cache/access_list.go
@@ -407,10 +407,10 @@ func (c *Cache) ListAccessListReviews(ctx context.Context, accessList string, pa
 		},
 	}
 
-	start := accessList
-	end := sortcache.NextKey(accessList + "/")
+	start := accessList + "/"
+	end := sortcache.NextKey(start)
 	if pageToken != "" {
-		start += "/" + pageToken
+		start += pageToken
 	}
 
 	out, next, err := lister.listRange(ctx, pageSize, start, end)

--- a/lib/cache/access_list_test.go
+++ b/lib/cache/access_list_test.go
@@ -341,6 +341,11 @@ func TestAccessListReviews(t *testing.T) {
 		assert.Len(t, out, 10)
 	}, 15*time.Second, 100*time.Millisecond)
 
+	// access-list is a prefix of access-list-test, make sure no reviews are
+	// returned from the wrong list.
+	out, _, err := p.cache.ListAccessListReviews(context.Background(), "access-list", 100, "")
+	require.NoError(t, err)
+	assert.Empty(t, out)
 }
 
 func TestListAccessListsV2(t *testing.T) {


### PR DESCRIPTION
Backport #63312 to branch/v18

changelog: Fixed a bug affecting access list review queries for lists where the name is a prefix of another list name
