### PR TITLE
Trim collected "OS username" on Linux

### DIFF
--- a/lib/devicetrust/native/device_linux.go
+++ b/lib/devicetrust/native/device_linux.go
@@ -175,6 +175,12 @@ func collectDeviceData(mode CollectDataMode) (*devicepb.DeviceCollectedData, err
 
 	osRelease := <-osReleaseC
 
+	displayName := u.Name
+	const maxUsernameLen = 40 // Matches server-side validation.
+	if len(displayName) > maxUsernameLen {
+		displayName = displayName[:maxUsernameLen]
+	}
+
 	return &devicepb.DeviceCollectedData{
 		CollectTime:           timestamppb.Now(),
 		OsType:                devicepb.OSType_OS_TYPE_LINUX,
@@ -183,7 +189,7 @@ func collectDeviceData(mode CollectDataMode) (*devicepb.DeviceCollectedData, err
 		OsId:                  osRelease.ID,
 		OsVersion:             osRelease.VersionID,
 		OsBuild:               osRelease.Version,
-		OsUsername:            u.Name,
+		OsUsername:            displayName, // Wrong, but kept for backwards compatibility.
 		ReportedAssetTag:      reportedAssetTag,
 		SystemSerialNumber:    systemSerialNumber,
 		BaseBoardSerialNumber: baseBoardSerialNumber,


### PR DESCRIPTION
Trim the collected "OS username" on tsh/Linux so it won't break server-side limits.

The collected username is in fact wrong, as tsh/Linux sends the display name instead. We can't simply change it to the correct value as it would break collected data validation. Follow-up PRs will address this issue, both client- and server-side, by adding a new "username" field.

#63295

Changelog: Fixed tsh/Linux sending a too-large username for device trust