### PR TITLE
Web UI: Discover AWS IaC tweaks redux

### DIFF
--- a/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuide.tsx
+++ b/web/packages/shared/components/SlidingSidePanel/InfoGuide/InfoGuide.tsx
@@ -20,7 +20,7 @@ import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 
 import { Box, Button, ButtonIcon, Flex, H3, Link, Text } from 'design';
-import { Cross, Info } from 'design/Icon';
+import { Cross, Info, NewTab } from 'design/Icon';
 import {
   InfoGuideConfig,
   useInfoGuide,
@@ -157,7 +157,10 @@ export const ReferenceLinks = ({ links }: { links: ReferenceLink[] }) => (
       {links.map(link => (
         <InfoLinkLi key={link.href}>
           <Link target="_blank" href={link.href}>
-            {link.title}
+            <Flex>
+              {link.title}
+              <NewTab size="small" ml={1} />
+            </Flex>
           </Link>
         </InfoLinkLi>
       ))}

--- a/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
+++ b/web/packages/teleport/src/Discover/Overview/SettingsTab.tsx
@@ -17,22 +17,24 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { Box, Card, Flex, Indicator } from 'design';
 import { Info as InfoAlert } from 'design/Alert';
-import { useInfoGuide } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
+import { InfoGuideContainer } from 'shared/components/SlidingSidePanel/InfoGuide';
 import Validation from 'shared/components/Validation';
 
+import { SlidingSidePanel } from 'teleport/components/SlidingSidePanel/SlidingSidePanel';
 import { DeploymentMethodSection } from 'teleport/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection';
 import {
   ConfigurationScopeSection,
   Divider,
-  InfoGuideTab,
   IntegrationSection,
 } from 'teleport/Integrations/Enroll/Cloud/Aws/EnrollAws';
 import {
   InfoGuideContent,
+  InfoGuideTab,
   InfoGuideTitle,
   TerraformInfoGuide,
 } from 'teleport/Integrations/Enroll/Cloud/Aws/InfoGuide';
@@ -44,6 +46,7 @@ import {
   WildcardRegion,
 } from 'teleport/Integrations/Enroll/Cloud/Aws/types';
 import { AwsResource } from 'teleport/Integrations/status/AwsOidc/Cards/StatCard';
+import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 import {
   IntegrationDiscoveryRule,
   integrationService,
@@ -54,7 +57,7 @@ import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeleteIntegrationSection } from './DeleteIntegrationSection';
 
-const infoGuidePanelWidth = 500;
+export const SETTINGS_PANEL_WIDTH = 500;
 
 export function SettingsTab({
   stats,
@@ -67,14 +70,6 @@ export function SettingsTab({
 }) {
   const integrationName = stats.name;
   const { clusterVersion } = useClusterVersion();
-  const [configCopied, setConfigCopied] = useState(false);
-
-  const handleConfigCopy = () => {
-    setConfigCopied(true);
-    setTimeout(() => {
-      setConfigCopied(false);
-    }, 1000);
-  };
 
   const { data: ec2Rules, isLoading } = useQuery({
     queryKey: ['integrationRules', stats.name, AwsResource.ec2],
@@ -135,52 +130,7 @@ export function SettingsTab({
     [integrationName, regions, ec2Config, clusterVersion]
   );
 
-  const { infoGuideConfig: currentInfoGuideConfig, setInfoGuideConfig } =
-    useInfoGuide();
-  const copyConfigButtonRef = useRef<HTMLButtonElement>(null);
-  const prevConfigRef = useRef(currentInfoGuideConfig);
-
-  const infoGuideConfig = useMemo(
-    () => ({
-      guide:
-        activeInfoGuideTab === 'terraform' ? (
-          <TerraformInfoGuide
-            terraformConfig={terraformConfig}
-            copyConfigButtonRef={copyConfigButtonRef}
-            configCopied={configCopied}
-          />
-        ) : (
-          <InfoGuideContent />
-        ),
-      title: (
-        <InfoGuideTitle
-          activeSection={activeInfoGuideTab}
-          onSectionChange={onInfoGuideTabChange}
-        />
-      ),
-      panelWidth: infoGuidePanelWidth,
-    }),
-    [terraformConfig, activeInfoGuideTab, onInfoGuideTabChange, configCopied]
-  );
-
-  useEffect(() => {
-    // set active info tab to null when panel closed externally
-    if (
-      prevConfigRef.current &&
-      !currentInfoGuideConfig &&
-      activeInfoGuideTab
-    ) {
-      onInfoGuideTabChange(null);
-    } else if (activeInfoGuideTab) {
-      // open info panel for active info tab
-      setInfoGuideConfig(infoGuideConfig);
-    } else {
-      // close panel
-      setInfoGuideConfig(null);
-    }
-
-    prevConfigRef.current = currentInfoGuideConfig;
-  }, [activeInfoGuideTab, currentInfoGuideConfig, infoGuideConfig]);
+  const isPanelOpen = activeInfoGuideTab !== null;
 
   if (isLoading) {
     return (
@@ -192,51 +142,86 @@ export function SettingsTab({
 
   return (
     <Validation>
-      <Flex pt={3}>
-        <Box flex="1" mr={3}>
-          <Card p={4} mb={3}>
-            <InfoAlert
-              mb={3}
-              details="Review the prerequisites and setup requirements before configuring this integration."
-              primaryAction={{
-                content: 'View Info Guide',
-                onClick: () => onInfoGuideTabChange('info'),
-              }}
-            >
-              Before You Begin
-            </InfoAlert>
-            <Box mb={4}>
-              <IntegrationSection
-                integrationName={integrationName}
-                onChange={() => {}}
-                disabled={true}
+      {({ validator }) => (
+        <Flex pt={3}>
+          <Box flex="1">
+            <Card p={4} mb={3}>
+              <InfoAlert
+                mb={3}
+                details="Review the prerequisites and setup requirements before configuring this integration."
+                primaryAction={{
+                  content: 'View Info Guide',
+                  onClick: () => onInfoGuideTabChange('info'),
+                }}
+              >
+                Before You Begin
+              </InfoAlert>
+              <Box mb={4}>
+                <IntegrationSection
+                  integrationName={integrationName}
+                  onChange={() => {}}
+                  disabled={true}
+                />
+              </Box>
+              <Divider />
+              <Box>
+                <ConfigurationScopeSection />
+              </Box>
+              <Divider />
+              <ResourcesSection
+                ec2Config={ec2Config}
+                onEc2Change={setEc2Config}
               />
-            </Box>
-            <Divider />
-            <Box>
-              <ConfigurationScopeSection />
-            </Box>
-            <Divider />
-            <ResourcesSection
-              ec2Config={ec2Config}
-              onEc2Change={setEc2Config}
-            />
-            <Divider />
-            <RegionsSection regions={regions} onChange={setRegions} />
-            <Divider />
-            <DeploymentMethodSection
-              terraformConfig={terraformConfig}
-              copyConfigButtonRef={copyConfigButtonRef}
-              integrationExists={true}
-              showVerificationStep={false}
-              configCopied={configCopied}
-              onConfigCopy={handleConfigCopy}
-            />
-          </Card>
+              <Divider />
+              <RegionsSection regions={regions} onChange={setRegions} />
+              <Divider />
+              <DeploymentMethodSection
+                terraformConfig={terraformConfig}
+                handleCopy={() => {
+                  if (validator.validate() && terraformConfig) {
+                    copyToClipboard(terraformConfig);
+                  }
+                }}
+                integrationExists={true}
+                showVerificationStep={false}
+              />
+            </Card>
 
-          <DeleteIntegrationSection integrationName={integrationName} />
-        </Box>
-      </Flex>
+            <DeleteIntegrationSection integrationName={integrationName} />
+          </Box>
+
+          <SlidingSidePanel
+            isVisible={isPanelOpen}
+            skipAnimation={false}
+            panelWidth={SETTINGS_PANEL_WIDTH}
+            zIndex={zIndexMap.infoGuideSidePanel}
+            slideFrom="right"
+          >
+            <InfoGuideContainer
+              onClose={() => onInfoGuideTabChange(null)}
+              title={
+                <InfoGuideTitle
+                  activeSection={activeInfoGuideTab}
+                  onSectionChange={onInfoGuideTabChange}
+                />
+              }
+            >
+              {activeInfoGuideTab === 'terraform' ? (
+                <TerraformInfoGuide
+                  terraformConfig={terraformConfig}
+                  handleCopy={() => {
+                    if (validator.validate() && terraformConfig) {
+                      copyToClipboard(terraformConfig);
+                    }
+                  }}
+                />
+              ) : (
+                <InfoGuideContent />
+              )}
+            </InfoGuideContainer>
+          </SlidingSidePanel>
+        </Flex>
+      )}
     </Validation>
   );
 }

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -27,6 +27,7 @@ import { TextSelectCopyMulti } from 'shared/components/TextSelectCopy';
 import { useValidation } from 'shared/components/Validation';
 
 import cfg from 'teleport/config';
+import { IntegrationKind } from 'teleport/services/integrations';
 
 import { CircleNumber } from './EnrollAws';
 
@@ -59,8 +60,9 @@ type DeploymentMethodSectionProps = {
   handleCopy: () => void;
   integrationExists?: boolean;
   integrationName?: string;
-  onCheckIntegration?: () => void;
-  onCancelCheckIntegration?: () => void;
+  handleCheckIntegration?: () => void;
+  handleCancelCheckIntegration?: () => void;
+  checkIntegrationError?: boolean;
   isCheckingIntegration?: boolean;
   showVerificationStep?: boolean;
 };
@@ -69,9 +71,10 @@ export function DeploymentMethodSection({
   handleCopy,
   integrationExists,
   integrationName,
-  onCheckIntegration,
+  handleCheckIntegration,
   isCheckingIntegration,
-  onCancelCheckIntegration,
+  checkIntegrationError,
+  handleCancelCheckIntegration,
   showVerificationStep = true,
 }: DeploymentMethodSectionProps) {
   const validator = useValidation();
@@ -142,7 +145,17 @@ export function DeploymentMethodSection({
                 3. Verify the integration
               </Text>
               {integrationExists ? (
-                <Alert kind="success" mb={2}>
+                <Alert
+                  kind="success"
+                  mb={2}
+                  primaryAction={{
+                    content: 'View Integration',
+                    linkTo: cfg.getIaCIntegrationRoute(
+                      IntegrationKind.AwsOidc,
+                      integrationName
+                    ),
+                  }}
+                >
                   Integration Detected
                   <Text fontWeight="regular">
                     Amazon Web Services successfully added
@@ -152,43 +165,49 @@ export function DeploymentMethodSection({
                 <>
                   <Box mb={3}>
                     {isCheckingIntegration ? (
-                      <Button
-                        fill="filled"
-                        intent="primary"
-                        disabled={true}
-                        onClick={onCheckIntegration}
-                        gap={2}
-                      >
-                        <AnimatedSpinner size="small" />
-                        Checking...
-                      </Button>
-                    ) : (
-                      <Button
-                        fill="filled"
-                        intent="primary"
-                        disabled={false}
-                        onClick={onCheckIntegration}
-                        gap={2}
-                      >
-                        Check Integration
-                      </Button>
-                    )}
-                  </Box>
-                  <Box mb={3}>
-                    {isCheckingIntegration ? (
                       <Alert
                         kind="info"
-                        icon={Notification}
+                        icon={AnimatedSpinner}
                         primaryAction={{
                           content: 'Cancel',
-                          onClick: onCancelCheckIntegration,
+                          onClick: handleCancelCheckIntegration,
                         }}
                         mb={0}
                       >
-                        Checking for integration '{integrationName}'...
+                        <Text fontWeight="regular" color="text.slightlyMuted">
+                          Checking for integration{' '}
+                          <Text as="span" fontWeight="bold">
+                            {integrationName}
+                          </Text>
+                          ...
+                        </Text>
+                      </Alert>
+                    ) : checkIntegrationError ? (
+                      <Alert
+                        kind="danger"
+                        mb={0}
+                        primaryAction={{
+                          content: 'Check Integration',
+                          onClick: handleCheckIntegration,
+                        }}
+                      >
+                        Failed to detect integration
+                        <Text fontWeight="regular" color="text.slightlyMuted">
+                          Unable to detect the AWS integration "
+                          {integrationName}". Please check your Terraform
+                          configuration and try again.
+                        </Text>
                       </Alert>
                     ) : (
-                      <Alert kind="neutral" icon={Notification} mb={0}>
+                      <Alert
+                        kind="neutral"
+                        icon={Notification}
+                        mb={0}
+                        primaryAction={{
+                          content: 'Check Integration',
+                          onClick: handleCheckIntegration,
+                        }}
+                      >
                         <Text fontWeight="regular" color="text.slightlyMuted">
                           After applying your Terraform configuration, verify
                           your integration was created successfully.

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.test.tsx
@@ -181,9 +181,16 @@ describe('EnrollAws', () => {
       );
     });
 
-    expect(
-      screen.getByRole('link', { name: /view integration/i })
-    ).toHaveAttribute('href', expect.stringContaining('/test-integration'));
+    const viewIntegrationLinks = screen.getAllByRole('link', {
+      name: /^view integration$/i,
+    });
+
+    viewIntegrationLinks.forEach(link => {
+      expect(link).toHaveAttribute(
+        'href',
+        expect.stringContaining('/test-integration')
+      );
+    });
   });
 
   test('integration not found shows an error', async () => {

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router';
+
+import { act, fireEvent, render, screen, waitFor } from 'design/utils/testing';
+import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
+
+import 'shared/components/TextEditor/TextEditor.mock';
+
+import { copyToClipboard } from 'design/utils/copyToClipboard';
+import { useToastNotifications } from 'shared/components/ToastNotification';
+
+import { ContextProvider } from 'teleport';
+import cfg from 'teleport/config';
+import { ContentMinWidth } from 'teleport/Main/Main';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import { ApiError } from 'teleport/services/api/parseError';
+import { integrationService } from 'teleport/services/integrations';
+
+import { EnrollAws } from './EnrollAws';
+
+jest.mock('design/utils/copyToClipboard', () => ({
+  copyToClipboard: jest.fn(),
+}));
+
+jest.mock(
+  'shared/components/ToastNotification/ToastNotificationContext',
+  () => {
+    const originalContext = jest.requireActual(
+      'shared/components/ToastNotification/ToastNotificationContext'
+    );
+    return {
+      ...originalContext,
+      useToastNotifications: jest.fn(),
+    };
+  }
+);
+
+const defaultProxyCluster = cfg.proxyCluster;
+
+describe('EnrollAws', () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  let mockAddToast: jest.Mock;
+
+  function renderEnrollAws() {
+    const ctx = createTeleportContext();
+    ctx.storeUser.state.cluster.authVersion = '1.0.0';
+
+    return render(
+      <ContextProvider ctx={ctx}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <InfoGuidePanelProvider>
+              <ContentMinWidth>
+                <EnrollAws />
+              </ContentMinWidth>
+            </InfoGuidePanelProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </ContextProvider>
+    );
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    queryClient.clear();
+    cfg.proxyCluster = 'my-cluster.cloud.gravitational.io';
+
+    mockAddToast = jest.fn();
+    (useToastNotifications as jest.Mock).mockReturnValue({
+      add: mockAddToast,
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    cfg.proxyCluster = defaultProxyCluster;
+  });
+
+  test('terraform template renders', async () => {
+    renderEnrollAws();
+
+    await waitFor(() => {
+      expect(screen.getByText(/module "aws_discovery"/)).toBeInTheDocument();
+    });
+
+    const editor = screen.getByTestId('mock-text-editor');
+    expect(editor).toHaveTextContent(/module "aws_discovery"/);
+  });
+
+  test('copy terraform configuration button validates and copies to clipboard', async () => {
+    renderEnrollAws();
+
+    const copyButtons = screen.getAllByRole('button', {
+      name: /copy terraform module/i,
+    });
+    const copyButton = copyButtons[0];
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/integration name is required/i)
+      ).toBeInTheDocument();
+    });
+
+    const input = screen.getByLabelText(/integration name/i);
+    fireEvent.change(input, {
+      target: { value: 'test-integration' },
+    });
+
+    fireEvent.click(copyButton);
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('teleport_integration_name')
+    );
+
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      expect.stringContaining('"test-integration"')
+    );
+  });
+
+  test('check integration button validates form', async () => {
+    renderEnrollAws();
+
+    const checkButton = screen.getByRole('button', {
+      name: /check integration/i,
+    });
+    fireEvent.click(checkButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/integration name is required/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('queries for integration and shows success toast when found', async () => {
+    jest
+      .spyOn(integrationService, 'fetchIntegration')
+      .mockResolvedValue({ name: 'test-integration' } as any);
+
+    renderEnrollAws();
+
+    fireEvent.change(screen.getByLabelText(/integration name/i), {
+      target: { value: 'test-integration' },
+    });
+
+    const checkButton = screen.getByRole('button', {
+      name: /check integration/i,
+    });
+    fireEvent.click(checkButton);
+
+    const success = await screen.findByText(/successfully added/i);
+    expect(success).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'success',
+        })
+      );
+    });
+
+    expect(
+      screen.getByRole('link', { name: /view integration/i })
+    ).toHaveAttribute('href', expect.stringContaining('/test-integration'));
+  });
+
+  test('integration not found shows an error', async () => {
+    jest.useFakeTimers();
+
+    jest.spyOn(integrationService, 'fetchIntegration').mockRejectedValue(
+      new ApiError({
+        message: '',
+        response: { status: 404 } as Response,
+      })
+    );
+
+    renderEnrollAws();
+
+    fireEvent.change(screen.getByLabelText(/integration name/i), {
+      target: { value: 'missing-integration' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /check integration/i }));
+
+    // wait until polling fails
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(35000);
+    });
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: 'error',
+        })
+      );
+    });
+
+    expect(
+      screen.getByRole('button', { name: /^view integration$/i })
+    ).toBeDisabled();
+
+    jest.useRealTimers();
+  });
+
+  test('panel switches between info and terraform tabs', async () => {
+    renderEnrollAws();
+
+    expect(
+      screen.getByRole('radio', { name: 'Terraform Configuration' })
+    ).toBeChecked();
+
+    const infoButton = screen.getByRole('radio', { name: 'Info Guide' });
+    fireEvent.click(infoButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Reference Links/i)).toBeInTheDocument();
+    });
+
+    const terraformButton = screen.getByRole('radio', {
+      name: 'Terraform Configuration',
+    });
+    fireEvent.click(terraformButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/module "aws_discovery"/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Reference Links')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -229,15 +229,17 @@ export function EnrollAws() {
                 }}
                 integrationExists={integrationExists}
                 integrationName={integrationName}
-                onCheckIntegration={() => {
+                handleCheckIntegration={() => {
                   if (validator.validate()) {
                     checkIntegration();
                   }
                 }}
-                onCancelCheckIntegration={() => {
+                handleCancelCheckIntegration={() => {
                   queryClient.cancelQueries({ queryKey: integrationQueryKey });
+                  queryClient.resetQueries({ queryKey: integrationQueryKey });
                 }}
                 isCheckingIntegration={isFetching}
+                checkIntegrationError={isError}
               />
             </Container>
             <Box mb={2}>

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -184,7 +184,7 @@ export function EnrollAws() {
   return (
     <Validation>
       {({ validator }) => (
-        <Flex pt={3}>
+        <Box pt={3}>
           <ContentWithSidePanel
             isPanelOpen={isPanelOpen}
             panelWidth={PANEL_WIDTH}
@@ -302,7 +302,7 @@ export function EnrollAws() {
               )}
             </InfoGuideContainer>
           </SlidingSidePanel>
-        </Flex>
+        </Box>
       )}
     </Validation>
   );

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
 import { Link as InternalLink } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -29,25 +29,18 @@ import {
   Subtitle1,
   Text,
 } from 'design';
-import { Info } from 'design/Icon';
-import { ResourceIcon } from 'design/ResourceIcon';
-import { HoverTooltip } from 'design/Tooltip';
-import {
-  ViewModeSwitchButton,
-  ViewModeSwitchContainer,
-} from 'shared/components/Controls/ViewModeSwitch';
+import { copyToClipboard } from 'design/utils/copyToClipboard';
 import FieldInput from 'shared/components/FieldInput';
-import {
-  InfoGuideConfig,
-  useInfoGuide,
-} from 'shared/components/SlidingSidePanel/InfoGuide';
+import { InfoGuideContainer } from 'shared/components/SlidingSidePanel/InfoGuide';
 import { useToastNotifications } from 'shared/components/ToastNotification';
 import Validation from 'shared/components/Validation';
 import { requiredIntegrationName } from 'shared/components/Validation/rules';
 
+import { SlidingSidePanel } from 'teleport/components/SlidingSidePanel/SlidingSidePanel';
 import cfg from 'teleport/config';
 import { Header } from 'teleport/Discover/Shared';
 import { useNoMinWidth } from 'teleport/Main';
+import { zIndexMap } from 'teleport/Navigation/zIndexMap';
 import { ApiError } from 'teleport/services/api/parseError';
 import {
   Regions as AwsRegion,
@@ -58,7 +51,10 @@ import { useClusterVersion } from 'teleport/useClusterVersion';
 
 import { DeploymentMethodSection } from './DeploymentMethodSection';
 import {
+  ContentWithSidePanel,
   InfoGuideContent,
+  InfoGuideSwitch,
+  InfoGuideTab,
   InfoGuideTitle,
   PANEL_WIDTH,
   TerraformInfoGuide,
@@ -71,8 +67,6 @@ import { Ec2Config, WildcardRegion } from './types';
 
 const INTEGRATION_CHECK_RETRIES = 6;
 const INTEGRATION_CHECK_RETRY_DELAY = 5000;
-
-export type InfoGuideTab = 'info' | 'terraform' | null;
 
 export function EnrollAws() {
   useNoMinWidth();
@@ -90,15 +84,6 @@ export function EnrollAws() {
     tags: [],
   });
 
-  const [configCopied, setConfigCopied] = useState(false);
-
-  const handleConfigCopy = () => {
-    setConfigCopied(true);
-    setTimeout(() => {
-      setConfigCopied(false);
-    }, 1000);
-  };
-
   const terraformConfig = useMemo(
     () =>
       buildTerraformConfig({
@@ -110,43 +95,11 @@ export function EnrollAws() {
     [integrationName, regions, ec2Config, clusterVersion]
   );
 
-  const copyConfigButtonRef = useRef<HTMLButtonElement>(null);
-
+  const [isPanelOpen, setIsPanelOpen] = useState(true);
   const [activeInfoGuideTab, setActiveInfoGuideTab] =
     useState<InfoGuideTab>('terraform');
 
-  const { infoGuideConfig: currentInfoGuideConfig, setInfoGuideConfig } =
-    useInfoGuide();
-
-  const infoGuideConfig = useMemo(
-    () => ({
-      guide:
-        activeInfoGuideTab === 'terraform' ? (
-          <TerraformInfoGuide
-            terraformConfig={terraformConfig}
-            copyConfigButtonRef={copyConfigButtonRef}
-            configCopied={configCopied}
-          />
-        ) : (
-          <InfoGuideContent />
-        ),
-      title: (
-        <InfoGuideTitle
-          activeSection={activeInfoGuideTab}
-          onSectionChange={setActiveInfoGuideTab}
-        />
-      ),
-      panelWidth: PANEL_WIDTH,
-    }),
-    [terraformConfig, activeInfoGuideTab, configCopied]
-  );
-
-  useEffect(() => {
-    setInfoGuideConfig(infoGuideConfig);
-  }, [setInfoGuideConfig, infoGuideConfig]);
-
   const toastNotifications = useToastNotifications();
-  const didShowToast = useRef(false);
 
   const integrationQueryKey = ['integration', integrationName];
 
@@ -158,7 +111,8 @@ export function EnrollAws() {
     refetch,
   } = useQuery({
     queryKey: integrationQueryKey,
-    queryFn: () => integrationService.fetchIntegration(integrationName),
+    queryFn: ({ signal }) =>
+      integrationService.fetchIntegration(integrationName, signal),
     enabled: false,
     retry: (failureCount, error: unknown) => {
       const shouldRetry =
@@ -171,16 +125,11 @@ export function EnrollAws() {
     gcTime: 0,
   });
 
-  const shouldShowErrorToast = isError && !isFetching && integrationName;
-  const shouldShowSuccessToast = isSuccess && !isFetching && integrationName;
+  const queryClient = useQueryClient();
 
-  // handle success / error toasts
+  // show success toast
   useEffect(() => {
-    if (isFetching) {
-      return;
-    }
-
-    if (shouldShowSuccessToast) {
+    if (isSuccess && !isFetching && integrationName) {
       toastNotifications.add({
         severity: 'success',
         content: {
@@ -199,7 +148,13 @@ export function EnrollAws() {
           isAutoRemovable: false,
         },
       });
-    } else if (shouldShowErrorToast) {
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isSuccess, isFetching, integrationName]);
+
+  // show error toast
+  useEffect(() => {
+    if (isError && !isFetching && integrationName) {
       toastNotifications.add({
         severity: 'error',
         content: {
@@ -208,23 +163,21 @@ export function EnrollAws() {
         },
       });
     }
-
-    didShowToast.current = true;
-  }, [isFetching]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isError, isFetching, integrationName]);
 
   const checkIntegration = () => {
-    didShowToast.current = false;
     refetch();
   };
 
   const integrationExists = !!integrationData;
 
   const onInfoGuideClick = (section: InfoGuideTab) => {
-    if (!!currentInfoGuideConfig && activeInfoGuideTab === section) {
-      setInfoGuideConfig(null);
+    if (isPanelOpen && activeInfoGuideTab === section) {
+      setIsPanelOpen(false);
     } else {
       setActiveInfoGuideTab(section);
-      setInfoGuideConfig(infoGuideConfig);
+      setIsPanelOpen(true);
     }
   };
 
@@ -232,11 +185,14 @@ export function EnrollAws() {
     <Validation>
       {({ validator }) => (
         <Flex pt={3}>
-          <Box flex="1" mr={3}>
+          <ContentWithSidePanel
+            isPanelOpen={isPanelOpen}
+            panelWidth={PANEL_WIDTH}
+          >
             <Flex justifyContent="space-between" alignItems="start" mb={1}>
               <Header>Connect Amazon Web Services</Header>
               <InfoGuideSwitch
-                currentConfig={currentInfoGuideConfig}
+                isPanelOpen={isPanelOpen}
                 activeTab={activeInfoGuideTab}
                 onSwitch={onInfoGuideClick}
               />
@@ -266,7 +222,11 @@ export function EnrollAws() {
               <Divider />
               <DeploymentMethodSection
                 terraformConfig={terraformConfig}
-                copyConfigButtonRef={copyConfigButtonRef}
+                handleCopy={() => {
+                  if (validator.validate() && terraformConfig) {
+                    copyToClipboard(terraformConfig);
+                  }
+                }}
                 integrationExists={integrationExists}
                 integrationName={integrationName}
                 onCheckIntegration={() => {
@@ -274,9 +234,10 @@ export function EnrollAws() {
                     checkIntegration();
                   }
                 }}
+                onCancelCheckIntegration={() => {
+                  queryClient.cancelQueries({ queryKey: integrationQueryKey });
+                }}
                 isCheckingIntegration={isFetching}
-                configCopied={configCopied}
-                onConfigCopy={handleConfigCopy}
               />
             </Container>
             <Box mb={2}>
@@ -307,7 +268,38 @@ export function EnrollAws() {
                 Back
               </ButtonSecondary>
             </Box>
-          </Box>
+          </ContentWithSidePanel>
+
+          <SlidingSidePanel
+            isVisible={isPanelOpen}
+            skipAnimation={false}
+            panelWidth={PANEL_WIDTH}
+            zIndex={zIndexMap.infoGuideSidePanel}
+            slideFrom="right"
+          >
+            <InfoGuideContainer
+              onClose={() => setIsPanelOpen(false)}
+              title={
+                <InfoGuideTitle
+                  activeSection={activeInfoGuideTab}
+                  onSectionChange={setActiveInfoGuideTab}
+                />
+              }
+            >
+              {activeInfoGuideTab === 'terraform' ? (
+                <TerraformInfoGuide
+                  terraformConfig={terraformConfig}
+                  handleCopy={() => {
+                    if (validator.validate() && terraformConfig) {
+                      copyToClipboard(terraformConfig);
+                    }
+                  }}
+                />
+              ) : (
+                <InfoGuideContent />
+              )}
+            </InfoGuideContainer>
+          </SlidingSidePanel>
         </Flex>
       )}
     </Validation>
@@ -379,53 +371,6 @@ export function ConfigurationScopeSection() {
     </>
   );
 }
-
-type InfoGuideSwitchProps = {
-  activeTab: InfoGuideTab;
-  currentConfig: InfoGuideConfig | null;
-  onSwitch: (activeTab: InfoGuideTab) => void;
-};
-
-export const InfoGuideSwitch = ({
-  activeTab,
-  currentConfig,
-  onSwitch,
-}: InfoGuideSwitchProps) => {
-  return (
-    <ViewModeSwitchContainer
-      aria-label="Info Guide Mode Switch"
-      aria-orientation="horizontal"
-      role="radiogroup"
-    >
-      <HoverTooltip tipContent="Info Guide">
-        <ViewModeSwitchButton
-          className={!!currentConfig && activeTab === 'info' ? 'selected' : ''}
-          onClick={() => onSwitch('info')}
-          role="radio"
-          aria-checked={!!currentConfig && activeTab === 'info'}
-          aria-label="Info Guide"
-          first
-        >
-          <Info size="small" color="text.main" />
-        </ViewModeSwitchButton>
-      </HoverTooltip>
-      <HoverTooltip tipContent="Terraform Configuration">
-        <ViewModeSwitchButton
-          className={
-            !!currentConfig && activeTab === 'terraform' ? 'selected' : ''
-          }
-          onClick={() => onSwitch('terraform')}
-          role="radio"
-          aria-checked={!!currentConfig && activeTab === 'terraform'}
-          aria-label="Terraform Configuration"
-          last
-        >
-          <ResourceIcon name="terraform" width="16px" height="16px" />
-        </ViewModeSwitchButton>
-      </HoverTooltip>
-    </ViewModeSwitchContainer>
-  );
-};
 
 export const Container = styled(Flex)`
   border-radius: 8px;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
@@ -18,30 +18,52 @@
 
 import styled from 'styled-components';
 
-import { Box, Button, Flex, Text } from 'design';
-import { Check, Copy } from 'design/Icon';
+import { Box, Flex, Text } from 'design';
+import { Info } from 'design/Icon';
+import { ResourceIcon } from 'design/ResourceIcon';
+import { HoverTooltip } from 'design/Tooltip';
+import {
+  ViewModeSwitchButton,
+  ViewModeSwitchContainer,
+} from 'shared/components/Controls/ViewModeSwitch';
 import {
   InfoParagraph,
   InfoTitle,
   ReferenceLinks,
   type ReferenceLink,
 } from 'shared/components/SlidingSidePanel/InfoGuide';
+import { marginTransitionCss } from 'shared/components/SlidingSidePanel/InfoGuide/const';
+import { useValidation } from 'shared/components/Validation';
 
 import LiveTextEditor from '../LiveTextEditor';
+import { CopyTerraformButton } from './DeploymentMethodSection';
 
 export const PANEL_WIDTH = 500;
 
+export type InfoGuideTab = 'info' | 'terraform' | null;
+
+export const ContentWithSidePanel = styled(Box)<{
+  isPanelOpen: boolean;
+  panelWidth: number;
+}>`
+  ${props =>
+    marginTransitionCss({
+      sidePanelOpened: props.isPanelOpen,
+      panelWidth: props.panelWidth,
+    })}
+`;
+
 export type TerraformInfoGuideProps = {
   terraformConfig: string;
-  copyConfigButtonRef: React.RefObject<HTMLButtonElement>;
-  configCopied: boolean;
+  handleCopy: () => void;
 };
 
 export function TerraformInfoGuide({
   terraformConfig,
-  copyConfigButtonRef,
-  configCopied,
+  handleCopy,
 }: TerraformInfoGuideProps) {
+  const validator = useValidation();
+
   return (
     <Flex
       ml={-3}
@@ -54,18 +76,21 @@ export function TerraformInfoGuide({
         data={[{ content: terraformConfig, type: 'terraform' }]}
       />
       <Box p={3}>
-        <Button
-          disabled={copyConfigButtonRef.current?.disabled}
-          onClick={() => {
-            copyConfigButtonRef.current?.click();
+        <CopyTerraformButton
+          onClick={e => {
+            const isValid = validator.validate();
+            if (!isValid) {
+              e.preventDefault();
+            } else {
+              handleCopy();
+            }
           }}
-          gap={2}
-          fill="border"
-          intent="primary"
-        >
-          {configCopied ? <Check size="small" /> : <Copy size="small" />}
-          Copy Terraform Module
-        </Button>
+        />
+        {validator.state.validating && !validator.state.valid && (
+          <Text color="error.main" mt={2} fontSize={1}>
+            Please complete the required fields
+          </Text>
+        )}
       </Box>
     </Flex>
   );
@@ -167,3 +192,48 @@ export const InfoGuideTab = styled(Text)<{ active: boolean }>`
   color: ${p =>
     p.active ? p.theme.colors.interactive.solid.primary.default : 'inherit'};
 `;
+
+type InfoGuideSwitchProps = {
+  activeTab: InfoGuideTab;
+  isPanelOpen: boolean;
+  onSwitch: (activeTab: InfoGuideTab) => void;
+};
+
+export const InfoGuideSwitch = ({
+  activeTab,
+  isPanelOpen,
+  onSwitch,
+}: InfoGuideSwitchProps) => {
+  return (
+    <ViewModeSwitchContainer
+      aria-label="Info Guide Mode Switch"
+      aria-orientation="horizontal"
+      role="radiogroup"
+    >
+      <HoverTooltip tipContent="Info Guide">
+        <ViewModeSwitchButton
+          className={isPanelOpen && activeTab === 'info' ? 'selected' : ''}
+          onClick={() => onSwitch('info')}
+          role="radio"
+          aria-checked={isPanelOpen && activeTab === 'info'}
+          aria-label="Info Guide"
+          first
+        >
+          <Info size="small" color="text.main" />
+        </ViewModeSwitchButton>
+      </HoverTooltip>
+      <HoverTooltip tipContent="Terraform Configuration">
+        <ViewModeSwitchButton
+          className={isPanelOpen && activeTab === 'terraform' ? 'selected' : ''}
+          onClick={() => onSwitch('terraform')}
+          role="radio"
+          aria-checked={isPanelOpen && activeTab === 'terraform'}
+          aria-label="Terraform Configuration"
+          last
+        >
+          <ResourceIcon name="terraform" width="16px" height="16px" />
+        </ViewModeSwitchButton>
+      </HoverTooltip>
+    </ViewModeSwitchContainer>
+  );
+};

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/tf_module.ts
@@ -91,7 +91,6 @@ module "aws_discovery" {
   teleport_discovery_group_name = "cloud-discovery-group"
   teleport_integration_name	    = ${integrationNameOrNull}
 
-
   match_aws_resource_types = ${matchAwsTypes}
 
   match_aws_regions = ${regionsOrNull}

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -41,7 +41,8 @@ test('fetch a single integration: fetchIntegration()', async () => {
       'integration-name'
     );
   expect(api.get).toHaveBeenCalledWith(
-    cfg.getIntegrationsUrl('integration-name')
+    cfg.getIntegrationsUrl('integration-name'),
+    undefined
   );
   expect(response).toEqual({
     kind: 'aws-oidc',

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -83,9 +83,9 @@ export const integrationService = {
     return api.get(cfg.getIntegrationCaUrl(clusterId, integrationName));
   },
 
-  fetchIntegration<T>(name: string): Promise<T> {
+  fetchIntegration<T>(name: string, abortSignal?: AbortSignal): Promise<T> {
     return api
-      .get(cfg.getIntegrationsUrl(name))
+      .get(cfg.getIntegrationsUrl(name), abortSignal)
       .then(resp => makeIntegration(resp) as T);
   },
 


### PR DESCRIPTION
## Description
Issue: https://github.com/gravitational/teleport/issues/60813
Figma: https://www.figma.com/design/3JcCgPFtJqCG68GWmMXIfn/Root-Account-Discovery?node-id=2600-123262&t=dWwqyLyq4OHFwDvb-1

- Moved 'check integration' button into Alert action
- adds basic testing for EnrollAws component
- Added global 'pop out' icons to InfoGuide Reference Links
- Refactored custom Info Guide to use local state instead of the useInfoGuide hook
- Validation error displays in info guide panel
- Add a cancel button when polling for integration
