### PR TITLE
rework scoped comparison helpers

### DIFF
--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/scopes"
+	"github.com/gravitational/teleport/lib/scopes/pinning"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/sshagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -530,7 +531,7 @@ func getServerWithResolver(ctx context.Context, scopePin *scopesv1.Pin, host, po
 				agentScope = server.GetScope()
 			}
 
-			if !scopes.ResourceScope(agentScope).IsSubjectToPolicyScope(scopePin.GetScope()) {
+			if !pinning.PinAppliesToResourceScope(scopePin, agentScope) {
 				return false
 			}
 		}

--- a/lib/scopes/cache/cache_test.go
+++ b/lib/scopes/cache/cache_test.go
@@ -1127,13 +1127,13 @@ func TestCacheOperations(t *testing.T) {
 	// verify that the concept of policies-applicable-to-resource used by the cache
 	// matches up with the definition expected by the scopes package.
 	for scope := range cache.PoliciesApplicableToResourceScope("/child/subchild") {
-		require.True(t, scopes.ResourceScope("/child/subchild").IsSubjectToPolicyScope(scope.Scope()), "scope=%s", scope.Scope())
+		require.True(t, scopes.ResourceScope("/child/subchild").IsSubjectToScopeOfEffect(scope.Scope()), "scope=%s", scope.Scope())
 	}
 
 	// verify that the concept of resources-subject-to-policy used by the cache
 	// matches up with the definition expected by the scopes package.
 	for scope := range cache.ResourcesSubjectToPolicyScope("/child") {
-		require.True(t, scopes.PolicyScope("/child").AppliesToResourceScope(scope.Scope()), "scope=%s", scope.Scope())
+		require.True(t, scopes.ScopeOfEffect("/child").AppliesToResourceScope(scope.Scope()), "scope=%s", scope.Scope())
 	}
 
 	// verify deletion of a single intermediate item

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -122,8 +122,8 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 		return trace.Wrap(err, "validating scoped token assigned scope")
 	}
 
-	if !scopes.ResourceScope(spec.AssignedScope).IsSubjectToPolicyScope(token.GetScope()) {
-		return trace.BadParameter("scoped token assigned scope must be descendant of its resource scope")
+	if !scopes.ScopeOfOrigin(token.GetScope()).IsAssignableToScopeOfEffect(spec.AssignedScope) {
+		return trace.BadParameter("scoped token assigned scope must be descendant of or equivalent to the token's resource scope")
 	}
 
 	if err := validateJoinMethod(token); err != nil {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -152,7 +152,7 @@ func TestValidateScopedToken(t *testing.T) {
 			modFn: func(tok *joiningv1.ScopedToken) {
 				tok.Spec.AssignedScope = "/bb/aa"
 			},
-			expectedStrongErr: "scoped token assigned scope must be descendant of its resource scope",
+			expectedStrongErr: "scoped token assigned scope must be descendant of or equivalent to the token's resource scope",
 		},
 		{
 			name: "invalid join method",

--- a/lib/scopes/pinning/pinning.go
+++ b/lib/scopes/pinning/pinning.go
@@ -127,7 +127,7 @@ func PinCompatibleWithPolicyScope(pin *scopesv1.Pin, scope string) bool {
 // a pin at a given scope. A pin at scope /foo/bar might still yield an allow decision at resource scope /foo, but only if
 // the target resource is assigned to /foo/bar or one of its descendants.
 func PinAppliesToResourceScope(pin *scopesv1.Pin, resourceScope string) bool {
-	return scopes.PolicyScope(pin.GetScope()).AppliesToResourceScope(resourceScope)
+	return scopes.ScopeOfEffect(pin.GetScope()).AppliesToResourceScope(resourceScope)
 }
 
 // AssignmentTreeFromMap builds an assignment tree from a nested mapping of the form scopeOfOrigin -> scopeOfEffect -> roles. This is useful

--- a/lib/scopes/scopes.go
+++ b/lib/scopes/scopes.go
@@ -408,7 +408,7 @@ func NormalizeForEquality(scope string) string {
 
 // Relationship describes the relationship between two scopes, as determined by the [Compare] function. Note
 // that direct use of this type in access-control logic is discouraged, as it is easier to accidentally
-// misuse than the provided helpers (e.g. [PolicyScope]).
+// misuse than the provided helpers (e.g. [ScopeOfOrigin]).
 type Relationship int
 
 const (
@@ -455,7 +455,7 @@ func (rel Relationship) String() string {
 //	Compare(/aa, /aa/bb) => Descendant
 //	Compare(/aa/bb, /aa) => Ancestor
 //
-// Prefer using one of the provided helpers (e.g. [PolicyScope]) over using this function directly,
+// Prefer using one of the provided helpers (e.g. [ScopeOfOrigin]) over using this function directly,
 // as direct usage of this function can lead to ambiguity and accidental misuse.
 //
 // Note that this function does not perform validation, and may return unexpected results when
@@ -541,17 +541,45 @@ func Sort(lhs, rhs string) int {
 	}
 }
 
-// PolicyScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// ScopeOfOrigin is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
 // this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
 //
-//	if scopes.PolicyScope(roleAssignmentScope).AppliesToResourceScope(nodeScope) { ... }
+//	if scopes.ScopeOfOrigin(roleScope).IsAssignableToScopeOfEffect(assignmentScope) { ... }
 //
 // Note that this helper does not perform validation, and may produce unexpected results when used against
 // invalid scope values.
-type PolicyScope string
+type ScopeOfOrigin string
 
-// AppliesToResourceScope checks if a resource in the specified scope would be subject to this policy scope.
-func (s PolicyScope) AppliesToResourceScope(scope string) bool {
+// IsAssignableToScopeOfEffect checks if the Scope of Origin is compatible with the specified Scope of Effect. More
+// specifically, this method returns true if a policy originating from this Scope of Origin is able to be assigned
+// to the provided Scope of Effect. Policies may only have Scopes of Effect that are equivalent or descendant. A policy
+// originating from a child scope being effectual in a parent scope would violate scope isolation principles.
+func (s ScopeOfOrigin) IsAssignableToScopeOfEffect(scope string) bool {
+	rel := Compare(string(s), scope)
+	return rel == Equivalent || rel == Descendant
+}
+
+// ScopeOfEffect is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
+//
+//	if scopes.ScopeOfEffect(assignment.ScopeOfEffect).IsAssignableFromScopeOfOrigin(assignment.ScopeOfOrigin) { ... }
+//
+//	if scopes.ScopeOfEffect(assignment.ScopeOfEffect).AppliesToResourceScope(node.Scope) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid scope values.
+type ScopeOfEffect string
+
+// IsAssignableFromScopeOfOrigin checks if the Scope of Effect is compatible with the specified Scope of Origin. See
+// [ScopeOfOrigin.IsAssignableToScopeOfEffect] for discussion of the importance of this check.
+func (s ScopeOfEffect) IsAssignableFromScopeOfOrigin(scope string) bool {
+	rel := Compare(string(s), scope)
+	return rel == Equivalent || rel == Ancestor
+}
+
+// AppliesToResourceScope checks if this scope of effect applies to the specified resource scope. See [ResourceScope.IsSubjectToScopeOfEffect]
+// for discussion of the importance of this check.
+func (s ScopeOfEffect) AppliesToResourceScope(scope string) bool {
 	rel := Compare(string(s), scope)
 	return rel == Equivalent || rel == Descendant
 }
@@ -559,33 +587,60 @@ func (s PolicyScope) AppliesToResourceScope(scope string) bool {
 // ResourceScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
 // this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
 //
-//	if scopes.ResourceScope(nodeScope).IsSubjectToPolicyScope(roleAssignmentScope) { ... }
+//	if scopes.ResourceScope(nodeScope).IsSubjectToScopeOfEffect(roleAssignmentScope) { ... }
 //
 // Note that this helper does not perform validation, and may produce unexpected results when used against
 // invalid scope values.
 type ResourceScope string
 
-// IsSubjectToPolicyScope checks if this resource scope is subject to the specified policy scope.
-func (s ResourceScope) IsSubjectToPolicyScope(scope string) bool {
+// IsSubjectToScopeOfEffect checks if this resource scope is subject to the specified policy Scope of Effect. Scoped
+// policies always apply only to a given scope and its descendants. This method tells us if the resource scope in
+// question falls under the purview of the specified Scope of Effect. Policies whose Scope of Effect does not apply
+// to a resource must have no effect on that resource in order to preserve scope isolation.
+func (s ResourceScope) IsSubjectToScopeOfEffect(scope string) bool {
 	rel := Compare(string(s), scope)
 	return rel == Equivalent || rel == Ancestor
 }
 
-// PolicyAssignmentScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// PolicyResourceScope is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
 // this over using the Compare function directly, as it improves readability and reduces the risk of misuse. Ex:
 //
-//	if scopes.PolicyAssignmentScope(subAssignment.Scope).IsSubjectToPolicyResourceScope(assignment.Scope) { ... }
+//	if scopes.PolicyResourceScope(assignment.Scope).CanDependOnStateFromPolicyResourceAtScope(role.Scope) { ... }
 //
 // Note that this helper does not perform validation, and may produce unexpected results when used against
 // invalid scope values.
-type PolicyAssignmentScope string
+type PolicyResourceScope string
 
-// IsSubjectToPolicyResourceScope checks if this policy assignment scope is subject to the specified policy resource
-// scope. This is used to validate that the individual assignments within a resource conform to the scoping of the
-// overall assignment resource.
-func (s PolicyAssignmentScope) IsSubjectToPolicyResourceScope(scope string) bool {
+// CanDependOnStateFromPolicyResourceAtScope checks if this policy resource scope can depend on state from a policy
+// resource at the specified scope. Policy state must always flow from ancestor/equivalent scopes to descendant/equivalent
+// scopes (e.g. a role assignment can only reference roles in its scope or its ancestor scopes).
+func (s PolicyResourceScope) CanDependOnStateFromPolicyResourceAtScope(scope string) bool {
 	rel := Compare(string(s), scope)
 	return rel == Equivalent || rel == Ancestor
+}
+
+// ScopeOfEffectGlob is a helper for constructing unambiguous checks in access control logic. Prefer helpers like
+// this over using the Glob type directly, as it improves readability and reduces the risk of misuse. Ex:
+//
+//	if scopes.ScopeOfEffectGlob(role.Spec.AssignableScopes[0]).MatchesScopeOfEffect(assignment.ScopeOfEffect) { ... }
+//
+// Note that this helper does not perform validation, and may produce unexpected results when used against
+// invalid glob values.
+type ScopeOfEffectGlob string
+
+// MatchesScopeOfEffectLiteral checks if the Scope of Effect glob matches the specified Scope of Effect literal. If the assignability
+// of a policy is constrained by a ScopeOfEffectGlob, this function can be used to determine if a given Scope of Effect will
+// be compatible with that constraint.
+func (s ScopeOfEffectGlob) MatchesScopeOfEffectLiteral(scope string) bool {
+	return Glob(s).MatchesScopeLiteral(scope)
+}
+
+// IsAlwaysAssignableFromScopeOfOrigin checks if the Scope of Effect glob will exclusively match Scope of Effect literals
+// that are considered assignable from the specified Scope of Origin. Policy resources such as scoped roles sometimes constrain
+// the scopes they are assignable to using globs. This function ensures that a glob being used in this manner will never match a
+// Scope of Effect that would be invalid given the Scope of Origin of the policy.
+func (s ScopeOfEffectGlob) IsAlwaysAssignableFromScopeOfOrigin(scope string) bool {
+	return Glob(s).OnlyMatchesSubjectsOf(scope)
 }
 
 // Glob is a helper for matching scope globs against scopes. This is currently used to support exactly
@@ -598,16 +653,15 @@ func (s PolicyAssignmentScope) IsSubjectToPolicyResourceScope(scope string) bool
 // invalid scope or glob values.
 type Glob string
 
-// Matches checks if the given scope matches this scope glob.
-func (s Glob) Matches(scope string) bool {
+// MatchesScopeLiteral checks if the given scope literal matches this scope glob.
+func (s Glob) MatchesScopeLiteral(scope string) bool {
 	return matchGlob(string(s), scope)
 }
 
-// IsSubjectToPolicyResourceScope checks if this glob exclusively matches scopes that would be subject to the
-// specified policy resource scope. This is used to validate that the assignable scope globs of a role only
-// permit assignment of that role to scopes that could permissibly be subject to the policies defined by that role.
-func (s Glob) IsSubjectToPolicyResourceScope(scope string) bool {
-	return globIsSubjectToPolicyResourceScope(string(s), scope)
+// OnlyMatchesSubjectsOf checks if this scope glob only matches scopes that are subjects of the specified scope literal. In this
+// case "subjects of" means "descendants of or equivalent to".
+func (s Glob) OnlyMatchesSubjectsOf(scope string) bool {
+	return globOnlyMatchesSubjectsOfScope(string(s), scope)
 }
 
 // matchGlob implements glob matching. note that this function technically supports some limited
@@ -655,8 +709,9 @@ func matchGlob(glob string, scope string) bool {
 	}
 }
 
-// globIsSubjectToPolicyResourceScope checks if the glob is subject to the specified policy resource scope.
-func globIsSubjectToPolicyResourceScope(glob string, scope string) bool {
+// globOnlyMatchesSubjectsOfScope checks if the given glob only matches scopes that are subjects of the specified scope
+// literal. In this case "subjects of" means "descendants of or equivalent to".
+func globOnlyMatchesSubjectsOfScope(glob string, scope string) bool {
 	if glob == "" || scope == "" {
 		return false
 	}
@@ -747,10 +802,10 @@ func EnforcementPointsForResourceScope(resourceScope string) iter.Seq[Enforcemen
 			// policies are evaluated before more general ones within each origin level.
 			// We use AscendingScopes to go from most specific (resourceScope) to least specific (scopeOfOrigin).
 			for scopeOfEffect := range AscendingScopes(resourceScope) {
-				// Only yield if the Scope of Effect is subject to the Scope of Origin.
+				// Only yield if the Scope of Origin permits assignment to this Scope of Effect.
 				// A scope of effect cannot be more ancestral than its origin (that would violate
 				// the rule that policies cannot reach up to affect parent scopes).
-				if !ResourceScope(scopeOfEffect).IsSubjectToPolicyScope(scopeOfOrigin) {
+				if !ScopeOfOrigin(scopeOfOrigin).IsAssignableToScopeOfEffect(scopeOfEffect) {
 					// we've reached scopes of effect that are too ancestral for this origin
 					break
 				}

--- a/lib/scopes/scopes_test.go
+++ b/lib/scopes/scopes_test.go
@@ -785,44 +785,68 @@ func TestSort(t *testing.T) {
 	}
 }
 
-// TestPolicyAndResourceScope tests the relationship between policy and resource scopes helpers
-// given various combinations of policy and resource scopes.
-func TestPolicyAndResourceScope(t *testing.T) {
+// TestScopeOfEffectAndResourceScope tests the relationship between scope of effect and resource scopes helpers
+// given various combinations of effect and resource scopes.
+func TestScopeOfEffectAndResourceScope(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
-		name      string
-		privilege string
-		resource  string
-		applies   bool
+		name     string
+		effect   string
+		resource string
+		applies  bool
 	}{
 		{
-			name:      "simple root",
-			privilege: "/",
-			resource:  "/",
-			applies:   true,
+			name:     "simple root",
+			effect:   "/",
+			resource: "/",
+			applies:  true,
 		},
 		{
-			name:      "simple root privilege",
-			privilege: "/",
-			resource:  "/aa",
-			applies:   true,
+			name:     "simple root effect",
+			effect:   "/",
+			resource: "/aa",
+			applies:  true,
 		},
 		{
-			name:      "simple root resource",
-			privilege: "/aa",
-			resource:  "/",
-			applies:   false,
+			name:     "simple root resource",
+			effect:   "/aa",
+			resource: "/",
+			applies:  false,
+		},
+		{
+			name:     "equivalent scopes",
+			effect:   "/staging",
+			resource: "/staging",
+			applies:  true,
+		},
+		{
+			name:     "effect at ancestor of resource",
+			effect:   "/staging",
+			resource: "/staging/west",
+			applies:  true,
+		},
+		{
+			name:     "effect at descendant of resource",
+			effect:   "/staging/west",
+			resource: "/staging",
+			applies:  false,
+		},
+		{
+			name:     "orthogonal scopes",
+			effect:   "/staging",
+			resource: "/prod",
+			applies:  false,
 		},
 	}
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.applies, PolicyScope(tt.privilege).AppliesToResourceScope(tt.resource),
-				"PolicyScope(%q).AppliesToResourceScope(%q)", tt.privilege, tt.resource)
+			require.Equal(t, tt.applies, ScopeOfEffect(tt.effect).AppliesToResourceScope(tt.resource),
+				"ScopeOfEffect(%q).AppliesToResourceScope(%q)", tt.effect, tt.resource)
 
-			require.Equal(t, tt.applies, ResourceScope(tt.resource).IsSubjectToPolicyScope(tt.privilege),
-				"ResourceScope(%q).IsSubjectToPolicyScope(%q)", tt.resource, tt.privilege)
+			require.Equal(t, tt.applies, ResourceScope(tt.resource).IsSubjectToScopeOfEffect(tt.effect),
+				"ResourceScope(%q).IsSubjectToScopeOfEffect(%q)", tt.resource, tt.effect)
 		})
 	}
 }
@@ -1081,13 +1105,13 @@ func TestGlobMatch(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.match, Glob(tt.glob).Matches(tt.scope),
-				"Glob(%q).Matches(%q)", tt.glob, tt.scope)
+			require.Equal(t, tt.match, Glob(tt.glob).MatchesScopeLiteral(tt.scope),
+				"Glob(%q).MatchesScopeLiteral(%q)", tt.glob, tt.scope)
 		})
 	}
 }
 
-func TestGlobIsSubjectToPolicyResourceScope(t *testing.T) {
+func TestGlobOnlyMatchesSubjectsOf(t *testing.T) {
 	t.Parallel()
 
 	tts := []struct {
@@ -1196,8 +1220,8 @@ func TestGlobIsSubjectToPolicyResourceScope(t *testing.T) {
 
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.subject, Glob(tt.glob).IsSubjectToPolicyResourceScope(tt.scope),
-				"Glob(%q).IsSubjectToPolicyResourceScope(%q)", tt.glob, tt.scope)
+			require.Equal(t, tt.subject, Glob(tt.glob).OnlyMatchesSubjectsOf(tt.scope),
+				"Glob(%q).OnlyMatchesSubjectsOf(%q)", tt.glob, tt.scope)
 		})
 	}
 }
@@ -1332,4 +1356,339 @@ func TestDepth(t *testing.T) {
 			require.Equal(t, splitLen, got, "Depth should match len(Split(scope))")
 		})
 	}
+}
+
+// TestScopeOfOriginAndEffect tests the relationship between Scope of Origin and Scope of Effect.
+// A Scope of Effect must be equivalent to or descendant from its Scope of Origin (cannot reach up).
+func TestScopeOfOriginAndEffect(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name       string
+		origin     string
+		effect     string
+		assignable bool
+	}{
+		{
+			name:       "equivalent root",
+			origin:     "/",
+			effect:     "/",
+			assignable: true,
+		},
+		{
+			name:       "root origin can assign to any child",
+			origin:     "/",
+			effect:     "/staging",
+			assignable: true,
+		},
+		{
+			name:       "root origin can assign to deep child",
+			origin:     "/",
+			effect:     "/staging/west/testbed",
+			assignable: true,
+		},
+		{
+			name:       "equivalent non-root",
+			origin:     "/staging",
+			effect:     "/staging",
+			assignable: true,
+		},
+		{
+			name:       "origin can assign to child",
+			origin:     "/staging",
+			effect:     "/staging/west",
+			assignable: true,
+		},
+		{
+			name:       "origin can assign to deep descendant",
+			origin:     "/staging",
+			effect:     "/staging/west/testbed",
+			assignable: true,
+		},
+		{
+			name:       "origin cannot assign to parent",
+			origin:     "/staging/west",
+			effect:     "/staging",
+			assignable: false,
+		},
+		{
+			name:       "origin cannot assign to root",
+			origin:     "/staging",
+			effect:     "/",
+			assignable: false,
+		},
+		{
+			name:       "origin cannot assign to orthogonal scope",
+			origin:     "/staging",
+			effect:     "/prod",
+			assignable: false,
+		},
+		{
+			name:       "origin cannot assign to orthogonal child",
+			origin:     "/staging/west",
+			effect:     "/staging/east",
+			assignable: false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test both directions of the relationship
+			require.Equal(t, tt.assignable, ScopeOfOrigin(tt.origin).IsAssignableToScopeOfEffect(tt.effect),
+				"ScopeOfOrigin(%q).IsAssignableToScopeOfEffect(%q)", tt.origin, tt.effect)
+
+			require.Equal(t, tt.assignable, ScopeOfEffect(tt.effect).IsAssignableFromScopeOfOrigin(tt.origin),
+				"ScopeOfEffect(%q).IsAssignableFromScopeOfOrigin(%q)", tt.effect, tt.origin)
+		})
+	}
+}
+
+// TestPolicyResourceScope tests the PolicyResourceScope helper, which represents the scope of a policy resource
+// itself (e.g., the top-level scope field of a role or assignment). Policy resources can only depend on state
+// from their own scope or ancestor scopes (configuration state flows down the hierarchy).
+func TestPolicyResourceScope(t *testing.T) {
+	t.Parallel()
+
+	tts := []struct {
+		name          string
+		resourceScope string
+		stateScope    string
+		canDepend     bool
+	}{
+		{
+			name:          "can depend on self",
+			resourceScope: "/staging",
+			stateScope:    "/staging",
+			canDepend:     true,
+		},
+		{
+			name:          "can depend on parent",
+			resourceScope: "/staging/west",
+			stateScope:    "/staging",
+			canDepend:     true,
+		},
+		{
+			name:          "can depend on root",
+			resourceScope: "/staging/west",
+			stateScope:    "/",
+			canDepend:     true,
+		},
+		{
+			name:          "cannot depend on child",
+			resourceScope: "/staging",
+			stateScope:    "/staging/west",
+			canDepend:     false,
+		},
+		{
+			name:          "cannot depend on orthogonal",
+			resourceScope: "/staging",
+			stateScope:    "/prod",
+			canDepend:     false,
+		},
+		{
+			name:          "cannot depend on orthogonal descendant",
+			resourceScope: "/staging/west",
+			stateScope:    "/staging/east",
+			canDepend:     false,
+		},
+	}
+
+	for _, tt := range tts {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.canDepend,
+				PolicyResourceScope(tt.resourceScope).CanDependOnStateFromPolicyResourceAtScope(tt.stateScope),
+				"PolicyResourceScope(%q).CanDependOnStateFromPolicyResourceAtScope(%q)",
+				tt.resourceScope, tt.stateScope)
+		})
+	}
+}
+
+// TestScopeOfEffectGlob tests the ScopeOfEffectGlob helper, which wraps Glob for use specifically
+// with Scope of Effect values. This is used when roles specify assignable_scopes globs.
+func TestScopeOfEffectGlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MatchesScopeOfEffectLiteral", func(t *testing.T) {
+		tts := []struct {
+			name    string
+			glob    string
+			literal string
+			matches bool
+		}{
+			{
+				name:    "exact match",
+				glob:    "/staging/west",
+				literal: "/staging/west",
+				matches: true,
+			},
+			{
+				name:    "child match",
+				glob:    "/staging",
+				literal: "/staging/west",
+				matches: true,
+			},
+			{
+				name:    "exclusive child glob match",
+				glob:    "/staging/**",
+				literal: "/staging/west",
+				matches: true,
+			},
+			{
+				name:    "exclusive child glob no match on parent",
+				glob:    "/staging/**",
+				literal: "/staging",
+				matches: false,
+			},
+			{
+				name:    "no match on orthogonal",
+				glob:    "/staging",
+				literal: "/prod",
+				matches: false,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				require.Equal(t, tt.matches,
+					ScopeOfEffectGlob(tt.glob).MatchesScopeOfEffectLiteral(tt.literal),
+					"ScopeOfEffectGlob(%q).MatchesScopeOfEffectLiteral(%q)", tt.glob, tt.literal)
+			})
+		}
+	})
+
+	t.Run("IsAlwaysAssignableFromScopeOfOrigin", func(t *testing.T) {
+		tts := []struct {
+			name       string
+			glob       string
+			origin     string
+			assignable bool
+		}{
+			{
+				name:       "glob at same scope as origin",
+				glob:       "/staging",
+				origin:     "/staging",
+				assignable: true,
+			},
+			{
+				name:       "glob at child of origin",
+				glob:       "/staging/west",
+				origin:     "/staging",
+				assignable: true,
+			},
+			{
+				name:       "exclusive child glob ok",
+				glob:       "/staging/**",
+				origin:     "/staging",
+				assignable: true,
+			},
+			{
+				name:       "glob at ancestor cannot be assigned from child origin",
+				glob:       "/staging",
+				origin:     "/staging/west",
+				assignable: false,
+			},
+			{
+				name:       "exclusive child glob at ancestor cannot be assigned from child origin",
+				glob:       "/staging/**",
+				origin:     "/staging/west",
+				assignable: false,
+			},
+			{
+				name:       "glob at root cannot be assigned from child origin",
+				glob:       "/",
+				origin:     "/staging",
+				assignable: false,
+			},
+			{
+				name:       "exclusive child glob at root cannot be assigned from child origin",
+				glob:       "/**",
+				origin:     "/staging",
+				assignable: false,
+			},
+			{
+				name:       "orthogonal glob",
+				glob:       "/prod",
+				origin:     "/staging",
+				assignable: false,
+			},
+			{
+				name:       "exclusive child glob orthogonal",
+				glob:       "/prod/**",
+				origin:     "/staging",
+				assignable: false,
+			},
+		}
+
+		for _, tt := range tts {
+			t.Run(tt.name, func(t *testing.T) {
+				require.Equal(t, tt.assignable,
+					ScopeOfEffectGlob(tt.glob).IsAlwaysAssignableFromScopeOfOrigin(tt.origin),
+					"ScopeOfEffectGlob(%q).IsAlwaysAssignableFromScopeOfOrigin(%q)", tt.glob, tt.origin)
+			})
+		}
+	})
+}
+
+// TestScopeHierarchyExample demonstrates a non-trivial scoping model with a realistic example.
+func TestScopeHierarchyExample(t *testing.T) {
+	t.Parallel()
+
+	// Scenario:
+	// - a role is defined at /staging with assignable_scopes = ["/staging/west", "/staging/east"]
+	// - an assignment assigns this role at /staging/west with effect at /staging/west
+	// - a user with this assignment tries to access a resource at /staging/west/db1
+
+	// role scoping
+	roleOrigin := "/staging"
+	assignableScopes := []string{
+		"/staging/west",
+		"/staging/east",
+	}
+
+	// assignment scoping
+	assignmentOrigin := "/staging/west"
+	assignmentEffect := "/staging/west"
+
+	// resource scoping
+	resourceScope := "/staging/west/db1"
+
+	// role assignable scopes enforcment
+	globMatched := false
+	for _, assignableScope := range assignableScopes {
+		if ScopeOfEffectGlob(assignableScope).MatchesScopeOfEffectLiteral(assignmentEffect) {
+			globMatched = true
+			break
+		}
+	}
+	require.True(t, globMatched, "assignment effect %q should match one of the assignable scopes", assignmentEffect)
+
+	// assignment effect/origin enforcement
+	require.True(t, ScopeOfOrigin(assignmentOrigin).IsAssignableToScopeOfEffect(assignmentEffect),
+		"assignment at %q should be able to assign effect at %q", assignmentOrigin, assignmentEffect)
+
+	// assignment state dependency check
+	require.True(t, PolicyResourceScope(assignmentOrigin).CanDependOnStateFromPolicyResourceAtScope(roleOrigin),
+		"assignment at %q should be able to reference role at %q", assignmentOrigin, roleOrigin)
+
+	// assignment applicability to resource check
+	require.True(t, ScopeOfEffect(assignmentEffect).AppliesToResourceScope(resourceScope),
+		"role with effect %q should apply to resource at %q", assignmentEffect, resourceScope)
+
+	// resource subject to effect check (inverse of above/redundant)
+	require.True(t, ResourceScope(resourceScope).IsSubjectToScopeOfEffect(assignmentEffect),
+		"resource at %q should be subject to effect at %q", resourceScope, assignmentEffect)
+
+	// checks that should fail (sanity check)
+
+	// verify that the assignment cannot reach up to effect a parent scope
+	require.False(t, ScopeOfOrigin(assignmentOrigin).IsAssignableToScopeOfEffect("/staging"),
+		"assignment at %q should not be able to assign effect at parent %q", assignmentOrigin, "/staging")
+
+	// verify that the assignment effect does not apply to an orthogonal resource
+	require.False(t, ScopeOfEffect(assignmentEffect).AppliesToResourceScope("/staging/east/db2"),
+		"role with effect %q should not apply to orthogonal resource", assignmentEffect)
+
+	// verify that the assignment cannot depend on state from an orthogonal scope
+	require.False(t, PolicyResourceScope(assignmentOrigin).CanDependOnStateFromPolicyResourceAtScope("/staging/east"),
+		"assignment at %q should not be able to reference role at orthogonal scope", assignmentOrigin)
 }

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -219,9 +219,9 @@ func evalScopeFilter(filter *scopesv1.Filter, scope string) bool {
 
 	switch filter.Mode {
 	case scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE:
-		return scopes.ResourceScope(scope).IsSubjectToPolicyScope(filter.Scope)
+		return scopes.ResourceScope(scope).IsSubjectToScopeOfEffect(filter.Scope)
 	case scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE:
-		return scopes.PolicyScope(scope).AppliesToResourceScope(filter.Scope)
+		return scopes.ScopeOfEffect(scope).AppliesToResourceScope(filter.Scope)
 	}
 
 	return true

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -655,7 +655,7 @@ func TestScopedTokenUpdate(t *testing.T) {
 				update.Spec.AssignedScope = "/notadescendant"
 			},
 			assert: func(t *testing.T, created, result *joiningv1.ScopedToken, err error) {
-				require.ErrorContains(t, err, "scoped token assigned scope must be descendant of its resource scope")
+				require.ErrorContains(t, err, "scoped token assigned scope must be descendant of or equivalent to the token's resource scope")
 			},
 		},
 	}


### PR DESCRIPTION
This PR builds upon the work in https://github.com/gravitational/teleport/pull/63219 and updates the `scopes` package comparison operators to use the updated conventions/patterns from the recent scopes RFD amendment (https://github.com/gravitational/teleport/pull/62353).