### PR TITLE
[v18] Add default token name for `tbot` helm chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -336,6 +336,7 @@ See [the join method reference](../../reference/deployment/join-methods.mdx) for
 
 `tbot.token` is the name of the token used by tbot to join the Teleport cluster.
 This value is not sensitive unless the `joinMethod` is set to `"token"`.
+If unset, defaults to `[release name]-tbot`.
 If `crd.create` is set to true, then a TeleportProvisionToken will be created with the provided token name.
 
 ## `crd`

--- a/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.tbot.mdx
@@ -262,6 +262,7 @@ Ignored if `tbotConfig` is set.
 
 `token` is the name of the token used by tbot to join the Teleport cluster.
 This value is not sensitive unless the `joinMethod` is set to `"token"`.
+Defaults to release name.
 Ignored if `tbotConfig` is set.
 
 ## `teleportVersionOverride`

--- a/examples/chart/event-handler/.lint/tbot-enabled.yaml
+++ b/examples/chart/event-handler/.lint/tbot-enabled.yaml
@@ -2,4 +2,3 @@ tbot:
   enabled: true
   clusterName: "test.teleport.sh"
   teleportProxyAddress: "test.teleport.sh:443"
-  token: "test-token"

--- a/examples/chart/event-handler/templates/_helpers.tpl
+++ b/examples/chart/event-handler/templates/_helpers.tpl
@@ -92,6 +92,17 @@ Create the embedded tbot's service account name.
 {{- end -}}
 
 {{/*
+Create the embedded tbot's token name.
+*/}}
+{{- define "event-handler.tbot.tokenName" -}}
+{{- if .Values.tbot.token -}}
+{{- .Values.tbot.token -}}
+{{- else -}}
+{{- .Release.Name }}-{{ default .Values.tbot.nameOverride "tbot" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the namespace that Operator custom resources will be created in.
 */}}
 {{- define "event-handler.crd.namespace" -}}
@@ -100,13 +111,6 @@ Create the namespace that Operator custom resources will be created in.
 {{- else -}}
 {{- .Release.Namespace -}}
 {{- end -}}
-{{- end -}}
-
-{{/*
-Create the name for TeleportProvisionToken custom resource.
-*/}}
-{{- define "event-handler.crd.tokenName" -}}
-{{- required "tbot.token cannot be empty in chart values" .Values.tbot.token -}}
 {{- end -}}
 
 {{/*

--- a/examples/chart/event-handler/templates/operator_crs.yaml
+++ b/examples/chart/event-handler/templates/operator_crs.yaml
@@ -29,7 +29,7 @@ spec:
 apiVersion: resources.teleport.dev/v2
 kind: TeleportProvisionToken
 metadata:
-  name: {{ include "event-handler.crd.tokenName" . }}
+  name: {{ include "event-handler.tbot.tokenName" . }}
   namespace: {{ include "event-handler.crd.namespace" . }}
   labels:
     {{- include "event-handler.labels" . | nindent 4 }}

--- a/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/event-handler/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -45,7 +45,7 @@ should match the snapshot (tokenSpecOverride set):
         app.kubernetes.io/name: teleport-plugin-event-handler
         app.kubernetes.io/version: 18.6.5
         helm.sh/chart: teleport-plugin-event-handler-18.6.5
-      name: test-token
+      name: RELEASE-NAME-tbot
       namespace: NAMESPACE
     spec:
       bot_name: RELEASE-NAME-teleport-plugin-event-handler

--- a/examples/chart/event-handler/tests/operator_crs_test.yaml
+++ b/examples/chart/event-handler/tests/operator_crs_test.yaml
@@ -37,7 +37,7 @@ tests:
       - containsDocument:
           kind: TeleportProvisionToken
           apiVersion: resources.teleport.dev/v2
-          name: test-token
+          name: RELEASE-NAME-tbot
   - it: creates custom resources in specified namespace
     values:
       - ../.lint/tbot-enabled.yaml
@@ -61,7 +61,7 @@ tests:
       - containsDocument:
           kind: TeleportProvisionToken
           apiVersion: resources.teleport.dev/v2
-          name: test-token
+          name: RELEASE-NAME-tbot
           namespace: test-namespace
   - it: creates no custom resources when crd.create is false
     values:
@@ -79,18 +79,6 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "Custom resources cannot be deployed without tbot enabled"
-  - it: should fail if token name is not provided
-    set:
-      tbot:
-        enabled: true
-        clusterName: "test.teleport.sh"
-        teleportProxyAddress: "test.teleport.sh:443"
-        token: ""
-      crd:
-        create: true
-    asserts:
-      - failedTemplate: 
-          errorMessage: "tbot.token cannot be empty in chart values"
   - it: should fail if tokenSpecOverride set and does not match tbot.joinMethod
     values:
       - ../.lint/tbot-enabled.yaml
@@ -111,7 +99,6 @@ tests:
         clusterName: "test.teleport.sh"
         teleportProxyAddress: "test.teleport.sh:443"
         joinMethod: "github"
-        token: "test-token"
       crd:
         create: true
     asserts:
@@ -124,7 +111,6 @@ tests:
         clusterName: "test.teleport.sh"
         teleportProxyAddress: "test.teleport.sh:443"
         joinMethod: "github"
-        token: "test-token"
       crd:
         create: true
         tokenSpecOverride:

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -153,6 +153,7 @@ tbot:
   joinMethod: "kubernetes"
   # tbot.token(string) -- is the name of the token used by tbot to join the Teleport cluster.
   # This value is not sensitive unless the `joinMethod` is set to `"token"`.
+  # If unset, defaults to `[release name]-tbot`.
   # If `crd.create` is set to true, then a TeleportProvisionToken will be created with the provided token name.
   token: ""
 

--- a/examples/chart/tbot/templates/_config.tpl
+++ b/examples/chart/tbot/templates/_config.tpl
@@ -4,9 +4,6 @@
 {{ if not .Values.clusterName }}
   {{- $_ := required "`clusterName` must be provided" "" }}
 {{ end }}
-{{ if not .Values.token }}
-  {{- $_ := required "`token` must be provided" "" }}
-{{ end }}
 {{ if (and .Values.teleportAuthAddress .Values.teleportProxyAddress) }}
   {{- $_ := required "`teleportAuthAddress` and `teleportProxyAddress` are mutually exclusive" "" }}
 {{ end }}
@@ -20,7 +17,7 @@ auth_server: {{ .Values.teleportAuthAddress }}
 {{- end }}
 onboarding:
   join_method: {{ .Values.joinMethod }}
-  token: {{ .Values.token }}
+  token: {{ include "tbot.tokenName" . }}
 {{- if eq .Values.persistence "disabled" }}
 storage:
   type: memory

--- a/examples/chart/tbot/templates/_helpers.tpl
+++ b/examples/chart/tbot/templates/_helpers.tpl
@@ -54,3 +54,7 @@ This is done to avoid naming conflicts when including the chart in other charts.
 {{- define "tbot.defaultOutputName" -}}
 {{- include "tbot.fullname" . }}-out
 {{- end -}}
+
+{{- define "tbot.tokenName" -}}
+{{ default (include "tbot.fullname" .) .Values.token }}
+{{- end -}}

--- a/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/tbot/tests/__snapshot__/config_test.yaml.snap
@@ -94,6 +94,28 @@ should match the snapshot (full):
         test-key: test-label-config
       name: RELEASE-NAME-tbot
       namespace: NAMESPACE
+should match the snapshot (no token name):
+  1: |
+    apiVersion: v1
+    data:
+      tbot.yaml: |-
+        onboarding:
+          join_method: kubernetes
+          token: RELEASE-NAME-tbot
+        outputs:
+        - destination:
+            name: RELEASE-NAME-tbot-out
+            type: kubernetes_secret
+          type: identity
+        proxy_server: test.teleport.sh:443
+        storage:
+          name: RELEASE-NAME-tbot
+          type: kubernetes_secret
+        version: v2
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME-tbot
+      namespace: NAMESPACE
 should match the snapshot (simple):
   1: |
     apiVersion: v1

--- a/examples/chart/tbot/tests/config_test.yaml
+++ b/examples/chart/tbot/tests/config_test.yaml
@@ -34,3 +34,9 @@ tests:
       - ../.lint/argocd.yaml
     asserts:
       - matchSnapshot: {}
+  - it: should match the snapshot (no token name)
+    set:
+      clusterName: "test.teleport.sh"
+      teleportProxyAddress: "test.teleport.sh:443"
+    asserts:
+      - matchSnapshot: {}

--- a/examples/chart/tbot/values.yaml
+++ b/examples/chart/tbot/values.yaml
@@ -145,6 +145,7 @@ joinMethod: "kubernetes"
 
 # token(string) -- is the name of the token used by tbot to join the Teleport cluster.
 # This value is not sensitive unless the `joinMethod` is set to `"token"`.
+# Defaults to release name.
 # Ignored if `tbotConfig` is set.
 token: ""
 


### PR DESCRIPTION
Backport #63212 to branch/v18

changelog: Modified `tbot` helm chart with default `token` value to simplify deployment