### PR TITLE
[v18] [mcp] fix an issue mcp JSON RPC parser is not case-sensitive

### DIFF
--- a/lib/srv/mcp/audit.go
+++ b/lib/srv/mcp/audit.go
@@ -395,7 +395,7 @@ func (a *sessionAuditor) updatePendingSessionStartEventWithInitializeRequest(msg
 		return
 	}
 	var params mcp.InitializeParams
-	if err := json.Unmarshal(paramsData, &params); err != nil {
+	if err := mcputils.UnmarshalJSONRPCMessage(paramsData, &params); err != nil {
 		return
 	}
 	a.updatePendingSessionStartEvent(func(sessionStartEvent *apievents.MCPSessionStart) {

--- a/lib/srv/mcp/helpers_test.go
+++ b/lib/srv/mcp/helpers_test.go
@@ -296,9 +296,9 @@ func checkToolsListResponse(t *testing.T, response mcp.JSONRPCMessage, wantID mc
 	require.NoError(t, json.Unmarshal(data, &mcpResponse))
 	require.Equal(t, wantID.String(), mcpResponse.ID.String())
 
-	var result mcp.ListToolsResult
-	require.NoError(t, json.Unmarshal(mcpResponse.Result, &result))
-	checkToolsListResult(t, &result, wantTools)
+	result, err := mcpResponse.GetListToolResult()
+	require.NoError(t, err)
+	checkToolsListResult(t, result, wantTools)
 }
 
 func checkToolsListResult(t *testing.T, result *mcp.ListToolsResult, wantTools []string) {

--- a/lib/srv/mcp/session.go
+++ b/lib/srv/mcp/session.go
@@ -20,7 +20,6 @@ package mcp
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net"
 	"net/http"
@@ -291,8 +290,8 @@ func (s *sessionHandler) makeToolsCallResponse(ctx context.Context, resp *mcputi
 		return resp
 	}
 
-	var listResult mcp.ListToolsResult
-	if err := json.Unmarshal(resp.Result, &listResult); err != nil {
+	listResult, err := resp.GetListToolResult()
+	if err != nil {
 		return mcp.NewJSONRPCError(resp.ID, mcp.INTERNAL_ERROR, "failed to unmarshal tools/list response", err)
 	}
 

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -232,6 +232,7 @@ func UnmarshalJSONRPCMessage(data []byte, v any) error {
 // caseSensitiveJSONConfig is used to decode JSON RPC messages. The config is
 // based on jsoniter.ConfigCompatibleWithStandardLibrary with the addition of
 // CaseSensitive enabled.
+// TODO(greedy52): Migrate to encoding/json/v2 once it's out of experimentation.
 var caseSensitiveJSONConfig = jsoniter.Config{
 	EscapeHTML:             true,
 	SortMapKeys:            true,

--- a/lib/utils/mcputils/protocol.go
+++ b/lib/utils/mcputils/protocol.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 
 	"github.com/gravitational/trace"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/mark3labs/mcp-go/mcp"
 
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -77,6 +78,15 @@ type BaseJSONRPCMessage struct {
 	Error json.RawMessage `json:"error,omitempty"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler with case-sensitive field matching.
+// This ensures that json.Unmarshal automatically enforces case sensitivity for
+// this type.
+func (m *BaseJSONRPCMessage) UnmarshalJSON(data []byte) error {
+	type Alias BaseJSONRPCMessage
+	aux := (*Alias)(m)
+	return trace.Wrap(caseSensitiveJSONConfig.Unmarshal(data, aux))
+}
+
 // IsNotification returns true if the message is a notification.
 func (m *BaseJSONRPCMessage) IsNotification() bool {
 	return m.ID.IsNil()
@@ -130,6 +140,15 @@ type JSONRPCNotification struct {
 	Params  JSONRPCParams `json:"params,omitempty"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler with case-sensitive field matching.
+// This ensures that json.Unmarshal automatically enforces case sensitivity for
+// this type.
+func (n *JSONRPCNotification) UnmarshalJSON(data []byte) error {
+	type Alias JSONRPCNotification
+	aux := (*Alias)(n)
+	return trace.Wrap(caseSensitiveJSONConfig.Unmarshal(data, aux))
+}
+
 // JSONRPCRequest defines a MCP request.
 //
 // https://modelcontextprotocol.io/specification/2025-03-26/basic#requests
@@ -138,6 +157,15 @@ type JSONRPCRequest struct {
 	Method  string        `json:"method"`
 	ID      mcp.RequestId `json:"id,omitempty"`
 	Params  JSONRPCParams `json:"params,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler with case-sensitive field matching.
+// This ensures that json.Unmarshal automatically enforces case sensitivity for
+// this type.
+func (r *JSONRPCRequest) UnmarshalJSON(data []byte) error {
+	type Alias JSONRPCRequest
+	aux := (*Alias)(r)
+	return trace.Wrap(caseSensitiveJSONConfig.Unmarshal(data, aux))
 }
 
 // JSONRPCResponse defines an MCP response.
@@ -154,11 +182,20 @@ type JSONRPCResponse struct {
 	Error   json.RawMessage `json:"error,omitempty"`
 }
 
+// UnmarshalJSON implements json.Unmarshaler with case-sensitive field matching.
+// This ensures that json.Unmarshal automatically enforces case sensitivity for
+// this type.
+func (r *JSONRPCResponse) UnmarshalJSON(data []byte) error {
+	type Alias JSONRPCResponse
+	aux := (*Alias)(r)
+	return trace.Wrap(caseSensitiveJSONConfig.Unmarshal(data, aux))
+}
+
 // GetListToolResult assumes the result is for MethodToolsList and returns
 // the corresponding go object.
 func (r *JSONRPCResponse) GetListToolResult() (*mcp.ListToolsResult, error) {
 	var listResult mcp.ListToolsResult
-	if err := json.Unmarshal([]byte(r.Result), &listResult); err != nil {
+	if err := UnmarshalJSONRPCMessage(r.Result, &listResult); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &listResult, nil
@@ -168,7 +205,7 @@ func (r *JSONRPCResponse) GetListToolResult() (*mcp.ListToolsResult, error) {
 // returns the corresponding go object.
 func (r *JSONRPCResponse) GetInitializeResult() (*mcp.InitializeResult, error) {
 	var result mcp.InitializeResult
-	if err := json.Unmarshal(r.Result, &result); err != nil {
+	if err := UnmarshalJSONRPCMessage(r.Result, &result); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return &result, nil
@@ -186,6 +223,21 @@ func unmarshalResponse(rawMessage string) (*JSONRPCResponse, error) {
 	}
 	return base.MakeResponse(), nil
 }
+
+// UnmarshalJSONRPCMessage performs case-sensitive JSON umarshal.
+func UnmarshalJSONRPCMessage(data []byte, v any) error {
+	return trace.Wrap(caseSensitiveJSONConfig.Unmarshal(data, v))
+}
+
+// caseSensitiveJSONConfig is used to decode JSON RPC messages. The config is
+// based on jsoniter.ConfigCompatibleWithStandardLibrary with the addition of
+// CaseSensitive enabled.
+var caseSensitiveJSONConfig = jsoniter.Config{
+	EscapeHTML:             true,
+	SortMapKeys:            true,
+	ValidateJsonRawMessage: true,
+	CaseSensitive:          true,
+}.Froze()
 
 const (
 	// MethodInitialize initiates connection and negotiates protocol capabilities.

--- a/lib/utils/mcputils/protocol_test.go
+++ b/lib/utils/mcputils/protocol_test.go
@@ -154,3 +154,26 @@ func TestJSONRPCResponse(t *testing.T) {
 		}},
 	}, toolList)
 }
+
+func TestUnmarshalJSONRPCMessage_caseSensitive(t *testing.T) {
+	input := []byte(`
+{ "jsonrpc": "2.0",
+  "id": "good-id",
+  "iD": "bad-id",
+  "method": "tools/call",
+  "params": { "name": "good-name" },
+  "Params": { "name": "bad-name" }
+}`)
+	// Test that json.Unmarshal automatically uses case-sensitive unmarshaling
+	// via the custom UnmarshalJSON method.
+	var output BaseJSONRPCMessage
+	require.NoError(t, json.Unmarshal(input, &output))
+	require.Equal(t, BaseJSONRPCMessage{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId("good-id"),
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name": "good-name",
+		},
+	}, output)
+}


### PR DESCRIPTION
Backport #63325 to branch/v18

changelog:  fixed an issue where MCP JSON-RPC messages with mixed-case field names could be parsed inconsistently and re-serialized to lower cases. Teleport now enforces canonical lowercase JSON-RPC fields.
