### PR TITLE
Don't mutate logger passed in to TDP/TDPB handshake handler.

### DIFF
--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -185,7 +185,6 @@ func (t *tdpHandshaker) performInitialHandshake(ctx context.Context, log *slog.L
 		)
 	}
 
-	*log = *log.With("width", width, "height", height)
 	msg, err = t.connection.ReadMessage()
 	if err != nil {
 		return trace.Wrap(err)
@@ -194,7 +193,7 @@ func (t *tdpHandshaker) performInitialHandshake(ctx context.Context, log *slog.L
 	keyboardLayout, gotKeyboardLayout := msg.(legacy.ClientKeyboardLayout)
 	if !gotKeyboardLayout {
 		t.withheld = append(t.withheld, msg)
-		log.InfoContext(ctx, "client did not send keyboard layout", "message_type", logutils.TypeAttr(msg))
+		log.InfoContext(ctx, "client did not send keyboard layout", "message_type", logutils.TypeAttr(msg), "width", width, "height", height)
 	} else {
 		t.keyboardLayout = &keyboardLayout
 	}


### PR DESCRIPTION
The width/height log keys aren't that useful to begin with, and mutating the logger in this way can be risky.
closes #63352