### PR TITLE
Web: show access graph CTA when roleDiffProps is undefined

### DIFF
--- a/web/packages/shared/components/FieldSelect/shared.tsx
+++ b/web/packages/shared/components/FieldSelect/shared.tsx
@@ -192,6 +192,7 @@ export function splitSelectProps<
     inputValue,
     isClearable,
     isDisabled,
+    isLoading,
     readOnly,
     isMulti,
     isSearchable,
@@ -238,6 +239,7 @@ export function splitSelectProps<
       inputValue,
       isClearable,
       isDisabled,
+      isLoading,
       readOnly,
       isMulti,
       isSearchable,
@@ -287,6 +289,7 @@ type KeysRemovedFromOthers =
   | 'inputValue'
   | 'isClearable'
   | 'isDisabled'
+  | 'isLoading'
   | 'readOnly'
   | 'isMulti'
   | 'isSearchable'

--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -70,6 +70,10 @@ export function PolicyPlaceholder({
     roleDiffProps?.roleDiffState === RoleDiffState.LoadingSettings ||
     waitingForSync;
 
+  // roleDiffProps can be undefined if not cloud and not role tester
+  // enabled.
+  const hideSalesButton = (cfg.isPolicyEnabled || cfg.isCloud) && roleDiffProps;
+
   return (
     <Box maxWidth={promoImageWidth + 2 * 2} minWidth={300}>
       {roleDiffProps?.roleDiffErrorMessage && !waitingForSync && (
@@ -99,7 +103,7 @@ export function PolicyPlaceholder({
                 {loading ? 'Creating graph…' : 'Preview Identity Security'}
               </ButtonPrimary>
             )}
-          {((!cfg.isPolicyEnabled && !cfg.isCloud) || !roleDiffProps) && ( // non-cloud must contact sales
+          {!hideSalesButton && ( // non-cloud must contact sales
             <>
               <ButtonLockedFeature noIcon py={0} width={undefined}>
                 Contact Sales

--- a/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
+++ b/web/packages/teleport/src/Roles/PolicyPlaceholder.tsx
@@ -99,22 +99,21 @@ export function PolicyPlaceholder({
                 {loading ? 'Creating graph…' : 'Preview Identity Security'}
               </ButtonPrimary>
             )}
-          {!cfg.isPolicyEnabled &&
-            !cfg.isCloud && ( // non-cloud must contact sales
-              <>
-                <ButtonLockedFeature noIcon py={0} width={undefined}>
-                  Contact Sales
-                </ButtonLockedFeature>
-                <ButtonSecondary
-                  as="a"
-                  href="https://goteleport.com/platform/policy/"
-                  target="_blank"
-                  ml={2}
-                >
-                  Learn More
-                </ButtonSecondary>
-              </>
-            )}
+          {((!cfg.isPolicyEnabled && !cfg.isCloud) || !roleDiffProps) && ( // non-cloud must contact sales
+            <>
+              <ButtonLockedFeature noIcon py={0} width={undefined}>
+                Contact Sales
+              </ButtonLockedFeature>
+              <ButtonSecondary
+                as="a"
+                href="https://goteleport.com/platform/policy/"
+                target="_blank"
+                ml={2}
+              >
+                Learn More
+              </ButtonSecondary>
+            </>
+          )}
         </Flex>
       </Flex>
       <Flex

--- a/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
+++ b/web/packages/teleport/src/Roles/RoleEditor/StandardEditor/Resources.tsx
@@ -292,7 +292,7 @@ export function ServerAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Logins"
-          placeholder="Type a login and press Enter"
+          placeholder={readOnly ? '' : 'Type a login and press Enter'}
           isDisabled={isProcessing}
           formatCreateLabel={label => `Login: ${label}`}
           components={{
@@ -351,7 +351,7 @@ export function KubernetesAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Groups"
-          placeholder="Type a group name and press Enter"
+          placeholder={readOnly ? '' : 'Type a group name and press Enter'}
           isDisabled={isProcessing}
           formatCreateLabel={label => `Group: ${label}`}
           components={{
@@ -370,7 +370,7 @@ export function KubernetesAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Users"
-          placeholder="Type a user name and press Enter"
+          placeholder={readOnly ? '' : 'Type a user name and press Enter'}
           isDisabled={isProcessing}
           formatCreateLabel={label => `User: ${label}`}
           components={{
@@ -778,7 +778,6 @@ export function DatabaseAccessSection({
           <LabelsInput
             atLeastOneRow
             legend="Labels"
-            tooltipContent="Access to databases with these labels will be affected by this role."
             disableBtns={isProcessing}
             labels={value.labels}
             setLabels={labels => onChange?.({ ...value, labels })}
@@ -791,7 +790,7 @@ export function DatabaseAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Database Names"
-          placeholder="Type a database name and press Enter"
+          placeholder={readOnly ? '' : 'Type a database name and press Enter'}
           toolTipContent={
             <>
               Database names allowed to connect to. Special value{' '}
@@ -815,7 +814,7 @@ export function DatabaseAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Database Users"
-          placeholder="Type a user name and press Enter"
+          placeholder={readOnly ? '' : 'Type a user name and press Enter'}
           toolTipContent={
             <>
               Database account names allowed to connect as. Special value{' '}
@@ -839,7 +838,7 @@ export function DatabaseAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Database Roles"
-          placeholder="Type a role name and press Enter"
+          placeholder={readOnly ? '' : 'Type a role name and press Enter'}
           toolTipContent="If automatic user provisioning is available, this is the list of database roles that will be assigned to the database user after it's created."
           isDisabled={isProcessing}
           formatCreateLabel={label => `Database Role: ${label}`}
@@ -913,7 +912,7 @@ export function WindowsDesktopAccessSection({
         <FieldSelectCreatable
           isMulti
           label="Logins"
-          placeholder="Type a login and press Enter"
+          placeholder={readOnly ? '' : 'Type a login and press Enter'}
           toolTipContent="List of Windows logins allowed to use for desktop sessions."
           isDisabled={isProcessing}
           formatCreateLabel={label => `Login: ${label}`}
@@ -956,7 +955,9 @@ export function GitHubOrganizationAccessSection({
           isMulti
           label="Organization Names"
           toolTipContent="A list of GitHub organization names allowed access to."
-          placeholder="Type an organization name and press Enter"
+          placeholder={
+            readOnly ? '' : 'Type an organization name and press Enter'
+          }
           isDisabled={isProcessing}
           formatCreateLabel={label => `Organization: ${label}`}
           components={{

--- a/web/packages/teleport/src/Roles/useRoles.ts
+++ b/web/packages/teleport/src/Roles/useRoles.ts
@@ -50,7 +50,7 @@ export function useRoles(ctx: TeleportContext) {
   };
 }
 
-async function toYaml(role: Partial<RoleWithYaml>): Promise<string> {
+export async function toYaml(role: Partial<RoleWithYaml>): Promise<string> {
   return (
     role.yaml ||
     (await yamlService.stringify(YamlSupportedResourceKind.Role, {


### PR DESCRIPTION
tiny random changes that were required by the feature https://github.com/gravitational/teleport.e/issues/7183

I would say the most important change is that access graph now shows CTA buttons for self hosted teleports (before only the info part of the access graph showed with CTA button missing)