### PR TITLE
Align UpdateAccessListWithPresetResponse response

### DIFF
--- a/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
+++ b/api/gen/proto/go/teleport/accesslist/v1/accesslist_service.pb.go
@@ -2861,9 +2861,14 @@ type UpdateAccessListWithPresetResponse struct {
 	// access_list is the updated access list with the latest configuration.
 	AccessList *AccessList `protobuf:"bytes,1,opt,name=access_list,json=accessList,proto3" json:"access_list,omitempty"`
 	// roles are the updated roles that grant permissions to resources. Managed by Teleport.
-	Roles         []*types.RoleV6 `protobuf:"bytes,2,rep,name=roles,proto3" json:"roles,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Roles []*types.RoleV6 `protobuf:"bytes,2,rep,name=roles,proto3" json:"roles,omitempty"`
+	// RolesToBeDeleted contains role names that are no longer valid for this access list preset.
+	// These roles may still be in use, so instead of deleting them in the backend and relying on
+	// "roles in use" error handling, deletion is deferred to a user.
+	// Where the UpdateAccessListWithPresetResponse should be ONLY by web API preset flow.
+	RolesToBeDeleted []string `protobuf:"bytes,6,rep,name=roles_to_be_deleted,json=rolesToBeDeleted,proto3" json:"roles_to_be_deleted,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *UpdateAccessListWithPresetResponse) Reset() {
@@ -2906,6 +2911,13 @@ func (x *UpdateAccessListWithPresetResponse) GetAccessList() *AccessList {
 func (x *UpdateAccessListWithPresetResponse) GetRoles() []*types.RoleV6 {
 	if x != nil {
 		return x.Roles
+	}
+	return nil
+}
+
+func (x *UpdateAccessListWithPresetResponse) GetRolesToBeDeleted() []string {
+	if x != nil {
+		return x.RolesToBeDeleted
 	}
 	return nil
 }
@@ -3090,11 +3102,12 @@ const file_teleport_accesslist_v1_accesslist_service_proto_rawDesc = "" +
 	"!UpdateAccessListWithPresetRequest\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\x12#\n" +
-	"\x05roles\x18\x02 \x03(\v2\r.types.RoleV6R\x05roles\"\x8e\x01\n" +
+	"\x05roles\x18\x02 \x03(\v2\r.types.RoleV6R\x05roles\"\xbd\x01\n" +
 	"\"UpdateAccessListWithPresetResponse\x12C\n" +
 	"\vaccess_list\x18\x01 \x01(\v2\".teleport.accesslist.v1.AccessListR\n" +
 	"accessList\x12#\n" +
-	"\x05roles\x18\x02 \x03(\v2\r.types.RoleV6R\x05roles2\xf4 \n" +
+	"\x05roles\x18\x02 \x03(\v2\r.types.RoleV6R\x05roles\x12-\n" +
+	"\x13roles_to_be_deleted\x18\x06 \x03(\tR\x10rolesToBeDeleted2\xf4 \n" +
 	"\x11AccessListService\x12o\n" +
 	"\x0eGetAccessLists\x12-.teleport.accesslist.v1.GetAccessListsRequest\x1a..teleport.accesslist.v1.GetAccessListsResponse\x12w\n" +
 	"\x0fListAccessLists\x12..teleport.accesslist.v1.ListAccessListsRequest\x1a/.teleport.accesslist.v1.ListAccessListsResponse\"\x03\x88\x02\x01\x12x\n" +

--- a/api/proto/teleport/accesslist/v1/accesslist_service.proto
+++ b/api/proto/teleport/accesslist/v1/accesslist_service.proto
@@ -569,4 +569,10 @@ message UpdateAccessListWithPresetResponse {
   AccessList access_list = 1;
   // roles are the updated roles that grant permissions to resources. Managed by Teleport.
   repeated types.RoleV6 roles = 2;
+
+  // RolesToBeDeleted contains role names that are no longer valid for this access list preset.
+  // These roles may still be in use, so instead of deleting them in the backend and relying on
+  // "roles in use" error handling, deletion is deferred to a user.
+  // Where the UpdateAccessListWithPresetResponse should be ONLY by web API preset flow.
+  repeated string roles_to_be_deleted = 6;
 }


### PR DESCRIPTION
### What

Align `UpdateAccessListWithPresetResponse` to return a roles that was been left behind from preset after narrowing down the access roles. 
The  `UpdateAccessListWithPresetResponse` is used in FE flow and FE is responsible to render a user popup that this roles are not longer valid in the preset flow an should be deleted manually. 


For more info see: https://github.com/gravitational/teleport/blob/master/rfd/0236-access-list-preset.md#deleting-access-lists-created-with-a-preset

> Deleting access lists created with a preset
The same [existing endpoint](https://github.com/gravitational/teleport/blob/e26f1f01a0a2433ae104f01ada73a1bf9b935963/api/proto/teleport/accesslist/v1/accesslist_service.proto#L43) will be used to delete an access list with a preset.
> 
> In the web UI after an access list has successfully deleted, a popup dialogue will render letting users know that they can optionally delete the roles related to the deleted access list. A row of related roles will be rendered, with a delete button for each row.

> Since deleting a role that is used (e.g. a role assigned in another role) can lock a user out with "role not found" error, a warning banner will also be rendered on the delete dialogue to let users know that it is their responsibility to ensure that the roles that they are about to delete is unused.