### PR TITLE
fix event handler name to unblock release

### DIFF
--- a/integrations/event-handler/main.go
+++ b/integrations/event-handler/main.go
@@ -36,7 +36,7 @@ var cli CLI
 
 const (
 	// pluginName is the plugin name
-	pluginName = "teleport-event-handler"
+	pluginName = "Teleport event handler"
 
 	// pluginDescription is the plugin description
 	pluginDescription = "Forwards Teleport AuditLog to external sources"


### PR DESCRIPTION
A change in https://github.com/gravitational/teleport/commit/6a5fb3c7e0a9d2421ef9fbbf1e85307ae2ee61f7#diff-98b193b6774f08b15f844ae89a23792518cf1a51a5e618821968b24d4564a242R39 broke the smoke tests.

This is the upstream PR of a v18 hotfix I made to unblock the v18 release.
https://github.com/gravitational/teleport/pull/63400