### PR TITLE
[v18] Add cache support for workload cluster

### DIFF
--- a/api/client/events.go
+++ b/api/client/events.go
@@ -34,6 +34,7 @@ import (
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -173,6 +174,10 @@ func EventToGRPC(in types.Event) (*proto.Event, error) {
 	case types.Resource153UnwrapperT[*presencev1.RelayServer]:
 		out.Resource = &proto.Event_RelayServer{
 			RelayServer: r.UnwrapT(),
+		}
+	case types.Resource153UnwrapperT[*workloadclusterv1.WorkloadCluster]:
+		out.Resource = &proto.Event_WorkloadCluster{
+			WorkloadCluster: r.UnwrapT(),
 		}
 	case *types.ResourceHeader:
 		out.Resource = &proto.Event_ResourceHeader{
@@ -682,6 +687,9 @@ func EventFromGRPC(in *proto.Event) (*types.Event, error) {
 		return &out, nil
 	} else if r := in.GetRecordingEncryption(); r != nil {
 		out.Resource = types.ProtoResource153ToLegacy(r)
+		return &out, nil
+	} else if r := in.GetWorkloadCluster(); r != nil {
+		out.Resource = types.Resource153ToLegacy(r)
 		return &out, nil
 	} else {
 		return nil, trace.BadParameter("received unsupported resource %T", in.Resource)

--- a/api/client/proto/event.pb.go
+++ b/api/client/proto/event.pb.go
@@ -41,6 +41,7 @@ import (
 	v11 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userloginstate/v1"
 	v2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	v112 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	v120 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	v115 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	types "github.com/gravitational/teleport/api/types"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -200,6 +201,7 @@ type Event struct {
 	//	*Event_RecordingEncryption
 	//	*Event_Plugin
 	//	*Event_AutoUpdateBotInstanceReport
+	//	*Event_WorkloadCluster
 	Resource      isEvent_Resource `protobuf_oneof:"Resource"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -969,6 +971,15 @@ func (x *Event) GetAutoUpdateBotInstanceReport() *v111.AutoUpdateBotInstanceRepo
 	return nil
 }
 
+func (x *Event) GetWorkloadCluster() *v120.WorkloadCluster {
+	if x != nil {
+		if x, ok := x.Resource.(*Event_WorkloadCluster); ok {
+			return x.WorkloadCluster
+		}
+	}
+	return nil
+}
+
 type isEvent_Resource interface {
 	isEvent_Resource()
 }
@@ -1378,6 +1389,11 @@ type Event_AutoUpdateBotInstanceReport struct {
 	AutoUpdateBotInstanceReport *v111.AutoUpdateBotInstanceReport `protobuf:"bytes,85,opt,name=AutoUpdateBotInstanceReport,proto3,oneof"`
 }
 
+type Event_WorkloadCluster struct {
+	// WorkloadCluster is a resource for defining workload clusters.
+	WorkloadCluster *v120.WorkloadCluster `protobuf:"bytes,88,opt,name=WorkloadCluster,proto3,oneof"`
+}
+
 func (*Event_ResourceHeader) isEvent_Resource() {}
 
 func (*Event_CertAuthority) isEvent_Resource() {}
@@ -1538,11 +1554,13 @@ func (*Event_Plugin) isEvent_Resource() {}
 
 func (*Event_AutoUpdateBotInstanceReport) isEvent_Resource() {}
 
+func (*Event_WorkloadCluster) isEvent_Resource() {}
+
 var File_teleport_legacy_client_proto_event_proto protoreflect.FileDescriptor
 
 const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xe30\n" +
+	"(teleport/legacy/client/proto/event.proto\x12\x05proto\x1a'teleport/accesslist/v1/accesslist.proto\x1a?teleport/accessmonitoringrules/v1/access_monitoring_rules.proto\x1a'teleport/autoupdate/v1/autoupdate.proto\x1a5teleport/clusterconfig/v1/access_graph_settings.proto\x1a'teleport/crownjewel/v1/crownjewel.proto\x1a#teleport/dbobject/v1/dbobject.proto\x1a1teleport/discoveryconfig/v1/discoveryconfig.proto\x1a7teleport/healthcheckconfig/v1/health_check_config.proto\x1a/teleport/identitycenter/v1/identitycenter.proto\x1a;teleport/kubewaitingcontainer/v1/kubewaitingcontainer.proto\x1a!teleport/legacy/types/types.proto\x1a(teleport/machineid/v1/bot_instance.proto\x1a&teleport/machineid/v1/federation.proto\x1a-teleport/notifications/v1/notifications.proto\x1a'teleport/presence/v1/relay_server.proto\x1a+teleport/provisioning/v1/provisioning.proto\x1a:teleport/recordingencryption/v1/recording_encryption.proto\x1a*teleport/scopes/access/v1/assignment.proto\x1a$teleport/scopes/access/v1/role.proto\x1a'teleport/secreports/v1/secreports.proto\x1a/teleport/userloginstate/v1/userloginstate.proto\x1a1teleport/userprovisioning/v2/statichostuser.proto\x1a&teleport/usertasks/v1/user_tasks.proto\x1a1teleport/workloadcluster/v1/workloadcluster.proto\x1a+teleport/workloadidentity/v1/resource.proto\x1a6teleport/workloadidentity/v1/revocation_resource.proto\"\xbd1\n" +
 	"\x05Event\x12$\n" +
 	"\x04Type\x18\x01 \x01(\x0e2\x10.proto.OperationR\x04Type\x12?\n" +
 	"\x0eResourceHeader\x18\x02 \x01(\v2\x15.types.ResourceHeaderH\x00R\x0eResourceHeader\x12>\n" +
@@ -1637,7 +1655,8 @@ const file_teleport_legacy_client_proto_event_proto_rawDesc = "" +
 	"\frelay_server\x18R \x01(\v2!.teleport.presence.v1.RelayServerH\x00R\vrelayServer\x12h\n" +
 	"\x13RecordingEncryption\x18S \x01(\v24.teleport.recordingencryption.v1.RecordingEncryptionH\x00R\x13RecordingEncryption\x12)\n" +
 	"\x06plugin\x18T \x01(\v2\x0f.types.PluginV1H\x00R\x06plugin\x12w\n" +
-	"\x1bAutoUpdateBotInstanceReport\x18U \x01(\v23.teleport.autoupdate.v1.AutoUpdateBotInstanceReportH\x00R\x1bAutoUpdateBotInstanceReportB\n" +
+	"\x1bAutoUpdateBotInstanceReport\x18U \x01(\v23.teleport.autoupdate.v1.AutoUpdateBotInstanceReportH\x00R\x1bAutoUpdateBotInstanceReport\x12X\n" +
+	"\x0fWorkloadCluster\x18X \x01(\v2,.teleport.workloadcluster.v1.WorkloadClusterH\x00R\x0fWorkloadClusterB\n" +
 	"\n" +
 	"\bResourceJ\x04\b\a\x10\bJ\x04\b1\x102J\x04\b?\x10@J\x04\bD\x10ER\x12ExternalCloudAuditR\x0eStaticHostUserR\x13AutoUpdateAgentPlan**\n" +
 	"\tOperation\x12\b\n" +
@@ -1740,6 +1759,7 @@ var file_teleport_legacy_client_proto_event_proto_goTypes = []any{
 	(*v119.RecordingEncryption)(nil),            // 76: teleport.recordingencryption.v1.RecordingEncryption
 	(*types.PluginV1)(nil),                      // 77: types.PluginV1
 	(*v111.AutoUpdateBotInstanceReport)(nil),    // 78: teleport.autoupdate.v1.AutoUpdateBotInstanceReport
+	(*v120.WorkloadCluster)(nil),                // 79: teleport.workloadcluster.v1.WorkloadCluster
 }
 var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	0,  // 0: proto.Event.Type:type_name -> proto.Operation
@@ -1823,11 +1843,12 @@ var file_teleport_legacy_client_proto_event_proto_depIdxs = []int32{
 	76, // 78: proto.Event.RecordingEncryption:type_name -> teleport.recordingencryption.v1.RecordingEncryption
 	77, // 79: proto.Event.plugin:type_name -> types.PluginV1
 	78, // 80: proto.Event.AutoUpdateBotInstanceReport:type_name -> teleport.autoupdate.v1.AutoUpdateBotInstanceReport
-	81, // [81:81] is the sub-list for method output_type
-	81, // [81:81] is the sub-list for method input_type
-	81, // [81:81] is the sub-list for extension type_name
-	81, // [81:81] is the sub-list for extension extendee
-	0,  // [0:81] is the sub-list for field type_name
+	79, // 81: proto.Event.WorkloadCluster:type_name -> teleport.workloadcluster.v1.WorkloadCluster
+	82, // [82:82] is the sub-list for method output_type
+	82, // [82:82] is the sub-list for method input_type
+	82, // [82:82] is the sub-list for extension type_name
+	82, // [82:82] is the sub-list for extension extendee
+	0,  // [0:82] is the sub-list for field type_name
 }
 
 func init() { file_teleport_legacy_client_proto_event_proto_init() }
@@ -1916,6 +1937,7 @@ func file_teleport_legacy_client_proto_event_proto_init() {
 		(*Event_RecordingEncryption)(nil),
 		(*Event_Plugin)(nil),
 		(*Event_AutoUpdateBotInstanceReport)(nil),
+		(*Event_WorkloadCluster)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/api/proto/teleport/legacy/client/proto/event.proto
+++ b/api/proto/teleport/legacy/client/proto/event.proto
@@ -39,6 +39,7 @@ import "teleport/secreports/v1/secreports.proto";
 import "teleport/userloginstate/v1/userloginstate.proto";
 import "teleport/userprovisioning/v2/statichostuser.proto";
 import "teleport/usertasks/v1/user_tasks.proto";
+import "teleport/workloadcluster/v1/workloadcluster.proto";
 import "teleport/workloadidentity/v1/resource.proto";
 import "teleport/workloadidentity/v1/revocation_resource.proto";
 
@@ -234,5 +235,7 @@ message Event {
     types.PluginV1 plugin = 84;
     // AutoUpdateAgentReport is a resource for counting connected bot instances.
     teleport.autoupdate.v1.AutoUpdateBotInstanceReport AutoUpdateBotInstanceReport = 85;
+    // WorkloadCluster is a resource for defining workload clusters.
+    teleport.workloadcluster.v1.WorkloadCluster WorkloadCluster = 88;
   }
 }

--- a/lib/auth/accesspoint/accesspoint.go
+++ b/lib/auth/accesspoint/accesspoint.go
@@ -115,6 +115,7 @@ type Config struct {
 	HealthCheckConfig       services.HealthCheckConfigReader
 	Plugin                  services.Plugins
 	RecordingEncryption     services.RecordingEncryption
+	WorkloadClusterService  services.WorkloadClusterService
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -202,6 +203,7 @@ func NewCache(cfg Config) (*cache.Cache, error) {
 		BotInstanceService:      cfg.BotInstance,
 		Plugin:                  cfg.Plugin,
 		RecordingEncryption:     cfg.RecordingEncryption,
+		WorkloadClusterService:  cfg.WorkloadClusterService,
 	}
 
 	return cache.New(cfg.Setup(cacheCfg))

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -1486,6 +1486,9 @@ type Cache interface {
 
 	// DiscoveryConfigsGetter defines methods for fetching discovery configs.
 	services.DiscoveryConfigsGetter
+
+	// WorkloadClusterServiceGetter defines methods for fetching workload clusters.
+	services.WorkloadClusterServiceGetter
 }
 
 type NodeWrapper struct {

--- a/lib/auth/authclient/clt.go
+++ b/lib/auth/authclient/clt.go
@@ -1515,6 +1515,7 @@ type ClientI interface {
 	services.HealthCheckConfig
 	types.Events
 	services.ScopedAccessClientGetter
+	services.WorkloadClusterService
 
 	types.WebSessionsGetter
 	services.WebToken

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -613,6 +613,7 @@ func InitAuthCache(p AuthCacheParams) error {
 		Plugin:                  p.AuthServer.Services.Plugins,
 		RecordingEncryption:     p.AuthServer.Services.RecordingEncryptionManager,
 		StaticScopedToken:       p.AuthServer.Services.ClusterConfigurationInternal,
+		WorkloadClusterService:  p.AuthServer.Services.WorkloadClusterService,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -216,6 +216,7 @@ func ForAuth(cfg Config) Config {
 		{Kind: types.KindRelayServer},
 		{Kind: types.KindBotInstance},
 		{Kind: types.KindRecordingEncryption},
+		{Kind: types.KindWorkloadCluster},
 	}
 	cfg.QueueSize = defaults.AuthQueueSize
 	// We don't want to enable partial health for auth cache because auth uses an event stream
@@ -776,6 +777,8 @@ type Config struct {
 	Plugin             services.Plugins
 	// RecordingEncryption manages state surrounding session recording encryption
 	RecordingEncryption services.RecordingEncryption
+	// WorkloadClusterService is a workload cluster service
+	WorkloadClusterService services.WorkloadClusterService
 }
 
 // CheckAndSetDefaults checks parameters and sets default values

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -38,6 +38,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningv2 "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
@@ -146,6 +147,7 @@ type collections struct {
 	botInstances                       *collection[*machineidv1.BotInstance, botInstanceIndex]
 	plugins                            *collection[types.Plugin, pluginIndex]
 	recordingEncryption                *collection[*recordingencryptionv1.RecordingEncryption, recordingEncryptionIndex]
+	workloadClusters                   *collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]
 }
 
 // isKnownUncollectedKind is true if a resource kind is not stored in
@@ -777,6 +779,14 @@ func setupCollections(c Config) (*collections, error) {
 
 			out.recordingEncryption = collect
 			out.byKind[resourceKind] = out.recordingEncryption
+		case types.KindWorkloadCluster:
+			collect, err := newWorkloadClusterCollection(c.WorkloadClusterService, watch)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			out.workloadClusters = collect
+			out.byKind[resourceKind] = out.workloadClusters
 		default:
 			if _, ok := out.byKind[resourceKind]; !ok {
 				return nil, trace.BadParameter("resource %q is not supported", watch.Kind)

--- a/lib/cache/workload_cluster.go
+++ b/lib/cache/workload_cluster.go
@@ -1,0 +1,104 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/protobuf/proto"
+
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type workloadClusterIndex string
+
+const workloadClusterNameIndex workloadClusterIndex = "name"
+
+func newWorkloadClusterCollection(upstream services.WorkloadClusterService, w types.WatchKind) (*collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex], error) {
+	if upstream == nil {
+		return nil, trace.BadParameter("missing parameter WorkloadClusters")
+	}
+
+	return &collection[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		store: newStore(
+			types.KindWorkloadCluster,
+			proto.CloneOf[*workloadclusterv1.WorkloadCluster],
+			map[workloadClusterIndex]func(*workloadclusterv1.WorkloadCluster) string{
+				workloadClusterNameIndex: func(r *workloadclusterv1.WorkloadCluster) string {
+					return r.GetMetadata().GetName()
+				},
+			}),
+		fetcher: func(ctx context.Context, loadSecrets bool) ([]*workloadclusterv1.WorkloadCluster, error) {
+			out, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, i int, nextToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+				return upstream.ListWorkloadClusters(ctx, i, nextToken)
+			}))
+			return out, trace.Wrap(err)
+		},
+		headerTransform: func(hdr *types.ResourceHeader) *workloadclusterv1.WorkloadCluster {
+			return &workloadclusterv1.WorkloadCluster{
+				Kind:    hdr.Kind,
+				Version: hdr.Version,
+				Metadata: &headerv1.Metadata{
+					Name: hdr.Metadata.Name,
+				},
+			}
+		},
+		watch: w,
+	}, nil
+}
+
+// ListWorkloadClusters returns a list of WorkloadCluster resources.
+func (c *Cache) ListWorkloadClusters(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/ListWorkloadClusters")
+	defer span.End()
+
+	lister := genericLister[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		cache:      c,
+		collection: c.collections.workloadClusters,
+		index:      workloadClusterNameIndex,
+		upstreamList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			out, next, err := c.Config.WorkloadClusterService.ListWorkloadClusters(ctx, pageSize, pageToken)
+			return out, next, trace.Wrap(err)
+		},
+		nextToken: func(t *workloadclusterv1.WorkloadCluster) string {
+			return t.GetMetadata().GetName()
+		},
+	}
+	out, next, err := lister.list(ctx, pageSize, pageToken)
+	return out, next, trace.Wrap(err)
+}
+
+// GetWorkloadCluster returns the specified WorkloadCluster resource.
+func (c *Cache) GetWorkloadCluster(ctx context.Context, name string) (*workloadclusterv1.WorkloadCluster, error) {
+	ctx, span := c.Tracer.Start(ctx, "cache/GetWorkloadCluster")
+	defer span.End()
+
+	getter := genericGetter[*workloadclusterv1.WorkloadCluster, workloadClusterIndex]{
+		cache:       c,
+		collection:  c.collections.workloadClusters,
+		index:       workloadClusterNameIndex,
+		upstreamGet: c.Config.WorkloadClusterService.GetWorkloadCluster,
+	}
+	out, err := getter.get(ctx, name)
+	return out, trace.Wrap(err)
+}

--- a/lib/cache/workload_cluster_test.go
+++ b/lib/cache/workload_cluster_test.go
@@ -1,0 +1,52 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+)
+
+// TestWorkloadClusters tests that CRUD operations on workload clusters resources are
+// replicated from the backend to the cache.
+func TestWorkloadClusters(t *testing.T) {
+	t.Parallel()
+
+	p := newTestPack(t, ForAuth)
+	t.Cleanup(p.Close)
+
+	testResources153(t, p, testFuncs[*workloadclusterv1.WorkloadCluster]{
+		newResource: func(name string) (*workloadclusterv1.WorkloadCluster, error) {
+			return newWorkloadCluster(t, name), nil
+		},
+		create: func(ctx context.Context, item *workloadclusterv1.WorkloadCluster) error {
+			_, err := p.workloadClusters.CreateWorkloadCluster(ctx, item)
+			return trace.Wrap(err)
+		},
+		list: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			return p.workloadClusters.ListWorkloadClusters(ctx, pageSize, pageToken)
+		},
+		cacheList: func(ctx context.Context, pageSize int, pageToken string) ([]*workloadclusterv1.WorkloadCluster, string, error) {
+			return p.workloadClusters.ListWorkloadClusters(ctx, pageSize, pageToken)
+		},
+		deleteAll: p.workloadClusters.DeleteAllWorkloadClusters,
+	})
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3043,6 +3043,7 @@ func (process *TeleportProcess) newAccessCacheForServices(cfg accesspoint.Config
 	cfg.BotInstance = services.BotInstance
 	cfg.Plugin = services.Plugins
 	cfg.RecordingEncryption = services.RecordingEncryptionManager
+	cfg.WorkloadClusterService = services.WorkloadClusterService
 
 	return accesspoint.NewCache(cfg)
 }


### PR DESCRIPTION
Backport #62866 to branch/v18

I had to manually create this backport since there were several conflicts.

I cherry-picked bc3ef9078ed1744f8877579780a97f68148793a0. Resolved conflicts and executed `make grpc` again.


Goal: https://github.com/gravitational/cloud/issues/15315 https://github.com/gravitational/cloud/issues/15870

---

List of conflicts:


```
~/projects/github.com/gravitational/teleport dustinspecker/backport-62866-branch/v18* cherry
❯ git status
On branch dustinspecker/backport-62866-branch/v18
You are currently cherry-picking commit bc3ef9078e.
  (fix conflicts and run "git cherry-pick --continue")
  (use "git cherry-pick --skip" to skip this patch)
  (use "git cherry-pick --abort" to cancel the cherry-pick operation)

Changes to be committed:
        modified:   lib/auth/authclient/clt.go
        new file:   lib/cache/workload_cluster.go
        new file:   lib/cache/workload_cluster_test.go

Unmerged paths:
  (use "git add/rm <file>..." as appropriate to mark resolution)
        both modified:   api/client/events.go
        both modified:   api/client/proto/event.pb.go
        both modified:   api/proto/teleport/legacy/client/proto/event.proto
        both modified:   lib/auth/accesspoint/accesspoint.go
        both modified:   lib/auth/authclient/api.go
        both modified:   lib/auth/authtest/authtest.go
        both modified:   lib/cache/cache.go
        both modified:   lib/cache/cache_test.go
        both modified:   lib/cache/collections.go
        deleted by us:   lib/cache/inventory/inventory_cache_test.go
        both modified:   lib/service/service.go
```