### PR TITLE
[Access Lists] Add helpers for equality comparison/normalization

### DIFF
--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -396,6 +396,195 @@ func TestAccessList_setInitialReviewDate(t *testing.T) {
 	}
 }
 
+func TestEqualAccessLists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    *AccessList
+		b    *AccessList
+		want bool
+	}{
+		{
+			name: "both nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "one nil",
+			a: &AccessList{
+				Spec: Spec{
+					Title: "Access List A",
+				},
+			},
+			b:    nil,
+			want: false,
+		},
+		{
+			name: "nil and empty slice",
+			a: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{
+						Roles:  []string{},
+						Traits: map[string][]string{},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{
+						Roles:  nil,
+						Traits: nil,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "nil and no empty slice",
+			a: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{
+						Roles: []string{"role1"},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{
+						Roles: nil,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil and no empty slice",
+			a: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{
+						Traits: map[string][]string{"trait1": {"value1"}},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					OwnershipRequires: Requires{},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ephemeral fields",
+			a: &AccessList{
+				Spec: Spec{
+					Owners: []Owner{
+						{
+							IneligibleStatus: "ineligible",
+						},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					Owners: []Owner{
+						{
+							IneligibleStatus: "not-ineligible",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if test.a == nil {
+				test.a = &AccessList{}
+			}
+			if test.b == nil {
+				test.b = &AccessList{}
+			}
+
+			originalA := test.a.Clone()
+			originalB := test.b.Clone()
+
+			require.Equal(t, test.want, EqualAccessLists(test.a, test.b, WithEquateEmpty(), WithIgnoreEphemeralFields()), "AccessList equality check failed for '%s'", test.name)
+
+			// Ensure ephemeral fields are not mutated
+			require.Equal(t, originalA, test.a, "AccessList a was mutated for '%s'", test.name)
+			require.Equal(t, originalB, test.b, "AccessList b was mutated for '%s'", test.name)
+		})
+	}
+}
+
+func TestAccessList_NormalizeSemanticallyEqualFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    *AccessList
+		b    *AccessList
+		want bool
+	}{
+		{
+			name: "equal lists with different role order",
+			a: &AccessList{
+				Spec: Spec{
+					Grants: Grants{
+						Roles: []string{"role1", "role2"},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					Grants: Grants{
+						Roles: []string{"role2", "role1"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "different trait values",
+			a: &AccessList{
+				Spec: Spec{
+					MembershipRequires: Requires{
+						Traits: map[string][]string{"env": {"prod"}},
+					},
+				},
+			},
+			b: &AccessList{
+				Spec: Spec{
+					MembershipRequires: Requires{
+						Traits: map[string][]string{"env": {"dev"}},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if test.a == nil {
+				test.a = &AccessList{}
+			}
+			if test.b == nil {
+				test.b = &AccessList{}
+			}
+			test.b.NormalizeSemanticallyEqualFields(test.a)
+			require.Equal(t, test.want, EqualAccessLists(test.b, test.a), "AccessList normalization failed for '%s'", test.name)
+		})
+	}
+}
+
 func TestAccessListClone(t *testing.T) {
 	item := &AccessList{}
 	err := structfill.Fill(item)

--- a/api/types/accesslist/derived.gen.go
+++ b/api/types/accesslist/derived.gen.go
@@ -15,6 +15,14 @@ func deriveTeleportEqualAccessList(this, that *AccessList) bool {
 			deriveTeleportEqual_(&this.Spec, &that.Spec)
 }
 
+// deriveTeleportEqualAccessListMember returns whether this and that are equal.
+func deriveTeleportEqualAccessListMember(this, that *AccessListMember) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			deriveTeleportEqual(&this.ResourceHeader, &that.ResourceHeader) &&
+			deriveTeleportEqual_1(&this.Spec, &that.Spec)
+}
+
 // deriveDeepCopyAccessList recursively copies the contents of src into dst.
 func deriveDeepCopyAccessList(dst, src *AccessList) {
 	func() {
@@ -69,7 +77,7 @@ func deriveTeleportEqual(this, that *header.ResourceHeader) bool {
 			this.Kind == that.Kind &&
 			this.SubKind == that.SubKind &&
 			this.Version == that.Version &&
-			deriveTeleportEqual_1(&this.Metadata, &that.Metadata)
+			deriveTeleportEqual_2(&this.Metadata, &that.Metadata)
 }
 
 // deriveTeleportEqual_ returns whether this and that are equal.
@@ -79,12 +87,27 @@ func deriveTeleportEqual_(this, that *Spec) bool {
 			this.Type == that.Type &&
 			this.Title == that.Title &&
 			this.Description == that.Description &&
-			deriveTeleportEqual_2(this.Owners, that.Owners) &&
-			deriveTeleportEqual_3(&this.Audit, &that.Audit) &&
-			deriveTeleportEqual_4(&this.MembershipRequires, &that.MembershipRequires) &&
-			deriveTeleportEqual_4(&this.OwnershipRequires, &that.OwnershipRequires) &&
-			deriveTeleportEqual_5(&this.Grants, &that.Grants) &&
-			deriveTeleportEqual_5(&this.OwnerGrants, &that.OwnerGrants)
+			deriveTeleportEqual_3(this.Owners, that.Owners) &&
+			deriveTeleportEqual_4(&this.Audit, &that.Audit) &&
+			deriveTeleportEqual_5(&this.MembershipRequires, &that.MembershipRequires) &&
+			deriveTeleportEqual_5(&this.OwnershipRequires, &that.OwnershipRequires) &&
+			deriveTeleportEqual_6(&this.Grants, &that.Grants) &&
+			deriveTeleportEqual_6(&this.OwnerGrants, &that.OwnerGrants)
+}
+
+// deriveTeleportEqual_1 returns whether this and that are equal.
+func deriveTeleportEqual_1(this, that *AccessListMemberSpec) bool {
+	return (this == nil && that == nil) ||
+		this != nil && that != nil &&
+			this.AccessList == that.AccessList &&
+			this.Name == that.Name &&
+			this.Title == that.Title &&
+			this.Joined.Equal(that.Joined) &&
+			this.Expires.Equal(that.Expires) &&
+			this.Reason == that.Reason &&
+			this.AddedBy == that.AddedBy &&
+			this.IneligibleStatus == that.IneligibleStatus &&
+			this.MembershipKind == that.MembershipKind
 }
 
 // deriveDeepCopy recursively copies the contents of src into dst.
@@ -268,18 +291,18 @@ func deriveDeepCopy_3(dst, src *ReviewSpec) {
 	}()
 }
 
-// deriveTeleportEqual_1 returns whether this and that are equal.
-func deriveTeleportEqual_1(this, that *header.Metadata) bool {
+// deriveTeleportEqual_2 returns whether this and that are equal.
+func deriveTeleportEqual_2(this, that *header.Metadata) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.Name == that.Name &&
 			this.Description == that.Description &&
-			deriveTeleportEqual_6(this.Labels, that.Labels) &&
+			deriveTeleportEqual_7(this.Labels, that.Labels) &&
 			this.Expires.Equal(that.Expires)
 }
 
-// deriveTeleportEqual_2 returns whether this and that are equal.
-func deriveTeleportEqual_2(this, that []Owner) bool {
+// deriveTeleportEqual_3 returns whether this and that are equal.
+func deriveTeleportEqual_3(this, that []Owner) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -294,8 +317,8 @@ func deriveTeleportEqual_2(this, that []Owner) bool {
 	return true
 }
 
-// deriveTeleportEqual_3 returns whether this and that are equal.
-func deriveTeleportEqual_3(this, that *Audit) bool {
+// deriveTeleportEqual_4 returns whether this and that are equal.
+func deriveTeleportEqual_4(this, that *Audit) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
 			this.NextAuditDate.Equal(that.NextAuditDate) &&
@@ -303,20 +326,20 @@ func deriveTeleportEqual_3(this, that *Audit) bool {
 			this.Notifications == that.Notifications
 }
 
-// deriveTeleportEqual_4 returns whether this and that are equal.
-func deriveTeleportEqual_4(this, that *Requires) bool {
+// deriveTeleportEqual_5 returns whether this and that are equal.
+func deriveTeleportEqual_5(this, that *Requires) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_7(this.Roles, that.Roles) &&
-			deriveTeleportEqual_8(this.Traits, that.Traits)
+			deriveTeleportEqual_8(this.Roles, that.Roles) &&
+			deriveTeleportEqual_9(this.Traits, that.Traits)
 }
 
-// deriveTeleportEqual_5 returns whether this and that are equal.
-func deriveTeleportEqual_5(this, that *Grants) bool {
+// deriveTeleportEqual_6 returns whether this and that are equal.
+func deriveTeleportEqual_6(this, that *Grants) bool {
 	return (this == nil && that == nil) ||
 		this != nil && that != nil &&
-			deriveTeleportEqual_7(this.Roles, that.Roles) &&
-			deriveTeleportEqual_8(this.Traits, that.Traits)
+			deriveTeleportEqual_8(this.Roles, that.Roles) &&
+			deriveTeleportEqual_9(this.Traits, that.Traits)
 }
 
 // deriveDeepCopy_4 recursively copies the contents of src into dst.
@@ -439,8 +462,8 @@ func deriveDeepCopy_9(dst, src *ReviewChanges) {
 	dst.ReviewDayOfMonthChanged = src.ReviewDayOfMonthChanged
 }
 
-// deriveTeleportEqual_6 returns whether this and that are equal.
-func deriveTeleportEqual_6(this, that map[string]string) bool {
+// deriveTeleportEqual_7 returns whether this and that are equal.
+func deriveTeleportEqual_7(this, that map[string]string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -459,8 +482,8 @@ func deriveTeleportEqual_6(this, that map[string]string) bool {
 	return true
 }
 
-// deriveTeleportEqual_7 returns whether this and that are equal.
-func deriveTeleportEqual_7(this, that []string) bool {
+// deriveTeleportEqual_8 returns whether this and that are equal.
+func deriveTeleportEqual_8(this, that []string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -475,8 +498,8 @@ func deriveTeleportEqual_7(this, that []string) bool {
 	return true
 }
 
-// deriveTeleportEqual_8 returns whether this and that are equal.
-func deriveTeleportEqual_8(this, that map[string][]string) bool {
+// deriveTeleportEqual_9 returns whether this and that are equal.
+func deriveTeleportEqual_9(this, that map[string][]string) bool {
 	if this == nil || that == nil {
 		return this == nil && that == nil
 	}
@@ -488,7 +511,7 @@ func deriveTeleportEqual_8(this, that map[string][]string) bool {
 		if !ok {
 			return false
 		}
-		if !(deriveTeleportEqual_7(v, thatv)) {
+		if !(deriveTeleportEqual_8(v, thatv)) {
 			return false
 		}
 	}

--- a/api/types/accesslist/member.go
+++ b/api/types/accesslist/member.go
@@ -143,3 +143,28 @@ func (a *AccessListMember) IsExpired(t time.Time) bool {
 func (a *AccessListMember) IsUser() bool {
 	return isMembershipKindUser(a.Spec.MembershipKind)
 }
+
+// EqualAccessListMembers compares two AccessListMembers for semantic equality.
+// The input members are cloned prior to comparison to avoid modifying the originals.
+// This function ignores ephemeral fields that are managed by reconcilers or the backend:
+//   - Spec.Title
+//   - Spec.IneligibleStatus
+//   - Metadata.Revision
+func EqualAccessListMembers(a, b *AccessListMember) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+
+	a = a.Clone()
+	b = b.Clone()
+
+	// Clear ephemeral fields
+	a.Spec.Title = ""
+	b.Spec.Title = ""
+	a.Metadata.Revision = ""
+	b.Metadata.Revision = ""
+	a.Spec.IneligibleStatus = ""
+	b.Spec.IneligibleStatus = ""
+
+	return deriveTeleportEqualAccessListMember(a, b)
+}


### PR DESCRIPTION
## Context
Remove usage of `cmp` in production code, replace usages via extending `EqualAccessLists` to handle equating empty slices/fields to nil, and to handle normalization of semantically equal slices/fields. Add `EqualAccessListmembers`; run derive target for updated derived.gen.go.

- See #53662
- Required for https://github.com/gravitational/teleport.e/pull/7977
