### PR TITLE
Fix automatic_upgrades for self-hosted

### DIFF
--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -82,7 +82,7 @@ type scriptSettings struct {
 
 // automaticUpgrades returns whether automaticUpgrades should be enabled.
 func automaticUpgrades(features proto.Features) bool {
-	return features.AutomaticUpgrades && features.Cloud
+	return features.AutomaticUpgrades
 }
 
 // Currently we aren't paginating this endpoint as we don't


### PR DESCRIPTION
We shouldn't hard-code this to only cloud tenants. The old behavior is that every `ping` response from a non-cloud instance will have `automatic_upgrades: false` no matter what.

This change would make it say `true` as long as the auth server has a license that _supports_ automatic upgrades.