### PR TITLE
IntegrationList - fix tooltip location on v18

### DIFF
--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -446,6 +446,9 @@ const IssuesCell = ({ integration }: { integration: IntegrationLike }) => {
               )}
             </Box>
           }
+          css={`
+            display: inline-flex;
+          `}
         >
           <PointerFlex inline alignItems="center" gap={1}>
             {issueCount.toLocaleString()}
@@ -530,6 +533,9 @@ const DetailsCell = ({ integration }: { integration: IntegrationLike }) => {
                 )}
               </Box>
             }
+            css={`
+              display: inline-flex;
+            `}
           >
             <PointerFlex inline gap={1}>
               {rc.enrolled.toLocaleString()} Resources enrolled ({enrolledPct})

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -60,6 +60,9 @@ export const StatusLabel = ({
           <Text>{tooltip}</Text>
         </Box>
       }
+      css={`
+        display: inline-flex;
+      `}
     >
       <PointerFlex inline alignItems="center">
         {statusLabel(status, label)}


### PR DESCRIPTION
HoverTooltip in branch/v18 behaves differently than master. REF https://github.com/gravitational/teleport/pull/55514

On branch/v18 HoverTooltip wraps its children in a <Flex> container, which makes it use 100% width where it wouldn't otherwise for inline content. The tooltip is anchored to the Flex wrapper, so if it's wider than the content, it pops up off to the side. Make the Flex wrapper inline-flex here keeps it the same width as the content, so the tooltip pops up over the content as expected.