### PR TITLE
fix: GitHub+SSH guide back behaviour

### DIFF
--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Welcome.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Welcome.tsx
@@ -16,17 +16,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useHistory, useLocation } from 'react-router';
 import styled, { useTheme } from 'styled-components';
 
 import { Info } from 'design/Alert/Alert';
 import Box from 'design/Box/Box';
-import { ButtonPrimary } from 'design/Button/Button';
+import { ButtonPrimary, ButtonSecondary } from 'design/Button/Button';
 import Flex from 'design/Flex/Flex';
 import Image from 'design/Image/Image';
 import Link from 'design/Link/Link';
 import { H2, P2 } from 'design/Text/Text';
 import { Theme } from 'design/theme/themes/types';
 
+import cfg from 'teleport/config';
 import {
   IntegrationEnrollStatusCode,
   IntegrationEnrollStep,
@@ -43,6 +45,8 @@ export function Welcome(props: FlowStepProps) {
 
   const theme = useTheme();
   const tracking = useTracking();
+  const location = useLocation();
+  const history = useHistory();
 
   const welcomeImage: ImageSpec = {
     light: welcomeLight,
@@ -56,6 +60,15 @@ export function Welcome(props: FlowStepProps) {
     );
 
     nextStep?.();
+  };
+
+  const handlePrevious = () => {
+    // If location.key is unset, or 'default', this is the first history entry in-app in the session.
+    if (!location.key || location.key === 'default') {
+      history.push(cfg.getIntegrationsEnrollRoute());
+    } else {
+      history.goBack();
+    }
   };
 
   return (
@@ -108,6 +121,7 @@ export function Welcome(props: FlowStepProps) {
 
           <Flex gap={2} pt={1}>
             <ButtonPrimary onClick={handleNext}>Start</ButtonPrimary>
+            <ButtonSecondary onClick={handlePrevious}>Back</ButtonSecondary>
           </Flex>
         </Box>
       </FormContainer>

--- a/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.test.tsx
@@ -90,11 +90,19 @@ describe('flowButtons component', () => {
     expect(nextMock).toHaveBeenCalledTimes(1);
   });
 
-  test('when useLocation.state is defined, the first step back button uses this state as pathname', async () => {
+  test('when there is a previous history location, then back button uses `history.goBack()`', async () => {
     const history = createMemoryHistory({
-      initialEntries: [{ state: { previousPathname: 'web/random/route' } }],
+      initialEntries: [
+        {
+          pathname: 'web/random/route',
+        },
+        {
+          pathname: cfg.getBotsNewRoute('github-actions-ssh'),
+        },
+      ],
     });
     history.push = jest.fn();
+    history.goBack = jest.fn();
 
     render(
       <Router history={history}>
@@ -103,12 +111,21 @@ describe('flowButtons component', () => {
     );
 
     await userEvent.click(screen.getByTestId('button-back-first-step'));
-    expect(history.push).toHaveBeenCalledWith('web/random/route');
+    expect(history.push).not.toHaveBeenCalled();
+    expect(history.goBack).toHaveBeenCalled();
   });
 
-  test('when useLocation.state is NOT defined, the first step back button defaults to bots pathname', async () => {
-    const history = createMemoryHistory();
+  test('when there is no previous history location, then back button pushes to integrations list', async () => {
+    const history = createMemoryHistory({
+      initialEntries: [
+        {
+          key: 'default',
+          pathname: cfg.getBotsNewRoute('github-actions-ssh'),
+        },
+      ],
+    });
     history.push = jest.fn();
+    history.goBack = jest.fn();
 
     render(
       <Router history={history}>
@@ -117,6 +134,7 @@ describe('flowButtons component', () => {
     );
 
     await userEvent.click(screen.getByTestId('button-back-first-step'));
-    expect(history.push).toHaveBeenCalledWith(cfg.getBotsNewRoute());
+    expect(history.goBack).not.toHaveBeenCalled();
+    expect(history.push).toHaveBeenCalledWith(cfg.getIntegrationsEnrollRoute());
   });
 });

--- a/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.tsx
+++ b/web/packages/teleport/src/Bots/Add/Shared/FlowButtons.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Link, useLocation } from 'react-router-dom';
+import { useHistory, useLocation } from 'react-router';
 
 import { ButtonPrimary, ButtonSecondary } from 'design/Button';
 
@@ -76,14 +76,21 @@ function BackButton({
   disabled: boolean;
   prevStep: () => void;
 }) {
-  const location = useLocation<{ previousPathname: string }>();
+  const history = useHistory();
+  const location = useLocation();
 
   if (isFirstStep) {
     return (
       <ButtonSecondary
         disabled={disabled}
-        as={Link}
-        to={location.state?.previousPathname || cfg.getBotsNewRoute()}
+        onClick={() => {
+          // If location.key is unset, or 'default', this is the first history entry in-app in the session.
+          if (!location.key || location.key === 'default') {
+            history.push(cfg.getIntegrationsEnrollRoute());
+          } else {
+            history.goBack();
+          }
+        }}
         data-testid="button-back-first-step"
       >
         Back


### PR DESCRIPTION
## Summary
Navigating back from the first step of the GitHub+SSH guide was not respecting the browser history. Instead, the integrations list was displayed always filtered by tag "bot".

This change uses the browser history when available, otherwise defaults to the unfiltered integrations page. Additionally, a back button was added to the first step of the GitHub+**K8s** guide to keep the guides consistent.

## Changes
- Fix back behaviour in GitHub+SSH guide and update tests
- Add button to GitHub+K8s guide

## Demo

https://github.com/user-attachments/assets/cbd34eec-9991-4a4a-b4df-138d0a2a8197

