### PR TITLE
Fix story title for `RegionMultiSelector`

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.story.tsx
@@ -27,7 +27,7 @@ import { awsRegionGroups } from '../Aws/regions';
 import { RegionMultiSelector } from './RegionMultiSelector';
 
 export default {
-  title: 'RegionMultiSelector',
+  title: 'Teleport/Integrations/Enroll/Cloud/RegionMultiSelector',
   component: RegionMultiSelector,
 };
 


### PR DESCRIPTION
It was added in #62683. Without this title, it was showing at the top of all stories.