### PR TITLE
[v18] Add workload cluster support for tctl

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -59,6 +59,7 @@ import (
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
+	workloadclusterv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	apistream "github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/mfa"
@@ -201,6 +202,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		scopedaccess.KindScopedRole:                  rc.createScopedRole,
 		scopedaccess.KindScopedRoleAssignment:        rc.createScopedRoleAssignment,
 		scopedaccess.KindScopedToken:                 rc.createScopedToken,
+		types.KindWorkloadCluster:                    rc.createWorkloadCluster,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:                               rc.updateUser,
@@ -232,6 +234,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		scopedaccess.KindScopedRole:                  rc.updateScopedRole,
 		scopedaccess.KindScopedRoleAssignment:        rc.updateScopedRoleAssignment,
 		scopedaccess.KindScopedToken:                 rc.updateScopedToken,
+		types.KindWorkloadCluster:                    rc.updateWorkloadCluster,
 	}
 	rc.config = config
 
@@ -2449,6 +2452,13 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			return trace.Wrap(err)
 		}
 		fmt.Printf("relay_server %+q has been deleted\n", rc.ref.Name)
+	case types.KindWorkloadCluster:
+		if _, err := client.WorkloadClustersClient().DeleteWorkloadCluster(ctx, &workloadclusterv1.DeleteWorkloadClusterRequest{
+			Name: rc.ref.Name,
+		}); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("workload_cluster %q has been deleted\n", rc.ref.Name)
 	case types.KindInferenceModel:
 		return trace.Wrap(rc.deleteInferenceModel(ctx, client))
 	case types.KindInferenceSecret:
@@ -3888,6 +3898,24 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 		}
 
 		return &scopedTokenCollection{tokens: tokens}, nil
+	case types.KindWorkloadCluster:
+		if rc.ref.Name != "" {
+			cluster, err := client.GetWorkloadCluster(ctx, rc.ref.Name)
+			if err != nil {
+				if trace.IsNotFound(err) {
+					return nil, trace.NotFound("workload_cluster %q not found", rc.ref.Name)
+				}
+				return nil, trace.Wrap(err)
+			}
+
+			return &workloadClusterCollection{workloadClusters: []*workloadclusterv1.WorkloadCluster{cluster}}, nil
+		}
+
+		clusters, err := stream.Collect(clientutils.Resources(ctx, client.ListWorkloadClusters))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return &workloadClusterCollection{workloadClusters: clusters}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }
@@ -4444,5 +4472,37 @@ func (rc *ResourceCommand) updateGitServer(ctx context.Context, client *authclie
 		return trace.Wrap(err)
 	}
 	fmt.Printf("git server %q has been updated\n", server.GetName())
+	return nil
+}
+
+func (rc *ResourceCommand) createWorkloadCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	cc, err := services.UnmarshalProtoResource[*workloadclusterv1.WorkloadCluster](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if rc.force {
+		_, err = client.UpsertWorkloadCluster(ctx, cc)
+	} else {
+		_, err = client.CreateWorkloadCluster(ctx, cc)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("workload cluster %q has been created\n", cc.Metadata.GetName())
+	return nil
+}
+
+func (rc *ResourceCommand) updateWorkloadCluster(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	cc, err := services.UnmarshalProtoResource[*workloadclusterv1.WorkloadCluster](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	_, err = client.UpdateWorkloadCluster(ctx, cc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf("workload cluster %q has been updated\n", cc.Metadata.GetName())
 	return nil
 }

--- a/tool/tctl/common/workloadcluster.go
+++ b/tool/tctl/common/workloadcluster.go
@@ -1,0 +1,54 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package common
+
+import (
+	"io"
+
+	"github.com/gravitational/trace"
+
+	workloadclusterv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadcluster/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/asciitable"
+)
+
+type workloadClusterCollection struct {
+	workloadClusters []*workloadclusterv1pb.WorkloadCluster
+}
+
+func (c *workloadClusterCollection) resources() []types.Resource {
+	resources := make([]types.Resource, 0, len(c.workloadClusters))
+
+	for _, cc := range c.workloadClusters {
+		resources = append(resources, types.ProtoResource153ToLegacy(cc))
+	}
+
+	return resources
+}
+
+func (c *workloadClusterCollection) writeText(w io.Writer, verbose bool) error {
+	t := asciitable.MakeTable([]string{"Name"})
+	for _, cc := range c.workloadClusters {
+		t.AddRow([]string{
+			cc.GetMetadata().GetName(),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}


### PR DESCRIPTION
Backport #62867 to branch/v18

I had to manually create this backport since there were conflicts and tctl implementation is significantly different on v18.

I cherry-picked 5cb5694c79117b978153a53beaa2b6942437a2b9 and resolved conflicts.


Goal: https://github.com/gravitational/cloud/issues/15315 https://github.com/gravitational/cloud/issues/15870

## Manual Test Plan
### Test Environment

Using a v19 cloud tenant in cloud's test environment using a dev build with workload cluster support.

### Test Cases

- [x] Get a single workload cluster
- [x] Get returns an error when workload cluster doesn't exist
- [x] List workload clusters
- [x] Create a workload cluster
- [x] Upsert a workload cluster that doesn't exist
- [x] Upsert a workload cluster that does exist
- [x] Edit a workload cluster
- [x] Remove a workload cluster