### PR TITLE
tctl resource command - add scoped token to new handler format

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -6037,6 +6037,11 @@ func (c *Client) ListScopedTokens(ctx context.Context, req *joiningv1.ListScoped
 	return res, trace.Wrap(err)
 }
 
+func (c *Client) GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.GetScopedToken(ctx, req)
+	return res.GetToken(), trace.Wrap(err)
+}
+
 // DeleteScopedToken deletes an existing scoped token.
 func (c *Client) DeleteScopedToken(ctx context.Context, name string) error {
 	_, err := c.grpc.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
@@ -6048,6 +6053,13 @@ func (c *Client) DeleteScopedToken(ctx context.Context, name string) error {
 // CreateScopedToken creates a new scoped token.
 func (c *Client) CreateScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
 	res, err := c.grpc.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	return res.GetToken(), trace.Wrap(err)
+}
+
+func (c *Client) UpsertScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{
 		Token: token,
 	})
 	return res.GetToken(), trace.Wrap(err)

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -305,6 +305,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindAppAuthConfig, nil
 	case types.KindWorkloadCluster, types.KindWorkloadCluster + "s":
 		return types.KindWorkloadCluster, nil
+	case scopedaccess.KindScopedToken, scopedaccess.KindScopedToken + "s", "scopedtoken", "scopedtokens":
+		return scopedaccess.KindScopedToken, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -48,21 +48,6 @@ import (
 	"github.com/gravitational/teleport/tool/tctl/common/resources"
 )
 
-func printMetadataLabels(labels map[string]string) string {
-	var sb strings.Builder
-	sb.Grow(len(labels) * 4)
-	i := 0
-	for key, value := range labels {
-		sb.WriteString(key + "=" + value)
-
-		if i < len(labels)-1 {
-			sb.WriteRune(',')
-		}
-		i++
-	}
-	return sb.String()
-}
-
 type reverseTunnelCollection struct {
 	tunnels []types.ReverseTunnel
 }

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -21,14 +21,11 @@ package common
 import (
 	"bytes"
 	"maps"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api"
@@ -344,43 +341,4 @@ func makeTestLabels(extraStaticLabels map[string]string) map[string]string {
 	maps.Copy(labels, staticLabelsFixture)
 	maps.Copy(labels, extraStaticLabels)
 	return labels
-}
-
-func BenchmarkPrintMetadataLabels(b *testing.B) {
-	largeLabels := make(map[string]string, 1000)
-	for i := range 1000 {
-		largeLabels[strconv.Itoa(i)] = "foo"
-	}
-
-	testCases := []struct {
-		name      string
-		labels    map[string]string
-		outputLen int
-	}{
-		{
-			name: "no labels",
-		},
-		{
-			name: "one label",
-			labels: map[string]string{
-				"test": "foo",
-			},
-			outputLen: 8,
-		},
-		{
-			name:      "many labels",
-			labels:    largeLabels,
-			outputLen: 7889,
-		},
-	}
-
-	for _, test := range testCases {
-		b.Run(test.name, func(b *testing.B) {
-			for b.Loop() {
-				out := printMetadataLabels(test.labels)
-				assert.Len(b, out, test.outputLen)
-				assert.False(b, strings.HasSuffix(out, ","))
-			}
-		})
-	}
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
 	apicommon "github.com/gravitational/teleport/api/types/common"
@@ -529,6 +530,143 @@ version: v1
 		case <-time.After(time.Millisecond * 100):
 		}
 	}
+}
+
+func TestScopedToken(t *testing.T) {
+	const scopedTokenYAML = `kind: scoped_token
+version: v1
+metadata:
+  name: test-token
+scope: "/"
+spec:
+  roles:
+    - Node
+  assigned_scope: "/foo"
+  join_method: "token"
+  usage_mode: "unlimited"
+`
+
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	scopedTokenYAMLPath := filepath.Join(t.TempDir(), "test-token.yaml")
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, []byte(scopedTokenYAML), 0644))
+
+	// Create the scoped token
+	_, err = runResourceCommand(t, clt, []string{"create", scopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// wait for cache propagation
+	var raw []byte
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// Get the scoped token by name
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		if !assert.NoError(ct, err) {
+			return
+		}
+		raw = buff.Bytes()
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
+
+	tokens, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](raw, services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+
+	// Compare with expected value
+	token := tokens[0]
+	require.Equal(t, types.KindScopedToken, token.GetKind())
+	require.Equal(t, "test-token", token.GetMetadata().GetName())
+	require.Equal(t, "/", token.GetScope())
+	require.Equal(t, []string{"Node"}, token.GetSpec().GetRoles())
+	require.Equal(t, "/foo", token.GetSpec().GetAssignedScope())
+	require.Equal(t, "token", token.GetSpec().GetJoinMethod())
+	require.Equal(t, "unlimited", token.GetSpec().GetUsageMode())
+	// Secret should be populated
+	require.Equal(t, "******", token.GetStatus().GetSecret())
+
+	// Get all scoped tokens
+	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json", "--with-secrets"})
+	require.NoError(t, err)
+	var allTokens []*joiningv1.ScopedToken
+	err = json.Unmarshal(buff.Bytes(), &allTokens)
+	require.NoError(t, err)
+	require.Len(t, allTokens, 1)
+	require.Equal(t, "test-token", allTokens[0].GetMetadata().GetName())
+	// Secret should be populated
+	require.NotEmpty(t, allTokens[0].GetStatus().GetSecret())
+	require.NotContains(t, allTokens[0].GetStatus().GetSecret(), "******")
+
+	// Overwrite scopedTokenYAMLPath with the retrieved token
+	retrievedBytes, err := services.MarshalProtoResource(allTokens[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, retrievedBytes, 0644))
+
+	// Create with --force for upsert
+	// Duplicate create without --force should fail
+	_, err = runResourceCommand(t, clt, []string{"create", scopedTokenYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
+
+	// Using --force should succeed and act as an upsert
+	_, err = runResourceCommand(t, clt, []string{"create", "--force", scopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// Update (upsert) scoped tokens
+	allTokens[0].Metadata.Labels = map[string]string{"env": "staging"}
+	allTokens[0].Spec.AssignedScope = "/bar"
+	updatedBytes, err := services.MarshalProtoResource(allTokens[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, updatedBytes, 0644))
+
+	_, err = runResourceCommand(t, clt, []string{"create", "--force", scopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// Wait for cache propagation and verify the update took effect
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		if !assert.NoError(ct, err) {
+			return
+		}
+		updated, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
+		if !assert.NoError(ct, err) || !assert.Len(ct, updated, 1) {
+			return
+		}
+		assert.Equal(ct, "/bar", updated[0].GetSpec().GetAssignedScope())
+		assert.Equal(ct, "staging", updated[0].GetMetadata().GetLabels()["env"])
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for upserted scoped token cache propagation")
+
+	// verify delete of token
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/test-token"})
+	require.NoError(t, err)
+
+	// wait for delete cache propagation
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		assert.True(ct, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 }
 
 // TestIntegrationResource tests tctl integration commands.

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -586,9 +586,7 @@ spec:
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		// Get the scoped token by name
 		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(t, err)
 		raw = buff.Bytes()
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 
@@ -631,10 +629,6 @@ spec:
 	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
 
 	// Using --force should succeed and act as an upsert
-	_, err = runResourceCommand(t, clt, []string{"create", "--force", scopedTokenYAMLPath})
-	require.NoError(t, err)
-
-	// Update (upsert) scoped tokens
 	allTokens[0].Metadata.Labels = map[string]string{"env": "staging"}
 	allTokens[0].Spec.AssignedScope = "/bar"
 	updatedBytes, err := services.MarshalProtoResource(allTokens[0])
@@ -647,15 +641,13 @@ spec:
 	// Wait for cache propagation and verify the update took effect
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
-		if !assert.NoError(ct, err) {
-			return
-		}
+		require.NoError(t, err)
 		updated, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
-		if !assert.NoError(ct, err) || !assert.Len(ct, updated, 1) {
-			return
-		}
-		assert.Equal(ct, "/bar", updated[0].GetSpec().GetAssignedScope())
-		assert.Equal(ct, "staging", updated[0].GetMetadata().GetLabels()["env"])
+		require.NoError(t, err)
+		require.Len(t, updated, 1)
+		require.Equal(t, "test-token", updated[0].GetMetadata().GetName())
+		require.Equal(ct, "/bar", updated[0].GetSpec().GetAssignedScope())
+		require.Equal(ct, "staging", updated[0].GetMetadata().GetLabels()["env"])
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for upserted scoped token cache propagation")
 
 	// verify delete of token
@@ -665,7 +657,7 @@ spec:
 	// wait for delete cache propagation
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
-		assert.True(ct, trace.IsNotFound(err), "expected a NotFound error, got %v", err)
+		require.True(ct, trace.IsNotFound(err))
 	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 }
 

--- a/tool/tctl/common/resources/resource.go
+++ b/tool/tctl/common/resources/resource.go
@@ -94,6 +94,7 @@ func Handlers() map[string]Handler {
 		scopedaccess.KindScopedRole:                  scopedRoleHandler(),
 		scopedaccess.KindScopedRoleAssignment:        scopedRoleAssignmentHandler(),
 		types.KindWorkloadCluster:                    workloadClusterHandler(),
+		scopedaccess.KindScopedToken:                 scopedTokenHandler(),
 	}
 }
 

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -1,0 +1,190 @@
+// Teleport
+// Copyright (C) 2026  Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+package resources
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/clientutils"
+	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+type scopedTokenCollection struct {
+	tokens []*joiningv1.ScopedToken
+}
+
+func NewScopedTokenCollection(tokens []*joiningv1.ScopedToken) Collection {
+	return &scopedTokenCollection{
+		tokens: tokens,
+	}
+}
+
+func (c *scopedTokenCollection) Resources() []types.Resource {
+	r := make([]types.Resource, len(c.tokens))
+	for i, resource := range c.tokens {
+		r[i] = types.ProtoResource153ToLegacy(resource)
+	}
+	return r
+}
+
+func (c *scopedTokenCollection) WriteText(w io.Writer, verbose bool) error {
+	// when calling the getScopedToken, the secrets would already have been properly hidden or exposed.
+	_, err := ScopedTokenTextHelper(c.tokens, false).WriteTo(w)
+	return trace.Wrap(err)
+}
+
+func scopedTokenHandler() Handler {
+	return Handler{
+		getHandler:    getScopedToken,
+		createHandler: createScopedToken,
+		deleteHandler: deleteScopedToken,
+		updateHandler: updateScopedToken,
+		description:   "Scoped invitation tokens that can be used to provision resources at a limited scope",
+	}
+}
+
+func createScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	r, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var token *joiningv1.ScopedToken
+	if opts.Force {
+		token, err = client.UpsertScopedToken(ctx, r)
+	} else {
+		token, err = client.CreateScopedToken(ctx, r)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		"%v %q has been created\n",
+		types.KindScopedToken,
+		token.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func updateScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	r, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	token, err := client.UpsertScopedToken(ctx, r)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		"%v %q has been updated\n",
+		types.KindScopedToken,
+		token.GetMetadata().GetName(),
+	)
+
+	return nil
+}
+
+func getScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref, opts GetOpts) (Collection, error) {
+	// If a specific token name is requested, filter the results
+	if ref.Name != "" {
+		token, err := client.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       ref.Name,
+			WithSecret: opts.WithSecrets,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !opts.WithSecrets {
+			token.GetStatus().Secret = "******"
+		}
+		return &scopedTokenCollection{[]*joiningv1.ScopedToken{token}}, nil
+	}
+
+	tokens, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*joiningv1.ScopedToken, string, error) {
+		res, err := client.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
+			Limit:       uint32(pageSize),
+			Cursor:      pageKey,
+			WithSecrets: opts.WithSecrets,
+		})
+		if err != nil {
+			return nil, "", trace.Wrap(err)
+		}
+		if !opts.WithSecrets {
+			for _, token := range res.GetTokens() {
+				token.GetStatus().Secret = "******"
+			}
+		}
+
+		return res.GetTokens(), res.GetCursor(), nil
+	}))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &scopedTokenCollection{tokens: tokens}, nil
+}
+
+func deleteScopedToken(ctx context.Context, client *authclient.Client, ref services.Ref) error {
+	if err := client.DeleteScopedToken(ctx, ref.Name); err != nil {
+		return trace.Wrap(err)
+	}
+	fmt.Printf(
+		"%v %q has been deleted\n",
+		types.KindScopedToken,
+		ref.Name,
+	)
+	return nil
+}
+
+func ScopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
+	table := asciitable.MakeTable([]string{"Token", "Secret", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
+
+	secretFunc := func(t *joiningv1.ScopedToken) string {
+		if withSecrets {
+			return t.GetStatus().GetSecret()
+		}
+		return "******"
+	}
+
+	now := time.Now()
+	for _, t := range tokens {
+		expiry := "never"
+		expiresAt := t.GetMetadata().GetExpires().AsTime()
+		if !expiresAt.IsZero() && expiresAt.Unix() != 0 {
+			exptime := expiresAt.Format(time.RFC822)
+			expdur := expiresAt.Sub(now).Round(time.Second)
+			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
+		}
+		table.AddRow([]string{t.GetMetadata().GetName(), secretFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), PrintMetadataLabels(t.GetMetadata().Labels), expiry})
+	}
+	return table.AsBuffer()
+}

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -63,12 +63,12 @@ func scopedTokenHandler() Handler {
 		getHandler:    getScopedToken,
 		createHandler: createScopedToken,
 		deleteHandler: deleteScopedToken,
-		updateHandler: updateScopedToken,
 		description:   "Scoped invitation tokens that can be used to provision resources at a limited scope",
 	}
 }
 
 func createScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
+	verb := "created"
 	r, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
 	if err != nil {
 		return trace.Wrap(err)
@@ -77,6 +77,7 @@ func createScopedToken(ctx context.Context, client *authclient.Client, raw servi
 	var token *joiningv1.ScopedToken
 	if opts.Force {
 		token, err = client.UpsertScopedToken(ctx, r)
+		verb = "upserted"
 	} else {
 		token, err = client.CreateScopedToken(ctx, r)
 	}
@@ -85,29 +86,10 @@ func createScopedToken(ctx context.Context, client *authclient.Client, raw servi
 	}
 
 	fmt.Printf(
-		"%v %q has been created\n",
+		"%v %q has been %s\n",
 		types.KindScopedToken,
 		token.GetMetadata().GetName(),
-	)
-
-	return nil
-}
-
-func updateScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource, opts CreateOpts) error {
-	r, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	token, err := client.UpsertScopedToken(ctx, r)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	fmt.Printf(
-		"%v %q has been updated\n",
-		types.KindScopedToken,
-		token.GetMetadata().GetName(),
+		verb,
 	)
 
 	return nil

--- a/tool/tctl/common/resources/scoped_token.go
+++ b/tool/tctl/common/resources/scoped_token.go
@@ -77,7 +77,7 @@ func createScopedToken(ctx context.Context, client *authclient.Client, raw servi
 	var token *joiningv1.ScopedToken
 	if opts.Force {
 		token, err = client.UpsertScopedToken(ctx, r)
-		verb = "upserted"
+		verb = "updated"
 	} else {
 		token, err = client.CreateScopedToken(ctx, r)
 	}

--- a/tool/tctl/common/resources/utils.go
+++ b/tool/tctl/common/resources/utils.go
@@ -145,3 +145,19 @@ func makeNamePredicate(name string) string {
 	}
 	return fmt.Sprintf(`name == %q`, name)
 }
+
+// PrintMetadataLabels formats resource metadata labels as a key=value pair string.
+func PrintMetadataLabels(labels map[string]string) string {
+	var sb strings.Builder
+	sb.Grow(len(labels) * 4)
+	i := 0
+	for key, value := range labels {
+		sb.WriteString(key + "=" + value)
+
+		if i < len(labels)-1 {
+			sb.WriteRune(',')
+		}
+		i++
+	}
+	return sb.String()
+}

--- a/tool/tctl/common/resources/utils_test.go
+++ b/tool/tctl/common/resources/utils_test.go
@@ -20,12 +20,14 @@ package resources
 
 import (
 	"maps"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -188,3 +190,42 @@ var (
 		"label3": "val3",
 	}
 )
+
+func BenchmarkPrintMetadataLabels(b *testing.B) {
+	largeLabels := make(map[string]string, 1000)
+	for i := range 1000 {
+		largeLabels[strconv.Itoa(i)] = "foo"
+	}
+
+	testCases := []struct {
+		name      string
+		labels    map[string]string
+		outputLen int
+	}{
+		{
+			name: "no labels",
+		},
+		{
+			name: "one label",
+			labels: map[string]string{
+				"test": "foo",
+			},
+			outputLen: 8,
+		},
+		{
+			name:      "many labels",
+			labels:    largeLabels,
+			outputLen: 7889,
+		},
+	}
+
+	for _, test := range testCases {
+		b.Run(test.name, func(b *testing.B) {
+			for b.Loop() {
+				out := PrintMetadataLabels(test.labels)
+				assert.Len(b, out, test.outputLen)
+				assert.False(b, strings.HasSuffix(out, ","))
+			}
+		})
+	}
+}

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -412,7 +412,7 @@ func (c *TokensCommand) List(ctx context.Context, client *authclient.Client) err
 					expdur := t.Expiry().Sub(now).Round(time.Second)
 					expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
 				}
-				table.AddRow([]string{nameFunc(t), t.GetRoles().String(), printMetadataLabels(t.GetMetadata().Labels), expiry})
+				table.AddRow([]string{nameFunc(t), t.GetRoles().String(), resources.PrintMetadataLabels(t.GetMetadata().Labels), expiry})
 			}
 			return table.AsBuffer().String()
 		}


### PR DESCRIPTION
Purpose:

Added scoped token support for the resources command.

Implementation:

* new `scoped_token.go` file for the new handler format
* added `GetScopedToken` in `client.go` to support retrieving scoped token by name, otherwise default to the listing operation
* additional tests for the new commands

#### 1. Get/List Behavior
- [x] As the admin user (has `read` verb), run `tctl get scoped_tokens --with-secret` 
- [x] As the admin user, run `tctl get scoped_tokens` (no `--with-secret` flag)
- [x] As the reader user (has only `readnosecrets` verb), run `tctl tokens get my-new-token` and verify the secret field is **empty**
- [x] Run as a reader with only readnosecret `tctl tokens get my-new-token --with-secret` and verify the command is **denied** (access denied error)

#### 1. Upsert Behavior
- [x] Use `tctl` to create and upsert a scoped token that does not exist yet at
- [x] Upsert the same token name, changing only the labels (e.g. add `env: production`)
- [x] Upsert the same token, changing `assigned_scope` from `/staging/aa` to `/staging/aa/nested`
- [x] Upsert the same token, changing `scope` from `/staging/aa` to `/staging` and verify that it fails
- [x] Upsert the same token with a different `secret` value and verify that it fails
- [x] Upsert the same token with a modified `status.usage` and verify that it fails (e.g. set a `single_use` status)
- [x] As a writer user (has only `create` verb), attempt to upsert a new token
- [x] Verify only users with create and update can upsert


#### 2. Upsert + Join Interaction

- [x] Create a token at `/staging/aa` with `assigned_scope: /staging/aa/nodes`, join a node using the token and upsert, changing labels only - verify that the rejoining works
- [x] Create a token at `/staging/aa` with `assigned_scope: /staging/aa/nodes`, join a node using the token and upsert, changing the assigned scope - verify that the rejoining works

changelog: Add `tctl add/get/delete scoped_tokens/...` support for the resource command