### PR TITLE
docs: Fix role mapping variables for tctl sso configure

### DIFF
--- a/docs/pages/includes/sso/role-mapping.mdx
+++ b/docs/pages/includes/sso/role-mapping.mdx
@@ -14,15 +14,15 @@ mapping takes the following format:
 ```
 
 For example, the following role mapping means that any user with the {{fieldType}}
-`group` with the value `admin` receives the Teleport roles `editor` and
+`groups` with the value `admin` receives the Teleport roles `editor` and
 `auditor`:
 
 ```text
-group,admin,editor,auditor
+groups,admin,editor,auditor
 ```
 
 For the purpose of this guide, assign two separate role mappings:
 
-- A more permissive role mapping: <Var name="mapping_1" initial="group,admins,auditor,editor" />
-- A more restrictive role mapping: <Var name="mapping_2" initial="group,users,access" />
+- A more permissive role mapping: <Var name="mapping_1" initial="groups,admins,auditor,editor" />
+- A more restrictive role mapping: <Var name="mapping_2" initial="groups,users,access" />
 


### PR DESCRIPTION
This fix's the mapping from `group` to `groups` in the variable for the example `'tctl sso configure saml --preset=okta'`
Because we use `groups` in the earlier configuration settings for the IDP this will fail to map traits to the correct roles.
Observed this failing in an end to end execution with Okta.