### PR TITLE
AccessList: Add safety dangling ownerOf reference check

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -462,6 +462,17 @@ func (a *AccessList) SetOwners(owners []Owner) {
 	a.Spec.Owners = owners
 }
 
+// HasOwnerList checks if the given access list name is configured as a list owner
+// (with MembershipKindList) of this access list.
+func (a *AccessList) HasOwnerList(name string) bool {
+	for _, owner := range a.Spec.Owners {
+		if owner.Name == name && owner.MembershipKind == MembershipKindList {
+			return true
+		}
+	}
+	return false
+}
+
 // GetMembershipRequires returns the membership requires configuration from the access list.
 func (a *AccessList) GetMembershipRequires() Requires {
 	return a.Spec.MembershipRequires

--- a/lib/accesslists/hierarchy.go
+++ b/lib/accesslists/hierarchy.go
@@ -584,6 +584,14 @@ func (s *Hierarchy) expandOwnerOf(ctx context.Context, accessList *accesslist.Ac
 			if err != nil {
 				return trace.Wrap(err)
 			}
+			// Verify that al is actually listed as a list owner in ownerList.
+			// This validates the OwnerOf relationship to guard against stale or
+			// inconsistent Status.OwnerOf references (e.g., if an owner was removed
+			// but Status.OwnerOf wasn't updated).
+			if !ownerList.HasOwnerList(al.GetName()) {
+				continue
+			}
+
 			if UserMeetsRequirements(user, ownerList.GetOwnershipRequires()) {
 				out = append(out, ownerList)
 			}


### PR DESCRIPTION
### What

This is safeguard that make sure that RBAC check that is calculated using owernOf to traversal access list graph will be excluded if ownerOf is dangling (there is not accualty addaguate ownership relation inside access list). 

### Why

This solution in current state will not happen since all access list update flows calculates the ownerOf + we have async reconciler process to verify the correctnes of ownerOf/memberOf failed. But just in case this will help if wrong path will be introduced. 