### PR TITLE
Ensure Device Trust Requirements Apply to Correct Applications

### DIFF
--- a/lib/auth/sessions.go
+++ b/lib/auth/sessions.go
@@ -557,14 +557,6 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		return nil, trace.Wrap(err)
 	}
 
-	deviceVerified := dtauthz.IsTLSDeviceVerified((*tlsca.DeviceExtensions)(&req.DeviceExtensions))
-	a.logger.DebugContext(ctx, "DEBUG: App Session Request Context",
-		"user", req.User,
-		"roles", req.Roles,
-		"device_verified", deviceVerified,
-		"mfa_present", req.MFAVerified != "",
-	)
-
 	// Audit fields used for both success and failure
 	sessionStartEvent := &apievents.AppSessionStart{
 		Metadata: apievents.Metadata{
@@ -587,83 +579,62 @@ func (a *Server) CreateAppSessionFromReq(ctx context.Context, req NewAppSessionR
 		},
 	}
 
+	app, err := a.GetApp(ctx, req.AppName)
+	if err != nil {
+		return nil, trace.AccessDenied("application metadata not found")
+	}
+
 	// Enforce device trust early via the AccessChecker.
-	deviceErr := checker.CheckDeviceAccess(services.AccessState{
-		DeviceVerified:           deviceVerified,
-		EnableDeviceVerification: true,
-		IsBot:                    req.BotName != "",
-	})
+	deviceErr := checker.CheckDeviceAccess(
+		app,
+		services.AccessState{
+			DeviceVerified:           dtauthz.IsTLSDeviceVerified((*tlsca.DeviceExtensions)(&req.DeviceExtensions)),
+			EnableDeviceVerification: true,
+			IsBot:                    req.BotName != "",
+		},
+		req.Traits,
+	)
 
 	if deviceErr != nil {
-		a.logger.DebugContext(ctx, "DEBUG: Primary device trust check failed", "error", deviceErr)
 
-		isExplicitlyIDAllowed := false
-		for _, resID := range req.RequestedResourceIDs {
-			if resID.Kind == types.KindApp && resID.Name == req.AppName {
-				isExplicitlyIDAllowed = true
-				break
-			}
-		}
-		a.logger.DebugContext(ctx, "Resource ID allow-list check", "app", req.AppName, "found", isExplicitlyIDAllowed)
-
-		appResource, _ := types.NewAppV3(
-			types.Metadata{Name: req.AppName},
-			types.AppSpecV3{URI: req.AppURI},
-		)
-
-		accessErr := checker.CheckAccess(appResource, services.AccessState{
-			MFAVerified:    req.MFAVerified != "",
-			DeviceVerified: deviceVerified,
-		})
-
-		if accessErr != nil {
-			a.logger.DebugContext(ctx, "CheckAccess REJECTED", "error", accessErr)
-		} else {
-			a.logger.DebugContext(ctx, "CheckAccess ALLOWED")
+		userKind := apievents.UserKind_USER_KIND_HUMAN
+		if req.BotName != "" {
+			userKind = apievents.UserKind_USER_KIND_BOT
 		}
 
-		if accessErr != nil && !isExplicitlyIDAllowed {
-			a.logger.DebugContext(ctx, "DEBUG: Emitting failure audit.", "error", accessErr)
-
-			userKind := apievents.UserKind_USER_KIND_HUMAN
-			if req.BotName != "" {
-				userKind = apievents.UserKind_USER_KIND_BOT
-			}
-
-			userMetadata := apievents.UserMetadata{
-				User:            req.User,
-				BotName:         req.BotName,
-				BotInstanceID:   req.BotInstanceID,
-				UserKind:        userKind,
-				UserRoles:       req.Roles,
-				UserClusterName: req.ClusterName,
-				UserTraits:      req.Traits,
-				AWSRoleARN:      req.AWSRoleARN,
-			}
-
-			if req.DeviceExtensions.DeviceID != "" {
-				userMetadata.TrustedDevice = &apievents.DeviceMetadata{
-					DeviceId:     req.DeviceExtensions.DeviceID,
-					AssetTag:     req.DeviceExtensions.AssetTag,
-					CredentialId: req.DeviceExtensions.CredentialID,
-				}
-			}
-			errMsg := "requires a trusted device"
-
-			sessionStartEvent.Metadata.SetCode(events.AppSessionStartFailureCode)
-			sessionStartEvent.UserMetadata = userMetadata
-			sessionStartEvent.SessionMetadata = apievents.SessionMetadata{
-				WithMFA: req.MFAVerified,
-			}
-			sessionStartEvent.Error = err.Error()
-			sessionStartEvent.UserMessage = errMsg
-
-			a.emitter.EmitAuditEvent(a.closeCtx, sessionStartEvent)
-			// err swallowed/obscured on purpose.
-			return nil, trace.AccessDenied("%s", errMsg)
-		} else {
-			a.logger.DebugContext(ctx, "DEBUG: not rejected.", "app", req.AppName)
+		userMetadata := apievents.UserMetadata{
+			User:            req.User,
+			BotName:         req.BotName,
+			BotInstanceID:   req.BotInstanceID,
+			UserKind:        userKind,
+			UserRoles:       req.Roles,
+			UserClusterName: req.ClusterName,
+			UserTraits:      req.Traits,
+			AWSRoleARN:      req.AWSRoleARN,
 		}
+
+		if req.DeviceExtensions.DeviceID != "" {
+			userMetadata.TrustedDevice = &apievents.DeviceMetadata{
+				DeviceId:     req.DeviceExtensions.DeviceID,
+				AssetTag:     req.DeviceExtensions.AssetTag,
+				CredentialId: req.DeviceExtensions.CredentialID,
+			}
+		}
+		errMsg := "requires a trusted device"
+
+		sessionStartEvent.Metadata.SetCode(events.AppSessionStartFailureCode)
+		sessionStartEvent.UserMetadata = userMetadata
+		sessionStartEvent.SessionMetadata = apievents.SessionMetadata{
+			WithMFA: req.MFAVerified,
+		}
+		sessionStartEvent.Error = deviceErr.Error()
+		sessionStartEvent.UserMessage = errMsg
+
+		a.emitter.EmitAuditEvent(a.closeCtx, sessionStartEvent)
+		// err swallowed/obscured on purpose.
+		return nil, trace.AccessDenied("%s", errMsg)
+	} else {
+		a.logger.DebugContext(ctx, "DEBUG: not rejected.", "app", req.AppName)
 	}
 
 	sessionID := req.SuggestedSessionID

--- a/lib/auth/sessions_test.go
+++ b/lib/auth/sessions_test.go
@@ -499,10 +499,11 @@ func TestCreateAppSession_UntrustedDevice(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, test := range []struct {
-		app    types.Application
-		assert require.ErrorAssertionFunc
+		app     types.Application
+		assert  require.ErrorAssertionFunc
+		wantErr string
 	}{
-		{app: prodApp, assert: require.Error},
+		{app: prodApp, assert: require.Error, wantErr: "device trust required"},
 		{app: devApp, assert: require.NoError},
 	} {
 		t.Run(test.app.GetName(), func(t *testing.T) {
@@ -517,7 +518,11 @@ func TestCreateAppSession_UntrustedDevice(t *testing.T) {
 			identity := tlsca.Identity{Username: user.GetName()}
 
 			_, err = testAuthServer.AuthServer.CreateAppSession(t.Context(), req, identity, checker)
-			test.assert(t, err)
+			if test.wantErr == "" {
+				assert.NoError(t, err, "CreateAppSession errored unexpectedly")
+				return
+			}
+			assert.ErrorContains(t, err, test.wantErr, "CreateAppSession error mismatch")
 		})
 	}
 }

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -65,10 +65,6 @@ type AccessChecker interface {
 	// CheckAccess checks access to the specified resource.
 	CheckAccess(r AccessCheckable, state AccessState, matchers ...RoleMatcher) error
 
-	// CheckDeviceAccess verifies if the current device state satisfies the
-	// device trust requirements of the user's RoleSet.
-	CheckDeviceAccess(r AccessCheckable, state AccessState, userTraits wrappers.Traits) error
-
 	// CheckAccessToRemoteCluster checks access to remote cluster
 	CheckAccessToRemoteCluster(cluster types.RemoteCluster) error
 

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -67,7 +67,7 @@ type AccessChecker interface {
 
 	// CheckDeviceAccess verifies if the current device state satisfies the
 	// device trust requirements of the user's RoleSet.
-	CheckDeviceAccess(state AccessState) error
+	CheckDeviceAccess(r AccessCheckable, state AccessState, userTraits wrappers.Traits) error
 
 	// CheckAccessToRemoteCluster checks access to remote cluster
 	CheckAccessToRemoteCluster(cluster types.RemoteCluster) error

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2816,17 +2816,13 @@ func (set RoleSet) CheckDeviceAccess(r AccessCheckable, state AccessState, userT
 	if !state.EnableDeviceVerification {
 		return nil
 	}
-	for _, role := range set {
 
+	// Check device trust mode across all roles that apply to the resource.
+	for _, role := range set {
+		// If a specific resource is provided, we only enforce Device Trust requirements
+		// for roles that grant access to that resource.
 		if r != nil {
-			matches, _, _ := checkRoleLabelsMatch(
-				types.Allow,
-				role,
-				userTraits,
-				r,
-				false,
-			)
-			if !matches {
+			if matches, _, _ := checkRoleLabelsMatch(types.Allow, role, userTraits, r, false); !matches {
 				continue
 			}
 		}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2812,11 +2812,24 @@ func (set RoleSet) checkAccess(r AccessCheckable, traits wrappers.Traits, state 
 //
 // This is used for early authorization checks where a full resource object
 // is not yet available, but we need to verify the device before proceeding.
-func (set RoleSet) CheckDeviceAccess(state AccessState) error {
+func (set RoleSet) CheckDeviceAccess(r AccessCheckable, state AccessState, userTraits wrappers.Traits) error {
 	if !state.EnableDeviceVerification {
 		return nil
 	}
 	for _, role := range set {
+
+		if r != nil {
+			matches, _, _ := checkRoleLabelsMatch(
+				types.Allow,
+				role,
+				userTraits,
+				r,
+				false,
+			)
+			if !matches {
+				continue
+			}
+		}
 		// Note: Unlike RoleSet.checkAccess, VerifyTrustedDeviceMode does not short-circuit
 		// if the device is already verified. It performs validation across the entire RoleSet.
 		if err := dtauthz.VerifyTrustedDeviceMode(


### PR DESCRIPTION
Fixes and issue introduced in #62019 where device trust requirements from a role were mistakenly applied to all applications instead of the specific applications matched by the role.

Test Plan

- [ ] Scenario 1: Original Device Trust
- Have an application with label `env: prod`
- Have a role with `device_trust_mode: required` and allows resources with labels `env: prod`
- After attempting to create an app session from an untrusted device, we should see an `Access Denied` page and an App Session Start Failure in the audit logs
- [ ] Scenario 2: Label-Based
- Have Application A with label `env: test` and another Application B with label `env: prod`
- Have Role A with `device_trust_mode: required` and allows resources with labels `env: prod` and another Role B with `device_trust_mode: off` and allows resources with labels `*: *`
- User with Role A and Role B from an untrusted device should be able to access Application A, but should not be able to access Application B
- [ ] Scenario 3: Static Apps
- Same as Scenario 2, but Application A and B are static apps with reasonable `keep_alive_interval`
- To recreate the case where `a.GetApp()` does not recognize the app, but passes the request along, start Teleport with `env: test` label on Application B, then restart Teleport with `env:prod` label on Application B, and access Application B with an untrusted device
- Right now, the UI doesn't show a `access denied page` and this event is audited as a`AppSessionStart`
- After a while, the UI updates the labels on Application B correctly but the same UI and audit issue persist when attempting to access the resource with an untrusted device
<img width="1512" height="273" alt="image" src="https://github.com/user-attachments/assets/4cb2f1d8-688e-4396-b8a6-35810afe0204" />
