### PR TITLE
[Connect] Support ResourceConstraints for Access Requests

### DIFF
--- a/lib/teleterm/apiserver/handler/handler_access_requests.go
+++ b/lib/teleterm/apiserver/handler/handler_access_requests.go
@@ -175,21 +175,23 @@ func newAPIAccessRequest(req clusters.AccessRequest) *api.AccessRequest {
 		}
 	}
 
-	requestedResourceIDs := req.GetRequestedResourceIDs()
-	resources := make([]*api.Resource, len(requestedResourceIDs))
-	for i, r := range requestedResourceIDs {
-		details := req.ResourceDetails[resourceIDToString(r)]
+	// GetAllRequestedResourceIDs returns all resources as ResourceAccessID, including constraints.
+	requestedResourceAccessIDs := req.GetAllRequestedResourceIDs()
+	resources := make([]*api.Resource, len(requestedResourceAccessIDs))
+	for i, r := range requestedResourceAccessIDs {
+		details := req.ResourceDetails[resourceIDToString(r.Id)]
 
 		resources[i] = &api.Resource{
 			Id: &api.ResourceID{
-				ClusterName:     r.ClusterName,
-				Kind:            r.Kind,
-				Name:            r.Name,
-				SubResourceName: r.SubResourceName,
+				ClusterName:     r.Id.ClusterName,
+				Kind:            r.Id.Kind,
+				Name:            r.Id.Name,
+				SubResourceName: r.Id.SubResourceName,
 			},
 			// If there are no details for this resource, the map lookup returns
 			// the default value which is empty details
-			Details: newAPIResourceDetails(details),
+			Details:     newAPIResourceDetails(details),
+			Constraints: r.Constraints,
 		}
 	}
 

--- a/lib/teleterm/apiserver/handler/handler_apps.go
+++ b/lib/teleterm/apiserver/handler/handler_apps.go
@@ -64,10 +64,11 @@ func newAPIApp(clusterApp clusters.App) *api.App {
 	awsRoles := []*api.AWSRole{}
 	for _, role := range clusterApp.AWSRoles {
 		awsRoles = append(awsRoles, &api.AWSRole{
-			Name:      role.Name,
-			Display:   role.Display,
-			Arn:       role.ARN,
-			AccountId: role.AccountID,
+			Name:            role.Name,
+			Display:         role.Display,
+			Arn:             role.ARN,
+			AccountId:       role.AccountID,
+			RequiresRequest: role.RequiresRequest,
 		})
 	}
 
@@ -79,21 +80,27 @@ func newAPIApp(clusterApp clusters.App) *api.App {
 		tcpPorts = append(tcpPorts, &api.PortRange{Port: portRange.Port, EndPort: portRange.EndPort})
 	}
 
+	supportedFeatureIDs := make([]int32, len(clusterApp.SupportedFeatureIDs))
+	for i, id := range clusterApp.SupportedFeatureIDs {
+		supportedFeatureIDs[i] = int32(id)
+	}
+
 	return &api.App{
-		Uri:            clusterApp.URI.String(),
-		EndpointUri:    app.GetURI(),
-		Name:           app.GetName(),
-		Desc:           app.GetDescription(),
-		AwsConsole:     app.IsAWSConsole(),
-		PublicAddr:     app.GetPublicAddr(),
-		Fqdn:           clusterApp.FQDN,
-		AwsRoles:       awsRoles,
-		FriendlyName:   types.FriendlyName(app),
-		SamlApp:        false,
-		Labels:         apiLabels,
-		TcpPorts:       tcpPorts,
-		SubKind:        app.GetSubKind(),
-		PermissionSets: permissionSets,
+		Uri:                 clusterApp.URI.String(),
+		EndpointUri:         app.GetURI(),
+		Name:                app.GetName(),
+		Desc:                app.GetDescription(),
+		AwsConsole:          app.IsAWSConsole(),
+		PublicAddr:          app.GetPublicAddr(),
+		Fqdn:                clusterApp.FQDN,
+		AwsRoles:            awsRoles,
+		FriendlyName:        types.FriendlyName(app),
+		SamlApp:             false,
+		Labels:              apiLabels,
+		TcpPorts:            tcpPorts,
+		SubKind:             app.GetSubKind(),
+		PermissionSets:      permissionSets,
+		SupportedFeatureIds: supportedFeatureIDs,
 	}
 }
 

--- a/lib/teleterm/clusters/cluster_apps.go
+++ b/lib/teleterm/clusters/cluster_apps.go
@@ -43,7 +43,12 @@ type App struct {
 	// clusters.Cluster.
 	FQDN string
 	// AWSRoles is a list of AWS IAM roles for the application representing AWS console.
+	// Each role's RequiresRequest field indicates whether it needs an access request.
 	AWSRoles aws.Roles
+	// SupportedFeatureIDs contains component feature IDs supported by this app and all
+	// other involved components (Auth, Proxy). Used to determine if features like resource
+	// constraints are available.
+	SupportedFeatureIDs []int
 
 	App types.Application
 }

--- a/lib/teleterm/daemon/daemon.go
+++ b/lib/teleterm/daemon/daemon.go
@@ -1152,7 +1152,7 @@ func (s *Service) ListUnifiedResources(ctx context.Context, clusterURI uri.Resou
 	var resources *unifiedresources.ListResponse
 
 	err = clusters.AddMetadataToRetryableError(ctx, func() error {
-		resources, err = unifiedresources.List(ctx, cluster, proxyClient.CurrentCluster(), req)
+		resources, err = unifiedresources.List(ctx, cluster, proxyClient.CurrentCluster(), req, s.cfg.Logger)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/teleterm/services/unifiedresources/unifiedresources_test.go
+++ b/lib/teleterm/services/unifiedresources/unifiedresources_test.go
@@ -1,0 +1,131 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package unifiedresources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils/aws"
+)
+
+func TestComputeAWSRolesWithRequiresRequest(t *testing.T) {
+	const accountID = "123456789012"
+	arnAdmin := "arn:aws:iam::123456789012:role/Admin"
+	arnDev := "arn:aws:iam::123456789012:role/Developer"
+	arnReadOnly := "arn:aws:iam::123456789012:role/ReadOnly"
+	arnOther := "arn:aws:iam::999999999999:role/OtherAccount"
+
+	grantedRoles := aws.Roles{
+		{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID},
+		{Name: "Developer", Display: "Developer", ARN: arnDev, AccountID: accountID},
+	}
+
+	tests := []struct {
+		name               string
+		visibleRoleARNs    []string
+		grantedRoles       aws.Roles
+		accountID          string
+		includeRequestable bool
+		expected           aws.Roles
+	}{
+		{
+			name:               "granted roles are not marked as requiring request",
+			visibleRoleARNs:    []string{arnAdmin, arnDev},
+			grantedRoles:       grantedRoles,
+			accountID:          accountID,
+			includeRequestable: false,
+			expected: aws.Roles{
+				{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID, RequiresRequest: false},
+				{Name: "Developer", Display: "Developer", ARN: arnDev, AccountID: accountID, RequiresRequest: false},
+			},
+		},
+		{
+			name:               "non-granted roles are excluded when includeRequestable is false",
+			visibleRoleARNs:    []string{arnAdmin, arnReadOnly},
+			grantedRoles:       grantedRoles,
+			accountID:          accountID,
+			includeRequestable: false,
+			expected: aws.Roles{
+				{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID, RequiresRequest: false},
+			},
+		},
+		{
+			name:               "non-granted roles are included and marked as requiring request when includeRequestable is true",
+			visibleRoleARNs:    []string{arnAdmin, arnReadOnly},
+			grantedRoles:       grantedRoles,
+			accountID:          accountID,
+			includeRequestable: true,
+			expected: aws.Roles{
+				{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID, RequiresRequest: false},
+				{Name: "ReadOnly", Display: "ReadOnly", ARN: arnReadOnly, AccountID: accountID, RequiresRequest: true},
+			},
+		},
+		{
+			name:               "roles from other accounts are filtered out",
+			visibleRoleARNs:    []string{arnAdmin, arnOther},
+			grantedRoles:       grantedRoles,
+			accountID:          accountID,
+			includeRequestable: true,
+			expected: aws.Roles{
+				{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID, RequiresRequest: false},
+			},
+		},
+		{
+			name:               "empty visible roles returns empty result",
+			visibleRoleARNs:    []string{},
+			grantedRoles:       grantedRoles,
+			accountID:          accountID,
+			includeRequestable: true,
+			expected:           aws.Roles{},
+		},
+		{
+			name:               "empty granted roles marks all visible roles as requiring request",
+			visibleRoleARNs:    []string{arnAdmin, arnDev},
+			grantedRoles:       aws.Roles{},
+			accountID:          accountID,
+			includeRequestable: true,
+			expected: aws.Roles{
+				{Name: "Admin", Display: "Admin", ARN: arnAdmin, AccountID: accountID, RequiresRequest: true},
+				{Name: "Developer", Display: "Developer", ARN: arnDev, AccountID: accountID, RequiresRequest: true},
+			},
+		},
+		{
+			name:               "empty granted roles and includeRequestable false returns no roles",
+			visibleRoleARNs:    []string{arnAdmin, arnDev},
+			grantedRoles:       aws.Roles{},
+			accountID:          accountID,
+			includeRequestable: false,
+			expected:           aws.Roles{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := computeAWSRolesWithRequiresRequest(
+				tt.visibleRoleARNs,
+				tt.grantedRoles,
+				tt.accountID,
+				tt.includeRequestable,
+			)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/lib/teleterm/services/unifiedresources/unififedresources_test.go
+++ b/lib/teleterm/services/unifiedresources/unififedresources_test.go
@@ -20,9 +20,11 @@ package unifiedresources
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -130,7 +132,7 @@ func TestUnifiedResourcesList(t *testing.T) {
 		nextKey:            mockedNextKey,
 	}
 
-	response, err := List(ctx, cluster, mockedClient, &proto.ListUnifiedResourcesRequest{})
+	response, err := List(ctx, cluster, mockedClient, &proto.ListUnifiedResourcesRequest{}, slog.New(slog.DiscardHandler))
 	require.NoError(t, err)
 
 	require.Equal(t, UnifiedResource{Server: &clusters.Server{
@@ -152,9 +154,10 @@ func TestUnifiedResourcesList(t *testing.T) {
 	require.Equal(t, UnifiedResource{App: &clusters.App{
 		URI: uri.NewClusterURI(cluster.ProfileName).AppendApp(app.GetApp().GetName()),
 		// FQDN looks weird because we cannot mock cluster.status.ProxyHost in tests.
-		FQDN:     "testApp.",
-		AWSRoles: aws.Roles{},
-		App:      app.GetApp(),
+		FQDN:                "testApp.",
+		AWSRoles:            aws.Roles{},
+		App:                 app.GetApp(),
+		SupportedFeatureIDs: []int{},
 	}}, response.Resources[3])
 
 	require.Equal(t, UnifiedResource{SAMLIdPServiceProvider: &clusters.SAMLIdPServiceProvider{
@@ -168,10 +171,11 @@ func TestUnifiedResourcesList(t *testing.T) {
 	}}, response.Resources[5])
 
 	require.Equal(t, UnifiedResource{App: &clusters.App{
-		FQDN:     "test-mcp.",
-		URI:      uri.NewClusterURI(cluster.ProfileName).AppendApp(mcp.GetName()),
-		AWSRoles: aws.Roles{},
-		App:      mcp.GetApp(),
+		FQDN:                "test-mcp.",
+		URI:                 uri.NewClusterURI(cluster.ProfileName).AppendApp(mcp.GetName()),
+		AWSRoles:            aws.Roles{},
+		App:                 mcp.GetApp(),
+		SupportedFeatureIDs: []int{},
 	}}, response.Resources[6])
 
 	require.Equal(t, mockedNextKey, response.NextKey)
@@ -187,4 +191,22 @@ func (m *mockClient) ListUnifiedResources(ctx context.Context, req *proto.ListUn
 		Resources: m.paginatedResources,
 		NextKey:   m.nextKey,
 	}, nil
+}
+
+// TODO(kiosion): DELETE in 21.0.0
+func (m *mockClient) GetProxies() ([]types.Server, error) {
+	return nil, trace.NotImplemented("GetProxies not implemented in test")
+}
+
+func (m *mockClient) ListProxyServers(context.Context, int, string) ([]types.Server, string, error) {
+	return nil, "", trace.NotImplemented("ListProxyServers not implemented in test")
+}
+
+// TODO(kiosion): DELETE in 21.0.0
+func (m *mockClient) GetAuthServers() ([]types.Server, error) {
+	return nil, trace.NotImplemented("GetAuthServers not implemented in test")
+}
+
+func (m *mockClient) ListAuthServers(context.Context, int, string) ([]types.Server, string, error) {
+	return nil, "", trace.NotImplemented("ListAuthServers not implemented in test")
 }

--- a/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/AppAWSRoleMenu.story.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/AppAWSRoleMenu.story.tsx
@@ -1,0 +1,213 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
+import { action } from 'storybook/actions';
+import { useArgs } from 'storybook/preview-api';
+
+import { Flex } from 'design';
+import {
+  getResourceIDString,
+  ResourceConstraints,
+  ResourceIDString,
+} from 'shared/services/accessRequests';
+import { AwsRole } from 'shared/services/apps';
+
+import { AppAWSRoleMenu } from './AppAWSRoleMenu';
+
+const clusterName = 'test-cluster';
+const appName = 'aws-console';
+const resourceKey = getResourceIDString({
+  cluster: clusterName,
+  kind: 'app',
+  name: appName,
+});
+
+function makeRole(
+  name: string,
+  accountId: string,
+  opts?: { requiresRequest?: boolean }
+): AwsRole & { launchUrl: string } {
+  return {
+    name,
+    display: name,
+    arn: `arn:aws:iam::${accountId}:role/${name}`,
+    accountId,
+    requiresRequest: opts?.requiresRequest ?? false,
+    launchUrl: `https://console.aws.amazon.com/federation?arn=arn:aws:iam::${accountId}:role/${name}`,
+  };
+}
+
+const grantedRoles = [
+  makeRole('Admin', '123456789012'),
+  makeRole('Developer', '123456789012'),
+  makeRole('ReadOnly', '123456789012'),
+];
+
+const requestableRoles = [
+  makeRole('StagingAdmin', '123456789012', { requiresRequest: true }),
+  makeRole('ProdAdmin', '123456789012', { requiresRequest: true }),
+  makeRole('SecurityAudit', '123456789012', { requiresRequest: true }),
+];
+
+export default {
+  title: 'Shared/AccessRequests/AppAWSRoleMenu',
+  component: AppAWSRoleMenu,
+  args: {
+    clusterName,
+    appName,
+    isAppInCart: false,
+    addedResourceConstraints: {},
+    requestStarted: false,
+    isNewRequestFlow: false,
+    width: '123px',
+    addOrRemoveApp: action('addOrRemoveApp'),
+    setResourceConstraints: action('setResourceConstraints'),
+  },
+  render: (args => {
+    const [{ isAppInCart, addedResourceConstraints }, updateArgs] =
+      useArgs<Meta<typeof AppAWSRoleMenu>['args']>();
+
+    const handleSetConstraints = (
+      key: ResourceIDString,
+      rc?: ResourceConstraints
+    ) => {
+      action('setResourceConstraints')(key, rc);
+      const next = { ...addedResourceConstraints };
+      if (rc) {
+        next[key] = rc;
+      } else {
+        delete next[key];
+      }
+      updateArgs({ addedResourceConstraints: next });
+    };
+
+    const handleAddOrRemoveApp = () => {
+      action('addOrRemoveApp')();
+      updateArgs({ isAppInCart: !isAppInCart });
+    };
+
+    return (
+      <Flex alignItems="center" minHeight="100px">
+        <AppAWSRoleMenu
+          {...args}
+          isAppInCart={isAppInCart}
+          addedResourceConstraints={addedResourceConstraints}
+          setResourceConstraints={handleSetConstraints}
+          addOrRemoveApp={handleAddOrRemoveApp}
+        />
+      </Flex>
+    );
+  }) satisfies StoryFn<typeof AppAWSRoleMenu>,
+} satisfies Meta<typeof AppAWSRoleMenu>;
+
+type Story = StoryObj<typeof AppAWSRoleMenu>;
+
+/**
+ * Both granted and requestable roles are available.
+ * The dropdown shows a "Connect:" section with direct launch links
+ * and a "Request Access:" section with checkboxes.
+ */
+export const GrantedAndRequestable: Story = {
+  args: {
+    awsRoles: [...grantedRoles, ...requestableRoles],
+  },
+};
+
+/**
+ * Only granted roles (no requestable). The dropdown shows
+ * launch links for each role.
+ */
+export const OnlyGrantedRoles: Story = {
+  args: {
+    awsRoles: grantedRoles,
+  },
+};
+
+/**
+ * Only requestable roles (no granted). The button shows "Request Access"
+ * and the dropdown shows only checkboxes.
+ */
+export const OnlyRequestableRoles: Story = {
+  args: {
+    awsRoles: requestableRoles,
+  },
+};
+
+/**
+ * A single granted role and no requestable roles.
+ * Renders as a simple "Connect" link button (no dropdown).
+ */
+export const SingleGrantedRole: Story = {
+  args: {
+    awsRoles: [grantedRoles[0]],
+  },
+};
+
+/**
+ * No roles at all. Shows a disabled "Connect" button
+ * with a "No available logins" tooltip.
+ */
+export const NoAvailableRoles: Story = {
+  args: {
+    awsRoles: [],
+  },
+};
+
+/**
+ * A request has been started (other resources already in the cart).
+ * The "Connect:" section is hidden, showing only requestable checkboxes.
+ * The button text says "Add to request".
+ */
+export const RequestStarted: Story = {
+  args: {
+    awsRoles: [...grantedRoles, ...requestableRoles],
+    requestStarted: true,
+  },
+};
+
+/**
+ * The app is already in the access request cart with some roles selected.
+ * The button appears in its "filled/primary" style.
+ */
+export const AppInCart: Story = {
+  args: {
+    awsRoles: [...grantedRoles, ...requestableRoles],
+    requestStarted: true,
+    isAppInCart: true,
+    addedResourceConstraints: {
+      [resourceKey]: {
+        aws_console: {
+          role_arns: [requestableRoles[0].arn],
+        },
+      },
+    },
+  },
+};
+
+/**
+ * New request flow: all roles are treated as requestable
+ * regardless of their `requiresRequest` flag.
+ * The button text says "Add to request".
+ */
+export const NewRequestFlow: Story = {
+  args: {
+    awsRoles: grantedRoles,
+    isNewRequestFlow: true,
+  },
+};

--- a/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/AppAWSRoleMenu.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/AppAWSRoleMenu.tsx
@@ -1,0 +1,372 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { Box, ButtonBorder, Menu, Text } from 'design';
+import { CheckboxInput } from 'design/Checkbox';
+import { ChevronDown } from 'design/Icon';
+import { MenuItem } from 'design/Menu';
+import { HoverTooltip } from 'design/Tooltip';
+import {
+  getResourceIDString,
+  ResourceConstraints,
+  ResourceConstraintsMap,
+  ResourceIDString,
+} from 'shared/services/accessRequests';
+import { AwsRole } from 'shared/services/apps';
+import { ComponentFeatureID } from 'shared/utils/componentFeatures';
+
+export type AWSLoginChoice = {
+  /** The ARN of the AWS role */
+  id: string;
+  /** Display label for the role */
+  label: string;
+  /** Whether an access request is needed to assume this role */
+  requiresRequest: boolean;
+  /** URL to launch the AWS console with this role */
+  launchUrl?: string;
+};
+
+/**
+ * Minimal interface for an app that can be checked for AWS Console support
+ */
+export interface AppWithAWSSupport {
+  kind: string;
+  awsConsole?: boolean;
+  awsRoles?: AwsRole[];
+  supportedFeatureIds?: number[];
+}
+
+/**
+ * Checks if an app supports resource constraints
+ */
+export function supportsResourceConstraints(app: AppWithAWSSupport): boolean {
+  return (
+    app.supportedFeatureIds?.includes?.(
+      ComponentFeatureID.ResourceConstraintsV1
+    ) || false
+  );
+}
+
+/**
+ * Checks if an app is an AWS Console app
+ */
+export function isAwsConsoleApp(app: AppWithAWSSupport): boolean {
+  return !!app.awsConsole;
+}
+
+/**
+ * Checks if an app is an AWS Console app that supports resource constraints
+ */
+export function isAwsConsoleAppWithConstraintSupport(
+  app: AppWithAWSSupport
+): boolean {
+  if (app.kind !== 'app') {
+    return false;
+  }
+  if (!isAwsConsoleApp(app)) {
+    return false;
+  }
+  return supportsResourceConstraints(app);
+}
+
+export type AppAWSRoleMenuProps = {
+  /** AWS roles available on the application */
+  awsRoles: AwsRole[];
+  /** Whether the app is currently in the access request cart */
+  isAppInCart: boolean;
+  /** Resource constraints that have been added to the access request cart */
+  addedResourceConstraints: ResourceConstraintsMap;
+  /** Name of the cluster where the app is located */
+  clusterName: string;
+  /** Kind of the resource (should be 'app') */
+  kind: string;
+  /** Name of the app */
+  appName: string;
+  /** Width of the button (default: '123px') */
+  width?: string;
+  /** Whether an access request has already been started. */
+  requestStarted?: boolean;
+  /**
+   * Whether we're in the "new request" flow where all roles should be treated
+   * as requestable (no granted roles)
+   */
+  isNewRequestFlow?: boolean;
+  /** Callback to add or remove the app from the access request cart */
+  addOrRemoveApp: (action?: 'add' | 'remove') => void;
+  /** Callback to update resource constraints for the app */
+  setResourceConstraints: (
+    key: ResourceIDString,
+    rc?: ResourceConstraints
+  ) => void;
+  /**
+   * Callback to compute the launch URL for a role
+   */
+  getLaunchUrl?: (role: AwsRole) => string;
+};
+
+/**
+ * Converts an AwsRole to an AWSLoginChoice for display purposes
+ */
+export function awsRoleToLoginChoice(
+  role: AwsRole,
+  getLaunchUrl?: (role: AwsRole) => string
+): AWSLoginChoice {
+  return {
+    id: role.arn,
+    label: `${role.accountId}: ${role.display}${role.display !== role.name ? ` (${role.name})` : ''}`,
+    requiresRequest: role.requiresRequest ?? false,
+    launchUrl: getLaunchUrl?.(role),
+  };
+}
+
+/**
+ * AppAWSRoleMenu allows selecting/requesting AWS IAM Roles for an AWS Console app.
+ *
+ * This component renders a dropdown that:
+ * - Shows granted roles that can be used to connect directly (if getLaunchUrl is provided)
+ * - Shows requestable roles that can be added to an access request
+ * - Manages the selected role ARNs as resource constraints
+ */
+export const AppAWSRoleMenu = ({
+  awsRoles,
+  isAppInCart,
+  addedResourceConstraints,
+  clusterName,
+  kind,
+  appName,
+  addOrRemoveApp,
+  setResourceConstraints,
+  getLaunchUrl,
+  requestStarted = false,
+  isNewRequestFlow = false,
+  width = '123px',
+}: AppAWSRoleMenuProps) => {
+  const anchorEl = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const { granted, requestable } = (awsRoles || [])
+    .map(role => awsRoleToLoginChoice(role, getLaunchUrl))
+    .reduce(
+      (acc, role) => {
+        // If in new request flow, all present roles are requestable
+        // and will not have 'requiresRequest' property.
+        const target =
+          role.requiresRequest || isNewRequestFlow
+            ? acc.requestable
+            : acc.granted;
+        target.push(role);
+        return acc;
+      },
+      { granted: [] as AWSLoginChoice[], requestable: [] as AWSLoginChoice[] }
+    );
+
+  const requestStartedOrNoGranted = requestStarted || !granted.length;
+
+  // Resource ID string for constraints map key
+  const key = getResourceIDString({
+    cluster: clusterName,
+    kind: kind,
+    name: appName,
+  });
+  const selectedARNs =
+    addedResourceConstraints[key]?.aws_console?.role_arns ?? [];
+
+  const isChecked = (choice: AWSLoginChoice) =>
+    selectedARNs.includes(choice.id);
+
+  const toggleRequestable = (choice: AWSLoginChoice) => {
+    const next = isChecked(choice)
+      ? selectedARNs.filter(arn => arn !== choice.id)
+      : [...selectedARNs, choice.id];
+    const rc = (
+      next.length
+        ? {
+            aws_console: { role_arns: next },
+          }
+        : undefined
+    ) satisfies ResourceConstraints | undefined;
+
+    // Add/remove agent from cart if needed
+    if (isAppInCart !== !!next.length) {
+      addOrRemoveApp();
+    }
+    setResourceConstraints(key, rc);
+  };
+
+  // If <= one granted login is available and none requestable, show normal button.
+  if (granted.length <= 1 && !requestable.length) {
+    // If getLaunchUrl is provided and we have a granted role, show Connect button
+    if (getLaunchUrl && granted.length === 1) {
+      return (
+        <ButtonBorder
+          as="a"
+          textTransform="none"
+          width={width}
+          size="small"
+          href={granted[0]?.launchUrl}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Connect
+        </ButtonBorder>
+      );
+    }
+    // No available logins
+    return (
+      <HoverTooltip tipContent="No available logins">
+        <ButtonBorder
+          textTransform="none"
+          width={width}
+          size="small"
+          disabled={true}
+        >
+          Connect
+        </ButtonBorder>
+      </HoverTooltip>
+    );
+  }
+
+  return (
+    <>
+      <ButtonBorder
+        textTransform="none"
+        width={width}
+        size="small"
+        ref={el => (anchorEl.current = el!)}
+        onClick={() => {
+          setOpen(true);
+        }}
+      >
+        {isNewRequestFlow
+          ? 'Add to request'
+          : requestStartedOrNoGranted
+            ? 'Request Access'
+            : 'Connect'}
+        <ChevronDown ml={1} mr={-2} size="small" color="text.slightlyMuted" />
+      </ButtonBorder>
+
+      <Menu
+        popoverCss={() => ({
+          marginTop: '4px',
+        })}
+        menuListCss={p => ({
+          minWidth: '220px',
+          maxHeight: '280px',
+          overflowY: 'auto',
+          overflowX: 'clip',
+          scrollbarWidth: 'thin',
+          scrollbarGutter: 'stable',
+          scrollbarColor: `${p.theme.colors.spotBackground[2]} transparent`,
+        })}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        getContentAnchorEl={null}
+        anchorEl={anchorEl.current}
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        {/* Hide 'connect' section when in request mode */}
+        {!requestStartedOrNoGranted && getLaunchUrl && (
+          <>
+            {!!requestable.length && <SectionHeader>Connect:</SectionHeader>}
+            <Box>
+              {granted.map(item => (
+                <StyledMenuItem
+                  as="a"
+                  key={`g:${item.id}`}
+                  px={2}
+                  mx={2}
+                  href={item.launchUrl}
+                  target="_blank"
+                  title={item.label}
+                  onClick={() => setOpen(false)}
+                >
+                  <Text>{item.label}</Text>
+                </StyledMenuItem>
+              ))}
+            </Box>
+          </>
+        )}
+        {!!requestable.length && (
+          <>
+            {!requestStartedOrNoGranted && getLaunchUrl && (
+              <SectionHeader>Request Access:</SectionHeader>
+            )}
+            <Box>
+              {requestable.map(item => (
+                <StyledMenuItem
+                  as="div"
+                  key={`r:${item.id}`}
+                  title={item.label}
+                  onClick={() => toggleRequestable(item)}
+                >
+                  <CheckboxInput
+                    type="checkbox"
+                    checked={isChecked(item)}
+                    onChange={() => toggleRequestable(item)}
+                  />
+                  <Text>{item.label}</Text>
+                </StyledMenuItem>
+              ))}
+            </Box>
+          </>
+        )}
+      </Menu>
+    </>
+  );
+};
+
+const SectionHeader = styled(Text)`
+  ${({ theme }) => theme.typography.body3};
+  font-weight: 500;
+  color: ${({ theme }) => theme.colors.text.muted};
+  padding: 0 ${({ theme }) => theme.space[3]}px;
+  pointer-events: none;
+
+  &:first-child {
+    margin-top: ${({ theme }) => theme.space[2]}px;
+  }
+`;
+
+const StyledMenuItem = styled(MenuItem)`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: ${({ theme }) => theme.space[2]}px;
+  min-height: 32px;
+  margin: 0;
+  padding: ${({ theme }) => theme.space[2]}px ${({ theme }) => theme.space[3]}px;
+  user-select: none;
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.spotBackground[0]};
+    color: ${({ theme }) => theme.colors.text.main};
+  }
+
+  &:first-child {
+    margin-top: ${({ theme }) => theme.space[1]}px;
+  }
+
+  &:last-child {
+    margin-bottom: ${({ theme }) => theme.space[1]}px;
+  }
+`;

--- a/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/index.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/index.ts
@@ -19,10 +19,5 @@
 export {
   AppAWSRoleMenu,
   awsRoleToLoginChoice,
-  isAwsConsoleApp,
-  isAwsConsoleAppWithConstraintSupport,
-  supportsResourceConstraints,
-  type AppAWSRoleMenuProps,
-  type AppWithAWSSupport,
-  type AWSLoginChoice,
+  type AwsLoginChoice,
 } from './AppAWSRoleMenu';

--- a/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/index.ts
+++ b/web/packages/shared/components/AccessRequests/NewRequest/AppAWSRoleMenu/index.ts
@@ -1,6 +1,6 @@
 /**
  * Teleport
- * Copyright (C) 2024 Gravitational, Inc.
+ * Copyright (C) 2026 Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,9 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export * from './RequestCheckout';
-export * from './Roles';
-export * from './AppAWSRoleMenu';
-export type { ResourceMap, RequestableResourceKind } from './resource';
-export { getEmptyResourceState } from './resource';
-export { isKubeClusterWithNamespaces } from './kube';
+export {
+  AppAWSRoleMenu,
+  awsRoleToLoginChoice,
+  isAwsConsoleApp,
+  isAwsConsoleAppWithConstraintSupport,
+  supportsResourceConstraints,
+  type AppAWSRoleMenuProps,
+  type AppWithAWSSupport,
+  type AWSLoginChoice,
+} from './AppAWSRoleMenu';

--- a/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
+++ b/web/packages/shared/components/AccessRequests/NewRequest/RequestCheckout/RequestCheckout.tsx
@@ -197,13 +197,11 @@ const AWSConsoleConstraintsList = <T extends PendingListItem>({
   createAttempt,
   clearAttempt,
   setResourceConstraints,
-  addedResourceConstraints,
 }: {
   item: WithResourceConstraints<'aws_console', DisplayRow<T>>;
   createAttempt: RequestCheckoutProps<T>['createAttempt'];
   clearAttempt: RequestCheckoutProps<T>['clearAttempt'];
   setResourceConstraints: RequestCheckoutProps<T>['setResourceConstraints'];
-  addedResourceConstraints: RequestCheckoutProps<T>['addedResourceConstraints'];
 }) => (
   <Flex flexDirection="column" gap={1} mt={1} width="100%">
     <Text bold>Role ARNs</Text>
@@ -222,17 +220,6 @@ const AWSConsoleConstraintsList = <T extends PendingListItem>({
             title="Remove Role ARN"
             onClick={() => {
               clearAttempt();
-              const ridStr = getResourceIDString({
-                cluster: item.clusterName,
-                kind: item.kind,
-                name: item.id,
-              });
-              console.log('toggling role arn', {
-                ridStr,
-                curConstraints: item.constraints,
-                addedResourceConstraints,
-                setResourceConstraints,
-              });
               toggleAWSConsoleConstraint(item, arn, setResourceConstraints);
             }}
             disabled={createAttempt.status === 'processing'}
@@ -442,7 +429,6 @@ export function RequestCheckout<T extends PendingListItem>({
                 setResourceConstraints={setResourceConstraints}
                 clearAttempt={clearAttempt}
                 createAttempt={createAttempt}
-                addedResourceConstraints={addedResourceConstraints}
               />
             </Flex>
           </td>

--- a/web/packages/shared/components/UnifiedResources/types.ts
+++ b/web/packages/shared/components/UnifiedResources/types.ts
@@ -24,6 +24,7 @@ import { LabelButtonWithIcon } from 'design/Label/LabelButtonWithIcon';
 import { ResourceIconName } from 'design/ResourceIcon';
 import { TargetHealth } from 'gen-proto-ts/teleport/lib/teleterm/v1/target_health_pb';
 import { AppSubKind, NodeSubKind } from 'shared/services';
+import { AwsRole } from 'shared/services/apps';
 import { DbProtocol } from 'shared/services/databases';
 import type { ComponentFeatureID } from 'shared/utils/componentFeatures';
 
@@ -91,6 +92,7 @@ export type UnifiedResourceApp = {
   permissionSets?: PermissionSet[];
   mcp?: AppMCP;
   supportedFeatureIds?: ComponentFeatureID[];
+  awsRoles?: AwsRole[];
 };
 
 export interface UnifiedResourceDatabase {

--- a/web/packages/teleterm/src/helpers.ts
+++ b/web/packages/teleterm/src/helpers.ts
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {
+  AWSConsoleResourceConstraints,
+  ResourceConstraints,
+} from 'gen-proto-ts/teleport/legacy/types/resources_pb';
 import { App } from 'gen-proto-ts/teleport/lib/teleterm/v1/app_pb';
 import { Database } from 'gen-proto-ts/teleport/lib/teleterm/v1/database_pb';
 import { Kube } from 'gen-proto-ts/teleport/lib/teleterm/v1/kube_pb';
@@ -216,4 +220,13 @@ export function statusOneOfIsWindowsServiceStatus(
   windowsServiceStatus: WindowsServiceStatus;
 } {
   return status.oneofKind === 'windowsServiceStatus';
+}
+
+export function constraintsOneOfIsAwsConsole(
+  details: ResourceConstraints['details']
+): details is {
+  oneofKind: 'awsConsole';
+  awsConsole: AWSConsoleResourceConstraints;
+} {
+  return details.oneofKind === 'awsConsole';
 }

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/AccessRequestCheckout.tsx
@@ -104,6 +104,8 @@ export function AccessRequestCheckout() {
     updateNamespacesForKubeCluster,
     reasonMode,
     reasonPrompts,
+    resourceConstraints,
+    setResourceConstraints,
   } = useAccessRequestCheckout();
 
   const isRoleRequest = pendingAccessRequests[0]?.kind === 'role';
@@ -286,9 +288,8 @@ export function AccessRequestCheckout() {
             updateNamespacesForKubeCluster={updateNamespacesForKubeCluster}
             requireReason={reasonMode === 'required'}
             reasonPrompts={reasonPrompts}
-            // TODO(kiosion): Support Resource Constraints in Connect's RequestCheckout
-            addedResourceConstraints={{}}
-            setResourceConstraints={() => null}
+            addedResourceConstraints={resourceConstraints}
+            setResourceConstraints={setResourceConstraints}
           />
         )}
       </Transition>

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -252,6 +252,7 @@ test('after creating an access request, pending requests and specifiable fields 
 
   expect(mockedCreateAccessRequestFn).toHaveBeenCalledWith({
     rootClusterUri,
+    resourceAccessIds: [],
     resourceIds: [
       {
         clusterName: 'teleport-local',
@@ -294,6 +295,7 @@ test('after creating an access request, pending requests and specifiable fields 
   );
   expect(mockedCreateAccessRequestFn).toHaveBeenCalledWith({
     rootClusterUri,
+    resourceAccessIds: [],
     resourceIds: [
       {
         clusterName: 'teleport-local',

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -303,7 +303,7 @@ export default function useAccessRequestCheckout() {
         name: d.id,
         clusterName: d.clusterName,
         kind: d.kind,
-        subResourceName: d.subResourceName,
+        subResourceName: d.subResourceName || '',
       };
       const key = getResourceIDString({
         cluster: d.clusterName,

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -16,9 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
+import { ResourceConstraints as ProtoResourceConstraints } from 'gen-proto-ts/teleport/legacy/types/resources_pb';
 import {
   getDryRunMaxDuration,
   isKubeClusterWithNamespaces,
@@ -29,6 +30,11 @@ import {
 import { useSpecifiableFields } from 'shared/components/AccessRequests/NewRequest/useSpecifiableFields';
 import { CreateRequest } from 'shared/components/AccessRequests/Shared/types';
 import useAttempt from 'shared/hooks/useAttemptNext';
+import {
+  getResourceIDString,
+  ResourceConstraints,
+  ResourceIDString,
+} from 'shared/services/accessRequests';
 
 import {
   CreateAccessRequestRequest,
@@ -106,6 +112,13 @@ export default function useAccessRequestCheckout() {
     pendingAccessRequests.filter(
       p => !isKubeClusterWithNamespaces(p, pendingAccessRequests)
     );
+
+  const resourceConstraints = workspaceAccessRequest?.getResourceConstraints();
+  const setResourceConstraints = useCallback(
+    (key: ResourceIDString, rc?: ResourceConstraints) =>
+      workspaceAccessRequest?.setResourceConstraints(key, rc),
+    [workspaceAccessRequest]
+  );
 
   useEffect(() => {
     // Do a new dry run per changes to pending access requests
@@ -276,37 +289,60 @@ export default function useAccessRequestCheckout() {
    * Shared logic used both during dry runs and regular access request creation.
    */
   function prepareAndCreateRequest(req: CreateRequest) {
+    const resourceItems = pendingAccessRequestsWithoutParentResource.filter(
+      d => d.kind !== 'role'
+    );
+    const roleItems = pendingAccessRequestsWithoutParentResource
+      .filter(d => d.kind === 'role')
+      .map(d => d.name);
+
+    // Build resourceAccessIds with constraints when any constraints are present.
+    const hasConstraints = Object.keys(resourceConstraints).length > 0;
+    const resourceAccessIds = resourceItems.map(d => {
+      const resourceId = {
+        name: d.id,
+        clusterName: d.clusterName,
+        kind: d.kind,
+        subResourceName: d.subResourceName,
+      };
+      const key = getResourceIDString({
+        cluster: d.clusterName,
+        kind: d.kind,
+        name: d.id,
+      });
+      const sharedConstraints = resourceConstraints[key];
+      return {
+        id: resourceId,
+        constraints: sharedConstraints
+          ? convertToProtoConstraints(sharedConstraints)
+          : undefined,
+      };
+    });
+
     const params: CreateAccessRequestRequest = {
       rootClusterUri,
       reason: req.reason,
       suggestedReviewers: req.suggestedReviewers || [],
       dryRun: req.dryRun,
-      resourceIds: pendingAccessRequestsWithoutParentResource
-        .filter(d => d.kind !== 'role')
-        .map(d => {
-          return {
-            name: d.id,
-            clusterName: d.clusterName,
-            kind: d.kind,
-            subResourceName: d.subResourceName || '',
-          };
-        }),
-      roles: pendingAccessRequestsWithoutParentResource
-        .filter(d => d.kind === 'role')
-        .map(d => d.name),
+      // For backwards-compat, if no constraints are present, use the prior 'resourceIds' field.
+      resourceIds: hasConstraints ? [] : resourceAccessIds.map(d => d.id),
+      resourceAccessIds: hasConstraints ? resourceAccessIds : [],
+      roles: roleItems,
       assumeStartTime: req.start && Timestamp.fromDate(req.start),
       maxDuration: req.maxDuration && Timestamp.fromDate(req.maxDuration),
       requestTtl: req.requestTTL && Timestamp.fromDate(req.requestTTL),
-      resourceAccessIds: undefined,
     };
 
     // Don't attempt creating anything if there are no resources selected.
-    if (!params.resourceIds.length && !params.roles.length) {
+    const resourceCount = hasConstraints
+      ? params.resourceAccessIds.length
+      : params.resourceIds.length;
+    if (!resourceCount && !params.roles.length) {
       return;
     }
 
     // if we have a resource access request, we pass along the selected roles from the checkout
-    if (params.resourceIds.length > 0) {
+    if (resourceCount > 0) {
       params.roles = selectedResourceRequestRoles;
     }
 
@@ -455,6 +491,8 @@ export default function useAccessRequestCheckout() {
     updateNamespacesForKubeCluster,
     reasonMode,
     reasonPrompts,
+    resourceConstraints,
+    setResourceConstraints,
   };
 }
 
@@ -490,3 +528,26 @@ export type PendingListKubeClusterWithOriginalItem = Omit<
   kind: Extract<ResourceKind, 'kube_cluster'>;
   originalItem: Extract<ResourceRequest, { kind: 'kube' }>;
 };
+
+/**
+ * Converts the shared ResourceConstraints type to the proto-ts ResourceConstraints type.
+ */
+function convertToProtoConstraints(
+  constraints: ResourceConstraints
+): ProtoResourceConstraints {
+  if (constraints.aws_console) {
+    return {
+      version: constraints.version || 'v1',
+      details: {
+        oneofKind: 'awsConsole',
+        awsConsole: {
+          roleArns: constraints.aws_console.role_arns,
+        },
+      },
+    };
+  }
+  return {
+    version: constraints.version || 'v1',
+    details: { oneofKind: undefined },
+  };
+}

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -33,6 +33,7 @@ import {
   ResourceConstraints,
 } from 'shared/services/accessRequests';
 
+import { constraintsOneOfIsAwsConsole } from 'teleterm/helpers';
 import { useAccessRequestsContext } from 'teleterm/ui/AccessRequests/AccessRequestsContext';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
@@ -123,12 +124,11 @@ function convertProtoConstraints(
     return undefined;
   }
 
-  const { details } = proto;
-  if ('awsConsole' in details) {
+  if (constraintsOneOfIsAwsConsole(proto.details)) {
     return {
       version: (proto.version || 'v1') as ResourceConstraints['version'],
       aws_console: {
-        role_arns: details.awsConsole.roleArns,
+        role_arns: proto.details.awsConsole.roleArns,
       },
     };
   }

--- a/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
+++ b/web/packages/teleterm/src/ui/DocumentAccessRequests/useAccessRequests.tsx
@@ -19,13 +19,18 @@
 import { useEffect } from 'react';
 
 import { Timestamp } from 'gen-proto-ts/google/protobuf/timestamp_pb';
-import { AccessRequest as TshdAccessRequest } from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
+import type { ResourceConstraints as ProtoResourceConstraints } from 'gen-proto-ts/teleport/legacy/types/resources_pb';
+import {
+  Resource as ProtoResource,
+  AccessRequest as TshdAccessRequest,
+} from 'gen-proto-ts/teleport/lib/teleterm/v1/access_request_pb';
 import { LoggedInUser } from 'gen-proto-ts/teleport/lib/teleterm/v1/cluster_pb';
 import { RequestFlags } from 'shared/components/AccessRequests/ReviewRequests';
 import { mapAttempt } from 'shared/hooks/useAsync';
 import {
   AccessRequest,
   makeAccessRequest,
+  ResourceConstraints,
 } from 'shared/services/accessRequests';
 
 import { useAccessRequestsContext } from 'teleterm/ui/AccessRequests/AccessRequestsContext';
@@ -102,10 +107,47 @@ export function makeUiAccessRequest(request: TshdAccessRequest) {
     })),
     suggestedReviewers: request.suggestedReviewers,
     thresholdNames: request.thresholdNames,
-    resources: request.resources,
+    resources: request.resources.map(convertProtoResource),
     reasonMode: request.reasonMode || 'optional',
     reasonPrompts: request.reasonPrompts,
   });
+}
+
+/**
+ * Converts proto-ts ResourceConstraints to the shared ResourceConstraints type (flattened).
+ */
+function convertProtoConstraints(
+  proto: ProtoResourceConstraints | undefined
+): ResourceConstraints | undefined {
+  if (!proto) {
+    return undefined;
+  }
+
+  const { details } = proto;
+  if ('awsConsole' in details) {
+    return {
+      version: (proto.version || 'v1') as ResourceConstraints['version'],
+      aws_console: {
+        role_arns: details.awsConsole.roleArns,
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function convertProtoResource(
+  proto: ProtoResource
+): Omit<ProtoResource, 'constraints'> & { constraints?: ResourceConstraints } {
+  const constraints = convertProtoConstraints(proto.constraints);
+
+  if (!constraints) {
+    // eslint-disable-next-line unused-imports/no-unused-vars
+    const { constraints: _, ...rest } = proto;
+    return rest;
+  }
+
+  return { ...proto, constraints };
 }
 
 // transform tsdh Access Request type into the web's Access Request

--- a/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/accessRequestsService.test.ts
@@ -55,6 +55,7 @@ function getMockPendingResourceAccessRequest(): PendingAccessRequest {
       [database.uri, { kind: 'database', resource: database }],
       [samlApp.uri, { kind: 'app', resource: samlApp }],
     ]),
+    resourceConstraints: {},
   };
 }
 
@@ -247,6 +248,7 @@ test('resources from different clusters but with the same ID can be combined in 
   const { accessRequestsService: service } = getTestSetup({
     kind: 'resource',
     resources: new Map(),
+    resourceConstraints: {},
   });
 
   const server1 = makeServer({

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -87,6 +87,7 @@ describe('restoring workspace', () => {
           pending: {
             kind: 'resource',
             resources: new Map(),
+            resourceConstraints: {},
           },
           isBarCollapsed: false,
         },
@@ -125,6 +126,7 @@ describe('restoring workspace', () => {
           pending: {
             kind: 'resource',
             resources: new Map(),
+            resourceConstraints: {},
           },
         },
         color: 'purple',

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -27,6 +27,7 @@ import {
   UnifiedResourcePreferences,
   ViewMode,
 } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
+import { ResourceConstraintsMap } from 'shared/services/accessRequests';
 import { arrayObjectIsEqual } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
@@ -97,6 +98,7 @@ export interface Workspace {
   accessRequests: {
     isBarCollapsed: boolean;
     pending: PendingAccessRequest;
+    resourceConstraints: ResourceConstraintsMap;
   };
   connectMyComputer?: {
     autoStart: boolean;
@@ -752,6 +754,7 @@ function getWorkspaceDefaultState(
     accessRequests: {
       pending: getEmptyPendingAccessRequest(),
       isBarCollapsed: false,
+      resourceConstraints: {},
     },
     location: defaultDocument.uri,
     documents: [defaultDocument],

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -27,7 +27,6 @@ import {
   UnifiedResourcePreferences,
   ViewMode,
 } from 'gen-proto-ts/teleport/userpreferences/v1/unified_resource_preferences_pb';
-import { ResourceConstraintsMap } from 'shared/services/accessRequests';
 import { arrayObjectIsEqual } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
@@ -98,7 +97,6 @@ export interface Workspace {
   accessRequests: {
     isBarCollapsed: boolean;
     pending: PendingAccessRequest;
-    resourceConstraints: ResourceConstraintsMap;
   };
   connectMyComputer?: {
     autoStart: boolean;
@@ -754,7 +752,6 @@ function getWorkspaceDefaultState(
     accessRequests: {
       pending: getEmptyPendingAccessRequest(),
       isBarCollapsed: false,
-      resourceConstraints: {},
     },
     location: defaultDocument.uri,
     documents: [defaultDocument],


### PR DESCRIPTION
## Context
Port support for ResourceConstraints in Access Requests to Connect.

- Requires https://github.com/gravitational/teleport/pull/63492
- Required for https://github.com/gravitational/teleport.e/pull/7987

## Testing
Updated relevant Stories/unit tests, manually tested:
- Access Request creation
  - With only constrained resources
  - Mix of constrained/unconstrained resources
- Access Request review
- Access Request assumption
  - With only constrained resources
  - Mix of constrained/unconstrained resources
