### PR TITLE
Add identity security settings to web config API

### DIFF
--- a/api/client/webclient/webconfig.go
+++ b/api/client/webclient/webconfig.go
@@ -134,6 +134,20 @@ type WebConfig struct {
 	// MobileDeviceManagement indicates whether adding Jamf plugin is enabled
 	// Deprecated, use entitlements
 	MobileDeviceManagement bool `json:"mobileDeviceManagement"`
+	// IdentitySecurity contains identity security features and settings.
+	IdentitySecurity IdentitySecurity `json:"identitySecurity"`
+}
+
+// IdentitySecurity contains identity security features and settings.
+type IdentitySecurity struct {
+	// IsClusterLicensed indicates whether identity security features are licensed
+	// for this cluster.
+	IsClusterLicensed bool `json:"licensed"`
+	// AccessGraphConfigSet indicates whether access graph configuration is set in
+	// Auth and/or Proxy.
+	AccessGraphConfigSet bool `json:"accessGraphConfigSet"`
+	// SessionSummarizationEnabled indicates whether session summarization is enabled.
+	SessionSummarizationEnabled bool `json:"sessionSummarizationEnabled"`
 }
 
 // EntitlementInfo is the state and limits of a particular entitlement; Example for feature X:

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2014,6 +2014,11 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		sessionSummarizerEnabled = isEnabledRes.Enabled
 	}
 
+	rsp, err := h.cfg.ProxyClient.GetClusterAccessGraphConfig(r.Context())
+	if err != nil && !trace.IsNotImplemented(err) {
+		h.logger.ErrorContext(r.Context(), "Cannot retrieve Access Graph config from auth server", "error", err)
+	}
+
 	webCfg := webclient.WebConfig{
 		Edition:                        modules.GetModules().BuildType(),
 		Auth:                           authSettings,
@@ -2036,6 +2041,11 @@ func (h *Handler) getWebConfig(w http.ResponseWriter, r *http.Request, p httprou
 		SessionSummarizerEnabled:       sessionSummarizerEnabled,
 		// Entitlements are reset/overridden in setEntitlementsWithLegacyLogic until setEntitlementsWithLegacyLogic is removed in v18
 		Entitlements: GetWebCfgEntitlements(clusterFeatures.GetEntitlements()),
+		IdentitySecurity: webclient.IdentitySecurity{
+			IsClusterLicensed:           modules.GetProtoEntitlement(&clusterFeatures, entitlements.Policy).Enabled,
+			AccessGraphConfigSet:        rsp.GetEnabled() && rsp.GetAddress() != "",
+			SessionSummarizationEnabled: sessionSummarizerEnabled,
+		},
 	}
 
 	// Set entitlements with backwards field compatibility
@@ -2080,7 +2090,8 @@ func globMatch(pattern, str string) (bool, error) {
 // userMatchesConnector is a helper function to check if a user matches any of a connector's user matchers.
 func userMatchesConnector(username string, connector interface {
 	GetUserMatchers() []string
-}) (isMatch bool, isFallback bool, err error) {
+},
+) (isMatch bool, isFallback bool, err error) {
 	matchers := connector.GetUserMatchers()
 	for _, pattern := range matchers {
 		matched, err := globMatch(pattern, username)


### PR DESCRIPTION
Exposes identity security features to the web client including cluster license status, access graph configuration state, and session summarization enablement.