### PR TITLE
Supporting items for better Identity Security errors

### DIFF
--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -161,6 +161,12 @@ const cfg = {
 
   defaultDatabaseTTL: '2190h',
 
+  identitySecurity: {
+    accessGraphConfigSet: false,
+    licensed: false,
+    sessionSummarizationEnabled: false,
+  },
+
   routes: {
     root: '/web',
     discover: '/web/discover',

--- a/web/packages/teleport/src/services/storageService/storageService.ts
+++ b/web/packages/teleport/src/services/storageService/storageService.ts
@@ -266,6 +266,10 @@ export const storageService = {
     return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_ENABLED, false);
   },
 
+  resetAccessGraphEnabled() {
+    window.localStorage.removeItem(KeysEnum.ACCESS_GRAPH_ENABLED);
+  },
+
   getAccessGraphIacEnabled(): boolean {
     return this.getParsedJSONValue(KeysEnum.ACCESS_GRAPH_IAC_ENABLED, false);
   },

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -110,6 +110,8 @@ class TeleportContext implements types.Context {
     }
 
     if (user.acl.accessGraph.list) {
+      storageService.resetAccessGraphEnabled();
+
       // If access graph is enabled, check what features are enabled and store them in local storage.
       // We await this so it is done by the time the page renders, otherwise the local storage event
       // wouldn't trigger a re-render and Policy could end up not being displayed until the navigation


### PR DESCRIPTION
Requires https://github.com/gravitational/teleport/pull/63482

This adds some supporting items for providing better errors when Identity Security is in the license but either isn't configured, or is configured and unreachable.

To support this, the identity security status added to `config.js` in Tiago's PR has been added to the OSS config in this PR, as well as the enabled status being reset on each page load (so if it once was active, and no longer is, the error message will still show - as if it fails to load, the status in local storage would not be updated otherwise)