### PR TITLE
feat: Add tctl recording summary commands for session summary management

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2390,6 +2390,29 @@ Arguments:
 |---|---|---|
 |query|*no default* (optional)|Natural language description of the sessions to find (e.g. "SSH sessions exfiltrating data to external endpoints").|
 
+## tctl recordings summary
+
+View an AI-generated session summary.
+
+Usage:
+
+```code
+$ tctl recordings summary [<flags>] <session-id>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--format`|`text` (one of: `text`, `json`, `yaml`)|Defines the output format for the summary.|
+|`-o`, `--output`|*no default*|Optional file path to write the summary to instead of stdout.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|session-id|*no default* (required)|ID of the session to retrieve the summary for.|
+
 ## tctl requests approve
 
 Approve pending Access Request.

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -37,6 +37,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v3"
 
@@ -705,9 +706,9 @@ func createFileWriter(ctx context.Context, sessionID session.ID, outputDir strin
 func (c *RecordingsCommand) GetSummary(ctx context.Context, tc *authclient.Client) error {
 	summarizerClient := tc.SummarizerServiceClient()
 
-	resp, err := summarizerClient.GetSummary(ctx, &summarizerv1pb.GetSummaryRequest{
+	resp, err := summarizerClient.GetSummary(ctx, summarizerv1pb.GetSummaryRequest_builder{
 		SessionId: c.summarySessionID,
-	})
+	}.Build())
 	if trace.IsNotImplemented(err) {
 		// unlicensedISMessage is returned when the cluster does not have the
 		// Identity Security license, which is required to use Session Summaries.
@@ -763,6 +764,69 @@ func marshalSessionSummary(summary *summarizerv1pb.Summary) ([]byte, error) {
 	return rBytes, nil
 }
 
+type summaryEventAnalysis interface {
+	GetCategory() summarizerv1pb.CommandCategory
+	GetRiskLevel() summarizerv1pb.RiskLevel
+	GetRiskScore() int32
+	GetThreatCategory() summarizerv1pb.ThreatCategory
+	GetShortDescription() string
+	GetDetailedDescription() string
+	GetSuspiciousPatterns() []string
+	GetIocs() []string
+	GetMitreAttackIds() []string
+	GetHasSensitiveData() bool
+	GetPrivilegeEscalation() bool
+	GetDataExfiltration() bool
+	GetPersistence() bool
+	GetStartOffset() *durationpb.Duration
+	GetEndOffset() *durationpb.Duration
+}
+
+type summaryCommand struct {
+	summaryEventAnalysis
+	command       string
+	success       bool
+	errorMessages []string
+}
+
+// summaryCommands normalizes command SessionEvents and commands from older
+// Auth Servers into the shape used by the text formatter.
+func summaryCommands(enhanced *summarizerv1pb.EnhancedSummary) []summaryCommand {
+	if enhanced == nil {
+		return nil
+	}
+
+	if events := enhanced.GetSessionEvents(); len(events) > 0 {
+		commands := make([]summaryCommand, 0, len(events))
+		for _, event := range events {
+			details := event.GetCommandEventDetails()
+			if details == nil {
+				continue
+			}
+			commands = append(commands, summaryCommand{
+				summaryEventAnalysis: event,
+				command:              details.GetCommand(),
+				success:              details.GetSuccess(),
+				errorMessages:        details.GetErrorMessages(),
+			})
+		}
+		return commands
+	}
+
+	//nolint:staticcheck // Read the deprecated field for compatibility with pre-v19 Auth Servers.
+	legacyCommands := enhanced.GetCommands()
+	commands := make([]summaryCommand, 0, len(legacyCommands))
+	for _, command := range legacyCommands {
+		commands = append(commands, summaryCommand{
+			summaryEventAnalysis: command,
+			command:              command.GetCommand(),
+			success:              command.GetSuccess(),
+			errorMessages:        command.GetErrorMessages(),
+		})
+	}
+	return commands
+}
+
 // formatSummaryText formats the summary in human-readable text format.
 func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
 	// Build the output in a buffer first
@@ -807,11 +871,11 @@ func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
 	}
 
 	// Display commands with their details
-	if enhanced := summary.GetEnhancedSummary(); enhanced != nil && len(enhanced.GetCommands()) > 0 {
-		fmt.Fprintf(&buf, "\n%s\n", bold(fmt.Sprintf("Commands Executed (%d total)", len(enhanced.GetCommands()))))
+	if commands := summaryCommands(summary.GetEnhancedSummary()); len(commands) > 0 {
+		fmt.Fprintf(&buf, "\n%s\n", bold(fmt.Sprintf("Commands Executed (%d total)", len(commands))))
 
-		for i, cmd := range enhanced.GetCommands() {
-			fmt.Fprintf(&buf, "[%d] %s\n", i+1, cmd.GetCommand())
+		for i, cmd := range commands {
+			fmt.Fprintf(&buf, "[%d] %s\n", i+1, cmd.command)
 
 			// Risk and category information
 			fmt.Fprintf(&buf, "    %s %s", bold("Risk Level:"), cmd.GetRiskLevel())
@@ -840,7 +904,7 @@ func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
 			}
 
 			// Status
-			if cmd.GetSuccess() {
+			if cmd.success {
 				fmt.Fprintf(&buf, "    %s Success\n", bold("Status:"))
 			} else {
 				fmt.Fprintf(&buf, "    %s Failed\n", bold("Status:"))
@@ -869,8 +933,9 @@ func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
 				fmt.Fprintf(&buf, "    %s %s\n", bold("Threat Category:"), cmd.GetThreatCategory())
 			}
 
-			// MITRE ATT&CK
+			// Threat framework mappings
 			if len(cmd.GetMitreAttackIds()) > 0 {
+				//nolint:misspell // MITRE ATT&CK is the official name.
 				fmt.Fprintf(&buf, "    %s %s\n", bold("MITRE ATT&CK:"), strings.Join(cmd.GetMitreAttackIds(), ", "))
 			}
 
@@ -883,9 +948,9 @@ func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
 			}
 
 			// Error messages
-			if len(cmd.GetErrorMessages()) > 0 {
+			if len(cmd.errorMessages) > 0 {
 				fmt.Fprintf(&buf, "\n    %s\n", bold("Errors:"))
-				for _, errMsg := range cmd.GetErrorMessages() {
+				for _, errMsg := range cmd.errorMessages {
 					fmt.Fprintf(&buf, "      - %s\n", errMsg)
 				}
 			}

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -19,7 +19,9 @@
 package common
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -33,8 +35,10 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
@@ -87,7 +91,6 @@ type RecordingsCommand struct {
 	recordingsDownloadSessionID string
 	// recordingsDownloadOutputDir is the output directory to download session recordings to
 	recordingsDownloadOutputDir string
-
 	// recordingsSearch implements the "tctl recordings search" subcommand.
 	recordingsSearch *kingpin.CmdClause
 	// searchQuery is the free-text semantic/keyword query.
@@ -133,6 +136,15 @@ type RecordingsCommand struct {
 	// searchReviewReasons filters results to sessions that have at least one of
 	// the specified review reasons. An empty slice disables this filter.
 	searchReviewReasons []string
+
+	// summary implements the "tctl recordings summary" subcommand.
+	summary *kingpin.CmdClause
+	// summarySessionID is the session ID to retrieve a summary for.
+	summarySessionID string
+	// summaryFormat is the summary output format.
+	summaryFormat string
+	// summaryOutputFile is the optional path to write the summary to.
+	summaryOutputFile string
 
 	// stdout allows to switch standard output source for resource command. Used in tests.
 	stdout io.Writer
@@ -189,6 +201,11 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.Glob
 	download.Flag("output-dir", "Directory to download session recordings to.").Short('o').Default(pwd).StringVar(&c.recordingsDownloadOutputDir)
 	c.recordingsDownload = download
 
+	c.summary = recordings.Command("summary", "View an AI-generated session summary.")
+	c.summary.Arg("session-id", "ID of the session to retrieve the summary for.").Required().StringVar(&c.summarySessionID)
+	c.summary.Flag("format", "Defines the output format for the summary.").Default(teleport.Text).EnumVar(&c.summaryFormat, defaults.DefaultFormats...)
+	c.summary.Flag("output", "Optional file path to write the summary to instead of stdout.").Short('o').StringVar(&c.summaryOutputFile)
+
 	if c.recordingsEncryption.stdout == nil {
 		c.recordingsEncryption.stdout = c.stdout
 	}
@@ -204,6 +221,8 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, clientFunc c
 		commandFunc = c.DownloadRecordings
 	case c.recordingsSearch.FullCommand():
 		commandFunc = c.SearchRecordings
+	case c.summary.FullCommand():
+		commandFunc = c.GetSummary
 	default:
 		return c.recordingsEncryption.TryRun(ctx, cmd, clientFunc)
 	}
@@ -680,4 +699,275 @@ func createFileWriter(ctx context.Context, sessionID session.ID, outputDir strin
 		},
 	)
 	return e, trace.Wrap(err, "creating session writer")
+}
+
+// GetSummary retrieves a session summary and writes it to stdout or a file.
+func (c *RecordingsCommand) GetSummary(ctx context.Context, tc *authclient.Client) error {
+	summarizerClient := tc.SummarizerServiceClient()
+
+	resp, err := summarizerClient.GetSummary(ctx, &summarizerv1pb.GetSummaryRequest{
+		SessionId: c.summarySessionID,
+	})
+	if trace.IsNotImplemented(err) {
+		// unlicensedISMessage is returned when the cluster does not have the
+		// Identity Security license, which is required to use Session Summaries.
+		const unlicensedISMessage = "this Teleport cluster is not licensed for Identity Security, " +
+			"which is required to use Session Summaries. Contact your Teleport " +
+			"account team to enable it."
+		return trace.NotImplemented("%s", unlicensedISMessage)
+	} else if err != nil {
+		return trace.Wrap(err, "failed to get session summary")
+	}
+
+	summary := resp.GetSummary()
+	if summary == nil {
+		return trace.NotFound("no summary found for session %s", c.summarySessionID)
+	}
+	return trace.Wrap(c.writeSummary(summary))
+}
+
+func (c *RecordingsCommand) writeSummary(summary *summarizerv1pb.Summary) error {
+	if c.summaryOutputFile == "" {
+		return trace.Wrap(c.formatSummary(c.stdout, summary))
+	}
+
+	var buf bytes.Buffer
+	if err := c.formatSummary(&buf, summary); err != nil {
+		return trace.Wrap(err, "failed to format summary")
+	}
+	if err := os.WriteFile(c.summaryOutputFile, buf.Bytes(), 0o600); err != nil {
+		return trace.Wrap(err, "failed to write summary to file")
+	}
+	return nil
+}
+
+// formatSummary formats and displays the summary based on the output format
+func (c *RecordingsCommand) formatSummary(w io.Writer, summary *summarizerv1pb.Summary) error {
+	switch c.summaryFormat {
+	case teleport.Text:
+		return formatSummaryText(w, summary)
+	case teleport.JSON:
+		return formatSummaryJSON(w, summary)
+	case teleport.YAML:
+		return formatSummaryYAML(w, summary)
+	default:
+		return trace.BadParameter("unsupported format %q", c.summaryFormat)
+	}
+}
+
+func marshalSessionSummary(summary *summarizerv1pb.Summary) ([]byte, error) {
+	rBytes, err := protojson.MarshalOptions{UseProtoNames: true, Multiline: true, Indent: "  "}.Marshal(summary)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to marshal summary to JSON")
+	}
+	return rBytes, nil
+}
+
+// formatSummaryText formats the summary in human-readable text format.
+func formatSummaryText(w io.Writer, summary *summarizerv1pb.Summary) error {
+	// Build the output in a buffer first
+	var buf bytes.Buffer
+	bold := func(s string) string { return utils.Color(utils.Bold, s) }
+
+	fmt.Fprintf(&buf, "%s %s\n", bold("Session ID:"), summary.GetSessionId())
+	fmt.Fprintf(&buf, "%s %s\n", bold("State:"), summary.GetState())
+	fmt.Fprintf(&buf, "%s %s\n", bold("Model:"), summary.GetModelName())
+
+	if summary.GetInferenceStartedAt() != nil {
+		fmt.Fprintf(&buf, "%s %s\n", bold("Started:"), summary.GetInferenceStartedAt().AsTime())
+	}
+	if summary.GetInferenceFinishedAt() != nil {
+		fmt.Fprintf(&buf, "%s %s\n", bold("Finished:"), summary.GetInferenceFinishedAt().AsTime())
+	}
+
+	// Enhanced summary information
+	if enhanced := summary.GetEnhancedSummary(); enhanced != nil {
+		fmt.Fprintf(&buf, "\n%s %s\n", bold("Risk Level:"), enhanced.GetRiskLevel())
+
+		if enhanced.GetCompromiseIndicators() {
+			fmt.Fprintf(&buf, "\n%s Compromise indicators detected!\n", bold("WARNING:"))
+		}
+
+		if len(enhanced.GetSuspiciousActivities()) > 0 {
+			fmt.Fprintf(&buf, "\n%s\n", bold("Suspicious Activities:"))
+			for _, activity := range enhanced.GetSuspiciousActivities() {
+				fmt.Fprintf(&buf, "  - %s\n", activity)
+			}
+		}
+	}
+
+	if summary.GetErrorMessage() != "" {
+		fmt.Fprintf(&buf, "\n%s %s\n", bold("Error:"), summary.GetErrorMessage())
+	}
+
+	if summary.GetContent() != "" {
+		// Convert markdown bold to terminal bold for better readability
+		content := convertMarkdownBoldToANSI(summary.GetContent())
+		fmt.Fprintf(&buf, "\n%s\n%s\n", bold("Summary:"), content)
+	}
+
+	// Display commands with their details
+	if enhanced := summary.GetEnhancedSummary(); enhanced != nil && len(enhanced.GetCommands()) > 0 {
+		fmt.Fprintf(&buf, "\n%s\n", bold(fmt.Sprintf("Commands Executed (%d total)", len(enhanced.GetCommands()))))
+
+		for i, cmd := range enhanced.GetCommands() {
+			fmt.Fprintf(&buf, "[%d] %s\n", i+1, cmd.GetCommand())
+
+			// Risk and category information
+			fmt.Fprintf(&buf, "    %s %s", bold("Risk Level:"), cmd.GetRiskLevel())
+			if cmd.GetRiskScore() > 0 {
+				fmt.Fprintf(&buf, " (Score: %d)", cmd.GetRiskScore())
+			}
+			fmt.Fprintf(&buf, "\n")
+
+			if cmd.GetCategory() != summarizerv1pb.CommandCategory_COMMAND_CATEGORY_UNSPECIFIED {
+				fmt.Fprintf(&buf, "    %s %s\n", bold("Category:"), cmd.GetCategory())
+			}
+
+			// Description
+			if desc := cmd.GetShortDescription(); desc != "" {
+				fmt.Fprintf(&buf, "    %s %s\n", bold("Description:"), desc)
+			}
+
+			// Timing information
+			if start := cmd.GetStartOffset(); start != nil {
+				fmt.Fprintf(&buf, "    %s %s", bold("Time:"), start.AsDuration())
+				if end := cmd.GetEndOffset(); end != nil {
+					duration := end.AsDuration() - start.AsDuration()
+					fmt.Fprintf(&buf, " (duration: %s)", duration)
+				}
+				fmt.Fprintf(&buf, "\n")
+			}
+
+			// Status
+			if cmd.GetSuccess() {
+				fmt.Fprintf(&buf, "    %s Success\n", bold("Status:"))
+			} else {
+				fmt.Fprintf(&buf, "    %s Failed\n", bold("Status:"))
+			}
+
+			// Security flags
+			var flags []string
+			if cmd.GetPrivilegeEscalation() {
+				flags = append(flags, "Privilege Escalation")
+			}
+			if cmd.GetDataExfiltration() {
+				flags = append(flags, "Data Exfiltration")
+			}
+			if cmd.GetPersistence() {
+				flags = append(flags, "Persistence")
+			}
+			if cmd.GetHasSensitiveData() {
+				flags = append(flags, "Sensitive Data")
+			}
+			if len(flags) > 0 {
+				fmt.Fprintf(&buf, "    %s %s\n", bold("Security Flags:"), strings.Join(flags, ", "))
+			}
+
+			// Threat information
+			if cmd.GetThreatCategory() != summarizerv1pb.ThreatCategory_THREAT_CATEGORY_UNSPECIFIED {
+				fmt.Fprintf(&buf, "    %s %s\n", bold("Threat Category:"), cmd.GetThreatCategory())
+			}
+
+			// MITRE ATT&CK
+			if len(cmd.GetMitreAttackIds()) > 0 {
+				fmt.Fprintf(&buf, "    %s %s\n", bold("MITRE ATT&CK:"), strings.Join(cmd.GetMitreAttackIds(), ", "))
+			}
+
+			// Detailed description if available
+			if detailed := cmd.GetDetailedDescription(); detailed != "" {
+				fmt.Fprintf(&buf, "\n    %s\n", bold("Details:"))
+				for _, line := range strings.Split(detailed, "\n") {
+					fmt.Fprintf(&buf, "      %s\n", line)
+				}
+			}
+
+			// Error messages
+			if len(cmd.GetErrorMessages()) > 0 {
+				fmt.Fprintf(&buf, "\n    %s\n", bold("Errors:"))
+				for _, errMsg := range cmd.GetErrorMessages() {
+					fmt.Fprintf(&buf, "      - %s\n", errMsg)
+				}
+			}
+
+			// Suspicious patterns and IOCs
+			if len(cmd.GetSuspiciousPatterns()) > 0 {
+				fmt.Fprintf(&buf, "\n    %s\n", bold("Suspicious Patterns:"))
+				for _, pattern := range cmd.GetSuspiciousPatterns() {
+					fmt.Fprintf(&buf, "      - %s\n", pattern)
+				}
+			}
+
+			if len(cmd.GetIocs()) > 0 {
+				fmt.Fprintf(&buf, "\n    %s\n", bold("IOCs:"))
+				for _, ioc := range cmd.GetIocs() {
+					fmt.Fprintf(&buf, "      - %s\n", ioc)
+				}
+			}
+
+			fmt.Fprintf(&buf, "\n")
+		}
+	}
+
+	_, err := w.Write(buf.Bytes())
+	return trace.Wrap(err)
+}
+
+// convertMarkdownBoldToANSI converts markdown bold (**text**) to ANSI bold escape codes
+func convertMarkdownBoldToANSI(text string) string {
+	// ANSI escape codes: \x1b[1m for bold, \x1b[0m to reset
+	result := text
+
+	// Replace **text** with ANSI bold
+	for {
+		start := strings.Index(result, "**")
+		if start == -1 {
+			break
+		}
+
+		// Find the closing **
+		end := strings.Index(result[start+2:], "**")
+		if end == -1 {
+			// No closing **, leave as is
+			break
+		}
+
+		// Calculate actual end position
+		end = start + 2 + end
+
+		// Extract the bold text
+		boldText := result[start+2 : end]
+
+		// Replace with ANSI codes
+		replacement := utils.Color(utils.Bold, boldText)
+		result = result[:start] + replacement + result[end+2:]
+	}
+
+	return result
+}
+
+// formatSummaryJSON formats the summary in JSON format.
+func formatSummaryJSON(w io.Writer, summary *summarizerv1pb.Summary) error {
+	rBytes, err := marshalSessionSummary(summary)
+	if err != nil {
+		return trace.Wrap(err, "failed to marshal summary")
+	}
+	_, err = w.Write(rBytes)
+	return trace.Wrap(err)
+}
+
+// formatSummaryYAML formats the summary in YAML format.
+func formatSummaryYAML(w io.Writer, summary *summarizerv1pb.Summary) error {
+	rBytes, err := marshalSessionSummary(summary)
+	if err != nil {
+		return trace.Wrap(err, "failed to marshal summary")
+	}
+	var jsonObj map[string]any
+	if err := json.Unmarshal(rBytes, &jsonObj); err != nil {
+		return trace.Wrap(err, "failed to unmarshal JSON")
+	}
+	encoder := yaml.NewEncoder(w)
+	encoder.SetIndent(2)
+	defer encoder.Close()
+	return trace.Wrap(encoder.Encode(jsonObj))
 }

--- a/tool/tctl/common/recordings_command_test.go
+++ b/tool/tctl/common/recordings_command_test.go
@@ -56,10 +56,10 @@ func TestRecordingsSummaryFlags(t *testing.T) {
 func TestWriteSummary(t *testing.T) {
 	t.Parallel()
 
-	summary := &summarizerv1pb.Summary{
+	summary := summarizerv1pb.Summary_builder{
 		SessionId: "session-123",
 		Content:   "Session content",
-	}
+	}.Build()
 
 	t.Run("stdout by default", func(t *testing.T) {
 		var stdout bytes.Buffer
@@ -69,7 +69,7 @@ func TestWriteSummary(t *testing.T) {
 		}
 
 		require.NoError(t, c.writeSummary(summary))
-		require.Contains(t, stdout.String(), `"session_id": "session-123"`)
+		require.JSONEq(t, `{"session_id":"session-123","content":"Session content"}`, stdout.String())
 	})
 
 	t.Run("optional output file", func(t *testing.T) {
@@ -91,6 +91,40 @@ func TestWriteSummary(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 	})
+}
+
+func TestFormatSummaryTextCommands(t *testing.T) {
+	t.Parallel()
+
+	summary := summarizerv1pb.Summary_builder{
+		EnhancedSummary: summarizerv1pb.EnhancedSummary_builder{
+			SessionEvents: []*summarizerv1pb.SessionEvent{
+				summarizerv1pb.SessionEvent_builder{
+					RiskLevel:      summarizerv1pb.RiskLevel_RISK_LEVEL_HIGH,
+					RiskScore:      9,
+					MitreAttackIds: []string{"T1059"},
+					CommandEventDetails: summarizerv1pb.CommandEventDetails_builder{
+						Command:       "rm -rf /",
+						ErrorMessages: []string{"permission denied"},
+					}.Build(),
+				}.Build(),
+				summarizerv1pb.SessionEvent_builder{
+					DesktopEventDetails: summarizerv1pb.DesktopEventDetails_builder{
+						Applications: []string{"Terminal"},
+					}.Build(),
+				}.Build(),
+			},
+		}.Build(),
+	}.Build()
+
+	var output bytes.Buffer
+	require.NoError(t, formatSummaryText(&output, summary))
+	require.Contains(t, output.String(), "Commands Executed (1 total)")
+	require.Contains(t, output.String(), "[1] rm -rf /")
+	require.Contains(t, output.String(), "permission denied")
+	//nolint:misspell // MITRE ATT&CK is the official name.
+	require.Contains(t, output.String(), "MITRE ATT&CK:")
+	require.Contains(t, output.String(), "T1059")
 }
 
 func TestRecordingsSearchResourcePropertyFlags(t *testing.T) {

--- a/tool/tctl/common/recordings_command_test.go
+++ b/tool/tctl/common/recordings_command_test.go
@@ -19,17 +19,79 @@
 package common
 
 import (
+	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	summarizerv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/summarizer/v1"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
+
+func TestRecordingsSummaryFlags(t *testing.T) {
+	t.Parallel()
+
+	var c RecordingsCommand
+	app := utils.InitCLIParser("tctl", GlobalHelpString)
+	c.Initialize(app, &tctlcfg.GlobalCLIFlags{}, servicecfg.MakeDefaultConfig())
+
+	selectedCmd, err := app.Parse([]string{
+		"recordings", "summary", "session-123",
+		"--format=yaml",
+		"--output=summary.yaml",
+	})
+	require.NoError(t, err)
+	require.Equal(t, c.summary.FullCommand(), selectedCmd)
+	require.Equal(t, "session-123", c.summarySessionID)
+	require.Equal(t, "yaml", c.summaryFormat)
+	require.Equal(t, "summary.yaml", c.summaryOutputFile)
+}
+
+func TestWriteSummary(t *testing.T) {
+	t.Parallel()
+
+	summary := &summarizerv1pb.Summary{
+		SessionId: "session-123",
+		Content:   "Session content",
+	}
+
+	t.Run("stdout by default", func(t *testing.T) {
+		var stdout bytes.Buffer
+		c := RecordingsCommand{
+			summaryFormat: teleport.JSON,
+			stdout:        &stdout,
+		}
+
+		require.NoError(t, c.writeSummary(summary))
+		require.Contains(t, stdout.String(), `"session_id": "session-123"`)
+	})
+
+	t.Run("optional output file", func(t *testing.T) {
+		var stdout bytes.Buffer
+		outputPath := filepath.Join(t.TempDir(), "summary.yaml")
+		c := RecordingsCommand{
+			summaryFormat:     teleport.YAML,
+			summaryOutputFile: outputPath,
+			stdout:            &stdout,
+		}
+
+		require.NoError(t, c.writeSummary(summary))
+		contents, err := os.ReadFile(outputPath)
+		require.NoError(t, err)
+		require.Contains(t, string(contents), "session_id: session-123")
+		require.Empty(t, stdout.String())
+
+		info, err := os.Stat(outputPath)
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	})
+}
 
 func TestRecordingsSearchResourcePropertyFlags(t *testing.T) {
 	var c RecordingsCommand


### PR DESCRIPTION
Add new `tctl recordings summary` command group for viewing and downloading AI-generated session summaries from the auth server.

- `tctl recordings summary <session-id>`