### PR TITLE
Connect: Fix link to the docs of client tools managed updates

### DIFF
--- a/web/packages/teleterm/src/mainProcess/navigationHandler.ts
+++ b/web/packages/teleterm/src/mainProcess/navigationHandler.ts
@@ -43,7 +43,9 @@ export function registerNavigationHandlers(
     if (settings.dev && new URL(navigationUrl).host === 'localhost:8080') {
       return;
     }
-    logger.warn(`Navigation to ${navigationUrl} blocked by 'will-navigate'`);
+    logger.warn(
+      `Navigation to ${navigationUrl} blocked by 'will-navigate'. Navigating away from the frontend app is not allowed. Does the anchor element have target="_blank" set?`
+    );
     event.preventDefault();
   });
 

--- a/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
+++ b/web/packages/teleterm/src/ui/AppUpdater/AutoUpdatesManagement.tsx
@@ -348,7 +348,10 @@ function makeContentForDisabledAutoUpdates(updateSource: AutoUpdatesDisabled): {
         description: (
           <>
             The cluster needs to{' '}
-            <Link href="https://goteleport.com/docs/upgrading/automatic-updates">
+            <Link
+              href="https://goteleport.com/docs/upgrading/client-tools-managed-updates/"
+              target="_blank"
+            >
               enroll in automatic updates
             </Link>{' '}
             to keep Teleport Connect updated.


### PR DESCRIPTION
The link didn't work because it didn't have `target="_blank"`, so Electron tried to open it within the main window which is blocked by our `will-navigate` handler. The href also pointed to a docs page that has since been moved.

I also updated the log message emitted from `will-navigate`. At first I couldn't understand what's wrong; I assumed the link was erroneously blocked by `isUrlSafe`. The new message should make it easier to locate the source of the problem.

I looked through all instances of `href` in the teleterm folder. It appears that all other links have the target set properly.