### PR TITLE
[web ui] clarify integration name validation error message

### DIFF
--- a/web/packages/shared/components/Validation/rules.test.ts
+++ b/web/packages/shared/components/Validation/rules.test.ts
@@ -22,6 +22,7 @@ import {
   requiredEmailLike,
   requiredField,
   requiredIamRoleName,
+  requiredIntegrationName,
   requiredMaxLength,
   requiredPassword,
   requiredPort,
@@ -103,6 +104,23 @@ describe('requiredIamRoleName', () => {
   `('IAM role name valid ($valid): $roleArn', ({ roleArn, valid }) => {
     const result = requiredIamRoleName(roleArn)();
     expect(result.valid).toEqual(valid);
+  });
+});
+
+describe('requiredIntegrationName', () => {
+  test.each`
+    name                     | expected
+    ${''}                    | ${{ valid: false, message: 'Integration name is required' }}
+    ${'zero_cool'}           | ${{ valid: false, message: "Name must only contain lowercase alphanumeric characters or '-'" }}
+    ${'ZeroKewl'}            | ${{ valid: false, message: "Name must only contain lowercase alphanumeric characters or '-'" }}
+    ${'0cool'}               | ${{ valid: false, message: 'Name must start with an alphabetic character' }}
+    ${'zero-cool-'}          | ${{ valid: false, message: 'Name must end with an alphanumeric character' }}
+    ${'my-cool-integration'} | ${{ valid: true }}
+    ${'my-integration-1'}    | ${{ valid: true }}
+  `('name: $name', ({ name, expected }) => {
+    expect(requiredIntegrationName(name)()).toEqual(
+      expect.objectContaining(expected)
+    );
   });
 });
 

--- a/web/packages/shared/components/Validation/rules.ts
+++ b/web/packages/shared/components/Validation/rules.ts
@@ -100,29 +100,51 @@ const requiredConfirmedPassword =
   };
 
 /**
- * DNS1035_LABEL_REGEX uses the same regex matcher as documented here:
+ * Using the IETF RFC 1035 Label Names rules documented here:
  * https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
  *
- * This matches how the backend validates integration names to satisfy a lowercase valid DNS subdomain.
+ * - contain at most 63 characters
+ * - contain only lowercase alphanumeric characters or '-'
+ * - start with an alphabetic character
+ * - end with an alphanumeric character
+ *
  */
-const DNS1035_LABEL_REGEX = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
-const DNS1035_LABEL_MAX_LENGTH = 63;
+const RFC1035_LABEL_ALLOWED_CHARS = /^[-a-z0-9]+$/;
+const RFC1035_LABEL_START = /^[a-z]/;
+const RFC1035_LABEL_END = /[a-z0-9]$/;
+const RFC1035_LABEL_MAX_LENGTH = 63;
 /**
  * @param name validIntegrationName verifies if the given value is a
  * valid Integration name.
  */
 const validIntegrationName = (name: string): ValidationResult => {
-  if (name.length > DNS1035_LABEL_MAX_LENGTH) {
+  if (name.length > RFC1035_LABEL_MAX_LENGTH) {
     return {
       valid: false,
-      message: 'Name should be <= ' + DNS1035_LABEL_MAX_LENGTH + ' characters',
+      message:
+        'Name must contain at most ' + RFC1035_LABEL_MAX_LENGTH + ' characters',
     };
   }
 
-  if (!name.match(DNS1035_LABEL_REGEX)) {
+  if (!name.match(RFC1035_LABEL_ALLOWED_CHARS)) {
     return {
       valid: false,
-      message: 'Name must be a lower case valid DNS subdomain',
+      message:
+        "Name must only contain lowercase alphanumeric characters or '-'",
+    };
+  }
+
+  if (!name.match(RFC1035_LABEL_START)) {
+    return {
+      valid: false,
+      message: 'Name must start with an alphabetic character',
+    };
+  }
+
+  if (!name.match(RFC1035_LABEL_END)) {
+    return {
+      valid: false,
+      message: 'Name must end with an alphanumeric character',
     };
   }
 
@@ -147,14 +169,15 @@ const validAwsIAMRoleName = (name: string): ValidationResult => {
   if (name.length > IAM_ROLE_NAME_MAX_LENGTH) {
     return {
       valid: false,
-      message: 'Name should be <= ' + IAM_ROLE_NAME_MAX_LENGTH + ' characters',
+      message: 'Name must be <= ' + IAM_ROLE_NAME_MAX_LENGTH + ' characters',
     };
   }
 
   if (!name.match(IAM_ROLE_NAME_REGEX)) {
     return {
       valid: false,
-      message: 'Name can only contain characters @ = , . + - and alphanumerics',
+      message:
+        'Name must only contain characters @ = , . + - and alphanumerics',
     };
   }
 
@@ -178,7 +201,7 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
     return {
       valid: false,
       message:
-        'Name should be <= ' + ROLES_ANYWHERE_NAME_MAX_LENGTH + ' characters',
+        'Name must be <= ' + ROLES_ANYWHERE_NAME_MAX_LENGTH + ' characters',
     };
   }
 
@@ -193,7 +216,8 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
   if (!name.match(ROLES_ANYWHERE_NAME_REGEX)) {
     return {
       valid: false,
-      message: 'Name can only contain characters [space] - _ and alphanumerics',
+      message:
+        'Name must only contain characters [space] - _ and alphanumerics',
     };
   }
   return {
@@ -203,7 +227,7 @@ const validAwsRaResourceName = (name: string): ValidationResult => {
 
 /**
  * requiredIntegrationName is a required field and checks for a
- * value which should also be a valid Integration name.
+ * value which must also be a valid Integration name.
  * @param name is an integration name.
  * @returns ValidationResult
  */
@@ -220,7 +244,7 @@ const requiredIntegrationName: Rule = name => (): ValidationResult => {
 
 /**
  * requiredIamRoleName is a required field and checks for a
- * value which should also be a valid AWS IAM Role name.
+ * value which must also be a valid AWS IAM Role name.
  * @param name is a role name.
  * @returns ValidationResult
  */
@@ -237,7 +261,7 @@ const requiredIamRoleName: Rule = name => (): ValidationResult => {
 
 /**
  * requiredIamTrustAnchorName is a required field and checks for a
- * value which should also be a valid AWS IAM Roles Anywhere Trust Anchor name.
+ * value which must also be a valid AWS IAM Roles Anywhere Trust Anchor name.
  * @param name is a trust anchor name.
  * @returns ValidationResult
  */
@@ -254,7 +278,7 @@ const requiredIamTrustAnchorName: Rule = name => (): ValidationResult => {
 
 /**
  * requiredIamProfileName is a required field and checks for a
- * value which should also be a valid AWS IAM Roles Anywhere Profile name.
+ * value which must also be a valid AWS IAM Roles Anywhere Profile name.
  * @param name is a profile name.
  * @returns ValidationResult
  */

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -136,7 +136,7 @@ describe('test AutoDeploy.tsx', () => {
     await waitForSubnetsAndSecurityGroups();
 
     expect(
-      screen.queryByText(/name can only contain/i)
+      screen.queryByText(/name must only contain/i)
     ).not.toBeInTheDocument();
 
     // add invalid characters in role name
@@ -144,12 +144,12 @@ describe('test AutoDeploy.tsx', () => {
     fireEvent.change(inputEl, { target: { value: 'invalidname!@#!$!%' } });
 
     fireEvent.click(screen.getByText(/generate command/i));
-    expect(screen.getByText(/name can only contain/i)).toBeInTheDocument();
+    expect(screen.getByText(/name must only contain/i)).toBeInTheDocument();
 
     // change back to valid name
     fireEvent.change(inputEl, { target: { value: 'llama' } });
     expect(
-      screen.queryByText(/name can only contain/i)
+      screen.queryByText(/name must only contain/i)
     ).not.toBeInTheDocument();
   });
 

--- a/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsConsole/IamIntegration/IamIntegration.test.tsx
@@ -122,11 +122,14 @@ test('flows through roles anywhere IAM setup', async () => {
   );
   fireEvent.click(screen.getByRole('button', { name: 'Generate Command' }));
   expect(
-    screen.getByText('Name must be a lower case valid DNS subdomain')
+    screen.getByText(
+      "Name must only contain lowercase alphanumeric characters or '-'"
+    )
   ).toBeInTheDocument();
-  expect(screen.getAllByText(/Name can only contain characters/i)).toHaveLength(
-    3
-  );
+
+  expect(
+    screen.getAllByText(/Name must only contain characters/i)
+  ).toHaveLength(3);
 
   fireEvent.change(screen.getByLabelText('Integration Name'), {
     target: { value: 'some-integration-name' },


### PR DESCRIPTION
### Description

Currently the integration name validation error message will warn users if the name is not a valid DNS subdomain but does not say what those rules are

### Fix

- Updates Integration name validation error message to show the IETC RFC 1035 validation rules

- Replaces `should` and `can` in validation error messages with `must`

### Screenshots 

_before_
<img width="400" height="276" alt="screenshot_2026-02-03_at_3 05 39___pm_720" src="https://github.com/user-attachments/assets/5a54077c-32bb-409e-8fc1-4e4fa8c37601" />

_now_
<img width="400" height="171" alt="Screenshot 2026-02-04 at 9 37 56 AM" src="https://github.com/user-attachments/assets/f1ae3380-da52-49f9-8103-08770a86b6a2" />
<img width="400" height="185" alt="Screenshot 2026-02-04 at 9 36 55 AM" src="https://github.com/user-attachments/assets/cb2991ae-c130-4320-bb5f-2fece60eaa60" />
<img width="400" height="185" alt="Screenshot 2026-02-04 at 9 36 38 AM" src="https://github.com/user-attachments/assets/9462ecca-9667-4b0c-bcb9-6aac4c606c1f" />
