### PR TITLE
Add IaC examples to join token guides

### DIFF
--- a/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
+++ b/docs/pages/enroll-resources/agents/add-service-to-agent.mdx
@@ -32,45 +32,92 @@ cluster with the new token and receive a new certificate.
 - A Teleport cluster
 - At least one Teleport Agent running in your cluster, either on a Linux server
   or a Kubernetes pod
- - (!docs/pages/includes/tctl.mdx!)
-
-As an example, this guide shows you how to add a service to an agent using the
-token join method. This is one of multiple available join methods. Read the
-[Using Teleport Agents overview](agents.mdx) for a complete list.
+- (!docs/pages/includes/iac-clients.mdx!)
+- Familiarity with at least one Teleport join method. Read the [Using Teleport
+  Agents overview](agents.mdx) for a complete list of guides to joining Teleport
+  Agents. This guide assumes that you have followed at least one how-to guide
+  for joining a Teleport Agent.
 
 ## Step 1/3. Generate a new join token
 
 Generate a new join token for all services running on an agent, including any
 new services you want to run. 
 
-For example, if an agent runs the Teleport Kubernetes Service, and you want it
-to run the Teleport Application Service as well, create a join token for the
-Teleport Kubernetes Service and Teleport Application Service. To do so, specify
-the two services in the `--type` flag of `tctl tokens add`:
-
-```code
-$ tctl tokens add --type=kube,app --ttl=5m
-```
-
 You can specify the following token types:
 
 (!docs/pages/includes/token-types.mdx!)
 
-If you are running your Teleport Agent using the `teleport-kube-agent` Helm
-chart, once you know your token types, update your values file so the `roles`
-field includes your required roles.
+For example, if an agent runs the Teleport Kubernetes Service, and you want it
+to run the Teleport Application Service as well, create a join token for the
+Teleport Kubernetes Service and Teleport Application Service. 
 
-For example, this change adds the `app` role to enable the Teleport Application
-Service:
+Modify the token type in the configuration you used to create the token,
+depending on your infrastructure as code tool and whether your agent runs from
+the `teleport-kube-agent` Helm chart:
+
+<Tabs>
+<TabItem label="tctl">
+
+Edit the `spec.roles` field in your token resource manifest. In this example, we
+are allowing this token to join the Teleport Application Service in addition to
+the Teleport Kubernetes Service:
 
 ```diff
-- roles: kube,db
-+ roles: kube,app,db
+# ...
+  spec:
+    # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+-   roles: [Kube]
++   roles: [Kube,App]
+```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Edit the `spec.roles` field in your resource configuration. In this example, we
+are allowing this token to join the Teleport Application Service in addition to
+the Teleport Kubernetes Service:
+
+```diff
+  resource "teleport_provision_token" "current" {
+  // ...
+    spec = {
+      // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+-     roles       = ["Kube"]
++     roles       = ["Kube","App"]
+```
+</TabItem>
+<TabItem label="Kubernetes">
+
+Edit the `spec.roles` field in your manifest. In this example, we are allowing
+this token to join the Teleport Application Service in addition to the Teleport
+Kubernetes Service:
+
+```diff
+# ...
+  spec:
+    # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+-   roles: [Kube]
++   roles: [Kube,App]
+```
+</TabItem>
+<TabItem label="teleport-kube-agent">
+
+Edit the `roles` field in your values file. In this example, we are allowing
+this token to join the Teleport Application Service in addition to the Teleport
+Kubernetes Service:
+
+```diff
+- roles: kube,
++ roles: kube,app
 ```
 
 See the `teleport-kube-agent` [chart
 reference](../../reference/helm-reference/teleport-kube-agent.mdx#roles) for the
 roles and token types that the chart supports.
+
+</TabItem>
+</Tabs>
+
 
 ## Step 2/3. Edit your agent configuration
 

--- a/docs/pages/enroll-resources/agents/aws-ec2.mdx
+++ b/docs/pages/enroll-resources/agents/aws-ec2.mdx
@@ -45,7 +45,7 @@ Teleport processes joining the cluster.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="self-hosted Teleport"!)
 
-- (!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
 - An AWS EC2 instance to host a Teleport process, with the Teleport binary
   installed. The host should not have an existing data dir (`/var/lib/teleport`
   by default). Remove the data directory if this instance has previously joined
@@ -101,12 +101,36 @@ Under the hood, services will prove that they are running in your AWS account by
 sending a signed EC2 Instance Identity Document which matches an allow rule
 configured in your AWS joining token.
 
+You can create the token with `tctl` as well as the Teleport Terraform provider
+or Kubernetes operator:
+
+<Tabs>
+<TabItem label="tctl">
+
 Create the following `token.yaml` with an `allow` rule specifying your AWS
 account and the AWS regions in which your EC2 instances will run.
 
 (!docs/pages/includes/provision-token/ec2-spec.mdx!)
 
 Run `tctl create token.yaml` to create the token.
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/ec2-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/ec2-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 ## Step 3/5 Install Teleport
 

--- a/docs/pages/enroll-resources/agents/aws-iam.mdx
+++ b/docs/pages/enroll-resources/agents/aws-iam.mdx
@@ -48,8 +48,7 @@ joining token.
 
 - An AWS EC2 instance to host a Teleport service, with the Teleport binary
   installed.
-
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
 
 ## Step 1/5. Set up AWS IAM credentials
 
@@ -70,7 +69,8 @@ policies.
 Create the following `token.yaml` with an `allow` rule specifying your AWS
 account and the ARN that the Teleport process's identity must match.
 
-(!docs/pages/includes/provision-token/iam-spec.mdx!)
+You can create the token with `tctl` as well as the Teleport Terraform provider
+or Kubernetes operator.
 
 The token name `iam-token` is just an example and can be any value you want to
 use, as long as you use the same value for `join_params.token_name` in Step 3.
@@ -79,11 +79,34 @@ The optional `aws_arn` field in the allow rules supports wildcard characters:
 - `*` to match any combination of characters
 - `?` to match any single character
 
+<Tabs>
+<TabItem label="tctl">
+
+(!docs/pages/includes/provision-token/iam-spec.mdx!)
+
 Run the following command to create the token:
 
 ```code
 $ tctl create -f token.yaml
 ```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/iam-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/iam-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 ## Step 3/5 Install Teleport
 

--- a/docs/pages/enroll-resources/agents/azure.mdx
+++ b/docs/pages/enroll-resources/agents/azure.mdx
@@ -34,7 +34,7 @@ your Azure joining token.
   Virtual Machine must have a [Managed
   Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
   assigned to it.
-- (!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
 
 ## Step 1/5. Set up a Managed Identity
 
@@ -90,18 +90,41 @@ $ az vmss update-instances --resource-group <resource-group> --name <vmss-name> 
 ## Step 2/5. Create the Azure joining token
 
 Create the following `token.yaml` with an `allow` rule specifying your Azure
-subscription and the resource group that your VM's identity must match.
-
-(!docs/pages/includes/provision-token/azure-spec.mdx!)
+subscription and the resource group that your VM's identity must match.  You can
+create the token with `tctl` as well as the Teleport Terraform provider or
+Kubernetes operator.
 
 The token name `azure-token` is just an example and can be any value you want to
 use, as long as you use the same value for `join_params.token_name` in Step 3.
+
+<Tabs>
+<TabItem label="tctl">
+
+(!docs/pages/includes/provision-token/azure-spec.mdx!)
 
 Run the following command to create the token:
 
 ```code
 $ tctl create -f token.yaml
 ```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/azure-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/azure-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 ## Step 3/5 Install Teleport
 

--- a/docs/pages/enroll-resources/agents/gcp.mdx
+++ b/docs/pages/enroll-resources/agents/gcp.mdx
@@ -31,12 +31,17 @@ joining token.
 
 - A GCP VM to host a Teleport service, with a service account assigned to it
   and with the Teleport binary installed.
-- (!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
 
 ## Step 1/4. Create the GCP joining token
 
 Configure your Teleport Auth Service with a special dynamic token which will
-allow services from your GCP projects to join your Teleport cluster.
+allow services from your GCP projects to join your Teleport cluster. You can
+create the token with `tctl` as well as the Teleport Terraform provider or
+Kubernetes operator:
+
+<Tabs>
+<TabItem label="tctl">
 
 Create the following `token.yaml` file with a `gcp.allow` rule specifying your GCP
 project ID(s), service account(s), and location(s) in which your GCP instances
@@ -49,6 +54,24 @@ Run the following command to create the token:
 ```code
 $ tctl create token.yaml
 ```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/gcp-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/gcp-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 ## Step 2/4 Install Teleport
 

--- a/docs/pages/enroll-resources/agents/join-token.mdx
+++ b/docs/pages/enroll-resources/agents/join-token.mdx
@@ -52,7 +52,11 @@ relationship with the Teleport cluster.
 
   </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
+
+  If you're managing Teleport resources with the Teleport Kubernetes operator,
+  this guide assumes that your resource manifests are placed together in a Helm
+  chart.
 
 ## Step 1/3. Install Teleport
 
@@ -70,7 +74,15 @@ In this section, we will join your Teleport process to your cluster by:
 ### Generate a token
 
 Teleport only allows access to resources in your infrastructure via Teleport
-processes that that have joined the cluster.
+processes that that have joined the cluster (i.e., **Teleport Agents**).
+Generate a token that the Teleport Auth Service can compare to a value that your
+Teleport process presents when it joins the cluster.
+
+You can create the token with `tctl` as well as the Teleport Terraform provider
+or Kubernetes operator:
+
+<Tabs>
+<TabItem label="tctl">
 
 On your local machine, use the `tctl` tool to generate a new token. In the
 following example, a new token is created with a TTL of five minutes:
@@ -123,6 +135,24 @@ Token                            Type Labels Expiry Time (UTC)
 -------------------------------- ---- ------ --------------------------
 (=presets.tokens.first=) Node        30 Mar 23 18:15 UTC (2m8s)
 ```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/token-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/token-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 <details>
 <summary>An insecure alternative: static tokens</summary>

--- a/docs/pages/enroll-resources/agents/kubernetes.mdx
+++ b/docs/pages/enroll-resources/agents/kubernetes.mdx
@@ -45,6 +45,7 @@ as the Auth Service.
   ClusterRole. Clusters deployed with the [`teleport-cluster` Helm
   chart](../../reference/helm-reference/teleport-cluster.mdx) 
   have the correct role by default.
+- (!docs/pages/includes/iac-clients.mdx!)
 
 ## Step 1/5. Create a Kubernetes join token
 
@@ -69,9 +70,12 @@ It is not recommended to use a single token that can join everything. You should
 restrict the token to the roles used by the joining instance. For example, a Teleport
 instance running both the Application Service and Database Service should use a token with
 `roles: [App, Db]`.
-Follow the instructions below to create the token depending on whether you have administrative access to the Auth Service pod:
+
+You can create the token with `tctl` as well as the Teleport Terraform provider
+or Kubernetes operator:
+
 <Tabs>
-<TabItem label="Using tctl locally as your current user">
+<TabItem label="tctl">
 
 Create the token:
 
@@ -96,48 +100,19 @@ version: v2
 ```
 
 </TabItem>
-<TabItem label="Using tctl on the Auth Service as an admin">
-Retrieve the name and namespace of the Auth Service deployment:
+<TabItem label="Terraform">
 
-```code
-$ kubectl get namespaces
-NAME              STATUS   AGE
-cert-manager      Active   40d
-default           Active   40d
-kube-system       Active   40d
-teleport          Active   40d
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
 
-# We look for deployments in the "teleport" namespace
-$ kubectl get deployments -n teleport
-NAME             READY   UP-TO-DATE   AVAILABLE   AGE
-teleport-auth    2/2     2            2           6d20h
-teleport-proxy   2/2     2            2           6d20h
+(!docs/pages/includes/provision-token/kubernetes-in-cluster-spec-hcl.mdx!)
 
-# Here, the deployment name is "teleport-auth".
-```
+</TabItem>
+<TabItem label="Kubernetes">
 
-Then run the following command to execute the `tctl create` command from inside
-one of the Auth Service pods:
+Add the following Kubernetes resource manifest, replacing values as indicated:
 
-```code
-$ kubectl exec -i -n teleport deployment/teleport-auth -- tctl create < token.yaml
-```
-
-Finally, validate the token was successfully created:
-
-```code
-$ kubectl exec -i -n teleport deployment/teleport-auth tctl get token/kubernetes-token
-
-kind: token
-metadata:
-  expires: "3000-01-01T00:00:00Z"
-  name: kubernetes-token
-spec:
-  join_method: kubernetes
-  roles:
-  - App
-version: v2
-```
+(!docs/pages/includes/provision-token/kubernetes-in-cluster-spec-kube.mdx!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/enroll-resources/agents/oracle.mdx
+++ b/docs/pages/enroll-resources/agents/oracle.mdx
@@ -35,12 +35,17 @@ self-authentication request to the OCI API for the Auth Service to execute.
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport (v17.3.0 or higher)"!)
 
 - An OCI Compute instance to host a Teleport service.
-- (!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/iac-clients.mdx!)
 
 ## Step 1/5. Create the Oracle joining token
 
 Configure your Teleport Auth Service with a special dynamic token which will
-allow services from your OCI tenants to join your Teleport cluster.
+allow services from your OCI tenants to join your Teleport cluster. You can
+create the token with `tctl` as well as the Teleport Terraform provider or
+Kubernetes operator:
+
+<Tabs>
+<TabItem label="tctl">
 
 Create the following `token.yaml` file with an `oracle.allow` rule specifying
 the Oracle tenant(s), compartment(s), and region(s) in which your OCI
@@ -55,6 +60,24 @@ Run the following command to create the token:
 ```code
 $ tctl create token.yaml
 ```
+
+</TabItem>
+<TabItem label="Terraform">
+
+Add the following resource to your Terraform configuration, replacing values as
+indicated:
+
+(!docs/pages/includes/provision-token/oracle-spec-hcl.mdx!)
+
+</TabItem>
+<TabItem label="Kubernetes">
+
+Add the following Kubernetes resource manifest, replacing values as indicated:
+
+(!docs/pages/includes/provision-token/oracle-spec-kube.mdx!)
+
+</TabItem>
+</Tabs>
 
 ## Step 2/5. Configure permissions
 

--- a/docs/pages/includes/iac-clients.mdx
+++ b/docs/pages/includes/iac-clients.mdx
@@ -1,0 +1,5 @@
+One of the following client tools for managing Teleport resources:
+
+- The `tctl` CLI, which you can install along with Teleport on your workstation ([documentation](../installation/installation.mdx)) on your workstation.
+- [Teleport Terraform provider](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)
+- [Teleport Kubernetes operator](../zero-trust-access/infrastructure-as-code/terraform-provider/terraform-provider.mdx)

--- a/docs/pages/includes/provision-token/azure-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/azure-spec-hcl.mdx
@@ -1,0 +1,37 @@
+```hcl
+resource "teleport_provision_token" "azure-token" {
+  version = "v2"
+  metadata = {
+    name = "azure-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic"
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles       = ["Node"]
+    join_method = "azure"
+    azure = {
+      allow = [
+        {
+          # specify the Azure subscription which Teleport processes may join from
+          subscription = "11111111-1111-1111-1111-111111111111"
+        },
+        {
+          # multiple allow rules are supported
+          subscription = "22222222-2222-2222-2222-222222222222"
+        },
+        {
+          # resource_groups is optional and allows you to restrict the resource group of
+          # joining Teleport processes
+          subscription = "33333333-3333-3333-3333-333333333333"
+          resource_groups = ["group1", "group2"]
+        },
+      ]
+    }
+  }
+}
+```

--- a/docs/pages/includes/provision-token/azure-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/azure-spec-kube.mdx
@@ -1,0 +1,24 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  name: "azure-token"
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  roles: [Node]
+  # set the join method allowed for this token
+  join_method: azure
+  azure:
+    allow:
+      # specify the Azure subscription which Teleport processes may join from
+      - subscription: 11111111-1111-1111-1111-111111111111
+      # multiple allow rules are supported
+      - subscription: 22222222-2222-2222-2222-222222222222
+      # resource_groups is optional and allows you to restrict the resource group of
+      # joining Teleport processes
+      - subscription: 33333333-3333-3333-3333-333333333333
+        resource_groups: ["group1", "group2"]
+```

--- a/docs/pages/includes/provision-token/ec2-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/ec2-spec-hcl.mdx
@@ -1,0 +1,36 @@
+```hcl
+resource "teleport_provision_token" "ec2-token" {
+  version = "v2"
+  metadata = {
+    name = "ec2-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic"
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles       = ["Node"]
+    join_method = "ec2"
+    // aws_iid_ttl is the amount of time after the EC2 instance is launched during
+    // which it should be allowed to join the cluster. Use a short TTL to decrease
+    // the risk of stolen EC2 Instance Identity Documents being used to join your
+    // cluster.
+    //
+    // When launching your first Teleport process using the EC2 join method, you may need to
+    // temporarily configure a higher `aws_iid_ttl` value so that you have time
+    // to get Teleport set up and configured. This feature works best once Teleport
+    // is configured in an EC2 AMI to start automatically on launch.
+    aws_iid_ttl = "5m"
+
+    allow = [
+      {
+        aws_account = "111111111111"             # your AWS account ID
+        aws_regions = ["us-west-1", "us-west-2"] # use the minimal set of AWS regions required
+      },
+    ]
+  }
+}
+```

--- a/docs/pages/includes/provision-token/ec2-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/ec2-spec-kube.mdx
@@ -1,0 +1,31 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  name: "ec2-token"
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  roles: [Node]
+  # set the join method allowed for this token
+  join_method: ec2
+
+  # aws_iid_ttl is the amount of time after the EC2 instance is launched during
+  # which it should be allowed to join the cluster. Use a short TTL to decrease
+  # the risk of stolen EC2 Instance Identity Documents being used to join your
+  # cluster.
+  #
+  # When launching your first Teleport process using the EC2 join method, you may need to
+  # temporarily configure a higher `aws_iid_ttl` value so that you have time
+  # to get Teleport set up and configured. This feature works best once Teleport
+  # is configured in an EC2 AMI to start automatically on launch.
+  aws_iid_ttl: 5m
+
+  allow:
+  - aws_account: "111111111111" # your AWS account ID
+    aws_regions: # use the minimal set of AWS regions required
+    - us-west-1
+    - us-west-2
+```

--- a/docs/pages/includes/provision-token/gcp-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/gcp-spec-hcl.mdx
@@ -1,0 +1,28 @@
+```hcl
+resource "teleport_provision_token" "gcp-token" {
+  version = "v2"
+  metadata = {
+    name = "gcp-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic" 
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles       = ["Node"]
+    join_method = "gcp"
+    gcp = {
+      allow = [
+        {
+          project_ids      = ["example-project-id"]
+          locations        = ["us-west1", "us-west2-a"]
+          service_accounts = ["example@example.com"]
+        },
+      ]
+    }
+  }
+}
+```

--- a/docs/pages/includes/provision-token/gcp-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/gcp-spec-kube.mdx
@@ -1,0 +1,24 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  name: "gcp-token"
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  roles: [Node]
+  # set the join method allowed for this token
+  join_method: gcp
+  gcp:
+    allow:
+      # The GCP project ID(s) that VMs can join from.
+      - project_ids: ["example-project-id"]
+        # (Optional) The locations that VMs can join from. Note: both regions and
+        # zones are accepted.
+        locations: ["us-west1", "us-west2-a"]
+        # (Optional) The email addresses of service accounts that VMs can join
+        # with.
+        service_accounts: ["example@example.com"]
+```

--- a/docs/pages/includes/provision-token/iam-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/iam-spec-hcl.mdx
@@ -1,0 +1,37 @@
+```hcl
+resource "teleport_provision_token" "iam-token" {
+  version = "v2"
+  metadata = {
+    name = "iam-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic"
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles = ["Node"]
+
+    join_method = "iam"
+
+    allow = [
+      {
+        aws_account = "111111111111"             # your AWS account ID
+        aws_regions = ["us-west-1", "us-west-2"] # use the minimal set of AWS regions required
+      },
+      {
+        # multiple allow rules are supported
+        aws_account = "222222222222"
+      },
+      {
+        # aws_arn is optional and allows you to restrict the IAM role of joining
+        # Teleport processes
+        aws_account = "333333333333"
+        aws_arn     = "arn:aws:sts::333333333333:assumed-role/teleport-node-role/i-*"
+      },
+    ]
+  }
+}
+```

--- a/docs/pages/includes/provision-token/iam-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/iam-spec-kube.mdx
@@ -1,0 +1,25 @@
+```yaml
+# token.yaml
+kind: token
+version: v2
+metadata:
+  # the token name is not a secret because instances must prove that they are
+  # running in your AWS account to use this token
+  name: iam-token
+spec:
+  # use the minimal set of roles required (e.g. Node, App, Kube, DB, WindowsDesktop)
+  roles: [Node]
+  
+  # set the join method allowed for this token
+  join_method: iam
+  
+  allow:
+    # specify the AWS account which Teleport processes may join from
+    - aws_account: "111111111111"
+    # multiple allow rules are supported
+    - aws_account: "222222222222"
+    # aws_arn is optional and allows you to restrict the IAM role of joining
+    # Teleport processes
+    - aws_account: "333333333333"
+      aws_arn: "arn:aws:sts::333333333333:assumed-role/teleport-node-role/i-*"
+```

--- a/docs/pages/includes/provision-token/kubernetes-in-cluster-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/kubernetes-in-cluster-spec-hcl.mdx
@@ -1,0 +1,29 @@
+```hcl
+resource "teleport_provision_token" "kube-token" {
+  version = "v2"
+  metadata = {
+    name = "kube-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic"
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles       = ["App"]
+    join_method = "kubernetes"
+    kubernetes = {
+      # If type is not specified, it defaults to in_cluster
+      type = "in_cluster"
+      allow = [
+        {
+          # Service account names follow the format "namespace:serviceaccountname".
+          service_account = "teleport-agent:teleport-app-service"
+        },
+      ]
+    }
+  }
+}
+```

--- a/docs/pages/includes/provision-token/kubernetes-in-cluster-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/kubernetes-in-cluster-spec-kube.mdx
@@ -1,0 +1,22 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  name: "kube-token"
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  roles: [App]
+
+  # set the join method allowed for this token
+  join_method: kubernetes
+  
+  kubernetes:
+    # If type is not specified, it defaults to in_cluster
+    type: in_cluster
+    allow:
+      # Service account names follow the format "namespace:serviceaccountname".
+      - service_account: "teleport-agent:teleport-app-service"
+```

--- a/docs/pages/includes/provision-token/oracle-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/oracle-spec-hcl.mdx
@@ -1,0 +1,38 @@
+```hcl
+resource "teleport_provision_token" "oracle-token" {
+  version = "v2"
+  metadata = {
+    name = "oracle-token"
+  }
+
+  labels = {
+    // This label is added on the Teleport side by default
+    "teleport.dev/origin" = "dynamic"
+  }
+
+  spec = {
+    // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+    roles       = ["Node"]
+    join_method = "oracle"
+    oracle = {
+      allow = [
+        {
+          # OCID of the tenancy to allow instances to join from. Required.
+          tenancy = "ocid1.tenancy.oc1..<unique_ID>"
+          # (Optional) OCIDs of compartments to allow instances to join from. Only the direct parent
+          # compartment applies; i.e. nested compartments are not taken into account.
+          # If empty, instances can join from any compartment in the tenancy.
+          parent_compartments = ["ocid1.compartment.oc1..<unique_ID>"]
+          # (Optional) Regions to allow instances to join from. Both full names ("us-phoenix-1")
+          # and abbreviations ("phx") are allowed. If empty, instances can join from any region.
+          regions = ["example-region"]
+          # (Optional) OCIDs of specific compute instances that should be allowed to join.
+          # If empty, any instance matching the other fields is allowed.
+          # The instances field is supported in Teleport v18.4.0+.
+          instances = ["ocid1.instance.oc1.<region>.<unique_ID>"]
+        },
+      ]
+    }
+  }
+}
+```

--- a/docs/pages/includes/provision-token/oracle-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/oracle-spec-kube.mdx
@@ -1,0 +1,33 @@
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  # The token name is not a secret because instances must prove that they are
+  # running in your Oracle tenant to use this token.
+  name: "oracle-token"
+  labels:
+    # This label is added on the Teleport side by default
+    "teleport.dev/origin": "dynamic"
+spec:
+  # Use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop).
+  roles: [Node]
+
+  # Set the join method allowed for this token.
+  join_method: oracle
+
+  oracle:
+    allow:
+      # OCID of the tenancy to allow instances to join from. Required.
+      - tenancy: "ocid1.tenancy.oc1..<unique_ID>"
+        # (Optional) OCIDs of compartments to allow instances to join from. Only the direct parent
+        # compartment applies; i.e. nested compartments are not taken into account.
+        # If empty, instances can join from any compartment in the tenancy.
+        parent_compartments: ["ocid1.compartment.oc1..<unique_ID>"]
+        # (Optional) Regions to allow instances to join from. Both full names ("us-phoenix-1")
+        # and abbreviations ("phx") are allowed. If empty, instances can join from any region.
+        regions: ["example-region"]
+        # (Optional) OCIDs of specific compute instances that should be allowed to join.
+        # If empty, any instance matching the other fields is allowed.
+        # The instances field is supported in Teleport v18.4.0+.
+        instances: ["ocid1.instance.oc1.<region>.<unique_ID>"]
+```

--- a/docs/pages/includes/provision-token/token-spec-hcl.mdx
+++ b/docs/pages/includes/provision-token/token-spec-hcl.mdx
@@ -1,0 +1,26 @@
+In this example, we declare a `random_string` resource in addition to the
+`teleport_provision_token` resource in order to generate a cryptographically
+secure value for the token:
+
+{/* cSpell:disable */}
+
+```hcl
+resource "random_string" "token" {
+  length           = 32
+  override_special = "-.+"
+}
+
+resource "teleport_provision_token" "agent" {
+  version = "v2"
+  // use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  spec = {
+    roles = ["Node"]
+  }
+  metadata = {
+    name    = random_string.token.result
+    expires = timeadd(timestamp(), "1h")
+  }
+}
+```
+
+{/* cSpell:enable */}

--- a/docs/pages/includes/provision-token/token-spec-kube.mdx
+++ b/docs/pages/includes/provision-token/token-spec-kube.mdx
@@ -1,0 +1,14 @@
+In this example, which assumes that you have placed the manifest in a Helm
+chart, we use the `randBytes` function to generate a cryptographically random
+token value and the `now` and `dateModify` functions to set a time to live:
+
+```yaml
+apiVersion: "resources.teleport.dev/v2"
+kind: TeleportProvisionToken
+metadata:
+  name: {{ randBytes 32 }}
+  expires: {{ now | dateModify "+1h" }}
+spec:
+  # use the minimal set of roles required (e.g. Node, Proxy, App, Kube, DB, WindowsDesktop)
+  roles: [Node]
+```


### PR DESCRIPTION
Resolves #37715

Add HCL and Kubernetes manifest counterparts for the `tctl` resource examples in `/docs/enroll-resources/agents`.

In the guide on adding a service to an agent, add reading one of the join token guides as a prerequisite, and include examples of editing each kind of manifest.

In the Kubernetes joining guide, remove the "on the Auth Service" tab from the instructions for creating a token with `tctl`. It's unnecessary, since we usually include instructions only for using `tctl` remotely, and removing it allows us to include IaC-related tabs without nested tabs.

In the secret token guide, include Helm as a requirement for managing tokens with the Kubernetes operator since we need to generate a random value for the token on creation.