### PR TITLE
[v17] Bump bytes from 1.11.0 to 1.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cbc"

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib"]
 bitflags = "2.5.0"
 boring = { git = "https://github.com/gravitational/boring", rev = "99897308abb5976ea05625b8314c24b16eebb01b", optional = true }
 byteorder = "1.5.0"
-bytes = "1.9.0"
+bytes = "1.11.1"
 env_logger = "0.11.5"
 ironrdp-cliprdr.workspace = true
 ironrdp-connector.workspace = true


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/63460 to branch/v17