### PR TITLE
Fix inconsistencies in group-role mappings in SSO guides 🐛 

### DIFF
--- a/docs/pages/includes/sso/role-mapping.mdx
+++ b/docs/pages/includes/sso/role-mapping.mdx
@@ -18,7 +18,7 @@ For example, the following role mapping means that any user with the {{fieldType
 `editor`:
 
 ```text
-groups,admins,auditor,editor,
+groups,admins,auditor,editor
 ```
 
 For the purpose of this guide, assign two separate role mappings:

--- a/docs/pages/includes/sso/role-mapping.mdx
+++ b/docs/pages/includes/sso/role-mapping.mdx
@@ -14,14 +14,14 @@ mapping takes the following format:
 ```
 
 For example, the following role mapping means that any user with the {{fieldType}}
-`groups` with the value `admin` receives the Teleport roles `editor` and
-`auditor`:
+`groups` with the value `admins` receives the Teleport roles `auditor` and
+`editor`:
 
 ```text
-groups,admin,editor,auditor
+groups,admins,auditor,editor,
 ```
 
 For the purpose of this guide, assign two separate role mappings:
 
-- A more permissive role mapping: <Var name="mapping_1" initial="groups,okta-admin,editor" />
-- A more restrictive role mapping: <Var name="mapping_2" initial="groups,okta-dev,dev" />
+- A more permissive role mapping: <Var name="mapping_1" initial="groups,admins,auditor,editor" />
+- A more restrictive role mapping: <Var name="mapping_2" initial="groups,devs,access" />

--- a/docs/pages/includes/sso/role-mapping.mdx
+++ b/docs/pages/includes/sso/role-mapping.mdx
@@ -1,5 +1,5 @@
 When a user authenticates to Teleport, the Teleport Auth Service issues SSH and
-TLS certificates to the user that contain the user's Teleport roles. 
+TLS certificates to the user that contain the user's Teleport roles.
 
 For SSO authentication connectors, the Auth Service determines which roles to
 encode in the certificate by reading the authentication connector's **role
@@ -14,15 +14,14 @@ mapping takes the following format:
 ```
 
 For example, the following role mapping means that any user with the {{fieldType}}
-`group` with the value `admin` receives the Teleport roles `editor` and
+`groups` with the value `admin` receives the Teleport roles `editor` and
 `auditor`:
 
 ```text
-group,admin,editor,auditor
+groups,admin,editor,auditor
 ```
 
 For the purpose of this guide, assign two separate role mappings:
 
-- A more permissive role mapping: <Var name="mapping_1" initial="group,admins,auditor,editor" />
-- A more restrictive role mapping: <Var name="mapping_2" initial="group,users,access" />
-
+- A more permissive role mapping: <Var name="mapping_1" initial="groups,okta-admin,editor" />
+- A more restrictive role mapping: <Var name="mapping_2" initial="groups,okta-dev,dev" />

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
@@ -212,8 +212,8 @@ Entra ID and issue certificates to users.
 (!docs/pages/includes/sso/role-mapping.mdx fieldType="claim"!)
 
 Note that the Entra ID `groups` claim includes group's object ID. As such, you
-will need to map groups by using groups object ID. Assign 
-<Var name="mapping_1"/> to the object ID of `ad-app-admin` and 
+will need to map groups by using groups object ID. Update the `groups` value in
+<Var name="mapping_1" /> to the object ID of `ad-app-admin` and
 <Var name="mapping_2" /> to the object ID of `ad-app-support`.
 
 ### Create an OIDC connector 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
@@ -37,12 +37,12 @@ like:
 ## Step 1/3. Configure GitLab
 
 You should have at least one group configured in GitLab to map to Teleport roles.
-In this example we use the names `gitlab-dev` and `gitlab-admin`.  Assign users
+In this example we use the names `devs` and `admins`.  Assign users
 to each of these groups.
 
 1. Create an application in one of your groups (**Group overview** ->
    **Settings** -> **Applications**) that will allow using GitLab as an OAuth
-   provider to Teleport. 
+   provider to Teleport.
 
    Assign <Var name="teleport.example.com" /> to your Teleport Proxy Service's
    public address. If you have a self-hosted cluster with multiple public
@@ -115,8 +115,8 @@ $ tctl sso configure oidc --preset gitlab \
 </TabItem>
 </Tabs>
 
-This example maps the two subgroups `admin` and `dev` of the parent group
-`company` to the `admin` and `dev` roles in Teleport, and creates the `oidc.yaml` file:
+This example maps the two subgroups `admins` and `devs` of the parent group
+`company` to the `auditor` and `access` roles in Teleport, and creates the `oidc.yaml` file:
 
 ```yaml
 kind: oidc
@@ -126,12 +126,13 @@ spec:
   claims_to_roles:
   - claim: groups
     roles:
-    - admin
-    value: company/admin
+    - auditor
+    - editor
+    value: company/admins
   - claim: groups
     roles:
-    - dev
-    value: company/gitlab-dev
+    - access
+    value: company/devs
   client_id: <APPLICATION-ID>
   client_secret: <APPLICATION-SECRET>
   display: GitLab

--- a/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
@@ -369,11 +369,12 @@ spec:
   - claim: groups
     roles:
     - auditor
-    value: auditor@example.com
+    - editor
+    value: admins@example.com
   - claim: groups
     roles:
     - access
-    value: teleport-developers@example.com
+    value: devs@example.com
   client_id: <CLIENT-ID>
   client_secret: <CLIENT-SECRET>
   display: Google
@@ -429,11 +430,11 @@ spec:
   - claim: groups
     roles:
     - auditor
-    value: auditor@example.com
+    value: admins@example.com
   - claim: groups
     roles:
     - access
-    value: teleport-developers@example.com
+    value: devs@example.com
   client_id: <CLIENT-ID>
   client_secret: <CLIENT-SECRET>
   display: Google

--- a/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
@@ -30,7 +30,7 @@ Keycloak groups. You can choose to configure other options.
 Before you get started, you’ll need:
 
 
-- An administrative account for the Keycloak Admin Console to manage realms 
+- An administrative account for the Keycloak Admin Console to manage realms
   and perform administrative tasks.
 - To be in a realm other than the master realm.
 - To register one or more users in the realm directory.
@@ -49,7 +49,7 @@ Before you get started, you’ll need:
 
 1. Select the Realm to be used for your SAML integration. Click **Clients** in the menu.
 
-1. Click **Create client** 
+1. Click **Create client**
 
    ![Create client](../../../../img/sso/keycloak/create_client.png)
 
@@ -84,7 +84,7 @@ Before you get started, you’ll need:
    ![Edit client scope](../../../../img/sso/keycloak/client_scope.png)
 
 1. On the Mappers tab, Click **Configure a new mapper**.
-   
+
    ![Configure mapper](../../../../img/sso/keycloak/configure_mapper.png)
 
 1. Select **Groups list** from the list of attribute mappings
@@ -148,8 +148,13 @@ spec:
   attributes_to_roles:
   - name: groups
     roles:
-    - dev
-    value: /devops
+    - editor
+    - auditor
+    value: /admins
+  - name: groups
+    roles:
+    - access
+    value: /devs
   audience: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   cert: ""
   display: ""
@@ -159,18 +164,18 @@ spec:
   service_provider_issuer: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   sso: ""
 version: v2
-``` 
+```
 
-To optionally test the auth connector, 
+To optionally test the auth connector,
 temporarily disable the **Client signature required** option
-by navigating to the **Keys** tab of the SAML client. 
-This will be enabled at a later step as you proceed through the guide. 
+by navigating to the **Keys** tab of the SAML client.
+This will be enabled at a later step as you proceed through the guide.
 
 ![Edit client scope](../../../../img/sso/keycloak/disable_signature.png)
 
 ### Test the connector
 
-With the connector in place on the cluster, you can test it with `tctl`: 
+With the connector in place on the cluster, you can test it with `tctl`:
 
 ```code
 $ cat keycloak-connector.yaml | tctl sso test
@@ -192,31 +197,31 @@ $ tctl create -f keycloak-connector.yaml
 
 ## Client Certificate Signature validation (Recommended)
 
-If Client Signature Required is enabled, 
-documents coming from the client are expected to be signed. 
-Keycloak will validate this signature using the client public key 
+If Client Signature Required is enabled,
+documents coming from the client are expected to be signed.
+Keycloak will validate this signature using the client public key
 or cert set up in the **Keys** tab.
 
 To have Keycloak require client signature validation from Teleport,
-you must configure the signing keys by generating and importing keys to Keycloak, 
+you must configure the signing keys by generating and importing keys to Keycloak,
 The client will sign their saml requests and responses and the signature will be validated.
 
 
 ### Create private keys for signing
 
-- Start by generating a private key and certificate. 
+- Start by generating a private key and certificate.
 
 ```code
 $ openssl genrsa -out priv.pem 2048
 $ openssl req -new -x509 -key priv.pem -out cert.pem
 ```
 
-- Convert the just generated certificate (in PEM format) to the PKCS#12 format 
+- Convert the just generated certificate (in PEM format) to the PKCS#12 format
 
 ```code
 openssl pkcs12 -in cert.pem -name teleport -export -out cert.pkcs12
 ```
-Take note of the **name** and the defined **export password** 
+Take note of the **name** and the defined **export password**
 as it will be used when importing the cert to Keycloak.
 
 ```code
@@ -232,13 +237,6 @@ metadata:
   name: keycloak
 spec:
   acs: https://mytenant.teleport.sh/v1/webapi/saml/acs/azure-saml
-  attributes_to_roles:
-  - name: groups
-    roles:
-    - editor
-    - access
-    - auditor
-    value: '*'
   audience: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   cert: ""
   display: Keycloak
@@ -281,9 +279,12 @@ spec:
   - name: groups
     roles:
     - editor
-    - access
     - auditor
-    value: '*'
+    value: /admins
+  - name: groups
+    roles:
+    - access
+    value: /devs
   audience: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   cert: ""
   display: Keycloak
@@ -317,7 +318,7 @@ Update the connector by saving and closing the file in your editor.
 
 ### Activate client signature validation
 
-- Navigate to **Clients** in left sidebar 
+- Navigate to **Clients** in left sidebar
 
 - Select your Teleport SAML client
 
@@ -346,7 +347,7 @@ If the SSO login with this connector is successful, the client signature validat
 
 ### Signature validation incompatibility
 
-When "Client signature required" is enabled with the appropriate signing keys, 
+When "Client signature required" is enabled with the appropriate signing keys,
 it results in an invalid requester error as shown in the image below.
 
 ![Import certificate](../../../../img/sso/keycloak/invalid_requester.png)
@@ -358,8 +359,8 @@ This occurs when Keycloak receives a SAML request that does not meet its signatu
 which causes Keycloak to fail when attempting to verify the SAML signature.
 
 To resolve the issue:
-- Refer to the **Client Certificate Signature validation** section 
-  to review the certificate configuration. Ensure the certificate is up-to-date 
-  and the private key is properly paired with it. 
-- Once the above has been verified, temporarily add the `spec.provider: ping` parameter 
+- Refer to the **Client Certificate Signature validation** section
+  to review the certificate configuration. Ensure the certificate is up-to-date
+  and the private key is properly paired with it.
+- Once the above has been verified, temporarily add the `spec.provider: ping` parameter
   to the Keycloak auth connector to match Keycloak strict signature requirements.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/keycloak.mdx
@@ -236,7 +236,7 @@ kind: saml
 metadata:
   name: keycloak
 spec:
-  acs: https://mytenant.teleport.sh/v1/webapi/saml/acs/azure-saml
+  acs: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   audience: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   cert: ""
   display: Keycloak
@@ -274,7 +274,7 @@ kind: saml
 metadata:
   name: keycloak
 spec:
-  acs: https://mytenant.teleport.sh/v1/webapi/saml/acs/azure-saml
+  acs: https://mytenant.teleport.sh/v1/webapi/saml/acs/keycloak
   attributes_to_roles:
   - name: groups
     roles:

--- a/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
@@ -12,7 +12,7 @@ enterprise: Enterprise SSO
 
 This guide will explain how to configure an SSO provider using [OpenID
 Connect](http://openid.net/connect/) (also known as OIDC) to issue Teleport
-credentials to specific groups of users. When used in combination with role-based 
+credentials to specific groups of users. When used in combination with role-based
 access control (RBAC), OIDC allows Teleport administrators to define
 policies like:
 
@@ -138,9 +138,10 @@ spec:
   - claim: groups
     roles:
     - access
-    value: /users
+    value: /devs
   - claim: groups
     roles:
+    - auditor
     - editor
     value: /admins
   client_id: teleport

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -199,15 +199,15 @@ metadata:
 spec:
   acs: https://teleport.example.com:443/v1/webapi/saml/acs/okta
   attributes_to_roles:
-    - name: groups
-      roles:
-        - auditor
-        - editor
-      value: admins
-    - name: groups
-      roles:
-        - access
-      value: dev
+  - name: groups
+    roles:
+    - auditor
+    - editor
+    value: admins
+  - name: groups
+    roles:
+    - access
+    value: dev
   audience: https://teleport.example.com:443/v1/webapi/saml/acs/okta
   cert: ''
   display: 'Okta'

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -209,13 +209,13 @@ spec:
     - access
     value: dev
   audience: https://teleport.example.com:443/v1/webapi/saml/acs/okta
-  cert: ''
-  display: 'Okta'
-  entity_descriptor: ''
+  cert: ""
+  display: "Okta"
+  entity_descriptor: ""
   entity_descriptor_url: https://example.okta.com/app/000000/sso/saml/metadata
-  issuer: ''
+  issuer: ""
   service_provider_issuer: https://teleport.example.com:443/v1/webapi/saml/acs/okta
-  sso: ''
+  sso: ""
 version: v2
 ```
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/okta.mdx
@@ -47,24 +47,24 @@ Then follow the instructions for the [guided Okta single sign-on integration](..
 (!docs/pages/includes/edition-prereqs-tabs.mdx edition="Teleport Enterprise"!)
 
 - A Teleport role with access to edit and maintain `saml` resources. This is
-  available in the default `editor` role.
+  available in the default `auditor` and `editor` roles.
 
 ## Step 1/3. Configure Okta
 
 Okta indicates a user's group membership as a SAML assertion in the data it
-provides to Teleport. We will configure Teleport to assign the "dev" role to
-members of the `okta-dev` Okta group, and the preset "editor" role to members of
-the `okta-admin` group.
+provides to Teleport. We will configure Teleport to assign the "access" role to
+members of the `devs` Okta group, and the preset "auditor" and "editor" roles to members of
+the `admins` group.
 
-If you already have Okta groups you want to assign to "dev" and "editor" roles in
+If you already have Okta groups you want to assign to "access", "auditor" and "editor" roles in
 Teleport, you can skip to the [next step](#step-13-configure-okta).
 
 ### Create Groups
 
-Create two groups: "okta-dev" and "okta-admin".
+Create two groups: "devs" and "admins".
 
 1. In Okta Console go to the go to **Directory** -> **Groups**, then click **Add group**.
-2. Add groups "okta-dev" and "okta-admin" with optional description.
+2. Add groups "devs" and "admins" with optional description.
 
 
 ### Create and configure an Okta app
@@ -106,21 +106,21 @@ Okta Integration Network support is still in beta. If unsure please proceed with
   5. That will bring you to the "Configure SAML" step where you'll have to provide a several values:
 
      - Single sign on URL:
- 
+
        ```
        https://<Var name="example.teleport.sh" />/v1/webapi/saml/acs/okta
        ```
- 
+
      - Audience URI (SP Entity ID):
- 
+
        ```
        https://<Var name="example.teleport.sh" />/v1/webapi/saml/acs/okta
        ```
- 
+
      - Name ID format `EmailAddress`
- 
-     - Application username `Okta username` 
- 
+
+     - Application username `Okta username`
+
      {/* NOTE: This image is shared in multiple guides. */}
      ![SAML general settings](../../../../img/sso/okta/legacy-general-settings.png)
 
@@ -147,7 +147,7 @@ Okta Integration Network support is still in beta. If unsure please proceed with
 
 1. In the same Okta Teleport app, go to the **Assignments** tab and click the **Assign** dropdown.
 
-2. Select "Assign to Groups" and search for the "okta-dev" and "okta-admin" Okta groups created in the previous step.
+2. Select "Assign to Groups" and search for the "devs" and "admins" Okta groups created in the previous step.
 
 3. Click **Assign** next to each selected group and click **Done**.
 
@@ -199,22 +199,23 @@ metadata:
 spec:
   acs: https://teleport.example.com:443/v1/webapi/saml/acs/okta
   attributes_to_roles:
-  - name: groups
-    roles:
-    - editor
-    value: okta-admin
-  - name: groups
-    roles:
-    - dev
-    value: okta-dev
+    - name: groups
+      roles:
+        - auditor
+        - editor
+      value: admins
+    - name: groups
+      roles:
+        - access
+      value: dev
   audience: https://teleport.example.com:443/v1/webapi/saml/acs/okta
-  cert: ""
-  display: "Okta"
-  entity_descriptor: ""
+  cert: ''
+  display: 'Okta'
+  entity_descriptor: ''
   entity_descriptor_url: https://example.okta.com/app/000000/sso/saml/metadata
-  issuer: ""
+  issuer: ''
   service_provider_issuer: https://teleport.example.com:443/v1/webapi/saml/acs/okta
-  sso: ""
+  sso: ''
 version: v2
 ```
 
@@ -233,13 +234,14 @@ Success! Logged in as: alice@example.com
 --------------------------------------------------------------------------------
 Authentication details:
    roles:
+   - auditor
    - editor
-   - dev
+   - access
    traits:
      groups:
      - Everyone
-     - okta-admin
-     - okta-dev
+     - admins
+     - devs
      username:
      - alice@example.com
    username: alice@example.com
@@ -247,19 +249,20 @@ Authentication details:
 [SAML] Attributes to roles:
 - name: groups
   roles:
+  - auditor
   - editor
-  value: okta-admin
+  value: admins
 - name: groups
   roles:
   - dev
-  value: okta-dev
+  value: devs
 
 --------------------------------------------------------------------------------
 [SAML] Attributes statements:
 groups:
 - Everyone
-- okta-admin
-- okta-dev
+- admins
+- devs
 username:
 - alice@example.com
 

--- a/examples/resources/oidc-connector.yaml
+++ b/examples/resources/oidc-connector.yaml
@@ -6,9 +6,10 @@ spec:
   - claim: groups
     roles:
     - access
-    value: users
+    value: devs
   - claim: groups
     roles:
+    - auditor
     - editor
     value: admins
   client_id: <CLIENT-NAME>

--- a/examples/resources/onelogin-connector.yaml
+++ b/examples/resources/onelogin-connector.yaml
@@ -7,12 +7,13 @@ spec:
   attributes_to_roles:
   - name: groups
     roles:
+    - auditor
     - editor
-    value: admin
+    value: admins
   - name: groups
     roles:
     - access
-    value: dev
+    value: devs
   audience: https://teleport.example.com:443/v1/webapi/saml/acs/onelogin
   cert: ""
   display: OneLogin


### PR DESCRIPTION
Just followed the [Okta SSO guide](https://goteleport.com/docs/zero-trust-access/sso/integrate-idp/okta/) while investigating https://github.com/gravitational/teleport/issues/62790. Ran into some issues with the doc because the group to role mappings are inconsistent with the whole doc.

Took another look at the other SSO guides and they also have problems, so I went through most of them that referenced `docs/pages/includes/sso/role-mapping.mdx` and tried to make them more consistent.

## Changes

1. We're now consistently using claim `groups` instead of `group`. The latter is incorrect for Okta, Keycloak, etc.
1. The default value for most of the guides now consistently use groups `admins` and `devs`. 
1. Users of group `admins` get the `auditor` and `editor` preset roles.
1. Users of group `dev` get the `access` preset role.
1. Fixed Keycloak guide was referencing Azure SAML URL.

## Backport?

Manual backport is needed for v18. No backport for v17 because it follows a different structure that was intro'd in v18.

## Manual tests

### Walkthrough Okta guide - PASSED ✅ 

My Okta connector config works as expected.

```yaml
kind: saml
metadata:
  name: okta
spec:
  acs: https://teleport.dev/v1/webapi/saml/acs/okta
  attributes_to_roles:
  - name: groups
    roles:
    - auditor
    - editor
    value: admins
  - name: groups
    roles:
    - access
    value: devs
  audience: https://teleport.dev/v1/webapi/saml/acs/okta
  cert: ""
  display: Okta
  entity_descriptor: ""
  entity_descriptor_url: https://[REDACTED].okta.com/app/[REDACTED]/sso/saml/metadata
  issuer: ""
  service_provider_issuer: https://teleport.dev/v1/webapi/saml/acs/okta
  sso: ""
  mfa:
    enabled: true
    entity_descriptor_url: https://[REDACTED].okta.com/app/[REDACTED]/sso/saml/metadata
    force_reauth: false
version: v2
```

### Walkthrough Keycloak guide - PASSED ✅ 

My Keycloak connector config works as expected.

```yaml
kind: saml
metadata:
  name: Keycloak
spec:
  acs: https://teleport.dev/v1/webapi/saml/acs/keycloak
  attributes_to_roles:
  - name: groups
    roles:
    - editor
    - auditor
    value: /admins
  - name: groups
    roles:
    - access
    value: /devs
  audience: https://teleport.dev/v1/webapi/saml/acs/keycloak
  cert: ""
  display: ""
  entity_descriptor: ""
  entity_descriptor_url: https://keycloak.dev:8443/realms/dev/protocol/saml/descriptor
  issuer: ""
  service_provider_issuer: https://teleport.dev/v1/webapi/saml/acs/keycloak
  sso: ""
  mfa:
    enabled: true
    entity_descriptor_url: https://keycloak.dev:8443/realms/dev/protocol/saml/descriptor
    force_reauth: false
version: v2
```

Note: Since I only have access to Okta and Keycloak, I can only test those. The changes are string value changes, so I don't expect them to break anything.