### PR TITLE
Add custom compare.Equal library as replacment for gocmp.Equal

### DIFF
--- a/api/types/compare/equal.go
+++ b/api/types/compare/equal.go
@@ -16,7 +16,92 @@ limitations under the License.
 
 package compare
 
-// IsEqual[T] will be used instead of cmp.Equal if a resource implements it.
+// IsEqual will be used instead of cmp.Equal if a resource implements it.
 type IsEqual[T any] interface {
 	IsEqual(T) bool
+}
+
+// Equal compares two objects for semantic equality using their IsEqual method.
+// The type T must implement IsEqual(T) bool and Clone() T methods.
+//
+// NOTE: this function by default CLONE the input objects before comparison to avoid
+// modifying the originals. Use WithSkipClone() to skip cloning if the inputs can be
+// safely modified. Use WithTransform() to apply custom field resets before comparison.
+// Use WithEqualFunc() to provide a custom equality function instead of using IsEqual.
+//
+// Example:
+//
+// Suppose you want to compare a resource during reconciliation.
+// You may already know that some spec fields should be excluded from the comparison,
+// because they are not relevant for your use case.
+//
+// For example, AccessList reconciliation may build objects on the fly where many fields
+// are unknown in the desired state but are populated by other flows.
+// In that case, you may want to reset/ignore those fields before comparing.
+//
+//	isEqual := compare.Equal(memberFromDesiredState, memberFromBackend,
+//	    compare.WithTransform(func(m *AccessListMember) {
+//	        m.Spec.IneligibleStatus = ""
+//	        m.Spec.AddedBy = ""
+//	        m.Spec.Reason = ""
+//	        m.Spec.Expires = time.Time{}
+//	        m.Spec.Joined = time.Time{}
+//	    }),
+//	)
+func Equal[T resource[T]](a, b T, opts ...EqualOption[T]) bool {
+	cfg := equalConfig[T]{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if !cfg.skipClone {
+		a = a.Clone()
+		b = b.Clone()
+	}
+	for _, resetFn := range cfg.transformFuncs {
+		resetFn(a)
+		resetFn(b)
+	}
+	if cfg.equalFunc != nil {
+		return cfg.equalFunc(a, b)
+	}
+	return a.IsEqual(b)
+}
+
+// WithSkipClone configures Equal to skip cloning and directly mutate the input objects.
+// Use this option only when you're certain the input objects can be safely modified
+// (e.g., they're already clones or will be discarded after comparison).
+func WithSkipClone[T any]() EqualOption[T] {
+	return func(c *equalConfig[T]) {
+		c.skipClone = true
+	}
+}
+
+// WithTransform configures Equal to apply a custom field reset function before comparison.
+// Multiple reset functions can be added and will be applied in order.
+func WithTransform[T any](resetFn func(T)) EqualOption[T] {
+	return func(c *equalConfig[T]) {
+		c.transformFuncs = append(c.transformFuncs, resetFn)
+	}
+}
+
+// WithEqualFunc configures Equal to use a custom equality function instead of IsEqual method.
+// This is useful when you want to use a different equality method (for example IsEqualV2)
+func WithEqualFunc[T any](equalFn func(T, T) bool) EqualOption[T] {
+	return func(c *equalConfig[T]) {
+		c.equalFunc = equalFn
+	}
+}
+
+type resource[T any] interface {
+	IsEqual[T]
+	Clone() T
+}
+
+// EqualOption is a functional option for configuring the behavior of Equal.
+type EqualOption[T any] func(*equalConfig[T])
+
+type equalConfig[T any] struct {
+	skipClone      bool
+	transformFuncs []func(T)
+	equalFunc      func(T, T) bool
 }

--- a/api/types/compare/equal_test.go
+++ b/api/types/compare/equal_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package compare
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// item is a simple test type that implements IsEqual and Cloner interfaces
+type item struct {
+	name  string
+	value int
+}
+
+func (t *item) IsEqual(other *item) bool {
+	return t.name == other.name && t.value == other.value
+}
+
+func (t *item) Clone() *item {
+	if t == nil {
+		return nil
+	}
+	return &item{name: t.name, value: t.value}
+}
+
+func TestEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *item
+		b        *item
+		opts     []EqualOption[*item]
+		expected bool
+	}{
+		{
+			name:     "equal objects",
+			a:        &item{name: "test", value: 42},
+			b:        &item{name: "test", value: 42},
+			expected: true,
+		},
+		{
+			name:     "different values",
+			a:        &item{name: "test", value: 42},
+			b:        &item{name: "test", value: 43},
+			expected: false,
+		},
+		{
+			name:     "different names",
+			a:        &item{name: "test1", value: 42},
+			b:        &item{name: "test2", value: 42},
+			expected: false,
+		},
+		{
+			name: "ignore value with reset function",
+			a:    &item{name: "test", value: 42},
+			b:    &item{name: "test", value: 100},
+			opts: []EqualOption[*item]{
+				WithTransform(func(obj *item) { obj.value = 0 }),
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Equal(tt.a, tt.b, tt.opts...)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEqualWithFunc(t *testing.T) {
+	t.Run("custom equal func ignores value field", func(t *testing.T) {
+		a := &item{name: "test", value: 42}
+		b := &item{name: "test", value: 100}
+
+		// Without custom equal func, they are not equal
+		require.False(t, Equal(a, b))
+
+		// With custom equal func that only compares names, they are equal
+		result := Equal(a, b, WithEqualFunc(func(x, y *item) bool { return x.name == y.name }))
+		require.True(t, result)
+	})
+
+	t.Run("combine reset fields with custom equal func", func(t *testing.T) {
+		c := &item{name: "test", value: 42}
+		d := &item{name: "test", value: 100}
+
+		result := Equal(c, d,
+			WithTransform(func(obj *item) { obj.value = 0 }),
+			WithEqualFunc(func(x, y *item) bool { return x.name == y.name }),
+		)
+		require.True(t, result)
+	})
+
+	t.Run("skip clone modifies originals", func(t *testing.T) {
+		a := &item{name: "test", value: 42}
+		b := &item{name: "test", value: 100}
+
+		originalValueA := a.value
+		originalValueB := b.value
+
+		result := Equal(a, b, WithTransform(func(obj *item) { obj.value = 0 }))
+
+		require.True(t, result)
+		require.Equal(t, originalValueA, a.value)
+		require.Equal(t, originalValueB, b.value)
+
+		// With WithSkipClone, originals should be modified
+		result = Equal(a, b, WithSkipClone[*item](), WithTransform(func(obj *item) { obj.value = 0 }))
+		require.True(t, result)
+		require.NotEqual(t, originalValueA, a.value)
+		require.NotEqual(t, originalValueB, b.value)
+	})
+}


### PR DESCRIPTION
### What

We use equality checks in many places. In some cases the comparison needs custom behavior such as ignoring specific fields that are not relevant for reconciliation treating slices as equal even when element order differs or handling nil and empty values as equivalent.

 this logic was often implemented using gocmp.Equal. However using gocmp in production code is considered an anti pattern due to performance cpu overhead and many allocations 


### Why 

The goal of compare.Equal is to provide a consistent, reusable interface for resource comparisons where custom logic is required. This also helps ensure that equality semantics are aligned across services and avoids each caller implementing slightly different behavior.

For instance: 

https://github.com/gravitational/teleport/pull/63483
