### PR TITLE
[v18] Backport operator synchronous tests

### DIFF
--- a/integrations/operator/apis/resources/scheme.go
+++ b/integrations/operator/apis/resources/scheme.go
@@ -1,0 +1,44 @@
+/*
+ * Teleport
+ * Copyright (C) 2025  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package resources
+
+import (
+	"github.com/gravitational/trace"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
+	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
+	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
+	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
+)
+
+func AddToScheme(scheme *runtime.Scheme) error {
+	return trace.NewAggregate(
+		resourcesv1.AddToScheme(scheme),
+		resourcesv2.AddToScheme(scheme),
+		resourcesv3.AddToScheme(scheme),
+		resourcesv5.AddToScheme(scheme),
+	)
+}
+
+func NewScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := AddToScheme(scheme)
+	return scheme, trace.Wrap(err)
+}

--- a/integrations/operator/apis/resources/teleportcr/constants.go
+++ b/integrations/operator/apis/resources/teleportcr/constants.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package resources
+package teleportcr
 
 const (
 	GroupName      = "resources.teleport.dev"

--- a/integrations/operator/apis/resources/teleportcr/status.go
+++ b/integrations/operator/apis/resources/teleportcr/status.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2025  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package resources
+package teleportcr
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/integrations/operator/apis/resources/v1/accesslist_types.go
+++ b/integrations/operator/apis/resources/v1/accesslist_types.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	accesslist "github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -38,7 +38,7 @@ type TeleportAccessList struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportAccessListSpec `json:"spec,omitempty"`
-	Status resources.Status       `json:"status,omitempty"`
+	Status teleportcr.Status      `json:"status,omitempty"`
 }
 
 // TeleportAccessListSpec defines the desired state of TeleportProvisionToken
@@ -64,7 +64,7 @@ func (l TeleportAccessList) ToTeleport() *accesslist.AccessList {
 			Version: types.V1,
 			Metadata: header.Metadata{
 				Name:        l.Name,
-				Description: l.Annotations[resources.DescriptionKey],
+				Description: l.Annotations[teleportcr.DescriptionKey],
 				Labels:      l.Labels,
 			},
 		},

--- a/integrations/operator/apis/resources/v1/appv3_types.go
+++ b/integrations/operator/apis/resources/v1/appv3_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportAppV3 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportAppV3Spec `json:"spec,omitempty"`
-	Status resources.Status  `json:"status,omitempty"`
+	Status teleportcr.Status `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportAppV3) ToTeleport() types.Application {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.AppSpecV3(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/autoupdateconfigv1_types.go
+++ b/integrations/operator/apis/resources/v1/autoupdateconfigv1_types.go
@@ -26,7 +26,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -48,7 +48,7 @@ type TeleportAutoupdateConfigV1 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   *TeleportAutoupdateConfigV1Spec `json:"spec,omitempty"`
-	Status resources.Status                `json:"status,omitempty"`
+	Status teleportcr.Status               `json:"status,omitempty"`
 }
 
 // TeleportAutoupdateConfigV1Spec defines the desired state of TeleportAutoupdateConfigV1
@@ -70,7 +70,7 @@ func (l *TeleportAutoupdateConfigV1) ToTeleport() *autoupdatev1pb.AutoUpdateConf
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*autoupdatev1pb.AutoUpdateConfigSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/autoupdateversionv1_types.go
+++ b/integrations/operator/apis/resources/v1/autoupdateversionv1_types.go
@@ -26,7 +26,7 @@ import (
 	autoupdatev1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -48,7 +48,7 @@ type TeleportAutoupdateVersionV1 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   *TeleportAutoupdateVersionV1Spec `json:"spec,omitempty"`
-	Status resources.Status                 `json:"status,omitempty"`
+	Status teleportcr.Status                `json:"status,omitempty"`
 }
 
 // TeleportAutoupdateVersionV1Spec defines the desired state of TeleportAutoupdateVersionV1
@@ -70,7 +70,7 @@ func (l *TeleportAutoupdateVersionV1) ToTeleport() *autoupdatev1pb.AutoUpdateVer
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*autoupdatev1pb.AutoUpdateVersionSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/botv1_types.go
+++ b/integrations/operator/apis/resources/v1/botv1_types.go
@@ -26,7 +26,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -42,7 +42,7 @@ type TeleportBotV1 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   *TeleportBotV1Spec `json:"spec,omitempty"`
-	Status resources.Status   `json:"status,omitempty"`
+	Status teleportcr.Status  `json:"status,omitempty"`
 }
 
 // TeleportBotV1Spec defines the desired state of TeleportBotV1
@@ -66,7 +66,7 @@ func (l *TeleportBotV1) ToTeleport() *machineidv1.Bot {
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*machineidv1.BotSpec)(l.Spec),

--- a/integrations/operator/apis/resources/v1/databasev3_types.go
+++ b/integrations/operator/apis/resources/v1/databasev3_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportDatabaseV3 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportDatabaseV3Spec `json:"spec,omitempty"`
-	Status resources.Status       `json:"status,omitempty"`
+	Status teleportcr.Status      `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportDatabaseV3) ToTeleport() types.Database {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.DatabaseSpecV3(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/groupversion_info.go
+++ b/integrations/operator/apis/resources/v1/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v1"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v1/loginrule_types.go
+++ b/integrations/operator/apis/resources/v1/loginrule_types.go
@@ -24,7 +24,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/wrappers"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,7 +40,7 @@ type TeleportLoginRule struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportLoginRuleSpec `json:"spec,omitempty"`
-	Status resources.Status      `json:"status,omitempty"`
+	Status teleportcr.Status     `json:"status,omitempty"`
 }
 
 // TeleportLoginRuleSpec matches the JSON of generated CRD spec
@@ -69,7 +69,7 @@ func (l TeleportLoginRule) ToTeleport() *LoginRuleResource {
 			Metadata: &types.Metadata{
 				Name:        l.Name,
 				Labels:      l.Labels,
-				Description: l.Annotations[resources.DescriptionKey],
+				Description: l.Annotations[teleportcr.DescriptionKey],
 			},
 			Version:          types.V1,
 			Priority:         l.Spec.Priority,

--- a/integrations/operator/apis/resources/v1/okta_import_rule.go
+++ b/integrations/operator/apis/resources/v1/okta_import_rule.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -39,7 +39,7 @@ type TeleportOktaImportRule struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportOktaImportRuleSpec `json:"spec,omitempty"`
-	Status resources.Status           `json:"status,omitempty"`
+	Status teleportcr.Status          `json:"status,omitempty"`
 }
 
 // TeleportOktaImportRuleSpec matches the JSON of generated CRD spec
@@ -80,7 +80,7 @@ func (o TeleportOktaImportRule) ToTeleport() types.OktaImportRule {
 			Metadata: types.Metadata{
 				Name:        o.Name,
 				Labels:      o.Labels,
-				Description: o.Annotations[resources.DescriptionKey],
+				Description: o.Annotations[teleportcr.DescriptionKey],
 			},
 			Version: types.V1,
 		},

--- a/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/openssheicserverv2_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportOpenSSHEICEServerV2 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportOpenSSHEICEServerV2Spec `json:"spec,omitempty"`
-	Status resources.Status                `json:"status,omitempty"`
+	Status teleportcr.Status               `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -61,7 +61,7 @@ func (r TeleportOpenSSHEICEServerV2) ToTeleport() types.Server {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ServerSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/opensshserverv2_types.go
+++ b/integrations/operator/apis/resources/v1/opensshserverv2_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportOpenSSHServerV2 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportOpenSSHServerV2Spec `json:"spec,omitempty"`
-	Status resources.Status            `json:"status,omitempty"`
+	Status teleportcr.Status           `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -61,7 +61,7 @@ func (r TeleportOpenSSHServerV2) ToTeleport() types.Server {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ServerSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev6_types.go
+++ b/integrations/operator/apis/resources/v1/rolev6_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV6 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportRoleV6Spec `json:"spec,omitempty"`
-	Status resources.Status   `json:"status,omitempty"`
+	Status teleportcr.Status  `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV6) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev7_types.go
+++ b/integrations/operator/apis/resources/v1/rolev7_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV7 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportRoleV7Spec `json:"spec,omitempty"`
-	Status resources.Status   `json:"status,omitempty"`
+	Status teleportcr.Status  `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV7) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/rolev8_types.go
+++ b/integrations/operator/apis/resources/v1/rolev8_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportRoleV8 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportRoleV8Spec `json:"spec,omitempty"`
-	Status resources.Status   `json:"status,omitempty"`
+	Status teleportcr.Status  `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRoleV8) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/trusted_cluster_types.go
+++ b/integrations/operator/apis/resources/v1/trusted_cluster_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -38,7 +38,7 @@ type TeleportTrustedClusterV2 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportTrustedClusterV2Spec `json:"spec,omitempty"`
-	Status resources.Status             `json:"status,omitempty"`
+	Status teleportcr.Status            `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -58,7 +58,7 @@ func (r TeleportTrustedClusterV2) ToTeleport() types.TrustedCluster {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.TrustedClusterSpecV2(r.Spec),
 	}

--- a/integrations/operator/apis/resources/v1/workload_identityv1_types.go
+++ b/integrations/operator/apis/resources/v1/workload_identityv1_types.go
@@ -26,7 +26,7 @@ import (
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -43,7 +43,7 @@ type TeleportWorkloadIdentityV1 struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   *TeleportWorkloadIdentityV1Spec `json:"spec,omitempty"`
-	Status resources.Status                `json:"status,omitempty"`
+	Status teleportcr.Status               `json:"status,omitempty"`
 }
 
 // TeleportWorkloadIdentityV1Spec defines the desired state of TeleportWorkloadIdentityV1
@@ -67,7 +67,7 @@ func (l *TeleportWorkloadIdentityV1) ToTeleport() *workloadidentityv1.WorkloadId
 		Version: types.V1,
 		Metadata: &headerv1.Metadata{
 			Name:        l.Name,
-			Description: l.Annotations[resources.DescriptionKey],
+			Description: l.Annotations[teleportcr.DescriptionKey],
 			Labels:      l.Labels,
 		},
 		Spec: (*workloadidentityv1.WorkloadIdentitySpec)(l.Spec),

--- a/integrations/operator/apis/resources/v2/groupversion_info.go
+++ b/integrations/operator/apis/resources/v2/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v2"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v2"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v2/provisiontoken_types.go
+++ b/integrations/operator/apis/resources/v2/provisiontoken_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportProvisionToken struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportProvisionTokenSpec `json:"spec,omitempty"`
-	Status resources.Status           `json:"status,omitempty"`
+	Status teleportcr.Status          `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportProvisionToken) ToTeleport() types.ProvisionToken {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.ProvisionTokenSpecV2(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v2/samlconnector_types.go
+++ b/integrations/operator/apis/resources/v2/samlconnector_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportSAMLConnector struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportSAMLConnectorSpec `json:"spec,omitempty"`
-	Status resources.Status          `json:"status,omitempty"`
+	Status teleportcr.Status         `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportSAMLConnector) ToTeleport() types.SAMLConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.SAMLConnectorSpecV2(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v2/user_types.go
+++ b/integrations/operator/apis/resources/v2/user_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,8 +40,8 @@ type TeleportUser struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   TeleportUserSpec `json:"spec,omitempty"`
-	Status resources.Status `json:"status,omitempty"`
+	Spec   TeleportUserSpec  `json:"spec,omitempty"`
+	Status teleportcr.Status `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (u TeleportUser) ToTeleport() types.User {
 		Metadata: types.Metadata{
 			Name:        u.Name,
 			Labels:      u.Labels,
-			Description: u.Annotations[resources.DescriptionKey],
+			Description: u.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.UserSpecV2(u.Spec),
 	}

--- a/integrations/operator/apis/resources/v3/githubconnector_types.go
+++ b/integrations/operator/apis/resources/v3/githubconnector_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -41,7 +41,7 @@ type TeleportGithubConnector struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportGithubConnectorSpec `json:"spec,omitempty"`
-	Status resources.Status            `json:"status,omitempty"`
+	Status teleportcr.Status           `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (c TeleportGithubConnector) ToTeleport() types.GithubConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.GithubConnectorSpecV3(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v3/groupversion_info.go
+++ b/integrations/operator/apis/resources/v3/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v3"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v3"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v3/oidcconnector_types.go
+++ b/integrations/operator/apis/resources/v3/oidcconnector_types.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -44,7 +44,7 @@ type TeleportOIDCConnector struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	Spec   TeleportOIDCConnectorSpec `json:"spec,omitempty"`
-	Status resources.Status          `json:"status,omitempty"`
+	Status teleportcr.Status         `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -63,7 +63,7 @@ func (c TeleportOIDCConnector) ToTeleport() types.OIDCConnector {
 		Metadata: types.Metadata{
 			Name:        c.Name,
 			Labels:      c.Labels,
-			Description: c.Annotations[resources.DescriptionKey],
+			Description: c.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.OIDCConnectorSpecV3(c.Spec),
 	}

--- a/integrations/operator/apis/resources/v5/groupversion_info.go
+++ b/integrations/operator/apis/resources/v5/groupversion_info.go
@@ -25,12 +25,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: resources.GroupName, Version: "v5"}
+	GroupVersion = schema.GroupVersion{Group: teleportcr.GroupName, Version: "v5"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/integrations/operator/apis/resources/v5/role_types.go
+++ b/integrations/operator/apis/resources/v5/role_types.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 func init() {
@@ -40,8 +40,8 @@ type TeleportRole struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   TeleportRoleSpec `json:"spec,omitempty"`
-	Status resources.Status `json:"status,omitempty"`
+	Spec   TeleportRoleSpec  `json:"spec,omitempty"`
+	Status teleportcr.Status `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true
@@ -60,7 +60,7 @@ func (r TeleportRole) ToTeleport() types.Role {
 		Metadata: types.Metadata{
 			Name:        r.Name,
 			Labels:      r.Labels,
-			Description: r.Annotations[resources.DescriptionKey],
+			Description: r.Annotations[teleportcr.DescriptionKey],
 		},
 		Spec: types.RoleSpecV6(r.Spec),
 	}

--- a/integrations/operator/controllers/reconcilers/generic_test.go
+++ b/integrations/operator/controllers/reconcilers/generic_test.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 )
 
 // newFakeTeleportResource creates a fakeTeleportResource
@@ -118,7 +118,7 @@ func (f *fakeTeleportResourceClient) resourceExists(name string) bool {
 // Its corresponding TeleportResource is fakeTeleportResource.
 type fakeTeleportKubernetesResource struct {
 	kclient.Object
-	status resources.Status
+	status teleportcr.Status
 }
 
 // ToTeleport implements the TeleportKubernetesResource interface.

--- a/integrations/operator/controllers/resources/appv3_controller_test.go
+++ b/integrations/operator/controllers/resources/appv3_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -125,15 +126,15 @@ func (g *appV3TestingPrimitives) CompareTeleportAndKubernetesResource(tResource 
 
 func TestTeleportAppV3Creation(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Application, *resourcesv1.TeleportAppV3](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3DeletionDrift(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Application, *resourcesv1.TeleportAppV3](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }
 
 func TestTeleportAppV3Update(t *testing.T) {
 	test := &appV3TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Application, *resourcesv1.TeleportAppV3](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Application, *resourcesv1.TeleportAppV3](t, resources.NewAppV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateconfig_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -168,15 +169,30 @@ func (g *autoUpdateConfigTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestAutoUpdateConfigCreation(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceCreationTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](t, test)
+	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+		t,
+		resources.NewAutoUpdateConfigV1Reconciler,
+		test,
+		testlib.WithResourceName(types.MetaNameAutoUpdateConfig),
+	)
 }
 
 func TestAutoUpdateConfigDeletionDrift(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+		t,
+		resources.NewAutoUpdateConfigV1Reconciler,
+		test,
+		testlib.WithResourceName(types.MetaNameAutoUpdateConfig),
+	)
 }
 
 func TestAutoUpdateConfigUpdate(t *testing.T) {
 	test := &autoUpdateConfigTestingPrimitives{}
-	testlib.ResourceUpdateTest[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](t, test)
+	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateConfig, *resourcesv1.TeleportAutoupdateConfigV1](
+		t,
+		resources.NewAutoUpdateConfigV1Reconciler,
+		test,
+		testlib.WithResourceName(types.MetaNameAutoUpdateConfig),
+	)
 }

--- a/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
+++ b/integrations/operator/controllers/resources/autoupdateversion_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport/api/types/autoupdate"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -148,15 +149,30 @@ func (g *autoUpdateVersionTestingPrimitives) CompareTeleportAndKubernetesResourc
 
 func TestAutoUpdateVersionCreation(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceCreationTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](t, test)
+	testlib.ResourceCreationSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+		t,
+		resources.NewAutoUpdateVersionV1Reconciler,
+		test,
+		testlib.WithResourceName("autoupdate-version"),
+	)
 }
 
 func TestAutoUpdateVersionDeletionDrift(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+		t,
+		resources.NewAutoUpdateVersionV1Reconciler,
+		test,
+		testlib.WithResourceName("autoupdate-version"),
+	)
 }
 
 func TestAutoUpdateVersionUpdate(t *testing.T) {
 	test := &autoUpdateVersionTestingPrimitives{}
-	testlib.ResourceUpdateTest[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](t, test)
+	testlib.ResourceUpdateTestSynchronous[*autoupdatev1pb.AutoUpdateVersion, *resourcesv1.TeleportAutoupdateVersionV1](
+		t,
+		resources.NewAutoUpdateVersionV1Reconciler,
+		test,
+		testlib.WithResourceName("autoupdate-version"),
+	)
 }

--- a/integrations/operator/controllers/resources/botv1_controller_test.go
+++ b/integrations/operator/controllers/resources/botv1_controller_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib/defaults"
 )
@@ -164,15 +165,15 @@ func (g *botTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestBotCreation(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceCreationTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, test)
+	testlib.ResourceCreationSynchronousTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotDeletionDrift(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
 }
 
 func TestBotUpdate(t *testing.T) {
 	test := &botTestingPrimitives{}
-	testlib.ResourceUpdateTest[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, test)
+	testlib.ResourceUpdateTestSynchronous[*machineidv1.Bot, *resourcesv1.TeleportBotV1](t, resources.NewBotV1Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/databasev3_controller_test.go
+++ b/integrations/operator/controllers/resources/databasev3_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -118,15 +119,15 @@ func (g *databaseV3TestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func TestTeleportDatabaseV3Creation(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3DeletionDrift(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }
 
 func TestTeleportDatabaseV3Update(t *testing.T) {
 	test := &databaseV3TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Database, *resourcesv1.TeleportDatabaseV3](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Database, *resourcesv1.TeleportDatabaseV3](t, resources.NewDatabaseV3Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
+++ b/integrations/operator/controllers/resources/okta_import_rule_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -162,17 +163,17 @@ func (g *oktaImportRuleTestingPrimitives) CompareTeleportAndKubernetesResource(t
 func TestOktaImportRuleCreation(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceCreationTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
+	testlib.ResourceCreationSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleDeletionDrift(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }
 
 func TestOktaImportRuleUpdate(t *testing.T) {
 	t.Skip("Skipping test since okta reconsider is not available in OSS")
 	test := &oktaImportRuleTestingPrimitives{}
-	testlib.ResourceUpdateTest[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.OktaImportRule, *resourcesv1.TeleportOktaImportRule](t, resources.NewOktaImportRuleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/openssheiceserverv2_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -125,15 +126,15 @@ func (g *opensshEICEServerV2TestingPrimitives) CompareTeleportAndKubernetesResou
 
 func TestTeleportOpensshEICEServerV2Creation(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2DeletionDrift(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshEICEServerV2Update(t *testing.T) {
 	test := &opensshEICEServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHEICEServerV2](t, resources.NewOpenSSHEICEServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
+++ b/integrations/operator/controllers/resources/opensshserverv2_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -117,15 +118,15 @@ func (g *opensshServerV2TestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func TestTeleportOpensshServerV2Creation(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2DeletionDrift(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }
 
 func TestTeleportOpensshServerV2Update(t *testing.T) {
 	test := &opensshServerV2TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Server, *resourcesv1.TeleportOpenSSHServerV2](t, resources.NewOpenSSHServerV2Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 )
@@ -410,7 +410,7 @@ func k8sCreateRole(ctx context.Context, t *testing.T, kc kclient.Client, role *r
 
 func getRoleStatusConditionError(object map[string]interface{}) []metav1.Condition {
 	var conditionsWithError []metav1.Condition
-	var status apiresources.Status
+	var status teleportcr.Status
 	_ = mapstructure.Decode(object["status"], &status)
 
 	for _, condition := range status.Conditions {

--- a/integrations/operator/controllers/resources/role_controller_test.go
+++ b/integrations/operator/controllers/resources/role_controller_test.go
@@ -20,25 +20,25 @@ package resources_test
 
 import (
 	"context"
-	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
-	"github.com/mitchellh/mapstructure"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/util/retry"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
 var TeleportRoleGVKV5 = schema.GroupVersionKind{
@@ -47,47 +47,12 @@ var TeleportRoleGVKV5 = schema.GroupVersionKind{
 	Kind:    "TeleportRole",
 }
 
-// When I create or delete a TeleportRole CR in Kubernetes,
-// the corresponding TeleportRole must be created/deleted in Teleport.
-func TestRoleCreation(t *testing.T) {
-	ctx := context.Background()
-	setup := setupTestEnv(t)
-	roleName := validRandomResourceName("role-")
-
-	// End of setup, we create the role in Kubernetes
-	k8sCreateDummyRole(ctx, t, setup.K8sClient, setup.Namespace.Name, roleName)
-
-	var tRole types.Role
-	var err error
-	// We wait for the role to be created in Teleport
-	fastEventually(t, func() bool {
-		tRole, err = setup.TeleportClient.GetRole(ctx, roleName)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-
-	// Role should have the same name, and have the Kubernetes origin label
-	require.Equal(t, roleName, tRole.GetName())
-	require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-	require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
-
-	// Cleanup and setup, we delete the role in Kubernetes
-	k8sDeleteRole(ctx, t, setup.K8sClient, roleName, setup.Namespace.Name)
-
-	// We wait for the role to be deleted in Teleport
-	fastEventually(t, func() bool {
-		_, err := setup.TeleportClient.GetRole(ctx, roleName)
-		return trace.IsNotFound(err)
-	})
-}
-
 func TestRoleCreationFromYAML(t *testing.T) {
 	ctx := context.Background()
-	setup := setupTestEnv(t)
+	setup := testlib.SetupFakeKubeTestEnv(t)
 	tests := []struct {
 		name         string
 		roleSpecYAML string
-		shouldFail   bool
 		expectedSpec *types.RoleSpecV6
 	}{
 		{
@@ -100,7 +65,6 @@ allow:
 options:
   create_host_user_mode: 3
 `,
-			shouldFail: false,
 			expectedSpec: &types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					Logins: []string{"ubuntu", "root"},
@@ -120,7 +84,6 @@ allow:
 options:
   create_host_user_mode: keep
 `,
-			shouldFail: false,
 			expectedSpec: &types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					Logins: []string{"ubuntu", "root"},
@@ -137,7 +100,6 @@ allow:
   node_labels:
     '*': ['*']
 `,
-			shouldFail: false,
 			expectedSpec: &types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					NodeLabels: map[string]apiutils.Strings{
@@ -153,7 +115,6 @@ allow:
   node_labels:
     '*': '*'
 `,
-			shouldFail: false,
 			expectedSpec: &types.RoleSpecV6{
 				Allow: types.RoleConditions{
 					NodeLabels: map[string]apiutils.Strings{
@@ -162,30 +123,10 @@ allow:
 				},
 			},
 		},
-		{
-			name: "Invalid node_labels (label value is integer)",
-			roleSpecYAML: `
-allow:
-  node_labels:
-    'foo': 1
-`,
-			shouldFail:   true,
-			expectedSpec: nil,
-		},
-		{
-			name: "Invalid node_labels (label value is object)",
-			roleSpecYAML: `
-allow:
-  node_labels:
-    'foo':
-      'bar': 'baz'
-    'logins':
-      - 'ubuntu'
-`,
-			shouldFail:   true,
-			expectedSpec: nil,
-		},
 	}
+
+	reconciler, err := resources.NewRoleReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
 
 	for _, tc := range tests {
 		tc := tc // capture range variable
@@ -206,45 +147,47 @@ allow:
 			err = setup.K8sClient.Create(ctx, obj)
 			require.NoError(t, err)
 
-			// If failure is expected we should not see the resource in Teleport
-			if tc.shouldFail {
-				fastEventually(t, func() bool {
-					// We check status.Conditions was updated, this means the reconciliation happened
-					_ = setup.K8sClient.Get(ctx, kclient.ObjectKey{
-						Namespace: setup.Namespace.Name,
-						Name:      roleName,
-					}, obj)
-					errorConditions := getRoleStatusConditionError(obj.Object)
-					// If there's no error condition, reconciliation has not happened yet
-					return len(errorConditions) != 0
-				})
-				_, err = setup.TeleportClient.GetRole(ctx, roleName)
-				require.True(t, trace.IsNotFound(err), "The role should not be created in Teleport")
-			} else {
-				var tRole types.Role
-				// We wait for Teleport resource creation
-				fastEventually(t, func() bool {
-					tRole, err = setup.TeleportClient.GetRole(ctx, roleName)
-					return !trace.IsNotFound(err)
-				})
-				// If the resource creation should succeed we check the resource was found and validate ownership labels
-				require.NoError(t, err)
-				require.Equal(t, roleName, tRole.GetName())
-				require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-				require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
-				expectedRole, _ := types.NewRoleWithVersion(roleName, types.V7, *tc.expectedSpec)
-				compareRoleSpecs(t, expectedRole, tRole)
+			// Test execution: Kick off the reconciliation.
+			req := reconcile.Request{
+				NamespacedName: apimachinerytypes.NamespacedName{
+					Namespace: setup.Namespace.Name,
+					Name:      roleName,
+				},
 			}
+			// First reconciliation should set the finalizer and exit.
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+			// Second reconciliation should create the Teleport resource.
+			// In a real cluster we should receive the event of our own finalizer change
+			// and this wakes us for a second round.
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+
+			var tRole types.Role
+			// We wait for the Teleport cache.
+			fastEventually(t, func() bool {
+				tRole, err = setup.TeleportClient.GetRole(ctx, roleName)
+				return !trace.IsNotFound(err)
+			})
+			// If the resource creation should succeed we check the resource was found and validate ownership labels
+			require.NoError(t, err)
+			require.Equal(t, roleName, tRole.GetName())
+			require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
+			require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
+			expectedRole, _ := types.NewRoleWithVersion(roleName, types.V7, *tc.expectedSpec)
+			compareRoleSpecs(t, expectedRole, tRole)
 			// Teardown
 
 			// The role is deleted in K8S
-			k8sDeleteRole(ctx, t, setup.K8sClient, roleName, setup.Namespace.Name)
-
-			// We wait for the role deletion in Teleport
-			fastEventually(t, func() bool {
-				_, err := setup.TeleportClient.GetRole(ctx, roleName)
-				return trace.IsNotFound(err)
-			})
+			role := resourcesv5.TeleportRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      roleName,
+					Namespace: setup.Namespace.Name,
+				},
+			}
+			require.NoError(t, setup.K8sClient.Delete(ctx, &role))
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -258,165 +201,115 @@ func compareRoleSpecs(t *testing.T, expectedRole, actualRole types.Role) {
 	require.Equal(t, expected["spec"], actual["spec"])
 }
 
-// TestRoleDeletionDrift tests how the Kubernetes operator reacts when it is asked to delete a role that was
-// already deleted in Teleport
-func TestRoleDeletionDrift(t *testing.T) {
-	// Setup section: start the operator, and create a role
-	ctx := context.Background()
-	setup := setupTestEnv(t)
-	roleName := validRandomResourceName("role-")
-
-	// The role is created in K8S
-	k8sCreateDummyRole(ctx, t, setup.K8sClient, setup.Namespace.Name, roleName)
-
-	var tRole types.Role
-	var err error
-	fastEventually(t, func() bool {
-		tRole, err = setup.TeleportClient.GetRole(ctx, roleName)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-	require.Equal(t, roleName, tRole.GetName())
-	require.Contains(t, tRole.GetMetadata().Labels, types.OriginLabel)
-	require.Equal(t, types.OriginKubernetes, tRole.GetMetadata().Labels[types.OriginLabel])
-
-	// We cause a drift by altering the Teleport resource.
-	// To make sure the operator does not reconcile while we're finished we suspend the operator
-	setup.StopKubernetesOperator()
-
-	err = setup.TeleportClient.DeleteRole(ctx, roleName)
-	require.NoError(t, err)
-	fastEventually(t, func() bool {
-		_, err := setup.TeleportClient.GetRole(ctx, roleName)
-		return trace.IsNotFound(err)
-	})
-
-	// We flag the role for deletion in Kubernetes (it won't be fully remopved until the operator has processed it and removed the finalizer)
-	k8sDeleteRole(ctx, t, setup.K8sClient, roleName, setup.Namespace.Name)
-
-	// Test section: We resume the operator, it should reconcile and recover from the drift
-	setup.StartKubernetesOperator(t)
-
-	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
-	var k8sRole resourcesv5.TeleportRole
-	fastEventually(t, func() bool {
-		err = setup.K8sClient.Get(ctx, kclient.ObjectKey{
-			Namespace: setup.Namespace.Name,
-			Name:      roleName,
-		}, &k8sRole)
-		return kerrors.IsNotFound(err)
-	})
-}
-
-func TestRoleUpdate(t *testing.T) {
-	ctx := context.Background()
-	setup := setupTestEnv(t)
-	roleName := validRandomResourceName("role-")
-
-	// The role does not exist in K8S
-	var r resourcesv5.TeleportRole
-	err := setup.K8sClient.Get(ctx, kclient.ObjectKey{
-		Namespace: setup.Namespace.Name,
-		Name:      roleName,
-	}, &r)
-	require.True(t, kerrors.IsNotFound(err))
-
-	require.NoError(t, teleportCreateDummyRole(ctx, roleName, setup.TeleportClient))
-
-	// The role is created in K8S
-	k8sRole := resourcesv5.TeleportRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
-			Namespace: setup.Namespace.Name,
-		},
-		Spec: resourcesv5.TeleportRoleSpec{
-			Allow: types.RoleConditions{
-				Logins: []string{"x", "z"},
+var roleV5Spec = types.RoleSpecV6{
+	Options: types.RoleOptions{
+		ForwardAgent: true,
+	},
+	Allow: types.RoleConditions{
+		Logins:           []string{"foo"},
+		KubernetesLabels: types.Labels{"env": {"dev", "prod"}},
+		KubernetesResources: []types.KubernetesResource{
+			{
+				Kind:      "pod",
+				Namespace: "monitoring",
+				Name:      "^prometheus-.*",
 			},
 		},
-	}
-	k8sCreateRole(ctx, t, setup.K8sClient, &k8sRole)
-
-	// The role is updated in Teleport
-	fastEventuallyWithT(t, func(c *assert.CollectT) {
-		tRole, err := setup.TeleportClient.GetRole(ctx, roleName)
-		require.NoError(c, err)
-
-		// TeleportRole updated with new logins
-		logins := tRole.GetLogins(types.Allow)
-		sort.Strings(logins)
-		assert.ElementsMatch(c, logins, []string{"x", "z"})
-	})
-
-	// Updating the role in K8S
-	// The modification can fail because of a conflict with the resource controller. We retry if that happens.
-	var k8sRoleNewVersion resourcesv5.TeleportRole
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := setup.K8sClient.Get(ctx, kclient.ObjectKey{
-			Namespace: setup.Namespace.Name,
-			Name:      roleName,
-		}, &k8sRoleNewVersion)
-		if err != nil {
-			return err
-		}
-
-		k8sRoleNewVersion.Spec.Allow.Logins = append(k8sRoleNewVersion.Spec.Allow.Logins, "admin", "root")
-		return setup.K8sClient.Update(ctx, &k8sRoleNewVersion)
-	})
-	require.NoError(t, err)
-
-	// Updates the role in Teleport
-	fastEventuallyWithT(t, func(c *assert.CollectT) {
-		tRole, err := setup.TeleportClient.GetRole(ctx, roleName)
-		require.NoError(c, err)
-
-		// TeleportRole updated with new logins
-		logins := tRole.GetLogins(types.Allow)
-		sort.Strings(logins)
-		assert.ElementsMatch(c, logins, []string{"admin", "root", "x", "z"})
-	})
+	},
+	Deny: types.RoleConditions{},
 }
 
-func k8sCreateDummyRole(ctx context.Context, t *testing.T, kc kclient.Client, namespace, roleName string) {
-	role := resourcesv5.TeleportRole{
+type roleTestingPrimitives struct {
+	setup *testSetup
+	reconcilers.ResourceWithLabelsAdapter[types.Role]
+}
+
+func (g *roleTestingPrimitives) Init(setup *testSetup) {
+	g.setup = setup
+}
+
+func (g *roleTestingPrimitives) SetupTeleportFixtures(ctx context.Context) error {
+	return nil
+}
+
+func (g *roleTestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
+	role, err := types.NewRoleWithVersion(name, types.V5, roleV5Spec)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	role.SetOrigin(types.OriginKubernetes)
+	_, err = g.setup.TeleportClient.CreateRole(ctx, role)
+	return trace.Wrap(err)
+}
+
+func (g *roleTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.Role, error) {
+	return g.setup.TeleportClient.GetRole(ctx, name)
+}
+
+func (g *roleTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
+	return trace.Wrap(g.setup.TeleportClient.DeleteRole(ctx, name))
+}
+
+func (g *roleTestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	role := &resourcesv5.TeleportRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
-			Namespace: namespace,
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
 		},
-		Spec: resourcesv5.TeleportRoleSpec{
-			Allow: types.RoleConditions{
-				Logins: []string{"a", "b"},
-			},
-		},
+		Spec: resourcesv5.TeleportRoleSpec(roleV5Spec),
 	}
-	k8sCreateRole(ctx, t, kc, &role)
+	return trace.Wrap(g.setup.K8sClient.Create(ctx, role))
 }
 
-func k8sDeleteRole(ctx context.Context, t *testing.T, kc kclient.Client, roleName, namespace string) {
-	role := resourcesv5.TeleportRole{
+func (g *roleTestingPrimitives) DeleteKubernetesResource(ctx context.Context, name string) error {
+	role := &resourcesv5.TeleportRole{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
-			Namespace: namespace,
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
 		},
 	}
-	err := kc.Delete(ctx, &role)
-	require.NoError(t, err)
+	return trace.Wrap(g.setup.K8sClient.Delete(ctx, role))
 }
 
-func k8sCreateRole(ctx context.Context, t *testing.T, kc kclient.Client, role *resourcesv5.TeleportRole) {
-	err := kc.Create(ctx, role)
-	require.NoError(t, err)
-}
-
-func getRoleStatusConditionError(object map[string]interface{}) []metav1.Condition {
-	var conditionsWithError []metav1.Condition
-	var status teleportcr.Status
-	_ = mapstructure.Decode(object["status"], &status)
-
-	for _, condition := range status.Conditions {
-		if condition.Status == metav1.ConditionFalse {
-			conditionsWithError = append(conditionsWithError, condition)
-		}
+func (g *roleTestingPrimitives) GetKubernetesResource(ctx context.Context, name string) (*resourcesv5.TeleportRole, error) {
+	role := &resourcesv5.TeleportRole{}
+	obj := kclient.ObjectKey{
+		Name:      name,
+		Namespace: g.setup.Namespace.Name,
 	}
-	return conditionsWithError
+	err := g.setup.K8sClient.Get(ctx, obj, role)
+	return role, trace.Wrap(err)
+}
+
+func (g *roleTestingPrimitives) ModifyKubernetesResource(ctx context.Context, name string) error {
+	role, err := g.GetKubernetesResource(ctx, name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	role.Spec.Allow.Logins = []string{"foo", "bar"}
+	return g.setup.K8sClient.Update(ctx, role)
+}
+
+func (g *roleTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.Role, kubeResource *resourcesv5.TeleportRole) (bool, string) {
+	ignoreServerSideDefaults := []cmp.Option{
+		cmpopts.IgnoreFields(types.RoleSpecV6{}, "Options"),
+		cmpopts.IgnoreFields(types.RoleConditions{}, "Namespaces"),
+	}
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions(ignoreServerSideDefaults...)...)
+	return diff == "", diff
+}
+
+func TestTeleportRoleCreation(t *testing.T) {
+	test := &roleTestingPrimitives{}
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
+}
+
+func TestTeleportRoleDeletionDrift(t *testing.T) {
+	test := &roleTestingPrimitives{}
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
+}
+
+func TestTeleportRoleUpdate(t *testing.T) {
+	test := &roleTestingPrimitives{}
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv5.TeleportRole](t, resources.NewRoleReconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev6_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev6_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -134,15 +135,15 @@ func (g *roleV6TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV6Creation(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Role, *resourcesv1.TeleportRoleV6](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6DeletionDrift(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Role, *resourcesv1.TeleportRoleV6](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }
 
 func TestTeleportRoleV6Update(t *testing.T) {
 	test := &roleV6TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Role, *resourcesv1.TeleportRoleV6](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV6](t, resources.NewRoleV6Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev7_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev7_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -131,15 +132,15 @@ func (g *roleV7TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV7Creation(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Role, *resourcesv1.TeleportRoleV7](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7DeletionDrift(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Role, *resourcesv1.TeleportRoleV7](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }
 
 func TestTeleportRoleV7Update(t *testing.T) {
 	test := &roleV7TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Role, *resourcesv1.TeleportRoleV7](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV7](t, resources.NewRoleV7Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/rolev8_controller_test.go
+++ b/integrations/operator/controllers/resources/rolev8_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -133,15 +134,15 @@ func (g *roleV8TestingPrimitives) CompareTeleportAndKubernetesResource(tResource
 
 func TestTeleportRoleV8Creation(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceCreationTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+	testlib.ResourceCreationSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8DeletionDrift(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+	testlib.ResourceDeletionDriftSynchronousTest[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }
 
 func TestTeleportRoleV8Update(t *testing.T) {
 	test := &roleV8TestingPrimitives{}
-	testlib.ResourceUpdateTest[types.Role, *resourcesv1.TeleportRoleV8](t, test)
+	testlib.ResourceUpdateTestSynchronous[types.Role, *resourcesv1.TeleportRoleV8](t, resources.NewRoleV8Reconciler, test)
 }

--- a/integrations/operator/controllers/resources/setup.go
+++ b/integrations/operator/controllers/resources/setup.go
@@ -31,9 +31,11 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 )
 
+type ReconcilerFactory func(client kclient.Client, tClient *client.Client) (controllers.Reconciler, error)
+
 type reconcilerFactory struct {
 	cr      string
-	factory func(kclient.Client, *client.Client) (controllers.Reconciler, error)
+	factory ReconcilerFactory
 }
 
 // SetupAllControllers sets up all controllers

--- a/integrations/operator/controllers/resources/suite_test.go
+++ b/integrations/operator/controllers/resources/suite_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
@@ -38,14 +37,8 @@ type testSetup = testlib.TestSetup
 
 // Temporary function "aliases" to slightly decrease the size of this commit,
 // they can be removed in a follow-up.
-func setupTestEnv(t *testing.T, opts ...testlib.TestOption) *testlib.TestSetup {
-	return testlib.SetupTestEnv(t, opts...)
-}
 func validRandomResourceName(prefix string) string       { return testlib.ValidRandomResourceName(prefix) }
 func fastEventually(t *testing.T, condition func() bool) { testlib.FastEventually(t, condition) }
-func fastEventuallyWithT(t *testing.T, condition func(*assert.CollectT)) {
-	testlib.FastEventuallyWithT(t, condition)
-}
 
 func teleportCreateDummyRole(ctx context.Context, roleName string, tClient *client.Client) error {
 	// The role is created in Teleport

--- a/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/accesslist_controller_tests.go
@@ -165,17 +165,32 @@ func (g *accessListTestingPrimitives) CompareTeleportAndKubernetesResource(tReso
 
 func AccessListCreationTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceCreationTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](t, test, WithTeleportClient(clt))
+	ResourceCreationSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }
 
 func AccessListDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceDeletionDriftTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](t, test, WithTeleportClient(clt))
+	ResourceDeletionDriftSynchronousTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }
 
 func AccessListUpdateTest(t *testing.T, clt *client.Client) {
 	test := &accessListTestingPrimitives{}
-	ResourceUpdateTest[*accesslist.AccessList, *resourcesv1.TeleportAccessList](t, test, WithTeleportClient(clt))
+	ResourceUpdateTestSynchronous[*accesslist.AccessList, *resourcesv1.TeleportAccessList](
+		t,
+		resources.NewAccessListReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }
 
 // AccessListMutateExistingTest checks that the operator propagates the expiry

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -24,6 +24,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -47,6 +49,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
+	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
@@ -182,6 +185,9 @@ type TestSetup struct {
 	OperatorName             string
 	stepByStepReconciliation bool
 	log                      *slog.Logger
+	TeleportServer           *helpers.TeleInstance
+	ResourceName             string
+	Context                  context.Context
 }
 
 // StartKubernetesOperator creates and start a new operator
@@ -191,6 +197,9 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 		s.StopKubernetesOperator()
 	}
 
+	if s.K8sRestConfig == nil {
+		require.FailNow(t, "K8sRestConfig is required to start the operator, you cannot run a full test against a fake cluster.")
+	}
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{
 		Scheme:  scheme,
 		Metrics: metricsserver.Options{BindAddress: "0"},
@@ -249,6 +258,7 @@ func setupTeleportClient(t *testing.T, setup *TestSetup) {
 	// Start a Teleport server for the test and set up a client connected to
 	// that server.
 	teleportServer, operatorName := defaultTeleportServiceConfig(t)
+	setup.TeleportServer = teleportServer
 	require.NoError(t, teleportServer.Start())
 	setup.TeleportClient = clientForTeleport(t, teleportServer, operatorName)
 	setup.OperatorName = operatorName
@@ -273,6 +283,56 @@ func WithTeleportClient(clt *client.Client) TestOption {
 
 func StepByStep(setup *TestSetup) {
 	setup.stepByStepReconciliation = true
+}
+
+// WithResourceName makes the test resource name static instead of letting the test generate a random one.
+// This is used if the resource name much match a specific pattern, or a fixture that was created beforehand
+// (e.g. trusted cluster).
+func WithResourceName(resourceName string) TestOption {
+	return func(setup *TestSetup) {
+		setup.ResourceName = resourceName
+	}
+}
+
+// SetupFakeKubeTestEnv is like SetupTestEnv but creates a fake Kubernetes
+// cluster by using controller-runtime's fake package.
+// This is way faster than using testEnv to spin up a full kube test cluster
+// on every test.
+// This does not support tests starting a full controller manager and can only be
+// used with Synchronous tests.
+func SetupFakeKubeTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
+	builder := fake.NewClientBuilder()
+	builder.WithScheme(scheme)
+	// Every CR kind must be registered as "WithStatusSubresource" so he fake client implements
+	// the status updates properly.
+	customScheme, err := apiresources.NewScheme()
+	require.NoError(t, err)
+	knownTypes := customScheme.AllKnownTypes()
+	for _, reflectType := range knownTypes {
+		reflectValue := reflect.New(reflectType).Interface()
+		obj, ok := reflectValue.(kclient.Object)
+		if !ok {
+			continue
+		}
+		builder.WithStatusSubresource(obj)
+	}
+	k8sClient := builder.Build()
+	ns := createNamespaceForTest(t, k8sClient)
+
+	setup := &TestSetup{
+		Context:      t.Context(),
+		K8sClient:    k8sClient,
+		Namespace:    ns,
+		ResourceName: ValidRandomResourceName("resource-"),
+	}
+
+	for _, opt := range opts {
+		opt(setup)
+	}
+
+	setupTeleportClient(t, setup)
+
+	return setup
 }
 
 // SetupTestEnv creates a Kubernetes server, a teleport server and starts the operator
@@ -303,9 +363,11 @@ func SetupTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 	})
 
 	setup := &TestSetup{
+		Context:       t.Context(),
 		K8sClient:     k8sClient,
 		Namespace:     ns,
 		K8sRestConfig: cfg,
+		ResourceName:  ValidRandomResourceName("resource-"),
 	}
 
 	for _, opt := range opts {

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -48,10 +47,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/integration/helpers"
-	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
-	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
-	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
-	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
 	"github.com/gravitational/teleport/integrations/operator/controllers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/lib/modules"
@@ -63,14 +58,6 @@ import (
 // scheme is our own test-specific scheme to avoid using the global
 // unprotected scheme.Scheme that triggers the race detector
 var scheme = controllers.Scheme
-
-func init() {
-	utilruntime.Must(core.AddToScheme(scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(scheme))
-	utilruntime.Must(resourcesv5.AddToScheme(scheme))
-}
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 	ns := &core.Namespace{

--- a/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
+++ b/integrations/operator/controllers/resources/testlib/login_rule_controller_tests.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types/wrappers"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
 
 type loginRuleTestingPrimitives struct {
@@ -146,15 +147,30 @@ func (l *loginRuleTestingPrimitives) CompareTeleportAndKubernetesResource(
 
 func LoginRuleCreationTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceCreationTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](t, test, WithTeleportClient(clt))
+	ResourceCreationSynchronousTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+		t,
+		resources.NewLoginRuleReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }
 
 func LoginRuleDeletionDriftTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceDeletionDriftTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](t, test, WithTeleportClient(clt))
+	ResourceDeletionDriftSynchronousTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+		t,
+		resources.NewLoginRuleReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }
 
 func LoginRuleUpdateTest(t *testing.T, clt *client.Client) {
 	test := &loginRuleTestingPrimitives{}
-	ResourceUpdateTest[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](t, test, WithTeleportClient(clt))
+	ResourceUpdateTestSynchronous[*resourcesv1.LoginRuleResource, *resourcesv1.TeleportLoginRule](
+		t,
+		resources.NewLoginRuleReconciler,
+		test,
+		WithTeleportClient(clt),
+	)
 }

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -26,10 +26,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
 
 type ResourceTestingPrimitives[T reconcilers.Resource, K reconcilers.KubernetesCR[T]] interface {
@@ -193,5 +196,236 @@ func ResourceUpdateTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t
 
 	// Delete the resource to avoid leftover state.
 	err = test.DeleteTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+}
+
+func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test setup: Creating resource in Teleport with Kube origin
+	err = test.CreateTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the resource to be served by Teleport, fail early if Teleport is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err, "Teleport resource still not served by Teleport, Teleport might be stale/with a broken cache.")
+	})
+
+	// Test setup: Creating Kubernetes CR
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Wait for the CR to be served by Kubernetes, fail early if Kubernetes is broken.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		_, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err, "Kubernetes resource still not served by Kubernetes, Kubernetes might be stale/with a broken cache.")
+	})
+
+	// Test setup: Kick off the reconciliation, make sure everything is in sync.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	// Test setup: Check if both Teleport and Kube resources are in-sync.
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		// Kubernetes and Teleport resources are in-sync
+		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+	})
+
+	// Test execution: Induce a drift by updating the Kubernetes CR
+	require.NoError(t, test.ModifyKubernetesResource(ctx, resourceName))
+
+	// Test execution: Trigger reconciliation
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var testPassed bool
+	debugInfo := func() {
+		// If the test passed, disarm the debugging dump
+		if testPassed {
+			return
+		}
+		// Little type crime
+		var debug any = test
+		if debuggableTest, ok := debug.(interface{ DebugDrifts(*testing.T, string) }); ok {
+			t.Log("Test failed, dumping the state for troubleshooting purposes")
+			debuggableTest.DebugDrifts(t, resourceName)
+		}
+	}
+	t.Cleanup(debugInfo)
+
+	// Test validation: Check the drift was correct and resource updated in Teleport
+	FastEventuallyWithT(t, func(t *assert.CollectT) {
+		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err)
+
+		// Kubernetes and Teleport resources are in-sync
+		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
+	})
+	testPassed = true
+
+	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
+	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
+	require.NoError(t, test.DeleteTeleportResource(ctx, resourceName))
+	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+}
+
+func ResourceCreationSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test execution: create a Kubernetes resource
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test execution: Kick off the reconciliation.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	var testPassed bool
+	debugInfo := func() {
+		// If the test passed, disarm the debugging dump
+		if testPassed {
+			return
+		}
+		// Little type crime
+		var debug any = test
+		if debuggableTest, ok := debug.(interface{ DebugDrifts(*testing.T, string) }); ok {
+			t.Log("Test failed, dumping the state for troubleshooting purposes")
+			debuggableTest.DebugDrifts(t, resourceName)
+		}
+	}
+	t.Cleanup(debugInfo)
+
+	// Test execution: wait for the cache to be refreshed.
+	var tResource T
+	FastEventually(t, func() bool {
+		tResource, err = test.GetTeleportResource(ctx, resourceName)
+		t.Log(err)
+		return !trace.IsNotFound(err)
+	})
+	require.NoError(t, err)
+	testPassed = true
+
+	// Test validation: we check that the Teleport resource has the right fields.
+
+	// We get the kube resource to get the resourceName as it might have been changed if this is a singleton resource
+	kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+	require.Equal(t, kubeResource.GetName(), test.GetResourceName(tResource))
+	require.Equal(t, types.OriginKubernetes, test.GetResourceOrigin(tResource))
+
+	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
+	require.NoError(t, test.DeleteKubernetesResource(ctx, resourceName))
+	require.NoError(t, test.DeleteTeleportResource(ctx, resourceName))
+	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+}
+
+func ResourceDeletionDriftSynchronousTest[T reconcilers.Resource, K reconcilers.KubernetesCR[T]](t *testing.T, newReconciler resources.ReconcilerFactory, test ResourceTestingPrimitives[T, K], opts ...TestOption) {
+	// Test setup
+	ctx := t.Context()
+	setup := SetupFakeKubeTestEnv(t, opts...)
+	test.Init(setup)
+	resourceName := setup.ResourceName
+
+	reconciler, err := newReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	err = test.SetupTeleportFixtures(ctx)
+	require.NoError(t, err)
+
+	// Test setup: create the Kube CR
+	err = test.CreateKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test setup: Reconcile and make sure the Teleport resource is created.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      resourceName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+
+	FastEventually(t, func() bool {
+		_, err = test.GetTeleportResource(ctx, resourceName)
+		return !trace.IsNotFound(err)
+	})
+
+	// Test execution: Cause a drift by deleting the Teleport resource.
+	err = test.DeleteTeleportResource(ctx, resourceName)
+	require.NoError(t, err)
+	FastEventually(t, func() bool {
+		_, err = test.GetTeleportResource(ctx, resourceName)
+		return trace.IsNotFound(err)
+	})
+
+	// Test execution: Flag the resource for deletion in Kubernetes
+	// It won't be fully removed until the reconciler has processed it and removed the finalizer.
+	err = test.DeleteKubernetesResource(ctx, resourceName)
+	require.NoError(t, err)
+
+	// Test execution: let the reonciler see that the Teleport resource was deleted and remove the finalizer on the kube resource.
+	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
 }

--- a/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
+++ b/integrations/operator/controllers/resources/trusted_clusterv2_controller_test.go
@@ -26,18 +26,18 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/secretlookup"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 	"github.com/gravitational/teleport/lib"
@@ -60,6 +60,32 @@ func (r *trustedClusterV2TestingPrimitives) Init(setup *testSetup) {
 }
 
 func (r *trustedClusterV2TestingPrimitives) SetupTeleportFixtures(ctx context.Context) error {
+	// Create trusted cluster join token
+	token := "secret_token"
+	tokenResource, err := types.NewProvisionToken(token, []types.SystemRole{types.RoleTrustedCluster}, time.Time{})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	r.remoteCluster.Process.GetAuthServer().UpsertToken(ctx, tokenResource)
+
+	// Create required role
+	localDev := "local-dev"
+	if err := teleportCreateDummyRole(ctx, localDev, r.setup.TeleportClient); err != nil {
+		return trace.Wrap(err, "creating dummy role")
+	}
+
+	r.trustedClusterSpec = types.TrustedClusterSpecV2{
+		Enabled:              true,
+		Token:                token,
+		ProxyAddress:         r.remoteCluster.Web,
+		ReverseTunnelAddress: r.remoteCluster.ReverseTunnel,
+		RoleMap: []types.RoleMapping{
+			{
+				Remote: "remote-dev",
+				Local:  []string{localDev},
+			},
+		},
+	}
 	return nil
 }
 
@@ -130,9 +156,9 @@ func (r *trustedClusterV2TestingPrimitives) CompareTeleportAndKubernetesResource
 }
 
 // setupTest initializes a remote cluster for testing trusted clusters.
+// This runs before we start any test.
+// Init() runs after the standardized test suite setup is done.
 func (r *trustedClusterV2TestingPrimitives) setupTest(t *testing.T, clusterName string) {
-	ctx := context.Background()
-
 	remoteCluster := helpers.NewInstance(t, helpers.InstanceConfig{
 		ClusterName: clusterName,
 		HostID:      uuid.New().String(),
@@ -154,174 +180,52 @@ func (r *trustedClusterV2TestingPrimitives) setupTest(t *testing.T, clusterName 
 	require.NoError(t, remoteCluster.CreateEx(t, nil, rcConf))
 	require.NoError(t, remoteCluster.Start())
 	t.Cleanup(func() { require.NoError(t, remoteCluster.StopAll()) })
-
-	// Create trusted cluster join token
-	token := "secret_token"
-	tokenResource, err := types.NewProvisionToken(token, []types.SystemRole{types.RoleTrustedCluster}, time.Time{})
-	require.NoError(t, err)
-	remoteCluster.Process.GetAuthServer().UpsertToken(ctx, tokenResource)
-
-	// Create required role
-	localDev := "local-dev"
-	require.NoError(t, teleportCreateDummyRole(ctx, localDev, r.setup.TeleportClient))
-
-	r.trustedClusterSpec = types.TrustedClusterSpecV2{
-		Enabled:              true,
-		Token:                token,
-		ProxyAddress:         remoteCluster.Web,
-		ReverseTunnelAddress: remoteCluster.ReverseTunnel,
-		RoleMap: []types.RoleMapping{
-			{
-				Remote: "remote-dev",
-				Local:  []string{localDev},
-			},
-		},
-	}
 }
 
 func TestTrustedClusterV2Creation(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
-	setup := testlib.SetupTestEnv(t)
-	test.Init(setup)
-	ctx := context.Background()
-
-	resourceName := "remote.example.com"
-	test.setupTest(t, resourceName)
-
-	require.NoError(t, test.CreateKubernetesResource(ctx, resourceName))
-
-	var resource types.TrustedCluster
-	var err error
-	testlib.FastEventually(t, func() bool {
-		resource, err = test.GetTeleportResource(ctx, resourceName)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-	require.Equal(t, resourceName, test.GetResourceName(resource))
-	require.Equal(t, types.OriginKubernetes, test.GetResourceOrigin(resource))
-
-	err = test.DeleteKubernetesResource(ctx, resourceName)
-	require.NoError(t, err)
-
-	testlib.FastEventually(t, func() bool {
-		_, err = test.GetTeleportResource(ctx, resourceName)
-		return trace.IsNotFound(err)
-	})
+	const remoteClusterName = "remote.example.com"
+	test.setupTest(t, remoteClusterName)
+	testlib.ResourceCreationSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+		t,
+		resources.NewTrustedClusterV2Reconciler,
+		test,
+		testlib.WithResourceName(remoteClusterName),
+	)
 }
 
 func TestTrustedClusterV2DeletionDrift(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
-	setup := testlib.SetupTestEnv(t)
-	test.Init(setup)
-	ctx := context.Background()
-
-	resourceName := "remote.example.com"
-	test.setupTest(t, resourceName)
-
-	require.NoError(t, test.CreateKubernetesResource(ctx, resourceName))
-
-	var resource types.TrustedCluster
-	var err error
-	testlib.FastEventually(t, func() bool {
-		resource, err = test.GetTeleportResource(ctx, resourceName)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-	require.Equal(t, resourceName, test.GetResourceName(resource))
-	require.Equal(t, types.OriginKubernetes, test.GetResourceOrigin(resource))
-
-	// We cause a drift by altering the Teleport resource.
-	// To make sure the operator does not reconcile while we're finished we suspend the operator
-	setup.StopKubernetesOperator()
-
-	err = test.DeleteTeleportResource(ctx, resourceName)
-	require.NoError(t, err)
-	testlib.FastEventually(t, func() bool {
-		_, err = test.GetTeleportResource(ctx, resourceName)
-		return trace.IsNotFound(err)
-	})
-
-	// We flag the resource for deletion in Kubernetes (it won't be fully removed until the operator has processed it and removed the finalizer)
-	err = test.DeleteKubernetesResource(ctx, resourceName)
-	require.NoError(t, err)
-
-	// Test section: We resume the operator, it should reconcile and recover from the drift
-	setup.StartKubernetesOperator(t)
-
-	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
-	testlib.FastEventually(t, func() bool {
-		_, err = test.GetKubernetesResource(ctx, resourceName)
-		return kerrors.IsNotFound(err)
-	})
+	const remoteClusterName = "remote.example.com"
+	test.setupTest(t, remoteClusterName)
+	testlib.ResourceDeletionDriftSynchronousTest[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+		t,
+		resources.NewTrustedClusterV2Reconciler,
+		test,
+		testlib.WithResourceName(remoteClusterName),
+	)
 }
 
-func TestTrustedClusterV2Update(t *testing.T) {
+func TestTrustedClusterUpdate(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
-	setup := testlib.SetupTestEnv(t)
-	test.Init(setup)
-	ctx := context.Background()
-
-	resourceName := "remote.example.com"
-	test.setupTest(t, resourceName)
-
-	// The resource is created in Teleport
-	require.NoError(t, test.CreateTeleportResource(ctx, resourceName))
-
-	// The resource is created in Kubernetes, with at least a field altered
-	require.NoError(t, test.CreateKubernetesResource(ctx, resourceName))
-
-	// Check the resource was updated in Teleport
-	testlib.FastEventuallyWithT(t, func(c *assert.CollectT) {
-		tResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(c, err)
-
-		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
-		require.NoError(c, err)
-
-		// Kubernetes and Teleport resources are in-sync
-		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
-		if !equal {
-			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
-		}
-		assert.True(c, equal)
-	})
-
-	// Updating the resource in Kubernetes
-	// The modification can fail because of a conflict with the resource controller. We retry if that happens.
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return test.ModifyKubernetesResource(ctx, resourceName)
-	})
-	require.NoError(t, err)
-
-	// Check the resource was updated in Teleport
-	testlib.FastEventuallyWithT(t, func(c *assert.CollectT) {
-		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
-		require.NoError(c, err)
-
-		tResource, err := test.GetTeleportResource(ctx, resourceName)
-		require.NoError(c, err)
-
-		// Kubernetes and Teleport resources are in-sync
-		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
-		if !equal {
-			t.Logf("Kubernetes and Teleport resources not sync-ed yet: %s", diff)
-		}
-		assert.True(c, equal)
-	})
-
-	// Delete the resource to avoid leftover state.
-	err = test.DeleteTeleportResource(ctx, resourceName)
-	require.NoError(t, err)
+	const remoteClusterName = "remote.example.com"
+	test.setupTest(t, remoteClusterName)
+	testlib.ResourceUpdateTestSynchronous[types.TrustedCluster, *resourcesv1.TeleportTrustedClusterV2](
+		t,
+		resources.NewTrustedClusterV2Reconciler,
+		test,
+		testlib.WithResourceName(remoteClusterName),
+	)
 }
 
 func TestTrustedClusterV2SecretLookup(t *testing.T) {
 	test := &trustedClusterV2TestingPrimitives{}
-	setup := testlib.SetupTestEnv(t)
+	const remoteClusterName = "remote.example.com"
+	test.setupTest(t, remoteClusterName)
+	setup := testlib.SetupFakeKubeTestEnv(t)
 	test.Init(setup)
-	ctx := context.Background()
-
-	resourceName := "remote.example.com"
-	test.setupTest(t, resourceName)
+	ctx := t.Context()
+	require.NoError(t, test.SetupTeleportFixtures(ctx))
 
 	secretName := validRandomResourceName("trusted-cluster-secret")
 	secretKey := "token"
@@ -332,11 +236,13 @@ func TestTrustedClusterV2SecretLookup(t *testing.T) {
 			Name:      secretName,
 			Namespace: setup.Namespace.Name,
 			Annotations: map[string]string{
-				secretlookup.AllowLookupAnnotation: resourceName,
+				secretlookup.AllowLookupAnnotation: remoteClusterName,
 			},
 		},
-		StringData: map[string]string{
-			secretKey: secretValue,
+		// Real kube servers convert stringData into data.
+		// The fake client does not, so we must use Data instead.
+		Data: map[string][]byte{
+			secretKey: []byte(secretValue),
 		},
 		Type: v1.SecretTypeOpaque,
 	}
@@ -344,13 +250,40 @@ func TestTrustedClusterV2SecretLookup(t *testing.T) {
 	require.NoError(t, kubeClient.Create(ctx, secret))
 
 	test.trustedClusterSpec.Token = "secret://" + secretName + "/" + secretKey
-	require.NoError(t, test.CreateKubernetesResource(ctx, resourceName))
+	require.NoError(t, test.CreateKubernetesResource(ctx, remoteClusterName))
+
+	reconciler, err := resources.NewTrustedClusterV2Reconciler(kubeClient, setup.TeleportClient)
+	require.NoError(t, err)
+
+	// Test execution: Kick off the reconciliation.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      remoteClusterName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
 
 	testlib.FastEventually(t, func() bool {
-		trustedCluster, err := test.GetTeleportResource(ctx, resourceName)
+		trustedCluster, err := test.GetTeleportResource(ctx, remoteClusterName)
 		if err != nil {
 			return false
 		}
 		return trustedCluster.GetToken() == secretValue
 	})
+
+	// Test cleanup: Delete the resource to avoid leftover state if we were running on a real instance.
+	require.NoError(t, test.DeleteKubernetesResource(ctx, remoteClusterName))
+	require.NoError(t, kubeClient.Delete(ctx, secret))
+	require.NoError(t, test.DeleteTeleportResource(ctx, remoteClusterName))
+	// Kicking of a reconciliation to remove the finalizer and let Kube remove the resource.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -26,70 +26,145 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/gravitational/trace"
-	"github.com/mitchellh/mapstructure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/util/retry"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
+	"github.com/gravitational/teleport/api/types/wrappers"
 	v2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
 const teleportUserKind = "TeleportUser"
 
-var teleportUserGVK = schema.GroupVersionKind{
-	Group:   v2.GroupVersion.Group,
-	Version: v2.GroupVersion.Version,
-	Kind:    teleportUserKind,
+var (
+	teleportUserGVK = schema.GroupVersionKind{
+		Group:   v2.GroupVersion.Group,
+		Version: v2.GroupVersion.Version,
+		Kind:    teleportUserKind,
+	}
+	userSpec = types.UserSpecV2{
+		Roles: []string{"a", "b"},
+	}
+)
+
+type userTestingPrimitives struct {
+	setup *testSetup
+	reconcilers.ResourceWithLabelsAdapter[types.User]
 }
 
-func TestUserCreation(t *testing.T) {
-	ctx := context.Background()
-	setup := setupTestEnv(t)
-	userName := validRandomResourceName("user-")
+func (g *userTestingPrimitives) Init(setup *testSetup) {
+	g.setup = setup
+}
 
-	require.NoError(t, teleportCreateDummyRole(ctx, "a", setup.TeleportClient))
-	require.NoError(t, teleportCreateDummyRole(ctx, "b", setup.TeleportClient))
+func (g *userTestingPrimitives) SetupTeleportFixtures(ctx context.Context) error {
+	return trace.NewAggregate(
+		teleportCreateDummyRole(ctx, "a", g.setup.TeleportClient),
+		teleportCreateDummyRole(ctx, "b", g.setup.TeleportClient),
+	)
+}
 
-	// The user is created in K8S
-	k8sCreateDummyUser(ctx, t, setup.K8sClient, setup.Namespace.Name, userName)
+func (g *userTestingPrimitives) CreateTeleportResource(ctx context.Context, name string) error {
+	user, err := types.NewUser(name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	user.SetOrigin(types.OriginKubernetes)
+	user.SetRoles(userSpec.Roles)
+	_, err = g.setup.TeleportClient.CreateUser(ctx, user)
+	return trace.Wrap(err)
+}
 
-	var tUser types.User
-	var err error
-	fastEventually(t, func() bool {
-		tUser, err = setup.TeleportClient.GetUser(ctx, userName, false)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-	require.Equal(t, userName, tUser.GetName())
-	require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-	require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
+func (g *userTestingPrimitives) GetTeleportResource(ctx context.Context, name string) (types.User, error) {
+	return g.setup.TeleportClient.GetUser(ctx, name, false)
+}
 
-	// The user is deleted in K8S
-	k8sDeleteUser(ctx, t, setup.K8sClient, userName, setup.Namespace.Name)
+func (g *userTestingPrimitives) DeleteTeleportResource(ctx context.Context, name string) error {
+	return trace.Wrap(g.setup.TeleportClient.DeleteUser(ctx, name))
+}
 
-	fastEventually(t, func() bool {
-		_, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		return trace.IsNotFound(err)
-	})
+func (g *userTestingPrimitives) CreateKubernetesResource(ctx context.Context, name string) error {
+	user := &v2.TeleportUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
+		},
+		Spec: v2.TeleportUserSpec(userSpec),
+	}
+	return trace.Wrap(g.setup.K8sClient.Create(ctx, user))
+}
+
+func (g *userTestingPrimitives) DeleteKubernetesResource(ctx context.Context, name string) error {
+	user := &v2.TeleportUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: g.setup.Namespace.Name,
+		},
+	}
+	return trace.Wrap(g.setup.K8sClient.Delete(ctx, user))
+}
+
+func (g *userTestingPrimitives) GetKubernetesResource(ctx context.Context, name string) (*v2.TeleportUser, error) {
+	user := &v2.TeleportUser{}
+	obj := kclient.ObjectKey{
+		Name:      name,
+		Namespace: g.setup.Namespace.Name,
+	}
+	err := g.setup.K8sClient.Get(ctx, obj, user)
+	return user, trace.Wrap(err)
+}
+
+func (g *userTestingPrimitives) ModifyKubernetesResource(ctx context.Context, name string) error {
+	user, err := g.GetKubernetesResource(ctx, name)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	user.Spec.Traits = wrappers.Traits{
+		"foo": []string{"bar", "baz"},
+	}
+	return g.setup.K8sClient.Update(ctx, user)
+}
+
+func (g *userTestingPrimitives) CompareTeleportAndKubernetesResource(tResource types.User, kubeResource *v2.TeleportUser) (bool, string) {
+	ignoreServerSideDefaults := []cmp.Option{
+		cmpopts.IgnoreFields(types.UserSpecV2{}, "CreatedBy"),
+		cmpopts.IgnoreFields(types.UserV2{}, "Status"),
+	}
+	diff := cmp.Diff(tResource, kubeResource.ToTeleport(), testlib.CompareOptions(ignoreServerSideDefaults...)...)
+	return diff == "", diff
+}
+
+func TestTeleportUserCreation(t *testing.T) {
+	test := &userTestingPrimitives{}
+	testlib.ResourceCreationSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
+}
+
+func TestTeleportUserDeletionDrift(t *testing.T) {
+	test := &userTestingPrimitives{}
+	testlib.ResourceDeletionDriftSynchronousTest[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
+}
+
+func TestTeleportUserUpdate(t *testing.T) {
+	test := &userTestingPrimitives{}
+	testlib.ResourceUpdateTestSynchronous[types.User, *v2.TeleportUser](t, resources.NewUserReconciler, test)
 }
 
 func TestUserCreationFromYAML(t *testing.T) {
 	ctx := context.Background()
-	setup := setupTestEnv(t)
+	setup := testlib.SetupFakeKubeTestEnv(t)
 	require.NoError(t, teleportCreateDummyRole(ctx, "a", setup.TeleportClient))
 	tests := []struct {
 		name         string
 		userSpecYAML string
-		shouldFail   bool
 		expectedSpec *types.UserSpecV2
 	}{
 		{
@@ -98,7 +173,6 @@ func TestUserCreationFromYAML(t *testing.T) {
 roles:
   - a
 `,
-			shouldFail: false,
 			expectedSpec: &types.UserSpecV2{
 				Roles: []string{"a"},
 			},
@@ -111,7 +185,6 @@ roles:
 traits:
   'foo': ['bar']
 `,
-			shouldFail: false,
 			expectedSpec: &types.UserSpecV2{
 				Roles: []string{"a"},
 				Traits: map[string][]string{
@@ -127,7 +200,6 @@ roles:
 traits:
   'foo': ['bar', 'baz']
 `,
-			shouldFail: false,
 			expectedSpec: &types.UserSpecV2{
 				Roles: []string{"a"},
 				Traits: map[string][]string{
@@ -135,25 +207,14 @@ traits:
 				},
 			},
 		},
-		{
-			name: "Invalid user with non-existing role",
-			userSpecYAML: `
-roles:
-  - does-not-exist
-traits:
-  'foo': ['bar', 'baz']
-`,
-			shouldFail:   true,
-			expectedSpec: nil,
-		},
 	}
 
 	for _, tc := range tests {
-		tc := tc // capture range variable
+		// capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			// Creating the Kubernetes resource. We are using an untyped client to be able to create invalid resources.
-			userManifest := map[string]interface{}{}
+			userManifest := map[string]any{}
 			err := yaml.Unmarshal([]byte(tc.userSpecYAML), &userManifest)
 			require.NoError(t, err)
 
@@ -167,50 +228,53 @@ traits:
 			err = setup.K8sClient.Create(ctx, obj)
 			require.NoError(t, err)
 
-			// If failure is expected we should not see the resource in Teleport
-			if tc.shouldFail {
-				fastEventually(t, func() bool {
-					// We check status.Conditions was updated, this means the reconciliation happened
-					_ = setup.K8sClient.Get(ctx, kclient.ObjectKey{
-						Namespace: setup.Namespace.Name,
-						Name:      userName,
-					}, obj)
-					errorConditions := getUserStatusConditionError(obj.Object)
-					// If there's no error condition, reconciliation has not happened yet
-					return len(errorConditions) != 0
-				})
-				_, err = setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
-				require.True(t, trace.IsNotFound(err), "The user should not be created in Teleport")
-			} else {
-				// We wait for Teleport resource creation
-				var tUser types.User
-				fastEventually(t, func() bool {
-					tUser, err = setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
-					// If the resource creation should succeed we check the resource was found and validate ownership labels
-					return !trace.IsNotFound(err)
-				})
-				require.NoError(t, err)
-				require.Equal(t, userName, tUser.GetName())
-				require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-				require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
-				require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name)
-				expectedUser := &types.UserV2{
-					Metadata: types.Metadata{},
-					Spec:     *tc.expectedSpec,
-				}
-				_ = expectedUser.CheckAndSetDefaults()
-				compareUserSpecs(t, expectedUser, tUser)
+			reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient)
+			require.NoError(t, err)
+			// Test execution: Kick off the reconciliation.
+			req := reconcile.Request{
+				NamespacedName: apimachinerytypes.NamespacedName{
+					Namespace: setup.Namespace.Name,
+					Name:      userName,
+				},
 			}
+			// First reconciliation should set the finalizer and exit.
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+			// Second reconciliation should create the Teleport resource.
+			// In a real cluster we should receive the event of our own finalizer change
+			// and this wakes us for a second round.
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
+
+			// We wait for Teleport resource creation
+			var tUser types.User
+			fastEventually(t, func() bool {
+				tUser, err = setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
+				// If the resource creation should succeed we check the resource was found and validate ownership labels
+				return !trace.IsNotFound(err)
+			})
+			require.NoError(t, err)
+			require.Equal(t, userName, tUser.GetName())
+			require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
+			require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
+			require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name)
+			expectedUser := &types.UserV2{
+				Metadata: types.Metadata{},
+				Spec:     *tc.expectedSpec,
+			}
+			_ = expectedUser.CheckAndSetDefaults()
+			compareUserSpecs(t, expectedUser, tUser)
 			// Teardown
 
-			// The role is deleted in K8S
-			k8sDeleteUser(ctx, t, setup.K8sClient, userName, setup.Namespace.Name)
-
-			// We wait for the role deletion in Teleport
-			fastEventually(t, func() bool {
-				_, err := setup.TeleportClient.GetUser(ctx, userName, false /* withSecrets */)
-				return trace.IsNotFound(err)
-			})
+			user := v2.TeleportUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      userName,
+					Namespace: setup.Namespace.Name,
+				},
+			}
+			require.NoError(t, setup.K8sClient.Delete(ctx, &user))
+			_, err = reconciler.Reconcile(ctx, req)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -223,68 +287,15 @@ func compareUserSpecs(t *testing.T, expectedUser, actualUser types.User) {
 
 	// We don't want compare spec.created_by and metadata as they were tested before and are not 100%
 	// managed by the operator
-	delete(expected["spec"].(map[string]interface{}), "created_by")
-	delete(actual["spec"].(map[string]interface{}), "created_by")
+	delete(expected["spec"].(map[string]any), "created_by")
+	delete(actual["spec"].(map[string]any), "created_by")
 
 	require.Equal(t, expected["spec"], actual["spec"])
 }
 
-// TestUserDeletionDrift tests how the Kubernetes operator reacts when it is asked to delete a user that was
-// already deleted in Teleport
-func TestUserDeletionDrift(t *testing.T) {
-	// Setup section: start the operator, and create a user
-	ctx := context.Background()
-	setup := setupTestEnv(t)
-	userName := validRandomResourceName("user-")
-
-	require.NoError(t, teleportCreateDummyRole(ctx, "a", setup.TeleportClient))
-	require.NoError(t, teleportCreateDummyRole(ctx, "b", setup.TeleportClient))
-
-	// The user is created in K8S
-	k8sCreateDummyUser(ctx, t, setup.K8sClient, setup.Namespace.Name, userName)
-
-	var tUser types.User
-	var err error
-	fastEventually(t, func() bool {
-		tUser, err = setup.TeleportClient.GetUser(ctx, userName, false)
-		return !trace.IsNotFound(err)
-	})
-	require.NoError(t, err)
-	require.Equal(t, userName, tUser.GetName())
-	require.Contains(t, tUser.GetMetadata().Labels, types.OriginLabel)
-	require.Equal(t, types.OriginKubernetes, tUser.GetMetadata().Labels[types.OriginLabel])
-
-	// We cause a drift by altering the Teleport resource.
-	// To make sure the operator does not reconcile while we're finished we suspend the operator
-	setup.StopKubernetesOperator()
-
-	err = setup.TeleportClient.DeleteUser(ctx, userName)
-	require.NoError(t, err)
-	fastEventually(t, func() bool {
-		_, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		return trace.IsNotFound(err)
-	})
-
-	// We flag the role for deletion in Kubernetes (it won't be fully removed until the operator has processed it and removed the finalizer)
-	k8sDeleteUser(ctx, t, setup.K8sClient, userName, setup.Namespace.Name)
-
-	// Test section: We resume the operator, it should reconcile and recover from the drift
-	setup.StartKubernetesOperator(t)
-
-	// The operator should handle the failed Teleport deletion gracefully and unlock the Kubernetes resource deletion
-	var k8sUser v2.TeleportUser
-	fastEventually(t, func() bool {
-		err = setup.K8sClient.Get(ctx, kclient.ObjectKey{
-			Namespace: setup.Namespace.Name,
-			Name:      userName,
-		}, &k8sUser)
-		return kerrors.IsNotFound(err)
-	})
-}
-
 func TestUserUpdate(t *testing.T) {
 	ctx := context.Background()
-	setup := setupTestEnv(t)
+	setup := testlib.SetupFakeKubeTestEnv(t)
 	require.NoError(t, teleportCreateDummyRole(ctx, "a", setup.TeleportClient))
 	require.NoError(t, teleportCreateDummyRole(ctx, "b", setup.TeleportClient))
 	require.NoError(t, teleportCreateDummyRole(ctx, "x", setup.TeleportClient))
@@ -320,6 +331,14 @@ func TestUserUpdate(t *testing.T) {
 	tUser, err = setup.TeleportClient.CreateUser(ctx, tUser)
 	require.NoError(t, err)
 
+	// Wait for the user to enter the cache
+	testlib.FastEventually(t, func() bool {
+		tUser, err = setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		return !trace.IsNotFound(err)
+	})
+	require.NoError(t, err)
+	oldRevision := tUser.GetRevision()
+
 	// The user is created in K8S
 	k8sUser := v2.TeleportUser{
 		ObjectMeta: metav1.ObjectMeta{
@@ -332,90 +351,52 @@ func TestUserUpdate(t *testing.T) {
 	}
 	k8sCreateUser(ctx, t, setup.K8sClient, &k8sUser)
 
-	// The user is updated in Teleport
-	fastEventually(t, func() bool {
-		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		assert.NoError(t, err)
+	reconciler, err := resources.NewUserReconciler(setup.K8sClient, setup.TeleportClient)
+	require.NoError(t, err)
+	// Test execution: Kick off the reconciliation.
+	req := reconcile.Request{
+		NamespacedName: apimachinerytypes.NamespacedName{
+			Namespace: setup.Namespace.Name,
+			Name:      userName,
+		},
+	}
+	// First reconciliation should set the finalizer and exit.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
+	// Second reconciliation should create the Teleport resource.
+	// In a real cluster we should receive the event of our own finalizer change
+	// and this wakes us for a second round.
+	_, err = reconciler.Reconcile(ctx, req)
+	require.NoError(t, err)
 
-		// TeleportUser was updated with new roles
-		return compareRoles([]string{"x", "z"}, tUser.GetRoles())
+	// Wait for the new user to enter the cache, else the next reconciliation will cause conflicts.
+	testlib.FastEventually(t, func() bool {
+		newUser, err := setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		assert.NoError(t, err)
+		// only proceed when the revision changes
+		return newUser.GetRevision() != oldRevision
 	})
+	require.NoError(t, err)
 
 	// Updating the user in K8S
 	// The modification can fail because of a conflict with the resource controller. We retry if that happens.
 	var k8sUserNewVersion v2.TeleportUser
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := setup.K8sClient.Get(ctx, kclient.ObjectKey{
+	require.NoError(t,
+		setup.K8sClient.Get(ctx, kclient.ObjectKey{
 			Namespace: setup.Namespace.Name,
 			Name:      userName,
-		}, &k8sUserNewVersion)
-		if err != nil {
-			return err
-		}
+		}, &k8sUserNewVersion),
+	)
 
-		k8sUserNewVersion.Spec.Roles = append(k8sUserNewVersion.Spec.Roles, "y")
-		return setup.K8sClient.Update(ctx, &k8sUserNewVersion)
-	})
+	k8sUserNewVersion.Spec.Roles = append(k8sUserNewVersion.Spec.Roles, "y")
+	require.NoError(t, setup.K8sClient.Update(ctx, &k8sUserNewVersion))
+
+	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
-
-	// Updates the user in Teleport
-	fastEventuallyWithT(t, func(c *assert.CollectT) {
-		tUser, err := setup.TeleportClient.GetUser(ctx, userName, false)
-		require.NoError(c, err)
-
-		// TeleportUser updated with new roles
-		assert.ElementsMatch(c, tUser.GetRoles(), []string{"x", "z", "y"})
-	})
 	require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name, "createdBy has not been erased")
-}
-
-func k8sCreateDummyUser(ctx context.Context, t *testing.T, kc kclient.Client, namespace, userName string) {
-	user := v2.TeleportUser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userName,
-			Namespace: namespace,
-		},
-		Spec: v2.TeleportUserSpec{
-			Roles: []string{"a", "b"},
-		},
-	}
-	k8sCreateUser(ctx, t, kc, &user)
-}
-
-func k8sDeleteUser(ctx context.Context, t *testing.T, kc kclient.Client, userName, namespace string) {
-	user := v2.TeleportUser{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      userName,
-			Namespace: namespace,
-		},
-	}
-	err := kc.Delete(ctx, &user)
-	require.NoError(t, err)
 }
 
 func k8sCreateUser(ctx context.Context, t *testing.T, kc kclient.Client, user *v2.TeleportUser) {
 	err := kc.Create(ctx, user)
 	require.NoError(t, err)
-}
-
-func getUserStatusConditionError(object map[string]interface{}) []metav1.Condition {
-	var conditionsWithError []metav1.Condition
-	var status teleportcr.Status
-	_ = mapstructure.Decode(object["status"], &status)
-
-	for _, condition := range status.Conditions {
-		if condition.Status == metav1.ConditionFalse {
-			conditionsWithError = append(conditionsWithError, condition)
-		}
-	}
-	return conditionsWithError
-}
-
-func compareRoles(expected, actual []string) bool {
-	opts := testlib.CompareOptions(cmpopts.SortSlices(func(a, b string) bool { return a < b }))
-	return cmp.Diff(
-		expected,
-		actual,
-		opts...,
-	) == ""
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -37,7 +37,7 @@ import (
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gravitational/teleport/api/types"
-	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	"github.com/gravitational/teleport/integrations/operator/apis/resources/teleportcr"
 	v2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
@@ -400,7 +400,7 @@ func k8sCreateUser(ctx context.Context, t *testing.T, kc kclient.Client, user *v
 
 func getUserStatusConditionError(object map[string]interface{}) []metav1.Condition {
 	var conditionsWithError []metav1.Condition
-	var status apiresources.Status
+	var status teleportcr.Status
 	_ = mapstructure.Decode(object["status"], &status)
 
 	for _, condition := range status.Conditions {

--- a/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
+++ b/integrations/operator/controllers/resources/workload_identityv1_controller_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
+	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
 	"github.com/gravitational/teleport/integrations/operator/controllers/resources/testlib"
 )
 
@@ -187,24 +188,24 @@ func (g *workloadIdentityTestingPrimitives) CompareTeleportAndKubernetesResource
 
 func TestWorkloadIdentityCreation(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceCreationTest[
+	testlib.ResourceCreationSynchronousTest[
 		*workloadidentityv1.WorkloadIdentity,
 		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, test)
+	](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityDeletionDrift(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceDeletionDriftTest[
+	testlib.ResourceDeletionDriftSynchronousTest[
 		*workloadidentityv1.WorkloadIdentity,
 		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, test)
+	](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }
 
 func TestWorkloadIdentityUpdate(t *testing.T) {
 	test := &workloadIdentityTestingPrimitives{}
-	testlib.ResourceUpdateTest[
+	testlib.ResourceUpdateTestSynchronous[
 		*workloadidentityv1.WorkloadIdentity,
 		*resourcesv1.TeleportWorkloadIdentityV1,
-	](t, test)
+	](t, resources.NewWorkloadIdentityV1Reconciler, test)
 }

--- a/integrations/operator/controllers/scheme.go
+++ b/integrations/operator/controllers/scheme.go
@@ -24,20 +24,14 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
-	resourcesv1 "github.com/gravitational/teleport/integrations/operator/apis/resources/v1"
-	resourcesv2 "github.com/gravitational/teleport/integrations/operator/apis/resources/v2"
-	resourcesv3 "github.com/gravitational/teleport/integrations/operator/apis/resources/v3"
-	resourcesv5 "github.com/gravitational/teleport/integrations/operator/apis/resources/v5"
+	apiresources "github.com/gravitational/teleport/integrations/operator/apis/resources"
 )
 
 // Scheme is a singleton scheme for all controllers
 var Scheme = runtime.NewScheme()
 
 func init() {
-	utilruntime.Must(resourcesv5.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(Scheme))
+	utilruntime.Must(apiresources.AddToScheme(Scheme))
 
 	// Not needed to reconcile the teleport CRs, but needed for the controller manager.
 	// We are not doing something very kubernetes friendly, but it's easier to have a single

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -36,8 +36,8 @@ import (
 
 const (
 	k8sKindPrefix     = "Teleport"
-	statusPackagePath = "github.com/gravitational/teleport/integrations/operator/apis"
-	statusPackageName = "resources"
+	statusPackagePath = "github.com/gravitational/teleport/integrations/operator/apis/resources"
+	statusPackageName = "teleportcr"
 	statusPackage     = statusPackagePath + "/" + statusPackageName
 	statusTypeName    = "Status"
 )
@@ -573,7 +573,7 @@ func getStatusSchema(parser *crdtools.Parser) (apiextv1.JSONSchemaProps, error) 
 	}
 	var statusType crdtools.TypeIdent
 	for _, pkg := range pkgs {
-		if pkg.Name == "resources" {
+		if pkg.Name == statusPackageName {
 			parser.NeedPackage(pkg)
 			statusType = crdtools.TypeIdent{
 				Package: pkg,


### PR DESCRIPTION
This PR backports 4 PRs converting operator tests so they can run synchronously on a fake kube cluster.
This does not contain user-facing changes. The backport had to be manual because the [modernize PR](https://github.com/gravitational/teleport/pull/55876) caused a few conflicts (all the `omitempty` changes you can see in the diff).

Backports: https://github.com/gravitational/teleport/pull/62625
Backports: https://github.com/gravitational/teleport/pull/62859
Backports: https://github.com/gravitational/teleport/pull/62945
Backports: https://github.com/gravitational/teleport/pull/62946

Fixes: https://github.com/gravitational/teleport/issues/63241