### PR TITLE
feat(integrations/terraform): support polling state changes

### DIFF
--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -148,10 +148,10 @@ type payload struct {
 	// TargetStates is a list of possible states that indicate a resource is ready for usage while polling. Any state
 	// that is found that is not in PendingStates or TargetStates is considered a terminal error.
 	TargetStates []string
-	// CreatePollIntervalSeconds is how long to wait before polling the pending resource again.
-	CreatePollIntervalSeconds int
-	// CreateTimeoutSeconds is the maximum amount of seconds to wait for a resource to reach a target state.
-	CreateTimeoutSeconds int
+	// StatePollIntervalSeconds is how long to wait before polling the pending resource again.
+	StatePollIntervalSeconds int
+	// StateTimeoutSeconds is the maximum amount of seconds to wait for a resource to reach a target state.
+	StateTimeoutSeconds int
 }
 
 func (p *payload) CheckAndSetDefaults() error {
@@ -176,12 +176,12 @@ func (p *payload) CheckAndSetDefaults() error {
 			return errors.New("TargetStates must be provided when StatePath is set")
 		}
 
-		if p.CreatePollIntervalSeconds == 0 {
-			return errors.New("CreatePollIntervalSeconds must be provided when StatePath is set")
+		if p.StatePollIntervalSeconds == 0 {
+			return errors.New("StatePollIntervalSeconds must be provided when StatePath is set")
 		}
 
-		if p.CreateTimeoutSeconds == 0 {
-			return errors.New("CreateTimeoutSeconds must be provided when StatePath is set")
+		if p.StateTimeoutSeconds == 0 {
+			return errors.New("StateTimeoutSeconds must be provided when StatePath is set")
 		}
 	}
 	return nil

--- a/integrations/terraform/gen/main.go
+++ b/integrations/terraform/gen/main.go
@@ -131,6 +131,12 @@ type payload struct {
 	// WithoutImportState skips generating the ImportState function, which may be
 	// not supported for resources with write-only fields.
 	WithoutImportState bool
+	// StatePoll optionally configures polling for state changes when creating or updating resources.
+	StatePoll *statePoll
+}
+
+// statePoll configures polling for state changes when creating or updating resources.
+type statePoll struct {
 	// StatePath is the object path to the current state to observe from the object returned from the provided GetMethod.
 	// StatePath provides a path to lookup the current state from the returned object from GetMethod.
 	// Each string is treated as a field name for a nested object. It's expected
@@ -167,21 +173,25 @@ func (p *payload) CheckAndSetDefaults() error {
 	if p.SchemaPackagePath == "" {
 		p.SchemaPackagePath = "github.com/gravitational/teleport/integrations/terraform/tfschema"
 	}
-	if len(p.StatePath) != 0 {
-		if len(p.PendingStates) == 0 {
-			return errors.New("PendingStates must be provided when StatePath is set")
+	if p.StatePoll != nil {
+		if len(p.StatePoll.StatePath) == 0 {
+			return errors.New("StatePath must be provided when StatePoll is set")
 		}
 
-		if len(p.TargetStates) == 0 {
-			return errors.New("TargetStates must be provided when StatePath is set")
+		if len(p.StatePoll.PendingStates) == 0 {
+			return errors.New("PendingStates must be provided when StatePoll is set")
 		}
 
-		if p.StatePollIntervalSeconds == 0 {
-			return errors.New("StatePollIntervalSeconds must be provided when StatePath is set")
+		if len(p.StatePoll.TargetStates) == 0 {
+			return errors.New("TargetStates must be provided when StatePoll is set")
 		}
 
-		if p.StateTimeoutSeconds == 0 {
-			return errors.New("StateTimeoutSeconds must be provided when StatePath is set")
+		if p.StatePoll.StatePollIntervalSeconds == 0 {
+			return errors.New("StatePollIntervalSeconds must be provided when StatePoll is set")
+		}
+
+		if p.StatePoll.StateTimeoutSeconds == 0 {
+			return errors.New("StateTimeoutSeconds must be provided when StatePoll is set")
 		}
 	}
 	return nil

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -271,8 +271,11 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 		PollInterval: {{ .CreatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, id)
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
 
-			return {{ .VarName }}, {{ .VarName }}{{ .StatePath }}, err
+			return {{ .VarName }}, {{ .VarName }}{{ .StatePath }}, nil
 		},
 	}
 

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -24,7 +24,7 @@ import (
     "encoding/hex"
 {{- end }}
 	"fmt"
-{{- if .StatePath }}
+{{- if .StatePoll }}
 	"time"
 {{- end }}
 {{- range $i, $a := .ExtraImports }}
@@ -43,7 +43,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-{{- if .StatePath }}
+{{- if .StatePoll }}
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 {{- end }}
 {{- if .Namespaced }}
@@ -254,21 +254,21 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-{{- if .StatePath }}
+{{- if .StatePoll }}
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{
-		{{- range $state := .PendingStates }}
+		{{- range $state := .StatePoll.PendingStates }}
 			"{{ $state }}",
 		{{- end }}
 		},
 		Target:  []string{
-		{{- range $state := .TargetStates }}
+		{{- range $state := .StatePoll.TargetStates }}
 			"{{ $state }}",
 		{{- end }}
 		},
-		Timeout:      {{ .StateTimeoutSeconds }} * time.Second,
-		PollInterval: {{ .StatePollIntervalSeconds }} * time.Second,
+		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
+		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, id)
 			if err != nil {
@@ -281,11 +281,11 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 
 			{{- $root := . }}
 			{{- $lastIndex := -1 }}
-			{{- range $i, $p := .StatePath }}
+			{{- range $i, $p := .StatePoll.StatePath }}
 				{{- $lastIndex = $i }}
 			{{- end }}
 			{{- $currentPath := "" }}
-			{{- range $i, $p := .StatePath }}
+			{{- range $i, $p := .StatePoll.StatePath }}
 				{{- if eq $i $lastIndex }}
 					{{- break }}
 				{{- end }}
@@ -295,7 +295,7 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			}
 			{{- end }}
 
-			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePath }}. {{- $p }}{{ end }}, nil
+			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePoll.StatePath }}. {{- $p }}{{ end }}, nil
 		},
 	}
 
@@ -491,21 +491,21 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 	if resp.Diagnostics.HasError() {
 		return
 	}
-{{- if .StatePath }}
+{{- if .StatePoll }}
 
 	stateConf := resource.StateChangeConf{
 		Pending: []string{
-		{{- range $state := .PendingStates }}
+		{{- range $state := .StatePoll.PendingStates }}
 			"{{ $state }}",
 		{{- end }}
 		},
 		Target:  []string{
-		{{- range $state := .TargetStates }}
+		{{- range $state := .StatePoll.TargetStates }}
 			"{{ $state }}",
 		{{- end }}
 		},
-		Timeout:      {{ .StateTimeoutSeconds }} * time.Second,
-		PollInterval: {{ .StatePollIntervalSeconds }} * time.Second,
+		Timeout:      {{ .StatePoll.StateTimeoutSeconds }} * time.Second,
+		PollInterval: {{ .StatePoll.StatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, name)
 			if err != nil {
@@ -518,11 +518,11 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 
 			{{- $root := . }}
 			{{- $lastIndex := -1 }}
-			{{- range $i, $p := .StatePath }}
+			{{- range $i, $p := .StatePoll.StatePath }}
 				{{- $lastIndex = $i }}
 			{{- end }}
 			{{- $currentPath := "" }}
-			{{- range $i, $p := .StatePath }}
+			{{- range $i, $p := .StatePoll.StatePath }}
 				{{- if eq $i $lastIndex }}
 					{{- break }}
 				{{- end }}
@@ -532,7 +532,7 @@ func (r resourceTeleport{{.Name}}) Update(ctx context.Context, req tfsdk.UpdateR
 			}
 			{{- end }}
 
-			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePath }}. {{- $p }}{{ end }}, nil
+			return {{ .VarName }}, {{ .VarName }}{{ range $p := .StatePoll.StatePath }}. {{- $p }}{{ end }}, nil
 		},
 	}
 

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -284,16 +284,12 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			{{- range $i, $p := .StatePath }}
 				{{- $lastIndex = $i }}
 			{{- end }}
+			{{- $currentPath := "" }}
 			{{- range $i, $p := .StatePath }}
 				{{- if eq $i $lastIndex }}
 					{{- break }}
 				{{- end }}
-				{{- $currentPath := "" }}
-				{{- range $j, $p := $root.StatePath }}
-					{{- if le $j $i }}
-						{{- $currentPath = print $currentPath "." $p }}
-					{{- end }}
-				{{- end }}
+				{{- $currentPath = print $currentPath "." $p }}
 			if {{ $root.VarName }}{{ $currentPath }} == nil {
 				return nil, "", trace.Errorf("response from {{ $root.GetMethod }} at {{ $currentPath }} was nil")
 			}

--- a/integrations/terraform/gen/plural_resource.go.tpl
+++ b/integrations/terraform/gen/plural_resource.go.tpl
@@ -267,8 +267,8 @@ func (r resourceTeleport{{.Name}}) Create(ctx context.Context, req tfsdk.CreateR
 			"{{ $state }}",
 		{{- end }}
 		},
-		Timeout:      {{ .CreateTimeoutSeconds }} * time.Second,
-		PollInterval: {{ .CreatePollIntervalSeconds }} * time.Second,
+		Timeout:      {{ .StateTimeoutSeconds }} * time.Second,
+		PollInterval: {{ .StatePollIntervalSeconds }} * time.Second,
 		Refresh: func() (any, string, error) {
 			{{ .VarName }}, err := r.p.Client.{{ .GetMethod }}(ctx, id)
 			if err != nil {


### PR DESCRIPTION
This pull request introduces support for generating Terraform resources with additional polling support for their create and update methods.

Most Teleport resources can simply be created and ready to use immediately. An upcoming resource, `workload_cluster`, is not this way. Teleport Cloud will provision a new Teleport Cloud cluster on behalf of the Teleport user. Teleport's workload cluster service queries Teleport Cloud's API for status of the new Teleport Cloud cluster. Teleport's Terraform provider should introduce polling to let a Terraform user known when the `workload_cluster` has reached an active state.

This uses `terraform-plugin-sdk/v2`'s [resource.StateChangeConf](https://github.com/hashicorp/terraform-plugin-sdk/blob/9cecd719095910f47ea6810329a18947dc6e353b/helper/resource/state.go#L24) (moved to [retry.StateChangeConf](https://github.com/hashicorp/terraform-plugin-sdk/blob/e04f990fd0c32c2198c97268b4af70391fb4a8e3/helper/retry/state.go#L27) in newer versions), which handles polling a resource until it reaches a configured target state. The resource will be polled until either the configured timeout is reached or a state not provided as a pending or target state is encountered, signaling an error.

Example of configuring a payload with polling: 64c2d4d4e4c6e73d545b4b9d16646897ace730e3
Example of generated polling code: 9e0d064d43ee0c125b5b21eafa55a62b81502f50

Goal: https://github.com/gravitational/cloud/issues/15870

---

Future ideas:

1. Consider supporting [timeout blocks](https://developer.hashicorp.com/terraform/plugin/framework/resources/timeouts)