### PR TITLE
[Web UI] add AWS IAM, SSM requirements to Discover IaC prerequisites

### DIFF
--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/EnrollAws.tsx
@@ -331,7 +331,6 @@ export function IntegrationSection({
       <FieldInput
         ml={4}
         mb={0}
-        autoFocus={true}
         rule={requiredIntegrationName}
         value={integrationName}
         required={true}

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/Prerequisites.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/Prerequisites.tsx
@@ -85,10 +85,49 @@ export function Prerequisites() {
             `}
           >
             <li>
-              <Text>AWS account access with admin permissions</Text>
+              <Text>
+                AWS IAM permissions required for AWS Terraform provider
+              </Text>
+              <ExternalLink
+                href="https://goteleport.com/docs/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-terraform#step-15-configure-aws-terraform-provider"
+                target="_blank"
+              >
+                Terraform EC2 Auto-Discovery Configuration{' '}
+                <ArrowSquareOut size="small" />
+              </ExternalLink>
+            </li>
+          </ul>
+          <Text typography="h3" fontSize="small">
+            For EC2 resources:
+          </Text>
+          <ul
+            css={`
+              margin: 0;
+              padding-left: ${p => p.theme.space[3]}px;
+            `}
+          >
+            <li>
+              <Text>
+                AmazonSSMManagedInstanceCore IAM policy attached to EC2
+                instance's role.
+              </Text>
+              <ExternalLink
+                href="https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonSSMManagedInstanceCore.html"
+                target="_blank"
+              >
+                AmazonSSMManagedInstanceCore Policy{' '}
+                <ArrowSquareOut size="small" />
+              </ExternalLink>
             </li>
             <li>
-              <Text>Permissions to create IAM roles</Text>
+              <Text>SSM agent running on EC2 instances to be discovered.</Text>
+              <ExternalLink
+                href="https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent.html"
+                target="_blank"
+              >
+                Working with SSM Agent
+                <ArrowSquareOut size="small" />
+              </ExternalLink>
             </li>
           </ul>
         </Box>


### PR DESCRIPTION
## Description

Adds the following to the to the Discover AWS IaC flow

- AWS IAM permissions needed for terraform module
- SSM role needed for EC2 Instances

## Screenshots 
<img width="500" height="508" alt="Screenshot 2026-02-05 at 3 10 51 PM" src="https://github.com/user-attachments/assets/ea61c26b-fe63-419f-85ec-e0b502ebb6ae" />
