### PR TITLE
Fix large event handling for Athena backend

### DIFF
--- a/lib/events/athena/querier_test.go
+++ b/lib/events/athena/querier_test.go
@@ -36,7 +36,6 @@ import (
 	athenaTypes "github.com/aws/aws-sdk-go-v2/service/athena/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/dustin/go-humanize"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -766,10 +765,9 @@ func Test_querier_fetchResults(t *testing.T) {
 		// fakeResp defines responses which will be returned based on given
 		// input token to GetQueryResults. Note that due to limit of GetQueryResults
 		// we are doing multiple calls, first always with empty token.
-		fakeResp     map[string]eventsWithToken
-		wantEvents   []apievents.AuditEvent
-		wantKeyset   string
-		wantErrorMsg string
+		fakeResp   map[string]eventsWithToken
+		wantEvents []apievents.AuditEvent
+		wantKeyset string
 	}{
 		{
 			name:  "no data returned from query, return empty results",
@@ -802,9 +800,9 @@ func Test_querier_fetchResults(t *testing.T) {
 				"": {returnToken: "", events: []apievents.AuditEvent{bigUntrimmableEvent}},
 			},
 			limit: 10,
-			wantErrorMsg: fmt.Sprintf(
-				"app.create event %s is 5.0 MiB and cannot be returned because it exceeds the maximum response size of %s",
-				bigUntrimmableEvent.Metadata.ID, humanize.IBytes(events.MaxEventBytesInResponse)),
+			// we still want to receive the untrimmable event
+			wantEvents: []apievents.AuditEvent{bigUntrimmableEvent},
+			wantKeyset: mustEventToKey(t, bigUntrimmableEvent),
 		},
 		{
 			name: "events with trimmable event exceeding > MaxEventBytesInResponse",
@@ -861,10 +859,6 @@ func Test_querier_fetchResults(t *testing.T) {
 				},
 			}
 			gotEvents, gotKeyset, err := q.fetchResults(context.Background(), "queryid", tt.limit, tt.condition)
-			if tt.wantErrorMsg != "" {
-				require.ErrorContains(t, err, tt.wantErrorMsg)
-				return
-			}
 			require.NoError(t, err)
 
 			want := make([]events.EventFields, 0, len(tt.wantEvents))


### PR DESCRIPTION
Fixes #54480

This PR modifies the large event handling logic for Athena backends by attempting to send the trimmed event instead of returning an error on trim failure. This matches the logic for the [DynamoDB PR](https://github.com/gravitational/teleport/pull/62899).

<details><summary>Manual Tests</summary>
<p>

Tested via Teleport Cloud (Athena backend).

- [x] Verify that when an PostgreSQL audit event is created with size > 1 MiB, the event handler successfully forwards to Fluentd and continues to forward future audit events.

</p>
</details> 

changelog: Fixed bug where event handler would throw an error on Athena backend when handling large events