### PR TITLE
Add Operator custom resources opt-in support for Discord access-plugin helm chart

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.access-discord.mdx
@@ -218,6 +218,89 @@ teleportAuthAddress: "teleport-auth.teleport-namespace.svc.cluster.local:3025"
 `tbot.joinMethod` describes how tbot joins the Teleport cluster.
 See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
 
+### `tbot.token`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`tbot.token` is the name of the token used by tbot to join the Teleport cluster.
+This value is not sensitive unless the `joinMethod` is set to `"token"`.
+If unset, defaults to `[release name]-tbot`.
+If `crd.create` is set to true, then a TeleportProvisionToken will be created with the provided token name.
+
+## `crd`
+
+`crd` controls whether the chart creates custom resources managed by the Teleport Kubernetes Operator.
+If enabled, the chart will create TeleportRoleV8, TeleportBotV1, and TeleportProvisionToken
+resources to automatically connect the plugin to Teleport.
+
+<Admonition type="warning" title="Interaction with Teleport Kubernetes Operator">
+The Teleport Kubernetes Operator must already be enabled in the Teleport cluster
+for the custom resources to be applied successfully. In addition,
+the custom resources must be deployed in the same namespace as the Teleport Kubernetes Operator.
+</Admonition>
+
+### `crd.create`
+
+| Type | Default |
+|------|---------|
+| `bool` | `false` |
+
+`crd.create` controls if the chart should create
+the Operator custom resources to automatically bootstrap the plugin.
+
+### `crd.namespace`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`crd.namespace` optionally overrides the Kubernetes namespace that the
+custom resources are created in. This should match the namespace in which the
+Teleport Kubernetes Operator is running. Defaults to the release namespace.
+
+### `crd.tokenSpecOverride`
+
+`crd.tokenSpecOverride` optionally overrides the join token spec for tbot to use to join the Teleport cluster.
+
+When tbot is enabled, the default configuration uses the `kubernetes` in_cluster join method.
+By default, the service account for tbot will be allowed for all `kubernetes` join types: in_cluster, JWKS, OIDC.
+
+You can also configure the token to use other supported join methods. The token specification
+must match `tbot.joinMethod` for the plugin to correctly join the cluster.
+See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
+
+<Admonition type="warning" title="Other Join Methods">
+When not using the `kubernetes` join method, or when tbot is not enabled, you must specify `join_method`.
+Ensure all necessary fields for the join token are present for the Operator
+to correctly create the Teleport token resource.
+</Admonition>
+
+Example (Kubernetes JWKS join method):
+```yaml
+tokenSpecOverride:
+  join_method: kubernetes
+  kubernetes:
+    type: static_jwks
+    static_jwks:
+      jwks: |
+        # Place the kubernetes JWKS here (`kubectl get --raw /openid/v1/jwks`)
+        {"keys":[--snip--]}
+```
+
+Example (Kubernetes OIDC join method):
+```yaml
+tokenSpecOverride:
+  join_method: kubernetes
+  kubernetes:
+    type: oidc
+    oidc:
+      # Insert the OIDC issuer value here, it will vary depending on your
+      # cluster and cloud provider.
+      issuer: https://oidc.eks.us-west-2.amazonaws.com/id/my-cluster
+```
+
 ## `annotations`
 
 `annotations` contains annotations to apply to the different Kubernetes

--- a/examples/chart/access/discord/.lint/tbot-enabled.yaml
+++ b/examples/chart/access/discord/.lint/tbot-enabled.yaml
@@ -1,0 +1,4 @@
+tbot:
+  enabled: true
+  clusterName: "test.teleport.sh"
+  teleportProxyAddress: "test.teleport.sh:443"  

--- a/examples/chart/access/discord/templates/_helpers.tpl
+++ b/examples/chart/access/discord/templates/_helpers.tpl
@@ -79,3 +79,68 @@ identity
 {{- .Values.teleport.identitySecretPath -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the embedded tbot's service account name.
+*/}}
+{{- define "discord.tbot.serviceAccountName" -}}
+{{- if .Values.tbot.serviceAccount.name -}}
+{{- .Values.tbot.serviceAccount.name -}}
+{{- else -}}
+{{- .Release.Name }}-{{ default .Values.tbot.nameOverride "tbot" }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create the embedded tbot's token name.
+*/}}
+{{- define "discord.tbot.tokenName" -}}
+{{- if .Values.tbot.token -}}
+{{- .Values.tbot.token -}}
+{{- else -}}
+{{- .Release.Name }}-{{ default .Values.tbot.nameOverride "tbot" }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the namespace that Operator custom resources will be created in.
+*/}}
+{{- define "discord.crd.namespace" -}}
+{{- if .Values.crd.namespace -}}
+{{- .Values.crd.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the default TeleportProvisionToken join spec when using kubernetes join method.
+*/}}
+{{- define "discord.crd.defaultKubeJoinSpec" -}}
+join_method: kubernetes
+kubernetes:
+  type: in_cluster
+  allow:
+  - service_account: "{{ .Release.Namespace }}:{{ include "discord.tbot.serviceAccountName" . }}"
+{{- end -}}
+
+{{/*
+Create the full TeleportProvisionToken join spec.
+*/}}
+{{- define "discord.crd.tokenJoinSpec" -}}
+{{/* Any overriden token spec must match tbot's join method */}}
+{{- if and (hasKey .Values.crd.tokenSpecOverride "join_method") (ne .Values.crd.tokenSpecOverride.join_method .Values.tbot.joinMethod) -}}
+{{- fail "crd.tokenSpecOverride.join_method must be same as tbot.joinMethod" -}}
+{{- end -}}
+{{- if eq .Values.tbot.joinMethod "kubernetes" -}}
+{{- mustMergeOverwrite (include "discord.crd.defaultKubeJoinSpec" . | fromYaml) .Values.crd.tokenSpecOverride | toYaml -}}
+{{- else -}}
+  {{- if empty .Values.crd.tokenSpecOverride -}}
+  {{- fail "crd.tokenSpecOverride cannot be empty in chart values" -}}
+  {{- end -}}
+  {{- if not (hasKey .Values.crd.tokenSpecOverride "join_method") -}}
+  {{- fail "crd.tokenSpecOverride.join_method cannot be empty in chart values" -}}
+  {{- end -}}
+{{- .Values.crd.tokenSpecOverride | toYaml -}}
+{{- end -}}
+{{- end -}}

--- a/examples/chart/access/discord/templates/operator_crs.yaml
+++ b/examples/chart/access/discord/templates/operator_crs.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.crd.create -}}
+{{- if not .Values.tbot.enabled -}}
+{{- fail "Custom resources cannot be deployed without tbot enabled" -}}
+{{- end -}}
+apiVersion: resources.teleport.dev/v1
+kind: TeleportBotV1
+metadata:
+  name: {{ include "discord.fullname" . }}
+  namespace: {{ include "discord.crd.namespace" . }}
+  labels:
+    {{- include "discord.labels" . | nindent 4 }}
+spec:
+  roles:
+    - access-plugin
+---
+apiVersion: resources.teleport.dev/v2
+kind: TeleportProvisionToken
+metadata:
+  name: {{ include "discord.tbot.tokenName" . }}
+  namespace: {{ include "discord.crd.namespace" . }}
+  labels:
+    {{- include "discord.labels" . | nindent 4 }}
+spec:
+  roles: [Bot]
+  bot_name: {{ include "discord.fullname" . }}
+  {{- include "discord.crd.tokenJoinSpec" . | nindent 2 -}}
+{{- end -}}

--- a/examples/chart/access/discord/tests/__snapshot__/operator_crs_test.yaml.snap
+++ b/examples/chart/access/discord/tests/__snapshot__/operator_crs_test.yaml.snap
@@ -1,0 +1,40 @@
+should match the snapshot (tokenSpecOverride set):
+  1: |
+    apiVersion: resources.teleport.dev/v1
+    kind: TeleportBotV1
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-discord
+        app.kubernetes.io/version: 19.0.0-dev
+        helm.sh/chart: teleport-plugin-discord-19.0.0-dev
+      name: RELEASE-NAME-teleport-plugin-discord
+      namespace: NAMESPACE
+    spec:
+      roles:
+      - access-plugin
+  2: |
+    apiVersion: resources.teleport.dev/v2
+    kind: TeleportProvisionToken
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: teleport-plugin-discord
+        app.kubernetes.io/version: 19.0.0-dev
+        helm.sh/chart: teleport-plugin-discord-19.0.0-dev
+      name: RELEASE-NAME-tbot
+      namespace: NAMESPACE
+    spec:
+      bot_name: RELEASE-NAME-teleport-plugin-discord
+      join_method: kubernetes
+      kubernetes:
+        allow:
+        - service_account: NAMESPACE:RELEASE-NAME-tbot
+        static_jwks:
+          jwks: |
+            test-jwks
+        type: static_jwks
+      roles:
+      - Bot

--- a/examples/chart/access/discord/tests/operator_crs_test.yaml
+++ b/examples/chart/access/discord/tests/operator_crs_test.yaml
@@ -1,0 +1,112 @@
+suite: Test operator custom resources
+templates:
+  - operator_crs.yaml
+tests:
+  - it: should match the snapshot (tokenSpecOverride set)
+    values:
+      - ../.lint/tbot-enabled.yaml
+    set:
+      crd:
+        create: true
+        tokenSpecOverride:
+          join_method: kubernetes
+          kubernetes:
+            type: static_jwks
+            static_jwks:
+              jwks: |
+                test-jwks
+    asserts:
+      - matchSnapshot: {}
+  - it: creates custom resources when crd.create is true
+    values:
+      - ../.lint/tbot-enabled.yaml
+    set:
+      crd:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: TeleportBotV1
+          apiVersion: resources.teleport.dev/v1
+          name: RELEASE-NAME-teleport-plugin-discord
+      - containsDocument:
+          kind: TeleportProvisionToken
+          apiVersion: resources.teleport.dev/v2
+          name: RELEASE-NAME-tbot
+  - it: creates custom resources in specified namespace
+    values:
+      - ../.lint/tbot-enabled.yaml
+    set:
+      crd:
+        create: true
+        namespace: test-namespace
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          kind: TeleportBotV1
+          apiVersion: resources.teleport.dev/v1
+          name: RELEASE-NAME-teleport-plugin-discord
+          namespace: test-namespace
+      - containsDocument:
+          kind: TeleportProvisionToken
+          apiVersion: resources.teleport.dev/v2
+          name: RELEASE-NAME-tbot
+          namespace: test-namespace
+  - it: creates no custom resources when crd.create is false
+    values:
+      - ../.lint/tbot-enabled.yaml
+    set:
+      crd:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should fail if crd.create is true but tbot not enabled
+    set:
+      crd:
+        create: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "Custom resources cannot be deployed without tbot enabled"
+  - it: should fail if tokenSpecOverride set and does not match tbot.joinMethod
+    values:
+      - ../.lint/tbot-enabled.yaml
+    set:
+      crd:
+        create: true
+        tokenSpecOverride:
+          join_method: github
+          github: |
+            test-github-config
+    asserts:
+      - failedTemplate:
+          errorMessage: "crd.tokenSpecOverride.join_method must be same as tbot.joinMethod"
+  - it: should fail if tbot.joinMethod not kubernetes and tokenSpecOverride not set
+    set:
+      tbot:
+        enabled: true
+        clusterName: "test.teleport.sh"
+        teleportProxyAddress: "test.teleport.sh:443"
+        joinMethod: "github"
+      crd:
+        create: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "crd.tokenSpecOverride cannot be empty in chart values"
+  - it: should fail if tbot.joinMethod not kubernetes and tokenSpecOverride not contains join_method
+    set:
+      tbot:
+        enabled: true
+        clusterName: "test.teleport.sh"
+        teleportProxyAddress: "test.teleport.sh:443"
+        joinMethod: "github"
+      crd:
+        create: true
+        tokenSpecOverride:
+          github: |
+            test-github-config
+    asserts:
+      - failedTemplate:
+          errorMessage: "crd.tokenSpecOverride.join_method cannot be empty in chart values"

--- a/examples/chart/access/discord/values.yaml
+++ b/examples/chart/access/discord/values.yaml
@@ -132,6 +132,10 @@ tbot:
   # tbot.joinMethod(string) -- describes how tbot joins the Teleport cluster.
   # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
   joinMethod: "kubernetes"
+  # tbot.token(string) -- is the name of the token used by tbot to join the Teleport cluster.
+  # This value is not sensitive unless the `joinMethod` is set to `"token"`.
+  # If unset, defaults to `[release name]-tbot`.
+  # If `crd.create` is set to true, then a TeleportProvisionToken will be created with the provided token name.
   token: ""
 
   # Don't touch the tbot values below, this will break the chart.
@@ -139,6 +143,63 @@ tbot:
   nameOverride: tbot
   defaultOutput:
     enabled: true
+
+# crd -- controls whether the chart creates custom resources managed by the Teleport Kubernetes Operator.
+# If enabled, the chart will create TeleportRoleV8, TeleportBotV1, and TeleportProvisionToken
+# resources to automatically connect the plugin to Teleport.
+#
+# <Admonition type="warning" title="Interaction with Teleport Kubernetes Operator">
+# The Teleport Kubernetes Operator must already be enabled in the Teleport cluster
+# for the custom resources to be applied successfully. In addition,
+# the custom resources must be deployed in the same namespace as the Teleport Kubernetes Operator.
+# </Admonition>
+crd:
+  # crd.create(bool) -- controls if the chart should create
+  # the Operator custom resources to automatically bootstrap the plugin.
+  create: false
+  # crd.namespace(string) -- optionally overrides the Kubernetes namespace that the
+  # custom resources are created in. This should match the namespace in which the
+  # Teleport Kubernetes Operator is running. Defaults to the release namespace.
+  namespace: ""
+  # crd.tokenSpecOverride -- optionally overrides the join token spec for tbot to use to join the Teleport cluster.
+  #
+  # When tbot is enabled, the default configuration uses the `kubernetes` in_cluster join method.
+  # By default, the service account for tbot will be allowed for all `kubernetes` join types: in_cluster, JWKS, OIDC.
+  #
+  # You can also configure the token to use other supported join methods. The token specification
+  # must match `tbot.joinMethod` for the plugin to correctly join the cluster.
+  # See [the join method reference](../../reference/deployment/join-methods.mdx) for a list of supported values and detailed explanations.
+  #
+  # <Admonition type="warning" title="Other Join Methods">
+  # When not using the `kubernetes` join method, or when tbot is not enabled, you must specify `join_method`.
+  # Ensure all necessary fields for the join token are present for the Operator
+  # to correctly create the Teleport token resource.
+  # </Admonition>
+  #
+  # Example (Kubernetes JWKS join method):
+  # ```yaml
+  # tokenSpecOverride:
+  #   join_method: kubernetes
+  #   kubernetes:
+  #     type: static_jwks
+  #     static_jwks:
+  #       jwks: |
+  #         # Place the kubernetes JWKS here (`kubectl get --raw /openid/v1/jwks`)
+  #         {"keys":[--snip--]}
+  # ```
+  #
+  # Example (Kubernetes OIDC join method):
+  # ```yaml
+  # tokenSpecOverride:
+  #   join_method: kubernetes
+  #   kubernetes:
+  #     type: oidc
+  #     oidc:
+  #       # Insert the OIDC issuer value here, it will vary depending on your
+  #       # cluster and cloud provider.
+  #       issuer: https://oidc.eks.us-west-2.amazonaws.com/id/my-cluster
+  # ```
+  tokenSpecOverride: {}
 
 secretVolumeName: "password-file"
 


### PR DESCRIPTION
Mirrors #62791 for the `teleport-plugin-discord` helm chart

This PR adds opt-in support to create Teleport Operator custom resources: TeleportBotV1, and TeleportProvisionToken on helm installation for the `teleport-plugin-discord`.

<details><summary>Copy+Paste summary from above PR</summary>
<p>

When `crd.create` is set to true in the chart values, the chart will create the Operator CRs to allow the plugin to automatically join the Teleport cluster. When embedded tbot is enabled, setting `tbot.token` will create TeleportProvisionToken with the provided token name.

The TeleportProvisionToken specification can be overridden via `crd.tokenSpecOverride` to configure other join methods. Default join method is `kubernetes` in_cluster. The tbot Kubernetes service account is bootstrapped to the spec to also allow for `kubernetes` JWKS and OIDC joining. When not using `kubernetes` join method, the user must provide their own full token specification.

</p>
</details> 

<details><summary>Manual Tests</summary>
<p>

Pre-requisites: `teleport-operator` is enabled and running on the cluster.

- [x]  When `crd.create: true`:
    - [x]  Verify TeleportBotV1, and TeleportProvisionToken custom resources are created in Kubernetes cluster
    - [x]  Verify corresponding Bot (user with `access-plugin` role), and Token resources are created in the Teleport cluster
    - [x]  Verify Bot instance exists and is healthy
    - [x]  Verify `teleport-plugin-discord` begins sending notifications to Discord server
- [x]  Verify no custom resources are created when `crd.create: false`
- [x]  Verify on `helm uninstall` that Bot (user) and Token are deleted from the Teleport cluster

</p>
</details> 

changelog: Added opt-in support to bootstrap the `teleport-plugin-discord` helm chart with MWI to auto-join Teleport clusters when Operator is enabled