### PR TITLE
Fix event handler plugin name for CLI help messages

### DIFF
--- a/integrations/event-handler/cli.go
+++ b/integrations/event-handler/cli.go
@@ -257,7 +257,7 @@ func (c *StartCmdConfig) Validate() error {
 func (c *StartCmdConfig) Dump(ctx context.Context, log *slog.Logger) {
 	// Log configuration variables
 	log.DebugContext(ctx, "Initializing plugin",
-		"name", "teleport-event-handler",
+		"name", pluginName,
 		"version", slog.GroupValue(
 			slog.String("teleport", Version),
 			slog.String("teleport_git", Gitref),

--- a/integrations/event-handler/configure_cmd.go
+++ b/integrations/event-handler/configure_cmd.go
@@ -151,7 +151,7 @@ func RunConfigureCmd(cfg *ConfigureCmdConfig) error {
 
 // Run runs the generator
 func (c *ConfigureCmd) Run() error {
-	fmt.Printf("Teleport event handler %v %v\n\n", Version, Gitref)
+	fmt.Printf("%v %v %v\n\n", pluginName, Version, Gitref)
 
 	c.step = 1
 

--- a/integrations/event-handler/main.go
+++ b/integrations/event-handler/main.go
@@ -36,7 +36,7 @@ var cli CLI
 
 const (
 	// pluginName is the plugin name
-	pluginName = "Teleport event handler"
+	pluginName = "teleport-event-handler"
 
 	// pluginDescription is the plugin description
 	pluginDescription = "Forwards Teleport AuditLog to external sources"


### PR DESCRIPTION
This PR fixes the plugin name for event-handler CLI help commands to show the correct usage.
Before: `Teleport event handler configure .`
After: `teleport-event-handler configure .`

Must be merged after [gravitational/teleport.e#7976](https://github.com/gravitational/teleport.e/pull/7976) to avoid breaking `e` smoke tests.

~TODO: bump e ref before merging~

changelog: Revised help messages for event handler CLI commands