### PR TITLE
docs: remove outdated External Audit Storage limitation for Access Monitoring

### DIFF
--- a/docs/pages/identity-governance/access-monitoring.mdx
+++ b/docs/pages/identity-governance/access-monitoring.mdx
@@ -21,12 +21,6 @@ or database sessions without MFA) and provides users with recommendations on sug
 
 Users are able to write their own custom access monitoring queries by querying the audit log.
 
-<Admonition type="note">
-  Access Monitoring is not currently supported with External Audit Storage
-  in Teleport Enterprise (Cloud). This functionality will be
-  enabled in a future Teleport release.
-</Admonition>
-
 ## Prerequisites
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 - For self-hosted Teleport the [Amazon Athena Backend](../reference/deployment/backends.mdx) is required.


### PR DESCRIPTION
Removes the admonition stating that Access Monitoring is not supported with External Audit Storage in Teleport Cloud, as this limitation has been resolved by https://github.com/gravitational/teleport.e/pull/8007.

Updates https://github.com/gravitational/teleport/issues/48744