### PR TITLE
Improve usertask desc for teleport agent installation failure

### DIFF
--- a/lib/usertasks/descriptions/ec2-ssm-script-failure.md
+++ b/lib/usertasks/descriptions/ec2-ssm-script-failure.md
@@ -8,3 +8,5 @@ Common causes:
 - The Teleport binary could not be downloaded
 - The SSM Agent version is below 3.1
 
+Below you'll find two links: the Resource Name links to the EC2 instance details, and the Invocation URL provides details on the cause of the failure.
+

--- a/lib/usertasks/descriptions/ec2-ssm-script-failure.md
+++ b/lib/usertasks/descriptions/ec2-ssm-script-failure.md
@@ -1,4 +1,10 @@
-# SSM Script failure
-Teleport was able to reach the SSM Agent inside the EC2 instance, however the install script returned an error.
+# SSM - Teleport Agent installation failure
 
-You can click below in the Invocation URL and get further details on why the script failed.
+Teleport reached the EC2 instance via AWS SSM, but the Teleport agent installation failed.
+
+Common causes:
+
+- The instance already has an agent configured for a different Teleport cluster
+- The Teleport binary could not be downloaded
+- The SSM Agent version is below 3.1
+

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -338,7 +338,7 @@ function makeImpactsTable(impacted: { rows: ImpactRow[] }): {
   const columns: TableColumn<ImpactRow>[] = [
     {
       key: 'id',
-      headerText: 'Resource',
+      headerText: 'Resource Name',
       render: row => {
         if (row.resourceUrl) {
           return (
@@ -376,7 +376,7 @@ function makeImpactsTable(impacted: { rows: ImpactRow[] }): {
   if (hasInvocation) {
     columns.push({
       altKey: 'invocation',
-      headerText: 'Invocation',
+      headerText: 'Invocation URL',
       render: row =>
         row.invocationUrl ? (
           <Cell align="center">


### PR DESCRIPTION
I changed the title and wording of this usertask description mostly to disambiguate ssm agent from teleport agent. 

I added 3 possible causes that I think are probable, but I might be wrong.

I also removed an instruction that imo is not only not helpful but might send the user on a wild goose chase (ask me how I know. 😬), being that the link it points to only opens a page for the aws instance settings, with lots and lots of potential links/configs to explore but nothing really narrowing down anything. 

<img width="1040" height="1050" alt="CleanShot 2026-02-05 at 09 03 43@2x" src="https://github.com/user-attachments/assets/4b74f1f4-e235-4d37-8282-87c8909b1708" />
