### PR TITLE
[v18] Bump Go to 1.25.7

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: '2'
 run:
-  go: '1.24'
+  go: '1.25'
   timeout: 15m
 linters:
   default: none

--- a/Makefile
+++ b/Makefile
@@ -1148,7 +1148,7 @@ test-go-flaky: GO_BUILD_TAGS ?= $(PAM_TAG) $(FIPS_TAG) $(RDPCLIENT_TAG) $(BPF_TA
 test-go-flaky: RENDER_FLAGS ?= -report-by flakiness -summary-file $(FLAKY_SUMMARY_FILE) -top $(FLAKY_TOP_N)
 test-go-flaky: test-go-prepare $(RENDER_TESTS) $(RERUN)
 	$(CGOFLAG) $(RERUN) -n $(FLAKY_RUNS) -t $(FLAKY_TIMEOUT) \
-		go test -count=1 -cover -json -tags "$(GO_BUILD_TAGS)" $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
+		go test -count=1 -json -tags "$(GO_BUILD_TAGS)" $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| $(RENDER_TESTS) $(RENDER_FLAGS)
 
 #

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/charlievieth/strcase v0.0.5

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -1,6 +1,6 @@
 module github.com/teleport/assets/backport
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/google/go-github/v41 v41.0.0

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/golang:1.24.12
+FROM docker.io/golang:1.25.7
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.24.12
+go 1.25.7
 
 require (
 	buf.build/go/bufplugin v0.9.0

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -3,8 +3,8 @@
 # Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.24.12
-GOLANGCI_LINT_VERSION ?= v2.1.5
+GOLANG_VERSION ?= go1.25.7
+GOLANGCI_LINT_VERSION ?= v2.7.2
 
 # NOTE: Remember to update engines.node in package.json to match the major version.
 NODE_VERSION ?= 22.21.0

--- a/docs/config.json
+++ b/docs/config.json
@@ -69,7 +69,7 @@
       "major_version": "18",
       "version": "18.6.6",
       "url": "teleport.example.com",
-      "golang": "1.24.12",
+      "golang": "1.25.7",
       "plugin": {
         "version": "18.6.6"
       },

--- a/examples/access-plugin-minimal/go.mod
+++ b/examples/access-plugin-minimal/go.mod
@@ -1,6 +1,6 @@
 module teleport-sheets
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707

--- a/examples/desktop-registration/go.mod
+++ b/examples/desktop-registration/go.mod
@@ -1,6 +1,6 @@
 module teleport-desktop-registration
 
-go 1.24.12
+go 1.25.7
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,6 @@
 module go-client
 
-go 1.24.12
+go 1.25.7
 
 require github.com/gravitational/teleport/api v0.0.0-20250818183108-571669ac0707
 

--- a/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
+++ b/examples/mcp-servers/verify-teleport-jwt-mcp-go/go.mod
@@ -1,6 +1,6 @@
 module verify-teleport-jwt-mcp-go
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/auth0/go-jwt-middleware/v2 v2.3.0

--- a/examples/service-discovery-api-client/go.mod
+++ b/examples/service-discovery-api-client/go.mod
@@ -1,6 +1,6 @@
 module register-app-service
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/docker/docker v28.3.3+incompatible

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,16 @@
 module github.com/gravitational/teleport
 
-go 1.24.12
+go 1.25.7
+
+ignore (
+	./build
+	./docs
+	./web
+	./webassets
+	node_modules
+	rfd
+	target
+)
 
 require (
 	cloud.google.com/go/alloydb v1.16.1

--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -22,7 +22,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -34,7 +33,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
@@ -182,7 +180,7 @@ func testWebsockets(p *Pack, t *testing.T) {
 		desc       string
 		inCookies  []*http.Cookie
 		outMessage string
-		err        error
+		wantErr    bool
 	}{
 		{
 			desc:       "root cluster, valid application session cookie, successful websocket (ws://) request",
@@ -212,7 +210,7 @@ func testWebsockets(p *Pack, t *testing.T) {
 					Value: "foobarbaz",
 				},
 			).ToSlice(),
-			err: errors.New(""),
+			wantErr: true,
 		},
 		{
 			desc: "invalid application session cookie, websocket request fails to dial",
@@ -222,7 +220,7 @@ func testWebsockets(p *Pack, t *testing.T) {
 					Value: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
 				},
 			},
-			err: errors.New(""),
+			wantErr: true,
 		},
 	}
 
@@ -231,8 +229,8 @@ func testWebsockets(p *Pack, t *testing.T) {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			body, err := p.makeWebsocketRequest(tt.inCookies, "/")
-			if tt.err != nil {
-				require.IsType(t, tt.err, trace.Unwrap(err))
+			if tt.wantErr {
+				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.outMessage, body)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -2466,7 +2466,7 @@ func twoClustersTunnel(t *testing.T, suite *integrationTestSuite, now time.Time,
 	// Stop "site-A" and try to connect to it again via "site-A" (expect a connection error)
 	require.NoError(t, a.StopAuth(false))
 	err = tc.SSH(ctx, cmd)
-	require.IsType(t, err, trace.ConnectionProblem(nil, ""))
+	require.ErrorAs(t, err, new(*trace.ConnectionProblemError))
 
 	// Reset and start "Site-A" again
 	a.Config.FileDescriptors = aFdCache

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/event-handler
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/alecthomas/kong v1.10.0

--- a/integrations/kube-agent-updater/pkg/controller/updater_test.go
+++ b/integrations/kube-agent-updater/pkg/controller/updater_test.go
@@ -60,7 +60,7 @@ func errorIsType(errType interface{}) require.ErrorAssertionFunc {
 	return func(t require.TestingT, err error, i ...interface{}) {
 		require.Error(t, err)
 		err = trace.Unwrap(err)
-		require.IsType(t, errType, err)
+		require.ErrorAs(t, err, &errType)
 	}
 }
 

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform-mwi
 
-go 1.24.12
+go 1.25.7
 
 require (
 	github.com/gravitational/teleport v0.0.0-00010101000000-000000000000

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/terraform
 
-go 1.24.12
+go 1.25.7
 
 // TF provider dependencies
 require (

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3391,11 +3391,11 @@ func TestNodesCRUD(t *testing.T) {
 		// Make sure can't delete with empty namespace or name.
 		err = clt.DeleteNode(ctx, apidefaults.Namespace, "")
 		require.Error(t, err)
-		require.IsType(t, trace.BadParameter(""), err)
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		err = clt.DeleteNode(ctx, "", node1.GetName())
 		require.Error(t, err)
-		require.IsType(t, trace.BadParameter(""), err)
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		// Delete node.
 		err = clt.DeleteNode(ctx, apidefaults.Namespace, node1.GetName())
@@ -3403,14 +3403,14 @@ func TestNodesCRUD(t *testing.T) {
 
 		// Expect node not found
 		_, err := clt.GetNode(ctx, apidefaults.Namespace, "node1")
-		require.IsType(t, trace.NotFound(""), err)
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
 	t.Run("DeleteAllNodes", func(t *testing.T) {
 		// Make sure can't delete with empty namespace.
 		err = clt.DeleteAllNodes(ctx, "")
 		require.Error(t, err)
-		require.IsType(t, trace.BadParameter(""), err)
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		// Delete nodes
 		err = clt.DeleteAllNodes(ctx, apidefaults.Namespace)
@@ -3803,11 +3803,11 @@ func TestAppsCRUD(t *testing.T) {
 
 	// Try to fetch an app that doesn't exist.
 	_, err = clt.GetApp(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create the same app.
 	err = clt.CreateApp(ctx, app1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Update an app.
 	app1.Metadata.Description = "description"
@@ -3846,7 +3846,7 @@ func TestAppsCRUD(t *testing.T) {
 
 	// Try to delete an app that doesn't exist.
 	err = clt.DeleteApp(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all apps.
 	err = clt.DeleteAllApps(ctx)
@@ -4100,11 +4100,11 @@ func TestDatabasesCRUD(t *testing.T) {
 
 	// Try to fetch a database that doesn't exist.
 	_, err = clt.GetDatabase(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create the same database.
 	err = clt.CreateDatabase(ctx, db1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Update a database.
 	db1.Metadata.Description = "description"
@@ -4133,7 +4133,7 @@ func TestDatabasesCRUD(t *testing.T) {
 
 	// Try to delete a database that doesn't exist.
 	err = clt.DeleteDatabase(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all databases.
 	err = clt.DeleteAllDatabases(ctx)
@@ -4257,7 +4257,7 @@ func TestDatabaseServicesCRUD(t *testing.T) {
 
 	// Try to delete a DatabaseService that doesn't exist.
 	err = clt.DeleteDatabaseService(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all DatabaseServices.
 	err = clt.DeleteAllDatabaseServices(ctx)

--- a/lib/automaticupgrades/maintenance/basichttp_test.go
+++ b/lib/automaticupgrades/maintenance/basichttp_test.go
@@ -117,8 +117,8 @@ func Test_basicHTTPMaintenanceClient_Get(t *testing.T) {
 			statusCode: http.StatusOK,
 			response:   "",
 			expected:   false,
-			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
-				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			assertErr: func(t2 require.TestingT, err2 error, _ ...any) {
+				require.ErrorAs(t2, trace.Unwrap(err2), new(*trace.BadParameterError))
 			},
 		},
 		{

--- a/lib/automaticupgrades/version/basichttp_test.go
+++ b/lib/automaticupgrades/version/basichttp_test.go
@@ -111,8 +111,8 @@ func Test_basicHTTPVersionClient_Get(t *testing.T) {
 			statusCode: http.StatusOK,
 			response:   "hello",
 			expected:   nil,
-			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
-				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			assertErr: func(t2 require.TestingT, err2 error, _ ...any) {
+				require.ErrorAs(t2, trace.Unwrap(err2), new(*trace.BadParameterError))
 			},
 		},
 		{
@@ -120,8 +120,8 @@ func Test_basicHTTPVersionClient_Get(t *testing.T) {
 			statusCode: http.StatusOK,
 			response:   "",
 			expected:   nil,
-			assertErr: func(t2 require.TestingT, err2 error, _ ...interface{}) {
-				require.IsType(t2, &trace.BadParameterError{}, trace.Unwrap(err2))
+			assertErr: func(t2 require.TestingT, err2 error, _ ...any) {
+				require.ErrorAs(t2, trace.Unwrap(err2), new(*trace.BadParameterError))
 			},
 		},
 		{

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -332,11 +332,7 @@ func (s *Service) mount() error {
 
 // unmount will unmount the cgroupv2 filesystem.
 func (s *Service) unmount() error {
-	// The exact args to the umount syscall come from a strace of umount(8):
-	//
-	//    umount2("/cgroup2", 0)                  = 0
-	err := unix.Unmount(s.MountPath, 0)
-	if err != nil {
+	if err := unix.Unmount(s.MountPath, unix.MNT_DETACH); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/client/db/mysql/optionfile_test.go
+++ b/lib/client/db/mysql/optionfile_test.go
@@ -83,5 +83,5 @@ func TestOptionFile(t *testing.T) {
 
 	_, err = optionFile.Env(profile.Name)
 	require.Error(t, err)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 }

--- a/lib/client/db/postgres/servicefile_test.go
+++ b/lib/client/db/postgres/servicefile_test.go
@@ -69,5 +69,5 @@ func TestServiceFile(t *testing.T) {
 
 	_, err = serviceFile.Env(profile.Name)
 	require.Error(t, err)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 }

--- a/lib/cloud/mocks/aws_config.go
+++ b/lib/cloud/mocks/aws_config.go
@@ -30,6 +30,7 @@ import (
 
 type AWSConfigProvider struct {
 	Err                   error
+	AWSConfig             *aws.Config
 	STSClient             *STSClient
 	OIDCIntegrationClient awsconfig.OIDCIntegrationClient
 }
@@ -37,6 +38,10 @@ type AWSConfigProvider struct {
 func (f *AWSConfigProvider) GetConfig(ctx context.Context, region string, optFns ...awsconfig.OptionsFn) (aws.Config, error) {
 	if f.Err != nil {
 		return aws.Config{}, f.Err
+	}
+
+	if f.AWSConfig != nil {
+		return *f.AWSConfig, nil
 	}
 
 	stsClt := f.STSClient

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1399,7 +1399,6 @@ func TestParseCachePolicy(t *testing.T) {
 	tcs := []struct {
 		in  *CachePolicy
 		out *servicecfg.CachePolicy
-		err error
 	}{
 		{in: &CachePolicy{EnabledFlag: "yes", TTL: "never"}, out: &servicecfg.CachePolicy{Enabled: true}},
 		{in: &CachePolicy{EnabledFlag: "true", TTL: "10h"}, out: &servicecfg.CachePolicy{Enabled: true}},
@@ -1410,12 +1409,8 @@ func TestParseCachePolicy(t *testing.T) {
 	for i, tc := range tcs {
 		comment := fmt.Sprintf("test case #%v", i)
 		out, err := tc.in.Parse()
-		if tc.err != nil {
-			require.IsType(t, tc.err, err, comment)
-		} else {
-			require.NoError(t, err, comment)
-			require.Equal(t, out, tc.out, comment)
-		}
+		require.NoError(t, err, comment)
+		require.Equal(t, out, tc.out, comment)
 	}
 }
 

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -44,7 +44,6 @@ func TestProtoStreamer(t *testing.T) {
 		name           string
 		minUploadBytes int64
 		events         []apievents.AuditEvent
-		err            error
 	}
 	testCases := []testCase{
 		{
@@ -92,10 +91,6 @@ func TestProtoStreamer(t *testing.T) {
 			evts := tc.events
 			for _, event := range evts {
 				err := stream.RecordEvent(ctx, eventstest.PrepareEvent(event))
-				if tc.err != nil {
-					require.IsType(t, tc.err, err)
-					return
-				}
 				require.NoError(t, err)
 			}
 			err = stream.Complete(ctx)

--- a/lib/events/filesessions/fileasync_test.go
+++ b/lib/events/filesessions/fileasync_test.go
@@ -1079,7 +1079,7 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 	select {
 	case event = <-eventsC:
 		require.Equal(t, event.SessionID, sid)
-		require.IsType(t, trace.ConnectionProblem(nil, "connection problem"), event.Error)
+		require.ErrorAs(t, event.Error, new(*trace.ConnectionProblemError))
 	case <-ctx.Done():
 		t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")
 	}
@@ -1101,7 +1101,7 @@ func runResume(t *testing.T, testCase resumeTestCase) {
 			if i == testCase.retries-1 {
 				require.NoError(t, event.Error)
 			} else {
-				require.IsType(t, trace.ConnectionProblem(nil, "connection problem"), event.Error)
+				require.ErrorAs(t, event.Error, new(*trace.ConnectionProblemError))
 			}
 		case <-ctx.Done():
 			t.Fatalf("Timeout waiting for async upload, try `go test -v` to get more logs for details")

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -175,7 +175,7 @@ func StreamEmpty(t *testing.T, handler events.MultipartHandler) {
 
 	select {
 	case status := <-stream.Status():
-		require.Equal(t, status.LastEventIndex, int64(-1))
+		require.Equal(t, int64(-1), status.LastEventIndex)
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for status update.")
 	}
@@ -217,7 +217,7 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 
 	select {
 	case status := <-stream.Status():
-		require.Equal(t, status.LastEventIndex, int64(-1))
+		require.Equal(t, int64(-1), status.LastEventIndex)
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for status update.")
 	}
@@ -308,7 +308,7 @@ func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, p
 	// that resume has been started successfully
 	select {
 	case status := <-stream.Status():
-		require.Equal(t, status.LastEventIndex, int64(-1))
+		require.Equal(t, int64(-1), status.LastEventIndex)
 	case <-time.After(time.Second):
 		t.Fatalf("Timed out waiting for status update.")
 	}

--- a/lib/integrations/awsra/profile_syncer_test.go
+++ b/lib/integrations/awsra/profile_syncer_test.go
@@ -277,16 +277,14 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 				"teleport.dev/integration":                    "test-integration",
 			}, appServer.GetAllLabels())
 
-			t.Run("integration status is updated", func(t *testing.T) {
-				status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
-				require.NotNil(t, status)
-				lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
-				require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusSuccess, lastSyncSummary.Status)
-				require.NotEmpty(t, lastSyncSummary.StartTime)
-				require.NotEmpty(t, lastSyncSummary.EndTime)
-				require.Equal(t, int32(1), lastSyncSummary.SyncedProfiles)
-				require.Empty(t, lastSyncSummary.ErrorMessage)
-			})
+			status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
+			require.NotNil(t, status)
+			lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync
+			require.Equal(t, types.IntegrationAWSRolesAnywhereProfileSyncStatusSuccess, lastSyncSummary.Status)
+			require.NotEmpty(t, lastSyncSummary.StartTime)
+			require.NotEmpty(t, lastSyncSummary.EndTime)
+			require.Equal(t, int32(1), lastSyncSummary.SyncedProfiles)
+			require.Empty(t, lastSyncSummary.ErrorMessage)
 		})
 	})
 
@@ -355,6 +353,7 @@ func TestRunAWSRolesAnywherProfileSyncer(t *testing.T) {
 
 			// Wait for the 1st profile sync iteration.
 			synctest.Wait()
+
 			status := serverClient.integrations[integrationWithProfileSync.GetName()].GetStatus()
 			require.NotNil(t, status)
 			lastSyncSummary := status.AWSRolesAnywhere.LastProfileSync

--- a/lib/services/license_test.go
+++ b/lib/services/license_test.go
@@ -37,7 +37,7 @@ func TestLicenseUnmarshal(t *testing.T) {
 		description string
 		input       string
 		expected    types.License
-		err         error
+		err         any
 	}
 	testCases := []testCase{
 		{
@@ -91,12 +91,12 @@ func TestLicenseUnmarshal(t *testing.T) {
 		{
 			description: "failed validation - unknown version",
 			input:       `{"kind": "license", "version": "v2", "metadata": {"name": "license"}, "spec": {"usage": "yes", "k8s": "yes", "aws_account": "123", "aws_pid": "4"}}`,
-			err:         trace.BadParameter(""),
+			err:         &trace.BadParameterError{},
 		},
 		{
 			description: "failed validation, bad types",
 			input:       `{"kind": "license", "version": "v3", "metadata": {"name": "license"}, "spec": {"usage": 1, "k8s": "yes", "aws_account": 14, "aws_pid": "4"}}`,
-			err:         trace.BadParameter(""),
+			err:         &trace.BadParameterError{},
 		},
 	}
 	for _, tc := range testCases {
@@ -111,7 +111,7 @@ func TestLicenseUnmarshal(t *testing.T) {
 			require.NoError(t, err, comment)
 			require.Empty(t, cmp.Diff(tc.expected, out2))
 		} else {
-			require.IsType(t, err, tc.err, comment)
+			require.ErrorAs(t, err, &tc.err, comment)
 		}
 	}
 }

--- a/lib/services/local/access_monitoring_rules_test.go
+++ b/lib/services/local/access_monitoring_rules_test.go
@@ -90,29 +90,29 @@ func TestAccessMonitoringRulesCRUD(t *testing.T) {
 
 	// Try to fetch a AccessMonitoringRule that doesn't exist.
 	_, err = service.GetAccessMonitoringRule(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create a duplicate AccessMonitoringRule.
 	_, err = service.CreateAccessMonitoringRule(ctx, AccessMonitoringRule1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Delete a AccessMonitoringRule.
 	err = service.DeleteAccessMonitoringRule(ctx, AccessMonitoringRule1.Metadata.Name)
 	require.NoError(t, err)
 	_, err = service.GetAccessMonitoringRule(ctx, AccessMonitoringRule1.Metadata.Name)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to delete a AccessMonitoringRule that doesn't exist.
 	err = service.DeleteAccessMonitoringRule(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all AccessMonitoringRule.
 	err = service.DeleteAllAccessMonitoringRules(ctx)
 	require.NoError(t, err)
 	_, err = service.GetAccessMonitoringRule(ctx, AccessMonitoringRule1.Metadata.Name)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 	_, err = service.GetAccessMonitoringRule(ctx, AccessMonitoringRule2.Metadata.Name)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 }
 
 func TestListAccessMonitoringRulesWithFilter(t *testing.T) {

--- a/lib/services/local/apps_test.go
+++ b/lib/services/local/apps_test.go
@@ -117,11 +117,11 @@ func TestAppsCRUD(t *testing.T) {
 
 	// Try to fetch an application that doesn't exist.
 	_, err = service.GetApp(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create the same application.
 	err = service.CreateApp(ctx, app1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Update an application.
 	app1.Metadata.Description = "description"
@@ -161,7 +161,7 @@ func TestAppsCRUD(t *testing.T) {
 
 	// Try to delete an application that doesn't exist.
 	err = service.DeleteApp(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all applications.
 	err = service.DeleteAllApps(ctx)

--- a/lib/services/local/databases_test.go
+++ b/lib/services/local/databases_test.go
@@ -125,11 +125,11 @@ func TestDatabasesCRUD(t *testing.T) {
 
 	// Try to fetch a database that doesn't exist.
 	_, err = service.GetDatabase(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create the same database.
 	err = service.CreateDatabase(ctx, db1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Update a database.
 	db1.Metadata.Description = "description"
@@ -165,7 +165,7 @@ func TestDatabasesCRUD(t *testing.T) {
 
 	// Try to delete a database that doesn't exist.
 	err = service.DeleteDatabase(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all databases.
 	err = service.DeleteAllDatabases(ctx)

--- a/lib/services/local/git_server_test.go
+++ b/lib/services/local/git_server_test.go
@@ -124,7 +124,7 @@ func TestGitServerCRUD(t *testing.T) {
 
 	t.Run("delete not found", func(t *testing.T) {
 		err := service.DeleteGitServer(ctx, "doesnotexist")
-		require.IsType(t, trace.NotFound(""), err)
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
 	t.Run("delete", func(t *testing.T) {

--- a/lib/services/local/kube_test.go
+++ b/lib/services/local/kube_test.go
@@ -115,11 +115,11 @@ func TestKubernetesCRUD(t *testing.T) {
 
 	// Try to fetch a Kubernetes that doesn't exist.
 	_, err = service.GetKubernetesCluster(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create the same Kubernetes.
 	err = service.CreateKubernetesCluster(ctx, kubeCluster1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Update a Kubernetes.
 	kubeCluster1.Metadata.Description = "description"
@@ -140,7 +140,7 @@ func TestKubernetesCRUD(t *testing.T) {
 
 	// Try to delete a Kubernetes that doesn't exist.
 	err = service.DeleteKubernetesCluster(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all Kubernetess.
 	err = service.DeleteAllKubernetesClusters(ctx)

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -91,11 +91,11 @@ func TestPluginsCRUD(t *testing.T) {
 
 	// Try to fetch a plugin that doesn't exist.
 	_, err = service.GetPlugin(ctx, "doesnotexist", true)
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Try to create a duplicate plugin.
 	err = service.CreatePlugin(ctx, plugin1)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	// Set plugin status.
 	status := &types.PluginStatusV1{
@@ -132,7 +132,7 @@ func TestPluginsCRUD(t *testing.T) {
 
 	// Try to delete a plugin that doesn't exist.
 	err = service.DeletePlugin(ctx, "doesnotexist")
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Delete all plugin.
 	err = service.DeleteAllPlugins(ctx)

--- a/lib/services/local/presence_test.go
+++ b/lib/services/local/presence_test.go
@@ -196,13 +196,13 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	// Make sure can't delete with empty namespace or host ID or name.
 	err = presence.DeleteDatabaseServer(ctx, server.GetNamespace(), server.GetHostID(), "")
 	require.Error(t, err)
-	require.IsType(t, trace.BadParameter(""), err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 	err = presence.DeleteDatabaseServer(ctx, server.GetNamespace(), "", server.GetName())
 	require.Error(t, err)
-	require.IsType(t, trace.BadParameter(""), err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 	err = presence.DeleteDatabaseServer(ctx, "", server.GetHostID(), server.GetName())
 	require.Error(t, err)
-	require.IsType(t, trace.BadParameter(""), err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 	// Remove the server.
 	err = presence.DeleteDatabaseServer(ctx, server.GetNamespace(), server.GetHostID(), server.GetName())
@@ -228,7 +228,7 @@ func TestDatabaseServersCRUD(t *testing.T) {
 	// Make sure can't delete all with empty namespace.
 	err = presence.DeleteAllDatabaseServers(ctx, "")
 	require.Error(t, err)
-	require.IsType(t, trace.BadParameter(""), err)
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 	// Delete all.
 	err = presence.DeleteAllDatabaseServers(ctx, server.GetNamespace())
@@ -333,7 +333,7 @@ func TestNodeCRUD(t *testing.T) {
 
 		// Expect node not found
 		_, err := presence.GetNode(ctx, apidefaults.Namespace, "node1")
-		require.IsType(t, trace.NotFound(""), err)
+		require.ErrorAs(t, err, new(*trace.NotFoundError))
 	})
 
 	t.Run("DeleteAllNodes", func(t *testing.T) {

--- a/lib/services/local/session_test.go
+++ b/lib/services/local/session_test.go
@@ -339,7 +339,7 @@ func TestWebTokenCRUD(t *testing.T) {
 		Token: "doesnotexist",
 		User:  "alice",
 	})
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	// Upsert.
 	expected[1].SetUser("alice")
@@ -396,7 +396,7 @@ func TestWebTokenCRUD(t *testing.T) {
 		Token: "doesnotexist",
 		User:  "doesnotexist",
 	})
-	require.IsType(t, trace.NotFound(""), err)
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
 
 	err = identity.DeleteWebToken(ctx, types.DeleteWebTokenRequest{
 		Token: expected[0].GetToken(),

--- a/lib/services/map_test.go
+++ b/lib/services/map_test.go
@@ -34,7 +34,7 @@ func TestRoleParsing(t *testing.T) {
 
 	testCases := []struct {
 		roleMap types.RoleMap
-		err     error
+		err     any
 	}{
 		{
 			roleMap: nil,
@@ -54,14 +54,14 @@ func TestRoleParsing(t *testing.T) {
 				{Remote: "remote-devs", Local: []string{"local-devs"}},
 				{Remote: "remote-devs", Local: []string{"local-devs"}},
 			},
-			err: trace.BadParameter(""),
+			err: &trace.BadParameterError{},
 		},
 		{
 			roleMap: types.RoleMap{
 				{Remote: types.Wildcard, Local: []string{"local-devs"}},
 				{Remote: types.Wildcard, Local: []string{"local-devs"}},
 			},
-			err: trace.BadParameter(""),
+			err: &trace.BadParameterError{},
 		},
 	}
 
@@ -70,7 +70,7 @@ func TestRoleParsing(t *testing.T) {
 			_, err := parseRoleMap(tc.roleMap)
 			if tc.err != nil {
 				require.Error(t, err)
-				require.IsType(t, err, tc.err)
+				require.ErrorAs(t, err, &tc.err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -86,7 +86,6 @@ func TestRoleMap(t *testing.T) {
 		local   []string
 		roleMap types.RoleMap
 		name    string
-		err     error
 	}{
 		{
 			name:    "all empty",
@@ -199,13 +198,8 @@ func TestRoleMap(t *testing.T) {
 		t.Run(fmt.Sprintf("test case '%v'", tc.name), func(t *testing.T) {
 
 			local, err := MapRoles(tc.roleMap, tc.remote)
-			if tc.err != nil {
-				require.Error(t, err)
-				require.IsType(t, err, tc.err)
-			} else {
-				require.NoError(t, err)
-				require.ElementsMatch(t, tc.local, local)
-			}
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.local, local)
 		})
 	}
 }

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -7865,7 +7865,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 				},
 			},
 			errorFunc: func(t *testing.T, err error) {
-				require.IsType(t, trace.AccessDenied(""), err)
+				require.ErrorAs(t, err, new(*trace.NotFoundError))
 			},
 		},
 		{
@@ -7890,7 +7890,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 				},
 			},
 			errorFunc: func(t *testing.T, err error) {
-				require.IsType(t, trace.AccessDenied(""), err)
+				require.ErrorAs(t, err, new(*trace.NotFoundError))
 			},
 		},
 		{
@@ -7914,7 +7914,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 				},
 			},
 			errorFunc: func(t *testing.T, err error) {
-				require.IsType(t, trace.AccessDenied(""), err)
+				require.ErrorAs(t, err, new(*trace.NotFoundError))
 			},
 		},
 		{
@@ -7939,7 +7939,7 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 				},
 			},
 			errorFunc: func(t *testing.T, err error) {
-				require.IsType(t, trace.AccessDenied(""), err)
+				require.ErrorAs(t, err, new(*trace.NotFoundError))
 			},
 		},
 		{

--- a/lib/srv/db/common/engines_test.go
+++ b/lib/srv/db/common/engines_test.go
@@ -65,8 +65,8 @@ func TestRegisterEngine(t *testing.T) {
 
 	engine, err := GetEngine(db, ec)
 	require.Nil(t, engine)
-	require.IsType(t, trace.NotFound(""), err)
-	require.IsType(t, trace.NotFound(""), CheckEngines("test"))
+	require.ErrorAs(t, err, new(*trace.NotFoundError))
+	require.ErrorAs(t, CheckEngines("test"), new(*trace.NotFoundError))
 
 	// Register a "test" engine.
 	RegisterEngine(func(ec EngineConfig) Engine {

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -248,8 +248,9 @@ func TestDiscoveryServerEKS(t *testing.T) {
 			t.Parallel()
 
 			synctest.Test(t, func(t *testing.T) {
-				ctx, cancel := context.WithCancel(t.Context())
+				ctx := t.Context()
 				fakeConfigProvider := mocks.AWSConfigProvider{
+					AWSConfig: &aws.Config{},
 					OIDCIntegrationClient: &mocks.FakeOIDCIntegrationClient{
 						Integration: awsOIDCIntegration,
 					},
@@ -289,9 +290,6 @@ func TestDiscoveryServerEKS(t *testing.T) {
 
 				// Wait for the discovery server to complete one iteration of discovering resources
 				synctest.Wait()
-
-				// Start server shutdown.
-				cancel()
 
 				// Discovery usage events are reported.
 				require.NotEmpty(t, mockAccessPoint.usageEvents)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -200,7 +200,7 @@ func TestHeartbeatKeepAlive(t *testing.T) {
 			require.Equal(t, HeartbeatStateKeepAlive, hb.state)
 			_, err = hb.announce()
 			require.Error(t, err)
-			require.IsType(t, announcer.err, err)
+			require.ErrorIs(t, err, announcer.err)
 			require.Equal(t, HeartbeatStateInit, hb.state)
 			require.Equal(t, 2, announcer.upsertCalls[hb.Mode])
 

--- a/lib/utils/anonymizer_test.go
+++ b/lib/utils/anonymizer_test.go
@@ -29,7 +29,7 @@ func TestHMACAnonymizer(t *testing.T) {
 	t.Parallel()
 
 	a, err := NewHMACAnonymizer(" ")
-	require.IsType(t, err, trace.BadParameter(""))
+	require.ErrorAs(t, err, new(*trace.BadParameterError))
 	require.Nil(t, a)
 
 	a, err = NewHMACAnonymizer("key")

--- a/lib/utils/parse/parse_test.go
+++ b/lib/utils/parse/parse_test.go
@@ -37,33 +37,33 @@ func TestVariable(t *testing.T) {
 	var tests = []struct {
 		title string
 		in    string
-		err   error
+		err   any
 		out   string
 	}{
 		{
 			title: "no curly bracket prefix",
 			in:    "external.foo}}",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "invalid syntax",
 			in:    `{{external.foo("bar")`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "invalid variable syntax",
 			in:    "{{internal.}}",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "invalid dot syntax",
 			in:    "{{external..foo}}",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "empty variable",
 			in:    "{{}}",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "string variable",
@@ -73,32 +73,32 @@ func TestVariable(t *testing.T) {
 		{
 			title: "invalid int variable",
 			in:    `{{123}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "incomplete variables are not allowed",
 			in:    `{{internal}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "no curly bracket suffix",
 			in:    "{{internal.foo",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "too many levels of nesting in the variable",
 			in:    "{{internal.foo.bar}}",
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "too many levels of nesting in the variable with property",
 			in:    `{{internal.foo["bar"]}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "regexp function call not allowed",
 			in:    `{{regexp.match(".*")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "valid with brackets",
@@ -148,12 +148,12 @@ func TestVariable(t *testing.T) {
 		{
 			title: "regexp replace with variable expression",
 			in:    `{{regexp.replace(internal.foo, internal.bar, "baz")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "regexp replace with variable replacement",
 			in:    `{{regexp.replace(internal.foo, "bar", internal.baz)}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "regexp replace constant expression",
@@ -163,27 +163,27 @@ func TestVariable(t *testing.T) {
 		{
 			title: "non existing function",
 			in:    `{{regexp.replac("abc", "c", "z")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "missing args",
 			in:    `{{regexp.replace("abc", "c")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "no args",
 			in:    `{{regexp.replace()}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "extra args",
 			in:    `{{regexp.replace("abc", "c", "x", "z")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "invalid arg type",
 			in:    `{{regexp.replace(regexp.match("a"), "c", "x")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 	}
 
@@ -191,7 +191,7 @@ func TestVariable(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			expr, err := NewTraitsTemplateExpression(tt.in)
 			if tt.err != nil {
-				require.IsType(t, tt.err, err)
+				require.ErrorAs(t, err, &tt.err)
 				return
 			}
 			require.NoError(t, err, trace.DebugReport(err))
@@ -386,43 +386,43 @@ func TestMatch(t *testing.T) {
 	tests := []struct {
 		title string
 		in    string
-		err   error
+		err   any
 		out   MatchExpression
 	}{
 		{
 			title: "no curly bracket prefix",
 			in:    `regexp.match(".*")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "no curly bracket suffix",
 			in:    `{{regexp.match(".*")`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "unknown function",
 			in:    `{{regexp.surprise(".*")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "bad regexp",
 			in:    `{{regexp.match("+foo")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "unknown namespace",
 			in:    `{{surprise.match(".*")}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "not a boolean expression",
 			in:    `{{email.local(external.email)}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "not a boolean variable",
 			in:    `{{external.email}}`,
-			err:   trace.BadParameter(""),
+			err:   &trace.BadParameterError{},
 		},
 		{
 			title: "string literal",
@@ -476,7 +476,7 @@ func TestMatch(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			matcher, err := NewMatcher(tt.in)
 			if tt.err != nil {
-				require.IsType(t, tt.err, err, err)
+				require.ErrorAs(t, err, &tt.err)
 				return
 			}
 			require.NoError(t, err)

--- a/tool/tctl/common/auth_command_test.go
+++ b/tool/tctl/common/auth_command_test.go
@@ -738,7 +738,7 @@ func TestGenerateDatabaseUserCertificates(t *testing.T) {
 		dbUser             string
 		expectedDbProtocol string
 		dbServices         []types.DatabaseServer
-		expectedErr        error
+		expectedErr        any
 	}{
 		"DatabaseExists": {
 			clusterName:        "example.com",
@@ -806,7 +806,7 @@ func TestGenerateDatabaseUserCertificates(t *testing.T) {
 			clusterName: "example.com",
 			dbService:   "db-2",
 			dbServices:  []types.DatabaseServer{},
-			expectedErr: trace.NotFound(""),
+			expectedErr: &trace.NotFoundError{},
 		},
 	}
 
@@ -842,7 +842,7 @@ func TestGenerateDatabaseUserCertificates(t *testing.T) {
 			err = ac.generateUserKeys(ctx, authClient)
 			if test.expectedErr != nil {
 				require.Error(t, err)
-				require.IsType(t, test.expectedErr, err)
+				require.ErrorAs(t, err, &test.expectedErr)
 				return
 			}
 

--- a/tool/tctl/common/resource_health_check_config_test.go
+++ b/tool/tctl/common/resource_health_check_config_test.go
@@ -99,7 +99,7 @@ spec:
 
 	_, err = runResourceCommand(t, clt, []string{"create", resourceYAMLPath})
 	require.Error(t, err)
-	require.IsType(t, trace.AlreadyExists(""), err)
+	require.ErrorAs(t, err, new(*trace.AlreadyExistsError))
 
 	_, err = runResourceCommand(t, clt, []string{"create", "-f", resourceYAMLPath})
 	require.NoError(t, err)

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -189,7 +189,7 @@ func TestConfigure(t *testing.T) {
 			// typo
 			output: "sddout",
 		})
-		require.IsType(t, trace.BadParameter(""), err)
+		require.ErrorAs(t, err, new(*trace.BadParameterError))
 
 		err = onConfigDump(dumpFlags{
 			output: "file://" + filepath.Join(t.TempDir(), "test"),


### PR DESCRIPTION
Update Go to the latest patch.

- https://go.dev/doc/devel/release#go1.25.7

Note: Including some changes from https://github.com/gravitational/teleport/commit/ad08e94b re: synctest and cgroup unmount. Pulled these in from https://github.com/gravitational/teleport/pull/58875.

Also had to upgrade `golangci-lint` (`v2.1.5` was built with `go1.24`) leading to linter issues. Pulled in changes from https://github.com/gravitational/teleport/pull/62066 to resolve these new issues. I chose `golangci-lint v2.7.2` since that is the latest version we have upgraded to in `master`.

https://github.com/gravitational/teleport/blob/84ba74517a81ea3937701fe92119762c11ee0660/build.assets/versions.mk#L6

Changelog: Updated Go to 1.25.7