### PR TITLE
Fix WindowsCA fallback scenarios in agents and tctl

### DIFF
--- a/tool/tctl/common/status_command.go
+++ b/tool/tctl/common/status_command.go
@@ -110,6 +110,11 @@ func newStatusModel(ctx context.Context, client *authclient.Client, pingResp pro
 			slog.WarnContext(ctx, "Failed to fetch CA", "type", caType, "error", err)
 			continue
 		}
+		// Filter repeated lines in case of WindowsCA query fallback.
+		// TODO(codingllama): DELETE IN 20. WindowsCA is guaranteed to exist by then.
+		if len(cas) > 0 && cas[0].GetType() != caType {
+			continue
+		}
 		authorities = append(authorities, cas...)
 	}
 	cluster, err := newClusterStatusModel(pingResp, authorities)


### PR DESCRIPTION
Fix a few fallback scenarios detected during test plan. Namely:

* Cached agent queries returning an empty CA list -> should fallback to UserCA
* `tctl status` showing duplicate "user" CA lines due to WindowsCA fallback -> should skip duplicate/mismatch CAs

Tested on master and v18 feature branch, against both "new" and "old" (pre-WindowsCA) Auth.

#10111