### PR TITLE
  test: optimize TestKube execution time by splitting root and leaf cluster tests

### DIFF
--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -93,10 +93,6 @@ jobs:
         with:
           flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "tool/tsh/**/*"
           target: test-go-tsh
-          # Reduced from 100 to 25 attempts to accommodate TestKubeLeaf (~8.7s/iteration).
-          # 25 attempts = ~3.6 min for TestKubeLeaf, ~1.1 min for TestKubeRoot, both within timeout.
-          # Default go test timeout is 10 minutes.
-          attempts: 25
 
       - name: Run api difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -93,10 +93,10 @@ jobs:
         with:
           flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "tool/tsh/**/*"
           target: test-go-tsh
-          # Reduced from 100 to 50 attempts to accommodate TestKubeLeaf (~8.7s/iteration).
-          # 50 attempts = ~7 min for TestKubeLeaf, ~2 min for TestKubeRoot, both within timeout.
+          # Reduced from 100 to 25 attempts to accommodate TestKubeLeaf (~8.7s/iteration).
+          # 25 attempts = ~3.6 min for TestKubeLeaf, ~1.1 min for TestKubeRoot, both within timeout.
           # Default go test timeout is 10 minutes.
-          attempts: 50
+          attempts: 25
 
       - name: Run api difftest
         uses: ./.github/actions/difftest

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -93,6 +93,10 @@ jobs:
         with:
           flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "tool/tsh/**/*"
           target: test-go-tsh
+          # Reduced from 100 to 50 attempts to accommodate TestKubeLeaf (~8.7s/iteration).
+          # 50 attempts = ~7 min for TestKubeLeaf, ~2 min for TestKubeRoot, both within timeout.
+          # Default go test timeout is 10 minutes.
+          attempts: 50
 
       - name: Run api difftest
         uses: ./.github/actions/difftest

--- a/tool/tsh/common/kube_proxy_test.go
+++ b/tool/tsh/common/kube_proxy_test.go
@@ -50,7 +50,8 @@ import (
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 )
 
-func (p *kubeTestPack) testProxyKube(t *testing.T) {
+// testProxyKubeRoot tests "tsh proxy kube" without leaf cluster dependencies.
+func (p *kubeTestPack) testProxyKubeRoot(t *testing.T) {
 	// Set default kubeconfig to a non-exist file to avoid loading other things.
 	t.Setenv("KUBECONFIG", filepath.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
 
@@ -72,8 +73,14 @@ func (p *kubeTestPack) testProxyKube(t *testing.T) {
 		)
 		require.NoError(t, err)
 	})
+}
 
-	// Test "tsh proxy kube" after "tsh login"s.
+// testProxyKubeLeaf tests "tsh proxy kube" which requires leaf cluster.
+func (p *kubeTestPack) testProxyKubeLeaf(t *testing.T) {
+	// Set default kubeconfig to a non-exist file to avoid loading other things.
+	t.Setenv("KUBECONFIG", filepath.Join(os.Getenv(types.HomeEnvVar), uuid.NewString()))
+
+	// Test "tsh proxy kube" after "tsh login"s to both root and leaf.
 	t.Run("without kube cluster arg", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -138,7 +138,6 @@ type kubeTestPack struct {
 func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 	t.Helper()
 
-	startTime := time.Now()
 	ctx := context.Background()
 	rootKubeCluster1 := "root-cluster"
 	rootKubeCluster2 := "first-cluster"
@@ -155,7 +154,6 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 		types.DiscoveredNameLabel: "leaf-cluster",
 	}
 
-	beforeSuite := time.Now()
 	s := newTestSuite(t,
 		withRootConfigFunc(func(cfg *servicecfg.Config) {
 			if withMultiplexMode {
@@ -195,15 +193,8 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 			return foundRoot1 && foundRoot2 && foundLeaf
 		}),
 	)
-	afterSuite := time.Now()
-	t.Logf("⏱️  newTestSuite: %v", afterSuite.Sub(beforeSuite))
 
-	beforeLogin := time.Now()
 	mustLoginSetEnvLegacy(t, s)
-	afterLogin := time.Now()
-	t.Logf("⏱️  mustLoginSetEnvLegacy: %v", afterLogin.Sub(beforeLogin))
-
-	t.Logf("⏱️  TOTAL setupKubeTestPack: %v", time.Since(startTime))
 
 	return &kubeTestPack{
 		suite:            s,
@@ -220,7 +211,6 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 func setupKubeTestPackRoot(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 	t.Helper()
 
-	startTime := time.Now()
 	ctx := context.Background()
 	rootKubeCluster1 := "root-cluster"
 	rootKubeCluster2 := "first-cluster"
@@ -229,7 +219,6 @@ func setupKubeTestPackRoot(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 		"ultra_long_label_for_teleport_kubernetes_service_list_kube_clusters_method": "ultra_long_label_value_for_teleport_kubernetes_service_list_kube_clusters_method",
 	}
 
-	beforeSuite := time.Now()
 	s := newTestSuite(t,
 		withRootConfigFunc(func(cfg *servicecfg.Config) {
 			if withMultiplexMode {
@@ -254,15 +243,8 @@ func setupKubeTestPackRoot(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 			return foundRoot1 && foundRoot2
 		}),
 	)
-	afterSuite := time.Now()
-	t.Logf("⏱️  newTestSuite: %v", afterSuite.Sub(beforeSuite))
 
-	beforeLogin := time.Now()
 	mustLoginSetEnvLegacy(t, s)
-	afterLogin := time.Now()
-	t.Logf("⏱️  mustLoginSetEnvLegacy: %v", afterLogin.Sub(beforeLogin))
-
-	t.Logf("⏱️  TOTAL setupKubeTestPackRoot: %v", time.Since(startTime))
 
 	return &kubeTestPack{
 		suite:            s,

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -82,7 +82,6 @@ func TestKubeLeaf(t *testing.T) {
 	t.Run("proxy kube without cluster arg", pack.testProxyKubeLeaf)
 }
 
-
 func TestKubeLogin(t *testing.T) {
 	lib.SetInsecureDevMode(true)
 	t.Cleanup(func() { lib.SetInsecureDevMode(false) })

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -289,44 +289,29 @@ func withValidationFunc(f func(*suite) bool) testSuiteOptionFunc {
 
 // deprecated: Use `tools/teleport/testenv.MakeTestServer` instead.
 func newTestSuite(t *testing.T, opts ...testSuiteOptionFunc) *suite {
-	startTime := time.Now()
 	var options testSuiteOptions
 	for _, opt := range opts {
 		opt(&options)
 	}
 	s := &suite{}
 
-	beforeRoot := time.Now()
 	s.setupRootCluster(t, options)
-	afterRoot := time.Now()
-	t.Logf("⏱️    setupRootCluster: %v", afterRoot.Sub(beforeRoot))
 
 	if options.leafCluster || options.leafConfigFunc != nil {
-		beforeLeaf := time.Now()
 		s.setupLeafCluster(t, options)
-		afterLeaf := time.Now()
-		t.Logf("⏱️    setupLeafCluster: %v", afterLeaf.Sub(beforeLeaf))
-
-		beforeTunnel := time.Now()
 		require.Eventually(t, func() bool {
 			rt, err := s.root.GetAuthServer().GetTunnelConnections(s.leaf.Config.Auth.ClusterName.GetClusterName())
 			require.NoError(t, err)
 			return len(rt) == 1
 		}, time.Second*10, 100*time.Millisecond)
-		afterTunnel := time.Now()
-		t.Logf("⏱️    wait for tunnel connection: %v", afterTunnel.Sub(beforeTunnel))
 	}
 
 	if options.validationFunc != nil {
-		beforeValidation := time.Now()
 		require.Eventually(t, func() bool {
 			return options.validationFunc(s)
 		}, 10*time.Second, 500*time.Millisecond)
-		afterValidation := time.Now()
-		t.Logf("⏱️    validation (cache propagation): %v", afterValidation.Sub(beforeValidation))
 	}
 
-	t.Logf("⏱️  TOTAL newTestSuite: %v", time.Since(startTime))
 	return s
 }
 


### PR DESCRIPTION
 Splits `TestKube` into `TestKubeRoot` and `TestKubeLeaf` to optimize CI execution time.
 
 Motivation: https://github.com/gravitational/teleport/pull/62996#issuecomment-3775333751

  ### Changes
  - **Split tests** by cluster requirements:
    - `TestKubeRoot`: 9 subtests using only root cluster (~2.7s/iteration)
    - `TestKubeLeaf`: 4 subtests requiring leaf cluster (~8.7s/iteration)
  - ~~**Updated CI workflow**: Reduced flaky test attempts from 100 to 25~~ (reverted per @zmb3 's comment)

  ### Performance Impact
  - **TestKubeRoot**: 3.2x faster (avoids 5.7s tunnel establishment)
  - ~~**CI execution**: 3.6 min for TestKubeLeaf + 1.1 min for TestKubeRoot (well within 10-min timeout)~~ (reverted per @zmb3 's comment)
  - **Previous behavior**: 100 attempts × 9s = 15 minutes (exceeded timeout)

  Fixes flaky test detector timeout in GitHub Actions.