### PR TITLE
DiscoveryConfig status: store the summary of the last 5 iterations

### DIFF
--- a/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
+++ b/api/gen/proto/go/teleport/discoveryconfig/v1/discoveryconfig.pb.go
@@ -269,8 +269,11 @@ type DiscoveryConfigStatus struct {
 	LastSyncTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=last_sync_time,json=lastSyncTime,proto3" json:"last_sync_time,omitempty"`
 	// IntegrationDiscoveredResources maps an integration to discovered resources summary.
 	IntegrationDiscoveredResources map[string]*IntegrationDiscoveredSummary `protobuf:"bytes,6,rep,name=integration_discovered_resources,json=integrationDiscoveredResources,proto3" json:"integration_discovered_resources,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
-	unknownFields                  protoimpl.UnknownFields
-	sizeCache                      protoimpl.SizeCache
+	// IntegrationDiscoveredSummaryHistory maps an integration to the history of discovered resources summary.
+	// Each entry has up to 5 summaries of the past iterations.
+	IntegrationDiscoveredResourcesHistory map[string]*IntegrationDiscoveredSummaryHistory `protobuf:"bytes,7,rep,name=integration_discovered_resources_history,json=integrationDiscoveredResourcesHistory,proto3" json:"integration_discovered_resources_history,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields                         protoimpl.UnknownFields
+	sizeCache                             protoimpl.SizeCache
 }
 
 func (x *DiscoveryConfigStatus) Reset() {
@@ -338,6 +341,60 @@ func (x *DiscoveryConfigStatus) GetIntegrationDiscoveredResources() map[string]*
 	return nil
 }
 
+func (x *DiscoveryConfigStatus) GetIntegrationDiscoveredResourcesHistory() map[string]*IntegrationDiscoveredSummaryHistory {
+	if x != nil {
+		return x.IntegrationDiscoveredResourcesHistory
+	}
+	return nil
+}
+
+// IntegrationDiscoveredSummaryHistory contains the a summary for each resource type that was discovered at a specific time in the past.
+type IntegrationDiscoveredSummaryHistory struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// List of summaries for past iterations.
+	// Contains at most 5 summaries of the past iterations, ordered from the most recent to the oldest.
+	Summaries     []*IntegrationDiscoveredSummary `protobuf:"bytes,1,rep,name=summaries,proto3" json:"summaries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *IntegrationDiscoveredSummaryHistory) Reset() {
+	*x = IntegrationDiscoveredSummaryHistory{}
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *IntegrationDiscoveredSummaryHistory) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*IntegrationDiscoveredSummaryHistory) ProtoMessage() {}
+
+func (x *IntegrationDiscoveredSummaryHistory) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use IntegrationDiscoveredSummaryHistory.ProtoReflect.Descriptor instead.
+func (*IntegrationDiscoveredSummaryHistory) Descriptor() ([]byte, []int) {
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *IntegrationDiscoveredSummaryHistory) GetSummaries() []*IntegrationDiscoveredSummary {
+	if x != nil {
+		return x.Summaries
+	}
+	return nil
+}
+
 // IntegrationDiscoveredSummary contains the a summary for each resource type that was discovered.
 type IntegrationDiscoveredSummary struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -348,14 +405,21 @@ type IntegrationDiscoveredSummary struct {
 	// AWSEKS contains the summary for the AWS EKS discovered clusters.
 	AwsEks *ResourcesDiscoveredSummary `protobuf:"bytes,3,opt,name=aws_eks,json=awsEks,proto3" json:"aws_eks,omitempty"`
 	// The summary for the Azure VM discovered instances.
-	AzureVms      *ResourcesDiscoveredSummary `protobuf:"bytes,4,opt,name=azure_vms,json=azureVms,proto3" json:"azure_vms,omitempty"`
+	AzureVms *ResourcesDiscoveredSummary `protobuf:"bytes,4,opt,name=azure_vms,json=azureVms,proto3" json:"azure_vms,omitempty"`
+	// ServerID identifies the server where this summary was generated.
+	// When multiple discovery services are watching this Discovery Config, this field identifies which server generated the summary.
+	ServerId string `protobuf:"bytes,5,opt,name=server_id,json=serverId,proto3" json:"server_id,omitempty"`
+	// Timestmap of when the discovery iteration started.
+	SyncStart *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=sync_start,json=syncStart,proto3" json:"sync_start,omitempty"`
+	// Timestmap of when the discovery iteration ended.
+	SyncEnd       *timestamppb.Timestamp `protobuf:"bytes,7,opt,name=sync_end,json=syncEnd,proto3" json:"sync_end,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
 func (x *IntegrationDiscoveredSummary) Reset() {
 	*x = IntegrationDiscoveredSummary{}
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -367,7 +431,7 @@ func (x *IntegrationDiscoveredSummary) String() string {
 func (*IntegrationDiscoveredSummary) ProtoMessage() {}
 
 func (x *IntegrationDiscoveredSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[3]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -380,7 +444,7 @@ func (x *IntegrationDiscoveredSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use IntegrationDiscoveredSummary.ProtoReflect.Descriptor instead.
 func (*IntegrationDiscoveredSummary) Descriptor() ([]byte, []int) {
-	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{3}
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *IntegrationDiscoveredSummary) GetAwsEc2() *ResourcesDiscoveredSummary {
@@ -411,6 +475,27 @@ func (x *IntegrationDiscoveredSummary) GetAzureVms() *ResourcesDiscoveredSummary
 	return nil
 }
 
+func (x *IntegrationDiscoveredSummary) GetServerId() string {
+	if x != nil {
+		return x.ServerId
+	}
+	return ""
+}
+
+func (x *IntegrationDiscoveredSummary) GetSyncStart() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SyncStart
+	}
+	return nil
+}
+
+func (x *IntegrationDiscoveredSummary) GetSyncEnd() *timestamppb.Timestamp {
+	if x != nil {
+		return x.SyncEnd
+	}
+	return nil
+}
+
 // ResourcesDiscoveredSummary represents the AWS resources that were discovered.
 type ResourcesDiscoveredSummary struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -427,7 +512,7 @@ type ResourcesDiscoveredSummary struct {
 
 func (x *ResourcesDiscoveredSummary) Reset() {
 	*x = ResourcesDiscoveredSummary{}
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -439,7 +524,7 @@ func (x *ResourcesDiscoveredSummary) String() string {
 func (*ResourcesDiscoveredSummary) ProtoMessage() {}
 
 func (x *ResourcesDiscoveredSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[4]
+	mi := &file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -452,7 +537,7 @@ func (x *ResourcesDiscoveredSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ResourcesDiscoveredSummary.ProtoReflect.Descriptor instead.
 func (*ResourcesDiscoveredSummary) Descriptor() ([]byte, []int) {
-	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{4}
+	return file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ResourcesDiscoveredSummary) GetFound() uint64 {
@@ -491,22 +576,32 @@ const file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc = "" +
 	"\x05azure\x18\x03 \x03(\v2\x13.types.AzureMatcherR\x05azure\x12#\n" +
 	"\x03gcp\x18\x04 \x03(\v2\x11.types.GCPMatcherR\x03gcp\x12,\n" +
 	"\x04kube\x18\x05 \x03(\v2\x18.types.KubernetesMatcherR\x04kube\x129\n" +
-	"\faccess_graph\x18\x06 \x01(\v2\x16.types.AccessGraphSyncR\vaccessGraph\"\xe7\x04\n" +
+	"\faccess_graph\x18\x06 \x01(\v2\x16.types.AccessGraphSyncR\vaccessGraph\"\xbd\a\n" +
 	"\x15DiscoveryConfigStatus\x12G\n" +
 	"\x05state\x18\x01 \x01(\x0e21.teleport.discoveryconfig.v1.DiscoveryConfigStateR\x05state\x12(\n" +
 	"\rerror_message\x18\x02 \x01(\tH\x00R\ferrorMessage\x88\x01\x01\x121\n" +
 	"\x14discovered_resources\x18\x03 \x01(\x04R\x13discoveredResources\x12@\n" +
 	"\x0elast_sync_time\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\flastSyncTime\x12\xa0\x01\n" +
-	" integration_discovered_resources\x18\x06 \x03(\v2V.teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntryR\x1eintegrationDiscoveredResources\x1a\x8c\x01\n" +
+	" integration_discovered_resources\x18\x06 \x03(\v2V.teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntryR\x1eintegrationDiscoveredResources\x12\xb6\x01\n" +
+	"(integration_discovered_resources_history\x18\a \x03(\v2].teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesHistoryEntryR%integrationDiscoveredResourcesHistory\x1a\x8c\x01\n" +
 	"#IntegrationDiscoveredResourcesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12O\n" +
-	"\x05value\x18\x02 \x01(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\x05value:\x028\x01B\x10\n" +
-	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"\xea\x02\n" +
+	"\x05value\x18\x02 \x01(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\x05value:\x028\x01\x1a\x9a\x01\n" +
+	"*IntegrationDiscoveredResourcesHistoryEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12V\n" +
+	"\x05value\x18\x02 \x01(\v2@.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryHistoryR\x05value:\x028\x01B\x10\n" +
+	"\x0e_error_messageJ\x04\b\x05\x10\x06R\x1caws_ec2_instances_discovered\"~\n" +
+	"#IntegrationDiscoveredSummaryHistory\x12W\n" +
+	"\tsummaries\x18\x01 \x03(\v29.teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryR\tsummaries\"\xf9\x03\n" +
 	"\x1cIntegrationDiscoveredSummary\x12P\n" +
 	"\aaws_ec2\x18\x01 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEc2\x12P\n" +
 	"\aaws_rds\x18\x02 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsRds\x12P\n" +
 	"\aaws_eks\x18\x03 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\x06awsEks\x12T\n" +
-	"\tazure_vms\x18\x04 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\bazureVms\"f\n" +
+	"\tazure_vms\x18\x04 \x01(\v27.teleport.discoveryconfig.v1.ResourcesDiscoveredSummaryR\bazureVms\x12\x1b\n" +
+	"\tserver_id\x18\x05 \x01(\tR\bserverId\x129\n" +
+	"\n" +
+	"sync_start\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\tsyncStart\x125\n" +
+	"\bsync_end\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\asyncEnd\"f\n" +
 	"\x1aResourcesDiscoveredSummary\x12\x14\n" +
 	"\x05found\x18\x01 \x01(\x04R\x05found\x12\x1a\n" +
 	"\benrolled\x18\x02 \x01(\x04R\benrolled\x12\x16\n" +
@@ -530,45 +625,52 @@ func file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDescGZIP() []byte
 }
 
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_teleport_discoveryconfig_v1_discoveryconfig_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_goTypes = []any{
-	(DiscoveryConfigState)(0),            // 0: teleport.discoveryconfig.v1.DiscoveryConfigState
-	(*DiscoveryConfig)(nil),              // 1: teleport.discoveryconfig.v1.DiscoveryConfig
-	(*DiscoveryConfigSpec)(nil),          // 2: teleport.discoveryconfig.v1.DiscoveryConfigSpec
-	(*DiscoveryConfigStatus)(nil),        // 3: teleport.discoveryconfig.v1.DiscoveryConfigStatus
-	(*IntegrationDiscoveredSummary)(nil), // 4: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
-	(*ResourcesDiscoveredSummary)(nil),   // 5: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	nil,                                  // 6: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
-	(*v1.ResourceHeader)(nil),            // 7: teleport.header.v1.ResourceHeader
-	(*types.AWSMatcher)(nil),             // 8: types.AWSMatcher
-	(*types.AzureMatcher)(nil),           // 9: types.AzureMatcher
-	(*types.GCPMatcher)(nil),             // 10: types.GCPMatcher
-	(*types.KubernetesMatcher)(nil),      // 11: types.KubernetesMatcher
-	(*types.AccessGraphSync)(nil),        // 12: types.AccessGraphSync
-	(*timestamppb.Timestamp)(nil),        // 13: google.protobuf.Timestamp
+	(DiscoveryConfigState)(0),                   // 0: teleport.discoveryconfig.v1.DiscoveryConfigState
+	(*DiscoveryConfig)(nil),                     // 1: teleport.discoveryconfig.v1.DiscoveryConfig
+	(*DiscoveryConfigSpec)(nil),                 // 2: teleport.discoveryconfig.v1.DiscoveryConfigSpec
+	(*DiscoveryConfigStatus)(nil),               // 3: teleport.discoveryconfig.v1.DiscoveryConfigStatus
+	(*IntegrationDiscoveredSummaryHistory)(nil), // 4: teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryHistory
+	(*IntegrationDiscoveredSummary)(nil),        // 5: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	(*ResourcesDiscoveredSummary)(nil),          // 6: teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	nil,                                         // 7: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
+	nil,                                         // 8: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesHistoryEntry
+	(*v1.ResourceHeader)(nil),                   // 9: teleport.header.v1.ResourceHeader
+	(*types.AWSMatcher)(nil),                    // 10: types.AWSMatcher
+	(*types.AzureMatcher)(nil),                  // 11: types.AzureMatcher
+	(*types.GCPMatcher)(nil),                    // 12: types.GCPMatcher
+	(*types.KubernetesMatcher)(nil),             // 13: types.KubernetesMatcher
+	(*types.AccessGraphSync)(nil),               // 14: types.AccessGraphSync
+	(*timestamppb.Timestamp)(nil),               // 15: google.protobuf.Timestamp
 }
 var file_teleport_discoveryconfig_v1_discoveryconfig_proto_depIdxs = []int32{
-	7,  // 0: teleport.discoveryconfig.v1.DiscoveryConfig.header:type_name -> teleport.header.v1.ResourceHeader
+	9,  // 0: teleport.discoveryconfig.v1.DiscoveryConfig.header:type_name -> teleport.header.v1.ResourceHeader
 	2,  // 1: teleport.discoveryconfig.v1.DiscoveryConfig.spec:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigSpec
 	3,  // 2: teleport.discoveryconfig.v1.DiscoveryConfig.status:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus
-	8,  // 3: teleport.discoveryconfig.v1.DiscoveryConfigSpec.aws:type_name -> types.AWSMatcher
-	9,  // 4: teleport.discoveryconfig.v1.DiscoveryConfigSpec.azure:type_name -> types.AzureMatcher
-	10, // 5: teleport.discoveryconfig.v1.DiscoveryConfigSpec.gcp:type_name -> types.GCPMatcher
-	11, // 6: teleport.discoveryconfig.v1.DiscoveryConfigSpec.kube:type_name -> types.KubernetesMatcher
-	12, // 7: teleport.discoveryconfig.v1.DiscoveryConfigSpec.access_graph:type_name -> types.AccessGraphSync
+	10, // 3: teleport.discoveryconfig.v1.DiscoveryConfigSpec.aws:type_name -> types.AWSMatcher
+	11, // 4: teleport.discoveryconfig.v1.DiscoveryConfigSpec.azure:type_name -> types.AzureMatcher
+	12, // 5: teleport.discoveryconfig.v1.DiscoveryConfigSpec.gcp:type_name -> types.GCPMatcher
+	13, // 6: teleport.discoveryconfig.v1.DiscoveryConfigSpec.kube:type_name -> types.KubernetesMatcher
+	14, // 7: teleport.discoveryconfig.v1.DiscoveryConfigSpec.access_graph:type_name -> types.AccessGraphSync
 	0,  // 8: teleport.discoveryconfig.v1.DiscoveryConfigStatus.state:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigState
-	13, // 9: teleport.discoveryconfig.v1.DiscoveryConfigStatus.last_sync_time:type_name -> google.protobuf.Timestamp
-	6,  // 10: teleport.discoveryconfig.v1.DiscoveryConfigStatus.integration_discovered_resources:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
-	5,  // 11: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 12: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 13: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	5,  // 14: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
-	4,  // 15: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
-	16, // [16:16] is the sub-list for method output_type
-	16, // [16:16] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	15, // 9: teleport.discoveryconfig.v1.DiscoveryConfigStatus.last_sync_time:type_name -> google.protobuf.Timestamp
+	7,  // 10: teleport.discoveryconfig.v1.DiscoveryConfigStatus.integration_discovered_resources:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry
+	8,  // 11: teleport.discoveryconfig.v1.DiscoveryConfigStatus.integration_discovered_resources_history:type_name -> teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesHistoryEntry
+	5,  // 12: teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryHistory.summaries:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	6,  // 13: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_ec2:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	6,  // 14: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_rds:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	6,  // 15: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.aws_eks:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	6,  // 16: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.azure_vms:type_name -> teleport.discoveryconfig.v1.ResourcesDiscoveredSummary
+	15, // 17: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.sync_start:type_name -> google.protobuf.Timestamp
+	15, // 18: teleport.discoveryconfig.v1.IntegrationDiscoveredSummary.sync_end:type_name -> google.protobuf.Timestamp
+	5,  // 19: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummary
+	4,  // 20: teleport.discoveryconfig.v1.DiscoveryConfigStatus.IntegrationDiscoveredResourcesHistoryEntry.value:type_name -> teleport.discoveryconfig.v1.IntegrationDiscoveredSummaryHistory
+	21, // [21:21] is the sub-list for method output_type
+	21, // [21:21] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_teleport_discoveryconfig_v1_discoveryconfig_proto_init() }
@@ -583,7 +685,7 @@ func file_teleport_discoveryconfig_v1_discoveryconfig_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc), len(file_teleport_discoveryconfig_v1_discoveryconfig_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
+++ b/api/proto/teleport/discoveryconfig/v1/discoveryconfig.proto
@@ -72,6 +72,10 @@ message DiscoveryConfigStatus {
 
   // IntegrationDiscoveredResources maps an integration to discovered resources summary.
   map<string, IntegrationDiscoveredSummary> integration_discovered_resources = 6;
+
+  // IntegrationDiscoveredSummaryHistory maps an integration to the history of discovered resources summary.
+  // Each entry has up to 5 summaries of the past iterations.
+  map<string, IntegrationDiscoveredSummaryHistory> integration_discovered_resources_history = 7;
 }
 
 // DiscoveryConfigState is the state of the discovery config resource.
@@ -87,6 +91,13 @@ enum DiscoveryConfigState {
   DISCOVERY_CONFIG_STATE_SYNCING = 3;
 }
 
+// IntegrationDiscoveredSummaryHistory contains the a summary for each resource type that was discovered at a specific time in the past.
+message IntegrationDiscoveredSummaryHistory {
+  // List of summaries for past iterations.
+  // Contains at most 5 summaries of the past iterations, ordered from the most recent to the oldest.
+  repeated IntegrationDiscoveredSummary summaries = 1;
+}
+
 // IntegrationDiscoveredSummary contains the a summary for each resource type that was discovered.
 message IntegrationDiscoveredSummary {
   // AWSEC2 contains the summary for the AWS EC2 discovered instances.
@@ -100,6 +111,16 @@ message IntegrationDiscoveredSummary {
 
   // The summary for the Azure VM discovered instances.
   ResourcesDiscoveredSummary azure_vms = 4;
+
+  // ServerID identifies the server where this summary was generated.
+  // When multiple discovery services are watching this Discovery Config, this field identifies which server generated the summary.
+  string server_id = 5;
+
+  // Timestmap of when the discovery iteration started.
+  google.protobuf.Timestamp sync_start = 6;
+
+  // Timestmap of when the discovery iteration ended.
+  google.protobuf.Timestamp sync_end = 7;
 }
 
 // ResourcesDiscoveredSummary represents the AWS resources that were discovered.

--- a/api/types/discoveryconfig/convert/v1/discoveryconfig.go
+++ b/api/types/discoveryconfig/convert/v1/discoveryconfig.go
@@ -89,11 +89,12 @@ func StatusFromProto(msg *discoveryconfigv1.DiscoveryConfigStatus) discoveryconf
 		lastSyncTime = msg.LastSyncTime.AsTime()
 	}
 	return discoveryconfig.Status{
-		State:                          discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
-		ErrorMessage:                   msg.ErrorMessage,
-		DiscoveredResources:            msg.DiscoveredResources,
-		LastSyncTime:                   lastSyncTime,
-		IntegrationDiscoveredResources: msg.IntegrationDiscoveredResources,
+		State:                                 discoveryconfigv1.DiscoveryConfigState_name[int32(msg.State)],
+		ErrorMessage:                          msg.ErrorMessage,
+		DiscoveredResources:                   msg.DiscoveredResources,
+		LastSyncTime:                          lastSyncTime,
+		IntegrationDiscoveredResources:        msg.IntegrationDiscoveredResources,
+		IntegrationDiscoveredResourcesHistory: msg.GetIntegrationDiscoveredResourcesHistory(),
 	}
 }
 
@@ -142,10 +143,11 @@ func StatusToProto(status discoveryconfig.Status) *discoveryconfigv1.DiscoveryCo
 	}
 
 	return &discoveryconfigv1.DiscoveryConfigStatus{
-		State:                          discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
-		ErrorMessage:                   status.ErrorMessage,
-		DiscoveredResources:            status.DiscoveredResources,
-		LastSyncTime:                   lastSyncTime,
-		IntegrationDiscoveredResources: status.IntegrationDiscoveredResources,
+		State:                                 discoveryconfigv1.DiscoveryConfigState(discoveryconfigv1.DiscoveryConfigState_value[status.State]),
+		ErrorMessage:                          status.ErrorMessage,
+		DiscoveredResources:                   status.DiscoveredResources,
+		LastSyncTime:                          lastSyncTime,
+		IntegrationDiscoveredResources:        status.IntegrationDiscoveredResources,
+		IntegrationDiscoveredResourcesHistory: status.IntegrationDiscoveredResourcesHistory,
 	}
 }

--- a/api/types/discoveryconfig/discoveryconfig.go
+++ b/api/types/discoveryconfig/discoveryconfig.go
@@ -85,6 +85,9 @@ type Status struct {
 	LastSyncTime time.Time `json:"last_sync_time,omitempty" yaml:"last_sync_time,omitempty"`
 	// IntegrationDiscoveredResources maps an integration to a summary of resources that were found using that integration.
 	IntegrationDiscoveredResources map[string]*discoveryconfigv1.IntegrationDiscoveredSummary `json:"integration_discovered_resources,omitempty" yaml:"integration_discovered_resources,omitempty"`
+	// IntegrationDiscoveredResourcesHistory maps an integration to a summary of resources that were found using that integration.
+	// Only the most recent 5 summaries are kept for each integration.
+	IntegrationDiscoveredResourcesHistory map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory `json:"integration_discovered_resources_history,omitempty" yaml:"integration_discovered_resources_history,omitempty"`
 }
 
 // NewDiscoveryConfig will create a new discovery config.

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -621,6 +621,9 @@ aws_ec2: # [...]
 aws_rds: # [...]
 aws_eks: # [...]
 azure_vms: # [...]
+server_id: "string"
+sync_start: # See description
+sync_end: # See description
 ```
 
 |Field Name|Description|Type|
@@ -629,6 +632,27 @@ azure_vms: # [...]
 |aws_eks|AWSEKS contains the summary for the AWS EKS discovered clusters.|[Resources Discovered Summary](#resources-discovered-summary)|
 |aws_rds|AWSRDS contains the summary for the AWS RDS discovered databases.|[Resources Discovered Summary](#resources-discovered-summary)|
 |azure_vms|The summary for the Azure VM discovered instances.|[Resources Discovered Summary](#resources-discovered-summary)|
+|server_id|ServerID identifies the server where this summary was generated. When multiple discovery services are watching this Discovery Config, this field identifies which server generated the summary.|string|
+|sync_end|Timestmap of when the discovery iteration ended.||
+|sync_start|Timestmap of when the discovery iteration started.||
+
+## Integration Discovered Summary History
+
+Contains the a summary for each resource type that was discovered at a specific time in the past.
+
+
+Example:
+
+```yaml
+summaries: 
+  - # [...]
+  - # [...]
+  - # [...]
+```
+
+|Field Name|Description|Type|
+|---|---|---|
+|summaries|List of summaries for past iterations. Contains at most 5 summaries of the past iterations, ordered from the most recent to the oldest.|[][Integration Discovered Summary](#integration-discovered-summary)|
 
 ## Join Method
 
@@ -763,6 +787,10 @@ integration_discovered_resources:
   "string": # [...]
   "string": # [...]
   "string": # [...]
+integration_discovered_resources_history: 
+  "string": # [...]
+  "string": # [...]
+  "string": # [...]
 ```
 
 |Field Name|Description|Type|
@@ -770,6 +798,7 @@ integration_discovered_resources:
 |discovered_resources|Holds the count of the discovered resources in the previous iteration.|number|
 |error_message|Holds the error message when state is DISCOVERY_CONFIG_STATE_ERROR.|string|
 |integration_discovered_resources|Maps an integration to a summary of resources that were found using that integration.|map[string][Integration Discovered Summary](#integration-discovered-summary)|
+|integration_discovered_resources_history|Maps an integration to a summary of resources that were found using that integration. Only the most recent 5 summaries are kept for each integration.|map[string][Integration Discovered Summary History](#integration-discovered-summary-history)|
 |last_sync_time|The timestamp when the Discovery Config was last sync.||
 |state|The current state of the discovery config.|string|
 

--- a/lib/auth/authclient/api.go
+++ b/lib/auth/authclient/api.go
@@ -879,8 +879,8 @@ type ReadDiscoveryAccessPoint interface {
 	// GetApp returns the specified application resource.
 	GetApp(ctx context.Context, name string) (types.Application, error)
 
-	// ListDiscoveryConfigs returns a paginated list of Discovery Config resources.
-	ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error)
+	// List and read discovery config resources.
+	services.DiscoveryConfigsGetter
 
 	// GetIntegration returns the specified integration resource.
 	GetIntegration(ctx context.Context, name string) (types.Integration, error)

--- a/lib/srv/discovery/access_graph_test.go
+++ b/lib/srv/discovery/access_graph_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/jonboulle/clockwork"
@@ -246,6 +247,8 @@ func TestServer_updateDiscoveryConfigStatus(t *testing.T) {
 				Config: &Config{
 					AccessPoint: accessPoint,
 					clock:       clock,
+					ServerID:    "server-id",
+					Log:         slog.New(slog.DiscardHandler),
 				},
 				tagSyncStatus: newTagSyncStatus(),
 			}

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -66,6 +66,8 @@ type WatcherConfig struct {
 	Origin string
 	// PreFetchHookFn is called before starting a new fetch cycle.
 	PreFetchHookFn func()
+	// PostFetchHookFn is called after completing a fetch cycle.
+	PostFetchHookFn func()
 }
 
 // CheckAndSetDefaults validates the config.
@@ -87,6 +89,12 @@ func (c *WatcherConfig) CheckAndSetDefaults() error {
 	}
 	if c.Origin == "" {
 		return trace.BadParameter("origin is not set")
+	}
+	if c.PreFetchHookFn == nil {
+		c.PreFetchHookFn = func() {}
+	}
+	if c.PostFetchHookFn == nil {
+		c.PostFetchHookFn = func() {}
 	}
 	return nil
 }
@@ -144,9 +152,8 @@ func (w *Watcher) Start() {
 
 // fetchAndSend fetches resources from all fetchers and sends them to the channel.
 func (w *Watcher) fetchAndSend() {
-	if w.cfg.PreFetchHookFn != nil {
-		w.cfg.PreFetchHookFn()
-	}
+	w.cfg.PreFetchHookFn()
+	defer w.cfg.PostFetchHookFn()
 
 	var (
 		newFetcherResources = make(types.ResourcesWithLabels, 0, 50)

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -68,14 +68,15 @@ func (s *Server) startDatabaseWatchers() error {
 
 	watcher, err := common.NewWatcher(s.ctx,
 		common.WatcherConfig{
-			FetchersFn:     s.getAllDatabaseFetchers,
-			Logger:         s.Log.With("kind", types.KindDatabase),
-			DiscoveryGroup: s.DiscoveryGroup,
-			Interval:       s.PollInterval,
-			TriggerFetchC:  s.newDiscoveryConfigChangedSub(),
-			Origin:         types.OriginCloud,
-			Clock:          s.clock,
-			PreFetchHookFn: s.databaseWatcherIterationStarted,
+			FetchersFn:      s.getAllDatabaseFetchers,
+			Logger:          s.Log.With("kind", types.KindDatabase),
+			DiscoveryGroup:  s.DiscoveryGroup,
+			Interval:        s.PollInterval,
+			TriggerFetchC:   s.newDiscoveryConfigChangedSub(),
+			Origin:          types.OriginCloud,
+			Clock:           s.clock,
+			PreFetchHookFn:  s.databaseWatcherIterationStarted,
+			PostFetchHookFn: s.databaseWatcherIterationEnded,
 		},
 	)
 	if err != nil {
@@ -178,6 +179,12 @@ func (s *Server) collectRDSIssuesAsUserTasks(db types.Database, integration, dis
 	)
 }
 
+func (s *Server) databaseWatcherIterationEnded() {
+	for resourceGroup := range s.awsRDSResourcesStatus.awsResourcesResults {
+		s.awsRDSResourcesStatus.iterationEnded(resourceGroup, s.clock.Now())
+	}
+}
+
 func (s *Server) databaseWatcherIterationStarted() {
 	allFetchers := s.getAllDatabaseFetchers()
 	if len(allFetchers) == 0 {
@@ -204,7 +211,7 @@ func (s *Server) databaseWatcherIterationStarted() {
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 	s.awsRDSResourcesStatus.reset()
 	for _, g := range awsResultGroups {
-		s.awsRDSResourcesStatus.iterationStarted(g)
+		s.awsRDSResourcesStatus.iterationStarted(g, s.clock.Now())
 	}
 
 	s.awsRDSTasks.reset()

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -524,6 +524,10 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 	return s, nil
 }
 
+func (s *Server) discoveryConfigStatusUpdater() *discoveryConfigStatusUpdater {
+	return newDiscoveryConfigStatusUpdater(s.Config)
+}
+
 func (s *Server) runDynamicMatchersWatcher(ctx context.Context) error {
 	watcher, err := s.AccessPoint.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{
@@ -692,7 +696,7 @@ func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 	s.awsEC2ResourcesStatus.reset()
 	for _, g := range awsResultGroups {
-		s.awsEC2ResourcesStatus.iterationStarted(g)
+		s.awsEC2ResourcesStatus.iterationStarted(g, s.clock.Now())
 	}
 
 	s.awsEC2Tasks.reset()

--- a/lib/srv/discovery/discovery_eks_test.go
+++ b/lib/srv/discovery/discovery_eks_test.go
@@ -453,6 +453,13 @@ func (m *mockAuthServer) UpsertUserTask(ctx context.Context, req *usertasksv1.Us
 	return req, nil
 }
 
+func (m *mockAuthServer) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	if dc, ok := m.storeDiscoveryConfigs[name]; ok {
+		return dc, nil
+	}
+	return nil, trace.NotFound("discovery config %q not found", name)
+}
+
 type mockEKSClusterEnroller struct {
 	resp *integrationpb.EnrollEKSClustersResponse
 	err  error

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -936,7 +936,13 @@ func TestDiscoveryServer(t *testing.T) {
 					require.Equal(t, want.ErrorMessage, got.ErrorMessage)
 					for expectedKey, expectedValue := range want.IntegrationDiscoveredResources {
 						require.Contains(t, got.IntegrationDiscoveredResources, expectedKey)
-						require.Equal(t, expectedValue, got.IntegrationDiscoveredResources[expectedKey])
+						diff := cmp.Diff(
+							expectedValue,
+							got.IntegrationDiscoveredResources[expectedKey],
+							protocmp.IgnoreFields(&discoveryconfigv1.IntegrationDiscoveredSummary{}, "sync_end"),
+							protocmp.Transform(),
+						)
+						require.Empty(t, diff, "unexpected difference in IntegrationDiscoveredSummary")
 					}
 					return true
 				}, 1*time.Second, 50*time.Millisecond)
@@ -4041,6 +4047,20 @@ func (d *combinedDiscoveryClient) UpdateDiscoveryConfigStatus(ctx context.Contex
 	return nil, trace.BadParameter("not implemented.")
 }
 
+func (d *combinedDiscoveryClient) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	return nil, trace.NotFound("discovery config not found")
+}
+
+func (d *combinedDiscoveryClient) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	return &types.SemaphoreLease{
+		Expires: params.Expires,
+	}, nil
+}
+
+func (d *combinedDiscoveryClient) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	return nil
+}
+
 func getDiscoveryAccessPointWithEKSEnroller(authServer *auth.Server, authClient authclient.ClientI, eksEnroller eksClustersEnroller) authclient.DiscoveryAccessPoint {
 	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: eksEnroller, discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
 }
@@ -4068,6 +4088,10 @@ type fakeAccessPoint struct {
 func (f *fakeAccessPoint) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
 	f.reports[name] = append(f.reports[name], status)
 	return nil, nil
+}
+
+func (f *fakeAccessPoint) GetDiscoveryConfig(_ context.Context, _ string) (*discoveryconfig.DiscoveryConfig, error) {
+	return nil, trace.NotFound("discovery config not found")
 }
 
 func newFakeAccessPoint() *fakeAccessPoint {
@@ -4144,6 +4168,16 @@ func (f *fakeAccessPoint) NewWatcher(ctx context.Context, watch types.Watch) (ty
 		return f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
 	}
 	return newFakeWatcher(), nil
+}
+
+func (f *fakeAccessPoint) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	return &types.SemaphoreLease{
+		Expires: params.Expires,
+	}, nil
+}
+
+func (f *fakeAccessPoint) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	return nil
 }
 
 type fakeWatcher struct{}

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -231,7 +231,7 @@ func (s *Server) kubernetesIntegrationWatcherIterationStarted() {
 	s.updateDiscoveryConfigStatus(discoveryConfigs...)
 	s.awsEKSResourcesStatus.reset()
 	for _, g := range awsResultGroups {
-		s.awsEKSResourcesStatus.iterationStarted(g)
+		s.awsEKSResourcesStatus.iterationStarted(g, s.clock.Now())
 	}
 
 	s.awsEKSTasks.reset()

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -92,18 +92,16 @@ func (s *Server) updateDiscoveryConfigStatus(discoveryConfigNames ...string) {
 		// Too large error messages will cause failures when clients (which use the default MaxCallRecvMsgSize of 4MB) try to read DiscoveryConfigs.
 		discoveryConfigStatus.ErrorMessage = truncateErrorMessage(discoveryConfigStatus)
 
-		func() {
-			ctx, cancel := context.WithTimeout(s.ctx, 5*time.Second)
-			defer cancel()
+		// Update the sync times and server ID for each integration summary.
+		for _, integrationSummary := range discoveryConfigStatus.IntegrationDiscoveredResources {
+			integrationSummary.ServerId = s.Config.ServerID
+			//integrationSummary.SyncStart = timestamppb.New(discoveryConfigStatus.LastSyncTime)
+			integrationSummary.SyncEnd = timestamppb.New(s.Config.clock.Now())
+		}
 
-			_, err := s.AccessPoint.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus)
-			switch {
-			case trace.IsNotImplemented(err):
-				s.Log.WarnContext(ctx, "UpdateDiscoveryConfigStatus method is not implemented in Auth Server. Please upgrade it to a recent version.")
-			case err != nil:
-				s.Log.WarnContext(ctx, "Error updating discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
-			}
-		}()
+		if err := s.discoveryConfigStatusUpdater().update(s.ctx, discoveryConfigName, discoveryConfigStatus); err != nil {
+			s.Log.WarnContext(s.ctx, "Failed to update discovery config status", "discovery_config_name", discoveryConfigName, "error", err)
+		}
 	}
 }
 
@@ -255,6 +253,8 @@ type awsResourcesStatus struct {
 	// awsResourcesResults maps the DiscoveryConfig name and integration to a summary of discovered/enrolled resources.
 	awsResourcesResults map[awsResourceGroup]awsResourceGroupResult
 	resourceType        string
+	syncStartTime       time.Time
+	syncEndTime         time.Time
 }
 
 // awsResourceGroup is the key for the summary
@@ -299,7 +299,9 @@ func (ars *awsResourcesStatus) mergeIntoGlobalStatus(discoveryConfigName string,
 		// Update counters specific to AWS resources discovered.
 		existingIntegrationResources, ok := existingStatus.IntegrationDiscoveredResources[group.integration]
 		if !ok {
-			existingIntegrationResources = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+			existingIntegrationResources = &discoveryconfigv1.IntegrationDiscoveredSummary{
+				//SyncEnd: timestamppb.New(syncTime),
+			}
 		}
 
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{
@@ -327,13 +329,24 @@ func (ars *awsResourcesStatus) incrementFailed(g awsResourceGroup, count int) {
 	ars.awsResourcesResults[g] = groupStats
 }
 
-func (ars *awsResourcesStatus) iterationStarted(g awsResourceGroup) {
+func (ars *awsResourcesStatus) iterationStarted(g awsResourceGroup, syncStartTime time.Time) {
 	ars.mu.Lock()
 	defer ars.mu.Unlock()
 	if ars.awsResourcesResults == nil {
 		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
 	}
 	ars.awsResourcesResults[g] = awsResourceGroupResult{}
+	ars.syncStartTime = syncStartTime
+}
+
+func (ars *awsResourcesStatus) iterationEnded(g awsResourceGroup, syncEndTime time.Time) {
+	ars.mu.Lock()
+	defer ars.mu.Unlock()
+	if ars.awsResourcesResults == nil {
+		ars.awsResourcesResults = make(map[awsResourceGroup]awsResourceGroupResult)
+	}
+	ars.awsResourcesResults[g] = awsResourceGroupResult{}
+	ars.syncEndTime = syncEndTime
 }
 
 func (ars *awsResourcesStatus) incrementFound(g awsResourceGroup, count int) {
@@ -1113,7 +1126,9 @@ func (s *resourceStatusMap) mergeIntoGlobalStatus(discoveryConfigName string, ex
 		var summary *discoveryconfigv1.IntegrationDiscoveredSummary
 		summary = existingStatus.IntegrationDiscoveredResources[key.integration]
 		if summary == nil {
-			summary = &discoveryconfigv1.IntegrationDiscoveredSummary{}
+			summary = &discoveryconfigv1.IntegrationDiscoveredSummary{
+				//SyncEnd: timestamppb.New(syncEnd),
+			}
 		}
 
 		resourcesSummary := &discoveryconfigv1.ResourcesDiscoveredSummary{

--- a/lib/srv/discovery/status_updater.go
+++ b/lib/srv/discovery/status_updater.go
@@ -1,0 +1,142 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+)
+
+type semaphoreAccessPoint interface {
+	// AcquireSemaphore acquires lease with requested resources from semaphore.
+	AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error)
+	// CancelSemaphoreLease cancels semaphore lease early.
+	CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error
+}
+
+type discoveryConfigService interface {
+	// GetDiscoveryConfig returns the DiscoveryConfig resource with the given name.
+	GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error)
+	// UpdateDiscoveryConfigStatus updates the Status field of the DiscoveryConfig resource with the given name.
+	UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
+}
+
+type discoveryConfigStatusUpdater struct {
+	log                    *slog.Logger
+	serverID               string
+	clock                  clockwork.Clock
+	semaphoreService       semaphoreAccessPoint
+	discoveryConfigService discoveryConfigService
+}
+
+func newDiscoveryConfigStatusUpdater(cfg *Config) *discoveryConfigStatusUpdater {
+	return &discoveryConfigStatusUpdater{
+		log:                    cfg.Log,
+		serverID:               cfg.ServerID,
+		clock:                  cfg.clock,
+		semaphoreService:       cfg.AccessPoint,
+		discoveryConfigService: cfg.AccessPoint,
+	}
+}
+
+// update receives a new status for a DiscoveryConfig and updates it in the backend.
+// The DiscoveryConfig Status keeps the last 5 fetch summaries (ie. how many resources were discovered/enrolled).
+// We might have concurrent Discovery Services working in the same Discovery Config, so a semaphore lock is acquired to ensure that the history is kept consistent and not overwritten by concurrent updates.
+func (s *discoveryConfigStatusUpdater) update(ctx context.Context, discoveryConfigName string, discoveryConfigStatus discoveryconfig.Status) error {
+	const operationTimeout = 10 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, operationTimeout)
+	defer cancel()
+
+	lease, err := s.semaphoreService.AcquireSemaphore(ctx, types.AcquireSemaphoreRequest{
+		SemaphoreKind: types.KindDiscoveryConfig,
+		SemaphoreName: discoveryConfigName,
+		MaxLeases:     1,
+		Expires:       s.clock.Now().Add(operationTimeout),
+		Holder:        s.serverID,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	defer func() {
+		if err := s.semaphoreService.CancelSemaphoreLease(ctx, *lease); err != nil {
+			s.log.WarnContext(ctx, "Failed to release DiscoveryConfig status update lock, it will expire automatically",
+				"discovery_config_name", discoveryConfigName,
+				"expiration", lease.Expires,
+				"error", err,
+			)
+		}
+	}()
+
+	existingDiscoveryConfig, err := s.discoveryConfigService.GetDiscoveryConfig(ctx, discoveryConfigName)
+	if err != nil && !trace.IsNotFound(err) {
+		return trace.Wrap(err)
+	}
+
+	discoveryConfigStatus = mergeSummaries(discoveryConfigStatus, existingDiscoveryConfig)
+
+	if _, err := s.discoveryConfigService.UpdateDiscoveryConfigStatus(ctx, discoveryConfigName, discoveryConfigStatus); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// DiscoveryConfigStatus has a HistoryIntegrationDiscoveredResources field which keeps a history of previous iteration summaries.
+// This function merges the existing summaries into the new status while ensuring the maximum number of summaries is not exceeded.
+func mergeSummaries(discoveryConfigStatus discoveryconfig.Status, existingDiscoveryConfig *discoveryconfig.DiscoveryConfig) discoveryconfig.Status {
+	const maxSummariesInHistory = 5
+
+	if existingDiscoveryConfig == nil {
+		return discoveryConfigStatus
+	}
+	existingStatus := existingDiscoveryConfig.Status
+
+	discoveryConfigStatus.IntegrationDiscoveredResourcesHistory = make(map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory)
+
+	for integration := range discoveryConfigStatus.IntegrationDiscoveredResources {
+		var summaries []*discoveryconfigv1.IntegrationDiscoveredSummary
+
+		if summary, ok := existingStatus.IntegrationDiscoveredResources[integration]; ok {
+			summaries = append(summaries, summary)
+		}
+
+		if history, ok := existingStatus.IntegrationDiscoveredResourcesHistory[integration]; ok {
+			for _, s := range history.GetSummaries() {
+				if len(summaries) >= maxSummariesInHistory {
+					break
+				}
+				summaries = append(summaries, s)
+			}
+		}
+		discoveryConfigStatus.IntegrationDiscoveredResourcesHistory[integration] = &discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+			Summaries: summaries,
+		}
+	}
+
+	return discoveryConfigStatus
+}

--- a/lib/srv/discovery/status_updater_test.go
+++ b/lib/srv/discovery/status_updater_test.go
@@ -1,0 +1,313 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package discovery
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	discoveryconfigv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/discoveryconfig/v1"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/discoveryconfig"
+)
+
+func statusFoundInstances(found uint64) *discoveryconfigv1.IntegrationDiscoveredSummary {
+	return &discoveryconfigv1.IntegrationDiscoveredSummary{
+		AwsEc2: &discoveryconfigv1.ResourcesDiscoveredSummary{
+			Found: found,
+		},
+	}
+}
+
+func TestMergeSummaries(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                    string
+		newStatus               discoveryconfig.Status
+		existingDiscoveryConfig *discoveryconfig.DiscoveryConfig
+		expectedStatus          discoveryconfig.Status
+	}{
+		{
+			name: "merging into discoveryconfig",
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(10),
+				},
+			},
+			existingDiscoveryConfig: nil,
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(10),
+				},
+			},
+		},
+		{
+			name: "existing has no history, a new history entry is created",
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(10),
+				},
+			},
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+						"my-integration": statusFoundInstances(5),
+					},
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(10),
+				},
+				IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+					"my-integration": {
+						Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+							statusFoundInstances(5),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "existing has history, a new history entry is added",
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(15),
+				},
+			},
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+						"my-integration": statusFoundInstances(10),
+					},
+					IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+						"my-integration": {
+							Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+								statusFoundInstances(5),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(15),
+				},
+				IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+					"my-integration": {
+						Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+							statusFoundInstances(10),
+							statusFoundInstances(5),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "a max of 5 items are kept in history",
+			newStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(100),
+				},
+			},
+			existingDiscoveryConfig: &discoveryconfig.DiscoveryConfig{
+				Status: discoveryconfig.Status{
+					IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+						"my-integration": statusFoundInstances(90),
+					},
+					IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+						"my-integration": {
+							Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+								statusFoundInstances(80),
+								statusFoundInstances(70),
+								statusFoundInstances(60),
+								statusFoundInstances(50),
+								statusFoundInstances(40),
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(100),
+				},
+				IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+					"my-integration": {
+						Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+							statusFoundInstances(90),
+							statusFoundInstances(80),
+							statusFoundInstances(70),
+							statusFoundInstances(60),
+							statusFoundInstances(50),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeSummaries(tc.newStatus, tc.existingDiscoveryConfig)
+			require.True(t, cmp.Equal(got, tc.expectedStatus, protocmp.Transform()), "unexpected result: %s", cmp.Diff(got, tc.expectedStatus, protocmp.Transform()))
+		})
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                     string
+		discoveryConfigName      string
+		discoveryConfigStatus    discoveryconfig.Status
+		existingDiscoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+		expectedDiscoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+	}{
+		{
+			name:                "successfully update discovery config status when no existing config is found",
+			discoveryConfigName: "test-config",
+			discoveryConfigStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(5),
+				},
+			},
+			existingDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{},
+			expectedDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+							"my-integration": statusFoundInstances(5),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                "successfully updates an existing discovery config and adds historical data",
+			discoveryConfigName: "test-config",
+			discoveryConfigStatus: discoveryconfig.Status{
+				IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+					"my-integration": statusFoundInstances(5),
+				},
+			},
+			existingDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+							"my-integration": statusFoundInstances(3),
+						},
+					},
+				},
+			},
+			expectedDiscoveryConfigs: map[string]*discoveryconfig.DiscoveryConfig{
+				"test-config": {
+					Status: discoveryconfig.Status{
+						IntegrationDiscoveredResources: map[string]*discoveryconfigv1.IntegrationDiscoveredSummary{
+							"my-integration": statusFoundInstances(5),
+						},
+						IntegrationDiscoveredResourcesHistory: map[string]*discoveryconfigv1.IntegrationDiscoveredSummaryHistory{
+							"my-integration": {
+								Summaries: []*discoveryconfigv1.IntegrationDiscoveredSummary{
+									statusFoundInstances(3),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			discoveryConfigService := &mockDiscoveryConfigService{
+				discoveryConfigs: tc.existingDiscoveryConfigs,
+			}
+			semaphoreService := &mockSemaphore{}
+
+			updater := &discoveryConfigStatusUpdater{
+				log:                    slog.New(slog.DiscardHandler),
+				serverID:               "test-server",
+				clock:                  clockwork.NewFakeClock(),
+				semaphoreService:       semaphoreService,
+				discoveryConfigService: discoveryConfigService,
+			}
+
+			err := updater.update(t.Context(), tc.discoveryConfigName, tc.discoveryConfigStatus)
+			require.NoError(t, err)
+
+			// Verify the final state of the discovery configs
+			for name, expectedConfig := range tc.expectedDiscoveryConfigs {
+				require.Contains(t, tc.existingDiscoveryConfigs, name)
+				storedDiscoveryConfig := tc.existingDiscoveryConfigs[name]
+
+				require.True(t, cmp.Equal(expectedConfig, storedDiscoveryConfig, protocmp.Transform()), "unexpected discovery config for %s: %s", name)
+			}
+
+			require.False(t, semaphoreService.stateLocked, "semaphore should be released after update")
+		})
+	}
+}
+
+type mockDiscoveryConfigService struct {
+	discoveryConfigs map[string]*discoveryconfig.DiscoveryConfig
+}
+
+func (m *mockDiscoveryConfigService) GetDiscoveryConfig(ctx context.Context, name string) (*discoveryconfig.DiscoveryConfig, error) {
+	if config, ok := m.discoveryConfigs[name]; ok {
+		return config, nil
+	}
+	return nil, trace.NotFound("discovery config not found: %s", name)
+}
+
+func (m *mockDiscoveryConfigService) UpdateDiscoveryConfigStatus(ctx context.Context, name string, status discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error) {
+	config, ok := m.discoveryConfigs[name]
+	if !ok {
+		config = &discoveryconfig.DiscoveryConfig{}
+	}
+	config.Status = status
+	m.discoveryConfigs[name] = config
+	return config, nil
+}
+
+type mockSemaphore struct {
+	mtx         sync.Mutex
+	stateLocked bool
+}
+
+func (m *mockSemaphore) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
+	m.mtx.Lock()
+	m.stateLocked = true
+	return &types.SemaphoreLease{
+		Expires: params.Expires,
+	}, nil
+}
+
+func (m *mockSemaphore) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
+	m.stateLocked = false
+	m.mtx.Unlock()
+	return nil
+}


### PR DESCRIPTION
Discovery Service calls cloud APIs to discover resources and enroll them into teleport.

We use Discovery Config to configure the matchers (ie. what resource types, regions, tag filters).

When an iteration ends, we update the Status of the Discovery Config with the summary of the iteration: count of resources discovered, enrolled and failed

Right now users only have access to the latest summary, and miss the evolution of their configurations.

This PR adds historical data for those summaries.
It only allows the storage of the last 5 summaries to ensure we don't store things indefinitely.

Demo:

`$ tctl get discovery_config`
```yaml
# ...
status:
  discovered_resources: 0
  integration_discovered_resources:
    discovery-aws-organization-o-vflomaa000:
      aws_ec2: {}
      sync_end:
        nanos: 634139000
        seconds: 1770314829
  integration_discovered_resources_history:
    discovery-aws-organization-o-vflomaa000:
      summaries:
      - aws_ec2: {}
        sync_end:
          nanos: 289311000
          seconds: 1770314765
      - aws_ec2: {}
        sync_end:
          nanos: 898193000
          seconds: 1770314700
      - aws_ec2: {}
        sync_end:
          nanos: 656847000
          seconds: 1770314636
      - aws_ec2: {}
        sync_end:
          nanos: 417968000
          seconds: 1770314572
      - aws_ec2: {}
        sync_end:
          nanos: 62826000
          seconds: 1770314508
  last_sync_time: "2026-02-05T18:07:09.634137Z"
  state: DISCOVERY_CONFIG_STATE_SYNCING
version: v1
```

If users have two running discovery services, we might see them adding summaries almost at the same time.
This is true for Teleport Cloud tenants.

We'll work on removing that duplication here
https://github.com/gravitational/teleport/issues/40546