### PR TITLE
Add an OIDC troubleshooting partial for SSO guides

### DIFF
--- a/docs/pages/includes/sso/loginerrortroubleshooting.mdx
+++ b/docs/pages/includes/sso/loginerrortroubleshooting.mdx
@@ -57,13 +57,3 @@ spec:
       'env': 'dev'
 version: v5
 ```
-
-### Single sign-on fails with OIDC
-
-When encountering the error message **"Failed to verify JWT: oidc: unable to verify JWT signature: no matching keys"**, it typically indicates a discrepancy between the algorithm used to sign the JWT token and the algorithm(s) supported by the JSON Web Key Set (JWKS). Specifically, the token might be signed with one algorithm, e.g., HS256, while the JWKS only lists keys for a different algorithm. e.g., RS256. This issue predominantly arises when using identity providers that offer extremely low-level functionality.
-
-Here are some things to check:
-- Verify the JWT header specifies the correct signing algorithm. This should match one of the algorithms listed in the keys section of the JWKS endpoint response.
-- Ensure the JWKS endpoint is returning all relevant public keys. Sometimes key rotation can cause valid keys to be omitted.
-
-To resolve the issue, align the JWT algorithm header with a supported algorithm in the JWKS. Rotate keys if necessary. Verify the JWKS only publishes the active public keys. With proper configuration, the signature should validate successfully.

--- a/docs/pages/includes/sso/oidc-login-troubleshooting.mdx
+++ b/docs/pages/includes/sso/oidc-login-troubleshooting.mdx
@@ -1,0 +1,12 @@
+{/*This comment is here so the partial below can render*/}
+(!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+
+### Single sign-on fails with OIDC
+
+When encountering the error message **"Failed to verify JWT: oidc: unable to verify JWT signature: no matching keys"**, it typically indicates a discrepancy between the algorithm used to sign the JWT token and the algorithm(s) supported by the JSON Web Key Set (JWKS). Specifically, the token might be signed with one algorithm, e.g., HS256, while the JWKS only lists keys for a different algorithm, e.g., RS256.
+
+Here are some things to check:
+- Verify the JWT header specifies the correct signing algorithm. This should match one of the algorithms listed in the keys section of the JWKS endpoint response.
+- Ensure the JWKS endpoint is returning all relevant public keys. Sometimes key rotation can cause valid keys to be omitted.
+
+To resolve the issue, align the JWT algorithm header with a supported algorithm in the JWKS. Rotate keys if necessary. Verify the JWKS only publishes the active public keys. With proper configuration, the signature should validate successfully.

--- a/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/entra-id-oidc.mdx
@@ -347,7 +347,7 @@ supports.
 
 ## Troubleshooting
 
-(!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+(!docs/pages/includes/sso/oidc-login-troubleshooting.mdx!)
 
 ### Identity provider callback failed, missing parameter "Name"
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/gitlab.mdx
@@ -209,5 +209,5 @@ automatically in a browser).
 
 ## Troubleshooting
 
-(!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+(!docs/pages/includes/sso/oidc-login-troubleshooting.mdx!)
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/google-workspace.mdx
@@ -514,7 +514,7 @@ automatically in a browser.
 
 ## Troubleshooting
 
-(!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+(!docs/pages/includes/sso/oidc-login-troubleshooting.mdx!)
 
 ## Further reading
 

--- a/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
+++ b/docs/pages/zero-trust-access/sso/integrate-idp/oidc.mdx
@@ -368,4 +368,4 @@ $ tctl create -f oidc-connector.yaml
 
 ## Troubleshooting
 
-(!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+(!docs/pages/includes/sso/oidc-login-troubleshooting.mdx!)


### PR DESCRIPTION
Closes #57686

All guides for integrating an IdP with a Teleport authentication connector include the partial `loginerrortroubleshooting.mdx`, which contains a specific troubleshooting step for OIDC connectors as well as general troubleshooting steps. Separate the OIDC-specific step into its own partial so we can include it in OIDC guides.