### PR TITLE
Improve performance of printMetadataLabels

### DIFF
--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -50,11 +50,18 @@ import (
 )
 
 func printMetadataLabels(labels map[string]string) string {
-	pairs := []string{}
+	var sb strings.Builder
+	sb.Grow(len(labels) * 4)
+	i := 0
 	for key, value := range labels {
-		pairs = append(pairs, fmt.Sprintf("%v=%v", key, value))
+		sb.WriteString(key + "=" + value)
+
+		if i < len(labels)-1 {
+			sb.WriteRune(',')
+		}
+		i++
 	}
-	return strings.Join(pairs, ",")
+	return sb.String()
 }
 
 type reverseTunnelCollection struct {

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -21,11 +21,14 @@ package common
 import (
 	"bytes"
 	"maps"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api"
@@ -341,4 +344,43 @@ func makeTestLabels(extraStaticLabels map[string]string) map[string]string {
 	maps.Copy(labels, staticLabelsFixture)
 	maps.Copy(labels, extraStaticLabels)
 	return labels
+}
+
+func BenchmarkPrintMetadataLabels(b *testing.B) {
+	largeLabels := make(map[string]string, 1000)
+	for i := range 1000 {
+		largeLabels[strconv.Itoa(i)] = "foo"
+	}
+
+	testCases := []struct {
+		name      string
+		labels    map[string]string
+		outputLen int
+	}{
+		{
+			name: "no labels",
+		},
+		{
+			name: "one label",
+			labels: map[string]string{
+				"test": "foo",
+			},
+			outputLen: 8,
+		},
+		{
+			name:      "many labels",
+			labels:    largeLabels,
+			outputLen: 7889,
+		},
+	}
+
+	for _, test := range testCases {
+		b.Run(test.name, func(b *testing.B) {
+			for b.Loop() {
+				out := printMetadataLabels(test.labels)
+				assert.Len(b, out, test.outputLen)
+				assert.False(b, strings.HasSuffix(out, ","))
+			}
+		})
+	}
 }


### PR DESCRIPTION
I noticed while reviewing https://github.com/gravitational/teleport/pull/63455 that we could improve how the function converts labels to a string. This isn't widely used so the real world impact is likely low, but it only took a few minutes to make the change and add a test.

```bash
benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/gravitational/teleport/tool/tctl/common
cpu: Apple M2 Pro
                                   │   old.txt    │              new.txt              │
                                   │    sec/op    │   sec/op     vs base              │
PrintMetadataLabels/no_labels-12     1582.0n ± 3%   855.9n ± 5%  -45.90% (p=0.000 n=10)
PrintMetadataLabels/one_label-12      4.014µ ± 2%   1.175µ ± 4%  -70.71% (p=0.000 n=10)
PrintMetadataLabels/many_labels-12   1770.0µ ± 4%   215.0µ ± 3%  -87.85% (p=0.000 n=10)
geomean                               22.40µ        6.003µ       -73.20%

                                   │     one.txt     │               new.txt                │
                                   │      B/op       │     B/op      vs base                │
PrintMetadataLabels/no_labels-12        0.000 ± 0%       0.000 ±  ?        ~ (p=1.000 n=10)
PrintMetadataLabels/one_label-12       152.00 ± 1%       32.00 ± 0%  -78.95% (p=0.000 n=10)
PrintMetadataLabels/many_labels-12   144.02Ki ± 0%     33.52Ki ± 0%  -76.73% (p=0.000 n=10)
geomean                                            ¹                 -63.41%                ¹
¹ summaries must be >0 to compute geomean

                                   │    one.txt     │              new.txt               │
                                   │   allocs/op    │ allocs/op   vs base                │
PrintMetadataLabels/no_labels-12       0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
PrintMetadataLabels/one_label-12       6.000 ± 0%     2.000 ± 0%  -66.67% (p=0.000 n=10)
PrintMetadataLabels/many_labels-12   3514.00 ± 0%     16.00 ± 0%  -99.54% (p=0.000 n=10)
geomean                                           ²               -88.51%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```