### PR TITLE
fix: tsh label based commands always running serially

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2891,7 +2891,7 @@ func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto
 
 // roleGetter retrieves roles for the current user
 type roleGetter interface {
-	GetRoles(ctx context.Context) ([]types.Role, error)
+	GetCurrentUserRoles(ctx context.Context) ([]types.Role, error)
 }
 
 // commandLimit determines how many commands may be executed in parallel.
@@ -2907,7 +2907,7 @@ func commandLimit(ctx context.Context, getter roleGetter, mfaRequired bool) int 
 		return 1
 	}
 
-	roles, err := getter.GetRoles(ctx)
+	roles, err := getter.GetCurrentUserRoles(ctx)
 	if err != nil {
 		return 1
 	}

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/cryptosuites/cryptosuitestest"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
@@ -937,99 +939,121 @@ func TestFormatConnectToProxyErr(t *testing.T) {
 
 type mockRoleGetter func(ctx context.Context) ([]types.Role, error)
 
-func (m mockRoleGetter) GetRoles(ctx context.Context) ([]types.Role, error) {
+func (m mockRoleGetter) GetCurrentUserRoles(ctx context.Context) ([]types.Role, error) {
 	return m(ctx)
 }
 
 func TestCommandLimit(t *testing.T) {
 	t.Parallel()
+
+	auth, err := authtest.NewTestServer(authtest.ServerConfig{
+		Auth: authtest.AuthServerConfig{
+			ClusterName: "test",
+			ClusterID:   "test",
+			Dir:         t.TempDir(),
+		},
+	})
+	require.NoError(t, err)
+
+	t.Cleanup(func() { require.NoError(t, auth.Close()) })
+
 	cases := []struct {
 		name        string
 		mfaRequired bool
-		getter      roleGetter
+		roleGetter  roleGetter
+		roles       []types.RoleSpecV6
 		expected    int
 	}{
 		{
 			name:        "mfa required",
 			mfaRequired: true,
 			expected:    1,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				role, err := types.NewRole("test", types.RoleSpecV6{
+			roles: []types.RoleSpecV6{
+				{
 					Options: types.RoleOptions{MaxConnections: 500},
-				})
-				require.NoError(t, err)
-
-				return []types.Role{role}, nil
-			}),
+				},
+			},
 		},
 		{
 			name:     "failure getting roles",
 			expected: 1,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
+			roleGetter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
 				return nil, errors.New("fail")
 			}),
 		},
 		{
 			name:     "no roles",
+			expected: 1,
+		},
+		{
+			name:     "max_connections=0",
 			expected: -1,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				return nil, nil
-			}),
+			roles: []types.RoleSpecV6{
+				{
+					Options: types.RoleOptions{MaxConnections: 0},
+				},
+			},
 		},
 		{
 			name:     "max_connections=1",
 			expected: 1,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				role, err := types.NewRole("test", types.RoleSpecV6{
+			roles: []types.RoleSpecV6{
+				{
 					Options: types.RoleOptions{MaxConnections: 1},
-				})
-				require.NoError(t, err)
-
-				return []types.Role{role}, nil
-			}),
+				},
+			},
 		},
 		{
 			name:     "max_connections=2",
 			expected: 1,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				role, err := types.NewRole("test", types.RoleSpecV6{
+			roles: []types.RoleSpecV6{
+				{
 					Options: types.RoleOptions{MaxConnections: 2},
-				})
-				require.NoError(t, err)
-
-				return []types.Role{role}, nil
-			}),
+				},
+			},
 		},
 		{
 			name:     "max_connections=500",
 			expected: 250,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				role, err := types.NewRole("test", types.RoleSpecV6{
+			roles: []types.RoleSpecV6{
+				{
 					Options: types.RoleOptions{MaxConnections: 500},
-				})
-				require.NoError(t, err)
-
-				return []types.Role{role}, nil
-			}),
+				},
+			},
 		},
 		{
 			name:     "max_connections=max",
 			expected: math.MaxInt64 / 2,
-			getter: mockRoleGetter(func(ctx context.Context) ([]types.Role, error) {
-				role, err := types.NewRole("test", types.RoleSpecV6{
+			roles: []types.RoleSpecV6{
+				{
 					Options: types.RoleOptions{MaxConnections: math.MaxInt64},
-				})
-				require.NoError(t, err)
-
-				return []types.Role{role}, nil
-			}),
+				},
+			},
 		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, tt.expected, commandLimit(context.Background(), tt.getter, tt.mfaRequired))
+			var getter roleGetter
+			if tt.roleGetter != nil {
+				getter = tt.roleGetter
+			} else {
+				roles := make([]types.Role, 0, len(tt.roles))
+				for _, spec := range tt.roles {
+					role, err := authtest.CreateRole(t.Context(), auth.Auth(), uuid.NewString(), spec)
+					require.NoError(t, err)
+					roles = append(roles, role)
+				}
+
+				user, err := authtest.CreateUser(t.Context(), auth.Auth(), uuid.NewString(), roles...)
+				require.NoError(t, err)
+
+				clt, err := auth.NewClient(authtest.TestUser(user.GetName()))
+				require.NoError(t, err)
+				getter = clt
+			}
+
+			require.Equal(t, tt.expected, commandLimit(t.Context(), getter, tt.mfaRequired))
 		})
 	}
 }


### PR DESCRIPTION
When using tsh ssh user@foo=bar uptime, the command is supposed to be run in parallel on all matching hosts unless Per-Session MFA is required, or the user has a restriction on the number of concurrent sessions.

To determine if limits are enforced, tsh would list roles and take the maximum from all of them and add with a small buffer to prevent exceeding the limit. It turns out that this only works for users that have permissions to read Role resources. ListRoles does **not** return the roles of the current user if they do not have permissions to read roles like GetRole does. The result is that users that cannot read roles have all of the command run serially instead of in parallel even if they have _no_ connection limits in their roles.

It looks like this has been the case for GetRoles and ListRoles since their inception. This has likely gone unnoticed because this is either a very uncommon workflow, or the users performing this regularly have read permissions for Role resources.

There does exist an RPC that provides a user with all of the roles they are assigned regardless of their permissions: GetCurrentUserRoles. This RPC is now used in place of ListRoles when determining connection limits in tsh label based ssh.

## Changelog

changelog: Fixed `tsh ssh user@foo=bar uptime` from running serially if users did not have `role:read` permissions.

## Manual Test Plan

- [x] Label based tsh ssh runs in parallel for users with permissions to read roles
- [x] Label based tsh ssh runs in parallel for users without permissions to read roles
- [x] Label based tsh ssh obeys users with max_connections specified in their roles