### PR TITLE
Add 'terraform' integration tag. Remove 'cloud' integration tag. Misc cleanup

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -271,15 +271,15 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
           kind="cta"
           dismissible={true}
           details={
-            'Connect your AWS, Azure, or GCP accounts to automatically scan and import all resources.'
+            'Use Terraform to connect your AWS, Azure, or GCP accounts to Teleport and automatically discover your resources.'
           }
           primaryAction={{
             content: 'Connect Cloud Account',
-            linkTo: cfg.getIntegrationsEnrollRoute({ tags: ['cloud'] }),
+            linkTo: cfg.getIntegrationsEnrollRoute({ tags: ['terraform'] }),
           }}
           linkColor="buttons.primary.text"
         >
-          Automatic Discovery
+          Automatically Discover
         </Alert>
       )}
       <Flex gap={3} mb={3}>

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/IntegrationTiles.tsx
@@ -16,19 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Link } from 'react-router-dom';
-
-import { Flex, Text } from 'design';
-import { ResourceIconName } from 'design/ResourceIcon';
-
 import {
   BadgeTitle,
   ToolTipNoPermBadge,
 } from 'teleport/components/ToolTipNoPermBadge';
-import cfg from 'teleport/config';
-import { IntegrationKind } from 'teleport/services/integrations';
-
-import { IntegrationIcon, IntegrationTile } from '../common';
 
 export function renderExternalAuditStorageBadge(
   hasExternalAuditStorageAccess: boolean,
@@ -66,33 +57,4 @@ export function GenericNoPermBadge({
       </ToolTipNoPermBadge>
     );
   }
-}
-
-export function GenericIntegrationTile({
-  kind,
-  hasAccess,
-  name,
-  icon,
-}: {
-  kind: IntegrationKind;
-  hasAccess: boolean;
-  name: string;
-  icon: ResourceIconName;
-}) {
-  return (
-    <IntegrationTile
-      disabled={!hasAccess}
-      as={hasAccess ? Link : null}
-      to={hasAccess ? cfg.getIntegrationEnrollRoute(kind) : null}
-      data-testid={`tile-${kind}`}
-    >
-      <Flex flexBasis={100}>
-        <IntegrationIcon name={icon} size={80} />
-      </Flex>
-      <Flex>
-        <Text>{name}</Text>
-      </Flex>
-      <GenericNoPermBadge noAccess={!hasAccess} />
-    </IntegrationTile>
-  );
 }

--- a/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/integrations.ts
+++ b/web/packages/teleport/src/Integrations/Enroll/IntegrationTiles/integrations.ts
@@ -70,28 +70,28 @@ const integrations: IntegrationTileSpec[] = [
     type: 'integration',
     kind: IntegrationKind.AwsCloud,
     icon: 'aws',
-    name: 'Amazon Web Services (AWS)',
+    name: 'AWS Discovery with Terraform',
     description:
-      'Connect your AWS account to automatically discover resources.',
-    tags: ['cloud', 'resourceaccess'],
+      'Use Terraform to connect your AWS account to Teleport and automatically discover resources.',
+    tags: ['terraform', 'resourceaccess'],
   },
   {
     type: 'integration',
     kind: IntegrationKind.AzureCloud,
     icon: 'azure',
-    name: 'Azure',
+    name: 'Azure Discovery with Terraform',
     description:
-      'Connect your Azure account to automatically discover resources.',
-    tags: ['cloud', 'resourceaccess'],
+      'Use Terraform to connect your Azure account to Teleport and automatically discover resources.',
+    tags: ['terraform', 'resourceaccess'],
   },
   {
     type: 'integration',
     kind: IntegrationKind.GoogleCloud,
     icon: 'google',
-    name: 'Google Cloud',
+    name: 'Google Cloud Discovery with Terraform',
     description:
-      'Connect your Google Cloud account to automatically discover resources.',
-    tags: ['cloud', 'resourceaccess'],
+      'Use Terraform to connect your Google Cloud account to Teleport and automatically discover resources.',
+    tags: ['terraform', 'resourceaccess'],
   },
 ];
 

--- a/web/packages/teleport/src/Integrations/Enroll/Shared/IntegrationPicker.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Shared/IntegrationPicker.tsx
@@ -88,7 +88,7 @@ export function IntegrationPicker<T extends BaseIntegration>({
     }
 
     return sorted;
-  }, [integrations, state.sortDirection, state.sortKey]);
+  }, [integrations, initialSort, state.sortDirection, state.sortKey]);
 
   const filteredIntegrations = useMemo(
     () =>

--- a/web/packages/teleport/src/Integrations/Enroll/Shared/Tile.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Shared/Tile.tsx
@@ -69,10 +69,10 @@ export function IntegrationTileWithSpec({
     );
   }
 
-  const comingSoon =
+  const isComingSoon =
     spec.kind === IntegrationKind.AzureCloud ||
     spec.kind === IntegrationKind.GoogleCloud;
-  if (comingSoon) {
+  if (isComingSoon) {
     Badge = <BadgeGuided>Coming Soon</BadgeGuided>;
     hasAccess = false;
   }

--- a/web/packages/teleport/src/Integrations/Enroll/Shared/common.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Shared/common.tsx
@@ -27,12 +27,12 @@ export type BaseIntegration = (
 export const integrationTagOptions = [
   { value: 'bot', label: 'Bot' },
   { value: 'cicd', label: 'CI/CD' },
-  { value: 'cloud', label: 'Cloud' },
   { value: 'devicetrust', label: 'Device Trust' },
   { value: 'idp', label: 'IdP' },
   { value: 'notifications', label: 'Notifications' },
   { value: 'resourceaccess', label: 'Resource Access' },
   { value: 'scim', label: 'SCIM' },
+  { value: 'terraform', label: 'Terraform' },
 ] as const satisfies { value: string; label: string }[];
 
 /**

--- a/web/packages/teleport/src/components/Empty/Empty.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.tsx
@@ -78,11 +78,11 @@ export default function Empty(props: Props) {
           {showCloud && (
             <Pane
               title="Automatically Discover"
-              text="Connect your AWS, Azure, or GCP accounts to automatically scan and import all resources."
+              text="Use Terraform to connect your AWS, Azure, or GCP accounts to Teleport and automatically discover your resources."
               button={
                 <ButtonPrimary
                   as={Link}
-                  to={cfg.getIntegrationsEnrollRoute({ tags: ['cloud'] })}
+                  to={cfg.getIntegrationsEnrollRoute({ tags: ['terraform'] })}
                   width="100%"
                 >
                   Connect Cloud Account


### PR DESCRIPTION
Minor updates to add clarity to the integration tiles. To make it more clear the new integrations are supported by Terraform, I updated the titles and descriptions. We're replacing the `Cloud` integration tag with `Terraform` to improve clarity around what the integration is. `Cloud` was too generic, and there were several cloud related tiles that weren't included.


<img width="969" height="472" alt="Screenshot 2026-02-05 at 3 42 24 PM" src="https://github.com/user-attachments/assets/e71e76e7-6e43-4e56-ad04-0122fe87d91e" />
