### PR TITLE
Fix bug in the log limiter

### DIFF
--- a/lib/loglimit/loglimit.go
+++ b/lib/loglimit/loglimit.go
@@ -106,9 +106,9 @@ func (l *LogLimiter) Handle(ctx context.Context, record slog.Record) error {
 						delete(l.windows, key)
 					}
 				}
+				l.lastSweep = l.config.Clock.Now()
 			}
 
-			l.lastSweep = l.config.Clock.Now()
 			l.mu.Unlock()
 		}()
 		lastSeen, ok := l.windows[messageSubstring]


### PR DESCRIPTION
We were setting last sweep on every call, even if we didn't actually perform a sweep. This means that if the handler is invoked more frequently than the sweep interval it will never actually perform the sweep, and old entries will continue to accumulate.