### PR TITLE
[v18] [18.6.4] bump cloud docs version

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -17,7 +17,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "18.6.2",
+      "version": "18.6.4",
       "major_version": "18",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Backport #63282 to branch/v18