### PR TITLE
Make rendered markdown links open new tab

### DIFF
--- a/web/packages/shared/components/Markdown/Markdown.test.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.test.tsx
@@ -51,6 +51,7 @@ describe('Markdown', () => {
 
       expect(link).toBeInTheDocument();
       expect(link).toHaveAttribute('href', 'https://example.com');
+      expect(link).toHaveAttribute('target', '_blank');
     });
 
     it('does not render links unless explicitly enabled', () => {

--- a/web/packages/shared/components/Markdown/Markdown.tsx
+++ b/web/packages/shared/components/Markdown/Markdown.tsx
@@ -66,7 +66,12 @@ const parsers: MarkdownParser[] = [
     condition: (opts: MarkdownOptions) => !!opts.enableLinks,
     pattern: /\[(?<content>[^\]]*)](?:\((?<url>https?:\/\/[^)]+|[^:)]+)\))?/,
     render: (activeParsers, content, key, url) => (
-      <StyledLink key={key} href={url}>
+      <StyledLink
+        key={key}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         {parseLine(activeParsers, content)}
       </StyledLink>
     ),


### PR DESCRIPTION
In places where markdown is turned into rendered react/html, we want the links to be opened in a new tab. These links are generally to external documentation.