### PR TITLE
Lint to enforce using t.Context() instead of context.TODO() 👮🏾

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
     - testifylint
     - unconvert
     - unused
+    - usetesting
   settings:
     depguard:
       rules:
@@ -374,6 +375,15 @@ linters:
         - len
         - suite-extra-assert-call
         - suite-thelper
+    usetesting:
+        context-todo: true
+        # TODO: Enable the following after the issues are fixed.
+        context-background: false
+        os-chdir: false
+        os-create-temp: false
+        os-mkdir-temp: false
+        os-setenv: false
+        os-temp-dir: false
   exclusions:
     generated: lax
     presets:

--- a/api/utils/keys/privatekey_test.go
+++ b/api/utils/keys/privatekey_test.go
@@ -56,7 +56,7 @@ func TestMarshalAndParseKey(t *testing.T) {
 		ClusterName: "billy.io",
 	}
 	s := hardwarekey.NewMockHardwareKeyService(nil /*prompt*/)
-	hwPriv, err := s.NewPrivateKey(context.TODO(), hardwarekey.PrivateKeyConfig{
+	hwPriv, err := s.NewPrivateKey(t.Context(), hardwarekey.PrivateKeyConfig{
 		ContextualKeyInfo: contextualKeyInfo,
 	})
 	require.NoError(t, err)

--- a/e2e/aws/databases_test.go
+++ b/e2e/aws/databases_test.go
@@ -257,7 +257,7 @@ func generateClientDBCert(t *testing.T, authSrv *auth.Server, user string, route
 	key, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)
 	require.NoError(t, err)
 
-	clusterName, err := authSrv.GetClusterName(context.TODO())
+	clusterName, err := authSrv.GetClusterName(t.Context())
 	require.NoError(t, err)
 
 	publicKeyPEM, err := keys.MarshalPublicKey(key.Public())

--- a/integration/helpers/trustedclusters.go
+++ b/integration/helpers/trustedclusters.go
@@ -57,7 +57,7 @@ func WaitForTunnelConnections(t *testing.T, authServer *auth.Server, clusterName
 // Duplicated in tool/tsh/tsh_test.go
 func TryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for range 10 {
 		_, err := authServer.CreateTrustedCluster(ctx, trustedCluster)
 		if err == nil {
@@ -81,7 +81,7 @@ func TryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 // propagate and services to start
 func TryUpdateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for range 10 {
 		_, err := authServer.UpdateTrustedCluster(ctx, trustedCluster)
 		if err == nil {
@@ -105,7 +105,7 @@ func TryUpdateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 // propagate and services to start
 func TryUpsertTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster, skipNameValidation bool) {
 	t.Helper()
-	ctx := context.TODO()
+	ctx := t.Context()
 	for range 10 {
 		var err error
 		if skipNameValidation {

--- a/integration/hsm/hsm_test.go
+++ b/integration/hsm/hsm_test.go
@@ -187,7 +187,7 @@ func testAdminClient(t *testing.T, authDataDir string, authAddr string) {
 			return err
 		}
 		defer clt.Close()
-		_, err = clt.GetClusterName(context.TODO())
+		_, err = clt.GetClusterName(t.Context())
 		return err
 	}
 	// We might be hitting a load balancer in front of two auths, running

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -668,7 +668,7 @@ func testInteroperability(t *testing.T, suite *integrationTestSuite) {
 			go func() {
 				// don't check for err, because sometimes this process should fail
 				// with an error and that's what the test is checking for.
-				cl.SSH(context.TODO(), []string{tt.inCommand})
+				cl.SSH(t.Context(), []string{tt.inCommand})
 				sessionEndC <- true
 			}()
 			err = waitFor(sessionEndC, time.Second*10)
@@ -2718,7 +2718,7 @@ func testMapRoles(t *testing.T, suite *integrationTestSuite) {
 	// and 'tc' (client) is also supposed to reconnect
 	for range 10 {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		if err == nil {
 			break
 		}
@@ -3660,7 +3660,7 @@ func testTrustedTunnelNode(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 	for range 10 {
 		time.Sleep(time.Millisecond * 50)
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		if err == nil {
 			break
 		}
@@ -5175,7 +5175,7 @@ func testPAM(t *testing.T, suite *integrationTestSuite) {
 				cl.Stdin = termSession
 
 				termSession.Type("\aecho hi\n\r\aexit\n\r\a")
-				err = cl.SSH(context.TODO(), []string{})
+				err = cl.SSH(t.Context(), []string{})
 				if !isSSHError(err) {
 					errCh <- err
 					return
@@ -5313,7 +5313,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// client works as is before servers have been rotated
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5341,7 +5341,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// new client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5362,7 +5362,7 @@ func testRotateSuccess(t *testing.T, suite *integrationTestSuite) {
 	waitForCredentialsUpdated()
 
 	// new client still works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5474,7 +5474,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// client works as is before servers have been rotated
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5503,7 +5503,7 @@ func testRotateRollback(t *testing.T, s *integrationTestSuite) {
 	waitForCredentialsUpdated()
 
 	// old client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 	checkSSHPrincipals(svc)
 
@@ -5627,7 +5627,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	clt, err := main.NewClientWithCreds(cfg, *initialCreds)
 	require.NoError(t, err)
 
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Setting rotation state to %v", types.RotationPhaseInit)
@@ -5680,7 +5680,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	waitForPhase(types.RotationPhaseUpdateClients)
 
 	// old client should work as is
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Service reloaded. Setting rotation state to %v", types.RotationPhaseUpdateServers)
@@ -5705,7 +5705,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	// new client works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Logf("Service reloaded. Setting rotation state to %v.", types.RotationPhaseStandby)
@@ -5724,7 +5724,7 @@ func testRotateTrustedClusters(t *testing.T, suite *integrationTestSuite) {
 	t.Log("Phase completed.")
 
 	// new client still works
-	err = runAndMatch(clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
+	err = runAndMatch(t.Context(), clt, 8, []string{"echo", "hello world"}, ".*hello world.*")
 	require.NoError(t, err)
 
 	t.Log("Service reloaded. Rotation has completed. Shutting down service.")
@@ -5757,12 +5757,12 @@ func waitForProcessEvent(svc *service.TeleportProcess, event string, timeout tim
 }
 
 // runAndMatch runs command and makes sure it matches the pattern
-func runAndMatch(tc *client.TeleportClient, attempts int, command []string, pattern string) error {
+func runAndMatch(ctx context.Context, tc *client.TeleportClient, attempts int, command []string, pattern string) error {
 	output := &bytes.Buffer{}
 	tc.Stdout = output
 	var err error
 	for range attempts {
-		err = tc.SSH(context.TODO(), command)
+		err = tc.SSH(ctx, command)
 		if err != nil {
 			time.Sleep(500 * time.Millisecond)
 			continue
@@ -6271,7 +6271,7 @@ func testBPFInteractive(t *testing.T, suite *integrationTestSuite) {
 
 				// "Type" a command into the terminal.
 				term.Type(fmt.Sprintf("\a%v\n\r\aexit\n\r\a", lsPath))
-				err = client.SSH(context.TODO(), []string{})
+				err = client.SSH(t.Context(), []string{})
 				require.NoError(t, err)
 
 				// Signal that the client has finished the interactive session.
@@ -7017,7 +7017,7 @@ func runCommandWithCertReissue(t *testing.T, instance *helpers.TeleInstance, cmd
 	out := &bytes.Buffer{}
 	tc.Stdout = out
 
-	err = tc.SSH(context.TODO(), cmd)
+	err = tc.SSH(t.Context(), cmd)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -236,7 +236,7 @@ func (p *Suite) mustConnectToClusterAndRunSSHCommand(t *testing.T, config helper
 
 	cmd := []string{"echo", "hello world"}
 	err = retryutils.RetryStaticFor(deadline, nextIterWaitTime, func() error {
-		err = tc.SSH(context.TODO(), cmd)
+		err = tc.SSH(t.Context(), cmd)
 		return trace.Wrap(err)
 	})
 	require.NoError(t, err)
@@ -519,7 +519,7 @@ func mustStartALPNLocalProxyWithConfig(t *testing.T, config alpnproxy.LocalProxy
 		config.Listener = helpers.MustCreateListener(t)
 	}
 	if config.ParentContext == nil {
-		config.ParentContext = context.TODO()
+		config.ParentContext = t.Context()
 	}
 
 	lp, err := alpnproxy.NewLocalProxy(config)

--- a/integrations/lib/testing/integration/authhelper.go
+++ b/integrations/lib/testing/integration/authhelper.go
@@ -130,7 +130,7 @@ type userCerts struct {
 func (a *MinimalAuthHelper) getUserCerts(t *testing.T, user types.User) userCerts {
 	authServer := a.server.Auth()
 
-	clusterName, err := authServer.GetClusterName(context.TODO())
+	clusterName, err := authServer.GetClusterName(t.Context())
 	require.NoError(t, err)
 	// Get user certs
 	userKey, err := cryptosuites.GenerateKeyWithAlgorithm(cryptosuites.ECDSAP256)

--- a/integrations/terraform/testlib/access_list_test.go
+++ b/integrations/terraform/testlib/access_list_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testlib
 
 import (
-	"context"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -37,7 +36,7 @@ type nextAuditDateComparer struct {
 
 func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
+		al, err := c.client.AccessListClient().GetAccessList(t.Context(), name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -48,7 +47,7 @@ func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestC
 
 func (c *nextAuditDateComparer) TestNextAuditDateUnchanged(name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
+		al, err := c.client.AccessListClient().GetAccessList(t.Context(), name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -67,7 +66,7 @@ func (s *TerraformSuiteEnterprise) TestAccessList() {
 	)
 
 	checkAccessListDestroyed := func(state *terraform.State) error {
-		_, err := s.client.AccessListClient().GetAccessList(context.TODO(), "test")
+		_, err := s.client.AccessListClient().GetAccessList(t.Context(), "test")
 		if trace.IsNotFound(err) {
 			return nil
 		}

--- a/integrations/terraform/testlib/access_list_test.go
+++ b/integrations/terraform/testlib/access_list_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testlib
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -36,7 +37,7 @@ type nextAuditDateComparer struct {
 
 func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(t.Context(), name)
+		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -47,7 +48,7 @@ func (c *nextAuditDateComparer) CaptureNextAuditDate(name string) resource.TestC
 
 func (c *nextAuditDateComparer) TestNextAuditDateUnchanged(name string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		al, err := c.client.AccessListClient().GetAccessList(t.Context(), name)
+		al, err := c.client.AccessListClient().GetAccessList(context.TODO(), name)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -66,7 +67,7 @@ func (s *TerraformSuiteEnterprise) TestAccessList() {
 	)
 
 	checkAccessListDestroyed := func(state *terraform.State) error {
-		_, err := s.client.AccessListClient().GetAccessList(t.Context(), "test")
+		_, err := s.client.AccessListClient().GetAccessList(context.TODO(), "test")
 		if trace.IsNotFound(err) {
 			return nil
 		}

--- a/lib/auth/export_test.go
+++ b/lib/auth/export_test.go
@@ -245,8 +245,8 @@ func ValidServerHostname(hostname string) bool {
 	return validServerHostname(hostname)
 }
 
-func FormatAccountName(s proxyDomainGetter, username string, authHostname string) (string, error) {
-	return formatAccountName(context.TODO(), s, username, authHostname)
+func FormatAccountName(ctx context.Context, s proxyDomainGetter, username string, authHostname string) (string, error) {
+	return formatAccountName(ctx, s, username, authHostname)
 }
 
 func ConfigureCAsForTrustedCluster(tc types.TrustedCluster, cas []types.CertAuthority) {

--- a/lib/auth/usertoken_test.go
+++ b/lib/auth/usertoken_test.go
@@ -221,7 +221,7 @@ func TestFormatAccountName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			accountName, err := auth.FormatAccountName(tt.inDebugAuth, "foo", "00000000-0000-0000-0000-000000000000")
+			accountName, err := auth.FormatAccountName(t.Context(), tt.inDebugAuth, "foo", "00000000-0000-0000-0000-000000000000")
 			tt.outError(t, err)
 			require.Equal(t, accountName, tt.outAccountName)
 		})

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -772,14 +772,14 @@ func testKeepAlive(t *testing.T, newBackend Constructor) {
 	require.Equal(t, bigValue[:], event.Item.Value)
 	require.WithinDuration(t, updatedAt, event.Item.Expires, 2*time.Second)
 
-	err = uut.Delete(context.TODO(), item.Key)
+	err = uut.Delete(t.Context(), item.Key)
 	require.NoError(t, err)
 
-	_, err = uut.Get(context.TODO(), item.Key)
+	_, err = uut.Get(t.Context(), item.Key)
 	require.True(t, trace.IsNotFound(err))
 
 	// keep alive on deleted or expired object should fail
-	err = uut.KeepAlive(context.TODO(), lease, updatedAt.Add(1*time.Second))
+	err = uut.KeepAlive(t.Context(), lease, updatedAt.Add(1*time.Second))
 	require.True(t, trace.IsNotFound(err))
 }
 
@@ -1022,7 +1022,7 @@ func testLocking(t *testing.T, newBackend Constructor) {
 	// has probably gone bad (e.g. db server has ceased to exist), so it's
 	// probably best to bail out with a sensible error (& call stack) rather
 	// than wait for the test to time out
-	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Minute)
 	defer cancel()
 
 	// Manually drive the clock at ~10x speed to make sure anyone waiting on it
@@ -1157,7 +1157,7 @@ func testConcurrentOperations(t *testing.T, newBackend Constructor) {
 	defer func() { require.NoError(t, uutB.Close()) }()
 
 	prefix := MakePrefix()
-	ctx := context.TODO()
+	ctx := t.Context()
 	value1 := "this first value should not be corrupted by concurrent ops"
 	value2 := "this second value should not be corrupted too"
 	const attempts = 50

--- a/lib/cloud/azure/kubernetes_test.go
+++ b/lib/cloud/azure/kubernetes_test.go
@@ -219,7 +219,7 @@ func Test_AKSClient_ClusterCredentials(t *testing.T) {
 			c := NewAKSClustersClient(tt.fields.api, func(options *azidentity.DefaultAzureCredentialOptions) (GetToken, error) {
 				return azIdentity, nil
 			})
-			got, _, err := c.ClusterCredentials(context.TODO(), tt.args.cfg)
+			got, _, err := c.ClusterCredentials(t.Context(), tt.args.cfg)
 			tt.checkErr(t, err)
 
 			if tt.validateRestConfig != nil {

--- a/lib/cloud/azure/redis_enterprise_test.go
+++ b/lib/cloud/azure/redis_enterprise_test.go
@@ -19,7 +19,6 @@
 package azure
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -72,7 +71,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 				t.Parallel()
 
 				c := NewRedisEnterpriseClientByAPI(nil, test.mockDatabaseAPI)
-				token, err := c.GetToken(context.TODO(), test.resourceID)
+				token, err := c.GetToken(t.Context(), test.resourceID)
 
 				if test.expectError {
 					require.Error(t, err)
@@ -112,7 +111,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 			}
 
 			c := NewRedisEnterpriseClientByAPI(mockClusterAPI, mockDatabaseAPI)
-			clusters, err := c.ListAll(context.TODO())
+			clusters, err := c.ListAll(t.Context())
 			require.NoError(t, err)
 			requireClusterDatabases(t, expectClusterDatabases, clusters)
 		})
@@ -125,7 +124,7 @@ func TestRedisEnterpriseClient(t *testing.T) {
 			}
 
 			c := NewRedisEnterpriseClientByAPI(mockClusterAPI, mockDatabaseAPI)
-			clusters, err := c.ListWithinGroup(context.TODO(), "group-prod")
+			clusters, err := c.ListWithinGroup(t.Context(), "group-prod")
 			require.NoError(t, err)
 			requireClusterDatabases(t, expectClusterDatabases, clusters)
 		})

--- a/lib/cloud/azure/redis_test.go
+++ b/lib/cloud/azure/redis_test.go
@@ -19,7 +19,6 @@
 package azure
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestRedisClient(t *testing.T) {
 				t.Parallel()
 
 				c := NewRedisClientByAPI(test.mockAPI)
-				token, err := c.GetToken(context.TODO(), "/subscriptions/sub-id/resourceGroups/group-name/providers/Microsoft.Cache/Redis/example-teleport")
+				token, err := c.GetToken(t.Context(), "/subscriptions/sub-id/resourceGroups/group-name/providers/Microsoft.Cache/Redis/example-teleport")
 				if test.expectError {
 					require.Error(t, err)
 				} else {
@@ -84,7 +83,7 @@ func TestRedisClient(t *testing.T) {
 			expectServers := []string{"redis-prod-1", "redis-prod-2", "redis-dev"}
 
 			c := NewRedisClientByAPI(mockAPI)
-			resources, err := c.ListAll(context.TODO())
+			resources, err := c.ListAll(t.Context())
 			require.NoError(t, err)
 			requireRedisServers(t, expectServers, resources)
 		})
@@ -94,7 +93,7 @@ func TestRedisClient(t *testing.T) {
 			expectServers := []string{"redis-prod-1", "redis-prod-2"}
 
 			c := NewRedisClientByAPI(mockAPI)
-			resources, err := c.ListWithinGroup(context.TODO(), "group-prod")
+			resources, err := c.ListWithinGroup(t.Context(), "group-prod")
 			require.NoError(t, err)
 			requireRedisServers(t, expectServers, resources)
 		})

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -478,7 +478,7 @@ func makeAccessRequestEvent(id string, in string) *events.AccessRequestDelete {
 }
 
 func mustSearchEvent(t *testing.T, log *FileLog, start time.Time) []events.AuditEvent {
-	ctx := context.TODO()
+	ctx := t.Context()
 	result, _, err := log.SearchEvents(ctx, SearchEventsRequest{
 		From:  start,
 		To:    start.Add(time.Hour),

--- a/lib/events/session_writer_test.go
+++ b/lib/events/session_writer_test.go
@@ -211,7 +211,7 @@ func TestSessionWriter(t *testing.T) {
 		terminateConnection.Store(1)
 
 		submitEvents := 600
-		hangCtx, hangCancel := context.WithCancel(context.TODO())
+		hangCtx, hangCancel := context.WithCancel(t.Context())
 		defer hangCancel()
 
 		test := newSessionWriterTest(t, func(streamer events.Streamer) (*events.CallbackStreamer, error) {
@@ -369,7 +369,7 @@ func newSessionWriterTest(t *testing.T, newStreamer newStreamerFn, opts ...sessi
 		streamer = protoStreamer
 	}
 
-	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 
 	sid := session.NewID()
 	preparer, err := events.NewPreparer(events.PreparerConfig{

--- a/lib/events/test/streamsuite.go
+++ b/lib/events/test/streamsuite.go
@@ -191,7 +191,7 @@ func StreamEmpty(t *testing.T, handler events.MultipartHandler) {
 
 // StreamWithParameters tests stream upload and subsequent download and reads the results
 func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params StreamParams) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: params.PrintEvents})
 	sid := session.ID(inEvents[0].(events.SessionMetadataGetter).GetSessionID())
@@ -271,7 +271,7 @@ func StreamWithParameters(t *testing.T, handler events.MultipartHandler, params 
 // StreamResumeWithParameters expects initial complete attempt to fail
 // but subsequent resume to succeed
 func StreamResumeWithParameters(t *testing.T, handler events.MultipartHandler, params StreamParams) {
-	ctx := context.TODO()
+	ctx := t.Context()
 
 	inEvents := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: params.PrintEvents})
 	sid := session.ID(inEvents[0].(events.SessionMetadataGetter).GetSessionID())

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -136,7 +136,7 @@ func UploadDownloadMetadata(t *testing.T, handler events.MultipartHandler) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.DownloadMetadata(context.TODO(), id, f)
+	err = handler.DownloadMetadata(t.Context(), id, f)
 	require.NoError(t, err)
 
 	_, err = f.Seek(0, 0)
@@ -159,7 +159,7 @@ func UploadDownloadThumbnail(t *testing.T, handler events.MultipartHandler) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.DownloadThumbnail(context.TODO(), id, f)
+	err = handler.DownloadThumbnail(t.Context(), id, f)
 	require.NoError(t, err)
 
 	_, err = f.Seek(0, 0)
@@ -179,7 +179,7 @@ func DownloadNotFound(t *testing.T, handler events.MultipartHandler) {
 	defer os.Remove(f.Name())
 	defer f.Close()
 
-	err = handler.Download(context.TODO(), id, f)
+	err = handler.Download(t.Context(), id, f)
 	require.True(t, trace.IsNotFound(err))
 }
 

--- a/lib/kube/grpc/utils_test.go
+++ b/lib/kube/grpc/utils_test.go
@@ -555,7 +555,7 @@ func WithMFAVerified() GenTestKubeClientTLSCertOptions {
 // GenTestKubeClientTLSCert generates a kube client to access kube service
 func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *rest.Config) {
 	authServer := c.AuthServer
-	clusterName, err := authServer.GetClusterName(context.TODO())
+	clusterName, err := authServer.GetClusterName(t.Context())
 	require.NoError(t, err)
 
 	// Fetch user info to get roles and max session TTL.

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -130,7 +130,7 @@ func TestGetKubeCreds(t *testing.T) {
 	t.Cleanup(func() { kubeMock.Close() })
 	targetAddr := kubeMock.Address
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	const teleClusterName = "teleport-cluster"
 	dir := t.TempDir()
 	kubeconfigPath := filepath.Join(dir, "kubeconfig")

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -698,7 +698,7 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 
 			exec, err := remotecommand.NewSPDYExecutor(tt.config, http.MethodPost, req.URL())
 			require.NoError(t, err)
-			err = exec.StreamWithContext(context.TODO(), streamOpts)
+			err = exec.StreamWithContext(t.Context(), streamOpts)
 			tt.assertErr(t, err)
 		})
 	}

--- a/lib/kube/proxy/self_subject_reviews_test.go
+++ b/lib/kube/proxy/self_subject_reviews_test.go
@@ -412,7 +412,7 @@ func TestSelfSubjectAccessReviewsRBAC(t *testing.T) {
 			)
 
 			rsp, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
-				context.TODO(),
+				t.Context(),
 				&authv1.SelfSubjectAccessReview{
 					Spec: authv1.SelfSubjectAccessReviewSpec{
 						ResourceAttributes: &authv1.ResourceAttributes{
@@ -587,7 +587,7 @@ func TestSelfSubjectAccessReviewsAllowed(t *testing.T) {
 
 			// Call the SelfSubjectAccessReview endpoint.
 			_, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(
-				context.TODO(),
+				t.Context(),
 				obj,
 				metav1.CreateOptions{},
 			)

--- a/lib/kube/proxy/utils_test.go
+++ b/lib/kube/proxy/utils_test.go
@@ -587,7 +587,7 @@ func (c *TestContext) GenTestKubeClientTLSCert(t *testing.T, userName, kubeClust
 // GenTestKubeClientsTLSCert generates a "regular" kube client and a dynamic one to access kube service
 func (c *TestContext) GenTestKubeClientsTLSCert(t *testing.T, userName, kubeCluster string, opts ...GenTestKubeClientTLSCertOptions) (*kubernetes.Clientset, *dynamic.DynamicClient, *rest.Config) {
 	authServer := c.AuthServer
-	clusterName, err := authServer.GetClusterName(context.TODO())
+	clusterName, err := authServer.GetClusterName(t.Context())
 	require.NoError(t, err)
 
 	// Fetch user info to get roles and max session TTL.

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -633,7 +633,7 @@ func TestMux(t *testing.T) {
 
 		gclient := test.NewPingerClient(conn)
 
-		out, err := gclient.Ping(context.TODO(), &test.Request{})
+		out, err := gclient.Ping(t.Context(), &test.Request{})
 		require.NoError(t, err)
 		require.Equal(t, "grpc backend", out.GetPayload())
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -438,7 +438,7 @@ func TestServiceCheckPrincipals(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		ok := checkServerIdentity(context.TODO(), testConnector, tt.inPrincipals, tt.inDNS, slog.Default().With("test", "TestServiceCheckPrincipals"))
+		ok := checkServerIdentity(t.Context(), testConnector, tt.inPrincipals, tt.inDNS, slog.Default().With("test", "TestServiceCheckPrincipals"))
 		require.Equal(t, tt.outRegenerate, ok, "test %d", i)
 	}
 }

--- a/lib/services/local/access_graph_test.go
+++ b/lib/services/local/access_graph_test.go
@@ -19,7 +19,6 @@
 package local
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,7 +38,7 @@ func TestAccessGraphAuthorizedKeys(t *testing.T) {
 	service, err := NewAccessGraphSecretsService(backend)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	pageSize := 10
 	pageToken := ""
 
@@ -149,7 +148,7 @@ func TestAccessGraphPrivateKeys(t *testing.T) {
 	service, err := NewAccessGraphSecretsService(backend)
 	require.NoError(t, err)
 
-	ctx := context.TODO()
+	ctx := t.Context()
 	pageSize := 10
 	pageToken := ""
 

--- a/lib/services/local/perf_test.go
+++ b/lib/services/local/perf_test.go
@@ -69,7 +69,7 @@ func BenchmarkGetNodes(b *testing.B) {
 			} else {
 				dir := b.TempDir()
 
-				bk, err = lite.NewWithConfig(context.TODO(), lite.Config{
+				bk, err = lite.NewWithConfig(b.Context(), lite.Config{
 					Path: dir,
 				})
 				require.NoError(b, err)

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -107,7 +107,7 @@ func TestAuthGetAzureCacheForRedisToken(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			token, err := auth.GetAzureCacheForRedisToken(context.TODO(), newAzureRedisDatabase(t, test.resourceID))
+			token, err := auth.GetAzureCacheForRedisToken(t.Context(), newAzureRedisDatabase(t, test.resourceID))
 			if test.expectError {
 				require.Error(t, err)
 			} else {
@@ -139,7 +139,7 @@ func TestAuthGetRedshiftServerlessAuthToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	dbUser, dbPassword, err := auth.GetRedshiftServerlessAuthToken(context.TODO(),
+	dbUser, dbPassword, err := auth.GetRedshiftServerlessAuthToken(t.Context(),
 		newRedshiftServerlessDatabase(t),
 		"some-user",
 		"some-database",
@@ -260,7 +260,7 @@ func TestAuthGetTLSConfig(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tlsConfig, err := auth.GetTLSConfig(context.TODO(),
+			tlsConfig, err := auth.GetTLSConfig(t.Context(),
 				time.Now().Add(time.Hour),
 				test.sessionDatabase,
 				"defaultUser")

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -99,7 +99,7 @@ func TestShutdown(t *testing.T) {
 	_, signer, err := cert.CreateTestEd25519Certificate("foo", ssh.HostCert)
 	require.NoError(t, err)
 
-	closeContext, cancel := context.WithCancel(context.TODO())
+	closeContext, cancel := context.WithCancel(t.Context())
 	fn := NewChanHandlerFunc(func(_ context.Context, ccx *ConnectionContext, nch ssh.NewChannel) {
 		ch, _, err := nch.Accept()
 		require.NoError(t, err)
@@ -133,18 +133,18 @@ func TestShutdown(t *testing.T) {
 	require.NoError(t, err)
 
 	// context will timeout because there is a connection around
-	ctx, ctxc := context.WithTimeout(context.TODO(), 50*time.Millisecond)
+	ctx, ctxc := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	defer ctxc()
 	require.True(t, trace.IsConnectionProblem(srv.Shutdown(ctx)))
 
 	// now shutdown will return
 	cancel()
-	ctx2, ctxc2 := context.WithTimeout(context.TODO(), time.Second)
+	ctx2, ctxc2 := context.WithTimeout(t.Context(), time.Second)
 	defer ctxc2()
 	require.NoError(t, srv.Shutdown(ctx2))
 
 	// shutdown is re-entrable
-	ctx3, ctxc3 := context.WithTimeout(context.TODO(), time.Second)
+	ctx3, ctxc3 := context.WithTimeout(t.Context(), time.Second)
 	defer ctxc3()
 	require.NoError(t, srv.Shutdown(ctx3))
 }

--- a/lib/tbot/services/application/helpers_test.go
+++ b/lib/tbot/services/application/helpers_test.go
@@ -20,7 +20,6 @@ package application
 
 import (
 	"bytes"
-	"context"
 	"log/slog"
 	"net"
 	"os"
@@ -119,7 +118,7 @@ func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testC
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/services/awsra/helpers_test.go
+++ b/lib/tbot/services/awsra/helpers_test.go
@@ -156,7 +156,7 @@ func (m *staticOverrideGetter) GetWorkloadIdentityX509CAOverride(ctx context.Con
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/services/workloadidentity/helpers_test.go
+++ b/lib/tbot/services/workloadidentity/helpers_test.go
@@ -156,7 +156,7 @@ func (m *staticOverrideGetter) GetWorkloadIdentityX509CAOverride(ctx context.Con
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -117,7 +117,7 @@ func defaultTestServerOpts(log *slog.Logger) testenv.TestServerOptFunc {
 
 // makeBot creates a server-side bot and returns joining parameters.
 func makeBot(t *testing.T, client *authclient.Client, name string, roles ...string) (*onboarding.Config, *machineidv1pb.Bot) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	t.Helper()
 
 	b, err := client.BotServiceClient().CreateBot(ctx, &machineidv1pb.CreateBotRequest{

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2565,7 +2565,7 @@ func mustStartWindowsDesktopMock(t *testing.T, authClient *auth.Server) *windows
 		HostUUID: "windows_server",
 		NodeName: "windows_server",
 	}
-	n, err := authClient.GetClusterName(context.TODO())
+	n, err := authClient.GetClusterName(t.Context())
 	require.NoError(t, err)
 	dns := []string{"localhost", "127.0.0.1", desktop.WildcardServiceDNS}
 	identity, err := auth.LocalRegister(authID, authClient, nil, dns, "", nil)

--- a/lib/web/databases_test.go
+++ b/lib/web/databases_test.go
@@ -303,7 +303,7 @@ func TestHandleDatabasesGetIAMPolicy(t *testing.T) {
 
 	// Add database servers for above databases.
 	for _, db := range []*types.DatabaseV3{redshift, elasticache, selfHosted} {
-		_, err = env.server.Auth().UpsertDatabaseServer(context.TODO(), mustCreateDatabaseServer(t, db))
+		_, err = env.server.Auth().UpsertDatabaseServer(t.Context(), mustCreateDatabaseServer(t, db))
 		require.NoError(t, err)
 	}
 
@@ -345,7 +345,7 @@ func TestHandleDatabasesGetIAMPolicy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.inputDatabaseName, func(t *testing.T) {
-			resp, err := pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databases", test.inputDatabaseName, "iam", "policy"), nil)
+			resp, err := pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "databases", test.inputDatabaseName, "iam", "policy"), nil)
 			test.verifyResponse(t, resp, err)
 		})
 	}

--- a/lib/web/notifications_test.go
+++ b/lib/web/notifications_test.go
@@ -149,7 +149,7 @@ func TestNotifications(t *testing.T) {
 
 	// Upsert last seen timestamp.
 	lastSeenTimeString := "2024-05-08T19:00:47.836Z"
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "lastseennotification"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "lastseennotification"),
 		UpsertUserLastSeenNotificationRequest{
 			Time: lastSeenTimeString,
 		})
@@ -180,7 +180,7 @@ func TestNotifications(t *testing.T) {
 	var fetchedNotifications []ui.Notification
 
 	// Get a page of 4.
-	notificationsResp, err := pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err := pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit": []string{"4"},
 	})
 	require.NoError(t, err)
@@ -194,7 +194,7 @@ func TestNotifications(t *testing.T) {
 	require.Equal(t, expectedNextKeys, unmarshaledNotificationsResp.NextKey)
 
 	// Get a page of 10, starting from the previously returned keys.
-	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err = pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit":    []string{"10"},
 		"startKey": []string{unmarshaledNotificationsResp.NextKey},
 	})
@@ -207,7 +207,7 @@ func TestNotifications(t *testing.T) {
 	require.Equal(t, lastSeenTimeString, unmarshaledNotificationsResp.UserLastSeenNotification)
 
 	// Mark the most recent notification as clicked.
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
 		upsertUserNotificationStateRequest{
 			NotificationId:    notificationIdMap["auditor-7"],
 			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_CLICKED,
@@ -215,7 +215,7 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mark the last notification as dismissed.
-	_, err = pack.clt.PutJSON(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
+	_, err = pack.clt.PutJSON(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notificationstate"),
 		upsertUserNotificationStateRequest{
 			NotificationId:    notificationIdMap["auditor-1"],
 			NotificationState: notificationsv1.NotificationState_NOTIFICATION_STATE_DISMISSED,
@@ -223,7 +223,7 @@ func TestNotifications(t *testing.T) {
 	require.NoError(t, err)
 
 	// List all notifications again.
-	notificationsResp, err = pack.clt.Get(context.TODO(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
+	notificationsResp, err = pack.clt.Get(t.Context(), pack.clt.Endpoint("webapi", "sites", env.server.ClusterName(), "notifications"), url.Values{
 		"limit": []string{"10"},
 	})
 	require.NoError(t, err)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2850,7 +2850,7 @@ func TestSSHCommands(t *testing.T) {
 //
 // Duplicated in integration/integration_test.go
 func tryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedCluster types.TrustedCluster) {
-	ctx := context.TODO()
+	ctx := t.Context()
 	for range 10 {
 		_, err := authServer.UpsertTrustedClusterV2(ctx, trustedCluster)
 		if err == nil {


### PR DESCRIPTION
Nice to have linter coverage for this.

Other rule enforcement, like for `context.Background()`, can come later. This was deliberately split from the others to minimize diff because this touches a ton of files.