### PR TITLE
Bump controller tools to fix build

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -197,7 +197,7 @@ $(LOCALBIN):
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
-CONTROLLER_TOOLS_VERSION ?= v0.19.0
+CONTROLLER_TOOLS_VERSION ?= v0.20.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Go 1.25 bump broke the operator build and tests. This is fixed by updating the controller-tools. Backports might require re-running the codegen.