### PR TITLE
Improve desktop reconciler failure handling

### DIFF
--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -20,6 +20,7 @@ package desktop
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"io"
 	"log/slog"
@@ -391,4 +392,192 @@ func TestDynamicWindowsDiscoveryExpiry(t *testing.T) {
 		require.Len(t, desktops, 1)
 		require.Equal(t, "test", desktops[0].GetName())
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestCurrentDesktops(t *testing.T) {
+	t.Parallel()
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	hostUUID := "test-host-id"
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	s := &WindowsService{
+		cfg: WindowsServiceConfig{
+			Heartbeat: HeartbeatConfig{
+				HostUUID: hostUUID,
+			},
+			Logger:      slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Clock:       clockwork.NewFakeClock(),
+			AccessPoint: client,
+		},
+	}
+
+	desktops := []struct {
+		name   string
+		hostID string
+		origin string
+		expect bool
+	}{
+		{
+			name:   "dynamic-same-host",
+			hostID: hostUUID,
+			origin: types.OriginDynamic,
+			expect: true, // Should be included
+		},
+		{
+			name:   "static-same-host",
+			hostID: hostUUID,
+			origin: types.OriginConfigFile,
+			expect: false, // Wrong origin
+		},
+		{
+			name:   "dynamic-different-host",
+			hostID: "other-host",
+			origin: types.OriginDynamic,
+			expect: false, // Wrong host
+		},
+		{
+			name:   "dynamic-same-host-2",
+			hostID: hostUUID,
+			origin: types.OriginDynamic,
+			expect: true, // Should be included
+		},
+	}
+
+	for _, d := range desktops {
+		desktop, err := types.NewWindowsDesktopV3(d.name, map[string]string{
+			types.OriginLabel: d.origin,
+		}, types.WindowsDesktopSpecV3{
+			Addr:   "addr-" + d.name,
+			HostID: d.hostID,
+		})
+		require.NoError(t, err)
+		err = tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop)
+		require.NoError(t, err)
+	}
+
+	// Call currentDesktops and verify results
+	result := s.currentDesktops(t.Context())
+
+	// Count expected desktops
+	var expectedCount int
+	for _, d := range desktops {
+		if d.expect {
+			expectedCount++
+		}
+	}
+
+	require.Len(t, result, expectedCount)
+
+	// Verify only the expected desktops are returned
+	for _, d := range desktops {
+		if d.expect {
+			desktop, ok := result[d.name]
+			require.True(t, ok, "expected desktop %s to be in results", d.name)
+			require.Equal(t, d.name, desktop.GetName())
+			require.Equal(t, d.hostID, desktop.GetHostID())
+			originLabel, _ := desktop.GetLabel(types.OriginLabel)
+			require.Equal(t, types.OriginDynamic, originLabel)
+		} else {
+			_, ok := result[d.name]
+			require.False(t, ok, "desktop %s should not be in results", d.name)
+		}
+	}
+}
+
+func TestLDAPDiscoveryFailurePreservesDesktops(t *testing.T) {
+	t.Parallel()
+
+	authServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		ClusterName: "test",
+		Dir:         t.TempDir(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authServer.Close()) })
+
+	tlsServer, err := authServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	const hostUUID = "test-host-uuid"
+	client, err := tlsServer.NewClient(authtest.TestServerID(types.RoleWindowsDesktop, hostUUID))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	clock := clockwork.NewFakeClock()
+
+	s := &WindowsService{
+		closeCtx: t.Context(),
+		cfg: WindowsServiceConfig{
+			Heartbeat:         HeartbeatConfig{HostUUID: hostUUID},
+			Logger:            slog.New(logutils.NewSlogTextHandler(io.Discard, logutils.SlogTextHandlerConfig{})),
+			Clock:             clock,
+			AccessPoint:       client,
+			AuthClient:        client,
+			DiscoveryInterval: 5 * time.Minute,
+		},
+
+		// pre-cache a TLS config so we don't ask auth to issue a real cert
+		// (there isn't a real LDAP server here to connect to)
+		ldapTLSConfig:          new(tls.Config),
+		ldapTLSConfigExpiresAt: clock.Now().Add(24 * time.Hour),
+	}
+
+	originalExpiry := clock.Now().Add(s.cfg.DiscoveryInterval * 3)
+
+	// Populate last discovery results with some desktops
+	lastDiscoveryResults := map[string]types.WindowsDesktop{}
+	for i := 1; i <= 3; i++ {
+		name := "desktop-" + strconv.Itoa(i)
+		desktop, err := types.NewWindowsDesktopV3(name, map[string]string{
+			types.OriginLabel:                      types.OriginDynamic,
+			types.DiscoveryLabelWindowsDNSHostName: name + ".example.com",
+			types.DiscoveryLabelWindowsOS:          "Windows Server 2019",
+		}, types.WindowsDesktopSpecV3{
+			HostID: hostUUID,
+			Addr:   name + ".example.com:3389",
+		})
+		require.NoError(t, err)
+		desktop.SetExpiry(originalExpiry)
+		lastDiscoveryResults[name] = desktop
+
+		require.NoError(t, tlsServer.Auth().UpsertWindowsDesktop(t.Context(), desktop))
+	}
+	s.lastDiscoveryResults = lastDiscoveryResults
+
+	// Force the reconciler to run.
+	// It will fail because we aren't running a real LDAP server in the test.
+	require.NoError(t, s.startDesktopDiscovery())
+	clock.BlockUntilContext(t.Context(), 1)
+	clock.Advance(15 * time.Second)
+	preReconcile := clock.Now()
+	clock.BlockUntilContext(t.Context(), 1)
+
+	// Verify that the reconciler failure did not delete desktops and that
+	// their expiry times were updated.
+	for i := 1; i <= 3; i++ {
+		name := "desktop-" + strconv.Itoa(i)
+		desktops, err := client.GetWindowsDesktops(
+			t.Context(),
+			types.WindowsDesktopFilter{HostID: hostUUID, Name: name},
+		)
+		require.NoError(t, err)
+		require.Len(t, desktops, 1)
+		require.Equal(t, name, desktops[0].GetName())
+
+		// Verify the TTL was updated (3x the discovery interval).
+		actualExpiry := desktops[0].Expiry()
+		require.Equal(t, 15*time.Minute, actualExpiry.Sub(preReconcile))
+	}
 }


### PR DESCRIPTION
This is a follow up to #62283, where we made sure that failure to query an LDAP server didn't result in desktops getting deleted.

That PR only handled the case where the LDAP query itself failed, but didn't handle failures to acquire a cert or connect to the LDAP server.

Also add more test coverage for this scenario.

In addition to the extra test coverage, I've run the following tests:
- set up discovery on a short (2 minute) discovery interval
- connect to a discovered host
- configure firewall to block access to LDAP server
- wait a few minutes and verify that the hosts are still present, even though logs show discovery failures
- verify that we can still connect to the host even though LDAP connectivity is broken
- restore firewall so that connectivity is allowed
- wait for next discovery and verify that it succeeded