### PR TITLE
[v17] Bump controller tools to fix build

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -187,7 +187,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.16.2
+CONTROLLER_TOOLS_VERSION ?= v0.20.0
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.


### PR DESCRIPTION
Manual backport of https://github.com/gravitational/teleport/pull/63599 to `branch/v17`