### PR TITLE
[v18] fix: tsh label based commands always running serially

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2892,7 +2892,7 @@ func (tc *TeleportClient) ListDatabases(ctx context.Context, customFilter *proto
 
 // roleGetter retrieves roles for the current user
 type roleGetter interface {
-	GetRoles(ctx context.Context) ([]types.Role, error)
+	GetCurrentUserRoles(ctx context.Context) ([]types.Role, error)
 }
 
 // commandLimit determines how many commands may be executed in parallel.
@@ -2908,7 +2908,7 @@ func commandLimit(ctx context.Context, getter roleGetter, mfaRequired bool) int 
 		return 1
 	}
 
-	roles, err := getter.GetRoles(ctx)
+	roles, err := getter.GetCurrentUserRoles(ctx)
 	if err != nil {
 		return 1
 	}


### PR DESCRIPTION
Backport #63555 to branch/v18

changelog: Fixed `tsh ssh user@foo=bar uptime` from running serially if users did not have `role:read` permissions.
