### PR TITLE
[v18] fix: out of sequence audit logs for same timestamp logs

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventList.test.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventList.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, within } from '@testing-library/react';
+
+import { render } from 'design/utils/testing';
+
+import { RawEvents } from '../../services/audit';
+import makeEvent from '../../services/audit/makeEvent';
+import EventList from './EventList';
+
+describe('EventList', () => {
+  it('should sort events with same timestamp by event index', () => {
+    const sameTimestamp = '2025-09-08T21:25:49.265Z';
+
+    const mcpSessionStart = {
+      code: 'TMCP001I',
+      event: 'mcp.session.start',
+      time: sameTimestamp,
+      uid: '5dcf76ab-3f31-40a7-8550-bb29ecea1e42',
+      user: 'admin',
+      ei: 269750, // Lower event index - should be first
+      sid: '5dcf76ab-3f31-40a7-8550-bb29ecea1e42',
+      app_name: 'teleport-mcp-demo',
+    } as RawEvents[typeof import('teleport/services/audit').eventCodes.MCP_SESSION_START];
+
+    const mcpSessionRequest = {
+      code: 'TMCP003I',
+      event: 'mcp.session.request',
+      time: sameTimestamp,
+      uid: 'int64:0',
+      user: 'admin',
+      ei: 667167, // Higher event index - should be second
+      app_name: 'teleport-mcp-demo',
+      message: {
+        id: 'init64:0',
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: {
+            name: 'claude-ai',
+            version: '0.1.0',
+          },
+          protocolVersion: '2025-06-18',
+        },
+      },
+    } as RawEvents[typeof import('teleport/services/audit').eventCodes.MCP_SESSION_REQUEST];
+
+    const events = [makeEvent(mcpSessionStart), makeEvent(mcpSessionRequest)];
+
+    render(
+      <EventList
+        events={events}
+        fetchMore={() => null}
+        fetchStatus=""
+        pageSize={50}
+      />
+    );
+
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+
+    const firstDataRow = rows[1];
+    const secondDataRow = rows[2];
+    expect(
+      within(firstDataRow).getByText(/MCP Session Started/i)
+    ).toBeInTheDocument();
+    expect(
+      within(secondDataRow).getByText(/MCP Session Request/i)
+    ).toBeInTheDocument();
+  });
+
+  it('should handle events with different timestamps correctly', () => {
+    const olderEvent = {
+      code: 'TMCP001I',
+      event: 'mcp.session.start',
+      time: '2025-09-08T21:25:48.000Z',
+      uid: 'uid-1',
+      user: 'admin',
+      ei: 999999,
+      sid: 'sid-1',
+      app_name: 'teleport-mcp-demo',
+    } as RawEvents[typeof import('teleport/services/audit').eventCodes.MCP_SESSION_START];
+
+    const newerEvent = {
+      code: 'TMCP003I',
+      event: 'mcp.session.request',
+      time: '2025-09-08T21:25:49.000Z',
+      uid: 'uid-2',
+      user: 'admin',
+      ei: 1,
+      app_name: 'teleport-mcp-demo',
+      message: {
+        id: 'int64:0',
+        jsonrpc: '2.0',
+        method: 'initialize',
+        params: {
+          capabilities: {},
+          clientInfo: {
+            name: 'claude-ai',
+            version: '0.1.0',
+          },
+          protocolVersion: '2025-06-18',
+        },
+      },
+    } as RawEvents[typeof import('teleport/services/audit').eventCodes.MCP_SESSION_REQUEST];
+
+    const events = [makeEvent(olderEvent), makeEvent(newerEvent)];
+
+    render(
+      <EventList
+        events={events}
+        fetchMore={() => null}
+        fetchStatus=""
+        pageSize={50}
+      />
+    );
+
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+
+    const firstDataRow = rows[1];
+    const secondDataRow = rows[2];
+
+    expect(
+      within(firstDataRow).getByText(/MCP Session Request/i)
+    ).toBeInTheDocument();
+    expect(
+      within(secondDataRow).getByText(/MCP Session Started/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/web/packages/teleport/src/Audit/EventList/EventList.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventList.tsx
@@ -53,6 +53,7 @@ export default function EventList(props: Props) {
             headerText: 'Created (UTC)',
             isSortable: true,
             render: renderTimeCell,
+            onSort: onSortTime,
           },
           {
             altKey: 'show-details-btn',
@@ -63,7 +64,10 @@ export default function EventList(props: Props) {
         isSearchable
         searchableProps={['code', 'codeDesc', 'time', 'user', 'message', 'id']}
         customSearchMatchers={[dateTimeMatcher(['time'])]}
-        initialSort={{ key: 'time', dir: 'DESC' }}
+        initialSort={{
+          key: 'time',
+          dir: 'DESC',
+        }}
         pagination={{ pageSize }}
         fetching={{
           onFetchMore: fetchMore,
@@ -105,6 +109,22 @@ export const renderTimeCell = ({ time }: Event) => (
 export function renderDescCell({ message }: Event) {
   return <Cell style={{ wordBreak: 'break-word' }}>{message}</Cell>;
 }
+
+const onSortTime = (a: Event, b: Event) => {
+  const aTime = a.time.getTime();
+  const bTime = b.time.getTime();
+
+  const timeDiff = aTime - bTime;
+  if (timeDiff !== 0) {
+    return timeDiff;
+  }
+
+  // If times are equal, sort by event index (ei)
+  const aEventIndex = a.eventIndex || 0;
+  const bEventIndex = b.eventIndex || 0;
+  // HIGHER index - lower index to counteract the reversal for desc sort
+  return bEventIndex - aEventIndex;
+};
 
 type Props = {
   events: State['events'];

--- a/web/packages/teleport/src/services/audit/audit.test.ts
+++ b/web/packages/teleport/src/services/audit/audit.test.ts
@@ -46,6 +46,7 @@ test('fetch events', async () => {
       code: 'T6000I',
       user: '90678c66-ffcc-4f02.im-a-cluster-name',
       time: new Date('2021-05-25T07:34:22.204Z'),
+      eventIndex: 0,
       raw: {
         cluster_name: 'im-a-cluster-name',
         code: 'T6000I',
@@ -67,6 +68,7 @@ test('fetch events', async () => {
       code: 'T1000I',
       user: 'root',
       time: new Date('2021-05-25T14:37:27.848Z'),
+      eventIndex: 0,
       raw: {
         cluster_name: 'im-a-cluster-name',
         code: 'T1000I',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -2558,6 +2558,7 @@ export default function makeEvent(json: any): Event {
     message: formatter.format(json as any),
     id: getId(json),
     code: json.code,
+    eventIndex: json.ei,
     user: json.user,
     time: new Date(json.time),
     raw: json,

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -2471,6 +2471,7 @@ export type Events = {
     code: key;
     codeDesc: string;
     raw: RawEvents[key];
+    eventIndex: number;
   };
 };
 


### PR DESCRIPTION
## What Changed
Added manual sorting to sort audit logs by event index only when the log timestamp is the same. This fixes the issue where in some cases MCP Session Started audit logs where being displayed after MCP Session Request which should be the other way round, more details in the issue attached.

## Automated Testing
Added a test to show that now when multiple events have the same timestamp we use the event index for sorting.
Also added a sanity test case to validate existing behaviour of sorting by timestamp.

## Manual Testing Done
Manually rendered the audit page and validated that the existing sorting behaviour is not broken.
It is hard to generate two audit logs at the exact same timestamp so used tdd to validate when timestamps are same the bug is reproducible.

## Related Issue
https://github.com/gravitational/teleport/issues/58322

## Changelog
changelog: Fixed out of sequent audit logs rendering in ui for same timestamp logs