### PR TITLE
[Access Requests] Show constrained resources in tsh/tctl

### DIFF
--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -223,6 +223,31 @@ func FormatResourceName(r types.ResourceWithLabels, verbose bool) string {
 	return r.GetName()
 }
 
+// FormatResourceAccessID returns the provided ResourceAccessID in its string form,
+// appending constraints when present and if verbose.
+func FormatResourceAccessID(rid types.ResourceAccessID, verbose bool) string {
+	resourceIDString := types.ResourceIDToString(rid.GetResourceID())
+	constraintsString := ""
+
+	if verbose {
+		if c := rid.GetConstraints(); c != nil && c.GetDetails() != nil {
+			switch d := c.GetDetails().(type) {
+			case *types.ResourceConstraints_AwsConsole:
+				if d.AwsConsole == nil {
+					break
+				}
+				constraintsString = fmt.Sprintf("role_arns=%s", strings.Join(d.AwsConsole.RoleArns, ", "))
+			}
+		}
+
+		if constraintsString != "" {
+			return fmt.Sprintf("%s (%s)", resourceIDString, constraintsString)
+		}
+	}
+
+	return resourceIDString
+}
+
 // GetDiscoveredResourceName returns the resource original name discovered in
 // the cloud by the Teleport Discovery Service.
 func GetDiscoveredResourceName(r types.ResourceWithLabels) (discoveredName string, ok bool) {

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -521,17 +521,9 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 	switch format {
 	case teleport.Text:
 		for _, req := range reqs {
-			resourceIDsString := ""
-			if resourceAccessIDs := req.GetAllRequestedResourceIDs(); len(resourceAccessIDs) > 0 {
-				resourceIDStrings := make([]string, 0, len(resourceAccessIDs))
-				for _, rid := range resourceAccessIDs {
-					resourceIDStrings = append(resourceIDStrings, common.FormatResourceAccessID(rid, true))
-				}
-				bytes, err := json.Marshal(resourceIDStrings)
-				if err != nil {
-					return trace.Wrap(err, "failed to marshal resource IDs")
-				}
-				resourceIDsString = string(bytes)
+			resourceIDsString, err := common.FormatResourceAccessIDs(req.GetAllRequestedResourceIDs())
+			if err != nil {
+				return trace.Wrap(err)
 			}
 			if resourceIDsString == "" {
 				resourceIDsString = "[none]"
@@ -546,7 +538,7 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 			table.AddRow([]string{"Request Reason: ", quoteOrDefault(req.GetRequestReason(), "[none]")})
 			table.AddRow([]string{"Resolve Reason: ", quoteOrDefault(req.GetResolveReason(), "[none]")})
 
-			_, err := table.AsBuffer().WriteTo(os.Stdout)
+			_, err = table.AsBuffer().WriteTo(os.Stdout)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/tool/tctl/common/access_request_command.go
+++ b/tool/tctl/common/access_request_command.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
 )
@@ -487,7 +488,9 @@ func printRequestsOverview(reqs []types.AccessRequest, format string) error {
 			"Full reason was truncated, use the `tctl requests get` subcommand to view the full reason.",
 		)
 		for _, req := range reqs {
-			resourceIDsString, err := types.ResourceIDsToString(req.GetRequestedResourceIDs())
+			// This table isn't a comprehensive overview of each request; omit constraints on resources for brevity
+			// and only print their stringified ResourceIDs.
+			resourceIDsString, err := types.ResourceIDsToString(types.RiskyExtractResourceIDs(req.GetAllRequestedResourceIDs()))
 			if err != nil {
 				return trace.Wrap(err)
 			}
@@ -518,9 +521,17 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 	switch format {
 	case teleport.Text:
 		for _, req := range reqs {
-			resourceIDsString, err := types.ResourceIDsToString(req.GetRequestedResourceIDs())
-			if err != nil {
-				return trace.Wrap(err)
+			resourceIDsString := ""
+			if resourceAccessIDs := req.GetAllRequestedResourceIDs(); len(resourceAccessIDs) > 0 {
+				resourceIDStrings := make([]string, 0, len(resourceAccessIDs))
+				for _, rid := range resourceAccessIDs {
+					resourceIDStrings = append(resourceIDStrings, common.FormatResourceAccessID(rid, true))
+				}
+				bytes, err := json.Marshal(resourceIDStrings)
+				if err != nil {
+					return trace.Wrap(err, "failed to marshal resource IDs")
+				}
+				resourceIDsString = string(bytes)
 			}
 			if resourceIDsString == "" {
 				resourceIDsString = "[none]"
@@ -535,7 +546,7 @@ func printRequestsDetailed(reqs []types.AccessRequest, format string) error {
 			table.AddRow([]string{"Request Reason: ", quoteOrDefault(req.GetRequestReason(), "[none]")})
 			table.AddRow([]string{"Resolve Reason: ", quoteOrDefault(req.GetResolveReason(), "[none]")})
 
-			_, err = table.AsBuffer().WriteTo(os.Stdout)
+			_, err := table.AsBuffer().WriteTo(os.Stdout)
 			if err != nil {
 				return trace.Wrap(err)
 			}

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -21,7 +21,6 @@ package common
 import (
 	"cmp"
 	"context"
-	"encoding/json"
 	"fmt"
 	"path"
 	"slices"
@@ -185,17 +184,9 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 		reviewers = strings.Join(r, ", ")
 	}
 
-	resourcesStr := ""
-	if resources := req.GetAllRequestedResourceIDs(); len(resources) > 0 {
-		resourceStrs := make([]string, 0, len(resources))
-		for _, r := range resources {
-			resourceStrs = append(resourceStrs, common.FormatResourceAccessID(r, true))
-		}
-		bytes, err := json.Marshal(resourceStrs)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		resourcesStr = string(bytes)
+	resourcesStr, err := common.FormatResourceAccessIDs(req.GetAllRequestedResourceIDs())
+	if err != nil {
+		return trace.Wrap(err)
 	}
 
 	table := asciitable.MakeHeadlessTable(2)
@@ -216,7 +207,7 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 	table.AddRow([]string{"Status:", req.GetState().String()})
 
-	_, err := table.AsBuffer().WriteTo(cf.Stdout())
+	_, err = table.AsBuffer().WriteTo(cf.Stdout())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -21,6 +21,7 @@ package common
 import (
 	"cmp"
 	"context"
+	"encoding/json"
 	"fmt"
 	"path"
 	"slices"
@@ -185,11 +186,16 @@ func printRequest(cf *CLIConf, req types.AccessRequest) error {
 	}
 
 	resourcesStr := ""
-	if resources := req.GetRequestedResourceIDs(); len(resources) > 0 {
-		var err error
-		if resourcesStr, err = types.ResourceIDsToString(resources); err != nil {
+	if resources := req.GetAllRequestedResourceIDs(); len(resources) > 0 {
+		resourceStrs := make([]string, 0, len(resources))
+		for _, r := range resources {
+			resourceStrs = append(resourceStrs, common.FormatResourceAccessID(r, true))
+		}
+		bytes, err := json.Marshal(resourceStrs)
+		if err != nil {
 			return trace.Wrap(err)
 		}
+		resourcesStr = string(bytes)
 	}
 
 	table := asciitable.MakeHeadlessTable(2)
@@ -363,7 +369,9 @@ func showRequestTable(cf *CLIConf, reqs []types.AccessRequest) error {
 		if now.After(req.GetAccessExpiry()) {
 			continue
 		}
-		resourceIDsString, err := types.ResourceIDsToString(req.GetRequestedResourceIDs())
+		// This table isn't a comprehensive overview of each request; omit constraints on resources for brevity
+		// and only print their stringified ResourceIDs.
+		resourceIDsString, err := types.ResourceIDsToString(types.RiskyExtractResourceIDs(req.GetAllRequestedResourceIDs()))
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -277,6 +277,69 @@ func TestShowRequestTable(t *testing.T) {
 			},
 			wantPresent: []string{"someName", "someUser", "role1,role2", assumeStartTime.UTC().Format(time.RFC822)},
 		},
+		{
+			name: "Access Requests with constrained resources",
+			reqs: []types.AccessRequest{
+				&types.AccessRequestV3{
+					Metadata: types.Metadata{
+						Name:    "constrainedRequest",
+						Expires: &expiresTime,
+					},
+					Spec: types.AccessRequestSpecV3{
+						User:       "someUser",
+						Roles:      []string{"aws-access"},
+						Expires:    expiresTime,
+						SessionTTL: expiresTime,
+						Created:    createdAtTime,
+						RequestedResourceAccessIDs: []types.ResourceAccessID{
+							{
+								Id: types.ResourceID{
+									ClusterName: "test-cluster",
+									Kind:        types.KindApp,
+									Name:        "awsconsole",
+								},
+								Constraints: &types.ResourceConstraints{
+									Version: types.V1,
+									Details: &types.ResourceConstraints_AwsConsole{
+										AwsConsole: &types.AWSConsoleResourceConstraints{
+											RoleArns: []string{"arn:aws:iam::123456789012:role/Admin"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPresent: []string{"constrainedRequest", "someUser", "aws-access"},
+		},
+		{
+			name: "Access Requests with namespace resources",
+			reqs: []types.AccessRequest{
+				&types.AccessRequestV3{
+					Metadata: types.Metadata{
+						Name:    "namespaceRequest",
+						Expires: &expiresTime,
+					},
+					Spec: types.AccessRequestSpecV3{
+						User:       "someUser",
+						Roles:      []string{"kube-access"},
+						Expires:    expiresTime,
+						SessionTTL: expiresTime,
+						Created:    createdAtTime,
+						RequestedResourceIDs: []types.ResourceID{
+							{
+								ClusterName:     "test-cluster",
+								Kind:            types.KindKubeNamespace,
+								Name:            "my-kube-cluster",
+								SubResourceName: "production",
+							},
+						},
+					},
+				},
+			},
+			wantPresent: []string{"namespaceRequest", "someUser", "kube-access"},
+		},
 	}
 
 	for _, tc := range tests {
@@ -290,6 +353,196 @@ func TestShowRequestTable(t *testing.T) {
 			require.NoError(t, err)
 			for _, wanted := range tc.wantPresent {
 				require.Contains(t, captureStdout.String(), wanted)
+			}
+		})
+	}
+}
+
+func TestPrintRequest(t *testing.T) {
+	t.Parallel()
+
+	createdAtTime := time.Now()
+	expiresTime := time.Now().Add(time.Hour)
+
+	tests := []struct {
+		name        string
+		req         types.AccessRequest
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name: "basic request without resources",
+			req: &types.AccessRequestV3{
+				Metadata: types.Metadata{
+					Name:    "basic-request",
+					Expires: &expiresTime,
+				},
+				Spec: types.AccessRequestSpecV3{
+					User:       "testuser",
+					Roles:      []string{"admin", "developer"},
+					Expires:    expiresTime,
+					SessionTTL: expiresTime,
+					Created:    createdAtTime,
+				},
+			},
+			wantPresent: []string{
+				"Request ID:",
+				"basic-request",
+				"Username:",
+				"testuser",
+				"Roles:",
+				"admin, developer",
+			},
+			wantAbsent: []string{"Resources:"},
+		},
+		{
+			name: "request with constrained AWS console resources",
+			req: &types.AccessRequestV3{
+				Metadata: types.Metadata{
+					Name:    "aws-request",
+					Expires: &expiresTime,
+				},
+				Spec: types.AccessRequestSpecV3{
+					User:       "testuser",
+					Roles:      []string{"aws-access"},
+					Expires:    expiresTime,
+					SessionTTL: expiresTime,
+					Created:    createdAtTime,
+					RequestedResourceAccessIDs: []types.ResourceAccessID{
+						{
+							Id: types.ResourceID{
+								ClusterName: "test-cluster",
+								Kind:        types.KindApp,
+								Name:        "awsconsole",
+							},
+							Constraints: &types.ResourceConstraints{
+								Version: types.V1,
+								Details: &types.ResourceConstraints_AwsConsole{
+									AwsConsole: &types.AWSConsoleResourceConstraints{
+										RoleArns: []string{
+											"arn:aws:iam::123456789012:role/Admin",
+											"arn:aws:iam::123456789012:role/ReadOnly",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPresent: []string{
+				"Request ID:",
+				"aws-request",
+				"Username:",
+				"testuser",
+				"Roles:",
+				"aws-access",
+				"Resources:",
+				"/test-cluster/app/awsconsole",
+				"role_arns=",
+				"arn:aws:iam::123456789012:role/Admin",
+				"arn:aws:iam::123456789012:role/ReadOnly",
+			},
+		},
+		{
+			name: "request with kubernetes namespace resources",
+			req: &types.AccessRequestV3{
+				Metadata: types.Metadata{
+					Name:    "kube-request",
+					Expires: &expiresTime,
+				},
+				Spec: types.AccessRequestSpecV3{
+					User:       "testuser",
+					Roles:      []string{"kube-access"},
+					Expires:    expiresTime,
+					SessionTTL: expiresTime,
+					Created:    createdAtTime,
+					RequestedResourceIDs: []types.ResourceID{
+						{
+							ClusterName:     "test-cluster",
+							Kind:            types.KindKubeNamespace,
+							Name:            "my-kube-cluster",
+							SubResourceName: "production",
+						},
+					},
+				},
+			},
+			wantPresent: []string{
+				"Request ID:",
+				"kube-request",
+				"Username:",
+				"testuser",
+				"Roles:",
+				"kube-access",
+				"Resources:",
+				"/test-cluster/namespace/my-kube-cluster/production",
+			},
+		},
+		{
+			name: "request with mixed resources and constraints",
+			req: &types.AccessRequestV3{
+				Metadata: types.Metadata{
+					Name:    "mixed-request",
+					Expires: &expiresTime,
+				},
+				Spec: types.AccessRequestSpecV3{
+					User:       "testuser",
+					Roles:      []string{"multi-access"},
+					Expires:    expiresTime,
+					SessionTTL: expiresTime,
+					Created:    createdAtTime,
+					RequestedResourceIDs: []types.ResourceID{
+						{
+							ClusterName: "test-cluster",
+							Kind:        types.KindNode,
+							Name:        "my-server",
+						},
+					},
+					RequestedResourceAccessIDs: []types.ResourceAccessID{
+						{
+							Id: types.ResourceID{
+								ClusterName: "test-cluster",
+								Kind:        types.KindApp,
+								Name:        "awsconsole",
+							},
+							Constraints: &types.ResourceConstraints{
+								Version: types.V1,
+								Details: &types.ResourceConstraints_AwsConsole{
+									AwsConsole: &types.AWSConsoleResourceConstraints{
+										RoleArns: []string{"arn:aws:iam::123456789012:role/Admin"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantPresent: []string{
+				"Request ID:",
+				"mixed-request",
+				"Resources:",
+				"/test-cluster/node/my-server",
+				"/test-cluster/app/awsconsole",
+				"role_arns=",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			captureStdout := new(bytes.Buffer)
+			cf := &CLIConf{
+				OverrideStdout: captureStdout,
+			}
+			err := printRequest(cf, tc.req)
+			require.NoError(t, err)
+			output := captureStdout.String()
+			for _, wanted := range tc.wantPresent {
+				require.Contains(t, output, wanted, "expected output to contain %q", wanted)
+			}
+			for _, unwanted := range tc.wantAbsent {
+				require.NotContains(t, output, unwanted, "expected output to not contain %q", unwanted)
 			}
 		})
 	}

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -552,7 +552,7 @@ func updateAccessRequestForDB(t *testing.T, s *suite, wantRequestReason, wantDBN
 			if accessRequest.GetRequestReason() != wantRequestReason {
 				continue
 			}
-			for _, resourceID := range accessRequest.GetRequestedResourceIDs() {
+			for _, resourceID := range types.RiskyExtractResourceIDs(accessRequest.GetAllRequestedResourceIDs()) {
 				if resourceID.Kind == types.KindDatabase &&
 					resourceID.Name == wantDBName {
 					accessRequestID = accessRequest.GetName()

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -741,7 +741,7 @@ func TestKubeSelection(t *testing.T) {
 			}
 
 			equal := reflect.DeepEqual(
-				accessRequests[0].GetRequestedResourceIDs(),
+				types.RiskyExtractResourceIDs(accessRequests[0].GetAllRequestedResourceIDs()),
 				[]types.ResourceID{
 					{
 						ClusterName: s.root.Config.Auth.ClusterName.GetClusterName(),


### PR DESCRIPTION
## Context
Part 1 of supporting Resource Constraints in tsh/tctl. Show constraints alongside relevant ResourceIDs when listing/showing an Access Request. We'll likely revisit how this info is presented as part of supporting specifying constraints and listing requestable principals on resources via tsh/tctl; this is intended to function as a stopgap until then, rather than the information being omitted entirely.

## Testing
Manually tested via Access Requests created via Web UI containing constrained resources; added test cases for updated helpers:
- `tsh request show`
- `tsh request ls`
- `tsh login`
- `tsh status`
