### PR TITLE
MWI: Add tctl examples to `tctl keypair create` template

### DIFF
--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
+	libboundkeypair "github.com/gravitational/teleport/lib/boundkeypair"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/tbot/bot/destination"
 	"github.com/gravitational/teleport/lib/tbot/bot/onboarding"
@@ -90,7 +91,7 @@ To register the keypair with Teleport, include this public key in the token's
 
 You can use 'tctl' to create a bot and token automatically:
 
-    $ tctl bots add bot-name \
+	$ tctl bots add bot-name \
 	  --roles=some-role,some-other-role \
 	  --initial-public-key='{{ .PublicKey }}'{{ if or .StaticKeyPath .EncodedPrivateKey }} \
 	  --recovery-mode=insecure{{ end }}
@@ -98,10 +99,11 @@ You can use 'tctl' to create a bot and token automatically:
 Refer to this token example as a reference:
 
 {{ .TokenExample }}
+
 {{- if or .EncodedPrivateKey .StaticKeyPath }}
 Note that you must also set 'spec.bound_keypair.recovery.mode' to 'insecure'
 to use static keys.
-{{ end }}{{- if .StaticKeyPath }}
+{{ if .StaticKeyPath }}
 The static key has been written to: {{ .StaticKeyPath }}
 
 Configure your bot to use this static key by setting the following 'tbot.yaml'
@@ -124,9 +126,16 @@ will be unable to join if a rotation is requested server-side via the token's
 shown above. Read more at:
 
 	https://goteleport.com/docs/reference/machine-workload-identity/machine-id/bound-keypair/concepts/#recovery
-`))
+{{- end }}`))
 
 func generateExampleToken(params KeypairMessageParams, indent string) (string, error) {
+	mode := string(libboundkeypair.RecoveryModeStandard)
+	if params.EncodedPrivateKey != "" {
+		// EncodedPrivateKey is always set if a static key is used, even if we
+		// only write the unencoded key to a file
+		mode = string(libboundkeypair.RecoveryModeInsecure)
+	}
+
 	token := &types.ProvisionTokenV2{
 		Version: types.V2,
 		Kind:    types.KindToken,
@@ -141,15 +150,12 @@ func generateExampleToken(params KeypairMessageParams, indent string) (string, e
 				Onboarding: &types.ProvisionTokenSpecV2BoundKeypair_OnboardingSpec{
 					InitialPublicKey: params.PublicKey,
 				},
-				Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{},
+				Recovery: &types.ProvisionTokenSpecV2BoundKeypair_RecoverySpec{
+					Mode:  mode,
+					Limit: 1,
+				},
 			},
 		},
-	}
-
-	if params.EncodedPrivateKey != "" {
-		// EncodedPrivateKey is always set if a static key is used, even if we
-		// only write the unencoded key to a file
-		token.Spec.BoundKeypair.Recovery.Mode = "insecure"
 	}
 
 	w := strings.Builder{}

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -126,7 +126,7 @@ will be unable to join if a rotation is requested server-side via the token's
 shown above. Read more at:
 
 	https://goteleport.com/docs/reference/machine-workload-identity/machine-id/bound-keypair/concepts/#recovery
-{{- end }}`))
+{{ end }}`))
 
 func generateExampleToken(params KeypairMessageParams, indent string) (string, error) {
 	mode := string(libboundkeypair.RecoveryModeStandard)

--- a/tool/tbot/keypair.go
+++ b/tool/tbot/keypair.go
@@ -88,13 +88,20 @@ To register the keypair with Teleport, include this public key in the token's
 
 	{{ .PublicKey }}
 
+You can use 'tctl' to create a bot and token automatically:
+
+    $ tctl bots add bot-name \
+	  --roles=some-role,some-other-role \
+	  --initial-public-key='{{ .PublicKey }}'{{ if or .StaticKeyPath .EncodedPrivateKey }} \
+	  --recovery-mode=insecure{{ end }}
+
 Refer to this token example as a reference:
 
 {{ .TokenExample }}
-{{- if .StaticKeyPath }}
+{{- if or .EncodedPrivateKey .StaticKeyPath }}
 Note that you must also set 'spec.bound_keypair.recovery.mode' to 'insecure'
 to use static keys.
-
+{{ end }}{{- if .StaticKeyPath }}
 The static key has been written to: {{ .StaticKeyPath }}
 
 Configure your bot to use this static key by setting the following 'tbot.yaml'


### PR DESCRIPTION
This includes some examples in the help template for `tbot keypair create` that use the new `tctl` support for adding bound keypair tokens via `tctl bots add`, which is added in #63422. These will help users avoid having to write any YAML directly to onboard a bot.

It also improves the provision token YAML example by setting an explicit mode (for `standard`) and limit. These are optional, but looked ugly. 

No backport is planned at this time. If we decide to backport #63422 in some form (e.g. inverted `--legacy` flag), we can reevaluate a v18 backport.

---

### Examples

#### Standard pre-generated keypair

```
$ tbot keypair create --proxy-server example.teleport.sh:443 --storage=./storage
To register the keypair with Teleport, include this public key in the token's
'spec.bound_keypair.onboarding.initial_public_key' field:

	ssh-ed25519 <..snip..>

You can use 'tctl' to create a bot and token automatically:

    $ tctl bots add bot-name \
	  --roles=some-role,some-other-role \
	  --initial-public-key='ssh-ed25519 <..snip..>'

Refer to this token example as a reference:

	kind: token
	metadata:
	  name: example-token
	spec:
	  bot_name: example-bot
	  bound_keypair:
	    onboarding:
	      initial_public_key: ssh-ed25519 <..snip..>
	    recovery:
	      limit: 1
	      mode: standard
	  join_method: bound_keypair
	  roles:
	  - Bot
	version: v2
```

#### Static key (environment variable)

```
$ tbot keypair create --proxy-server example.teleport.sh:443  --storage=./storage --static
To register the keypair with Teleport, include this public key in the token's
'spec.bound_keypair.onboarding.initial_public_key' field:

	ssh-ed25519 <..snip..>

You can use 'tctl' to create a bot and token automatically:

	$ tctl bots add bot-name \
	  --roles=some-role,some-other-role \
	  --initial-public-key='ssh-ed25519 <..snip..> \
	  --recovery-mode=insecure

Refer to this token example as a reference:

	kind: token
	metadata:
	  name: example-token
	spec:
	  bot_name: example-bot
	  bound_keypair:
	    onboarding:
	      initial_public_key: ssh-ed25519 <..snip..>
	    recovery:
	      limit: 1
	      mode: insecure
	  join_method: bound_keypair
	  roles:
	  - Bot
	version: v2

Note that you must also set 'spec.bound_keypair.recovery.mode' to 'insecure'
to use static keys.

Configure your bot to use this static key by inserting the following private key
value into the bot's environment, ideally via a platform-specific keystore if
available:

	export TBOT_BOUND_KEYPAIR_STATIC_KEY=<..snip..>

Note that bots joined with static tokens do not support keypair rotation and
will be unable to join if a rotation is requested server-side via the token's
'rotate_after' field. Additionally, 'insecure' recovery mode must be used, as
shown above. Read more at:

	https://goteleport.com/docs/reference/machine-workload-identity/machine-id/bound-keypair/concepts/#recovery
```

#### Static key (file)

```
tbot keypair create --proxy-server example.teleport.sh:443  --storage=./storage --static --static-key-path=./static-test
2026-02-06T20:17:16.591-07:00 INFO [TBOT]      Loaded existing static key from path path:./static-test tbot/keypair.go:251
2026-02-06T20:17:16.591-07:00 INFO [TBOT]      An existing static key was found at the given path and will be printed. To generate a new key, pass --overwrite tbot/keypair.go:277
2026-02-06T20:17:16.591-07:00 INFO [TBOT]      A static keypair has been written to the specified static key path path:./static-test tbot/keypair.go:300

To register the keypair with Teleport, include this public key in the token's
'spec.bound_keypair.onboarding.initial_public_key' field:

	ssh-ed25519 <..snip..>

You can use 'tctl' to create a bot and token automatically:

	$ tctl bots add bot-name \
	  --roles=some-role,some-other-role \
	  --initial-public-key='ssh-ed25519 <..snip..>' \
	  --recovery-mode=insecure

Refer to this token example as a reference:

	kind: token
	metadata:
	  name: example-token
	spec:
	  bot_name: example-bot
	  bound_keypair:
	    onboarding:
	      initial_public_key: ssh-ed25519 <..snip..>
	    recovery:
	      limit: 1
	      mode: insecure
	  join_method: bound_keypair
	  roles:
	  - Bot
	version: v2

Note that you must also set 'spec.bound_keypair.recovery.mode' to 'insecure'
to use static keys.

The static key has been written to: ./static-test

Configure your bot to use this static key by setting the following 'tbot.yaml'
field:

	onboarding:
	  join_method: bound_keypair
	  bound_keypair:
	    static_private_key_path: ./static-test

Note that bots joined with static tokens do not support keypair rotation and
will be unable to join if a rotation is requested server-side via the token's
'rotate_after' field. Additionally, 'insecure' recovery mode must be used, as
shown above. Read more at:

	https://goteleport.com/docs/reference/machine-workload-identity/machine-id/bound-keypair/concepts/#recovery
```