### PR TITLE
[Docs] Add disclaimer to `tctl users ls` docs about SSO users not being included

### DIFF
--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -2212,6 +2212,9 @@ Arguments:
 
 Lists all user accounts.
 
+Note: if you use a single sign-on (SSO) provider, you may not see all users in the output of this command. SSO user records are temporary 
+and only exist for the duration of their session, so only SSO users who are currently or recently logged in will appear.
+
 Usage:
 
 ```code


### PR DESCRIPTION
## Purpose

SSO users are temporarily created in the backend only for the duration of their session, so unless they're currently logged in, they'll be missing from `tctl users ls`.

This PR adds a note to the docs for this command explaining this since it's otherwise not obvious, and this confusion has caused multiple support tickets (like [this one](https://gravitational.zendesk.com/agent/tickets/16049)).