### PR TITLE
MWI: Use bound keypair tokens for the Linux deployment guide

### DIFF
--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -32,6 +32,18 @@ authentication methods:
   Kubernetes cluster or Amazon EC2 instance, provides a signed identity document
   that Teleport can verify using the platform's certificate authority. This is
   the recommended approach because it avoids the use of shared secrets.
+- **Bound keypair token:** Your `tbot` agent generates a public/private keypair
+  and the Teleport Auth Service is configured to trust the public key. This
+  trust can either be established manually - by an administrator copying the key
+  to Teleport - or automatically if a single-use joining secret is provided to
+  the `tbot` client.
+
+  Once trusted, the `tbot` agent can use its keypair to prove its long-term
+  identity to Teleport and receive a renewable certificate. It authenticates to
+  Teleport for as long as the renewable credential remains valid, but can use
+  the bound keypair to automatically recover if it ever expires - if allowed to
+  do so by your own policy. [Read more about Bound Keypair
+  Joining](../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx).
 - **Static join token:** Your Teleport client tool generates a string and stores
   it on the Teleport Auth Service. `tbot` provides this string when it first
   connects to your Teleport cluster, demonstrating to the Auth Service that it

--- a/docs/pages/machine-workload-identity/deployment/deployment.mdx
+++ b/docs/pages/machine-workload-identity/deployment/deployment.mdx
@@ -32,6 +32,7 @@ authentication methods:
   Kubernetes cluster or Amazon EC2 instance, provides a signed identity document
   that Teleport can verify using the platform's certificate authority. This is
   the recommended approach because it avoids the use of shared secrets.
+
 - **Bound keypair token:** Your `tbot` agent generates a public/private keypair
   and the Teleport Auth Service is configured to trust the public key. This
   trust can either be established manually - by an administrator copying the key
@@ -44,6 +45,7 @@ authentication methods:
   the bound keypair to automatically recover if it ever expires - if allowed to
   do so by your own policy. [Read more about Bound Keypair
   Joining](../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx).
+
 - **Static join token:** Your Teleport client tool generates a string and stores
   it on the Teleport Auth Service. `tbot` provides this string when it first
   connects to your Teleport cluster, demonstrating to the Auth Service that it

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -22,9 +22,6 @@ the preferred join method is [`bound_keypair`]. Unlike other join methods, a
 `bound_keypair` join token can only be used to join a single bot. [Read more
 about Bound Keypair Joining][bkp].
 
-[`bound_keypair`]: ../../reference/deployment/join-methods.mdx#bound-keypair-bound_keypair
-[bkp]: ../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx
-
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
@@ -112,3 +109,6 @@ doing so.
 - Read the [configuration reference](../../reference/machine-workload-identity/configuration.mdx) to explore
   all the available configuration options.
 - [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../../reference/machine-workload-identity/telemetry.mdx)
+
+[`bound_keypair`]: ../../reference/deployment/join-methods.mdx#bound-keypair-bound_keypair
+[bkp]: ../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx

--- a/docs/pages/machine-workload-identity/deployment/linux.mdx
+++ b/docs/pages/machine-workload-identity/deployment/linux.mdx
@@ -17,11 +17,13 @@ The process in which `tbot` initially authenticates with the Teleport cluster is
 known as joining. A join method is a specific technique for the bot to prove its
 identity.
 
-On platforms where there is no form of identity available to the machine, the
-only available join method is `token`. The `token` join method is special as
-it is the only join method that relies on a shared secret. In order to mitigate
-the risks associated with this, the `token` join method is single use and it
-is not possible to use the same token multiple times.
+On platforms where there is no native form of identity available to the machine,
+the preferred join method is [`bound_keypair`]. Unlike other join methods, a
+`bound_keypair` join token can only be used to join a single bot. [Read more
+about Bound Keypair Joining][bkp].
+
+[`bound_keypair`]: ../../reference/deployment/join-methods.mdx#bound-keypair-bound_keypair
+[bkp]: ../../reference/machine-workload-identity/bound-keypair/bound-keypair.mdx
 
 ## Prerequisites
 
@@ -47,14 +49,21 @@ Install Teleport as appropriate for your platform:
 
 **This step is completed on your local machine.**
 
-Create the bot:
+Create the bot with `tctl bots add`:
 
 ```code
 $ tctl bots add example
+The bot joining URI: tbot+proxy+bound-keypair://bot-example-abc123:secret@example.teleport.sh:443
+This token must be used within 59 minutes after which it must be recreated.
+
+[...]
 ```
 
-A join token will be included in the results of `tctl bots add`, record this
-value as it will be needed when configuring `tbot`.
+Take note of the joining URI as it will be used in the next step. Joining URIs
+contain all the information needed for the `tbot` client to connect to and
+authenticate with your Teleport cluster. Be aware that this URI contains a
+single use secret value (shown as `secret` in the above example) and should be
+copied with care.
 
 ## Step 3/4. Configure `tbot`
 
@@ -64,10 +73,7 @@ Create `/etc/tbot.yaml`:
 
 ```yaml
 version: v2
-proxy_server: example.teleport.sh:443
-onboarding:
-  join_method: token
-  token: (=presets.tokens.first=)
+join_uri: tbot+proxy+bound-keypair://bot-example-abc123:secret@example.teleport.sh:443
 storage:
   type: directory
   path: /var/lib/teleport/bot
@@ -76,16 +82,15 @@ services: []
 ```
 
 Replace:
-- `example.teleport.sh:443` with the address of your Teleport Proxy or
-  Auth Service. Prefer using the address of a Teleport Proxy.
-- `(=presets.tokens.first=)` with the token that was returned by `tctl bots add`
-  in the previous step.
+- The `join_uri` field value with the joining URI printed by `tctl` in step 2.
 
 <Admonition type="note">
-The first time that `tbot` runs, this token will be exchanged for a certificate
-that the bot uses for authentication. At this point, the token is invalidated.
-This means you may remove the token from the configuration file after the first
-run has completed, but there is no tangible security benefit to doing so.
+The first time that `tbot` runs, the registration secret contained within the
+joining URI will be used to authenticate the first connection. After the first
+successful join, the registration secret is invalidated. You may remove it from
+the join URI (shown as `secret` in the example token) in your configuration file
+after the first run has completed, but there is no tangible security benefit to
+doing so.
 </Admonition>
 
 ### Prepare the storage directory


### PR DESCRIPTION
This updates the Linux deployment guide to use bound keypair tokens, planned to be the default in (at the latest) v19.

Additionally, it makes the first recommendation toward joining URIs, though these are only intended for use in situations where we can fully generate the connection string, either in the UI or in `tctl`.