### PR TITLE
Fix smart card command validation

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/src/piv.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/piv.rs
@@ -115,7 +115,7 @@ impl<const S: usize> Card<S> {
         //
         // P1=04 and P2=00 means selection of DF (usually) application by name. Everything else not
         // supported.
-        if cmd.p1 != 0x04 && cmd.p2 != 0x00 {
+        if cmd.p1 != 0x04 || cmd.p2 != 0x00 {
             return Ok(Response::new(Status::NotFound));
         }
         if !PIV_AID.matches(cmd.data()) {
@@ -155,7 +155,7 @@ impl<const S: usize> Card<S> {
     fn handle_get_data(&mut self, cmd: Command<S>) -> PduResult<Response> {
         // See https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73-4.pdf section
         // 3.1.2.
-        if cmd.p1 != 0x3F && cmd.p2 != 0xFF {
+        if cmd.p1 != 0x3F || cmd.p2 != 0xFF {
             return Ok(Response::new(Status::NotFound));
         }
         let request_tlv = Tlv::from_bytes(cmd.data()).map_err(

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -463,7 +463,7 @@ impl ScardBackend {
             // USB/serial/TPM). Type "vendor" means a proprietary vendor bus.
             //
             // See "ReaderType" in
-            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/smclib/ns-smclib-_scard_reader_capabilitiesconst SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
+            // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/smclib/ns-smclib-_scard_reader_capabilities
             const SCARD_READER_TYPE_VENDOR: u32 = 0xF0;
             self.send_device_control_response(
                 req,


### PR DESCRIPTION
These logical errors have been present since the original implementation, causing us to be too lenient in what we accept.