### PR TITLE
[ci] add upload of test results to s3

### DIFF
--- a/.github/actions/upload-test-metrics/action.yml
+++ b/.github/actions/upload-test-metrics/action.yml
@@ -1,0 +1,27 @@
+name: Upload test metrics
+description: Uploads test logs to s3. Designed to be used in test workflows after test execution.
+
+# Requires 'write' on 'id-token'.
+# Assumes default artifact location of "$GITHUB_WORKSPACE/test-logs/"
+runs:
+  using: "composite"
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
+      id: aws-setup
+      if: always()
+      continue-on-error: true
+      with:
+        aws-region: us-west-2
+        role-to-assume: arn:aws:iam::278576220453:role/tf-ci-test-artifacts-upload-gha-role
+        role-session-name: gha-ci-test-artifacts-${{ github.event.repository.name }}-${{ github.run_number }}
+        role-duration-seconds: 900 # Minimum by policy.
+
+    - name: Normalize test results and push to s3
+      uses: gravitational/shared-workflows/tools/ci-normalize@b676318d4b4d54844f19a6fc59473b95962b1887 # tools/ci-normalize/v0.0.4
+      if: always() && steps.aws-setup.outcome == 'success'
+      continue-on-error: true # Do not fail the workflow
+      with:
+        s3-bucket: "s3://tp-278576220453-ci-test-artifacts-storage/ci-metrics"
+        junit-files: "$GITHUB_WORKSPACE/test-logs/*.xml"
+        tool-version: v0.0.4

--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -97,3 +97,8 @@ jobs:
         timeout-minutes: 10
         run: |
           runuser -u ci -g ci make e2e-aws RDPCLIENT_SKIP_BUILD=1
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -42,6 +42,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write # required for AWS credentials
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
@@ -82,3 +83,8 @@ jobs:
       - name: Run tests
         timeout-minutes: 40
         run: runuser -u ci -g ci make integration RDPCLIENT_SKIP_BUILD=1
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -41,6 +41,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # required for AWS credentials
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
@@ -60,3 +61,8 @@ jobs:
         timeout-minutes: 40
         run: |
           make integration-root RDPCLIENT_SKIP_BUILD=1
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/.github/workflows/kube-integration-tests-non-root.yaml
+++ b/.github/workflows/kube-integration-tests-non-root.yaml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write # required for AWS credentials
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
@@ -100,9 +101,14 @@ jobs:
           # load the image into the kind cluster
           make load-image
 
-          cd - 
+          cd -
 
       - name: Run tests
         timeout-minutes: 40
         run: |
           runuser -u ci -g ci make integration-kube RDPCLIENT_SKIP_BUILD=1
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -34,6 +34,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      id-token: write # required for AWS credentials
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
@@ -71,3 +72,8 @@ jobs:
       - name: Run tests
         timeout-minutes: 20
         run: make -j"$(nproc)" test-go test-sh test-api
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -46,6 +46,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write # required for AWS credentials
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport19
@@ -89,3 +90,8 @@ jobs:
       - name: Run teleport-usage tests
         timeout-minutes: 15
         run: make test-teleport-usage
+
+      - name: Upload test metrics
+        if: always()
+        continue-on-error: true # Do not fail the workflow
+        uses: ./.github/actions/upload-test-metrics

--- a/integrations/Makefile
+++ b/integrations/Makefile
@@ -1,22 +1,26 @@
+TEST_LOG_DIR ?= ${abspath ./test-logs}
+
 .PHONY: test
 test: test-access test-lib test-event-handler test-terraform-provider test-terraform-provider-mwi
 
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
+
 .PHONY: test-access
-test-access:
-	gotestsum --junitfile unit-tests-integrations-access.xml --jsonfile unit-tests-integrations-access.json ./access/...
+test-access: | $(TEST_LOG_DIR)
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-integrations-access.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-integrations-access.json ./access/...
 
 .PHONY: test-lib
-test-lib:
-	gotestsum --junitfile unit-tests-integrations-lib.xml --jsonfile unit-tests-integrations-lib.json ./lib/...
-
+test-lib: | $(TEST_LOG_DIR)
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-integrations-lib.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-integrations-lib.json ./lib/...
 .PHONY: test-event-handler
-test-event-handler:
-	make -C event-handler test
+test-event-handler:  | $(TEST_LOG_DIR)
+	make -C event-handler test TEST_LOG_DIR=$(TEST_LOG_DIR)
 
 .PHONY: test-terraform-provider
-test-terraform-provider:
-	make -C terraform test
+test-terraform-provider:  | $(TEST_LOG_DIR)
+	make -C terraform test TEST_LOG_DIR=$(TEST_LOG_DIR)
 
 .PHONY: test-terraform-provider-mwi
-test-terraform-provider-mwi:
-	make -C terraform-mwi test
+test-terraform-provider-mwi:  | $(TEST_LOG_DIR)
+	make -C terraform-mwi test TEST_LOG_DIR=$(TEST_LOG_DIR)

--- a/integrations/event-handler/Makefile
+++ b/integrations/event-handler/Makefile
@@ -14,6 +14,7 @@ GENTERRAFORMPATH := $(shell go env GOPATH)/bin
 
 BUILDDIR ?= build
 BINARY = $(BUILDDIR)/teleport-event-handler
+TEST_LOG_DIR ?= ${abspath ./test-logs}
 
 GITREF ?= $(shell git describe --dirty --long --tags --match '$(VERSION)')
 ADDFLAGS ?=
@@ -94,9 +95,13 @@ docker-publish: ## Publishes a docker image from the private ECR registry to the
 install: build
 	go install
 
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
+
+
 .PHONY: test
-test:
-	gotestsum --junitfile unit-tests-event-handler.xml --jsonfile unit-tests-event-handler.json
+test: | $(TEST_LOG_DIR)
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-event-handler.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-event-handler.json
 
 .PHONY: configure
 configure: build

--- a/integrations/kube-agent-updater/Makefile
+++ b/integrations/kube-agent-updater/Makefile
@@ -7,10 +7,14 @@ include ../../build.assets/images.mk
 # Configure which compiler and buildbox to use
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
+TEST_LOG_DIR ?= ${abspath ./test-logs}
 
 .PHONY: test
-test: pkg/img/cosign_fixtures_test.go
-	gotestsum --junitfile unit-tests-kube-agent-updater.xml --jsonfile unit-tests-kube-agent-updater.json
+test: pkg/img/cosign_fixtures_test.go | $(TEST_LOG_DIR)
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-kube-agent-updater.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-kube-agent-updater.json
+
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
 
 .PHONY: docker-build
 docker-build: ## Build docker image

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -41,6 +41,8 @@ PLATFORM_BUILDBOX ?= $(BUILDBOX_ARM)
 endif
 endif
 
+TEST_LOG_DIR ?= ${abspath ./test-logs}
+
 .PHONY: all
 all: build
 
@@ -165,9 +167,12 @@ debug-dump-request:
 			"$${proto}"; \
 	done
 
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
+
 .PHONY: test
-test: generate ## Run tests.
-	gotestsum --junitfile unit-tests-operator.xml --jsonfile unit-tests-operator.json
+test: generate | $(TEST_LOG_DIR) ## Run tests.
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-operator.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-operator.json
 
 ##@ Build
 

--- a/integrations/terraform-mwi/Makefile
+++ b/integrations/terraform-mwi/Makefile
@@ -7,6 +7,7 @@ TERRAFORM_ARCH=$(OS)_$(ARCH)
 RELEASE = terraform-provider-teleportmwi-v$(VERSION)-$(OS)-$(ARCH)-bin
 
 BUILDDIR ?= build
+TEST_LOG_DIR ?= ${abspath ./test-logs}
 
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -trimpath -ldflags '-w -s'
@@ -56,9 +57,12 @@ release: build
 endif
 	tar -C $(BUILDDIR) -czf $(RELEASE).tar.gz .
 
-PHONY: test
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
+
+PHONY: test | $(TEST_LOG_DIR)
 test:
-	gotestsum --junitfile unit-tests-terraform-mwi.xml --jsonfile unit-tests-terraform-mwi.json
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-terraform-mwi.xml --jsonfile $(TEST_LOG_DIR)/unit-tests-terraform-mwi.json
 
 PHONY: testacc
 testacc:

--- a/integrations/terraform/Makefile
+++ b/integrations/terraform/Makefile
@@ -5,6 +5,7 @@ PROTOC_GEN_TERRAFORM:= $(shell command -v protoc-gen-terraform)
 
 BUILDDIR ?= build
 TFDIR ?= example
+TEST_LOG_DIR ?= ${abspath ./test-logs}
 
 ADDFLAGS ?=
 BUILDFLAGS ?= $(ADDFLAGS) -trimpath -ldflags '-w -s'
@@ -209,15 +210,19 @@ CURRENT_ULIMIT := $(shell ulimit -n)
 
 TEST_ARGS?=
 
+
+$(TEST_LOG_DIR):
+	mkdir $(TEST_LOG_DIR)
+
 .PHONY: test
-test: install
+test: install | $(TEST_LOG_DIR)
 ifndef TERRAFORM_EXISTS
 	@echo "Terraform v1.4+ is not installed (tfenv install 1.5.6 && tfenv use 1.5.6)."
 	terraform -version
 	@exit -1
 endif
 
-	gotestsum --junitfile unit-tests-terraform.xml --jsonfile unit-tests-terraform.json -- ./testlib -v $(TEST_ARGS)
+	gotestsum --junitfile $(TEST_LOG_DIR)/unit-tests-terraform.xml --jsonfile unit-tests-terraform.json -- ./testlib -v $(TEST_ARGS)
 
 .PHONY: test-full
 test-full: TEST_ARGS=--tags enterprisetests


### PR DESCRIPTION
The upload steps are non-blocking, should they
fail the workflow status will not be affected.

This commit also changes the way the test logs are created, now each Makefile accepts `TEST_LOG_DIR` as an optional parameter, defaulting to `./test-logs`. This allows the top level Makefile to propagate the location for the sub modules to write their junit output, such that the CI jobs do not need to track which top level make target corresponds to which directory. Instead a simple glob is used to grab all the xml JUNIT files.

This approach also allows more targets to be added or removed in the future without modifying the CI job definitons. Another benefit is allowing the caller to modify the output destination should we want to bundle the files as job artifacts in the future.

Makes `TEST_LOG_DIR` an order only dep for all targets.