### PR TITLE
Refactor: rename backend.CircularBuffer -> backend.EventFanout

### DIFF
--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -54,8 +54,8 @@ type BufferOption = EventFanoutOption
 // Deprecated: Use EventFanout instead.
 type CircularBuffer = EventFanout
 
-// BufferCapacity sets the event capacity of the event fanout.
-func BufferCapacity(c int) EventFanoutOption {
+// WithCapacity sets the event capacity of the event fanout.
+func WithCapacity(c int) EventFanoutOption {
 	return func(cfg *eventFanoutConfig) {
 		if c > 0 {
 			cfg.capacity = c
@@ -63,8 +63,8 @@ func BufferCapacity(c int) EventFanoutOption {
 	}
 }
 
-// BacklogGracePeriod sets the amount of time a watcher with a backlog will be tolerated.
-func BacklogGracePeriod(d time.Duration) EventFanoutOption {
+// WithBacklogGracePeriod sets the amount of time a watcher with a backlog will be tolerated.
+func WithBacklogGracePeriod(d time.Duration) EventFanoutOption {
 	return func(cfg *eventFanoutConfig) {
 		if d > 0 {
 			cfg.gracePeriod = d
@@ -72,9 +72,9 @@ func BacklogGracePeriod(d time.Duration) EventFanoutOption {
 	}
 }
 
-// CreationGracePeriod sets the amount of time delay after watcher creation before
+// WithCreationGracePeriod sets the amount of time delay after watcher creation before
 // it will be considered for removal due to backlog.
-func CreationGracePeriod(d time.Duration) EventFanoutOption {
+func WithCreationGracePeriod(d time.Duration) EventFanoutOption {
 	return func(cfg *eventFanoutConfig) {
 		if d > 0 {
 			cfg.creationGracePeriod = d
@@ -82,8 +82,8 @@ func CreationGracePeriod(d time.Duration) EventFanoutOption {
 	}
 }
 
-// BufferClock sets a custom clock for the event fanout (used in tests).
-func BufferClock(c clockwork.Clock) EventFanoutOption {
+// WithClock sets a custom clock for the event fanout (used in tests).
+func WithClock(c clockwork.Clock) EventFanoutOption {
 	return func(cfg *eventFanoutConfig) {
 		if c != nil {
 			cfg.clock = c

--- a/lib/backend/buffer.go
+++ b/lib/backend/buffer.go
@@ -37,18 +37,26 @@ import (
 	logutils "github.com/gravitational/teleport/lib/utils/log"
 )
 
-type bufferConfig struct {
+type eventFanoutConfig struct {
 	gracePeriod         time.Duration
 	creationGracePeriod time.Duration
 	capacity            int
 	clock               clockwork.Clock
 }
 
-type BufferOption func(*bufferConfig)
+type EventFanoutOption func(*eventFanoutConfig)
 
-// BufferCapacity sets the event capacity of the circular buffer.
-func BufferCapacity(c int) BufferOption {
-	return func(cfg *bufferConfig) {
+// BufferOption is a deprecated alias for EventFanoutOption.
+// Deprecated: Use EventFanoutOption instead.
+type BufferOption = EventFanoutOption
+
+// CircularBuffer is a deprecated alias for EventFanout.
+// Deprecated: Use EventFanout instead.
+type CircularBuffer = EventFanout
+
+// BufferCapacity sets the event capacity of the event fanout.
+func BufferCapacity(c int) EventFanoutOption {
+	return func(cfg *eventFanoutConfig) {
 		if c > 0 {
 			cfg.capacity = c
 		}
@@ -56,8 +64,8 @@ func BufferCapacity(c int) BufferOption {
 }
 
 // BacklogGracePeriod sets the amount of time a watcher with a backlog will be tolerated.
-func BacklogGracePeriod(d time.Duration) BufferOption {
-	return func(cfg *bufferConfig) {
+func BacklogGracePeriod(d time.Duration) EventFanoutOption {
+	return func(cfg *eventFanoutConfig) {
 		if d > 0 {
 			cfg.gracePeriod = d
 		}
@@ -66,36 +74,36 @@ func BacklogGracePeriod(d time.Duration) BufferOption {
 
 // CreationGracePeriod sets the amount of time delay after watcher creation before
 // it will be considered for removal due to backlog.
-func CreationGracePeriod(d time.Duration) BufferOption {
-	return func(cfg *bufferConfig) {
+func CreationGracePeriod(d time.Duration) EventFanoutOption {
+	return func(cfg *eventFanoutConfig) {
 		if d > 0 {
 			cfg.creationGracePeriod = d
 		}
 	}
 }
 
-// BufferClock sets a custom clock for the buffer (used in tests).
-func BufferClock(c clockwork.Clock) BufferOption {
-	return func(cfg *bufferConfig) {
+// BufferClock sets a custom clock for the event fanout (used in tests).
+func BufferClock(c clockwork.Clock) EventFanoutOption {
+	return func(cfg *eventFanoutConfig) {
 		if c != nil {
 			cfg.clock = c
 		}
 	}
 }
 
-// CircularBuffer implements in-memory circular buffer
-// of predefined size, that is capable of fan-out of the backend events.
-type CircularBuffer struct {
+// EventFanout implements in-memory event fanout broadcaster
+// that is capable of fan-out of the backend events to multiple watchers.
+type EventFanout struct {
 	sync.Mutex
 	logger       *slog.Logger
-	cfg          bufferConfig
+	cfg          eventFanoutConfig
 	init, closed bool
 	watchers     *watcherTree
 }
 
-// NewCircularBuffer returns a new uninitialized instance of circular buffer.
-func NewCircularBuffer(opts ...BufferOption) *CircularBuffer {
-	cfg := bufferConfig{
+// NewEventFanout returns a new uninitialized instance of event fanout.
+func NewEventFanout(opts ...EventFanoutOption) *EventFanout {
+	cfg := eventFanoutConfig{
 		gracePeriod:         DefaultBacklogGracePeriod,
 		creationGracePeriod: DefaultCreationGracePeriod,
 		capacity:            DefaultBufferCapacity,
@@ -104,16 +112,22 @@ func NewCircularBuffer(opts ...BufferOption) *CircularBuffer {
 	for _, opt := range opts {
 		opt(&cfg)
 	}
-	return &CircularBuffer{
+	return &EventFanout{
 		logger:   slog.With(teleport.ComponentKey, teleport.ComponentBuffer),
 		cfg:      cfg,
 		watchers: newWatcherTree(),
 	}
 }
 
+// NewCircularBuffer is a deprecated alias for NewEventFanout.
+// Deprecated: Use NewEventFanout instead.
+func NewCircularBuffer(opts ...EventFanoutOption) *EventFanout {
+	return NewEventFanout(opts...)
+}
+
 // Clear clears all events from the queue and closes all active watchers,
 // but does not modify init state.
-func (c *CircularBuffer) Clear() {
+func (c *EventFanout) Clear() {
 	c.Lock()
 	defer c.Unlock()
 	c.clear()
@@ -123,14 +137,14 @@ func (c *CircularBuffer) Clear() {
 // an uninitialized state.  This method should only be used when resetting
 // after a broken event stream.  If only closure of watchers is desired,
 // use Clear instead.
-func (c *CircularBuffer) Reset() {
+func (c *EventFanout) Reset() {
 	c.Lock()
 	defer c.Unlock()
 	c.clear()
 	c.init = false
 }
 
-func (c *CircularBuffer) clear() {
+func (c *EventFanout) clear() {
 	// could close multiple times
 	c.watchers.walk(func(w *BufferWatcher) {
 		w.closeWatcher()
@@ -142,7 +156,7 @@ func (c *CircularBuffer) clear() {
 // will be sent init events, and watchers added after this call will have their init events sent immediately.
 // This function must be called *after* establishing a healthy parent event stream in order to preserve
 // correct cache behavior.
-func (c *CircularBuffer) SetInit() {
+func (c *EventFanout) SetInit() {
 	c.Lock()
 	defer c.Unlock()
 	if c.init {
@@ -166,7 +180,7 @@ func (c *CircularBuffer) SetInit() {
 }
 
 // Close closes circular buffer and all watchers
-func (c *CircularBuffer) Close() error {
+func (c *EventFanout) Close() error {
 	c.Lock()
 	defer c.Unlock()
 	c.clear()
@@ -180,7 +194,7 @@ func (c *CircularBuffer) Close() error {
 // Emit emits events to currently registered watchers and stores them to
 // the buffer.  Panics if called before SetInit(), and returns false if called
 // after Close().
-func (c *CircularBuffer) Emit(events ...Event) (ok bool) {
+func (c *EventFanout) Emit(events ...Event) (ok bool) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -194,14 +208,14 @@ func (c *CircularBuffer) Emit(events ...Event) (ok bool) {
 	return true
 }
 
-func (c *CircularBuffer) emit(r Event) {
+func (c *EventFanout) emit(r Event) {
 	if !c.init {
 		panic("push called on uninitialized buffer instance")
 	}
 	c.fanOutEvent(r)
 }
 
-func (c *CircularBuffer) fanOutEvent(r Event) {
+func (c *EventFanout) fanOutEvent(r Event) {
 	var watchersToDelete []*BufferWatcher
 	c.watchers.walkPath(r.Item.Key.String(), func(watcher *BufferWatcher) {
 		if watcher.MetricComponent != "" {
@@ -243,7 +257,7 @@ func RemoveRedundantPrefixes(prefixes []Key) []Key {
 }
 
 // NewWatcher adds a new watcher to the events buffer
-func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, error) {
+func (c *EventFanout) NewWatcher(ctx context.Context, watch Watch) (Watcher, error) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -267,13 +281,13 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 
 	closeCtx, cancel := context.WithCancel(ctx)
 	w := &BufferWatcher{
-		buffer:   c,
-		Watch:    watch,
-		eventsC:  make(chan Event, watch.QueueSize),
-		created:  c.cfg.clock.Now(),
-		ctx:      closeCtx,
-		cancel:   cancel,
-		capacity: watch.QueueSize,
+		eventFanout: c,
+		Watch:       watch,
+		eventsC:     make(chan Event, watch.QueueSize),
+		created:     c.cfg.clock.Now(),
+		ctx:         closeCtx,
+		cancel:      cancel,
+		capacity:    watch.QueueSize,
 	}
 	c.logger.DebugContext(ctx, "Adding watcher", "watcher", logutils.StringerAttr(w))
 	if c.init {
@@ -286,7 +300,7 @@ func (c *CircularBuffer) NewWatcher(ctx context.Context, watch Watch) (Watcher, 
 	return w, nil
 }
 
-func (c *CircularBuffer) removeWatcherWithLock(watcher *BufferWatcher) {
+func (c *EventFanout) removeWatcherWithLock(watcher *BufferWatcher) {
 	ctx := context.Background()
 	c.Lock()
 	defer c.Unlock()
@@ -302,9 +316,9 @@ func (c *CircularBuffer) removeWatcherWithLock(watcher *BufferWatcher) {
 }
 
 // BufferWatcher is a watcher connected to the
-// buffer and receiving fan-out events from the watcher
+// event fanout and receiving fan-out events from the watcher
 type BufferWatcher struct {
-	buffer *CircularBuffer
+	eventFanout *EventFanout
 	Watch
 	eventsC chan Event
 
@@ -367,7 +381,7 @@ func (w *BufferWatcher) emit(e Event) (ok bool) {
 	defer w.bmu.Unlock()
 
 	if !w.flushBacklog() {
-		if now := w.buffer.cfg.clock.Now(); now.After(w.backlogSince.Add(w.buffer.cfg.gracePeriod)) && now.After(w.created.Add(w.buffer.cfg.creationGracePeriod)) {
+		if now := w.eventFanout.cfg.clock.Now(); now.After(w.backlogSince.Add(w.eventFanout.cfg.gracePeriod)) && now.After(w.created.Add(w.eventFanout.cfg.creationGracePeriod)) {
 			// backlog has existed for longer than grace period,
 			// this watcher needs to be removed.
 			return false
@@ -382,7 +396,7 @@ func (w *BufferWatcher) emit(e Event) (ok bool) {
 	default:
 		// primary event buffer is full; start backlog.
 		w.backlog = append(w.backlog, e)
-		w.backlogSince = w.buffer.cfg.clock.Now()
+		w.backlogSince = w.eventFanout.cfg.clock.Now()
 	}
 	return true
 }
@@ -431,9 +445,9 @@ const (
 func (w *BufferWatcher) closeAndRemove(sync bool) {
 	w.closeWatcher()
 	if sync {
-		w.buffer.removeWatcherWithLock(w)
+		w.eventFanout.removeWatcherWithLock(w)
 	} else {
-		go w.buffer.removeWatcherWithLock(w)
+		go w.eventFanout.removeWatcherWithLock(w)
 	}
 }
 

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -35,7 +35,7 @@ import (
 func TestWatcherSimple(t *testing.T) {
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(3),
+		WithCapacity(3),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -80,10 +80,10 @@ func TestWatcherCapacity(t *testing.T) {
 
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(1),
-		BufferClock(clock),
-		BacklogGracePeriod(gracePeriod),
-		CreationGracePeriod(time.Nanosecond),
+		WithCapacity(1),
+		WithClock(clock),
+		WithBacklogGracePeriod(gracePeriod),
+		WithCreationGracePeriod(time.Nanosecond),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -154,10 +154,10 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(1),
-		BufferClock(clock),
-		BacklogGracePeriod(backlogGracePeriod),
-		CreationGracePeriod(creationGracePeriod),
+		WithCapacity(1),
+		WithClock(clock),
+		WithBacklogGracePeriod(backlogGracePeriod),
+		WithCreationGracePeriod(creationGracePeriod),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -216,7 +216,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 func TestWatcherClose(t *testing.T) {
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(3),
+		WithCapacity(3),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -274,7 +274,7 @@ func TestRemoveRedundantPrefixes(t *testing.T) {
 func TestWatcherMulti(t *testing.T) {
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(3),
+		WithCapacity(3),
 	)
 	defer b.Close()
 	b.SetInit()
@@ -306,7 +306,7 @@ func TestWatcherMulti(t *testing.T) {
 func TestWatcherReset(t *testing.T) {
 	ctx := context.Background()
 	b := NewEventFanout(
-		BufferCapacity(3),
+		WithCapacity(3),
 	)
 	defer b.Close()
 	b.SetInit()

--- a/lib/backend/buffer_test.go
+++ b/lib/backend/buffer_test.go
@@ -34,7 +34,7 @@ import (
 // TestWatcherSimple tests scenarios with watchers
 func TestWatcherSimple(t *testing.T) {
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(3),
 	)
 	defer b.Close()
@@ -79,7 +79,7 @@ func TestWatcherCapacity(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(1),
 		BufferClock(clock),
 		BacklogGracePeriod(gracePeriod),
@@ -153,7 +153,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(1),
 		BufferClock(clock),
 		BacklogGracePeriod(backlogGracePeriod),
@@ -215,7 +215,7 @@ func TestWatcherCreationGracePeriod(t *testing.T) {
 // will be removed
 func TestWatcherClose(t *testing.T) {
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(3),
 	)
 	defer b.Close()
@@ -273,7 +273,7 @@ func TestRemoveRedundantPrefixes(t *testing.T) {
 // with multiple matching prefixes will get an event only once
 func TestWatcherMulti(t *testing.T) {
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(3),
 	)
 	defer b.Close()
@@ -305,7 +305,7 @@ func TestWatcherMulti(t *testing.T) {
 // TestWatcherReset tests scenarios with watchers and buffer resets
 func TestWatcherReset(t *testing.T) {
 	ctx := context.Background()
-	b := NewCircularBuffer(
+	b := NewEventFanout(
 		BufferCapacity(3),
 	)
 	defer b.Close()

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -334,7 +334,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 		logger:      l,
 		Config:      *cfg,
 		clock:       clockwork.NewRealClock(),
-		eventFanout: backend.NewEventFanout(backend.BufferCapacity(cfg.BufferSize)),
+		eventFanout: backend.NewEventFanout(backend.WithCapacity(cfg.BufferSize)),
 		svc:         dynamoClient,
 		streams:     streamsClient,
 	}

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -165,11 +165,11 @@ type dynamoClient interface {
 
 // Backend is a DynamoDB-backed key value backend implementation.
 type Backend struct {
-	svc     dynamoClient
-	clock   clockwork.Clock
-	logger  *slog.Logger
-	streams *dynamodbstreams.Client
-	buf     *backend.CircularBuffer
+	svc         dynamoClient
+	clock       clockwork.Clock
+	logger      *slog.Logger
+	streams     *dynamodbstreams.Client
+	eventFanout *backend.EventFanout
 	Config
 	// closedFlag is set to indicate that the database is closed
 	closedFlag int32
@@ -331,12 +331,12 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 
 	streamsClient := dynamodbstreams.NewFromConfig(awsConfig, streamsOpts...)
 	b := &Backend{
-		logger:  l,
-		Config:  *cfg,
-		clock:   clockwork.NewRealClock(),
-		buf:     backend.NewCircularBuffer(backend.BufferCapacity(cfg.BufferSize)),
-		svc:     dynamoClient,
-		streams: streamsClient,
+		logger:      l,
+		Config:      *cfg,
+		clock:       clockwork.NewRealClock(),
+		eventFanout: backend.NewEventFanout(backend.BufferCapacity(cfg.BufferSize)),
+		svc:         dynamoClient,
+		streams:     streamsClient,
 	}
 
 	if err := b.configureTable(ctx, applicationautoscaling.NewFromConfig(awsConfig)); err != nil {
@@ -887,7 +887,7 @@ func (b *Backend) ConditionalDelete(ctx context.Context, key backend.Key, rev st
 
 // NewWatcher returns a new event watcher
 func (b *Backend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	return b.buf.NewWatcher(ctx, watch)
+	return b.eventFanout.NewWatcher(ctx, watch)
 }
 
 // KeepAlive keeps object from expiring, updates lease on the existing object,
@@ -931,13 +931,13 @@ func (b *Backend) setClosed() {
 // and releases associated resources
 func (b *Backend) Close() error {
 	b.setClosed()
-	return b.buf.Close()
+	return b.eventFanout.Close()
 }
 
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (b *Backend) CloseWatchers() {
-	b.buf.Clear()
+	b.eventFanout.Clear()
 }
 
 type tableStatus int

--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -154,8 +154,8 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 	}
 
 	// shard iterators are initialized, unblock any registered watchers
-	b.buf.SetInit()
-	defer b.buf.Reset()
+	b.eventFanout.SetInit()
+	defer b.eventFanout.Reset()
 
 	timer := time.NewTimer(b.PollStreamPeriod)
 	defer timer.Stop()
@@ -177,7 +177,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				}
 				b.logger.Log(ctx, logutils.TraceLevel, "Shard exited gracefully.", "shard_id", event.shardID)
 			} else {
-				b.buf.Emit(event.events...)
+				b.eventFanout.Emit(event.events...)
 			}
 		case <-timer.C:
 			if err := refreshShards(false); err != nil {

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -262,7 +262,7 @@ func New(ctx context.Context, params backend.Params, opts ...Option) (*EtcdBacke
 	}
 
 	eventFanout := backend.NewEventFanout(
-		backend.BufferCapacity(cfg.BufferSize),
+		backend.WithCapacity(cfg.BufferSize),
 	)
 	closeCtx, cancel := context.WithCancel(ctx)
 

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -157,7 +157,7 @@ type EtcdBackend struct {
 	cancelC     chan bool
 	stopC       chan bool
 	clock       clockwork.Clock
-	buf         *backend.CircularBuffer
+	eventFanout *backend.EventFanout
 	leaseBucket time.Duration
 	leaseCache  *utils.FnCache
 	ctx         context.Context
@@ -261,7 +261,7 @@ func New(ctx context.Context, params backend.Params, opts ...Option) (*EtcdBacke
 		return nil, trace.Wrap(err)
 	}
 
-	buf := backend.NewCircularBuffer(
+	eventFanout := backend.NewEventFanout(
 		backend.BufferCapacity(cfg.BufferSize),
 	)
 	closeCtx, cancel := context.WithCancel(ctx)
@@ -288,7 +288,7 @@ func New(ctx context.Context, params backend.Params, opts ...Option) (*EtcdBacke
 		cancel:      cancel,
 		ctx:         closeCtx,
 		watchDone:   make(chan struct{}),
-		buf:         buf,
+		eventFanout: eventFanout,
 		leaseBucket: retryutils.SeventhJitter(options.leaseBucket),
 		leaseCache:  leaseCache,
 	}
@@ -414,7 +414,7 @@ func (b *EtcdBackend) Clock() clockwork.Clock {
 
 func (b *EtcdBackend) Close() error {
 	b.cancel()
-	b.buf.Close()
+	b.eventFanout.Close()
 	var errs []error
 	if b.clients != nil {
 		b.clients.ForEach(func(clt *clientv3.Client) {
@@ -427,7 +427,7 @@ func (b *EtcdBackend) Close() error {
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (b *EtcdBackend) CloseWatchers() {
-	b.buf.Clear()
+	b.eventFanout.Clear()
 }
 
 func (b *EtcdBackend) reconnect(ctx context.Context) error {
@@ -575,13 +575,13 @@ func (b *EtcdBackend) watchEvents(ctx context.Context) error {
 	eventsC := b.clients.Next().Watch(ctx, b.cfg.Key, clientv3.WithPrefix())
 
 	// set buffer to initialized state.
-	b.buf.SetInit()
+	b.eventFanout.SetInit()
 
 	// ensure correct cleanup ordering (buffer must not be reset until event emission has halted).
 	defer func() {
 		q.Close()
 		<-emitDone
-		b.buf.Reset()
+		b.eventFanout.Reset()
 	}()
 
 	// launch background process responsible for event emission.
@@ -595,7 +595,7 @@ func (b *EtcdBackend) watchEvents(ctx context.Context) error {
 					b.logger.ErrorContext(ctx, "Failed to unmarshal event", "event", r.original, "error", r.err)
 					continue EmitEvents
 				}
-				b.buf.Emit(r.event)
+				b.eventFanout.Emit(r.event)
 			case <-q.Done():
 				return
 			}
@@ -646,7 +646,7 @@ func (b *EtcdBackend) watchEvents(ctx context.Context) error {
 
 // NewWatcher returns a new event watcher
 func (b *EtcdBackend) NewWatcher(ctx context.Context, watch backend.Watch) (backend.Watcher, error) {
-	return b.buf.NewWatcher(ctx, watch)
+	return b.eventFanout.NewWatcher(ctx, watch)
 }
 
 func (b *EtcdBackend) Items(ctx context.Context, params backend.ItemsParams) iter.Seq2[backend.Item, error] {

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -409,7 +409,7 @@ func New(ctx context.Context, params backend.Params, options Options) (*Backend,
 	defer firestoreAdminClient.Close()
 
 	eventFanout := backend.NewEventFanout(
-		backend.BufferCapacity(cfg.BufferSize),
+		backend.WithCapacity(cfg.BufferSize),
 	)
 
 	b := &Backend{

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -245,7 +245,7 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 	// and in-memory go locks are faster than sqlite locks
 	db.SetMaxOpenConns(1)
 	eventFanout := backend.NewEventFanout(
-		backend.BufferCapacity(cfg.BufferSize),
+		backend.WithCapacity(cfg.BufferSize),
 	)
 	closeCtx, cancel := context.WithCancel(ctx)
 	l := &Backend{

--- a/lib/backend/lite/periodic.go
+++ b/lib/backend/lite/periodic.go
@@ -150,7 +150,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 			return rowid, trace.Wrap(err)
 		}
 		l.logger.DebugContext(l.ctx, "Initialized event ID iterator", "event_id", rowid)
-		l.buf.SetInit()
+		l.eventFanout.SetInit()
 	}
 
 	var events []backend.Event
@@ -187,7 +187,7 @@ func (l *Backend) pollEvents(rowid int64) (int64, error) {
 	if err != nil {
 		return rowid, trace.Wrap(err)
 	}
-	l.buf.Emit(events...)
+	l.eventFanout.Emit(events...)
 	if len(events) != 0 {
 		return lastID, nil
 	}

--- a/lib/backend/memory/atomicwrite.go
+++ b/lib/backend/memory/atomicwrite.go
@@ -98,7 +98,7 @@ func (m *Memory) AtomicWrite(ctx context.Context, condacts []backend.Conditional
 	for _, event := range events {
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Emit(event)
+			m.eventFanout.Emit(event)
 		}
 	}
 

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -95,7 +95,7 @@ func New(cfg Config) (*Memory, error) {
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
 	eventFanout := backend.NewEventFanout(
-		backend.BufferCapacity(cfg.BufferSize),
+		backend.WithCapacity(cfg.BufferSize),
 	)
 	eventFanout.SetInit()
 	m := &Memory{

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -94,10 +94,10 @@ func New(cfg Config) (*Memory, error) {
 		return nil, trace.Wrap(err)
 	}
 	ctx, cancel := context.WithCancel(cfg.Context)
-	buf := backend.NewCircularBuffer(
+	eventFanout := backend.NewEventFanout(
 		backend.BufferCapacity(cfg.BufferSize),
 	)
-	buf.SetInit()
+	eventFanout.SetInit()
 	m := &Memory{
 		Mutex:  &sync.Mutex{},
 		logger: slog.With(teleport.ComponentKey, teleport.ComponentMemory),
@@ -105,10 +105,10 @@ func New(cfg Config) (*Memory, error) {
 		tree: btree.NewG(cfg.BTreeDegree, func(a, b *btreeItem) bool {
 			return a.Less(b)
 		}),
-		heap:   newMinHeap(),
-		cancel: cancel,
-		ctx:    ctx,
-		buf:    buf,
+		heap:        newMinHeap(),
+		cancel:      cancel,
+		ctx:         ctx,
+		eventFanout: eventFanout,
 	}
 	return m, nil
 }
@@ -126,8 +126,8 @@ type Memory struct {
 	// all operations
 	cancel context.CancelFunc
 	// ctx is a context signaling close
-	ctx context.Context
-	buf *backend.CircularBuffer
+	ctx         context.Context
+	eventFanout *backend.EventFanout
 }
 
 func (m *Memory) GetName() string {
@@ -139,14 +139,14 @@ func (m *Memory) Close() error {
 	m.cancel()
 	m.Lock()
 	defer m.Unlock()
-	m.buf.Close()
+	m.eventFanout.Close()
 	return nil
 }
 
 // CloseWatchers closes all the watchers
 // without closing the backend
 func (m *Memory) CloseWatchers() {
-	m.buf.Clear()
+	m.eventFanout.Clear()
 }
 
 // Clock returns clock used by this backend
@@ -172,7 +172,7 @@ func (m *Memory) Create(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return backend.NewLease(i), nil
 }
@@ -212,7 +212,7 @@ func (m *Memory) Update(ctx context.Context, i backend.Item) (*backend.Lease, er
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return backend.NewLease(i), nil
 }
@@ -235,7 +235,7 @@ func (m *Memory) Put(ctx context.Context, i backend.Item) (*backend.Lease, error
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return backend.NewLease(i), nil
 }
@@ -260,7 +260,7 @@ func (m *Memory) Delete(ctx context.Context, key backend.Key) error {
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return nil
 }
@@ -296,7 +296,7 @@ func (m *Memory) DeleteRange(ctx context.Context, startKey, endKey backend.Key) 
 		}
 		m.processEvent(event)
 		if !m.EventsOff {
-			m.buf.Emit(event)
+			m.eventFanout.Emit(event)
 		}
 	}
 	return nil
@@ -428,7 +428,7 @@ func (m *Memory) KeepAlive(ctx context.Context, lease backend.Lease, expires tim
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return nil
 }
@@ -464,7 +464,7 @@ func (m *Memory) CompareAndSwap(ctx context.Context, expected backend.Item, repl
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return backend.NewLease(replaceWith), nil
 }
@@ -491,7 +491,7 @@ func (m *Memory) ConditionalDelete(ctx context.Context, key backend.Key, rev str
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return nil
 }
@@ -519,7 +519,7 @@ func (m *Memory) ConditionalUpdate(ctx context.Context, i backend.Item) (*backen
 	}
 	m.processEvent(event)
 	if !m.EventsOff {
-		m.buf.Emit(event)
+		m.eventFanout.Emit(event)
 	}
 	return backend.NewLease(i), nil
 }
@@ -529,7 +529,7 @@ func (m *Memory) NewWatcher(ctx context.Context, watch backend.Watch) (backend.W
 	if m.EventsOff {
 		return nil, trace.BadParameter("events are turned off for this backend")
 	}
-	return m.buf.NewWatcher(ctx, watch)
+	return m.eventFanout.NewWatcher(ctx, watch)
 }
 
 // removeExpired makes a pass through map and removes expired elements
@@ -560,7 +560,7 @@ func (m *Memory) removeExpired() int {
 			},
 		}
 		if !m.EventsOff {
-			m.buf.Emit(event)
+			m.eventFanout.Emit(event)
 		}
 	}
 	if removed > 0 {


### PR DESCRIPTION
### What

The current backend.CircularBuffer is  confusing itself is is not [Circular buffer](https://en.wikipedia.org/wiki/Circular_buffer). Rename it  backend.CircularBuffer ->  backend.EventFanout to not confuse the reader how backend event stream is working. 


#### Backward compatibility. 

Type alias was created to not break crdb e dependency that will be updated shortly. 