### PR TITLE
Web: Process origin query param when generating resources path

### DIFF
--- a/web/packages/design/src/Alert/Alert.tsx
+++ b/web/packages/design/src/Alert/Alert.tsx
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { LocationDescriptor } from 'history';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled, { useTheme } from 'styled-components';
@@ -155,7 +156,7 @@ export interface Action {
   /**
    * a link that takes you to a different route within the app
    */
-  linkTo?: string;
+  linkTo?: LocationDescriptor;
   onClick?: (event: React.MouseEvent) => void;
 }
 

--- a/web/packages/teleport/src/generateResourcePath.ts
+++ b/web/packages/teleport/src/generateResourcePath.ts
@@ -79,6 +79,7 @@ export default function generateResourcePath(
     .replace(':upgraders?', processedParams.upgraders || '')
     .replace(':regions?', processedParams.regions || '')
     .replace(':owners?', processedParams.owners || '')
+    .replace(':origin?', processedParams.origin || '')
     .replace(':roles?', processedParams.roles || '')
     .replace(
       ':includedResourceMode?',


### PR DESCRIPTION
Adds origin query param when generating resources path required by https://github.com/gravitational/teleport.e/pull/8028

I also sneaked in a type change where Alert.tsx, you can now pass a string or location descriptor with `linkTo` field e.g. `linkTo: {pathname: cfg.XXX, state: {...some state to pass...}`