### PR TITLE
[v17] Fix event handler plugin name for CLI help messages

### DIFF
--- a/integrations/event-handler/configure_cmd.go
+++ b/integrations/event-handler/configure_cmd.go
@@ -141,7 +141,7 @@ func RunConfigureCmd(cfg *ConfigureCmdConfig) error {
 
 // Run runs the generator
 func (c *ConfigureCmd) Run() error {
-	fmt.Printf("Teleport event handler %v %v\n\n", Version, Gitref)
+	fmt.Printf("%v %v %v\n\n", pluginName, Version, Gitref)
 
 	c.step = 1
 

--- a/integrations/event-handler/main.go
+++ b/integrations/event-handler/main.go
@@ -36,7 +36,7 @@ var cli CLI
 
 const (
 	// pluginName is the plugin name
-	pluginName = "Teleport event handler"
+	pluginName = "teleport-event-handler"
 
 	// pluginDescription is the plugin description
 	pluginDescription = "Forwards Teleport AuditLog to external sources"


### PR DESCRIPTION
Backport #63525 to branch/v17

TODO: bump e ref before merging

changelog: Revised help messages for event handler CLI commands