### PR TITLE
chore(discover): address misc user feedback for Aws IaC flow

### DIFF
--- a/web/packages/build/jest/setupTests.ts
+++ b/web/packages/build/jest/setupTests.ts
@@ -43,6 +43,8 @@ try {
 Object.defineProperty(globalThis, 'crypto', {
   value: {
     randomUUID: () => crypto.randomUUID(),
+    getRandomValues: (arr =>
+      crypto.getRandomValues(arr)) as typeof crypto.getRandomValues,
   },
 });
 

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/DeploymentMethodSection.tsx
@@ -130,15 +130,26 @@ export function DeploymentMethodSection({
           <Text bold={true} fontSize="14px">
             2. Initialize and apply the configuration
           </Text>
-          <Text>
-            Run the following commands in your terminal. <br />
-            Initialize Terraform to download the module, then apply the
-            configuration to create the integration and configure the discovery
-            service.
-          </Text>
-          <TextSelectCopyMulti
-            lines={[{ text: `terraform init` }, { text: `terraform apply` }]}
-          />
+          <DeploymentList>
+            <li>
+              <Text>
+                In your terminal, initialize Terraform to download the Teleport
+                discovery module.
+              </Text>
+              <TextSelectCopyMulti lines={[{ text: `terraform init` }]} />
+            </li>
+            <li>
+              <Text>Verify your changes.</Text>
+              <TextSelectCopyMulti lines={[{ text: `terraform plan` }]} />
+            </li>
+            <li>
+              <Text>
+                Apply the configuration to create the integration and configure
+                the discovery service.
+              </Text>
+              <TextSelectCopyMulti lines={[{ text: `terraform apply` }]} />
+            </li>
+          </DeploymentList>
           {showVerificationStep && (
             <Box>
               <Text bold={true} fontSize="14px" mb={2}>
@@ -250,4 +261,14 @@ export function DeploymentMethodSection({
 
 const AnimatedSpinner = styled(Spinner)`
   animation: ${rotate360} 1.5s linear infinite;
+`;
+
+const DeploymentList = styled.ul`
+  padding-left: 0px;
+  list-style-type: none;
+  margin-top: 0;
+
+  li > * {
+    margin-bottom: ${p => p.theme.space[2]}px;
+  }
 `;

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/InfoGuide.tsx
@@ -45,7 +45,11 @@ export type InfoGuideTab = 'info' | 'terraform' | null;
 export const ContentWithSidePanel = styled(Box)<{
   isPanelOpen: boolean;
   panelWidth: number;
+  contentMinWidth?: number;
 }>`
+  min-width: ${props =>
+    props.contentMinWidth ? `${props.contentMinWidth}px` : '650px'};
+
   ${props =>
     marginTransitionCss({
       sidePanelOpened: props.isPanelOpen,

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/Aws/ResourcesSection.tsx
@@ -64,7 +64,15 @@ export function ResourcesSection({
       </Text>
       <AwsService
         label="EC2 Instances"
-        helperText="Discover EC2 instances and establish SSH access through the Teleport proxy."
+        helperText={
+          <Text>
+            Discover EC2 instances and establish SSH access through the Teleport
+            proxy.
+            <br />
+            Note: If no tags are specified, all EC2 instances in the selected
+            regions will be enrolled.
+          </Text>
+        }
         tooltipText="Filter for EC2 instances by their tags. If no tags are added, Teleport will enroll all EC2 instances."
         config={ec2Config}
         onChange={onEc2Change}
@@ -77,7 +85,7 @@ type ServiceConfig = Ec2Config;
 
 type AwsServiceProps = {
   label: string;
-  helperText: string;
+  helperText: React.ReactNode;
   tooltipText: string;
   config: ServiceConfig;
   onChange: (config: ServiceConfig) => void;
@@ -107,8 +115,11 @@ function AwsService({
         checked={config.enabled}
         onChange={toggle}
       />
+      <Text fontSize="small" ml={4}>
+        Note
+      </Text>
       <Box ml={4}>
-        <FilterButton onClick={toggle} size="small">
+        <FilterButton onClick={toggle}>
           <Flex alignItems="center" gap={1} mb={2}>
             <FilterChevron size="small" expanded={config.enabled} />
             Filter by tag

--- a/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/Cloud/RegionMultiSelector/RegionMultiSelector.tsx
@@ -29,7 +29,7 @@ import { Rule } from 'shared/components/Validation/rules';
 
 import { RegionGroup, RegionId } from './types';
 
-type RegionOption = Option<RegionId>;
+type RegionOption = Option<RegionId, React.ReactNode>;
 type RegionOptionGroup = {
   label: string;
   options: RegionOption[];
@@ -60,9 +60,9 @@ function OptionWithCheckbox(
 ) {
   return (
     <components.Option {...props}>
-      <Flex alignItems="center" gap={2}>
+      <Flex gap={2}>
         <CheckboxInput checked={props.isSelected} />
-        <span>{props.children}</span>
+        <Flex flex="1">{props.children}</Flex>
       </Flex>
     </components.Option>
   );
@@ -99,7 +99,12 @@ export function RegionMultiSelector({
     label: regionGroup.name,
     options: regionGroup.regions.map(region => ({
       value: region.id,
-      label: region.name,
+      label: (
+        <Flex justifyContent="space-between" width="100%">
+          <Text as="span">{region.name}</Text>
+          <Text as="span">{region.id}</Text>
+        </Flex>
+      ),
     })),
   }));
 


### PR DESCRIPTION
## Description
Issue: https://github.com/gravitational/teleport/issues/60813
Feedback: https://docs.google.com/document/d/1uX9snRUFDxRLXb0Cu9r-eryRy37bDwOaBDBeSm9wGKU

This PR includes changes to address feedback from user testing.

- Removes Toast success, failure messages


<img width="500" height="545" alt="Screenshot 2026-02-09 at 12 33 14 PM" src="https://github.com/user-attachments/assets/58ad3d3f-f866-4fca-9445-c3dd0ba9f388" />

- _Include region id for AWS regions dropdown_


<img width="500" height="601" alt="Screenshot 2026-02-11 at 10 04 05 AM" src="https://github.com/user-attachments/assets/24b2655c-7392-4cee-9cc6-8fa1ded52db7" />

- _Break up deployment steps, include `terraform plan`_


<img width="500" height="252" alt="Screenshot 2026-02-09 at 12 32 36 PM" src="https://github.com/user-attachments/assets/95a99b5e-2b50-41c0-8066-d52fcc6902c1" />

- _Add Note clarifying Tag matchers_


<img width="450" height="171" alt="Screenshot 2026-02-09 at 12 32 30 PM" src="https://github.com/user-attachments/assets/ab54d05c-a068-462f-bb9c-bee8ba9c1eed" />

- _Provide an initial integration name_

### Manual Testing done

- clicked 'check integration' with the provided integration name and verified it displayed an error, no toasts
- used an existing integration name and was able to complete the form and navigate to the integration page
