### PR TITLE
docs: Updating cli for `tctl users update` to have correct flag in `getting-started/deploy-community.mdx`

### DIFF
--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -314,9 +314,12 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
      If a user does not already exist, you can create it with `adduser <login>` or
      use [host user creation](../enroll-resources/server-access/guides/host-user-creation.mdx).
    
-     If you do not have the permission to create new users on the Linux host, run
-     `tctl users update teleport-admin --set-logins=root,ubuntu,ec2-user,$(whoami)` to explicitly allow Teleport to
-     authenticate as the user that you have currently logged in as.
+     If you do not have permission to create new users on the Linux host, run the following command to explicitly allow Teleport to 
+     authenticate as the user that you have currently logged in as:
+     
+     ```code
+     $ tctl users update teleport-admin --set-logins=root,ubuntu,ec2-user,$(whoami)
+     ```
    
    </Admonition>
 

--- a/docs/pages/get-started/deploy-community.mdx
+++ b/docs/pages/get-started/deploy-community.mdx
@@ -315,7 +315,7 @@ allowed to log into SSH hosts as any of the principals `root`, `ubuntu`, or
      use [host user creation](../enroll-resources/server-access/guides/host-user-creation.mdx).
    
      If you do not have the permission to create new users on the Linux host, run
-     `tctl users update teleport-admin --logins=root,ubuntu,ec2-user,$(whoami)` to explicitly allow Teleport to
+     `tctl users update teleport-admin --set-logins=root,ubuntu,ec2-user,$(whoami)` to explicitly allow Teleport to
      authenticate as the user that you have currently logged in as.
    
    </Admonition>


### PR DESCRIPTION
Current command shows `--logins` for `tctl users update` when it should be `--set-logins`.