### PR TITLE
Adding scope to quic peered dials

### DIFF
--- a/lib/proxy/peer/quic/quic_test.go
+++ b/lib/proxy/peer/quic/quic_test.go
@@ -324,6 +324,9 @@ func TestBasicFunctionality(t *testing.T) {
 			if request.ConnType != "echo" {
 				return nil, trace.CompareFailed("the only conntype is echo")
 			}
+			if request.TargetScope != "/echo" {
+				return nil, trace.CompareFailed("the only scope is /echo")
+			}
 			p1, p2 := net.Pipe()
 			go func() {
 				defer close(pipeClosed)
@@ -337,7 +340,7 @@ func TestBasicFunctionality(t *testing.T) {
 
 		conn, err := client.Dial(
 			"echo.echo",
-			"",
+			"/echo",
 			&utils.NetAddr{
 				AddrNetwork: "tcp",
 				Addr:        "1.2.3.4:56",

--- a/lib/proxy/peer/quic/server.go
+++ b/lib/proxy/peer/quic/server.go
@@ -385,8 +385,9 @@ func (s *Server) handleStream(stream *quic.Stream, conn *quic.Conn, log *slog.Lo
 			Addr:        req.GetDestination().GetAddr(),
 			AddrNetwork: req.GetDestination().GetNetwork(),
 		},
-		ServerID: req.GetTargetHostId(),
-		ConnType: types.TunnelType(req.GetConnectionType()),
+		ServerID:    req.GetTargetHostId(),
+		ConnType:    types.TunnelType(req.GetConnectionType()),
+		TargetScope: req.GetTargetScope(),
 	})
 	if err != nil {
 		sendErr(err)

--- a/lib/reversetunnel/local_cluster.go
+++ b/lib/reversetunnel/local_cluster.go
@@ -691,6 +691,7 @@ func (s *localCluster) getConn(params reversetunnelclient.DialParams) (conn net.
 		}
 	}
 
+	log := s.logger.With("target_addr", logutils.StringerAttr(params.To), "tunnel_error", tunnelErr, "peer_error", peerErr)
 	// If a connection via tunnel failed directly and via a remote peer,
 	// then update the tunnel message to indicate that tunnels were not
 	// found in either place. Avoid aggregating the local and peer errors
@@ -705,13 +706,16 @@ func (s *localCluster) getConn(params reversetunnelclient.DialParams) (conn net.
 	// Skip direct dial when the tunnel error is not a not found error. This
 	// means the agent is tunneling but the connection failed for some reason.
 	if !trace.IsNotFound(tunnelErr) {
+		log.DebugContext(s.srv.ctx, "Tunnel dial failed, agent is tunneling but connection failed")
 		return nil, false, trace.ConnectionProblem(tunnelErr, "%s", tunnelMsg)
 	}
 
 	skip, err := s.skipDirectDial(params)
 	if err != nil {
+		log.DebugContext(s.srv.ctx, "Tunnel dial failed, cannot determine direct dial eligibility", "error", err)
 		return nil, false, trace.Wrap(err)
 	} else if skip {
+		log.DebugContext(s.srv.ctx, "Tunnel dial failed, skipping direct dial")
 		return nil, false, trace.ConnectionProblem(tunnelErr, "%s", tunnelMsg)
 	}
 
@@ -719,10 +723,7 @@ func (s *localCluster) getConn(params reversetunnelclient.DialParams) (conn net.
 	conn, directErr = s.dialDirect(params)
 	if directErr != nil {
 		directMsg := getTunnelErrorMessage(params, "direct dial", directErr)
-		s.logger.DebugContext(s.srv.ctx, "All attempted dial methods failed",
-			"target_addr", logutils.StringerAttr(params.To),
-			"tunnel_error", tunnelErr,
-			"peer_error", peerErr,
+		log.DebugContext(s.srv.ctx, "All attempted dial methods failed",
 			"direct_error", directErr,
 		)
 		aggregateErr := trace.NewAggregate(tunnelErr, peerErr, directErr)


### PR DESCRIPTION
This PR populates the `TargetScope` request field when doing a peered dial using QUIC. It also adds a few more logs when acquiring a tunnel so we get more error context even if we skip direct dial.

# Manual testing
- [x] Create a cluster configured to use QUIC proxy peering (using a cloud tenant is probably the easiest way since both proxy peering and QUIC are configured by default)
- [x] Provision a node using a scoped token
- [x] Attempt to connect to the node through a proxy that is not maintaining a tunnel with that node (you can do this in cloud by using an instance geographically far from you)