### PR TITLE
Adding support for immutable labels in static scoped tokens

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1084,6 +1084,8 @@ func (t StaticToken) Parse() ([]types.ProvisionTokenV1, error) {
 // resource.
 type StaticScopedTokens []StaticScopedToken
 
+// Parse converts [StaticScopedTokens] into [*joiningv1.StaticScopedTokens] so
+// they can be used to provision static scoped tokens.
 func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 	var scopedTokens []*joiningv1.ScopedToken
 	for _, st := range t {
@@ -1107,6 +1109,10 @@ func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 			return nil, trace.Wrap(err)
 		}
 
+		immutableLabels, err := st.ImmutableLabels.Parse()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		scopedToken := &joiningv1.ScopedToken{
 			Version: types.V1,
 			Kind:    types.KindScopedToken,
@@ -1116,10 +1122,11 @@ func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 			},
 			Scope: scopes.Root,
 			Spec: &joiningv1.ScopedTokenSpec{
-				Roles:         roles.StringSlice(),
-				AssignedScope: st.Scope,
-				JoinMethod:    string(types.JoinMethodToken),
-				UsageMode:     string(joining.TokenUsageModeUnlimited),
+				Roles:           roles.StringSlice(),
+				AssignedScope:   st.Scope,
+				JoinMethod:      string(types.JoinMethodToken),
+				UsageMode:       string(joining.TokenUsageModeUnlimited),
+				ImmutableLabels: immutableLabels,
 			},
 			Status: &joiningv1.ScopedTokenStatus{
 				Secret: st.Secret,
@@ -1149,6 +1156,18 @@ func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 // ImmutableLabels capture yaml configuration used to generate [joiningv1.ImmutableLabels].
 type ImmutableLabels struct {
 	SSH map[string]string `yaml:"ssh"`
+}
+
+// Parse converts [ImmutableLabels] into [*joininv1.ImmutableLabels] so they
+// can be used to provision static scoped tokens.
+func (il *ImmutableLabels) Parse() (*joiningv1.ImmutableLabels, error) {
+	if il == nil {
+		return nil, nil
+	}
+
+	return &joiningv1.ImmutableLabels{
+		Ssh: il.SSH,
+	}, nil
 }
 
 // StaticScopedToken is a statically defined scoped token. It is meant to capture

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -39,7 +39,6 @@ import (
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/ssh"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v2"
 
 	"github.com/gravitational/teleport"
@@ -1117,8 +1116,7 @@ func (t StaticScopedTokens) Parse() (*joiningv1.StaticScopedTokens, error) {
 			Version: types.V1,
 			Kind:    types.KindScopedToken,
 			Metadata: &headerv1.Metadata{
-				Name:    st.Name,
-				Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+				Name: st.Name,
 			},
 			Scope: scopes.Root,
 			Spec: &joiningv1.ScopedTokenSpec{

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/yaml.v2"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -621,8 +620,7 @@ teleport:
 					Version: types.V1,
 					Kind:    types.KindScopedToken,
 					Metadata: &headerv1.Metadata{
-						Name:    "fully_defined_token",
-						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+						Name: "fully_defined_token",
 					},
 					Scope: "/",
 					Spec: &joiningv1.ScopedTokenSpec{
@@ -657,8 +655,7 @@ teleport:
 					Version: types.V1,
 					Kind:    types.KindScopedToken,
 					Metadata: &headerv1.Metadata{
-						Name:    "file_scoped_token",
-						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+						Name: "file_scoped_token",
 					},
 					Scope: "/",
 					Spec: &joiningv1.ScopedTokenSpec{
@@ -707,8 +704,7 @@ teleport:
 					Version: types.V1,
 					Kind:    types.KindScopedToken,
 					Metadata: &headerv1.Metadata{
-						Name:    "fully_defined_token",
-						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+						Name: "fully_defined_token",
 					},
 					Scope: "/",
 					Spec: &joiningv1.ScopedTokenSpec{
@@ -725,8 +721,7 @@ teleport:
 					Version: types.V1,
 					Kind:    types.KindScopedToken,
 					Metadata: &headerv1.Metadata{
-						Name:    "file_scoped_token",
-						Expires: timestamppb.New(time.Unix(0, 0).UTC()),
+						Name: "file_scoped_token",
 					},
 					Scope: "/",
 					Spec: &joiningv1.ScopedTokenSpec{

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -609,6 +609,9 @@ auth_service:
       roles: [node]
       secret: secret_token_value
       scope: /test
+      immutable_labels:
+        ssh:
+            hello: world
 teleport:
   nodename: testing
 `,
@@ -627,6 +630,11 @@ teleport:
 						AssignedScope: "/test",
 						JoinMethod:    string(types.JoinMethodToken),
 						UsageMode:     string(joining.TokenUsageModeUnlimited),
+						ImmutableLabels: &joiningv1.ImmutableLabels{
+							Ssh: map[string]string{
+								"hello": "world",
+							},
+						},
 					},
 					Status: &joiningv1.ScopedTokenStatus{
 						Secret: "secret_token_value",


### PR DESCRIPTION
This PR parses immutable labels configured in the file config and includes them in the resulting static scoped tokens. The types involved were added in the original immutable labels PR, but I missed adding the parsing itself. This also fixes an issue introduced after the single use token PR was merged where static scoped tokens were failing to provision nodes because they appeared to be expired

# Manual testing
- [x] Configure a static scoped token with immutable labels
```yaml
auth_service:
  scoped_tokens:
    - name: my_token
      secret: abc123
      roles: [node]
      scope: /local
      immutable_labels:
        ssh:
          hello: world
          foo: bar
```
- [x] Provision an SSH node using `--token my_token --token-secret abc123`
- [x] Verify that the node has the labels `hello=wolrd, foo=bar` either in the web UI or using `tsh ls`
