### PR TITLE
[vnet] linux support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,7 @@ require (
 	github.com/go-webauthn/webauthn v0.11.2
 	github.com/gobwas/ws v1.4.0
 	github.com/gocql/gocql v1.7.0
+	github.com/godbus/dbus/v5 v5.2.2
 	github.com/gofrs/flock v0.13.0
 	github.com/gogo/protobuf v1.3.2 // replaced
 	github.com/golang-jwt/jwt/v4 v4.5.2
@@ -427,7 +428,6 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
-	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/golang-sql/sqlexp v0.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect

--- a/lib/vnet/admin_process_darwin.go
+++ b/lib/vnet/admin_process_darwin.go
@@ -18,16 +18,14 @@ package vnet
 
 import (
 	"context"
-	"errors"
-	"os"
-	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
-	"golang.zx2c4.com/wireguard/tun"
 
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet/daemon"
+)
+
+const (
+	tunInterfaceName = "utun"
 )
 
 // RunDarwinAdminProcess must run as root. It creates and sets up a TUN device
@@ -54,101 +52,5 @@ func RunDarwinAdminProcess(ctx context.Context, config daemon.Config) error {
 	}
 	defer clt.close()
 
-	tun, tunName, err := createTUNDevice(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	defer tun.Close()
-
-	networkStackConfig, err := newNetworkStackConfig(ctx, tun, clt)
-	if err != nil {
-		return trace.Wrap(err, "creating network stack config")
-	}
-	networkStack, err := newNetworkStack(networkStackConfig)
-	if err != nil {
-		return trace.Wrap(err, "creating network stack")
-	}
-
-	if err := clt.ReportNetworkStackInfo(ctx, &vnetv1.NetworkStackInfo{
-		InterfaceName: tunName,
-		Ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
-	}); err != nil {
-		return trace.Wrap(err, "reporting network stack info to client application")
-	}
-
-	osConfigProvider, err := newOSConfigProvider(osConfigProviderConfig{
-		clt:           clt,
-		tunName:       tunName,
-		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
-		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
-		addDNSAddress: networkStack.addDNSAddress,
-	})
-	if err != nil {
-		return trace.Wrap(err, "creating OS config provider")
-	}
-	osConfigurator := newOSConfigurator(osConfigProvider)
-
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "Network stack terminated.")
-		if err := networkStack.run(ctx); err != nil {
-			return trace.Wrap(err, "running network stack")
-		}
-		return errors.New("network stack terminated")
-	})
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "OS configuration loop exited.")
-		if err := osConfigurator.runOSConfigurationLoop(ctx); err != nil {
-			return trace.Wrap(err, "running OS configuration loop")
-		}
-		return errors.New("OS configuration loop terminated")
-	})
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "Ping loop exited.")
-		tick := time.Tick(time.Second)
-		for {
-			select {
-			case <-tick:
-				if err := clt.Ping(ctx); err != nil {
-					return trace.Wrap(err, "failed to ping client application, it may have exited, shutting down")
-				}
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-	})
-
-	done := make(chan error)
-	go func() {
-		done <- g.Wait()
-	}()
-
-	select {
-	case err := <-done:
-		return trace.Wrap(err, "running VNet admin process")
-	case <-ctx.Done():
-	}
-
-	select {
-	case err := <-done:
-		// network stack exited cleanly within timeout
-		return trace.Wrap(err, "running VNet admin process")
-	case <-time.After(10 * time.Second):
-		log.ErrorContext(ctx, "VNet admin process did not exit within 10 seconds, forcing shutdown.")
-		os.Exit(1)
-		return nil
-	}
-}
-
-func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
-	log.DebugContext(ctx, "Creating TUN device.")
-	dev, err := tun.CreateTUN("utun", mtu)
-	if err != nil {
-		return nil, "", trace.Wrap(err, "creating TUN device")
-	}
-	name, err := dev.Name()
-	if err != nil {
-		return nil, "", trace.Wrap(err, "getting TUN device name")
-	}
-	return dev, name, nil
+	return runUnixAdminProcess(ctx, clt, tunInterfaceName)
 }

--- a/lib/vnet/admin_process_linux.go
+++ b/lib/vnet/admin_process_linux.go
@@ -1,0 +1,127 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"golang.zx2c4.com/wireguard/tun"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+type LinuxAdminProcessConfig struct {
+	ClientApplicationServiceAddr string
+	ServiceCredentialPath        string
+}
+
+// RunLinuxAdminProcess must run as root.
+func RunLinuxAdminProcess(ctx context.Context, config LinuxAdminProcessConfig) error {
+	log.InfoContext(ctx, "Running VNet admin process")
+
+	serviceCreds, err := readCredentials(config.ServiceCredentialPath)
+	if err != nil {
+		return trace.Wrap(err, "reading service IPC credentials")
+	}
+	clt, err := newClientApplicationServiceClient(ctx, serviceCreds, config.ClientApplicationServiceAddr)
+	if err != nil {
+		return trace.Wrap(err, "creating user process client")
+	}
+	defer clt.close()
+
+	tun, err := tun.CreateTUN("TeleportVNet", mtu)
+	if err != nil {
+		return trace.Wrap(err, "creating TUN device")
+	}
+	defer tun.Close()
+	tunName, err := tun.Name()
+	if err != nil {
+		return trace.Wrap(err, "getting TUN device name")
+	}
+
+	networkStackConfig, err := newNetworkStackConfig(ctx, tun, clt)
+	if err != nil {
+		return trace.Wrap(err, "creating network stack config")
+	}
+	networkStack, err := newNetworkStack(networkStackConfig)
+	if err != nil {
+		return trace.Wrap(err, "creating network stack")
+	}
+
+	if err := clt.ReportNetworkStackInfo(ctx, &vnetv1.NetworkStackInfo{
+		InterfaceName: tunName,
+		Ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+	}); err != nil {
+		return trace.Wrap(err, "reporting network stack info to client application")
+	}
+
+	osConfigProvider, err := newRemoteOSConfigProvider(
+		clt,
+		tunName,
+		networkStackConfig.ipv6Prefix.String(),
+		networkStackConfig.dnsIPv6.String(),
+	)
+	if err != nil {
+		return trace.Wrap(err, "creating OS config provider")
+	}
+	osConfigurator := newOSConfigurator(osConfigProvider)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		if err := networkStack.run(ctx); err != nil {
+			return trace.Wrap(err, "running network stack")
+		}
+		return errors.New("network stack terminated")
+	})
+	g.Go(func() error {
+		if err := osConfigurator.runOSConfigurationLoop(ctx); err != nil {
+			return trace.Wrap(err, "running OS configuration loop")
+		}
+		return errors.New("OS configuration loop terminated")
+	})
+	g.Go(func() error {
+		tick := time.Tick(time.Second)
+		for {
+			select {
+			case <-tick:
+				if err := clt.Ping(ctx); err != nil {
+					return trace.Wrap(err, "failed to ping client application, it may have exited, shutting down")
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+	return trace.Wrap(g.Wait(), "running VNet admin process")
+}
+
+func createTUNDevice(ctx context.Context) (tun.Device, string, error) {
+	log.DebugContext(ctx, "Creating TUN device.")
+	dev, err := tun.CreateTUN("utun", mtu)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "creating TUN device")
+	}
+	name, err := dev.Name()
+	if err != nil {
+		return nil, "", trace.Wrap(err, "getting TUN device name")
+	}
+	return dev, name, nil
+}

--- a/lib/vnet/admin_process_linux.go
+++ b/lib/vnet/admin_process_linux.go
@@ -18,15 +18,12 @@ package vnet
 
 import (
 	"context"
-	"errors"
-	"os"
-	"time"
 
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
-	"golang.zx2c4.com/wireguard/tun"
+)
 
-	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+const (
+	tunInterfaceName = "TeleportVNet"
 )
 
 // LinuxAdminProcessConfig configures RunLinuxAdminProcess.
@@ -47,98 +44,12 @@ func RunLinuxAdminProcess(ctx context.Context, config LinuxAdminProcessConfig) e
 	if err != nil {
 		return trace.Wrap(err, "reading service IPC credentials")
 	}
+	// TODO(tangyatsu): change to gRPC client over unix socket instead of TCP.
 	clt, err := newClientApplicationServiceClient(ctx, serviceCreds, config.ClientApplicationServiceAddr)
 	if err != nil {
 		return trace.Wrap(err, "creating user process client")
 	}
 	defer clt.close()
 
-	tun, err := tun.CreateTUN("TeleportVNet", mtu)
-	if err != nil {
-		return trace.Wrap(err, "creating TUN device")
-	}
-	defer tun.Close()
-	tunName, err := tun.Name()
-	if err != nil {
-		return trace.Wrap(err, "getting TUN device name")
-	}
-
-	networkStackConfig, err := newNetworkStackConfig(ctx, tun, clt)
-	if err != nil {
-		return trace.Wrap(err, "creating network stack config")
-	}
-	networkStack, err := newNetworkStack(networkStackConfig)
-	if err != nil {
-		return trace.Wrap(err, "creating network stack")
-	}
-
-	if err := clt.ReportNetworkStackInfo(ctx, &vnetv1.NetworkStackInfo{
-		InterfaceName: tunName,
-		Ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
-	}); err != nil {
-		return trace.Wrap(err, "reporting network stack info to client application")
-	}
-
-	osConfigProvider, err := newOSConfigProvider(osConfigProviderConfig{
-		clt:           clt,
-		tunName:       tunName,
-		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
-		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
-		addDNSAddress: networkStack.addDNSAddress,
-	})
-	if err != nil {
-		return trace.Wrap(err, "creating OS config provider")
-	}
-	osConfigurator := newOSConfigurator(osConfigProvider)
-
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "Network stack terminated.")
-		if err := networkStack.run(ctx); err != nil {
-			return trace.Wrap(err, "running network stack")
-		}
-		return errors.New("network stack terminated")
-	})
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "OS configuration loop exited.")
-		if err := osConfigurator.runOSConfigurationLoop(ctx); err != nil {
-			return trace.Wrap(err, "running OS configuration loop")
-		}
-		return errors.New("OS configuration loop terminated")
-	})
-	g.Go(func() error {
-		defer log.InfoContext(ctx, "Ping loop exited.")
-		tick := time.Tick(time.Second)
-		for {
-			select {
-			case <-tick:
-				if err := clt.Ping(ctx); err != nil {
-					return trace.Wrap(err, "failed to ping client application, it may have exited, shutting down")
-				}
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-	})
-
-	done := make(chan error)
-	go func() {
-		done <- g.Wait()
-	}()
-
-	select {
-	case err := <-done:
-		return trace.Wrap(err, "running VNet admin process")
-	case <-ctx.Done():
-	}
-
-	select {
-	case err := <-done:
-		// network stack exited cleanly within timeout
-		return trace.Wrap(err, "running VNet admin process")
-	case <-time.After(10 * time.Second):
-		log.ErrorContext(ctx, "VNet admin process did not exit within 10 seconds, forcing shutdown.")
-		os.Exit(1)
-		return nil
-	}
+	return runUnixAdminProcess(ctx, clt, tunInterfaceName)
 }

--- a/lib/vnet/admin_process_linux.go
+++ b/lib/vnet/admin_process_linux.go
@@ -29,9 +29,14 @@ import (
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 )
 
+// LinuxAdminProcessConfig configures RunLinuxAdminProcess.
 type LinuxAdminProcessConfig struct {
+	// ClientApplicationServiceAddr is the address of the client application
+	// service the admin process connects to.
 	ClientApplicationServiceAddr string
-	ServiceCredentialPath        string
+	// ServiceCredentialPath is the path to IPC credentials used to authenticate
+	// with the client application service.
+	ServiceCredentialPath string
 }
 
 // RunLinuxAdminProcess must run as root.

--- a/lib/vnet/admin_process_unix.go
+++ b/lib/vnet/admin_process_unix.go
@@ -1,0 +1,132 @@
+// Teleport
+// Copyright (C) 2025 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build darwin || linux
+
+package vnet
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
+	"golang.zx2c4.com/wireguard/tun"
+
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+func runUnixAdminProcess(ctx context.Context, clt *clientApplicationServiceClient, tunInterfaceName string) error {
+	tun, tunName, err := createTUNDevice(ctx, tunInterfaceName)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer tun.Close()
+
+	networkStackConfig, err := newNetworkStackConfig(ctx, tun, clt)
+	if err != nil {
+		return trace.Wrap(err, "creating network stack config")
+	}
+	networkStack, err := newNetworkStack(networkStackConfig)
+	if err != nil {
+		return trace.Wrap(err, "creating network stack")
+	}
+
+	if err := clt.ReportNetworkStackInfo(ctx, &vnetv1.NetworkStackInfo{
+		InterfaceName: tunName,
+		Ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+	}); err != nil {
+		return trace.Wrap(err, "reporting network stack info to client application")
+	}
+
+	osConfigProvider, err := newOSConfigProvider(osConfigProviderConfig{
+		clt:           clt,
+		tunName:       tunName,
+		ipv6Prefix:    networkStackConfig.ipv6Prefix.String(),
+		dnsIPv6:       networkStackConfig.dnsIPv6.String(),
+		addDNSAddress: networkStack.addDNSAddress,
+	})
+	if err != nil {
+		return trace.Wrap(err, "creating OS config provider")
+	}
+	osConfigurator := newOSConfigurator(osConfigProvider)
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		defer log.InfoContext(ctx, "Network stack terminated.")
+		if err := networkStack.run(ctx); err != nil {
+			return trace.Wrap(err, "running network stack")
+		}
+		return errors.New("network stack terminated")
+	})
+	g.Go(func() error {
+		defer log.InfoContext(ctx, "OS configuration loop exited.")
+		if err := osConfigurator.runOSConfigurationLoop(ctx); err != nil {
+			return trace.Wrap(err, "running OS configuration loop")
+		}
+		return errors.New("OS configuration loop terminated")
+	})
+	g.Go(func() error {
+		defer log.InfoContext(ctx, "Ping loop exited.")
+		tick := time.Tick(time.Second)
+		for {
+			select {
+			case <-tick:
+				if err := clt.Ping(ctx); err != nil {
+					return trace.Wrap(err, "failed to ping client application, it may have exited, shutting down")
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	done := make(chan error)
+	go func() {
+		done <- g.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		return trace.Wrap(err, "running VNet admin process")
+	case <-ctx.Done():
+	}
+
+	select {
+	case err := <-done:
+		// network stack exited cleanly within timeout
+		return trace.Wrap(err, "running VNet admin process")
+	case <-time.After(10 * time.Second):
+		log.ErrorContext(ctx, "VNet admin process did not exit within 10 seconds, forcing shutdown.")
+		os.Exit(1)
+		return nil
+	}
+}
+
+func createTUNDevice(ctx context.Context, interfaceName string) (tun.Device, string, error) {
+	log.DebugContext(ctx, "Creating TUN device.")
+	dev, err := tun.CreateTUN(interfaceName, mtu)
+	if err != nil {
+		return nil, "", trace.Wrap(err, "creating TUN device")
+	}
+	name, err := dev.Name()
+	if err != nil {
+		return nil, "", trace.Wrap(err, "getting TUN device name")
+	}
+	return dev, name, nil
+}

--- a/lib/vnet/admin_process_unix.go
+++ b/lib/vnet/admin_process_unix.go
@@ -126,6 +126,7 @@ func createTUNDevice(ctx context.Context, interfaceName string) (tun.Device, str
 	}
 	name, err := dev.Name()
 	if err != nil {
+		dev.Close()
 		return nil, "", trace.Wrap(err, "getting TUN device name")
 	}
 	return dev, name, nil

--- a/lib/vnet/dbus_client_linux.go
+++ b/lib/vnet/dbus_client_linux.go
@@ -1,0 +1,54 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gravitational/trace"
+)
+
+func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return trace.NotFound("system D-Bus is unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	obj := conn.Object(vnetDBusServiceName, dbus.ObjectPath(vnetDBusObjectPath))
+	call := obj.CallWithContext(ctx, vnetDBusStartMethod, 0, cfg.ClientApplicationServiceAddr, cfg.ServiceCredentialPath)
+	if call.Err != nil {
+		return trace.Wrap(call.Err, "calling D-Bus Start")
+	}
+	return nil
+}
+
+func stopService(ctx context.Context) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return trace.NotFound("system D-Bus is unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	obj := conn.Object(vnetDBusServiceName, dbus.ObjectPath(vnetDBusObjectPath))
+	call := obj.CallWithContext(ctx, vnetDBusStopMethod, 0)
+	if call.Err != nil {
+		return trace.Wrap(call.Err, "calling D-Bus Stop")
+	}
+	return nil
+}

--- a/lib/vnet/dbus_client_linux.go
+++ b/lib/vnet/dbus_client_linux.go
@@ -23,6 +23,10 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// startService is called from the normal user process to start
+// the privileged VNet daemon. It connects to the system D-Bus
+// and calls the corresponding Start method, exposed on the VNet
+// D-Bus interface, passing the client service address and credential path.
 func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
@@ -30,6 +34,15 @@ func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	}
 	defer conn.Close()
 
+	// basically this corresponds to calling something like
+	// `busctl --system call org.teleport.vnet1 /org/teleport/vnet1 org.teleport.vnet1.Daemon Start ss "<addr>" "<credPath>"`
+	// each D-Bus service owns a well-known name you refer to, then you specify an
+	// object path. object path is for granularity (a service can expose
+	// multiple objects, but it rarely used, so in our case it is the same as the name but
+	// slash-separated). then you call a method on a specific interface. the interface
+	// is implemented by some object, for vnet it’s the dbusDaemon struct. the D-Bus
+	// interface exposes the same methods as dbusDaemon, so we can call them over
+	// D-Bus.
 	obj := conn.Object(vnetDBusServiceName, dbus.ObjectPath(vnetDBusObjectPath))
 	call := obj.CallWithContext(ctx, vnetDBusStartMethod, 0, cfg.ClientApplicationServiceAddr, cfg.ServiceCredentialPath)
 	if call.Err != nil {
@@ -38,6 +51,10 @@ func startService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	return nil
 }
 
+// stopService is called from the normal user process to stop
+// the privileged VNet daemon. It connects to the system D-Bus
+// and calls the corresponding Stop method, exposed on the VNet
+// D-Bus interface.
 func stopService(ctx context.Context) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {

--- a/lib/vnet/dbus_linux.go
+++ b/lib/vnet/dbus_linux.go
@@ -1,5 +1,5 @@
 // Teleport
-// Copyright (C) 2024 Gravitational, Inc.
+// Copyright (C) 2026 Gravitational, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -14,15 +14,15 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build (!vnetdaemon || !darwin) && !linux
+package vnet
 
-package common
-
-import (
-	"github.com/alecthomas/kingpin/v2"
+const (
+	vnetDBusServiceName = "org.teleport.vnet1"
+	vnetDBusObjectPath  = "/org/teleport/vnet1"
+	vnetDBusInterface   = "org.teleport.vnet1.Daemon"
+	vnetDBusStartMethod = vnetDBusInterface + ".Start"
+	vnetDBusStopMethod  = vnetDBusInterface + ".Stop"
+	// vnetPolkitAction must match the action ID defined in the polkit policy file.
+	vnetPolkitAction    = "org.teleport.vnet1.manage-daemon"
+	vnetSystemdUnitName = "teleport-vnet.service"
 )
-
-// The vnet-daemon command is only supported with the vnetdaemon tag on darwin.
-func newPlatformVnetDaemonCommand(app *kingpin.Application) vnetCommandNotSupported {
-	return vnetCommandNotSupported{}
-}

--- a/lib/vnet/dbus_linux.go
+++ b/lib/vnet/dbus_linux.go
@@ -16,6 +16,24 @@
 
 package vnet
 
+// VNet's D-Bus daemon claims the org.teleport.vnet1 service name
+// and exposes the org.teleport.vnet1.Daemon interface, which has Start
+// and Stop methods. For it to work the system must include:
+//   - /usr/share/dbus-1/system.d/org.teleport.vnet1.conf to allow the daemon to
+//     claim the org.teleport.vnet1 name on the system bus.
+//   - /usr/share/dbus-1/system-services/org.teleport.vnet1.service to enable
+//     D-Bus activation of the daemon.
+//   - /usr/lib/systemd/system/teleport-vnet.service to manage the daemon
+//     lifecycle under systemd.
+//   - /usr/share/polkit-1/actions/org.teleport.vnet1.policy to define who can
+//     perform the org.teleport.vnet1.manage-daemon action (and therefore call
+//     Start and Stop methods).
+//
+// The daemon is managed by systemd. we don’t use systemd directly
+// because `systemctl start` takes only unit names and doesn’t let us pass
+// per start args. the closest options are template units or environment
+// file, but those are clunky so we wrap the admin process in a D-Bus daemon
+// and expose Start with explicit parameters.
 const (
 	vnetDBusServiceName = "org.teleport.vnet1"
 	vnetDBusObjectPath  = "/org/teleport/vnet1"

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -1,0 +1,213 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"sync"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/godbus/dbus/v5/introspect"
+	"github.com/gravitational/trace"
+)
+
+// polkitAllowUserInteraction allows polkit to prompt the user
+// for a password if it is required.
+const polkitAllowUserInteraction = uint32(1)
+
+// introspectNode describes the exported D-Bus API. Update it if any method
+// signature is changed or new methods are added.
+var introspectNode = &introspect.Node{
+	Name: vnetDBusObjectPath,
+	Interfaces: []introspect.Interface{
+		introspect.IntrospectData,
+		{
+			Name: vnetDBusInterface,
+			Methods: []introspect.Method{
+				{
+					Name: "Start",
+					Args: []introspect.Arg{
+						{Name: "addr", Type: "s", Direction: "in"},
+						{Name: "credPath", Type: "s", Direction: "in"},
+					},
+				},
+				{Name: "Stop"},
+			},
+		},
+	},
+}
+
+// RunLinuxDBusService runs the VNet D-Bus service that can start the VNet admin process.
+func RunLinuxDBusService(ctx context.Context) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return trace.Wrap(err, "connecting to system D-Bus")
+	}
+	defer conn.Close()
+
+	serviceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	daemon := &dbusDaemon{
+		ctx:    serviceCtx,
+		cancel: cancel,
+		conn:   conn,
+	}
+	if err := conn.Export(daemon, dbus.ObjectPath(vnetDBusObjectPath), vnetDBusInterface); err != nil {
+		return trace.Wrap(err, "exporting D-Bus object")
+	}
+	if err := conn.Export(
+		introspect.NewIntrospectable(introspectNode),
+		dbus.ObjectPath(vnetDBusObjectPath),
+		"org.freedesktop.DBus.Introspectable",
+	); err != nil {
+		return trace.Wrap(err, "exporting D-Bus introspection")
+	}
+
+	reply, err := conn.RequestName(vnetDBusServiceName, dbus.NameFlagDoNotQueue)
+	if err != nil {
+		return trace.Wrap(err, "requesting D-Bus name")
+	}
+	if reply != dbus.RequestNameReplyPrimaryOwner {
+		return trace.Errorf("D-Bus name %s is already owned", vnetDBusServiceName)
+	}
+	log.InfoContext(serviceCtx, "Acquired D-Bus name", "name", vnetDBusServiceName)
+
+	<-serviceCtx.Done()
+	return nil
+}
+
+type dbusDaemon struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+	conn   *dbus.Conn
+
+	mu      sync.Mutex
+	started bool
+}
+
+// Start is a D-Bus method that starts the VNet admin process.
+func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Error {
+	if err := d.authorize(sender); err != nil {
+		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
+	}
+
+	uid, err := d.lookupSenderUID(sender)
+	if err != nil {
+		return dbus.MakeFailedError(trace.Wrap(err, "looking up D-Bus sender UID"))
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.started {
+		return dbus.MakeFailedError(trace.Errorf("VNet admin process already started"))
+	}
+	d.started = true
+
+	log.InfoContext(d.ctx, "Starting VNet admin process", "uid", uid)
+
+	go func() {
+		err := RunLinuxAdminProcess(d.ctx, LinuxAdminProcessConfig{
+			ClientApplicationServiceAddr: addr,
+			ServiceCredentialPath:        credPath,
+		})
+		// TODO: D-Bus supports signals, we might want to emit a signal when the admin process exits.
+		if err != nil {
+			log.ErrorContext(d.ctx, "VNet admin process exited with error", "error", err)
+		}
+		d.cancel()
+	}()
+
+	return nil
+}
+
+// Stop is a D-Bus method that stops the VNet admin process.
+func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
+	if err := d.authorize(sender); err != nil {
+		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
+	}
+	uid, err := d.lookupSenderUID(sender)
+	if err != nil {
+		return dbus.MakeFailedError(trace.Wrap(err, "looking up D-Bus sender UID"))
+	}
+	// We intentionally do not reset started here to avoid a race with Start
+	// while the process is exiting. A new Start is allowed only after
+	// a new daemon instance is started.
+	//
+	// D-Bus activation can start the daemon on any method call. We allow
+	// Stop before Start so the service can exit immediately instead of idling
+	// waiting for a Start call that may never come.
+	log.InfoContext(d.ctx, "Stopping VNet admin process", "uid", uid)
+	d.cancel()
+	return nil
+}
+
+func (d *dbusDaemon) authorize(sender dbus.Sender) error {
+	uid, err := d.lookupSenderUID(sender)
+	if err != nil {
+		return trace.Wrap(err, "looking up D-Bus sender UID")
+	}
+	if uid == 0 {
+		return nil
+	}
+
+	subject := polkitSubject{
+		Kind: "system-bus-name",
+		Details: map[string]dbus.Variant{
+			"name": dbus.MakeVariant(string(sender)),
+		},
+	}
+	var result struct {
+		Authorized bool
+		Challenge  bool
+		Details    map[string]string
+	}
+	if err := d.conn.Object("org.freedesktop.PolicyKit1", "/org/freedesktop/PolicyKit1/Authority").
+		Call(
+			"org.freedesktop.PolicyKit1.Authority.CheckAuthorization",
+			0,
+			subject,
+			vnetPolkitAction,
+			map[string]string{},
+			polkitAllowUserInteraction,
+			"",
+		).Store(&result); err != nil {
+		return trace.Wrap(err, "checking polkit authorization")
+	}
+	if !result.Authorized {
+		if result.Challenge {
+			return trace.Errorf("polkit authentication required")
+		}
+		return trace.Errorf("polkit authorization denied")
+	}
+	return nil
+}
+
+func (d *dbusDaemon) lookupSenderUID(sender dbus.Sender) (uint32, error) {
+	var uid uint32
+	if err := d.conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus").
+		Call("org.freedesktop.DBus.GetConnectionUnixUser", 0, string(sender)).
+		Store(&uid); err != nil {
+		return 0, trace.Wrap(err, "querying D-Bus sender UID")
+	}
+	return uid, nil
+}
+
+type polkitSubject struct {
+	Kind    string
+	Details map[string]dbus.Variant
+}

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -18,7 +18,6 @@ package vnet
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -26,7 +25,6 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/gravitational/trace"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/lib/vnet/polkit"
 )
@@ -76,19 +74,17 @@ func newDBusDaemon() (_ *dbusDaemon, err error) {
 	if err != nil {
 		return nil, trace.Wrap(err, "connecting to system D-Bus")
 	}
+	ctx, cancel := context.WithCancel(context.Background())
 	defer func() {
 		if err != nil {
+			cancel()
 			_ = conn.Close()
 		}
 	}()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := errgroup.WithContext(ctx)
-
 	daemon := &dbusDaemon{
 		conn: conn,
-		g:    g,
-		done: make(chan struct{}),
+		done: make(chan error, 1),
 		startAdminProcess: func(addr, credPath string) error {
 			return trace.Wrap(RunLinuxAdminProcess(ctx, LinuxAdminProcessConfig{
 				ClientApplicationServiceAddr: addr,
@@ -123,9 +119,9 @@ func newDBusDaemon() (_ *dbusDaemon, err error) {
 
 type dbusDaemon struct {
 	conn      *dbus.Conn
-	g         *errgroup.Group
 	started   atomic.Bool
-	done      chan struct{}
+	closing   atomic.Bool
+	done      chan error // buffered 1; receives the admin process error or nil
 	closeOnce sync.Once
 
 	startAdminProcess  func(addr, credPath string) error
@@ -133,20 +129,19 @@ type dbusDaemon struct {
 }
 
 func (d *dbusDaemon) Close() {
+	d.closing.Store(true)
 	d.closeOnce.Do(func() {
-		close(d.done)
 		d.cancelAdminProcess()
 		_ = d.conn.Close()
+		// If no admin process goroutine was started, unblock Wait.
+		if !d.started.Load() {
+			d.done <- nil
+		}
 	})
 }
 
 func (d *dbusDaemon) Wait() error {
-	<-d.done
-	err := d.g.Wait()
-	if err != nil && !errors.Is(err, context.Canceled) {
-		log.DebugContext(context.Background(), "D-Bus daemon background task exited with error after close", "error", err)
-	}
-	return nil
+	return <-d.done
 }
 
 // Start starts actual VNet admin process with passed address and credential path.
@@ -158,10 +153,8 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
 	}
 
-	select {
-	case <-d.done:
+	if d.closing.Load() {
 		return dbus.MakeFailedError(trace.Errorf("VNet D-Bus daemon is shutting down"))
-	default:
 	}
 
 	if !d.started.CompareAndSwap(false, true) {
@@ -170,15 +163,15 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 
 	log.InfoContext(context.Background(), "Starting VNet admin process", "uid", uid)
 
-	d.g.Go(func() error {
+	go func() {
 		err := d.startAdminProcess(addr, credPath)
 		// TODO(tangyatsu): D-Bus supports signals, we might want to emit a signal when the admin process exits.
 		if err != nil {
 			log.ErrorContext(context.Background(), "VNet admin process exited with error", "error", err)
 		}
+		d.done <- err
 		d.Close()
-		return trace.Wrap(err)
-	})
+	}()
 
 	return nil
 }

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -18,14 +18,20 @@ package vnet
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/godbus/dbus/v5/introspect"
 	"github.com/gravitational/trace"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport/lib/vnet/polkit"
 )
+
+const polkitAuthorizationTimeout = 30 * time.Second
 
 // introspectNode describes the exported D-Bus API. Update it if any method
 // signature is changed or new methods are added.
@@ -54,51 +60,93 @@ var introspectNode = &introspect.Node{
 // exposes Start and Stop methods that normal client processes can call via
 // system D-Bus. The daemon blocks until the context is canceled.
 func RunLinuxDBusService(ctx context.Context) error {
+	daemon, err := newDBusDaemon()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	stop := context.AfterFunc(ctx, daemon.Close)
+	defer stop()
+
+	return trace.Wrap(daemon.Wait())
+}
+
+func newDBusDaemon() (_ *dbusDaemon, err error) {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
-		return trace.Wrap(err, "connecting to system D-Bus")
+		return nil, trace.Wrap(err, "connecting to system D-Bus")
 	}
-	defer conn.Close()
+	defer func() {
+		if err != nil {
+			_ = conn.Close()
+		}
+	}()
 
-	serviceCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	g, ctx := errgroup.WithContext(ctx)
 
 	daemon := &dbusDaemon{
-		ctx:    serviceCtx,
-		cancel: cancel,
-		conn:   conn,
+		conn: conn,
+		g:    g,
+		done: make(chan struct{}),
+		startAdminProcess: func(addr, credPath string) error {
+			return trace.Wrap(RunLinuxAdminProcess(ctx, LinuxAdminProcessConfig{
+				ClientApplicationServiceAddr: addr,
+				ServiceCredentialPath:        credPath,
+			}))
+		},
+		cancelAdminProcess: cancel,
 	}
+
 	if err := conn.Export(daemon, dbus.ObjectPath(vnetDBusObjectPath), vnetDBusInterface); err != nil {
-		return trace.Wrap(err, "exporting D-Bus object")
+		return nil, trace.Wrap(err, "exporting D-Bus object")
 	}
 	if err := conn.Export(
 		introspect.NewIntrospectable(introspectNode),
 		dbus.ObjectPath(vnetDBusObjectPath),
 		"org.freedesktop.DBus.Introspectable",
 	); err != nil {
-		return trace.Wrap(err, "exporting D-Bus introspection")
+		return nil, trace.Wrap(err, "exporting D-Bus introspection")
 	}
 
 	reply, err := conn.RequestName(vnetDBusServiceName, dbus.NameFlagDoNotQueue)
 	if err != nil {
-		return trace.Wrap(err, "requesting D-Bus name")
+		return nil, trace.Wrap(err, "requesting D-Bus name")
 	}
 	if reply != dbus.RequestNameReplyPrimaryOwner {
-		return trace.Errorf("D-Bus name %s is already owned", vnetDBusServiceName)
+		return nil, trace.Errorf("D-Bus name %s is already owned", vnetDBusServiceName)
 	}
-	log.InfoContext(serviceCtx, "Acquired D-Bus name", "name", vnetDBusServiceName)
 
-	<-serviceCtx.Done()
-	return nil
+	log.InfoContext(context.Background(), "Acquired D-Bus name", "name", vnetDBusServiceName)
+	return daemon, nil
 }
 
 type dbusDaemon struct {
-	ctx    context.Context
-	cancel context.CancelFunc
-	conn   *dbus.Conn
+	conn      *dbus.Conn
+	g         *errgroup.Group
+	started   atomic.Bool
+	done      chan struct{}
+	closeOnce sync.Once
 
-	mu      sync.Mutex
-	started bool
+	startAdminProcess  func(addr, credPath string) error
+	cancelAdminProcess context.CancelFunc
+}
+
+func (d *dbusDaemon) Close() {
+	d.closeOnce.Do(func() {
+		close(d.done)
+		d.cancelAdminProcess()
+		_ = d.conn.Close()
+	})
+}
+
+func (d *dbusDaemon) Wait() error {
+	<-d.done
+	err := d.g.Wait()
+	if err != nil && !errors.Is(err, context.Canceled) {
+		log.DebugContext(context.Background(), "D-Bus daemon background task exited with error after close", "error", err)
+	}
+	return nil
 }
 
 // Start starts actual VNet admin process with passed address and credential path.
@@ -110,31 +158,32 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
 	}
 
-	d.mu.Lock()
-	defer d.mu.Unlock()
-	if d.started {
+	select {
+	case <-d.done:
+		return dbus.MakeFailedError(trace.Errorf("VNet D-Bus daemon is shutting down"))
+	default:
+	}
+
+	if !d.started.CompareAndSwap(false, true) {
 		return dbus.MakeFailedError(trace.Errorf("VNet admin process already started"))
 	}
-	d.started = true
 
-	log.InfoContext(d.ctx, "Starting VNet admin process", "uid", uid)
+	log.InfoContext(context.Background(), "Starting VNet admin process", "uid", uid)
 
-	go func() {
-		err := RunLinuxAdminProcess(d.ctx, LinuxAdminProcessConfig{
-			ClientApplicationServiceAddr: addr,
-			ServiceCredentialPath:        credPath,
-		})
+	d.g.Go(func() error {
+		err := d.startAdminProcess(addr, credPath)
 		// TODO(tangyatsu): D-Bus supports signals, we might want to emit a signal when the admin process exits.
 		if err != nil {
-			log.ErrorContext(d.ctx, "VNet admin process exited with error", "error", err)
+			log.ErrorContext(context.Background(), "VNet admin process exited with error", "error", err)
 		}
-		d.cancel()
-	}()
+		d.Close()
+		return trace.Wrap(err)
+	})
 
 	return nil
 }
 
-// Stop stops actual VNet admin process by canceling the daemon context.
+// Stop stops actual VNet admin process and exits the daemon.
 // It uses polkit to authorize the calling D-Bus sender.
 func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
 	uid, err := d.authorize(sender)
@@ -148,8 +197,8 @@ func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
 	// D-Bus activation can start the daemon on any method call. We allow
 	// Stop before Start so the service can exit immediately instead of idling
 	// waiting for a Start call that may never come.
-	log.InfoContext(d.ctx, "Stopping VNet admin process", "uid", uid)
-	d.cancel()
+	log.InfoContext(context.Background(), "Stopping VNet admin process", "uid", uid)
+	d.Close()
 	return nil
 }
 
@@ -165,9 +214,12 @@ func (d *dbusDaemon) authorize(sender dbus.Sender) (uint32, error) {
 		return uid, nil
 	}
 
+	authCtx, cancel := context.WithTimeout(context.Background(), polkitAuthorizationTimeout)
+	defer cancel()
+
 	subject := polkit.NewSystemBusNameSubject(string(sender))
 	result, err := polkit.CheckAuthorization(
-		d.ctx,
+		authCtx,
 		d.conn,
 		subject,
 		vnetPolkitAction,

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -165,18 +165,14 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 	}
 
 	d.mu.Lock()
+	defer d.mu.Unlock()
 	if d.closing {
-		d.mu.Unlock()
 		return dbus.MakeFailedError(trace.Errorf("VNet D-Bus daemon is shutting down"))
 	}
-
 	if d.started {
-		d.mu.Unlock()
 		return dbus.MakeFailedError(trace.Errorf("VNet admin process already started"))
 	}
 	d.started = true
-	d.mu.Unlock()
-
 	log.InfoContext(context.Background(), "Starting VNet admin process", "uid", uid)
 
 	go func() {

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -144,7 +144,7 @@ func (d *dbusDaemon) Close() {
 func (d *dbusDaemon) Wait() error {
 	err := <-d.done
 	if err != nil && !errors.Is(err, context.Canceled) {
-		log.DebugContext(context.Background(), "D-Bus daemon background task exited with error after close", "error", err)
+		return err
 	}
 	return nil
 }
@@ -171,8 +171,10 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 	go func() {
 		err := d.startAdminProcess(addr, credPath)
 		// TODO(tangyatsu): D-Bus supports signals, we might want to emit a signal when the admin process exits.
-		if err != nil {
+		if err != nil && !errors.Is(err, context.Canceled) {
 			log.ErrorContext(context.Background(), "VNet admin process exited with error", "error", err)
+		} else {
+			log.InfoContext(context.Background(), "VNet admin process exited")
 		}
 		d.done <- err
 		d.Close()

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -105,13 +105,9 @@ type dbusDaemon struct {
 // It uses polkit to authorize the calling D-Bus sender.
 // It returns an error if the admin process has already been started.
 func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Error {
-	if err := d.authorize(sender); err != nil {
-		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
-	}
-
-	uid, err := d.lookupSenderUID(sender)
+	uid, err := d.authorize(sender)
 	if err != nil {
-		return dbus.MakeFailedError(trace.Wrap(err, "looking up D-Bus sender UID"))
+		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
 	}
 
 	d.mu.Lock()
@@ -141,12 +137,9 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 // Stop stops actual VNet admin process by canceling the daemon context.
 // It uses polkit to authorize the calling D-Bus sender.
 func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
-	if err := d.authorize(sender); err != nil {
-		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
-	}
-	uid, err := d.lookupSenderUID(sender)
+	uid, err := d.authorize(sender)
 	if err != nil {
-		return dbus.MakeFailedError(trace.Wrap(err, "looking up D-Bus sender UID"))
+		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
 	}
 	// We intentionally do not reset started here to avoid a race with Start
 	// while the process is exiting. A new Start is allowed only after
@@ -160,14 +153,16 @@ func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
 	return nil
 }
 
-func (d *dbusDaemon) authorize(sender dbus.Sender) error {
+// authorize checks polkit authorization for the calling D-Bus sender and
+// returns the sender UID.
+func (d *dbusDaemon) authorize(sender dbus.Sender) (uint32, error) {
 	uid, err := d.lookupSenderUID(sender)
 	if err != nil {
-		return trace.Wrap(err, "looking up D-Bus sender UID")
+		return 0, trace.Wrap(err, "looking up D-Bus sender UID")
 	}
 	if uid == 0 {
 		// Always allow root to start the daemon.
-		return nil
+		return uid, nil
 	}
 
 	subject := polkit.NewSystemBusNameSubject(string(sender))
@@ -181,15 +176,15 @@ func (d *dbusDaemon) authorize(sender dbus.Sender) error {
 		"",
 	)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	if !result.Authorized {
 		if result.Challenge {
-			return trace.Errorf("polkit authentication required")
+			return 0, trace.Errorf("polkit authentication required")
 		}
-		return trace.Errorf("polkit authorization denied")
+		return 0, trace.Errorf("polkit authorization denied")
 	}
-	return nil
+	return uid, nil
 }
 
 func (d *dbusDaemon) lookupSenderUID(sender dbus.Sender) (uint32, error) {

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -214,7 +214,7 @@ func (d *dbusDaemon) authorize(sender dbus.Sender) (uint32, error) {
 		return uid, nil
 	}
 
-	authCtx, cancel := context.WithTimeout(context.Background(), polkitAuthorizationTimeout)
+	authCtx, cancel := context.WithTimeout(d.conn.Context(), polkitAuthorizationTimeout)
 	defer cancel()
 
 	subject := polkit.NewSystemBusNameSubject(string(sender))

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/godbus/dbus/v5"
@@ -119,26 +118,33 @@ func newDBusDaemon() (_ *dbusDaemon, err error) {
 }
 
 type dbusDaemon struct {
-	conn      *dbus.Conn
-	started   atomic.Bool
-	closing   atomic.Bool
-	done      chan error // buffered 1; receives the admin process error or nil
-	closeOnce sync.Once
+	mu      sync.Mutex
+	conn    *dbus.Conn
+	started bool
+	closing bool
+	done    chan error // buffered 1; receives the admin process error or nil
 
 	startAdminProcess  func(addr, credPath string) error
 	cancelAdminProcess context.CancelFunc
 }
 
 func (d *dbusDaemon) Close() {
-	d.closing.Store(true)
-	d.closeOnce.Do(func() {
-		d.cancelAdminProcess()
-		_ = d.conn.Close()
-		// If no admin process goroutine was started, unblock Wait.
-		if !d.started.Load() {
-			d.done <- nil
-		}
-	})
+	d.mu.Lock()
+	if d.closing {
+		d.mu.Unlock()
+		return
+	}
+	d.closing = true
+	started := d.started
+	d.mu.Unlock()
+
+	d.cancelAdminProcess()
+	_ = d.conn.Close()
+
+	// If no admin process goroutine was started, unblock Wait.
+	if !started {
+		d.done <- nil
+	}
 }
 
 func (d *dbusDaemon) Wait() error {
@@ -158,13 +164,18 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
 	}
 
-	if d.closing.Load() {
+	d.mu.Lock()
+	if d.closing {
+		d.mu.Unlock()
 		return dbus.MakeFailedError(trace.Errorf("VNet D-Bus daemon is shutting down"))
 	}
 
-	if !d.started.CompareAndSwap(false, true) {
+	if d.started {
+		d.mu.Unlock()
 		return dbus.MakeFailedError(trace.Errorf("VNet admin process already started"))
 	}
+	d.started = true
+	d.mu.Unlock()
 
 	log.InfoContext(context.Background(), "Starting VNet admin process", "uid", uid)
 
@@ -232,9 +243,9 @@ func (d *dbusDaemon) authorize(sender dbus.Sender) (uint32, error) {
 	}
 	if !result.Authorized {
 		if result.Challenge {
-			return 0, trace.Errorf("polkit authentication required")
+			return 0, trace.AccessDenied("polkit authentication required")
 		}
-		return 0, trace.Errorf("polkit authorization denied")
+		return 0, trace.AccessDenied("polkit authorization denied")
 	}
 	return uid, nil
 }

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -18,6 +18,7 @@ package vnet
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -141,7 +142,11 @@ func (d *dbusDaemon) Close() {
 }
 
 func (d *dbusDaemon) Wait() error {
-	return <-d.done
+	err := <-d.done
+	if err != nil && !errors.Is(err, context.Canceled) {
+		log.DebugContext(context.Background(), "D-Bus daemon background task exited with error after close", "error", err)
+	}
+	return nil
 }
 
 // Start starts actual VNet admin process with passed address and credential path.

--- a/lib/vnet/dbus_service_linux.go
+++ b/lib/vnet/dbus_service_linux.go
@@ -49,7 +49,10 @@ var introspectNode = &introspect.Node{
 	},
 }
 
-// RunLinuxDBusService runs the VNet D-Bus service that can start the VNet admin process.
+// RunLinuxDBusService runs the privileged VNet D-Bus daemon on the system bus.
+// It claims the VNet service name and exports the VNet interface that
+// exposes Start and Stop methods that normal client processes can call via
+// system D-Bus. The daemon blocks until the context is canceled.
 func RunLinuxDBusService(ctx context.Context) error {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
@@ -98,7 +101,9 @@ type dbusDaemon struct {
 	started bool
 }
 
-// Start is a D-Bus method that starts the VNet admin process.
+// Start starts actual VNet admin process with passed address and credential path.
+// It uses polkit to authorize the calling D-Bus sender.
+// It returns an error if the admin process has already been started.
 func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Error {
 	if err := d.authorize(sender); err != nil {
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
@@ -123,7 +128,7 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 			ClientApplicationServiceAddr: addr,
 			ServiceCredentialPath:        credPath,
 		})
-		// TODO: D-Bus supports signals, we might want to emit a signal when the admin process exits.
+		// TODO(tangyatsu): D-Bus supports signals, we might want to emit a signal when the admin process exits.
 		if err != nil {
 			log.ErrorContext(d.ctx, "VNet admin process exited with error", "error", err)
 		}
@@ -133,7 +138,8 @@ func (d *dbusDaemon) Start(addr, credPath string, sender dbus.Sender) *dbus.Erro
 	return nil
 }
 
-// Stop is a D-Bus method that stops the VNet admin process.
+// Stop stops actual VNet admin process by canceling the daemon context.
+// It uses polkit to authorize the calling D-Bus sender.
 func (d *dbusDaemon) Stop(sender dbus.Sender) *dbus.Error {
 	if err := d.authorize(sender); err != nil {
 		return dbus.MakeFailedError(trace.Wrap(err, "authorization failed"))
@@ -160,6 +166,7 @@ func (d *dbusDaemon) authorize(sender dbus.Sender) error {
 		return trace.Wrap(err, "looking up D-Bus sender UID")
 	}
 	if uid == 0 {
+		// Always allow root to start the daemon.
 		return nil
 	}
 

--- a/lib/vnet/diag/routeconflict_other.go
+++ b/lib/vnet/diag/routeconflict_other.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
+// TODO: linux diagnostics
+
 func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (string, error) {
 	return "", trace.NotImplemented("InterfaceApp is not implemented")
 }

--- a/lib/vnet/diag/routeconflict_other.go
+++ b/lib/vnet/diag/routeconflict_other.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// TODO: linux diagnostics
+// TODO(tangyatsu): linux diagnostics
 
 func (n *NetInterfaces) interfaceApp(ctx context.Context, ifaceName string) (string, error) {
 	return "", trace.NotImplemented("InterfaceApp is not implemented")

--- a/lib/vnet/dns/dns.go
+++ b/lib/vnet/dns/dns.go
@@ -29,8 +29,6 @@ import (
 	"golang.org/x/net/dns/dnsmessage"
 	"golang.org/x/sync/errgroup"
 	"gvisor.dev/gvisor/pkg/tcpip"
-
-	"github.com/gravitational/teleport"
 )
 
 const (
@@ -88,7 +86,7 @@ type Server struct {
 // NewServer returns a DNS server that handles the details of the DNS protocol and asks [resolver] to answer
 // DNS questions. If [resolver] has no answer, requests will be forwarded to the upstream nameservers provided
 // by [upstreamNameserverSource].
-func NewServer(resolver Resolver, upstreamNameserverSource UpstreamNameserverSource) (*Server, error) {
+func NewServer(resolver Resolver, upstreamNameserverSource UpstreamNameserverSource, logger *slog.Logger) (*Server, error) {
 	return &Server{
 		resolver:                 resolver,
 		upstreamNameserverSource: upstreamNameserverSource,
@@ -98,7 +96,7 @@ func NewServer(resolver Resolver, upstreamNameserverSource UpstreamNameserverSou
 				return &buf
 			},
 		},
-		slog: slog.With(teleport.ComponentKey, teleport.Component("vnet", "dns")),
+		slog: logger,
 	}, nil
 }
 

--- a/lib/vnet/dns/dns_test.go
+++ b/lib/vnet/dns/dns_test.go
@@ -59,7 +59,7 @@ func TestServer(t *testing.T) {
 	// Create two upstream nameservers that are able to resolve A and AAAA records for all names.
 	var upstreamAddrs []string
 	for i := range 2 {
-		upstreamServer, err := NewServer(staticResolver, noUpstreams)
+		upstreamServer, err := NewServer(staticResolver, noUpstreams, slog.Default())
 		require.NoError(t, err)
 		conn, err := net.ListenUDP("udp", udpLocalhost)
 		require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestServer(t *testing.T) {
 		},
 	}
 	upstreams := &stubUpstreamNamservers{nameservers: upstreamAddrs}
-	server, err := NewServer(resolver, upstreams)
+	server, err := NewServer(resolver, upstreams, slog.Default())
 	require.NoError(t, err)
 
 	conn, err := net.ListenUDP("udp", udpLocalhost)

--- a/lib/vnet/dns/osnameservers.go
+++ b/lib/vnet/dns/osnameservers.go
@@ -56,6 +56,6 @@ func loadUpstreamNameservers(ctx context.Context) ([]string, error) {
 	return platformLoadUpstreamNameservers(ctx)
 }
 
-func withDNSPort(addr netip.Addr) string {
+func WithDNSPort(addr netip.Addr) string {
 	return netip.AddrPortFrom(addr, 53).String()
 }

--- a/lib/vnet/dns/osnameservers.go
+++ b/lib/vnet/dns/osnameservers.go
@@ -56,6 +56,7 @@ func loadUpstreamNameservers(ctx context.Context) ([]string, error) {
 	return platformLoadUpstreamNameservers(ctx)
 }
 
-func WithDNSPort(addr netip.Addr) string {
+// AddrWithDNSPort returns addr with DNS port 53.
+func AddrWithDNSPort(addr netip.Addr) string {
 	return netip.AddrPortFrom(addr, 53).String()
 }

--- a/lib/vnet/dns/osnameservers.go
+++ b/lib/vnet/dns/osnameservers.go
@@ -18,6 +18,7 @@ package dns
 
 import (
 	"context"
+	"log/slog"
 	"net/netip"
 	"time"
 
@@ -31,10 +32,11 @@ import (
 // these nameservers.
 type OSUpstreamNameserverSource struct {
 	ttlCache *utils.FnCache
+	slog     *slog.Logger
 }
 
 // NewOSUpstreamNameserverSource returns a new *OSUpstreamNameserverSource.
-func NewOSUpstreamNameserverSource() (*OSUpstreamNameserverSource, error) {
+func NewOSUpstreamNameserverSource(logger *slog.Logger) (*OSUpstreamNameserverSource, error) {
 	ttlCache, err := utils.NewFnCache(utils.FnCacheConfig{
 		TTL: 10 * time.Second,
 	})
@@ -43,17 +45,18 @@ func NewOSUpstreamNameserverSource() (*OSUpstreamNameserverSource, error) {
 	}
 	return &OSUpstreamNameserverSource{
 		ttlCache: ttlCache,
+		slog:     logger,
 	}, nil
 }
 
 // UpstreamNameservers returns a cached view of the host OS's current default
 // nameservers.
 func (s *OSUpstreamNameserverSource) UpstreamNameservers(ctx context.Context) ([]string, error) {
-	return utils.FnCacheGet(ctx, s.ttlCache, 0, loadUpstreamNameservers)
+	return utils.FnCacheGet(ctx, s.ttlCache, 0, s.loadUpstreamNameservers)
 }
 
-func loadUpstreamNameservers(ctx context.Context) ([]string, error) {
-	return platformLoadUpstreamNameservers(ctx)
+func (s *OSUpstreamNameserverSource) loadUpstreamNameservers(ctx context.Context) ([]string, error) {
+	return platformLoadUpstreamNameservers(ctx, s.slog)
 }
 
 // AddrWithDNSPort returns addr with DNS port 53.

--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -63,7 +63,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			continue
 		}
 
-		nameservers = append(nameservers, withDNSPort(ip))
+		nameservers = append(nameservers, WithDNSPort(ip))
 	}
 
 	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "config_file", confFilePath)

--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -37,7 +37,7 @@ const (
 // with the current default nameservers as configured for the OS, and it is the
 // easiest place to read them. Eventually we should probably use a better
 // method, but for now this works.
-func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+func platformLoadUpstreamNameservers(ctx context.Context, slog *slog.Logger) ([]string, error) {
 	f, err := os.Open(confFilePath)
 	if err != nil {
 		return nil, trace.Wrap(err, "opening %s", confFilePath)

--- a/lib/vnet/dns/osnameservers_darwin.go
+++ b/lib/vnet/dns/osnameservers_darwin.go
@@ -63,7 +63,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			continue
 		}
 
-		nameservers = append(nameservers, WithDNSPort(ip))
+		nameservers = append(nameservers, AddrWithDNSPort(ip))
 	}
 
 	slog.DebugContext(ctx, "Loaded host upstream nameservers.", "nameservers", nameservers, "config_file", confFilePath)

--- a/lib/vnet/dns/osnameservers_darwin_test.go
+++ b/lib/vnet/dns/osnameservers_darwin_test.go
@@ -20,6 +20,7 @@ package dns
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"testing"
 
@@ -39,9 +40,9 @@ func TestOSUpstreamNameservers(t *testing.T) {
 	t.Cleanup(cancel)
 
 	resolver := &stubResolver{}
-	upstreams, err := NewOSUpstreamNameserverSource()
+	upstreams, err := NewOSUpstreamNameserverSource(slog.Default())
 	require.NoError(t, err)
-	server, err := NewServer(resolver, upstreams)
+	server, err := NewServer(resolver, upstreams, slog.Default())
 	require.NoError(t, err)
 
 	conn, err := net.ListenUDP("udp", udpLocalhost)

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -84,7 +84,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 		if addr.IsUnspecified() {
 			continue
 		}
-		nameservers = append(nameservers, withDNSPort(addr))
+		nameservers = append(nameservers, WithDNSPort(addr))
 	}
 
 	slog.DebugContext(ctx, "Loaded host upstream nameservers", "nameservers", nameservers)

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -1,0 +1,92 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dns
+
+import (
+	"context"
+	"log/slog"
+	"net/netip"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gravitational/trace"
+)
+
+const (
+	systemdResolvedService    = "org.freedesktop.resolve1"
+	systemdResolvedObjectPath = "/org/freedesktop/resolve1"
+	systemdResolvedManager    = "org.freedesktop.resolve1.Manager"
+
+	systemdResolvedDNSProperty = "DNS"
+)
+
+type systemdResolvedDNS struct {
+	InterfaceIndex int32
+	Family         int32
+	Address        []byte
+}
+
+// platformLoadUpstreamNameservers returns the list of DNS upstreams configured in systemd-resolved.
+func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return nil, trace.NotFound("system D-Bus is unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	var hasOwner bool
+	err = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus").
+		CallWithContext(ctx, "org.freedesktop.DBus.NameHasOwner", 0, systemdResolvedService).
+		Store(&hasOwner)
+	if err != nil {
+		return nil, trace.Wrap(err, "checking systemd-resolved D-Bus service owner")
+	}
+	if !hasOwner {
+		return nil, trace.Errorf("systemd-resolved D-Bus service %s is not available", systemdResolvedService)
+	}
+
+	obj := conn.Object(systemdResolvedService, dbus.ObjectPath(systemdResolvedObjectPath))
+	call := obj.CallWithContext(ctx, "org.freedesktop.DBus.Properties.Get", 0, systemdResolvedManager, systemdResolvedDNSProperty)
+	if call.Err != nil {
+		return nil, trace.Wrap(call.Err, "getting systemd-resolved property %s", systemdResolvedDNSProperty)
+	}
+
+	var variant dbus.Variant
+	if err := call.Store(&variant); err != nil {
+		return nil, trace.Wrap(err, "decoding systemd-resolved property %s", systemdResolvedDNSProperty)
+	}
+
+	var dns []systemdResolvedDNS
+	if err := dbus.Store([]any{variant.Value()}, &dns); err != nil {
+		return nil, trace.Wrap(err, "decoding systemd-resolved property %s", systemdResolvedDNSProperty)
+	}
+
+	nameservers := make([]string, 0, len(dns))
+	for _, entry := range dns {
+		addr, ok := netip.AddrFromSlice(entry.Address)
+		if !ok {
+			slog.DebugContext(ctx, "Skipping invalid DNS server address", "address_bytes", entry.Address)
+			continue
+		}
+		if addr.IsUnspecified() {
+			continue
+		}
+		nameservers = append(nameservers, withDNSPort(addr))
+	}
+
+	slog.DebugContext(ctx, "Loaded host upstream nameservers", "nameservers", nameservers)
+	return nameservers, nil
+}

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -19,6 +19,7 @@ package dns
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/netip"
 
 	"github.com/godbus/dbus/v5"
@@ -52,6 +53,19 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 		}
 		if addr.IsUnspecified() || addr.IsLoopback() {
 			continue
+		}
+		// Link-local IPv6 addresses require a scope to be routable.
+		if addr.Is6() && addr.IsLinkLocalUnicast() {
+			if entry.InterfaceIndex == 0 {
+				slog.DebugContext(ctx, "Skipping link-local DNS server without interface index", "address", addr.String())
+				continue
+			}
+			iface, err := net.InterfaceByIndex(int(entry.InterfaceIndex))
+			if err != nil {
+				slog.DebugContext(ctx, "Skipping link-local DNS server with unknown interface", "address", addr.String(), "interface_index", entry.InterfaceIndex, "error", err)
+				continue
+			}
+			addr = addr.WithZone(iface.Name)
 		}
 		nameservers = append(nameservers, WithDNSPort(addr))
 	}

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -67,7 +67,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			}
 			addr = addr.WithZone(iface.Name)
 		}
-		nameservers = append(nameservers, WithDNSPort(addr))
+		nameservers = append(nameservers, AddrWithDNSPort(addr))
 	}
 
 	slog.DebugContext(ctx, "Loaded host upstream nameservers", "nameservers", nameservers)

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -29,7 +29,7 @@ import (
 )
 
 // platformLoadUpstreamNameservers returns the list of DNS upstreams configured in systemd-resolved.
-func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+func platformLoadUpstreamNameservers(ctx context.Context, slog *slog.Logger) ([]string, error) {
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
 		return nil, trace.NotFound("system D-Bus is unavailable: %v", err)

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -50,7 +50,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			slog.DebugContext(ctx, "Skipping invalid DNS server address", "address_bytes", entry.Address)
 			continue
 		}
-		if addr.IsUnspecified() {
+		if addr.IsUnspecified() || addr.IsLoopback() {
 			continue
 		}
 		nameservers = append(nameservers, WithDNSPort(addr))

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin && !windows
+//go:build !darwin && !windows && !linux
 
 package dns
 

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -30,7 +30,7 @@ var (
 	vnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 
 	// Satisfy unused linter.
-	_ = withDNSPort
+	_ = WithDNSPort
 )
 
 func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -20,6 +20,7 @@ package dns
 
 import (
 	"context"
+	"log/slog"
 	"runtime"
 
 	"github.com/gravitational/trace"
@@ -30,6 +31,7 @@ var (
 	vnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
 )
 
-func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+func platformLoadUpstreamNameservers(ctx context.Context, slog *slog.Logger) ([]string, error) {
+	_ = slog
 	return nil, trace.Wrap(vnetNotImplemented)
 }

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -32,6 +32,5 @@ var (
 )
 
 func platformLoadUpstreamNameservers(ctx context.Context, slog *slog.Logger) ([]string, error) {
-	_ = slog
 	return nil, trace.Wrap(vnetNotImplemented)
 }

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -28,9 +28,6 @@ import (
 var (
 	// vnetNotImplemented is an error indicating that VNet is not implemented on the host OS.
 	vnetNotImplemented = &trace.NotImplementedError{Message: "VNet is not implemented on " + runtime.GOOS}
-
-	// Satisfy unused linter.
-	_ = WithDNSPort
 )
 
 func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {

--- a/lib/vnet/dns/osnameservers_unix.go
+++ b/lib/vnet/dns/osnameservers_unix.go
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+//go:build linux || darwin
+
 package dns
 
 import (
@@ -22,13 +24,10 @@ import (
 	"log/slog"
 	"net/netip"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/gravitational/trace"
-)
-
-const (
-	confFilePath = "/etc/resolv.conf"
 )
 
 // platformLoadUpstreamNameservers reads the OS DNS nameservers found in
@@ -38,6 +37,20 @@ const (
 // easiest place to read them. Eventually we should probably use a better
 // method, but for now this works.
 func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+	// TODO: this is very hacky and just happens to work on the EC2 I've been
+	// testing on, figure out a good way to find upstream nameservers on Linux
+	// or a better way of resolving queries VNet can't handle (names in custom
+	// DNS zones that don't match a teleport app may resolve to some other
+	// company internal app outside of VNet/Teleport).
+	var confFilePath string
+	switch runtime.GOOS {
+	case "darwin":
+		confFilePath = "/etc/resolv.conf"
+	case "linux":
+		confFilePath = "/run/systemd/resolve/resolv.conf"
+	default:
+		return nil, trace.NotImplemented("unsupported os %s", runtime.GOOS)
+	}
 	f, err := os.Open(confFilePath)
 	if err != nil {
 		return nil, trace.Wrap(err, "opening %s", confFilePath)

--- a/lib/vnet/dns/osnameservers_windows.go
+++ b/lib/vnet/dns/osnameservers_windows.go
@@ -48,7 +48,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			if ignoreUpstreamNameserver(ifaceNameserver) {
 				continue
 			}
-			nameservers = append(nameservers, withDNSPort(ifaceNameserver))
+			nameservers = append(nameservers, WithDNSPort(ifaceNameserver))
 		}
 	}
 	slog.DebugContext(ctx, "Loaded host upstream nameservers", "nameservers", nameservers)

--- a/lib/vnet/dns/osnameservers_windows.go
+++ b/lib/vnet/dns/osnameservers_windows.go
@@ -48,7 +48,7 @@ func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
 			if ignoreUpstreamNameserver(ifaceNameserver) {
 				continue
 			}
-			nameservers = append(nameservers, WithDNSPort(ifaceNameserver))
+			nameservers = append(nameservers, AddrWithDNSPort(ifaceNameserver))
 		}
 	}
 	slog.DebugContext(ctx, "Loaded host upstream nameservers", "nameservers", nameservers)

--- a/lib/vnet/dns/osnameservers_windows.go
+++ b/lib/vnet/dns/osnameservers_windows.go
@@ -30,7 +30,7 @@ import (
 // platformLoadUpstreamNameservers attempts to find the default DNS nameservers
 // that VNet should forward unmatched queries to. To do this, it finds the
 // nameservers configured for each interface and sorts by the interface metric.
-func platformLoadUpstreamNameservers(ctx context.Context) ([]string, error) {
+func platformLoadUpstreamNameservers(ctx context.Context, slog *slog.Logger) ([]string, error) {
 	interfaces, err := winipcfg.GetIPInterfaceTable(windows.AF_INET)
 	if err != nil {
 		return nil, trace.Wrap(err, "looking up local network interfaces")

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -1,0 +1,32 @@
+package vnet
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	"github.com/gravitational/trace"
+)
+
+func execAdminProcess(ctx context.Context, cfg LinuxAdminProcessConfig) error {
+	executableName, err := os.Executable()
+	if err != nil {
+		return trace.Wrap(err, "getting executable path")
+	}
+
+	// TODO: find a proper way to start the service without just running sudo
+	// and hoping there's no password requirement...
+	//
+	// Also need to figure out how we want to set up a service that runs as root
+	// that can be started from Connect, maybe some systemd service but that
+	// doesn't solve how we allow the service to be started.
+	cmd := exec.CommandContext(ctx, "sudo", executableName, "-d",
+		"vnet-service",
+		"--addr", cfg.ClientApplicationServiceAddr,
+		"--cred-path", cfg.ServiceCredentialPath,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	log.DebugContext(ctx, "Escalating to root with sudo")
+	return trace.Wrap(cmd.Run(), "escalating to root with sudo")
+}

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -1,32 +1,168 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package vnet
 
 import (
 	"context"
 	"os"
 	"os/exec"
+	"slices"
+	"time"
 
+	systemddbus "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport"
+)
+
+const (
+	terminateTimeout = 30 * time.Second
 )
 
 func execAdminProcess(ctx context.Context, cfg LinuxAdminProcessConfig) error {
+	if err := checkDBusServiceAvailability(ctx); err != nil {
+		if os.Geteuid() == 0 {
+			log.WarnContext(ctx, "VNet daemon not available via D-Bus, running daemon as a child process", "error", err)
+			return trace.Wrap(runAdminSubcommand(ctx, cfg))
+		} else {
+			return trace.Wrap(err)
+		}
+	}
+
+	return trace.Wrap(runService(ctx, cfg))
+}
+
+func runService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
+	err := startService(ctx, cfg)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	log.InfoContext(ctx, "Started systemd service", "service", vnetSystemdUnitName)
+
+	conn, err := systemddbus.NewWithContext(ctx)
+	if err != nil {
+		return trace.NotFound("systemd D-Bus is unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			log.InfoContext(ctx, "Context canceled, stopping systemd service")
+			err := stopService(ctx)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			break loop
+		case <-ticker.C:
+			state, err := systemdUnitActiveState(ctx, conn, vnetSystemdUnitName)
+			if err != nil {
+				return trace.Wrap(err, "querying systemd service %s", vnetSystemdUnitName)
+			}
+			if state != "active" && state != "activating" {
+				return trace.Errorf("service stopped running prematurely, status: %s", state)
+			}
+		}
+	}
+
+	// Wait for the service to actually stop
+	deadline := time.After(terminateTimeout + 5*time.Second)
+	for {
+		select {
+		case <-deadline:
+			return trace.Errorf("systemd service %s failed to stop with %v", vnetSystemdUnitName, terminateTimeout)
+		case <-ticker.C:
+			state, err := systemdUnitActiveState(ctx, conn, vnetSystemdUnitName)
+			if err != nil {
+				return trace.Wrap(err, "querying systemd service %s", vnetSystemdUnitName)
+			}
+			if state == "inactive" {
+				return nil
+			}
+		}
+	}
+}
+
+func systemdUnitActiveState(ctx context.Context, conn *systemddbus.Conn, unit string) (string, error) {
+	props, err := conn.GetUnitPropertiesContext(ctx, unit)
+	if err != nil {
+		return "", err
+	}
+	state, ok := props["ActiveState"].(string)
+	if !ok || state == "" {
+		return "", trace.Errorf("systemd ActiveState is missing for %s", unit)
+	}
+	return state, nil
+}
+
+func checkDBusServiceAvailability(ctx context.Context) error {
+	conn, err := dbus.ConnectSystemBus()
+	if err != nil {
+		return trace.Wrap(err, "system D-Bus is unavailable")
+	}
+	defer conn.Close()
+
+	// Check if the service is already running.
+	var hasOwner bool
+	err = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus").
+		CallWithContext(ctx, "org.freedesktop.DBus.NameHasOwner", 0, vnetDBusServiceName).
+		Store(&hasOwner)
+	if err != nil {
+		return trace.Wrap(err, "checking D-Bus service owner")
+	}
+	if hasOwner {
+		return nil
+	}
+
+	// If it is not running, check that it can be activated via D-Bus.
+	var services []string
+	err = conn.Object("org.freedesktop.DBus", "/org/freedesktop/DBus").
+		CallWithContext(ctx, "org.freedesktop.DBus.ListActivatableNames", 0).
+		Store(&services)
+	if err != nil {
+		return trace.Wrap(err, "listing activatable D-Bus names")
+	}
+
+	if slices.Contains(services, vnetDBusServiceName) {
+		return nil
+	} else {
+		return trace.Errorf("D-Bus service %s is not available", vnetDBusServiceName)
+	}
+	// TODO: Maybe also check the systemd unit file exists. D-Bus can report a name
+	// as activatable even if the corresponding systemd unit is missing.
+}
+
+func runAdminSubcommand(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	executableName, err := os.Executable()
 	if err != nil {
 		return trace.Wrap(err, "getting executable path")
 	}
 
-	// TODO: find a proper way to start the service without just running sudo
-	// and hoping there's no password requirement...
-	//
-	// Also need to figure out how we want to set up a service that runs as root
-	// that can be started from Connect, maybe some systemd service but that
-	// doesn't solve how we allow the service to be started.
-	cmd := exec.CommandContext(ctx, "sudo", executableName, "-d",
-		"vnet-service",
+	cmd := exec.CommandContext(ctx, executableName, "-d",
+		teleport.VnetAdminSetupSubCommand,
 		"--addr", cfg.ClientApplicationServiceAddr,
 		"--cred-path", cfg.ServiceCredentialPath,
 	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	log.DebugContext(ctx, "Escalating to root with sudo")
-	return trace.Wrap(cmd.Run(), "escalating to root with sudo")
+	return trace.Wrap(cmd.Run(), "running %s", teleport.VnetAdminSetupSubCommand)
 }

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -34,6 +34,22 @@ const (
 	terminateTimeout = 30 * time.Second
 )
 
+// systemdUnitActiveState is the ActiveState property of a systemd unit.
+// The values and descriptions below are copied from the official
+// org.freedesktop.systemd1 D-Bus interface documentation.
+type systemdUnitState string
+
+const (
+	// systemdUnitActive means started, bound, plugged in, …, depending on the unit type.
+	systemdUnitActive systemdUnitState = "active"
+	// systemdUnitInactive means stopped, unbound, unplugged, …, depending on the unit type.
+	systemdUnitInactive systemdUnitState = "inactive"
+	// systemdUnitFailed means similar to inactive, but the unit failed in some way (process returned error code on exit, crashed, an operation timed out, or after too many restarts).
+	systemdUnitFailed systemdUnitState = "failed"
+	// systemdUnitActivating means changing from inactive to active.
+	systemdUnitActivating systemdUnitState = "activating"
+)
+
 func execAdminProcess(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	if err := checkDBusServiceAvailability(ctx); err != nil {
 		if os.Geteuid() == 0 {
@@ -74,11 +90,11 @@ loop:
 			}
 			break loop
 		case <-ticker.C:
-			state, err := systemdUnitActiveState(ctx, conn, vnetSystemdUnitName)
+			state, err := getSystemdUnitState(ctx, conn, vnetSystemdUnitName)
 			if err != nil {
 				return trace.Wrap(err, "querying systemd service %s", vnetSystemdUnitName)
 			}
-			if state != "active" && state != "activating" {
+			if state != systemdUnitActive && state != systemdUnitActivating {
 				return trace.Errorf("service stopped running prematurely, status: %s", state)
 			}
 		}
@@ -91,18 +107,18 @@ loop:
 		case <-deadline:
 			return trace.Errorf("systemd service %s failed to stop with %v", vnetSystemdUnitName, terminateTimeout)
 		case <-ticker.C:
-			state, err := systemdUnitActiveState(ctx, conn, vnetSystemdUnitName)
+			state, err := getSystemdUnitState(ctx, conn, vnetSystemdUnitName)
 			if err != nil {
 				return trace.Wrap(err, "querying systemd service %s", vnetSystemdUnitName)
 			}
-			if state == "inactive" {
+			if state == systemdUnitInactive || state == systemdUnitFailed {
 				return nil
 			}
 		}
 	}
 }
 
-func systemdUnitActiveState(ctx context.Context, conn *systemddbus.Conn, unit string) (string, error) {
+func getSystemdUnitState(ctx context.Context, conn *systemddbus.Conn, unit string) (systemdUnitState, error) {
 	props, err := conn.GetUnitPropertiesContext(ctx, unit)
 	if err != nil {
 		return "", err
@@ -111,7 +127,7 @@ func systemdUnitActiveState(ctx context.Context, conn *systemddbus.Conn, unit st
 	if !ok || state == "" {
 		return "", trace.Errorf("systemd ActiveState is missing for %s", unit)
 	}
-	return state, nil
+	return systemdUnitState(state), nil
 }
 
 func checkDBusServiceAvailability(ctx context.Context) error {

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -79,16 +79,21 @@ func runService(ctx context.Context, cfg LinuxAdminProcessConfig) error {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-loop:
 	for {
 		select {
 		case <-ctx.Done():
-			log.InfoContext(ctx, "Context canceled, stopping systemd service")
-			err := stopService(ctx)
-			if err != nil {
-				return trace.Wrap(err)
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), terminateTimeout)
+			defer stopCancel()
+			log.InfoContext(stopCtx, "Context canceled, stopping systemd service")
+			if err := stopService(stopCtx); err != nil {
+				return trace.Wrap(err, "sending stop request to systemd service %s", vnetSystemdUnitName)
 			}
-			break loop
+			err := waitForServiceStop(stopCtx, vnetSystemdUnitName)
+			if err != nil {
+				return trace.Wrap(err, "systemd service %s failed to stop with %v", vnetSystemdUnitName, terminateTimeout)
+			}
+			log.InfoContext(stopCtx, "Successfully stopped systemd service")
+			return nil
 		case <-ticker.C:
 			state, err := getSystemdUnitState(ctx, conn, vnetSystemdUnitName)
 			if err != nil {
@@ -99,17 +104,28 @@ loop:
 			}
 		}
 	}
+}
 
-	// Wait for the service to actually stop
-	deadline := time.After(terminateTimeout + 5*time.Second)
+func waitForServiceStop(ctx context.Context, unit string) error {
+	// Open a fresh connection here because the main loop's connection is bound to
+	// the original context and may be closed when that context is canceled.
+	conn, err := systemddbus.NewWithContext(ctx)
+	if err != nil {
+		return trace.NotFound("systemd D-Bus is unavailable: %v", err)
+	}
+	defer conn.Close()
+
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
 	for {
 		select {
-		case <-deadline:
-			return trace.Errorf("systemd service %s failed to stop with %v", vnetSystemdUnitName, terminateTimeout)
+		case <-ctx.Done():
+			return ctx.Err()
 		case <-ticker.C:
-			state, err := getSystemdUnitState(ctx, conn, vnetSystemdUnitName)
+			state, err := getSystemdUnitState(ctx, conn, unit)
 			if err != nil {
-				return trace.Wrap(err, "querying systemd service %s", vnetSystemdUnitName)
+				return trace.Wrap(err, "querying systemd service %s", unit)
 			}
 			if state == systemdUnitInactive || state == systemdUnitFailed {
 				return nil

--- a/lib/vnet/escalate_linux.go
+++ b/lib/vnet/escalate_linux.go
@@ -147,7 +147,7 @@ func checkDBusServiceAvailability(ctx context.Context) error {
 	} else {
 		return trace.Errorf("D-Bus service %s is not available", vnetDBusServiceName)
 	}
-	// TODO: Maybe also check the systemd unit file exists. D-Bus can report a name
+	// TODO(tangyatsu): Maybe also check the systemd unit file exists. D-Bus can report a name
 	// as activatable even if the corresponding systemd unit is missing.
 }
 

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -192,6 +192,8 @@ type filteredUpstreamSource struct {
 	exclude map[string]struct{}
 }
 
+// filteredUpstreamSource wraps an upstream source and excludes addresses added via AddExclude.
+// It is mainly used to filter VNet's own DNS addresses.
 func newFilteredUpstreamSource(base dns.UpstreamNameserverSource) *filteredUpstreamSource {
 	return &filteredUpstreamSource{
 		base:    base,
@@ -213,9 +215,11 @@ func (f *filteredUpstreamSource) UpstreamNameservers(ctx context.Context) ([]str
 	if err != nil {
 		return nil, err
 	}
+	slog.DebugContext(ctx, "Loaded upstream nameservers (pre-filter)", "nameservers", nameservers)
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	if len(f.exclude) == 0 {
+		slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", nameservers)
 		return nameservers, nil
 	}
 	filtered := nameservers[:0]
@@ -225,6 +229,7 @@ func (f *filteredUpstreamSource) UpstreamNameservers(ctx context.Context) ([]str
 		}
 		filtered = append(filtered, nameserver)
 	}
+	slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", filtered)
 	return filtered, nil
 }
 

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -301,7 +301,7 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 		if !ok {
 			return nil, trace.Errorf("error parsing IPv6 DNS address %v", cfg.dnsIPv6)
 		}
-		upstreamFilter.AddExclude(dns.WithDNSPort(addr))
+		upstreamFilter.AddExclude(dns.AddrWithDNSPort(addr))
 	}
 	dnsServer, err := dns.NewServer(ns, upstreamFilter)
 	if err != nil {
@@ -620,7 +620,7 @@ func (ns *networkStack) addDNSAddress(ip net.IP) error {
 		return trace.Errorf("error parsing IPv4 DNS address %s", ip.String())
 	}
 	if ns.upstreamFilter != nil {
-		ns.upstreamFilter.AddExclude(dns.WithDNSPort(addr))
+		ns.upstreamFilter.AddExclude(dns.AddrWithDNSPort(addr))
 	}
 	return trace.Wrap(ns.assignUDPHandler(tcpip.AddrFromSlice(ip), ns.dnsServer),
 		"adding UDP handler at %s", ip.String())

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -50,6 +50,7 @@ var log = logutils.NewPackageLogger(teleport.ComponentKey, logComponent)
 
 const (
 	logComponent                     = "vnet"
+	dnsLogComponent                  = "dns"
 	nicID                            = 1
 	mtu                              = 1500
 	tcpReceiveBufferSize             = 0 // 0 means a default will be used.
@@ -190,14 +191,16 @@ type filteredUpstreamSource struct {
 	base    dns.UpstreamNameserverSource
 	mu      sync.RWMutex
 	exclude map[string]struct{}
+	slog    *slog.Logger
 }
 
 // filteredUpstreamSource wraps an upstream source and excludes addresses added via AddExclude.
 // It is mainly used to filter VNet's own DNS addresses.
-func newFilteredUpstreamSource(base dns.UpstreamNameserverSource) *filteredUpstreamSource {
+func newFilteredUpstreamSource(base dns.UpstreamNameserverSource, slog *slog.Logger) *filteredUpstreamSource {
 	return &filteredUpstreamSource{
 		base:    base,
 		exclude: make(map[string]struct{}),
+		slog:    slog,
 	}
 }
 
@@ -215,11 +218,11 @@ func (f *filteredUpstreamSource) UpstreamNameservers(ctx context.Context) ([]str
 	if err != nil {
 		return nil, err
 	}
-	slog.DebugContext(ctx, "Loaded upstream nameservers (pre-filter)", "nameservers", nameservers)
+	f.slog.DebugContext(ctx, "Loaded upstream nameservers (pre-filter)", "nameservers", nameservers)
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 	if len(f.exclude) == 0 {
-		slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", nameservers)
+		f.slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", nameservers)
 		return nameservers, nil
 	}
 	filtered := nameservers[:0]
@@ -229,7 +232,7 @@ func (f *filteredUpstreamSource) UpstreamNameservers(ctx context.Context) ([]str
 		}
 		filtered = append(filtered, nameserver)
 	}
-	slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", filtered)
+	f.slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", filtered)
 	return filtered, nil
 }
 
@@ -265,7 +268,8 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 	if err := cfg.checkAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	slog := slog.With(teleport.ComponentKey, logComponent)
+	logger := slog.With(teleport.ComponentKey, logComponent)
+	dnsLogger := slog.With(teleport.ComponentKey, teleport.Component(logComponent, dnsLogComponent))
 
 	stack, linkEndpoint, err := createStack()
 	if err != nil {
@@ -284,17 +288,17 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 		tcpHandlerResolver: cfg.tcpHandlerResolver,
 		destroyed:          make(chan struct{}),
 		state:              newState(),
-		slog:               slog,
+		slog:               logger,
 	}
 
 	upstreamNameserverSource := cfg.upstreamNameserverSource
 	if upstreamNameserverSource == nil {
-		upstreamNameserverSource, err = dns.NewOSUpstreamNameserverSource()
+		upstreamNameserverSource, err = dns.NewOSUpstreamNameserverSource(dnsLogger)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
-	upstreamFilter := newFilteredUpstreamSource(upstreamNameserverSource)
+	upstreamFilter := newFilteredUpstreamSource(upstreamNameserverSource, dnsLogger)
 	ns.upstreamFilter = upstreamFilter
 	if cfg.dnsIPv6 != (tcpip.Address{}) {
 		addr, ok := netip.AddrFromSlice(cfg.dnsIPv6.AsSlice())
@@ -303,7 +307,7 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 		}
 		upstreamFilter.AddExclude(dns.AddrWithDNSPort(addr))
 	}
-	dnsServer, err := dns.NewServer(ns, upstreamFilter)
+	dnsServer, err := dns.NewServer(ns, upstreamFilter, dnsLogger)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -319,7 +323,7 @@ func newNetworkStack(cfg *networkStackConfig) (*networkStack, error) {
 		if err := ns.assignUDPHandler(cfg.dnsIPv6, dnsServer); err != nil {
 			return nil, trace.Wrap(err)
 		}
-		slog.DebugContext(context.Background(), "Serving DNS on IPv6.", "dns_addr", cfg.dnsIPv6)
+		logger.DebugContext(context.Background(), "Serving DNS on IPv6.", "dns_addr", cfg.dnsIPv6)
 	}
 
 	return ns, nil

--- a/lib/vnet/network_stack.go
+++ b/lib/vnet/network_stack.go
@@ -225,7 +225,7 @@ func (f *filteredUpstreamSource) UpstreamNameservers(ctx context.Context) ([]str
 		f.slog.DebugContext(ctx, "Loaded upstream nameservers (post-filter)", "nameservers", nameservers)
 		return nameservers, nil
 	}
-	filtered := nameservers[:0]
+	filtered := make([]string, 0, len(nameservers))
 	for _, nameserver := range nameservers {
 		if _, ok := f.exclude[nameserver]; ok {
 			continue

--- a/lib/vnet/osconfig_linux.go
+++ b/lib/vnet/osconfig_linux.go
@@ -1,0 +1,110 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"slices"
+
+	"github.com/gravitational/teleport/api/utils"
+	"github.com/gravitational/trace"
+)
+
+type platformOSConfigState struct {
+	configuredIPv6       bool
+	configuredIPv4       bool
+	configuredCidrRanges []string
+	configuredNameserver bool
+	configuredDNSZones   []string
+	broughtUpInterface   bool
+}
+
+// platformConfigureOS configures the host OS according to cfg.
+func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
+	// TODO: we should probably use proper APIs (dbus?) to set up IPs, routes,
+	// DNS etc and add checks that the host is actually using systemd-resolved
+	// before trying to run or supporting other DNS setups.
+	if cfg.tunIPv6 != "" && !state.configuredIPv6 {
+		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
+		addrWithPrefix := cfg.tunIPv6 + "/64"
+		if err := runCommand(ctx,
+			"ip", "addr", "add", addrWithPrefix, "dev", cfg.tunName,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+		state.configuredIPv6 = true
+	}
+	if cfg.tunIPv4 != "" && !state.configuredIPv4 {
+		log.InfoContext(ctx, "Setting IPv4 address for the TUN device.",
+			"device", cfg.tunName, "address", cfg.tunIPv4)
+		if err := runCommand(ctx,
+			"ip", "addr", "add", cfg.tunIPv4, "dev", cfg.tunName,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+		state.configuredIPv4 = true
+	}
+	if cfg.dnsAddr != "" && !state.configuredNameserver {
+		log.InfoContext(ctx, "Configuring DNS nameserver", "nameserver", cfg.dnsAddr)
+		if err := runCommand(ctx,
+			"resolvectl", "dns", cfg.tunName, cfg.dnsAddr,
+		); err != nil {
+			return trace.Wrap(err)
+		}
+		state.configuredNameserver = true
+	}
+	if shouldReconfiguredDNSZones(cfg, state) {
+		log.InfoContext(ctx, "Configuring DNS zones", "zones", cfg.dnsZones)
+		domains := make([]string, 0, len(cfg.dnsZones))
+		for _, dnsZone := range cfg.dnsZones {
+			domains = append(domains, "~"+dnsZone)
+		}
+		args := append([]string{"domain", cfg.tunName}, domains...)
+		if err := runCommand(ctx, "resolvectl", args...); err != nil {
+			return trace.Wrap(err)
+		}
+		state.configuredDNSZones = cfg.dnsZones
+	}
+	if state.configuredIPv6 && state.configuredNameserver && !state.broughtUpInterface {
+		log.InfoContext(ctx, "Bringing up the VNet interface", "device", cfg.tunName)
+		if err := runCommand(ctx,
+			"ip", "link", "set", cfg.tunName, "up",
+		); err != nil {
+			return trace.Wrap(err)
+		}
+		state.broughtUpInterface = true
+	}
+	if cfg.tunIPv4 != "" && state.configuredIPv4 && state.broughtUpInterface {
+		for _, cidrRange := range cfg.cidrRanges {
+			if slices.Contains(state.configuredCidrRanges, cidrRange) {
+				continue
+			}
+			log.InfoContext(ctx, "Setting an IPv4 route", "netmask", cidrRange)
+			if err := runCommand(ctx,
+				"ip", "route", "add", cidrRange, "via", cfg.tunIPv4, "dev", cfg.tunName,
+			); err != nil {
+				return trace.Wrap(err)
+			}
+			state.configuredCidrRanges = append(state.configuredCidrRanges, cidrRange)
+		}
+	}
+	return nil
+}
+
+func shouldReconfiguredDNSZones(cfg *osConfig, state *platformOSConfigState) bool {
+	return !utils.ContainSameUniqueElements(cfg.dnsZones, state.configuredDNSZones)
+}

--- a/lib/vnet/osconfig_linux.go
+++ b/lib/vnet/osconfig_linux.go
@@ -18,8 +18,10 @@ package vnet
 
 import (
 	"context"
+	"errors"
 	"net"
 	"slices"
+	"strings"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/gravitational/trace"
@@ -109,6 +111,7 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 	if len(cfg.dnsAddrs) > 0 && cfg.tunName == "" {
 		return trace.BadParameter("empty TUN interface name with non-empty nameserver")
 	}
+	deconfigure := len(cfg.dnsAddrs) == 0 && len(cfg.dnsZones) == 0
 
 	conn, err := dbus.ConnectSystemBus()
 	if err != nil {
@@ -122,6 +125,12 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 	if shouldReconfigureDNSZones(cfg, state) {
 		iface, err := net.InterfaceByName(state.tunName)
 		if err != nil {
+			if deconfigure && isNoSuchNetworkInterfaceError(err) {
+				// During shutdown the TUN can disappear before deconfigure runs.
+				// In that case there is no link left to clear.
+				log.DebugContext(ctx, "Skipping DNS deconfiguration because TUN interface is unavailable.", "device", state.tunName)
+				return nil
+			}
 			return trace.Wrap(err, "looking up interface %s", state.tunName)
 		}
 		log.InfoContext(ctx, "Configuring DNS zones", "zones", cfg.dnsZones)
@@ -166,4 +175,12 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 	}
 
 	return nil
+}
+
+func isNoSuchNetworkInterfaceError(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return strings.Contains(opErr.Err.Error(), "no such network interface")
+	}
+	return false
 }

--- a/lib/vnet/osconfig_linux.go
+++ b/lib/vnet/osconfig_linux.go
@@ -40,7 +40,7 @@ type platformOSConfigState struct {
 
 // platformConfigureOS configures the host OS according to cfg.
 func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSConfigState) error {
-	// TODO: use github.com/vishvananda/netlink to set up IPs and routes?
+	// TODO(tangyatsu): use github.com/vishvananda/netlink to set up IPs and routes?
 	if cfg.tunIPv6 != "" && !state.configuredIPv6 {
 		log.InfoContext(ctx, "Setting IPv6 address for the TUN device.", "device", cfg.tunName, "address", cfg.tunIPv6)
 		addrWithPrefix := cfg.tunIPv6 + "/64"
@@ -90,7 +90,7 @@ func platformConfigureOS(ctx context.Context, cfg *osConfig, state *platformOSCo
 	return nil
 }
 
-func shouldReconfiguredDNSZones(cfg *osConfig, state *platformOSConfigState) bool {
+func shouldReconfigureDNSZones(cfg *osConfig, state *platformOSConfigState) bool {
 	return !utils.ContainSameUniqueElements(cfg.dnsZones, state.configuredDNSZones)
 }
 
@@ -119,7 +119,7 @@ func configureDNS(ctx context.Context, cfg *osConfig, state *platformOSConfigSta
 		return err
 	}
 
-	if shouldReconfiguredDNSZones(cfg, state) {
+	if shouldReconfigureDNSZones(cfg, state) {
 		iface, err := net.InterfaceByName(state.tunName)
 		if err != nil {
 			return trace.Wrap(err, "looking up interface %s", state.tunName)

--- a/lib/vnet/polkit/polkit.go
+++ b/lib/vnet/polkit/polkit.go
@@ -1,0 +1,91 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package polkit
+
+import (
+	"context"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gravitational/trace"
+)
+
+const (
+	AuthorityServiceName = "org.freedesktop.PolicyKit1"
+	AuthorityObjectPath  = "/org/freedesktop/PolicyKit1/Authority"
+	AuthorityInterface   = "org.freedesktop.PolicyKit1.Authority"
+
+	CheckAuthorizationMethod = AuthorityInterface + ".CheckAuthorization"
+
+	CheckAuthorizationFlagNone                 = uint32(0x00000000)
+	CheckAuthorizationFlagAllowUserInteraction = uint32(0x00000001)
+
+	SubjectKindSystemBusName = "system-bus-name"
+	SubjectDetailNameKey     = "name"
+)
+
+// Subject describes the entity being authorized.
+type Subject struct {
+	// Kind is the subject kind, e.g. "system-bus-name".
+	Kind string
+	// Details are subject kind specific key/value pairs.
+	Details map[string]dbus.Variant
+}
+
+// AuthorizationResult is the result of CheckAuthorization.
+type AuthorizationResult struct {
+	// Authorized is true if the subject is authorized for the action.
+	Authorized bool
+	// Challenge is true if the subject could be authorized after authentication.
+	Challenge bool
+	// Details contains extra result information.
+	Details map[string]string
+}
+
+// NewSystemBusNameSubject returns a polkit subject for a system bus name.
+func NewSystemBusNameSubject(name string) Subject {
+	return Subject{
+		Kind: SubjectKindSystemBusName,
+		Details: map[string]dbus.Variant{
+			SubjectDetailNameKey: dbus.MakeVariant(name),
+		},
+	}
+}
+
+// CheckAuthorization calls polkit's CheckAuthorization method.
+func CheckAuthorization(
+	ctx context.Context,
+	conn *dbus.Conn,
+	subject Subject,
+	actionID string,
+	details map[string]string,
+	allowUserInteraction bool,
+	cancellationID string,
+) (AuthorizationResult, error) {
+	var flags uint32
+	if allowUserInteraction {
+		flags = CheckAuthorizationFlagAllowUserInteraction
+	} else {
+		flags = CheckAuthorizationFlagNone
+	}
+	var result AuthorizationResult
+	if err := conn.Object(AuthorityServiceName, dbus.ObjectPath(AuthorityObjectPath)).
+		CallWithContext(ctx, CheckAuthorizationMethod, 0, subject, actionID, details, flags, cancellationID).
+		Store(&result); err != nil {
+		return AuthorizationResult{}, trace.Wrap(err, "checking polkit authorization")
+	}
+	return result, nil
+}

--- a/lib/vnet/polkit/polkit.go
+++ b/lib/vnet/polkit/polkit.go
@@ -75,11 +75,9 @@ func CheckAuthorization(
 	allowUserInteraction bool,
 	cancellationID string,
 ) (AuthorizationResult, error) {
-	var flags uint32
+	flags := CheckAuthorizationFlagNone
 	if allowUserInteraction {
 		flags = CheckAuthorizationFlagAllowUserInteraction
-	} else {
-		flags = CheckAuthorizationFlagNone
 	}
 	var result AuthorizationResult
 	if err := conn.Object(AuthorityServiceName, dbus.ObjectPath(AuthorityObjectPath)).

--- a/lib/vnet/systemdresolved/dbus.go
+++ b/lib/vnet/systemdresolved/dbus.go
@@ -110,7 +110,7 @@ func loadDNSProperty(ctx context.Context, conn *dbus.Conn) ([]DNS, error) {
 	return dns, nil
 }
 
-// SetLinkDomains configures per-link DNS search domains.
+// SetLinkDomains configures per-link DNS domains.
 func SetLinkDomains(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, domains []Domain) error {
 	call := Object(conn).CallWithContext(ctx, SetDomainsMethod, 0, ifaceIndex, domains)
 	if call.Err != nil {
@@ -137,7 +137,7 @@ func SetLinkDNS(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, addresse
 	return nil
 }
 
-// DNSAddressForIP converts an IP adress into a systemd-resolved DNSAddress.
+// DNSAddressForIP converts an IP address into a systemd-resolved DNSAddress.
 func DNSAddressForIP(raw string) (DNSAddress, error) {
 	ip := net.ParseIP(raw)
 	if ip == nil {

--- a/lib/vnet/systemdresolved/dbus.go
+++ b/lib/vnet/systemdresolved/dbus.go
@@ -1,0 +1,159 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package systemdresolved
+
+import (
+	"context"
+	"net"
+	"syscall"
+
+	"github.com/godbus/dbus/v5"
+	"github.com/gravitational/trace"
+)
+
+const (
+	DBusService       = "org.freedesktop.DBus"
+	DBusObjectPath    = "/org/freedesktop/DBus"
+	DBusNameHasOwner  = "org.freedesktop.DBus.NameHasOwner"
+	DBusPropertiesGet = "org.freedesktop.DBus.Properties.Get"
+
+	Service    = "org.freedesktop.resolve1"
+	ObjectPath = "/org/freedesktop/resolve1"
+	Manager    = "org.freedesktop.resolve1.Manager"
+
+	SetLinkDNSMethod      = Manager + ".SetLinkDNS"
+	SetDomainsMethod      = Manager + ".SetLinkDomains"
+	SetDefaultRouteMethod = Manager + ".SetLinkDefaultRoute"
+
+	DNSProperty = "DNS"
+)
+
+// DNSAddress is the systemd-resolved representation of a DNS address.
+type DNSAddress struct {
+	Family  int32
+	Address []byte
+}
+
+// Domain is the systemd-resolved representation of a DNS domain.
+type Domain struct {
+	Domain      string
+	RoutingOnly bool
+}
+
+// DNS is a single DNS server entry from systemd-resolved's DNS property.
+type DNS struct {
+	InterfaceIndex int32
+	Family         int32
+	Address        []byte
+}
+
+// CheckAvailability returns an error if systemd-resolved is unavailable on D-Bus.
+func CheckAvailability(ctx context.Context, conn *dbus.Conn) error {
+	var hasOwner bool
+	err := conn.Object(DBusService, dbus.ObjectPath(DBusObjectPath)).
+		CallWithContext(ctx, DBusNameHasOwner, 0, Service).
+		Store(&hasOwner)
+	if err != nil {
+		return trace.Wrap(err, "checking systemd-resolved D-Bus service owner")
+	}
+	if hasOwner {
+		return nil
+	}
+	return trace.Errorf(
+		"systemd-resolved is not running (D-Bus service %s has no owner).\n"+
+			"you can enable it with:\n"+
+			"  sudo systemctl enable --now systemd-resolved\n",
+		Service,
+	)
+}
+
+// Object returns the systemd-resolved D-Bus object.
+func Object(conn *dbus.Conn) dbus.BusObject {
+	return conn.Object(Service, dbus.ObjectPath(ObjectPath))
+}
+
+// LoadConfiguredDNSServers returns DNS servers currently configured in systemd-resolved.
+func LoadConfiguredDNSServers(ctx context.Context, conn *dbus.Conn) ([]DNS, error) {
+	return loadDNSProperty(ctx, conn)
+}
+
+// loadDNSProperty loads the systemd-resolved DNS property via D-Bus.
+func loadDNSProperty(ctx context.Context, conn *dbus.Conn) ([]DNS, error) {
+	call := Object(conn).CallWithContext(ctx, DBusPropertiesGet, 0, Manager, DNSProperty)
+	if call.Err != nil {
+		return nil, trace.Wrap(call.Err, "getting systemd-resolved property %s", DNSProperty)
+	}
+
+	var variant dbus.Variant
+	if err := call.Store(&variant); err != nil {
+		return nil, trace.Wrap(err, "decoding systemd-resolved property %s", DNSProperty)
+	}
+
+	var dns []DNS
+	if err := dbus.Store([]any{variant.Value()}, &dns); err != nil {
+		return nil, trace.Wrap(err, "decoding systemd-resolved property %s", DNSProperty)
+	}
+	return dns, nil
+}
+
+// SetLinkDomains configures per-link DNS search domains.
+func SetLinkDomains(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, domains []Domain) error {
+	call := Object(conn).CallWithContext(ctx, SetDomainsMethod, 0, ifaceIndex, domains)
+	if call.Err != nil {
+		return trace.Wrap(call.Err, "setting systemd-resolved link domains")
+	}
+	return nil
+}
+
+// SetLinkDefaultRoute configures whether this link is the default DNS route.
+func SetLinkDefaultRoute(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, enabled bool) error {
+	call := Object(conn).CallWithContext(ctx, SetDefaultRouteMethod, 0, ifaceIndex, enabled)
+	if call.Err != nil {
+		return trace.Wrap(call.Err, "setting systemd-resolved link default route")
+	}
+	return nil
+}
+
+// SetLinkDNS configures per-link DNS servers.
+func SetLinkDNS(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, addresses []DNSAddress) error {
+	call := Object(conn).CallWithContext(ctx, SetLinkDNSMethod, 0, ifaceIndex, addresses)
+	if call.Err != nil {
+		return trace.Wrap(call.Err, "setting systemd-resolved link DNS")
+	}
+	return nil
+}
+
+// DNSAddressForIP converts an IP adress into a systemd-resolved DNSAddress.
+func DNSAddressForIP(raw string) (DNSAddress, error) {
+	ip := net.ParseIP(raw)
+	if ip == nil {
+		return DNSAddress{}, trace.Errorf("invalid IP address")
+	}
+	if ip4 := ip.To4(); ip4 != nil {
+		return DNSAddress{
+			Family:  syscall.AF_INET,
+			Address: []byte(ip4),
+		}, nil
+	}
+	if ip16 := ip.To16(); ip16 != nil {
+		return DNSAddress{
+			Family:  syscall.AF_INET6,
+			Address: []byte(ip16),
+		}, nil
+	}
+	return DNSAddress{}, trace.Errorf("unsupported IP address")
+}

--- a/lib/vnet/systemdresolved/dbus.go
+++ b/lib/vnet/systemdresolved/dbus.go
@@ -141,7 +141,7 @@ func SetLinkDNS(ctx context.Context, conn *dbus.Conn, ifaceIndex int32, addresse
 func DNSAddressForIP(raw string) (DNSAddress, error) {
 	ip := net.ParseIP(raw)
 	if ip == nil {
-		return DNSAddress{}, trace.Errorf("invalid IP address")
+		return DNSAddress{}, trace.BadParameter("invalid IP address: %s", raw)
 	}
 	if ip4 := ip.To4(); ip4 != nil {
 		return DNSAddress{

--- a/lib/vnet/unsupported_os.go
+++ b/lib/vnet/unsupported_os.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin && !windows
+//go:build !darwin && !windows && !linux
 
 package vnet
 

--- a/lib/vnet/user_process_linux.go
+++ b/lib/vnet/user_process_linux.go
@@ -1,0 +1,105 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package vnet
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	grpccredentials "google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
+)
+
+// runPlatformUserProcess launches a daemon in the background that will handle
+// all networking and OS configuration. The user process exposes a gRPC
+// interface that the daemon uses to query application names and get user
+// certificates for apps. If successful it sets p.processManager and
+// p.networkStackInfo.
+func (p *UserProcess) runPlatformUserProcess(processCtx context.Context) error {
+	ipcCreds, err := newIPCCredentials()
+	if err != nil {
+		return trace.Wrap(err, "creating credentials for IPC")
+	}
+	serverTLSConfig, err := ipcCreds.server.serverTLSConfig()
+	if err != nil {
+		return trace.Wrap(err, "generating gRPC server TLS config")
+	}
+
+	credDir, err := os.MkdirTemp("", "vnet_service_certs")
+	if err != nil {
+		return trace.Wrap(err, "creating temp dir for service certs")
+	}
+	// Write credentials with 0200 so that only root can read them and no user
+	// processes should be able to connect to the service.
+	if err := ipcCreds.client.write(credDir, 0200); err != nil {
+		return trace.Wrap(err, "writing service IPC credentials")
+	}
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return trace.Wrap(err, "listening on tcp socket")
+	}
+	// grpcServer.Serve takes ownership of (and closes) the listener.
+	grpcServer := grpc.NewServer(
+		grpc.Creds(grpccredentials.NewTLS(serverTLSConfig)),
+		grpc.UnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
+		grpc.StreamInterceptor(interceptors.GRPCServerStreamErrorInterceptor),
+	)
+	vnetv1.RegisterClientApplicationServiceServer(grpcServer, p.clientApplicationService)
+
+	p.processManager.AddCriticalBackgroundTask("admin process", func() error {
+		defer func() {
+			// Delete service credentials after the service terminates.
+			if ipcCreds.client.remove(credDir); err != nil {
+				log.ErrorContext(processCtx, "Failed to remove service credential files", "error", err)
+			}
+			if err := os.RemoveAll(credDir); err != nil {
+				log.ErrorContext(processCtx, "Failed to remove service credential directory", "error", err)
+			}
+		}()
+		return trace.Wrap(execAdminProcess(processCtx, LinuxAdminProcessConfig{
+			ServiceCredentialPath:        credDir,
+			ClientApplicationServiceAddr: listener.Addr().String(),
+		}))
+	})
+	p.processManager.AddCriticalBackgroundTask("gRPC service", func() error {
+		log.InfoContext(processCtx, "Starting gRPC service",
+			"addr", listener.Addr().String())
+		return trace.Wrap(grpcServer.Serve(listener),
+			"serving VNet user process gRPC service")
+	})
+	p.processManager.AddCriticalBackgroundTask("gRPC server closer", func() error {
+		// grpcServer.Serve does not stop on its own when processCtx is done, so
+		// this task waits for processCtx and then explicitly stops grpcServer.
+		<-processCtx.Done()
+		grpcServer.GracefulStop()
+		return nil
+	})
+
+	select {
+	case nsi := <-p.clientApplicationService.networkStackInfo:
+		p.networkStackInfo = nsi
+		return nil
+	case <-processCtx.Done():
+		return trace.Wrap(p.processManager.Wait(), "process manager exited before network stack info was received")
+	}
+}

--- a/tool/tsh/common/vnet_daemon_linux.go
+++ b/tool/tsh/common/vnet_daemon_linux.go
@@ -1,0 +1,56 @@
+// Teleport
+// Copyright (C) 2024 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+//go:build linux
+
+package common
+
+import (
+	"log/slog"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/vnet"
+)
+
+const (
+	// On linux the command must match the command provided in the systemd unit file.
+	vnetDaemonSubCommand = "vnet-daemon"
+)
+
+// vnetDaemonCommand implements the vnet-daemon subcommand to run the VNet D-Bus daemon.
+type vnetDaemonCommand struct {
+	*kingpin.CmdClause
+}
+
+func newPlatformVnetDaemonCommand(app *kingpin.Application) *vnetDaemonCommand {
+	return &vnetDaemonCommand{
+		CmdClause: app.Command(vnetDaemonSubCommand, "Start the VNet D-Bus daemon.").Hidden(),
+	}
+}
+
+func (c *vnetDaemonCommand) run(cf *CLIConf) error {
+	level := slog.LevelInfo
+	if cf.Debug {
+		level = slog.LevelDebug
+	}
+	if _, err := utils.InitLogger(utils.LoggingForDaemon, level); err != nil {
+		return trace.Wrap(err, "initializing logger")
+	}
+	return trace.Wrap(vnet.RunLinuxDBusService(cf.Context))
+}

--- a/tool/tsh/common/vnet_linux.go
+++ b/tool/tsh/common/vnet_linux.go
@@ -22,31 +22,34 @@ import (
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	vnetv1 "github.com/gravitational/teleport/gen/proto/go/teleport/lib/vnet/v1"
 	"github.com/gravitational/teleport/lib/vnet"
 )
 
-func newPlatformVnetAdminSetupCommand(app *kingpin.Application) vnetCommandNotSupported {
-	return vnetCommandNotSupported{}
-}
-
-// vnetServiceCommand runs the VNet service.
-type vnetServiceCommand struct {
+// vnetAdminSetupCommand is the fallback command ran as root when there is no
+// available vnet daemon on system.
+type vnetAdminSetupCommand struct {
 	*kingpin.CmdClause
 	cfg vnet.LinuxAdminProcessConfig
 }
 
-func (c *vnetServiceCommand) run(clf *CLIConf) error {
+func (c *vnetAdminSetupCommand) run(clf *CLIConf) error {
 	return trace.Wrap(vnet.RunLinuxAdminProcess(clf.Context, c.cfg))
 }
 
-func newPlatformVnetServiceCommand(app *kingpin.Application) *vnetServiceCommand {
-	cmd := &vnetServiceCommand{
-		CmdClause: app.Command("vnet-service", "Start the VNet admin subprocess.").Hidden(),
+func newPlatformVnetAdminSetupCommand(app *kingpin.Application) *vnetAdminSetupCommand {
+	cmd := &vnetAdminSetupCommand{
+		CmdClause: app.Command(teleport.VnetAdminSetupSubCommand, "Start the VNet admin subprocess.").Hidden(),
 	}
-	cmd.Flag("addr", "client application service address").Required().StringVar(&cmd.cfg.ClientApplicationServiceAddr)
-	cmd.Flag("cred-path", "path to TLS credentials for connecting to client application").Required().StringVar(&cmd.cfg.ServiceCredentialPath)
+	cmd.Flag("addr", "Client application service address.").Required().StringVar(&cmd.cfg.ClientApplicationServiceAddr)
+	cmd.Flag("cred-path", "Path to TLS credentials for connecting to client application.").Required().StringVar(&cmd.cfg.ServiceCredentialPath)
 	return cmd
+}
+
+// The vnet-service command is only supported on windows.
+func newPlatformVnetServiceCommand(app *kingpin.Application) vnetCommandNotSupported {
+	return vnetCommandNotSupported{}
 }
 
 // The vnet-install-service command is only supported on windows.

--- a/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetConnectionItem.tsx
@@ -114,6 +114,7 @@ const VnetConnectionItemBase = forwardRef<
     diagnosticsAttempt,
     getDisabledDiagnosticsReason,
     showDiagWarningIndicator,
+    isDiagSupported,
     installTimeRequirementsCheck,
   } = useVnetContext();
   const { close: closeConnectionsPanel } = useConnectionsContext();
@@ -268,16 +269,18 @@ const VnetConnectionItemBase = forwardRef<
                 </ButtonIcon>
               )}
 
-              <ButtonIcon
-                title={disabledDiagnosticsReason || 'Run diagnostics'}
-                disabled={!!disabledDiagnosticsReason}
-                onClick={e => {
-                  e.stopPropagation();
-                  props.runDiagnosticsFromVnetPanel();
-                }}
-              >
-                <icons.ListMagnifyingGlass size={18} />
-              </ButtonIcon>
+              {isDiagSupported && (
+                <ButtonIcon
+                  title={disabledDiagnosticsReason || 'Run diagnostics'}
+                  disabled={!!disabledDiagnosticsReason}
+                  onClick={e => {
+                    e.stopPropagation();
+                    props.runDiagnosticsFromVnetPanel();
+                  }}
+                >
+                  <icons.ListMagnifyingGlass size={18} />
+                </ButtonIcon>
+              )}
             </>
           )}
 

--- a/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/VnetSliderStep.story.tsx
@@ -37,6 +37,7 @@ import { useVnetContext, VnetContextProvider } from './vnetContext';
 import { VnetSliderStep as Component } from './VnetSliderStep';
 
 type StoryProps = {
+  platform: 'darwin' | 'win32' | 'linux';
   startVnet: 'success' | 'error' | 'processing';
   autoStart: boolean;
   appDnsZones: string[];
@@ -55,6 +56,7 @@ type StoryProps = {
 };
 
 const defaultArgs: StoryProps = {
+  platform: 'darwin',
   startVnet: 'success',
   autoStart: true,
   appDnsZones: ['teleport.example.com', 'company.test'],
@@ -81,6 +83,10 @@ const meta: Meta<StoryProps> = {
     },
   ],
   argTypes: {
+    platform: {
+      control: { type: 'inline-radio' },
+      options: ['darwin', 'win32', 'linux'],
+    },
     startVnet: {
       control: { type: 'inline-radio' },
       options: ['success', 'error', 'processing'],
@@ -122,7 +128,7 @@ const meta: Meta<StoryProps> = {
 export default meta;
 
 function VnetSliderStep(props: StoryProps) {
-  const appContext = new MockAppContext();
+  const appContext = new MockAppContext({ platform: props.platform });
 
   if (props.windowsVNetServiceNotFound) {
     appContext.vnet.checkInstallTimeRequirements = () =>

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -175,7 +175,8 @@ export const VnetContextProvider: FC<
     () => mainProcessClient.getRuntimeSettings().platform,
     [mainProcessClient]
   );
-  const isSupported = platform === 'darwin' || platform === 'win32';
+  const isSupported =
+    platform === 'darwin' || platform === 'win32' || platform === 'linux';
 
   const [checkInstallTimeRequirementsAttempt, checkInstallTimeRequirements] =
     useAsync(

--- a/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
+++ b/web/packages/teleterm/src/ui/Vnet/vnetContext.tsx
@@ -58,6 +58,10 @@ export type VnetContext = {
    * Describes whether the given OS can run VNet.
    */
   isSupported: boolean;
+  /**
+   * Describes whether the given OS can run VNet diagnostics.
+   */
+  isDiagSupported: boolean;
   status: VnetStatus;
   start: () => Promise<[void, Error]>;
   startAttempt: Attempt<void>;
@@ -177,6 +181,7 @@ export const VnetContextProvider: FC<
   );
   const isSupported =
     platform === 'darwin' || platform === 'win32' || platform === 'linux';
+  const isDiagSupported = platform === 'darwin' || platform === 'win32';
 
   const [checkInstallTimeRequirementsAttempt, checkInstallTimeRequirements] =
     useAsync(
@@ -485,6 +490,10 @@ export const VnetContextProvider: FC<
 
   useEffect(
     function periodicallyRunDiagnostics() {
+      if (!isDiagSupported) {
+        return;
+      }
+
       if (status.value !== 'running') {
         return;
       }
@@ -506,6 +515,7 @@ export const VnetContextProvider: FC<
       };
     },
     [
+      isDiagSupported,
       diagnosticsIntervalMs,
       runDiagnosticsAndShowNotification,
       status.value,
@@ -541,6 +551,7 @@ export const VnetContextProvider: FC<
     <VnetContext.Provider
       value={{
         isSupported,
+        isDiagSupported,
         status,
         start,
         startAttempt,


### PR DESCRIPTION
builds on #55542.
### D-bus daemon

changelog: Added Linux support for VNet

D-bus is basically a hybrid IPC/RPC mechanism used in Unix-based distros. Services can register and expose methods on the bus, and authorization is handled by polkit, your service must call the polkit API over D-bus.  
Good article describing D-bus and polkit: https://u1f383.github.io/linux/2025/05/25/dbus-and-polkit-introduction.html.

The VNet daemon is managed by systemd. The systemd unit runs `tsh vnet-daemon`. To allow D-bus to activate the unit when it isn’t running, we add a D-Bus service file that points to this systemd unit.

The daemon registers on the system bus as `org.teleport.vnet1` and exports interface `org.teleport.vnet1.Daemon`. It exposes two methods:

 `Start(addr, credPath)`
 `Stop()`

For authorization we use a single polkit action: `org.teleport.vnet1.manage-daemon`. There’s no automatic mapping from polkit action IDs to D-Bus methods, the mapping is enforced in code, and we use the same action for both Start and Stop.

The daemon exits completely when `Stop()` is called or when the admin process exits on its own. It gets brought back on the next `Start()` call.

### No D-Bus daemon

If the D-Bus service is not available:

- If running as root, we fall back and launch the admin process via `tsh vnet-admin-setup`.
- If not root, we return an error.


## Manual Test Plan
### Test Environment
it relies on the presence of systemd, D-Bus and polkit, most modern desktop Linux distros include them.

To make it work, you need to install the required polkit and D-Bus configuration files.

Polkit action:

```bash
sudo tee /usr/share/polkit-1/actions/org.teleport.vnet1.policy > /dev/null <<'EOF'
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE policyconfig PUBLIC
  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
  "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
<policyconfig>

  <action id="org.teleport.vnet1.manage-daemon">
    <description>Start Teleport VNet</description>
    <message>Authentication is required to start Teleport VNet</message>
    <defaults>
      <allow_any>no</allow_any>
      <allow_inactive>no</allow_inactive>
      <!-- Default behavior if no rule matches -->
      <allow_active>yes</allow_active>
    </defaults>
  </action>

</policyconfig>
EOF
```


D‑Bus config
By default, d-bus will not allow any user (including root) to own the `org.teleport.vnet1` name:

```bash
sudo tee /usr/share/dbus-1/system.d/org.teleport.vnet1.conf > /dev/null <<'EOF'
<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
 "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
<busconfig>
  <policy user="root">
    <allow own="org.teleport.vnet1"/>
  </policy>

  <policy context="default">
    <allow send_destination="org.teleport.vnet1"/>
  </policy>
</busconfig>
EOF

```

D‑Bus service file (activates systemd unit)

```bash
sudo tee /usr/share/dbus-1/system-services/org.teleport.vnet1.service > /dev/null <<'EOF'
[D-BUS Service]
Name=org.teleport.vnet1
SystemdService=teleport-vnet.service
User=root
Exec=/bin/false
EOF
```

Systemd unit

```bash
sudo tee /usr/lib/systemd/system/teleport-vnet.service > /dev/null <<'EOF'
[Unit]
Description=Teleport VNet D-Bus service
After=dbus.service
Requires=dbus.service

[Service]
Type=dbus
BusName=org.teleport.vnet1
ExecStart=/usr/bin/tsh vnet-daemon --debug
User=root
Group=root
EOF
```

I tested this on a cluster with:
- PostgreSQL as a TCP app
- dummy NGINX server as an HTTP app

I also set `google.com` as a custom DNS zone for VNet and checked access to `workspace.google.com` with VNet turned on.

It is actually convenient to inspect DNS behavior with `resolvectl`.

`resolvectl status` shows all active links.  
`resolvectl domain` shows domains attached to each link, for example:

`Link 37 (TeleportVNet): ~internal.example.com ~google.com ~teleport.tangyatsu.com ~teleport.dev`

You can query and verify which link handled DNS:

```bash
resolvectl query workspace.google.com --legend=yes
```

Example output:

```bash
workspace.google.com: 165.xxx.xxx.xxx  -- link: TeleportVNet
```

### Test Cases

- [x] can start VNet with `tsh vnet`
- [x] can connect to TCP app over VNet
- [x]  can connect to SSH node over VNet
- [x] HTTP app access continues to work with VNet on and off
- [x] public URIs under a custom DNS zone are still reachable (with VNet on and off)
- [x] can view daemon logs with `journalctl -u teleport-vnet.service`
- [x] can start and stop VNet from Connect
- [x] can start VNet with `sudo tsh vnet` without presence of config files
