### PR TITLE
[v18] MWI: Add `tbot start noop` to start or configure bots with no services

### DIFF
--- a/lib/tbot/cli/start_empty.go
+++ b/lib/tbot/cli/start_empty.go
@@ -1,0 +1,57 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib/tbot/config"
+)
+
+// NoopCommand implements `tbot start noop` and
+// `tbot configure identity`.
+type NoopCommand struct {
+	*sharedStartArgs
+	*genericMutatorHandler
+}
+
+// NewNoopCommand initializes the command and flags for identity outputs
+// and returns a struct that will contain the parse result.
+func NewNoopCommand(parentCmd *kingpin.CmdClause, action MutatorAction, mode CommandMode) *NoopCommand {
+	cmd := parentCmd.Command("noop", fmt.Sprintf("%s tbot with no configured services to test onboarding config.", mode)).Alias("no-op")
+
+	c := &NoopCommand{}
+	c.sharedStartArgs = newSharedStartArgs(cmd)
+
+	c.genericMutatorHandler = newGenericMutatorHandler(cmd, c, action)
+
+	return c
+}
+
+func (c *NoopCommand) ApplyConfig(cfg *config.BotConfig, l *slog.Logger) error {
+	if err := c.sharedStartArgs.ApplyConfig(cfg, l); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}

--- a/lib/tbot/cli/start_empty_test.go
+++ b/lib/tbot/cli/start_empty_test.go
@@ -1,0 +1,72 @@
+/*
+ * Teleport
+ * Copyright (C) 2024  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tbot/bot/destination"
+	"github.com/gravitational/teleport/lib/tbot/config"
+)
+
+// TestNoopCommand tests that the IdentityCommand properly parses its arguments
+// and applies as expected onto a BotConfig.
+func TestNoopCommand(t *testing.T) {
+	testStartConfigureCommand(t, NewNoopCommand, []startConfigureTestCase{
+		{
+			name: "success",
+			args: []string{
+				"start",
+				"noop",
+				"--token=foo",
+				"--ca-pin=bar",
+				"--certificate-ttl=10m",
+				"--renewal-interval=5m",
+				"--join-method=github",
+				"--oneshot",
+				"--diag-addr=0.0.0.0:8080",
+				"--storage=/foo",
+				"--proxy-server=example.com:443",
+			},
+			assertConfig: func(t *testing.T, cfg *config.BotConfig) {
+				token, err := cfg.Onboarding.Token()
+				require.NoError(t, err)
+				require.Equal(t, "foo", token)
+
+				require.ElementsMatch(t, cfg.Onboarding.CAPins, []string{"bar"})
+				require.Equal(t, time.Minute*10, cfg.CredentialLifetime.TTL)
+				require.Equal(t, time.Minute*5, cfg.CredentialLifetime.RenewalInterval)
+				require.Equal(t, types.JoinMethodGitHub, cfg.Onboarding.JoinMethod)
+				require.True(t, cfg.Oneshot)
+				require.Equal(t, "0.0.0.0:8080", cfg.DiagAddr)
+				require.Equal(t, "example.com:443", cfg.ProxyServer)
+
+				dir, ok := cfg.Storage.Destination.(*destination.Directory)
+				require.True(t, ok)
+				require.Equal(t, "/foo", dir.Path)
+
+				require.Len(t, cfg.Services, 0)
+			},
+		},
+	})
+}

--- a/lib/tbot/cli/start_empty_test.go
+++ b/lib/tbot/cli/start_empty_test.go
@@ -65,7 +65,7 @@ func TestNoopCommand(t *testing.T) {
 				require.True(t, ok)
 				require.Equal(t, "/foo", dir.Path)
 
-				require.Len(t, cfg.Services, 0)
+				require.Empty(t, cfg.Services)
 			},
 		},
 	})

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -132,6 +132,9 @@ func Run(args []string, stdout io.Writer) error {
 		cli.NewLegacyCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
 		cli.NewLegacyCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),
 
+		cli.NewNoopCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
+		cli.NewNoopCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),
+
 		cli.NewIdentityCommand(startCmd, buildConfigAndStart(ctx, globalCfg), cli.CommandModeStart),
 		cli.NewIdentityCommand(configureCmd, buildConfigAndConfigure(ctx, globalCfg, &configureOutPath, stdout), cli.CommandModeConfigure),
 


### PR DESCRIPTION
Backport #63624 to branch/v18

changelog: MWI: Add new `tbot start no-op` helper that starts no services

### Manual testing

- [x] Built and ran `tbot start noop --join-uri=... --storage=./storage`