### PR TITLE
Patch minGetUserCASemver to v18.7.0

### DIFF
--- a/lib/auth/trust/trustv1/service.go
+++ b/lib/auth/trust/trustv1/service.go
@@ -39,7 +39,7 @@ import (
 )
 
 // TODO(codingllama): DELETE IN 20. All valid clients support WindowsCA by then.
-var minGetUserCASemver = semver.New("18.8.0")
+var minGetUserCASemver = semver.New("18.7.0")
 
 type authServer interface {
 	// GetClusterName returns cluster name


### PR DESCRIPTION
The Windows CA feature is on track to release on v18.7.0, so this updates minGetUserCASemver accordingly.

#10111