### PR TITLE
Tweak tsh helpers to reduce test time

### DIFF
--- a/tool/tsh/common/access_request_test.go
+++ b/tool/tsh/common/access_request_test.go
@@ -62,6 +62,7 @@ func TestAccessRequestSearch(t *testing.T) {
 			cfg.Auth.ClusterName.SetClusterName(rootClusterName)
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			cfg.Kube.Enabled = true
+			cfg.SSH.Enabled = false
 			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
 			cfg.Kube.KubeconfigPath = newKubeConfigFile(t, rootKubeCluster)
 		}),
@@ -71,6 +72,7 @@ func TestAccessRequestSearch(t *testing.T) {
 				cfg.Auth.ClusterName.SetClusterName(leafClusterName)
 				cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 				cfg.Kube.Enabled = true
+				cfg.SSH.Enabled = false
 				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
 				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
 			},

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -167,6 +167,7 @@ func testDatabaseLogin(t *testing.T) {
 				accessRequestorRole,
 				alice,
 			)
+			cfg.SSH.Enabled = false
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			// separate MySQL port with TLS routing.
 			// set the public address to be sure even on v2+, tsh clients will see the separate port.
@@ -709,6 +710,7 @@ func testListDatabase(t *testing.T) {
 			cfg.Auth.StorageConfig.Params["poll_stream_period"] = 50 * time.Millisecond
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			cfg.Databases.Enabled = true
+			cfg.SSH.Enabled = false
 			cfg.Databases.Databases = []servicecfg.Database{{
 				Name:     fullName,
 				Protocol: defaults.ProtocolPostgres,
@@ -728,6 +730,7 @@ func testListDatabase(t *testing.T) {
 		withLeafCluster(),
 		withLeafConfigFunc(func(cfg *servicecfg.Config) {
 			cfg.Auth.StorageConfig.Params["poll_stream_period"] = 50 * time.Millisecond
+			cfg.SSH.Enabled = false
 			cfg.Databases.Enabled = true
 			cfg.Databases.Databases = []servicecfg.Database{{
 				Name:     "leaf-postgres",
@@ -1599,6 +1602,7 @@ func testDatabaseSelection(t *testing.T) {
 			cfg.Auth.BootstrapResources = append(cfg.Auth.BootstrapResources, alice)
 			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
 			cfg.Databases.Enabled = true
+			cfg.SSH.Enabled = false
 			cfg.Databases.Databases = []servicecfg.Database{
 				fooDB1, fooRDSDB, fooRDSCustomDB,
 				barRDSDB1, barRDSDB2,

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -153,6 +153,7 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 			cfg.Kube.StaticLabels = rootLabels
 			cfg.Proxy.Kube.Enabled = true
 			cfg.Proxy.Kube.ListenAddr = *utils.MustParseAddr(localListenerAddr())
+			cfg.SSH.Enabled = false
 		}),
 		withLeafCluster(),
 		withLeafConfigFunc(
@@ -164,6 +165,7 @@ func setupKubeTestPack(t *testing.T, withMultiplexMode bool) *kubeTestPack {
 				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
 				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
 				cfg.Kube.StaticLabels = leafLabels
+				cfg.SSH.Enabled = false
 			},
 		),
 		withValidationFunc(func(s *suite) bool {

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -104,6 +104,8 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 	cfg.FileDescriptors = dynAddr.Descriptors
 
 	cfg.Proxy.DisableWebInterface = true
+	cfg.Proxy.DisableDatabaseProxy = true
+	cfg.Proxy.IdP.SAMLIdP.Enabled = false
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{{
 			Roles:   []types.SystemRole{types.RoleProxy, types.RoleDatabase, types.RoleTrustedCluster, types.RoleNode, types.RoleApp},
@@ -204,6 +206,8 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 	require.NoError(t, err)
 
 	cfg.Proxy.DisableWebInterface = true
+	cfg.Proxy.DisableDatabaseProxy = true
+	cfg.Proxy.IdP.SAMLIdP.Enabled = false
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
 		StaticTokens: []types.ProvisionTokenV1{{
 			Roles:   []types.SystemRole{types.RoleProxy, types.RoleDatabase, types.RoleTrustedCluster, types.RoleNode, types.RoleApp},
@@ -303,13 +307,13 @@ func newTestSuite(t *testing.T, opts ...testSuiteOptionFunc) *suite {
 			rt, err := s.root.GetAuthServer().GetTunnelConnections(s.leaf.Config.Auth.ClusterName.GetClusterName())
 			require.NoError(t, err)
 			return len(rt) == 1
-		}, time.Second*10, time.Second)
+		}, 10*time.Second, 100*time.Millisecond)
 	}
 
 	if options.validationFunc != nil {
 		require.Eventually(t, func() bool {
 			return options.validationFunc(s)
-		}, 10*time.Second, 500*time.Millisecond)
+		}, 10*time.Second, 100*time.Millisecond)
 	}
 
 	return s

--- a/tool/tsh/common/workload_identity_test.go
+++ b/tool/tsh/common/workload_identity_test.go
@@ -63,6 +63,7 @@ func TestWorkloadIdentityIssueX509(t *testing.T) {
 		user.AddRole(role.GetName())
 		cfg.Auth.BootstrapResources[1] = user
 		cfg.Auth.BootstrapResources = append(cfg.Auth.BootstrapResources, role)
+		cfg.SSH.Enabled = false
 	}))
 	setWorkloadIdentityX509CAOverride(ctx, t, s.root)
 


### PR DESCRIPTION
- Disables services that are not used
- Increases the frequency validation checks run