### PR TITLE
RFD plan to instrument product metrics for the Discovery IAC flow

### DIFF
--- a/rfd/0247-discover-iac-metrics.md
+++ b/rfd/0247-discover-iac-metrics.md
@@ -1,0 +1,440 @@
+---
+authors: Charles Bryan (charles@goteleport.com)
+state: draft
+---
+
+# RFD 0247 - IaC Discovery Flow Product Metrics
+
+## Purpose
+
+Complete instrumentation of the IaC discovery flow by adding new events (ResourceDiscoveredEvent, DiscoveryConfigCreateEvent) and IAC flow UI events to measure adoption growth, setup success rates, and enable future product analysis.
+
+## Goals
+
+1. **Track adoption and growth**
+   - Current adoption: What % of active clusters use discovery?
+   - Growth trajectory: What is the week-over-week adoption rate?
+   - New adopters: How many clusters adopt discovery each week?
+
+2. **Measure setup success and identify blockers**
+   - Success rate: What % complete the full funnel (config → resources → no errors)?
+   - Drop-off analysis: Where in the funnel do users fail?
+   - Common issues: What errors block users from successful setup?
+
+3. **Ensure complete instrumentation**
+   - Instrument all key discovery events (config creation, resource enrollment, failures)
+   - Enable answering future product questions without requiring new events
+   - Establish baseline metrics for ongoing discovery feature development
+
+## Background
+
+There are three ways resources get enrolled in Teleport through discovery:
+
+1. **IAC flow** -- Users start in the web UI at Integrations, configure resource discovery options, and receive generated Terraform HCL. They run `terraform apply` which creates an Integration and DiscoveryConfig via the Teleport Terraform provider. The official Terraform module applies the `teleport.dev/iac-tool` label to the DiscoveryConfig resource. The discovery service then polls cloud providers and enrolls matching resources.
+
+2. **Guided Discover flow** -- Users start in the web UI at Discover, select a resource type, and walk through a multi-step setup. The UI creates a DiscoveryConfig directly via API. Available for EC2 auto-enrollment, RDS auto-enrollment, and EKS auto-enrollment.
+
+3. **Static configuration** -- Matchers defined in `teleport.yaml`. No DiscoveryConfig resource is created. The discovery service reads matchers directly from its config file.
+
+Resources created outside of discovery are considered manually enrolled.
+
+## Existing Instrumentation
+
+### Guided Discover flow events -- no changes needed
+
+The Guided Discover flow already emits a full step-by-step funnel via `tp.ui.discover.*` events, including resource selection, service deployment, discovery config creation, test connection, completion, and abort/error at each step. These events include resource type, discovery config method, and error messages.
+
+### UserTaskStateEvent -- no changes needed
+
+Already emitted with all required fields: `task_type`, `issue_type`, `state`, `instances_count`.
+
+### Integration enrollment events -- require instrumentation in IAC flow
+
+The `UIIntegrationEnroll*` event types exist and are used by other integration flows (AWS OIDC, AWS Identity Center, GitHub). The IAC flow at `Integrations/Enroll/Cloud/Aws/EnrollAws.tsx` does not emit these events. A new `IntegrationEnrollKind` value is needed for the AWS Cloud IAC flow.
+
+### ResourceCreateEvent -- requires changes
+
+Currently emitted only by the discovery service via `emitUsageEvents()` when it discovers cloud resources. Auth does not emit `ResourceCreateEvent`; it emits `ResourceHeartbeatEvent` on every resource heartbeat/upsert. There is no event that fires exactly once when a resource is first created, which makes it impossible to query for resources created in a time window.
+
+Changes needed:
+
+- Auth must emit `ResourceCreateEvent` once per resource on first creation for all resource types (nodes, databases, kubernetes clusters, apps, windows desktops).
+- The discovery service's current `ResourceCreateEvent` emission will be replaced by the new `ResourceDiscoveredEvent`.
+
+## Event Specifications
+
+### Changes to Existing Events
+
+#### IntegrationEnrollKind
+
+Add a new enum value for the AWS Cloud IAC flow:
+
+```protobuf
+enum IntegrationEnrollKind {
+  // ... existing values ...
+  INTEGRATION_ENROLL_KIND_AWS_CLOUD = 30;
+}
+```
+
+Add corresponding frontend value in `IntegrationEnrollKind`:
+
+```typescript
+AwsCloud = 'INTEGRATION_ENROLL_KIND_AWS_CLOUD',
+```
+
+#### ResourceCreateEvent
+
+Currently only emitted by the discovery service. Auth emits `ResourceHeartbeatEvent` on every heartbeat but has no event for first resource creation. This means there is no way to query for resources created in a time window.
+
+Add `ResourceCreateEvent` emission from auth on first resource creation. For initial implementation we will attempt to get the resource before the `Put` call to check if the resource is new. Where a resource is new, emit `ResourceCreateEvent` with:
+
+```protobuf
+// ResourceCreateEvent is emitted when a resource is created.
+message ResourceCreateEvent {
+  // resource_type is the type of resource ("node", "node.openssh", "db", "k8s", "app").
+  string resource_type = 1;
+  // resource_origin is the origin of the resource ("cloud", "kubernetes").
+  string resource_origin = 2;
+  // cloud_provider is the cloud provider the resource came from ("AWS", "Azure", "GCP")
+  // if resource_origin == "cloud".
+  string cloud_provider = 3;
+  // database contains additional database information if resource_type == "db".
+  DiscoveredDatabaseMetadata database = 4;
+}
+```
+
+No proto changes are needed — the existing message is sufficient. The change is to emit this event from auth in the following code paths:
+
+| Resource type       | Auth method                                     |
+| ------------------- | ----------------------------------------------- |
+| Nodes               | `UpsertNode` (when `GetNode` returns not found) |
+| Databases           | `CreateDatabase`                                |
+| Kubernetes clusters | `CreateKubernetesCluster`                       |
+| Apps                | `CreateApplicationServer`                       |
+| Windows desktops    | `CreateWindowsDesktop`                          |
+
+The discovery service's current `ResourceCreateEvent` emission will be removed and replaced by `ResourceDiscoveredEvent`.
+
+**Athena event type:** `'tp.resource.create'`
+
+### New Events
+
+#### ResourceDiscoveredEvent
+
+Emitted by the discovery service when it discovers a resource from a cloud provider. Replaces the current `ResourceCreateEvent` emission in `emitUsageEvents()`, avoiding the duplicate event bug where both the discovery service and auth emit `ResourceCreateEvent` for the same resource.
+
+```protobuf
+message ResourceDiscoveredEvent {
+  string resource_type = 1;
+  string resource_name = 2;
+  string cloud_provider = 3;
+  string discovery_config_name = 4;
+  string discovery_method = 5;
+}
+```
+
+**`discovery_method` values:**
+
+| Value      | Meaning                                                                                 |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `"static"` | Discovered via matchers defined in `teleport.yaml`. No DiscoveryConfig resource exists. |
+| `"guided"` | Discovered via a DiscoveryConfig created in the Guided Discover flow.                   |
+| `"iac"`    | Discovered via a DiscoveryConfig created by the IAC flow.                               |
+
+**How `discovery_method` is resolved:**
+
+The discovery service resolves the method centrally in `emitUsageEvents()` before submitting each event. It looks up the DiscoveryConfig by name from its in-memory cache and checks for the `teleport.dev/iac-tool` label:
+
+- No DiscoveryConfig name present: `"static"`
+- DiscoveryConfig exists with `teleport.dev/iac-tool` label: `"iac"`
+- DiscoveryConfig exists without that label: `"guided"`
+
+**`resource_name`:** anonymized name of the discovered resource. Enables joining with `ResourceCreateEvent` to determine which created resources came from discovery.
+
+**`discovery_config_name`:** anonymized name of the DiscoveryConfig that triggered discovery. Empty for static configuration. Enables joining with `DiscoveryConfigCreateEvent`.
+
+**Emission points:**
+
+| Path                | File                                    | discovery_config_name source                         |
+| ------------------- | --------------------------------------- | ---------------------------------------------------- |
+| EC2 instances       | `lib/srv/discovery/discovery.go`        | From `EC2Instances.DiscoveryConfigName`              |
+| Azure VMs           | `lib/srv/discovery/discovery.go`        | From `AzureInstances.DiscoveryConfigName`            |
+| GCP VMs             | `lib/srv/discovery/discovery.go`        | From `GCPInstances.DiscoveryConfigName`              |
+| Kubernetes clusters | `lib/srv/discovery/kube_watcher.go`     | From `teleport.internal/discovery-config-name` label |
+| Databases           | `lib/srv/discovery/database_watcher.go` | From `teleport.internal/discovery-config-name` label |
+
+**Athena event type:** `'tp.resource.discovered'`
+
+#### DiscoveryConfigCreateEvent
+
+Emitted when a DiscoveryConfig resource is created, regardless of creation method. This captures all discovery paths: IAC flow, Guided Discover flow, and API/tctl.
+
+```protobuf
+message DiscoveryConfigCreateEvent {
+  string discovery_config_name = 1;
+  string creation_method = 2;
+}
+```
+
+**`creation_method` values:**
+
+| Value      | Meaning                                                             |
+| ---------- | ------------------------------------------------------------------- |
+| `"iac"`    | DiscoveryConfig has `teleport.dev/iac-tool` label at creation time. |
+| `"guided"` | DiscoveryConfig created without `teleport.dev/iac-tool` label.      |
+
+**`discovery_config_name`:** anonymized name of the DiscoveryConfig, for correlation with `ResourceDiscoveredEvent.discovery_config_name`.
+
+Emitted in `CreateDiscoveryConfig()` in the discoveryconfig service. The creation method is resolved by checking for the `teleport.dev/iac-tool` label on the resource being created.
+
+**Athena event type:** `'tp.discovery.config.create'`
+
+### IAC Flow UI Instrumentation
+
+Instrument `Integrations/Enroll/Cloud/Aws/EnrollAws.tsx` to emit existing `UIIntegrationEnroll*` events with `kind = INTEGRATION_ENROLL_KIND_AWS_CLOUD`:
+
+| Action                    | Event type                         | Fields                                                              |
+| ------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| User lands on page        | `tp.ui.integrationEnroll.start`    | `kind = AWS_CLOUD`                                                  |
+| User copies Terraform HCL | `tp.ui.integrationEnroll.codeCopy` | `kind = AWS_CLOUD`, `type = INTEGRATION_ENROLL_CODE_TYPE_TERRAFORM` |
+
+## Event-to-Goal Mapping
+
+| Goal                                   | Events Used                                                                                                                              |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Goal 1: Adoption and Growth**        | ResourceCreateEvent, ResourceDiscoveredEvent, DiscoveryConfigCreateEvent                                                                 |
+| **Goal 2: Setup Success and Blockers** | UIIntegrationEnrollStartEvent, UIIntegrationEnrollCodeCopyEvent, DiscoveryConfigCreateEvent, ResourceDiscoveredEvent, UserTaskStateEvent |
+| **Goal 3: Complete Instrumentation**   | All of the above                                                                                                                         |
+
+## Queries
+
+**Table:** `prehog_events_v1`
+
+**Field extraction:** `json_extract_scalar(event_data, '$.properties["tp.field_name"]')`
+
+### Goal 1: Track Adoption and Growth
+
+#### What percentage of active clusters use discovery?
+
+Active clusters are those that created any resource in the last 30 days. Discovery clusters are those that also have `tp.resource.discovered` events.
+
+```sql
+WITH active_clusters AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.create'
+    AND event_date >= current_date - interval '30' day
+),
+discovery_clusters AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.discovered'
+    AND event_date >= current_date - interval '30' day
+)
+SELECT
+  COUNT(DISTINCT d.cluster_name) AS discovery_clusters,
+  COUNT(DISTINCT a.cluster_name) AS total_active_clusters,
+  CAST(COUNT(DISTINCT d.cluster_name) AS DOUBLE) * 100.0 /
+    CAST(COUNT(DISTINCT a.cluster_name) AS DOUBLE) AS adoption_pct
+FROM active_clusters a
+LEFT JOIN discovery_clusters d ON a.cluster_name = d.cluster_name;
+```
+
+#### What is the week-over-week discovery adoption rate?
+
+```sql
+WITH weekly_discovery AS (
+  SELECT
+    date_trunc('week', from_iso8601_timestamp(json_extract_scalar(event_data, '$.timestamp'))) AS week,
+    COUNT(DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]')) AS clusters
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.discovered'
+    AND event_date >= current_date - interval '90' day
+  GROUP BY 1
+),
+weekly_total AS (
+  SELECT
+    date_trunc('week', from_iso8601_timestamp(json_extract_scalar(event_data, '$.timestamp'))) AS week,
+    COUNT(DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]')) AS clusters
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.create'
+    AND event_date >= current_date - interval '90' day
+  GROUP BY 1
+)
+SELECT
+  t.week,
+  COALESCE(d.clusters, 0) AS discovery_clusters,
+  t.clusters AS total_active_clusters,
+  CAST(COALESCE(d.clusters, 0) AS DOUBLE) * 100.0 / CAST(t.clusters AS DOUBLE) AS adoption_pct,
+  COALESCE(d.clusters, 0) - LAG(COALESCE(d.clusters, 0)) OVER (ORDER BY t.week) AS wow_change
+FROM weekly_total t
+LEFT JOIN weekly_discovery d ON t.week = d.week
+ORDER BY t.week DESC
+LIMIT 12;
+```
+
+#### How many new clusters adopt discovery each week?
+
+First-time discovery event per cluster.
+
+```sql
+WITH first_discovery AS (
+  SELECT
+    json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name,
+    date_trunc('week', MIN(from_iso8601_timestamp(json_extract_scalar(event_data, '$.timestamp')))) AS first_week
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.discovered'
+  GROUP BY 1
+)
+SELECT first_week AS week, COUNT(*) AS new_clusters
+FROM first_discovery
+GROUP BY 1
+ORDER BY 1 DESC
+LIMIT 12;
+```
+
+#### What is the adoption split across discovery methods?
+
+```sql
+SELECT
+  json_extract_scalar(event_data, '$.properties["tp.discovery_method"]') AS discovery_method,
+  COUNT(DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]')) AS clusters,
+  COUNT(*) AS resources_discovered
+FROM prehog_events_v1
+WHERE event_type = 'tp.resource.discovered'
+  AND event_date >= current_date - interval '30' day
+GROUP BY 1;
+```
+
+### Goal 2: Measure Setup Success and Identify Blockers
+
+#### IAC funnel
+
+The IAC discovery funnel has five stages:
+
+1. **Start IAC integration configuration** -- user lands on the IAC enrollment page
+2. **Configure** -- user enters integration name, selects resources, regions, and tag filters
+3. **Copy Terraform** -- user copies the generated Terraform HCL
+4. **Create DiscoveryConfig** -- user runs `terraform apply`, which creates the Integration and DiscoveryConfig
+5. **First resource discovered** -- the discovery service finds a matching resource
+
+Stages 1-3 happen in the web UI at `Integrations/Enroll/Cloud/Aws/EnrollAws.tsx`. Stages 4-5 are backend events.
+
+| Stage                        | Event                                                      |
+| ---------------------------- | ---------------------------------------------------------- |
+| 1. Start IAC configuration   | `tp.ui.integrationEnroll.start` with `kind = AWS_CLOUD`    |
+| 2. Configure                 | Implied by reaching stage 3                                |
+| 3. Copy Terraform            | `tp.ui.integrationEnroll.codeCopy` with `kind = AWS_CLOUD` |
+| 4. Create DiscoveryConfig    | `tp.discovery.config.create`                               |
+| 5. First resource discovered | `tp.resource.discovered` with `discovery_method = 'iac'`   |
+
+#### What percentage of clusters that start the IAC flow go on to discover resources?
+
+```sql
+WITH stage1_start AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.ui.integrationEnroll.start'
+    AND json_extract_scalar(event_data, '$.properties["tp.kind"]') = 'AWS_CLOUD'
+    AND event_date >= current_date - interval '30' day
+),
+stage3_copy AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.ui.integrationEnroll.codeCopy'
+    AND json_extract_scalar(event_data, '$.properties["tp.kind"]') = 'AWS_CLOUD'
+    AND event_date >= current_date - interval '30' day
+),
+stage4_config AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.discovery.config.create'
+    AND json_extract_scalar(event_data, '$.properties["tp.creation_method"]') = 'iac'
+    AND event_date >= current_date - interval '30' day
+),
+stage5_discovered AS (
+  SELECT DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.discovered'
+    AND json_extract_scalar(event_data, '$.properties["tp.discovery_method"]') = 'iac'
+    AND event_date >= current_date - interval '30' day
+)
+SELECT
+  (SELECT COUNT(*) FROM stage1_start) AS started,
+  (SELECT COUNT(*) FROM stage3_copy) AS copied_terraform,
+  (SELECT COUNT(*) FROM stage4_config) AS created_config,
+  (SELECT COUNT(*) FROM stage5_discovered) AS discovered_resources,
+  CAST((SELECT COUNT(*) FROM stage3_copy) AS DOUBLE) * 100.0 /
+    NULLIF(CAST((SELECT COUNT(*) FROM stage1_start) AS DOUBLE), 0) AS start_to_copy_pct,
+  CAST((SELECT COUNT(*) FROM stage4_config) AS DOUBLE) * 100.0 /
+    NULLIF(CAST((SELECT COUNT(*) FROM stage3_copy) AS DOUBLE), 0) AS copy_to_config_pct,
+  CAST((SELECT COUNT(*) FROM stage5_discovered) AS DOUBLE) * 100.0 /
+    NULLIF(CAST((SELECT COUNT(*) FROM stage4_config) AS DOUBLE), 0) AS config_to_discovered_pct;
+```
+
+#### What are the most common discovery issues blocking users?
+
+```sql
+SELECT
+  json_extract_scalar(event_data, '$.properties["tp.task_type"]') AS task_type,
+  json_extract_scalar(event_data, '$.properties["tp.issue_type"]') AS issue_type,
+  SUM(CAST(json_extract_scalar(event_data, '$.properties["tp.instances_count"]') AS INTEGER)) AS affected_resources,
+  COUNT(DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]')) AS affected_clusters
+FROM prehog_events_v1
+WHERE event_type = 'tp.usertask.state'
+  AND json_extract_scalar(event_data, '$.properties["tp.state"]') = 'OPEN'
+  AND json_extract_scalar(event_data, '$.properties["tp.task_type"]') LIKE 'discover-%'
+  AND event_date >= current_date - interval '30' day
+GROUP BY 1, 2
+ORDER BY affected_resources DESC;
+```
+
+### Goal 3: Complete Instrumentation
+
+#### What resource types and cloud providers are being discovered?
+
+```sql
+SELECT
+  json_extract_scalar(event_data, '$.properties["tp.discovery_method"]') AS discovery_method,
+  json_extract_scalar(event_data, '$.properties["tp.resource_type"]') AS resource_type,
+  json_extract_scalar(event_data, '$.properties["tp.cloud_provider"]') AS cloud_provider,
+  COUNT(*) AS resources_discovered,
+  COUNT(DISTINCT json_extract_scalar(event_data, '$.properties["tp.cluster_name"]')) AS clusters
+FROM prehog_events_v1
+WHERE event_type = 'tp.resource.discovered'
+  AND event_date >= current_date - interval '30' day
+GROUP BY 1, 2, 3
+ORDER BY resources_discovered DESC;
+```
+
+#### What is the median time from config creation to first resource discovery?
+
+```sql
+WITH config_created AS (
+  SELECT
+    json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name,
+    json_extract_scalar(event_data, '$.properties["tp.discovery_config_name"]') AS config_name,
+    MIN(from_iso8601_timestamp(json_extract_scalar(event_data, '$.timestamp'))) AS config_time
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.discovery.config.create'
+    AND event_date >= current_date - interval '30' day
+  GROUP BY 1, 2
+),
+first_discovered AS (
+  SELECT
+    json_extract_scalar(event_data, '$.properties["tp.cluster_name"]') AS cluster_name,
+    json_extract_scalar(event_data, '$.properties["tp.discovery_config_name"]') AS config_name,
+    MIN(from_iso8601_timestamp(json_extract_scalar(event_data, '$.timestamp'))) AS discovered_time
+  FROM prehog_events_v1
+  WHERE event_type = 'tp.resource.discovered'
+    AND event_date >= current_date - interval '30' day
+  GROUP BY 1, 2
+)
+SELECT
+  approx_percentile(date_diff('minute', c.config_time, d.discovered_time), 0.5) AS median_minutes,
+  approx_percentile(date_diff('minute', c.config_time, d.discovered_time), 0.9) AS p90_minutes,
+  COUNT(*) AS configs
+FROM config_created c
+JOIN first_discovered d ON c.cluster_name = d.cluster_name AND c.config_name = d.config_name
+WHERE d.discovered_time > c.config_time;
+```


### PR DESCRIPTION
Discovery Metrics plan

This RFD covers instrumenting the new Discovery IAC flow with usage events to enable product metrics queries. The proposed changes include increased usage event reporting for all resource creation, as well as changing the event currently being reported in the discovery service. I'd love the team's feedback in those areas.


**note: The athena queries in the plan do not need to be reviewed. I'm experimenting with how easy, and how well AI can generate queries to answer product questions. They aren't verified / ironed out yet.**

Reference https://github.com/gravitational/teleport/pull/63680 for the first implementation step based on this plan.