### PR TITLE
[v18] Adding `gcp` join method to scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -160,7 +160,9 @@ type ScopedTokenSpec struct {
 	// using this token.
 	ImmutableLabels *ImmutableLabels `protobuf:"bytes,5,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
 	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
-	Aws           *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	Aws *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	// The GCP-specific configuration used with the "gcp" join method.
+	Gcp           *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -233,6 +235,13 @@ func (x *ScopedTokenSpec) GetImmutableLabels() *ImmutableLabels {
 func (x *ScopedTokenSpec) GetAws() *AWS {
 	if x != nil {
 		return x.Aws
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetGcp() *GCP {
+	if x != nil {
+		return x.Gcp
 	}
 	return nil
 }
@@ -774,6 +783,53 @@ func (x *AWS) GetIntegration() string {
 	return ""
 }
 
+// The GCP-specific configuration used with the "gcp" join method.
+type GCP struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*GCP_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GCP) Reset() {
+	*x = GCP{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP) ProtoMessage() {}
+
+func (x *GCP) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP.ProtoReflect.Descriptor instead.
+func (*GCP) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GCP) GetAllow() []*GCP_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
 // A rule that a joining node must match in order to use the associated token
 // with AWS join methods.
 type AWS_Rule struct {
@@ -798,7 +854,7 @@ type AWS_Rule struct {
 
 func (x *AWS_Rule) Reset() {
 	*x = AWS_Rule{}
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -810,7 +866,7 @@ func (x *AWS_Rule) String() string {
 func (*AWS_Rule) ProtoMessage() {}
 
 func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
-	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -861,6 +917,71 @@ func (x *AWS_Rule) GetAwsOrganizationId() string {
 	return ""
 }
 
+// A rule that a joining node must match in order to use the associated token
+// with the "gcp" join method.
+type GCP_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of project IDs (e.g. `<example-id-123456>`).
+	ProjectIds []string `protobuf:"bytes,1,rep,name=project_ids,json=projectIds,proto3" json:"project_ids,omitempty"`
+	// A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+	Locations []string `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
+	// A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+	ServiceAccounts []string `protobuf:"bytes,3,rep,name=service_accounts,json=serviceAccounts,proto3" json:"service_accounts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *GCP_Rule) Reset() {
+	*x = GCP_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP_Rule) ProtoMessage() {}
+
+func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP_Rule.ProtoReflect.Descriptor instead.
+func (*GCP_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10, 0}
+}
+
+func (x *GCP_Rule) GetProjectIds() []string {
+	if x != nil {
+		return x.ProjectIds
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetLocations() []string {
+	if x != nil {
+		return x.Locations
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetServiceAccounts() []string {
+	if x != nil {
+		return x.ServiceAccounts
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -873,7 +994,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x99\x02\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xcc\x02\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -882,7 +1003,8 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\n" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
 	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
-	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\"\xb6\x01\n" +
+	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
+	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -926,7 +1048,14 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"awsRegions\x12\x19\n" +
 	"\baws_role\x18\x03 \x01(\tR\aawsRole\x12\x17\n" +
 	"\aaws_arn\x18\x04 \x01(\tR\x06awsArn\x12.\n" +
-	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationIdBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationId\"\xb3\x01\n" +
+	"\x03GCP\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.GCP.RuleR\x05allow\x1ap\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vproject_ids\x18\x01 \x03(\tR\n" +
+	"projectIds\x12\x1c\n" +
+	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccountsBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -940,7 +1069,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -952,32 +1081,36 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*StaticScopedTokensSpec)(nil), // 7: teleport.scopes.joining.v1.StaticScopedTokensSpec
 	(*ImmutableLabels)(nil),        // 8: teleport.scopes.joining.v1.ImmutableLabels
 	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
-	nil,                            // 10: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*AWS_Rule)(nil),               // 11: teleport.scopes.joining.v1.AWS.Rule
-	(*v1.Metadata)(nil),            // 12: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 13: google.protobuf.Timestamp
+	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
+	nil,                            // 11: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 12: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 13: teleport.scopes.joining.v1.GCP.Rule
+	(*v1.Metadata)(nil),            // 14: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 15: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	12, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	14, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	8,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
 	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
-	13, // 5: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	13, // 6: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 7: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 8: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 9: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	12, // 10: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	7,  // 11: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 12: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	10, // 13: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	11, // 14: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
+	15, // 6: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	15, // 7: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 8: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 9: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 10: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	14, // 11: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	7,  // 12: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 13: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 14: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	12, // 15: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	13, // 16: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	17, // [17:17] is the sub-list for method output_type
+	17, // [17:17] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -994,7 +1127,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   12,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -73,6 +73,9 @@ message ScopedTokenSpec {
 
   // The AWS-specific configuration used with the "ec2" and "iam" join methods.
   AWS aws = 6;
+
+  // The GCP-specific configuration used with the "gcp" join method.
+  GCP gcp = 7;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -190,4 +193,21 @@ message AWS {
   // Integration name which provides credentials for validating join attempts.
   // Currently only in use for validating the AWS Organization ID in the IAM Join method.
   string integration = 3;
+}
+
+// The GCP-specific configuration used with the "gcp" join method.
+message GCP {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "gcp" join method.
+  message Rule {
+    // A list of project IDs (e.g. `<example-id-123456>`).
+    repeated string project_ids = 1;
+    // A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+    repeated string locations = 2;
+    // A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+    repeated string service_accounts = 3;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -530,7 +530,7 @@ func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 	p.Spec.Allow = rules
 }
 
-// GetGCPRules will return the GCP rules within this token.
+// GetGCPRules will return the GCP-specific configuration for this token.
 func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
 }

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -88,6 +88,18 @@ func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override
 			Allow:       allow,
 			Integration: base.Integration,
 		}
+	case types.JoinMethodGCP:
+		allow := make([]*joiningv1.GCP_Rule, len(base.GCP.Allow))
+		for i, rule := range base.GCP.Allow {
+			allow[i] = &joiningv1.GCP_Rule{
+				ProjectIds:      rule.ProjectIDs,
+				Locations:       rule.Locations,
+				ServiceAccounts: rule.ServiceAccounts,
+			}
+		}
+		scopedToken.Spec.Gcp = &joiningv1.GCP{
+			Allow: allow,
+		}
 	default:
 		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
 	}

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -58,4 +58,6 @@ type Token interface {
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
+	// GetGCPRules returns the GCP-specific configuration for this token.
+	GetGCPRules() *types.ProvisionTokenSpecV2GCP
 }

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -35,10 +35,26 @@ var rolesSupportingScopes = types.SystemRoles{
 	types.RoleNode,
 }
 
-var joinMethodsSupportingScopes = map[string]struct{}{
-	string(types.JoinMethodToken): {},
-	string(types.JoinMethodEC2):   {},
-	string(types.JoinMethodIAM):   {},
+func validateJoinMethod(token *joiningv1.ScopedToken) error {
+
+	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
+	case types.JoinMethodToken:
+		if token.GetStatus().GetSecret() == "" {
+			return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
+		}
+	case types.JoinMethodEC2, types.JoinMethodIAM:
+		if len(token.GetSpec().GetAws().GetAllow()) == 0 {
+			return trace.BadParameter("aws configuration must be defined for a scoped token when using the ec2 or iam join methods")
+		}
+	case types.JoinMethodGCP:
+		if len(token.GetSpec().GetGcp().GetAllow()) == 0 {
+			return trace.BadParameter("gcp configuration must be defined for a scoped token when using the gcp join method")
+		}
+	default:
+		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
+	}
+
+	return nil
 }
 
 // TokenUsageMode represents the possible usage modes of a scoped token.
@@ -91,12 +107,8 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 		return trace.BadParameter("scoped token assigned scope must be descendant of its resource scope")
 	}
 
-	if _, ok := joinMethodsSupportingScopes[spec.JoinMethod]; !ok {
-		return trace.BadParameter("join method %q does not support scoping", spec.JoinMethod)
-	}
-
-	if token.GetStatus().GetSecret() == "" && types.JoinMethod(spec.JoinMethod) == types.JoinMethodToken {
-		return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
+	if err := validateJoinMethod(token); err != nil {
+		return trace.Wrap(err)
 	}
 
 	switch TokenUsageMode(spec.GetUsageMode()) {
@@ -150,8 +162,8 @@ func WeakValidateToken(token *joiningv1.ScopedToken) error {
 		return trace.BadParameter("scoped token must have at least one role")
 	}
 
-	if _, ok := joinMethodsSupportingScopes[token.GetSpec().GetJoinMethod()]; !ok {
-		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
+	if err := validateJoinMethod(token); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil
@@ -270,7 +282,12 @@ func (t *Token) GetAssignedScope() string {
 	return t.scoped.GetSpec().GetAssignedScope()
 }
 
-// GetAWSAllowRules returns the list of AWS-specific allow rules.
+// GetSecret returns the token's secret value.
+func (t *Token) GetSecret() (string, bool) {
+	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken
+}
+
+// GetAllowRules returns the list of allow rules.
 func (t *Token) GetAWSAllowRules() []*types.TokenRule {
 	allow := make([]*types.TokenRule, len(t.scoped.GetSpec().GetAws().GetAllow()))
 	for i, rule := range t.scoped.GetSpec().GetAws().GetAllow() {
@@ -302,9 +319,20 @@ func (t *Token) GetIntegration() string {
 	return t.scoped.GetSpec().GetAws().GetIntegration()
 }
 
-// GetSecret returns the token's secret value.
-func (t *Token) GetSecret() (string, bool) {
-	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken
+// GetGCPRules returns the GCP-specific configuration for this token.
+func (t *Token) GetGCPRules() *types.ProvisionTokenSpecV2GCP {
+	allow := make([]*types.ProvisionTokenSpecV2GCP_Rule, len(t.scoped.GetSpec().GetGcp().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetGcp().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2GCP_Rule{
+			ProjectIDs:      rule.GetProjectIds(),
+			Locations:       rule.GetLocations(),
+			ServiceAccounts: rule.GetServiceAccounts(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2GCP{
+		Allow: allow,
+	}
 }
 
 // GetScopedToken attempts to return the underlying [*joiningv1.ScopedToken] backing a

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -382,7 +382,62 @@ func TestValidateScopedToken(t *testing.T) {
 					UsageMode:     string(joining.TokenUsageModeUnlimited),
 				},
 			},
-			expectedStrongErr: "secret value must be defined for a scoped token",
+			expectedStrongErr: "secret value must be defined for a scoped token when using the token join method",
+			expectedWeakErr:   "secret value must be defined for a scoped token when using the token join method",
+		},
+		{
+			name: "ec2 token without aws configuration",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodEC2),
+				},
+			},
+			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+		},
+		{
+			name: "iam token without aws configuration",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodIAM),
+				},
+			},
+			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+		},
+		{
+			name: "gcp token without gcp configuration",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/aa/bb",
+					Roles:         []string{types.RoleNode.String()},
+					JoinMethod:    string(types.JoinMethodGCP),
+				},
+			},
+			expectedStrongErr: "gcp configuration must be defined for a scoped token when using the gcp join method",
+			expectedWeakErr:   "gcp configuration must be defined for a scoped token when using the gcp join method",
 		},
 		{
 			name: "invalid usage mode",
@@ -486,6 +541,75 @@ func TestValidateScopedToken(t *testing.T) {
 				},
 				Status: &joiningv1.ScopedTokenStatus{
 					Secret: "secret",
+				},
+			},
+		},
+		{
+			name: "valid ec2 scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodEC2),
+					Aws: &joiningv1.AWS{
+						Allow: []*joiningv1.AWS_Rule{
+							{
+								AwsAccount: "1234567890",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid iam scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodIAM),
+					Aws: &joiningv1.AWS{
+						Allow: []*joiningv1.AWS_Rule{
+							{
+								AwsAccount: "1234567890",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "valid gcp scoped token",
+			token: &joiningv1.ScopedToken{
+				Kind:    types.KindScopedToken,
+				Scope:   "/aa/bb",
+				Version: types.V1,
+				Metadata: &headerv1.Metadata{
+					Name: "testtoken",
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					Roles:         []string{types.RoleNode.String()},
+					AssignedScope: "/aa/bb",
+					JoinMethod:    string(types.JoinMethodGCP),
+					Gcp: &joiningv1.GCP{
+						Allow: []*joiningv1.GCP_Rule{
+							{
+								ProjectIds: []string{"1234567890"},
+							},
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Backports #63302 to branch/v18

# Manual testing
- [ ] Create a scoped token that uses the `gcp` join method `tctl scoped tokens add --type node --join-method gcp --scope /local --assign-scope /local`
- [ ] Provision a GCP node using the scoped token.