### PR TITLE
[vnet] add authoritative DNS mode on Linux

### DIFF
--- a/lib/vnet/dns/dns_test.go
+++ b/lib/vnet/dns/dns_test.go
@@ -67,7 +67,7 @@ func TestServer(t *testing.T) {
 		testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
 			Name: fmt.Sprintf("upstream nameserver %d", i),
 			Task: func(ctx context.Context) error {
-				err := upstreamServer.ListenAndServeUDP(ctx, conn)
+				err := upstreamServer.ListenAndServeUDP(ctx, conn, DNSModeRecursive)
 				if err == nil || utils.IsOKNetworkError(err) {
 					return nil
 				}
@@ -117,7 +117,7 @@ func TestServer(t *testing.T) {
 	testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
 		Name: "nameserver under test",
 		Task: func(ctx context.Context) error {
-			err := server.ListenAndServeUDP(ctx, conn)
+			err := server.ListenAndServeUDP(ctx, conn, DNSModeRecursive)
 			if err == nil || utils.IsOKNetworkError(err) {
 				return nil
 			}
@@ -158,6 +158,136 @@ func TestServer(t *testing.T) {
 		{
 			desc:      "no domain",
 			host:      "fake.example.com.",
+			expectErr: "no such host",
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			addrs, err := netResolver.LookupHost(ctx, tc.host)
+			if tc.expectErr != "" {
+				require.ErrorContains(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			require.ElementsMatch(t, tc.expectAddrs, addrs)
+		})
+	}
+}
+
+func TestServerAuthoritativeMode(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	defaultIP4 := tcpip.AddrFrom4([4]byte{1, 2, 3, 4})
+	defaultIP6 := tcpip.AddrFrom16([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	staticResolver := &staticResolver{Result{
+		A:    defaultIP4.As4(),
+		AAAA: defaultIP6.As16(),
+	}}
+	noUpstreams := &stubUpstreamNamservers{}
+
+	// Create two upstream nameservers that are able to resolve A and AAAA records for all names.
+	var upstreamAddrs []string
+	for i := range 2 {
+		upstreamServer, err := NewServer(staticResolver, noUpstreams)
+		require.NoError(t, err)
+		conn, err := net.ListenUDP("udp", udpLocalhost)
+		require.NoError(t, err)
+
+		testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
+			Name: fmt.Sprintf("upstream nameserver %d", i),
+			Task: func(ctx context.Context) error {
+				err := upstreamServer.ListenAndServeUDP(ctx, conn, DNSModeRecursive)
+				if err == nil || utils.IsOKNetworkError(err) {
+					return nil
+				}
+				return trace.Wrap(err)
+			},
+			Terminate: conn.Close,
+		})
+
+		upstreamAddrs = append(upstreamAddrs, conn.LocalAddr().String())
+	}
+
+	// Create the nameserver under test.
+	goTeleportIPv4 := tcpip.AddrFrom4([4]byte{1, 1, 1, 1})
+	goTeleportIPv6 := tcpip.AddrFrom16([16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1})
+	teleportShIPv6 := tcpip.AddrFrom16([16]byte{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2})
+	resolver := &stubResolver{
+		aRecords: map[string]Result{
+			"goteleport.com.": Result{
+				A: goTeleportIPv4.As4(),
+			},
+			"teleport.sh.": Result{
+				NoRecord: true,
+			},
+			"fake.example.com.": Result{
+				NXDomain: true,
+			},
+		},
+		aaaaRecords: map[string]Result{
+			"goteleport.com.": Result{
+				AAAA: goTeleportIPv6.As16(),
+			},
+			"teleport.sh.": Result{
+				AAAA: teleportShIPv6.As16(),
+			},
+			"fake.example.com.": Result{
+				NXDomain: true,
+			},
+		},
+	}
+	upstreams := &stubUpstreamNamservers{nameservers: upstreamAddrs}
+	server, err := NewServer(resolver, upstreams)
+	require.NoError(t, err)
+
+	conn, err := net.ListenUDP("udp", udpLocalhost)
+	require.NoError(t, err)
+
+	testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
+		Name: "nameserver under test",
+		Task: func(ctx context.Context) error {
+			err := server.ListenAndServeUDP(ctx, conn, DNSModeAuthoritative)
+			if err == nil || utils.IsOKNetworkError(err) {
+				return nil
+			}
+			return trace.Wrap(err)
+		},
+		Terminate: conn.Close,
+	})
+
+	netResolver := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			// Always dial the resolver under test.
+			return net.Dial(network, conn.LocalAddr().String())
+		},
+	}
+
+	for _, tc := range []struct {
+		desc        string
+		host        string
+		expectAddrs []string
+		expectErr   string
+	}{
+		{
+			desc:        "v4 and v6",
+			host:        "goteleport.com.",
+			expectAddrs: []string{goTeleportIPv4.String(), goTeleportIPv6.String()},
+		},
+		{
+			desc:        "only v6",
+			host:        "teleport.sh.",
+			expectAddrs: []string{teleportShIPv6.String()},
+		},
+		{
+			desc:      "no domain",
+			host:      "fake.example.com.",
+			expectErr: "no such host",
+		},
+		{
+			desc:      "forward disabled",
+			host:      "example.com.",
 			expectErr: "no such host",
 		},
 	} {

--- a/lib/vnet/dns/osnameservers_darwin_test.go
+++ b/lib/vnet/dns/osnameservers_darwin_test.go
@@ -50,7 +50,7 @@ func TestOSUpstreamNameservers(t *testing.T) {
 	testutils.RunTestBackgroundTask(ctx, t, &testutils.TestBackgroundTask{
 		Name: "nameserver",
 		Task: func(ctx context.Context) error {
-			err := server.ListenAndServeUDP(ctx, conn)
+			err := server.ListenAndServeUDP(ctx, conn, DNSModeRecursive)
 			if err == nil || utils.IsOKNetworkError(err) {
 				return nil
 			}

--- a/lib/vnet/dns/osnameservers_linux.go
+++ b/lib/vnet/dns/osnameservers_linux.go
@@ -1,0 +1,33 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dns
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+)
+
+// platformLoadUpstreamNameservers returns an error on Linux. VNet relies
+// on systemd-resolved to handle unresolved queries. We should not attempt
+// to forward those queries to other upstream servers.
+func platformLoadUpstreamNameservers(context.Context) ([]string, error) {
+	return nil, trace.NotImplemented("upstream nameserver discovery is not supported on Linux")
+}
+
+// Satisfy linter in linux build where withDNSPort isn't referenced.
+var _ = withDNSPort

--- a/lib/vnet/dns/osnameservers_other.go
+++ b/lib/vnet/dns/osnameservers_other.go
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//go:build !darwin && !windows
+//go:build !darwin && !windows && !linux
 
 package dns
 


### PR DESCRIPTION
This PR is a part of #63664. It adds authoritative DNS mode for VNet on Linux, which is required for correct interaction with systemd-resolved.

systemd-resolved can merge DNS zones and will query multiple upstream servers:

> “One more thing to mention: in systemd-resolved.service if lookups match the search/routing domains of multiple interfaces at once, then they are sent to all of them in parallel, and the first positive reply used. If all lookups fail the last negative reply is used. This means the DNS zones on the relevant interfaces are “merged”: domains existing on one but not the other will “just work” and vice versa.”

Currently VNet works in recursive mode: it lists upstream servers and forwards queries it can’t resolve. I also added authoritative mode: unresolved queries return NXDOMAIN without forwarding, which delegates these queries to systemd-resolved. I tested this with a dummy DNS using the same zone as VNet and it worked.
