### PR TITLE
Improve ssh server reexec process error handling

### DIFF
--- a/lib/client/x11_session.go
+++ b/lib/client/x11_session.go
@@ -21,7 +21,6 @@ package client
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"time"
@@ -63,8 +62,6 @@ func (ns *NodeSession) handleX11Forwarding(ctx context.Context, sess *tracessh.S
 	}
 
 	if err := x11.RequestForwarding(ctx, sess, ns.spoofedXAuthEntry); err != nil {
-		// Notify the user that x11 forwarding request failed regardless of debug level
-		fmt.Fprintln(os.Stderr, "X11 forwarding request failed")
 		slog.DebugContext(ctx, "X11 forwarding request error", "err", err)
 		// If the X11 forwarding request fails, we must reject all X11 channel requests.
 		return ns.rejectX11Channels(ctx)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -326,7 +326,7 @@ func (h *AuthHandlers) CheckX11Forward(ctx *ServerContext) error {
 		return nil
 	}
 
-	return trace.AccessDenied("x11 forwarding not permitted")
+	return trace.AccessDenied("X11 forwarding not permitted")
 }
 
 // CheckPortForward checks if port forwarding is allowed for the users RoleSet.

--- a/lib/srv/bpf_test.go
+++ b/lib/srv/bpf_test.go
@@ -847,7 +847,8 @@ func runCommand(t *testing.T, srv Server, bpfSrv bpf.BPF, command string, expect
 	// Create a channel that will be used to signal that execution is complete.
 	cmdDone := make(chan error, 1)
 	go func() {
-		cmdDone <- cmd.Wait()
+		_, exitErr := cmd.Wait()
+		cmdDone <- exitErr
 	}()
 
 	// Program should have executed now. If the complete signal has not come
@@ -863,8 +864,6 @@ func runCommand(t *testing.T, srv Server, bpfSrv bpf.BPF, command string, expect
 
 		if expectedCmdFail {
 			require.Error(t, err)
-			var exitErr *exec.ExitError
-			require.ErrorAs(t, err, &exitErr)
 		} else {
 			require.NoError(t, err)
 		}

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -71,9 +71,6 @@ type Exec interface {
 	// GetCommand returns the command to be executed.
 	GetCommand() string
 
-	// SetCommand sets the command to be executed.
-	SetCommand(string)
-
 	// Start will start the execution of the command.
 	Start(ctx context.Context, channel ssh.Channel) (*ExecResult, error)
 
@@ -136,11 +133,6 @@ type localExec struct {
 // GetCommand returns the command string.
 func (e *localExec) GetCommand() string {
 	return e.Command
-}
-
-// SetCommand gets the command string.
-func (e *localExec) SetCommand(command string) {
-	e.Command = command
 }
 
 // Start launches the given command returns (nil, nil) if successful.
@@ -336,11 +328,6 @@ func (e *remoteExec) String() string {
 // GetCommand returns the command string.
 func (e *remoteExec) GetCommand() string {
 	return e.command
-}
-
-// SetCommand gets the command string.
-func (e *remoteExec) SetCommand(command string) {
-	e.command = command
 }
 
 // Start launches the given command returns (nil, nil) if successful.

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -31,7 +31,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	decisionpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/decision/v1alpha1"
@@ -196,7 +195,8 @@ func TestContinue(t *testing.T) {
 			cmdDone <- err
 			return
 		}
-		cmdDone <- trace.Wrap(cmd.Wait())
+		_, exitErr := cmd.Wait()
+		cmdDone <- exitErr
 	}()
 
 	// Wait for the process. Since the continue pipe has not been closed, the

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -94,7 +94,12 @@ func TestOSCommandPrep(t *testing.T) {
 	reexecCfg, err := scx.ReexecConfig()
 	require.NoError(t, err)
 
-	cmd, err := buildCommand(reexecCfg, usr, nil, nil)
+	stdio := stdio{
+		in:  os.Stdin,
+		out: os.Stdout,
+		err: os.Stderr,
+	}
+	cmd, err := buildCommand(reexecCfg, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -109,7 +114,7 @@ func TestOSCommandPrep(t *testing.T) {
 	reexecCfg, err = scx.ReexecConfig()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(reexecCfg, usr, nil, nil)
+	cmd, err = buildCommand(reexecCfg, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -124,7 +129,7 @@ func TestOSCommandPrep(t *testing.T) {
 	reexecCfg, err = scx.ReexecConfig()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(reexecCfg, usr, nil, nil)
+	cmd, err = buildCommand(reexecCfg, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "/bin/sh", cmd.Path)
@@ -137,7 +142,7 @@ func TestOSCommandPrep(t *testing.T) {
 	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"
-	cmd, err = buildCommand(reexecCfg, usr, nil, nil)
+	cmd, err = buildCommand(reexecCfg, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, root, cmd.Dir)

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -57,11 +57,10 @@ func NewSFTPProxy(
 		logger = slog.With(teleport.ComponentKey, "SFTP")
 	}
 
-	client, err := sftp.NewClient(scx.RemoteClient.Client)
+	remoteFS, err := sftputils.OpenRemoteFilesystem(scx.CancelContext(), scx.RemoteClient, "" /*moderatedSessionID*/)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteFS := sftputils.NewRemoteFilesystem(client)
 	wd, err := remoteFS.Getwd()
 	if err != nil {
 		logger.WarnContext(scx.CancelContext(), `Unable to get working directory, defaulting to "/"`)

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -113,7 +113,9 @@ func (p *SFTPProxy) Serve() error {
 		p.handlers.logger.WarnContext(scx.CancelContext(), "Failed to emit SFTP summary event", "error", err)
 	}
 
-	return trace.Wrap(serveErr)
+	// Close the backend remote filesystem to propagate session completion gracefully.
+	closeErr := p.handlers.remoteFS.Close()
+	return trace.NewAggregate(serveErr, closeErr)
 }
 
 // Close closes the SFTP proxy.

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1290,6 +1290,18 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 	scx.AddCloser(ch)
 	ch = scx.TrackActivity(ch)
 
+	// Start copying stderr right away.
+	stderr, err := remoteSession.StderrPipe()
+	if err != nil {
+		s.logger.WarnContext(ctx, "Error setting remote stderr pipe", "error", err)
+	} else {
+		go func() {
+			if _, err := io.Copy(ch.Stderr(), stderr); err != nil {
+				s.logger.DebugContext(ctx, "Error reading remote stderr", "error", err)
+			}
+		}()
+	}
+
 	// inform the client of the session ID that is going to be used in a new
 	// goroutine to reduce latency.
 	go func() {
@@ -1345,6 +1357,11 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 			span.End()
 		case result := <-scx.ExecResultCh:
 			s.logger.DebugContext(ctx, "Exec request complete", "command", result.Command, "code", result.Code)
+
+			if result.Error != nil {
+				message := utils.FormatErrorWithNewline(result.Error)
+				s.stderrWrite(ctx, ch, message)
+			}
 
 			// The exec process has finished and delivered the execution result, send
 			// the result back to the client, and close the session and channel.
@@ -1414,7 +1431,12 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 	case sshutils.SubsystemRequest:
 		return s.handleSubsystem(ctx, ch, req, scx)
 	case x11.ForwardRequest:
-		return s.handleX11Forward(ctx, ch, req, scx)
+		// X11 forwarding requests should not fail, just send the error message to the client
+		// and attempt to continue the session.
+		if err := s.handleX11Forward(ctx, ch, req, scx); err != nil {
+			scx.Logger.DebugContext(ctx, "failure x11 forwarding", "error", err)
+		}
+		return nil
 	case sshutils.AgentForwardRequest:
 		// to maintain interoperability with OpenSSH, agent forwarding requests
 		// should never fail, all errors should be logged and we should continue
@@ -1540,12 +1562,6 @@ func (s *Server) handleX11Forward(ctx context.Context, ch ssh.Channel, req *ssh.
 			event.Metadata.Code = events.X11ForwardFailureCode
 			event.Status.Success = false
 			event.Status.Error = err.Error()
-		}
-		if trace.IsAccessDenied(err) {
-			// denied X11 requests are ok from a protocol perspective so we
-			// don't return them, just reply over ssh and emit the audit log.
-			s.replyError(ctx, ch, req, err)
-			err = nil
 		}
 		if err := s.EmitAuditEvent(ctx, event); err != nil {
 			scx.Logger.WarnContext(ctx, "Failed to emit x11-forward event", "error", err)

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1358,6 +1358,12 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 		case result := <-scx.ExecResultCh:
 			s.logger.DebugContext(ctx, "Exec request complete", "command", result.Command, "code", result.Code)
 
+			// Avoid broadcasting basic exit errors.
+			if result.Error != nil && !srv.IsExitError(result.Error) {
+				message := utils.FormatErrorWithNewline(result.Error)
+				s.stderrWrite(ctx, ch, message)
+			}
+
 			// The exec process has finished and delivered the execution result, send
 			// the result back to the client, and close the session and channel.
 			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.Code)}))

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1358,11 +1358,6 @@ func (s *Server) handleSessionChannel(ctx context.Context, nch ssh.NewChannel) {
 		case result := <-scx.ExecResultCh:
 			s.logger.DebugContext(ctx, "Exec request complete", "command", result.Command, "code", result.Code)
 
-			if result.Error != nil {
-				message := utils.FormatErrorWithNewline(result.Error)
-				s.stderrWrite(ctx, ch, message)
-			}
-
 			// The exec process has finished and delivered the execution result, send
 			// the result back to the client, and close the session and channel.
 			_, err := ch.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.Code)}))

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -242,7 +242,8 @@ func (r *remoteSFTPSubsystem) Wait() error {
 		exitStatus = 1
 	}
 	r.subsystem.serverContext.SendExecResult(r.subsystem.ctx, srv.ExecResult{
-		Code: exitStatus,
+		Command: teleport.SFTPSubCommand,
+		Code:    exitStatus,
 	})
 
 	// emit an event to the audit log with the result of execution

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -189,7 +189,7 @@ func (r *remoteSFTPSubsystem) Start(ctx context.Context, channel ssh.Channel) er
 
 	go func() {
 		defer r.subsystem.serverContext.RemoteSession.Close()
-		errCh := make(chan error)
+		errCh := make(chan error, 1)
 		go func() {
 			errCh <- proxy.Serve()
 			close(errCh)

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -72,7 +72,7 @@ func parseRemoteSubsystem(ctx context.Context, subsystemName string, serverConte
 			subsystem: r,
 		}
 	}
-	r.errorCh = make(chan error, 3) // one error each for stdin, stdout, and stderr
+	r.errorCh = make(chan error, 2) // one error each for stdin and stdout
 	return r
 }
 
@@ -89,17 +89,13 @@ func (r *remoteSubsystem) Start(ctx context.Context, channel ssh.Channel) error 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	stderr, err := session.StderrPipe()
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	stdin, err := session.StdinPipe()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	// request the subsystem from the remote node. if successful, the user can
-	// interact with the remote subsystem with stdin, stdout, and stderr.
+	// interact with the remote subsystem with stdin and stdout.
 	err = session.RequestSubsystem(ctx, r.subsystemName)
 	if err != nil {
 		// emit an event to the audit log with the reason remote execution failed
@@ -108,17 +104,11 @@ func (r *remoteSubsystem) Start(ctx context.Context, channel ssh.Channel) error 
 		return trace.Wrap(err)
 	}
 
-	// copy back and forth between stdin, stdout, and stderr and the SSH channel.
+	// copy back and forth between stdin and stdout and the SSH channel.
 	go func() {
 		defer session.Close()
 
 		_, err := io.Copy(channel, stdout)
-		r.errorCh <- err
-	}()
-	go func() {
-		defer session.Close()
-
-		_, err := io.Copy(channel.Stderr(), stderr)
 		r.errorCh <- err
 	}()
 	go func() {
@@ -135,7 +125,7 @@ func (r *remoteSubsystem) Start(ctx context.Context, channel ssh.Channel) error 
 func (r *remoteSubsystem) Wait() error {
 	var lastErr error
 
-	for range 3 {
+	for range 2 {
 		select {
 		case err := <-r.errorCh:
 			if err != nil && !errors.Is(err, io.EOF) {

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -150,7 +150,7 @@ func RunCommand() (code int, err error) {
 		shellStdio.in = tty
 		shellStdio.out = tty
 		shellStdio.err = tty
-	} else if c.Command == teleport.SFTPSubCommand {
+	} else if c.IsSFTPRequest {
 		// std{in/out} is not used by the SFTP sub process, just collect stderr.
 		shellStdio = stdio{
 			in:  bytes.NewReader([]byte{}),

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -231,8 +231,13 @@ func (s *sftpSubsys) Wait() error {
 	exitCode, exitErr := s.reexecCmd.Wait()
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
+	command := teleport.SFTPSubCommand
+	if execRequest, err := s.serverCtx.GetExecRequest(); err == nil {
+		command = execRequest.GetCommand()
+	}
+
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
-		Command: s.reexecCmd.Command(),
+		Command: command,
 		Code:    exitCode,
 		Error:   exitErr,
 	})

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -226,17 +226,18 @@ func (s *sftpSubsys) Start(ctx context.Context,
 }
 
 func (s *sftpSubsys) Wait() error {
-	ctx := context.Background()
-	waitErr := s.reexecCmd.Wait()
+	ctx := s.serverCtx.GetServer().Context()
+
+	exitCode, exitErr := s.reexecCmd.Wait()
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
 		Command: s.reexecCmd.Command(),
-		Code:    s.reexecCmd.ExitCode(),
-		Error:   s.reexecCmd.ChildError(),
+		Code:    exitCode,
+		Error:   exitErr,
 	})
 
-	errs := []error{waitErr}
+	errs := []error{exitErr}
 	for range copyingGoroutines {
 		err := <-s.errCh
 		if err != nil && !utils.IsOKNetworkError(err) {

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -216,7 +216,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 				s.logger.WarnContext(ctx, "Unknown event type received from SFTP server process", "error", err, "event_type", event.GetType())
 			}
 
-			if err := serverCtx.GetServer().EmitAuditEvent(ctx, event); err != nil {
+			if err := serverCtx.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), event); err != nil {
 				s.logger.WarnContext(ctx, "Failed to emit SFTP event", "error", err)
 			}
 		}
@@ -233,6 +233,7 @@ func (s *sftpSubsys) Wait() error {
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
 		Command: s.reexecCmd.Command(),
 		Code:    s.reexecCmd.ExitCode(),
+		Error:   s.reexecCmd.ChildError(),
 	})
 
 	errs := []error{waitErr}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1786,7 +1786,8 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 		case result := <-scx.ExecResultCh:
 			scx.Logger.DebugContext(ctx, "Exec request complete", "command", result.Command, "code", result.Code)
 
-			if result.Error != nil {
+			// Avoid broadcasting basic exit errors.
+			if result.Error != nil && !srv.IsExitError(result.Error) {
 				message := utils.FormatErrorWithNewline(result.Error)
 				s.writeStderr(ctx, ch, message)
 			}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1281,8 +1281,10 @@ func (s *Server) getNetworkingProcess(scx *srv.ServerContext) (*networking.Proce
 // startNetworkingProcess launches a new networking process. It should be closed once
 // the server connection is closed.
 func (s *Server) startNetworkingProcess(scx *srv.ServerContext) (*networking.Process, error) {
+	ctx := scx.CancelContext()
+
 	// Create context for the networking process.
-	nsctx, err := srv.NewServerContext(context.Background(), scx.ConnectionContext, s, scx.Identity, nil)
+	nsctx, err := srv.NewServerContext(ctx, scx.ConnectionContext, s, scx.Identity, nil)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1298,7 +1300,7 @@ func (s *Server) startNetworkingProcess(scx *srv.ServerContext) (*networking.Pro
 		return nil, trace.Wrap(err)
 	}
 
-	proc, err := networking.NewProcess(nsctx.CancelContext(), cmd)
+	proc, err := networking.NewProcess(ctx, cmd)
 	if err != nil {
 		cmd.Close()
 		return nil, trace.Wrap(err)
@@ -1784,6 +1786,11 @@ func (s *Server) handleSessionRequests(ctx context.Context, ccx *sshutils.Connec
 		case result := <-scx.ExecResultCh:
 			scx.Logger.DebugContext(ctx, "Exec request complete", "command", result.Command, "code", result.Code)
 
+			if result.Error != nil {
+				message := utils.FormatErrorWithNewline(result.Error)
+				s.writeStderr(ctx, ch, message)
+			}
+
 			// The exec process has finished and delivered the execution result, send
 			// the result back to the client, and close the session and channel.
 			_, err := trackingChan.SendRequest("exit-status", false, ssh.Marshal(struct{ C uint32 }{C: uint32(result.Code)}))
@@ -1877,7 +1884,8 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			// processing requests.
 			err := s.handleAgentForwardNode(ctx, req, serverContext)
 			if err != nil {
-				serverContext.Logger.WarnContext(ctx, "failure forwarding agent", "error", err)
+				message := utils.FormatErrorWithNewline(err)
+				s.writeStderr(ctx, ch, "Agent forwarding request failed: "+message)
 			}
 			return nil
 		case sshutils.PuTTYWinadjRequest:
@@ -1910,7 +1918,13 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// they are in essence SSH session extensions, allowing to implement new SSH commands
 		return s.handleSubsystem(ctx, ch, req, serverContext)
 	case x11.ForwardRequest:
-		return s.handleX11Forward(ctx, ch, req, serverContext)
+		// X11 forwarding requests should not fail, just send the error message to the client
+		// and attempt to continue the session.
+		if err := s.handleX11Forward(ctx, ch, req, serverContext); err != nil {
+			message := utils.FormatErrorWithNewline(err)
+			s.writeStderr(ctx, ch, "X11 forwarding request failed: "+message)
+		}
+		return nil
 	case sshutils.AgentForwardRequest:
 		// This happens when SSH client has agent forwarding enabled, in this case
 		// client sends a special request, in return SSH server opens new channel
@@ -1924,7 +1938,8 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		// processing requests.
 		err := s.handleAgentForwardNode(ctx, req, serverContext)
 		if err != nil {
-			serverContext.Logger.WarnContext(ctx, "failure forwarding agent", "error", err)
+			message := utils.FormatErrorWithNewline(err)
+			s.writeStderr(ctx, ch, "Agent forwarding request failed: "+message)
 		}
 		return nil
 	case sshutils.PuTTYWinadjRequest:
@@ -2037,12 +2052,6 @@ func (s *Server) handleX11Forward(ctx context.Context, ch ssh.Channel, req *ssh.
 			event.Metadata.Code = events.X11ForwardFailureCode
 			event.Status.Success = false
 			event.Status.Error = err.Error()
-		}
-		if trace.IsAccessDenied(err) {
-			// denied X11 requests are ok from a protocol perspective so we
-			// don't return them, just reply over ssh and emit the audit s.Logger.
-			s.replyError(ctx, ch, req, err)
-			err = nil
 		}
 		s.emitAuditEventWithLog(s.ctx, event)
 	}()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1473,6 +1473,11 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 			s.logger.ErrorContext(ctx, "Received error waiting for the interactive session to finish.", "error", err)
 		}
 
+		exitErr := err
+		if result != nil {
+			exitErr = result.Error
+		}
+
 		// wait for copying from the pty to be complete or a timeout before
 		// broadcasting the result (which will close the pty) if it has not been
 		// closed already.
@@ -1489,7 +1494,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 		}
 
 		if execRequest, err := scx.GetExecRequest(); err == nil && execRequest.GetCommand() != "" {
-			emitExecAuditEvent(scx, execRequest.GetCommand(), err)
+			emitExecAuditEvent(scx, execRequest.GetCommand(), exitErr)
 		}
 
 		s.emitSessionEndEvent()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1470,7 +1470,7 @@ func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *p
 	go func() {
 		result := s.term.Wait()
 		if result.Error != nil {
-			s.logger.ErrorContext(ctx, "Received error waiting for the interactive session to finish.", "error", err)
+			s.logger.ErrorContext(ctx, "Received error waiting for the interactive session to finish.", "error", result.Error)
 		}
 
 		// wait for copying from the pty to be complete or a timeout before

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -213,6 +213,7 @@ func (t *terminal) Wait() (*ExecResult, error) {
 	return &ExecResult{
 		Code:    t.reexecCmd.ExitCode(),
 		Command: t.reexecCmd.Path(),
+		Error:   t.reexecCmd.ChildError(),
 	}, nil
 }
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -200,10 +200,15 @@ func (t *terminal) Run(ctx context.Context) error {
 
 // Wait will block until the terminal is complete.
 func (t *terminal) Wait() ExecResult {
+	var command string
+	if execRequest, err := t.serverContext.GetExecRequest(); err == nil {
+		command = execRequest.GetCommand()
+	}
+
 	exitCode, exitErr := t.reexecCmd.Wait()
 	return ExecResult{
 		Code:    exitCode,
-		Command: t.reexecCmd.Path(),
+		Command: command,
 		Error:   exitErr,
 	}
 }

--- a/lib/sshutils/networking/networking.go
+++ b/lib/sshutils/networking/networking.go
@@ -140,6 +140,8 @@ func NewProcess(ctx context.Context, cmd *reexec.Command) (*Process, error) {
 	select {
 	case <-ready:
 		return proc, nil
+	case <-ctx.Done():
+		return nil, trace.Wrap(ctx.Err(), "networking process failed to signal ready")
 	case <-proc.cmd.Done():
 		return nil, proc.cmd.ExitError()
 	}

--- a/lib/sshutils/networking/networking.go
+++ b/lib/sshutils/networking/networking.go
@@ -141,7 +141,7 @@ func NewProcess(ctx context.Context, cmd *reexec.Command) (*Process, error) {
 	case <-ready:
 		return proc, nil
 	case <-proc.cmd.Done():
-		return nil, proc.cmd.ChildError()
+		return nil, proc.cmd.ExitError()
 	}
 }
 

--- a/lib/sshutils/reexec/command.go
+++ b/lib/sshutils/reexec/command.go
@@ -197,7 +197,7 @@ func (c *Command) Start(closerOnExit ...io.Closer) error {
 		childErr, err := readChildError(context.Background(), stderrR)
 		if err != nil {
 			c.logger.WarnContext(context.Background(), "Failed to read child process stderr", "error", err)
-		} else {
+		} else if childErr != nil {
 			c.exitErr = childErr
 		}
 
@@ -452,7 +452,7 @@ func readChildError(ctx context.Context, stderr io.Reader) (childErr error, err 
 
 	// It should be empty or include an error message like "Failed to launch: ..."
 	if !strings.HasPrefix(errMsg.String(), "Failed to launch: ") {
-		return nil, trace.Wrap(err, "Unexpected error message from child process: %s", errMsg.String())
+		return nil, trace.BadParameter("Unexpected error message from child process: %s", errMsg.String())
 	}
 
 	// TODO(Joerger): Process the err msg from stderr to provide deeper insights into

--- a/lib/sshutils/reexec/command_test.go
+++ b/lib/sshutils/reexec/command_test.go
@@ -54,10 +54,10 @@ func TestCommand(t *testing.T) {
 
 		// Close stdin to end the cmd with success.
 		stdin.Close()
-		require.NoError(t, reexecCmd.Wait())
+		exitCode, exitErr := reexecCmd.Wait()
+		require.NoError(t, exitErr)
+		require.Zero(t, exitCode)
 		require.Equal(t, echoString, stdout.String())
-
-		require.Zero(t, reexecCmd.ExitCode())
 	})
 
 	t.Run("continue", func(t *testing.T) {
@@ -81,10 +81,10 @@ func TestCommand(t *testing.T) {
 
 		// Close stdin to end the cmd with success.
 		stdin.Close()
-		require.NoError(t, reexecCmd.Wait())
+		exitCode, exitErr := reexecCmd.Wait()
+		require.NoError(t, exitErr)
+		require.Zero(t, exitCode)
 		require.Equal(t, echoString, stdout.String())
-
-		require.Zero(t, reexecCmd.ExitCode())
 	})
 
 	t.Run("never ready", func(t *testing.T) {
@@ -116,10 +116,10 @@ func TestCommand(t *testing.T) {
 		// Terminate the command prematurely.
 		err := reexecCmd.stop(3 * time.Second)
 		require.NoError(t, err)
-		require.NoError(t, reexecCmd.Wait())
+		exitCode, exitErr := reexecCmd.Wait()
+		require.NoError(t, exitErr)
+		require.Zero(t, exitCode)
 		require.Empty(t, stdout.Bytes())
-
-		require.Zero(t, reexecCmd.ExitCode())
 	})
 
 	t.Run("kill", func(t *testing.T) {
@@ -137,10 +137,10 @@ func TestCommand(t *testing.T) {
 		// Kill the command prematurely.
 		err := reexecCmd.stop(500 * time.Millisecond)
 		require.NoError(t, err)
-		require.Error(t, reexecCmd.Wait())
+		exitCode, exitErr := reexecCmd.Wait()
+		require.Error(t, exitErr)
+		require.NotZero(t, exitCode)
 		require.Empty(t, stdout.Bytes())
-
-		require.NotZero(t, reexecCmd.ExitCode())
 	})
 
 	t.Run("extra pipe", func(t *testing.T) {
@@ -162,10 +162,10 @@ func TestCommand(t *testing.T) {
 		// Close the pipe and stdin to end the cmd with success.
 		echoPipe.Close()
 		stdin.Close()
-		require.NoError(t, reexecCmd.Wait())
+		exitCode, exitErr := reexecCmd.Wait()
+		require.NoError(t, exitErr)
+		require.Zero(t, exitCode)
 		require.Equal(t, echoString, stdout.String())
-
-		require.Zero(t, reexecCmd.ExitCode())
 	})
 }
 

--- a/lib/sshutils/reexec/command_test.go
+++ b/lib/sshutils/reexec/command_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"sync"
 	"testing"
 	"time"
@@ -41,7 +42,7 @@ func TestCommand(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		reexecCmd, stdin, stdout := newTestReexecCommand(t)
+		reexecCmd, stdin, stdout := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess")
 
 		// Start the command and go through the ready signal flow.
 		require.NoError(t, reexecCmd.Start())
@@ -63,7 +64,7 @@ func TestCommand(t *testing.T) {
 	t.Run("continue", func(t *testing.T) {
 		t.Parallel()
 
-		reexecCmd, stdin, stdout := newTestReexecCommand(t)
+		reexecCmd, stdin, stdout := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess")
 
 		// Start the command.
 		require.NoError(t, reexecCmd.Start())
@@ -90,7 +91,7 @@ func TestCommand(t *testing.T) {
 	t.Run("never ready", func(t *testing.T) {
 		t.Parallel()
 
-		reexecCmd, _, _ := newTestReexecCommand(t, "REEXEC_SKIP_READY=1")
+		reexecCmd, _, _ := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess", "REEXEC_SKIP_READY=1")
 
 		// Start the command.
 		require.NoError(t, reexecCmd.Start())
@@ -106,7 +107,7 @@ func TestCommand(t *testing.T) {
 	t.Run("graceful termination", func(t *testing.T) {
 		t.Parallel()
 
-		reexecCmd, _, stdout := newTestReexecCommand(t)
+		reexecCmd, _, stdout := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess")
 
 		// Start the command and go through the ready signal flow.
 		require.NoError(t, reexecCmd.Start())
@@ -127,7 +128,7 @@ func TestCommand(t *testing.T) {
 
 		// Purposely don't handle the terminate signal since graceful termination
 		// is always attempted first.
-		reexecCmd, _, stdout := newTestReexecCommand(t, "REEXEC_IGNORE_TERMINATE=1")
+		reexecCmd, _, stdout := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess", "REEXEC_IGNORE_TERMINATE=1")
 
 		// Start the command and go through the ready signal flow.
 		require.NoError(t, reexecCmd.Start())
@@ -146,7 +147,7 @@ func TestCommand(t *testing.T) {
 	t.Run("extra pipe", func(t *testing.T) {
 		t.Parallel()
 
-		reexecCmd, stdin, stdout := newTestReexecCommand(t, "REEXEC_USE_EXTRA=1")
+		reexecCmd, stdin, stdout := newTestReexecCommand(t, "-test.run=TestReexecEchoProcess", "REEXEC_USE_EXTRA=1")
 
 		echoPipe, err := reexecCmd.AddParentToChildPipe()
 		require.NoError(t, err)
@@ -167,50 +168,6 @@ func TestCommand(t *testing.T) {
 		require.Zero(t, exitCode)
 		require.Equal(t, echoString, stdout.String())
 	})
-}
-
-func TestCommandCloseIdempotent(t *testing.T) {
-	t.Parallel()
-
-	reexecCmd, err := NewCommand(newBasicConfig(t))
-	require.NoError(t, err)
-
-	require.NoError(t, reexecCmd.Close())
-	require.NoError(t, reexecCmd.Close())
-}
-
-func newTestReexecCommand(t *testing.T, env ...string) (cmd *Command, stdin io.WriteCloser, stdout *safeBuffer) {
-	t.Helper()
-
-	reexecCmd, err := NewCommand(newBasicConfig(t))
-	require.NoError(t, err)
-
-	reexecCmd.cmd.Env = append(reexecCmd.cmd.Env, "GO_WANT_HELPER_PROCESS=1")
-	reexecCmd.cmd.Env = append(reexecCmd.cmd.Env, env...)
-
-	stdout = &safeBuffer{}
-	reexecCmd.cmd.Stdout = stdout
-	reexecCmd.cmd.Stderr = io.Discard
-
-	stdin, err = reexecCmd.cmd.StdinPipe()
-	require.NoError(t, err)
-	t.Cleanup(func() { stdin.Close() })
-
-	return reexecCmd, stdin, stdout
-}
-
-func newBasicConfig(t *testing.T) *Config {
-	t.Helper()
-
-	return &Config{
-		ReexecCommand: "-test.run=TestReexecEchoProcess",
-		LogConfig: LogConfig{
-			ExtraFields: []string{
-				teleport.ComponentKey, "echo-process",
-			},
-		},
-		LogWriter: os.Stderr,
-	}
 }
 
 func TestReexecEchoProcess(t *testing.T) {
@@ -263,6 +220,130 @@ func TestReexecEchoProcess(t *testing.T) {
 
 	slog.DebugContext(t.Context(), "stdin closed, exiting")
 	os.Exit(0)
+}
+func TestCommandCloseIdempotent(t *testing.T) {
+	t.Parallel()
+
+	reexecCmd, err := NewCommand(newConfigForReexec(t, ""))
+	require.NoError(t, err)
+
+	require.NoError(t, reexecCmd.Close())
+	require.NoError(t, reexecCmd.Close())
+}
+
+func TestCommandStderrHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("normal stderr", func(t *testing.T) {
+		t.Parallel()
+
+		reexecCmd, _, _ := newTestReexecCommand(t, "-test.run=TestReexecErrorProcess")
+		stderrEchoPipe, err := reexecCmd.AddParentToChildPipe()
+		require.NoError(t, err)
+		require.NoError(t, reexecCmd.Start())
+
+		errMsg := "Failed to launch: big bad bug\n"
+		_, err = io.WriteString(stderrEchoPipe, errMsg)
+		require.NoError(t, err)
+		stderrEchoPipe.Close()
+
+		exitCode, exitErr := reexecCmd.Wait()
+		require.Equal(t, 7, exitCode)
+		require.Error(t, exitErr)
+		require.ErrorContains(t, exitErr, errMsg)
+	})
+
+	t.Run("empty stderr", func(t *testing.T) {
+		t.Parallel()
+
+		reexecCmd, _, _ := newTestReexecCommand(t, "-test.run=TestReexecErrorProcess")
+		stderrEchoPipe, err := reexecCmd.AddParentToChildPipe()
+		require.NoError(t, err)
+		require.NoError(t, reexecCmd.Start())
+
+		// End the process without any stderr.
+		stderrEchoPipe.Close()
+
+		exitCode, err := reexecCmd.Wait()
+		require.Equal(t, 7, exitCode)
+		require.Error(t, err)
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+	})
+
+	t.Run("malformed stderr", func(t *testing.T) {
+		t.Parallel()
+
+		reexecCmd, _, _ := newTestReexecCommand(t, "-test.run=TestReexecErrorProcess")
+		stderrEchoPipe, err := reexecCmd.AddParentToChildPipe()
+		require.NoError(t, err)
+		require.NoError(t, reexecCmd.Start())
+
+		errMsg := "malformed stderr\n"
+		_, err = io.WriteString(stderrEchoPipe, errMsg)
+		require.NoError(t, err)
+		stderrEchoPipe.Close()
+
+		exitCode, err := reexecCmd.Wait()
+		require.Equal(t, 7, exitCode)
+		require.Error(t, err)
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr)
+	})
+}
+
+func TestReexecErrorProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	cfg := os.NewFile(ConfigFile, "config")
+	echoStderr := os.NewFile(FirstExtraFile, "stderr")
+
+	var cfgPayload Config
+	_ = json.NewDecoder(cfg).Decode(&cfgPayload)
+	_ = cfg.Close()
+
+	InitLogger("echo-reexec", cfgPayload.LogConfig)
+
+	if _, err := io.Copy(os.Stderr, echoStderr); err != nil {
+		slog.DebugContext(t.Context(), "Stderr copy loop ended with error", "err", err)
+	}
+
+	os.Exit(7)
+}
+
+func newTestReexecCommand(t *testing.T, reexecCommand string, env ...string) (cmd *Command, stdin io.WriteCloser, stdout *safeBuffer) {
+	t.Helper()
+
+	reexecCmd, err := NewCommand(newConfigForReexec(t, reexecCommand))
+	require.NoError(t, err)
+
+	reexecCmd.cmd.Env = append(reexecCmd.cmd.Env, "GO_WANT_HELPER_PROCESS=1")
+	reexecCmd.cmd.Env = append(reexecCmd.cmd.Env, env...)
+
+	stdout = &safeBuffer{}
+	reexecCmd.cmd.Stdout = stdout
+
+	stdin, err = reexecCmd.cmd.StdinPipe()
+	require.NoError(t, err)
+	t.Cleanup(func() { stdin.Close() })
+
+	return reexecCmd, stdin, stdout
+}
+
+func newConfigForReexec(t *testing.T, reexecCommand string) *Config {
+	t.Helper()
+
+	return &Config{
+		ReexecCommand: reexecCommand,
+		LogConfig: LogConfig{
+			ExtraFields: []string{
+				teleport.ComponentKey, "reexec-logs",
+			},
+		},
+		LogWriter: os.Stderr,
+	}
 }
 
 func waitForClose(r io.Reader) <-chan struct{} {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4503,7 +4503,7 @@ func convertSSHExitCode(tc *client.TeleportClient, err error) error {
 			// Already have an exitCodeError, return that.
 			return trace.Wrap(err)
 		}
-		if err != nil {
+		if err != nil && status != teleport.RemoteCommandFailure {
 			// Print the error here so we don't lose it when returning the exitCodeError.
 			fmt.Fprintln(tc.Stderr, utils.UserMessageFromError(err))
 		}


### PR DESCRIPTION
Changelog: Make ssh server connection error messages more user friendly.

Primary changes:
- Remove cryptic `ERROR: Process exited with status 255` error from the client as it did not provide anything but confusion for the user. The actual error is now written straight to stderr and the 255 exit code is ignored by the client. Other unexpected exit codes are still printed.
- Isolate child reexec process stderr from the grandchild shell/exec process stderr or tty. This enables the server to process the stderr before passing it on to the client, e.g. for audit events or for [adding context to the error for better UX](https://github.com/gravitational/teleport/pull/62314).

Related changes:
- Report errors with X11/Agent forwarding and sftp sessions to the client. Previously these would be logged on the server and result in unexpected client errors, as seen in the old example output below.
  - Note: Port Forwarding errors remain unreported to the client due to the lack of an ssh channel as a global request.
- In proxy recording mode, forward the stderr from the remote node session over to the client. Previously, stderr was lost.

Note: originally opened in https://github.com/gravitational/teleport/pull/62285 before rebasing

Depends on https://github.com/gravitational/teleport/pull/63674

<details>
<summary>Example output</summary>

Before:
```
> tsh ssh dne@server01   
Failed to launch: user: unknown user dne
ERROR: Process exited with status 255

> tsh ssh -A -X -L 4000:localhost:2000 -R 5000:localhost:2000 dne@server01
X11 forwarding request failed
ERROR: EOF

> tsh scp dne@server01:sample.txt sample.txt
ERROR: error receiving version packet from server: server unexpectedly closed connection: unexpected EOF

> tsh ssh server01 dne
zsh:1: command not found: dne
Failed to launch: exit status 127.
ERROR: Process exited with status 127
```

After:
```
> tsh ssh dne@server01
Failed to launch: user: unknown user dne.

> tsh ssh -A -X -L 4000:localhost:2000 -R 5000:localhost:2000 dne@server01
X11 forwarding request failed: Failed to launch: user: unknown user dne
Agent forwarding request failed: Failed to launch: user: unknown user dne
Failed to launch: user: unknown user dne

> tsh scp dne@server01:sample.txt sample.txt
ERROR: Failed to launch: user: unknown user dne

> tsh ssh server01 dne
zsh:1: command not found: dne
ERROR: Process exited with status 127
```

</details>

<details>
<summary>Manual Tests | 43f3ac05c352d5e1f2d6e66a2ce2b22431e41dbd</summary>

Failure cases:
- [x] non-existant user:
  - [x] interactive session - error returned to client
  - [x] exec session - error returned to client
  - [x] exec session w/ tty - error returned to client
  - [x] x11 forwarding - error returned to client
  - [x] agent forwarding - error returned to client
  - [x] port forwarding - error logged to server
  - [x] sftp session - error returned to client
    - [x] remote -> local
    - [x] local -> remote
- [x] non-existant command
  - [x] exec session - exit code returned to client
  - [x] exec session w/ tty - exit code returned to client

- [x] Re-run tests with Proxy recording mode on, excluding agent forwarding.

</details>