### PR TITLE
app: Add connection limiter support to app service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 The minimum version of macOS required to run Teleport or associated client tools
 is now macOS 12 (Monterey).
 
+#### Application Access connection limits
+
+The `connection_limits` configuration now applies to the Application
+Service. If you have `connection_limits` configured, app access
+connections will be subject to those limits after upgrading to v19.
+
 ## 18.5.0 (12/04/25)
 
 ### Kubernetes support for Relay Service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ is now macOS 12 (Monterey).
 #### Application Access connection limits
 
 The `connection_limits` configuration now applies to the Application
-Service. If you have `connection_limits` configured, app access
-connections will be subject to those limits after upgrading to v19.
+Service. App access connections are subject to the same default cap
+(15,000 max connections) as all other services. If you have
+`connection_limits` configured, those values apply to app access
+connections after upgrading to v19.
 
 ## 18.5.0 (12/04/25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ is now macOS 12 (Monterey).
 #### Application Access connection limits
 
 The `connection_limits` configuration now applies to the Application
-Service. App access connections are subject to the same default cap
-(15,000 max connections per `app_service` instance) as all other
-services. If you have `connection_limits` configured, those values
-apply to app access connections after upgrading to v19.
+Service. Each `app_service` instance enforces the same per-client-IP
+default (15,000 max simultaneous connections per source IP) as all
+other services. The limit is aggregated across all apps on the
+`app_service` instance, not tracked per app. If you have
+`connection_limits` configured, those values apply to app access
+connections after upgrading to v19.
 
 ## 18.5.0 (12/04/25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ is now macOS 12 (Monterey).
 
 The `connection_limits` configuration now applies to the Application
 Service. App access connections are subject to the same default cap
-(15,000 max connections) as all other services. If you have
-`connection_limits` configured, those values apply to app access
-connections after upgrading to v19.
+(15,000 max connections per `app_service` instance) as all other
+services. If you have `connection_limits` configured, those values
+apply to app access connections after upgrading to v19.
 
 ## 18.5.0 (12/04/25)
 

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -111,8 +111,9 @@ teleport:
     #shutdown_delay: "0s"
 
     # Teleport can limit the number of connections coming from each client
-    # IP address to avoid abuse. Note that these limits are enforced separately
-    # for each service (SSH, Kubernetes, etc.)
+    # IP address to avoid abuse. These limits are enforced separately for
+    # each service (Auth, Proxy, SSH, Kubernetes, Database, Windows
+    # Desktop, and Application).
     connection_limits:
         max_connections: 1000
 

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -6,138 +6,138 @@ version: v3
 # This section of the configuration file applies to all teleport
 # services.
 teleport:
-    # nodename allows one to assign an alternative name this node can be
-    # reached by. By default it's equal to hostname.
-    nodename: graviton
+  # nodename allows one to assign an alternative name this node can be
+  # reached by. By default it's equal to hostname.
+  nodename: graviton
 
-    # Data directory where Teleport daemon keeps its data.
-    data_dir: /var/lib/teleport
+  # Data directory where Teleport daemon keeps its data.
+  data_dir: /var/lib/teleport
 
-    # PID file for Teleport process
-    #pid_file: /var/run/teleport.pid
+  # PID file for Teleport process
+  #pid_file: /var/run/teleport.pid
 
-    # The invitation token or an absolute path to a file containing the token used
-    # to join a cluster. It is not used on subsequent starts.
+  # The invitation token or an absolute path to a file containing the token used
+  # to join a cluster. It is not used on subsequent starts.
+  # If using a file, it only needs to exist when teleport is first ran.
+  #
+  # File path example:
+  # auth_token: /var/lib/teleport/tokenjoin
+  #
+  # This is the same as setting join_params.method to "token", and join_params.token_name
+  # to the value of auth_token.
+  # You should only use either auth_token or join_params.
+  auth_token: xxxx-token-xxxx
+
+  # join_params are parameters to set when joining a cluster via
+  # EC2, IAM or a token.
+  join_params:
+    # When `method` is set to "token", it is the equivalent to using `auth_token` above.
+    # You should only use either auth_token or join_params.
+    method: "token"|"ec2"|"iam"|"github"|"circleci"|"kubernetes"
+
+    # If method is not "token", token_name will be will be the name of
+    # the joining token resource, e.g., "ec2-token" or "iam-token" as created
+    # in the Joining Nodes via EC2 or IAM guides.
+
+    # If method is "token", token_name will be the invitation token
+    # or an absolute path to a file containing the token used to join a cluster.
+    # It is not used on subsequent starts.
     # If using a file, it only needs to exist when teleport is first ran.
     #
     # File path example:
-    # auth_token: /var/lib/teleport/tokenjoin
-    #
-    # This is the same as setting join_params.method to "token", and join_params.token_name
-    # to the value of auth_token.
-    # You should only use either auth_token or join_params.
-    auth_token: xxxx-token-xxxx
+    # token_name: /var/lib/teleport/tokenjoin
+    token_name: "token-name"
 
-    # join_params are parameters to set when joining a cluster via
-    # EC2, IAM or a token.
-    join_params:
-        # When `method` is set to "token", it is the equivalent to using `auth_token` above.
-        # You should only use either auth_token or join_params.
-        method: "token"|"ec2"|"iam"|"github"|"circleci"|"kubernetes"
+  # Optional CA pin of the Auth Service. Specifying a CA pin enables new
+  # agents to trust a Teleport cluster when joining via the Auth Service
+  # directly. You can assign the ca_pin field to the literal value of the CA
+  # pin or an absolute path to a file. If you specify a file, the file should
+  # only contain the CA pin.
+  #
+  # You can also specify the value of the ca_pin key as a YAML list of CA pins
+  # or file paths, e.g.:
+  #
+  # ca_pin:
+  #   - /var/lib/teleport/pin1
+  #   - /var/lib/teleport/pin2
+  ca_pin:
+    "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
 
-        # If method is not "token", token_name will be will be the name of
-        # the joining token resource, e.g., "ec2-token" or "iam-token" as created
-        # in the Joining Nodes via EC2 or IAM guides.
+  # When running in multi-homed or NATed environments Teleport Nodes need
+  # to know which IP it will be reachable at by other Nodes.
+  #
+  # This value can be specified as FQDN e.g. host.example.com
+  advertise_ip: 10.1.0.5
 
-        # If method is "token", token_name will be the invitation token
-        # or an absolute path to a file containing the token used to join a cluster.
-        # It is not used on subsequent starts.
-        # If using a file, it only needs to exist when teleport is first ran.
-        #
-        # File path example:
-        # token_name: /var/lib/teleport/tokenjoin
-        token_name: "token-name"
+  # Teleport provides HTTP endpoints for monitoring purposes. They are
+  # disabled by default but you can enable them using the diagnosis address.
+  diag_addr: "127.0.0.1:3000"
 
-    # Optional CA pin of the Auth Service. Specifying a CA pin enables new
-    # agents to trust a Teleport cluster when joining via the Auth Service
-    # directly. You can assign the ca_pin field to the literal value of the CA
-    # pin or an absolute path to a file. If you specify a file, the file should
-    # only contain the CA pin.
-    #
-    # You can also specify the value of the ca_pin key as a YAML list of CA pins
-    # or file paths, e.g.:
-    #
-    # ca_pin:
-    #   - /var/lib/teleport/pin1
-    #   - /var/lib/teleport/pin2
-    ca_pin:
-      "sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
+  # Only use one of auth_server or proxy_server.
+  #
+  # When you have either the application service or database service enabled,
+  # only tunneling through the proxy is supported, so you should specify proxy_server.
+  # All other services support both tunneling through the proxy and directly connecting
+  # to the auth server, so you can specify either auth_server or proxy_server.
 
-    # When running in multi-homed or NATed environments Teleport Nodes need
-    # to know which IP it will be reachable at by other Nodes.
-    #
-    # This value can be specified as FQDN e.g. host.example.com
-    advertise_ip: 10.1.0.5
+  # Auth Server address and port to connect to. If you enable the Teleport
+  # Auth Server to run in High Availability configuration, the address should
+  # point to a Load Balancer.
+  # If adding a node located behind NAT, use the Proxy URL (e.g. teleport-proxy.example.com:443)
+  # and set `proxy_server` instead.
+  auth_server: 10.1.0.5:3025
 
-    # Teleport provides HTTP endpoints for monitoring purposes. They are
-    # disabled by default but you can enable them using the diagnosis address.
-    diag_addr: "127.0.0.1:3000"
+  # Proxy Server address and port to connect to. If you enable the Teleport
+  # Proxy Server to run in High Availability configuration, the address should
+  # point to a Load Balancer.
+  proxy_server: teleport-proxy.example.com:443
 
-    # Only use one of auth_server or proxy_server.
-    #
-    # When you have either the application service or database service enabled,
-    # only tunneling through the proxy is supported, so you should specify proxy_server.
-    # All other services support both tunneling through the proxy and directly connecting
-    # to the auth server, so you can specify either auth_server or proxy_server.
+  # Relay tunnel address and port to connect to, if set. Used by some services
+  # to open additional tunnels to a Relay group if Teleport is configured to
+  # connect to a Proxy Server. If a Relay group consists of more than one
+  # Relay Service instance, the address should point to a Load Balancer.
+  # Used in Teleport v18.3.0 and later for the SSH service.
+  relay_server: teleport-relay.example.com:3042
 
-    # Auth Server address and port to connect to. If you enable the Teleport
-    # Auth Server to run in High Availability configuration, the address should
-    # point to a Load Balancer.
-    # If adding a node located behind NAT, use the Proxy URL (e.g. teleport-proxy.example.com:443)
-    # and set `proxy_server` instead.
-    auth_server: 10.1.0.5:3025
+  # cache:
+  #  # The cache is enabled by default, it can be disabled with this flag
+  #  enabled: true
 
-    # Proxy Server address and port to connect to. If you enable the Teleport
-    # Proxy Server to run in High Availability configuration, the address should
-    # point to a Load Balancer.
-    proxy_server: teleport-proxy.example.com:443
+  # The duration (in string form) of the delay between receiving a termination
+  # signal and the beginning of the shutdown procedures. It can be used to
+  # give time to load balancers to stop routing connections to the Teleport
+  # instance while the instance is still capable of handling them. If unset or
+  # negative, no delay is applied.
+  #shutdown_delay: "0s"
 
-    # Relay tunnel address and port to connect to, if set. Used by some services
-    # to open additional tunnels to a Relay group if Teleport is configured to
-    # connect to a Proxy Server. If a Relay group consists of more than one
-    # Relay Service instance, the address should point to a Load Balancer.
-    # Used in Teleport v18.3.0 and later for the SSH service.
-    relay_server: teleport-relay.example.com:3042
+  # Teleport can limit the number of connections coming from each client
+  # IP address to avoid abuse. These limits are enforced separately for
+  # each service (Auth, Proxy, SSH, Kubernetes, Database, Windows
+  # Desktop, and Application).
+  connection_limits:
+    max_connections: 1000
 
-    # cache:
-    #  # The cache is enabled by default, it can be disabled with this flag
-    #  enabled: true
+  # Auth Service connection configuration.
+  # These settings can be tweaked to control how aggresively the Proxy or Agent instances will retry to connect. In addition
+  # each instance will apply jitter.
+  # auth_connection_config:
+  #   upper_limit_between_retries: "90s"  # Cannot be lower than 10s
+  #   initial_connection_delay: "9s"      # When unset upper_limit_between_retries / 10
+  #   backoff_step_duration: "18s"        # When unset upper_limit_between_retries / 5
 
-    # The duration (in string form) of the delay between receiving a termination
-    # signal and the beginning of the shutdown procedures. It can be used to
-    # give time to load balancers to stop routing connections to the Teleport
-    # instance while the instance is still capable of handling them. If unset or
-    # negative, no delay is applied.
-    #shutdown_delay: "0s"
+  # Logging configuration. Possible output values to disk via
+  # '/var/lib/teleport/teleport.log',
+  # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,
+  # and ERROR.
+  log:
+    output: /var/lib/teleport/teleport.log
+    severity: INFO
 
-    # Teleport can limit the number of connections coming from each client
-    # IP address to avoid abuse. These limits are enforced separately for
-    # each service (Auth, Proxy, SSH, Kubernetes, Database, Windows
-    # Desktop, and Application).
-    connection_limits:
-        max_connections: 1000
-
-    # Auth Service connection configuration.
-    # These settings can be tweaked to control how aggresively the Proxy or Agent instances will retry to connect. In addition
-    # each instance will apply jitter.
-    # auth_connection_config:
-    #     upper_limit_between_retries: "90s"  # Cannot be lower than 10s
-    #     initial_connection_delay: "9s"      # When unset upper_limit_between_retries / 10
-    #     backoff_step_duration: "18s"        # When unset upper_limit_between_retries / 5
-
-    # Logging configuration. Possible output values to disk via
-    # '/var/lib/teleport/teleport.log',
-    # 'stdout', 'stderr' and 'syslog'. Possible severity values are DEBUG, INFO (default), WARN,
-    # and ERROR.
-    log:
-        output: /var/lib/teleport/teleport.log
-        severity: INFO
-
-        # Log format configuration
-        # Possible output values are 'json' and 'text' (default).
-        # Possible extra_fields values include: timestamp, component, caller,
-        # and level.
-        # All extra fields are included by default.
-        format:
-          output: text
-          extra_fields: [level, timestamp, component, caller]
+    # Log format configuration
+    # Possible output values are 'json' and 'text' (default).
+    # Possible extra_fields values include: timestamp, component, caller,
+    # and level.
+    # All extra fields are included by default.
+    format:
+      output: text
+      extra_fields: [level, timestamp, component, caller]

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -718,6 +718,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		&cfg.Databases.Limiter,
 		&cfg.Kube.Limiter,
 		&cfg.WindowsDesktop.ConnLimiter,
+		&cfg.Apps.Limiter,
 	}
 	for _, l := range limiters {
 		if fc.Limits.MaxConnections > 0 {

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -945,6 +945,27 @@ SREzU8onbBsjMg9QDiSf5oJLKvd/Ren+zGY7
 	require.True(t, cfg.Okta.SyncSettings.SyncAccessLists)
 }
 
+func TestApplyConfigAppsLimiter(t *testing.T) {
+	fc := &FileConfig{
+		Global: Global{
+			Limits: ConnectionLimits{
+				MaxConnections: 100,
+				Rates: []ConnectionRate{
+					{Average: 10, Burst: 10, Period: time.Minute},
+				},
+			},
+		},
+	}
+	cfg := servicecfg.MakeDefaultConfig()
+	require.NoError(t, ApplyFileConfig(fc, cfg))
+
+	require.Equal(t, int64(100), cfg.Apps.Limiter.MaxConnections)
+	require.Len(t, cfg.Apps.Limiter.Rates, 1)
+	require.Equal(t, int64(10), cfg.Apps.Limiter.Rates[0].Average)
+	require.Equal(t, int64(10), cfg.Apps.Limiter.Rates[0].Burst)
+	require.Equal(t, time.Minute, cfg.Apps.Limiter.Rates[0].Period)
+}
+
 // TestApplyConfigNoneEnabled makes sure that if a section is not enabled,
 // it's fields are not read in.
 func TestApplyConfigNoneEnabled(t *testing.T) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -6806,6 +6806,7 @@ func (process *TeleportProcess) initApps() {
 			ConnectionMonitor: connMonitor,
 			ServiceComponent:  teleport.ComponentApp,
 			Logger:            logger,
+			LimiterConfig:     process.Config.Apps.Limiter,
 			MCPDemoServer:     process.Config.Apps.MCPDemoServer,
 		})
 		if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5406,6 +5406,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ConnectionMonitor: connMonitor,
 			CipherSuites:      cfg.CipherSuites,
 			ServiceComponent:  teleport.ComponentWebProxy,
+			LimiterConfig:     cfg.Apps.Limiter,
 			AWSConfigOptions: []awsconfig.OptionsFn{
 				awsconfig.WithOIDCIntegrationClient(conn.Client),
 				awsconfig.WithRolesAnywhereIntegrationClient(conn.Client),

--- a/lib/service/servicecfg/app.go
+++ b/lib/service/servicecfg/app.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	netutils "github.com/gravitational/teleport/api/utils/net"
+	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 )
@@ -49,7 +50,10 @@ type AppsConfig struct {
 	// Apps is the list of applications that are being proxied.
 	Apps []App
 
-	// ResourceMatchers match cluster database resources.
+	// Limiter limits the connection and request rates.
+	Limiter limiter.Config
+
+	// ResourceMatchers match cluster application resources.
 	ResourceMatchers []services.ResourceMatcher
 
 	// MonitorCloseChannel will be signaled when a monitor closes a connection.

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -722,6 +722,7 @@ func ApplyDefaults(cfg *Config) {
 
 	// Apps service defaults. It's disabled by default.
 	cfg.Apps.Enabled = false
+	defaults.ConfigureLimiter(&cfg.Apps.Limiter)
 
 	// Databases proxy service is disabled by default.
 	cfg.Databases.Enabled = false

--- a/lib/srv/app/connections_handler.go
+++ b/lib/srv/app/connections_handler.go
@@ -279,10 +279,7 @@ func NewConnectionsHandler(closeContext context.Context, cfg *ConnectionsHandler
 	}
 
 	// Create and configure HTTP server with authorizing middleware.
-	c.httpServer, err = c.newHTTPServer(clustername.GetClusterName())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	c.httpServer = c.newHTTPServer(clustername.GetClusterName())
 
 	// TCP server will handle TCP applications.
 	tcpServer, err := c.newTCPServer()
@@ -614,8 +611,7 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 	// (HTTP, TCP, MCP) before any protocol-specific handling.
 	// Skip limiting when the client IP cannot be extracted (e.g.
 	// net.Pipe connections used by integration app proxying).
-	release := func() {}
-	releaseOnReturn := true
+	var release func()
 	if clientIP, err := utils.ClientIPFromConn(conn); err == nil {
 		release, err = c.limiter.RegisterRequestAndConnection(clientIP)
 		if err != nil {
@@ -623,7 +619,7 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 		}
 	}
 	defer func() {
-		if releaseOnReturn {
+		if release != nil {
 			release()
 		}
 	}()
@@ -686,9 +682,14 @@ func (c *ConnectionsHandler) handleConnection(conn net.Conn) (func(), error) {
 		return nil, trace.Wrap(c.mcpServer.HandleSession(ctx, &sessionCtx))
 
 	default:
-		releaseOnReturn = false
+		// Transfer release ownership to the cleanup function so
+		// the deferred release above becomes a no-op.
+		releaseConn := release
+		release = nil
 		cleanup := func() {
-			release()
+			if releaseConn != nil {
+				releaseConn()
+			}
 			cancel(nil)
 			c.deleteConnAuth(tlsConn)
 		}
@@ -724,7 +725,7 @@ func (c *ConnectionsHandler) handleTCPApp(ctx context.Context, conn net.Conn, id
 
 // newHTTPServer creates an *http.Server that can authorize and forward
 // requests to a target application.
-func (c *ConnectionsHandler) newHTTPServer(clusterName string) (*http.Server, error) {
+func (c *ConnectionsHandler) newHTTPServer(clusterName string) *http.Server {
 	// Reuse the auth.Middleware to authorize requests but only accept
 	// certificates that were specifically generated for applications.
 
@@ -744,7 +745,7 @@ func (c *ConnectionsHandler) newHTTPServer(clusterName string) (*http.Server, er
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			return context.WithValue(ctx, connContextKey, c)
 		},
-	}, nil
+	}
 }
 
 // ServeHTTP will forward the *http.Request to the target application.

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -1,0 +1,110 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/limiter"
+)
+
+func TestNewHTTPServer(t *testing.T) {
+	t.Parallel()
+
+	c := &ConnectionsHandler{
+		cfg: &ConnectionsHandlerConfig{
+			ServiceComponent: teleport.ComponentApp,
+		},
+	}
+
+	srv, err := c.newHTTPServer("test-cluster")
+	require.NoError(t, err)
+
+	// The HTTP server no longer wraps a limiter (limiting is applied at
+	// the connection level in handleConnection). Verify that requests
+	// are never rejected with 429 by the HTTP handler itself.
+	for i := range 5 {
+		rec := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+		require.NotEqual(t, http.StatusTooManyRequests, rec.Code,
+			"request %d should not be rate-limited", i+1)
+	}
+}
+
+func TestConnectionLimiter_MaxConnections(t *testing.T) {
+	t.Parallel()
+
+	lim, err := limiter.NewLimiter(limiter.Config{
+		MaxConnections: 2,
+	})
+	require.NoError(t, err)
+
+	// Acquire two connections from the same IP.
+	release1, err := lim.RegisterRequestAndConnection("10.0.0.1")
+	require.NoError(t, err)
+	release2, err := lim.RegisterRequestAndConnection("10.0.0.1")
+	require.NoError(t, err)
+
+	// Third connection from same IP is rejected.
+	_, err = lim.RegisterRequestAndConnection("10.0.0.1")
+	require.Error(t, err)
+
+	// Different IP still works.
+	release3, err := lim.RegisterRequestAndConnection("10.0.0.2")
+	require.NoError(t, err)
+
+	// Releasing one connection unblocks the original IP.
+	release1()
+	release4, err := lim.RegisterRequestAndConnection("10.0.0.1")
+	require.NoError(t, err)
+
+	release2()
+	release3()
+	release4()
+}
+
+func TestConnectionLimiter_RateLimiting(t *testing.T) {
+	t.Parallel()
+
+	lim, err := limiter.NewLimiter(limiter.Config{
+		Rates: []limiter.Rate{
+			{
+				Period:  time.Minute,
+				Average: 1,
+				Burst:   1,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	// First connection should succeed.
+	release, err := lim.RegisterRequestAndConnection("10.0.0.1")
+	require.NoError(t, err)
+	release()
+
+	// Second connection from same IP within the rate window is rejected.
+	_, err = lim.RegisterRequestAndConnection("10.0.0.1")
+	require.Error(t, err)
+}

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -75,8 +75,8 @@ func newTestHandler(t *testing.T, cfg limiter.Config) *ConnectionsHandler {
 			ServiceComponent: teleport.ComponentApp,
 		},
 		closeContext: ctx,
-		limiter:     lim,
-		log:         slog.Default(),
+		limiter:      lim,
+		log:          slog.Default(),
 	}
 }
 

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -167,10 +167,14 @@ func TestHandleConnection_RateLimiting(t *testing.T) {
 func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 	t.Parallel()
 
-	// Even with a very restrictive limiter, net.Pipe connections
-	// (whose RemoteAddr cannot be parsed as host:port) skip
-	// limiting entirely.
-	c := newTestHandler(t, limiter.Config{MaxConnections: 0})
+	// net.Pipe connections (whose RemoteAddr cannot be parsed as
+	// host:port) skip limiting entirely. Configure a real limit and
+	// pre-fill it so that a normal connection would be rejected.
+	c := newTestHandler(t, limiter.Config{MaxConnections: 1})
+
+	held, err := c.limiter.RegisterRequestAndConnection("10.0.0.1")
+	require.NoError(t, err)
+	defer held()
 
 	server, client := net.Pipe()
 	t.Cleanup(func() {
@@ -179,9 +183,9 @@ func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 	})
 	client.Close()
 
-	// handleConnection should not return a LimitExceeded error;
-	// it will fail later (at TLS) because there is no TLS config.
-	_, err := c.handleConnection(server)
+	// handleConnection should bypass the limiter (which is full)
+	// and fail later at TLS instead.
+	_, err = c.handleConnection(server)
 	require.Error(t, err)
 	require.False(t, trace.IsLimitExceeded(err),
 		"unexpected LimitExceeded error: %v", err)

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -19,7 +19,6 @@
 package app
 
 import (
-	"context"
 	"log/slog"
 	"net"
 	"net/http"
@@ -63,9 +62,6 @@ func TestNewHTTPServer(t *testing.T) {
 // functional; TLS and auth are not configured.
 func newTestHandler(t *testing.T, cfg limiter.Config) *ConnectionsHandler {
 	t.Helper()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	lim, err := limiter.NewLimiter(cfg)
 	require.NoError(t, err)
 
@@ -74,7 +70,7 @@ func newTestHandler(t *testing.T, cfg limiter.Config) *ConnectionsHandler {
 			Clock:            clockwork.NewFakeClock(),
 			ServiceComponent: teleport.ComponentApp,
 		},
-		closeContext: ctx,
+		closeContext: t.Context(),
 		limiter:      lim,
 		log:          slog.Default(),
 	}
@@ -174,7 +170,7 @@ func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 	defer release()
 
 	server, client := net.Pipe()
-	t.Cleanup(func() { _ = server.Close() })
+	t.Cleanup(func() { server.Close() })
 	client.Close()
 
 	// handleConnection should bypass the limiter (which is full)

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -104,16 +104,15 @@ func TestHandleConnection_MaxConnections(t *testing.T) {
 
 	// Pre-fill the limiter to capacity for this IP so the next
 	// handleConnection call from the same IP is rejected.
-	held, err := c.limiter.RegisterRequestAndConnection(clientIP)
+	release, err := c.limiter.RegisterRequestAndConnection(clientIP)
 	require.NoError(t, err)
-	defer held()
+	defer release()
 
 	conn, client := newConnWithIP(t, clientIP, 10001)
 	client.Close() // prevent blocking on TLS handshake
 
 	_, err = c.handleConnection(conn)
-	require.True(t, trace.IsLimitExceeded(err),
-		"expected LimitExceeded error, got: %v", err)
+	require.True(t, trace.IsLimitExceeded(err), "expected LimitExceeded error, got: %v", err)
 }
 
 func TestHandleConnection_MaxConnectionsRelease(t *testing.T) {
@@ -125,9 +124,9 @@ func TestHandleConnection_MaxConnectionsRelease(t *testing.T) {
 
 	// Acquire and immediately release the slot so the limiter
 	// has capacity when handleConnection runs.
-	held, err := c.limiter.RegisterRequestAndConnection(clientIP)
+	release, err := c.limiter.RegisterRequestAndConnection(clientIP)
 	require.NoError(t, err)
-	held()
+	release()
 
 	conn, client := newConnWithIP(t, clientIP, 10001)
 	client.Close()
@@ -136,8 +135,7 @@ func TestHandleConnection_MaxConnectionsRelease(t *testing.T) {
 	// (at TLS handshake). The error must not be about limits.
 	_, err = c.handleConnection(conn)
 	require.Error(t, err)
-	require.False(t, trace.IsLimitExceeded(err),
-		"unexpected LimitExceeded error: %v", err)
+	require.False(t, trace.IsLimitExceeded(err), "unexpected LimitExceeded error: %v", err)
 }
 
 func TestHandleConnection_RateLimiting(t *testing.T) {
@@ -160,8 +158,7 @@ func TestHandleConnection_RateLimiting(t *testing.T) {
 	client.Close()
 
 	_, err := c.handleConnection(conn)
-	require.True(t, trace.IsLimitExceeded(err),
-		"expected LimitExceeded error, got: %v", err)
+	require.True(t, trace.IsLimitExceeded(err), "expected LimitExceeded error, got: %v", err)
 }
 
 func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
@@ -172,21 +169,17 @@ func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
 	// pre-fill it so that a normal connection would be rejected.
 	c := newTestHandler(t, limiter.Config{MaxConnections: 1})
 
-	held, err := c.limiter.RegisterRequestAndConnection("10.0.0.1")
+	release, err := c.limiter.RegisterRequestAndConnection("10.0.0.1")
 	require.NoError(t, err)
-	defer held()
+	defer release()
 
 	server, client := net.Pipe()
-	t.Cleanup(func() {
-		server.Close()
-		client.Close()
-	})
+	t.Cleanup(func() { _ = server.Close() })
 	client.Close()
 
 	// handleConnection should bypass the limiter (which is full)
 	// and fail later at TLS instead.
 	_, err = c.handleConnection(server)
 	require.Error(t, err)
-	require.False(t, trace.IsLimitExceeded(err),
-		"unexpected LimitExceeded error: %v", err)
+	require.False(t, trace.IsLimitExceeded(err), "unexpected LimitExceeded error: %v", err)
 }

--- a/lib/srv/app/connections_handler_test.go
+++ b/lib/srv/app/connections_handler_test.go
@@ -19,15 +19,21 @@
 package app
 
 import (
+	"context"
+	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestNewHTTPServer(t *testing.T) {
@@ -39,8 +45,7 @@ func TestNewHTTPServer(t *testing.T) {
 		},
 	}
 
-	srv, err := c.newHTTPServer("test-cluster")
-	require.NoError(t, err)
+	srv := c.newHTTPServer("test-cluster")
 
 	// The HTTP server no longer wraps a limiter (limiting is applied at
 	// the connection level in handleConnection). Verify that requests
@@ -53,58 +58,131 @@ func TestNewHTTPServer(t *testing.T) {
 	}
 }
 
-func TestConnectionLimiter_MaxConnections(t *testing.T) {
-	t.Parallel()
+// newTestHandler creates a ConnectionsHandler with a limiter for testing
+// handleConnection. The handler is minimal - only the limiter wiring is
+// functional; TLS and auth are not configured.
+func newTestHandler(t *testing.T, cfg limiter.Config) *ConnectionsHandler {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
-	lim, err := limiter.NewLimiter(limiter.Config{
-		MaxConnections: 2,
-	})
+	lim, err := limiter.NewLimiter(cfg)
 	require.NoError(t, err)
 
-	// Acquire two connections from the same IP.
-	release1, err := lim.RegisterRequestAndConnection("10.0.0.1")
-	require.NoError(t, err)
-	release2, err := lim.RegisterRequestAndConnection("10.0.0.1")
-	require.NoError(t, err)
-
-	// Third connection from same IP is rejected.
-	_, err = lim.RegisterRequestAndConnection("10.0.0.1")
-	require.Error(t, err)
-
-	// Different IP still works.
-	release3, err := lim.RegisterRequestAndConnection("10.0.0.2")
-	require.NoError(t, err)
-
-	// Releasing one connection unblocks the original IP.
-	release1()
-	release4, err := lim.RegisterRequestAndConnection("10.0.0.1")
-	require.NoError(t, err)
-
-	release2()
-	release3()
-	release4()
+	return &ConnectionsHandler{
+		cfg: &ConnectionsHandlerConfig{
+			Clock:            clockwork.NewFakeClock(),
+			ServiceComponent: teleport.ComponentApp,
+		},
+		closeContext: ctx,
+		limiter:     lim,
+		log:         slog.Default(),
+	}
 }
 
-func TestConnectionLimiter_RateLimiting(t *testing.T) {
+// newConnWithIP creates a net.Pipe-backed connection whose RemoteAddr
+// returns the given IP and port. Close the returned client side when
+// done; the server side is used by handleConnection.
+func newConnWithIP(t *testing.T, ip string, port int) (server, client net.Conn) {
+	t.Helper()
+	server, client = net.Pipe()
+	t.Cleanup(func() {
+		server.Close()
+		client.Close()
+	})
+	addr := &net.TCPAddr{IP: net.ParseIP(ip), Port: port}
+	server = utils.NewConnWithSrcAddr(server, addr)
+	return server, client
+}
+
+func TestHandleConnection_MaxConnections(t *testing.T) {
 	t.Parallel()
 
-	lim, err := limiter.NewLimiter(limiter.Config{
-		Rates: []limiter.Rate{
-			{
-				Period:  time.Minute,
-				Average: 1,
-				Burst:   1,
-			},
-		},
-	})
-	require.NoError(t, err)
+	c := newTestHandler(t, limiter.Config{MaxConnections: 1})
 
-	// First connection should succeed.
-	release, err := lim.RegisterRequestAndConnection("10.0.0.1")
-	require.NoError(t, err)
-	release()
+	const clientIP = "10.0.0.1"
 
-	// Second connection from same IP within the rate window is rejected.
-	_, err = lim.RegisterRequestAndConnection("10.0.0.1")
+	// Pre-fill the limiter to capacity for this IP so the next
+	// handleConnection call from the same IP is rejected.
+	held, err := c.limiter.RegisterRequestAndConnection(clientIP)
+	require.NoError(t, err)
+	defer held()
+
+	conn, client := newConnWithIP(t, clientIP, 10001)
+	client.Close() // prevent blocking on TLS handshake
+
+	_, err = c.handleConnection(conn)
+	require.True(t, trace.IsLimitExceeded(err),
+		"expected LimitExceeded error, got: %v", err)
+}
+
+func TestHandleConnection_MaxConnectionsRelease(t *testing.T) {
+	t.Parallel()
+
+	c := newTestHandler(t, limiter.Config{MaxConnections: 1})
+
+	const clientIP = "10.0.0.1"
+
+	// Acquire and immediately release the slot so the limiter
+	// has capacity when handleConnection runs.
+	held, err := c.limiter.RegisterRequestAndConnection(clientIP)
+	require.NoError(t, err)
+	held()
+
+	conn, client := newConnWithIP(t, clientIP, 10001)
+	client.Close()
+
+	// handleConnection should pass the limiter and fail later
+	// (at TLS handshake). The error must not be about limits.
+	_, err = c.handleConnection(conn)
 	require.Error(t, err)
+	require.False(t, trace.IsLimitExceeded(err),
+		"unexpected LimitExceeded error: %v", err)
+}
+
+func TestHandleConnection_RateLimiting(t *testing.T) {
+	t.Parallel()
+
+	c := newTestHandler(t, limiter.Config{
+		Rates: []limiter.Rate{{
+			Period:  time.Minute,
+			Average: 1,
+			Burst:   1,
+		}},
+	})
+
+	const clientIP = "10.0.0.1"
+
+	// Consume the one allowed request so the next is rate-limited.
+	require.NoError(t, c.limiter.RegisterRequest(clientIP))
+
+	conn, client := newConnWithIP(t, clientIP, 10001)
+	client.Close()
+
+	_, err := c.handleConnection(conn)
+	require.True(t, trace.IsLimitExceeded(err),
+		"expected LimitExceeded error, got: %v", err)
+}
+
+func TestHandleConnection_PipeSkipsLimiter(t *testing.T) {
+	t.Parallel()
+
+	// Even with a very restrictive limiter, net.Pipe connections
+	// (whose RemoteAddr cannot be parsed as host:port) skip
+	// limiting entirely.
+	c := newTestHandler(t, limiter.Config{MaxConnections: 0})
+
+	server, client := net.Pipe()
+	t.Cleanup(func() {
+		server.Close()
+		client.Close()
+	})
+	client.Close()
+
+	// handleConnection should not return a LimitExceeded error;
+	// it will fail later (at TLS) because there is no TLS config.
+	_, err := c.handleConnection(server)
+	require.Error(t, err)
+	require.False(t, trace.IsLimitExceeded(err),
+		"unexpected LimitExceeded error: %v", err)
 }


### PR DESCRIPTION
The app service is the only Teleport service without rate limiter
support. Every other service (SSH, Auth, Proxy, Database, Kube,
Windows Desktop) already has a `limiter.Config` field populated
from `connection_limits` in the file config.

Wire the limiter through the same path: add `Limiter` to
`AppsConfig`, include it in the `limiters` slice in
`configuration.go`, and pass it into `ConnectionsHandlerConfig`.

Apply the limiter in `handleConnection` - the shared entry point
for all app protocols - rather than in the HTTP middleware chain.
This ensures HTTP, TCP, and MCP connections all honour
`connection_limits`. Follow the database service pattern: call
`RegisterRequestAndConnection` with the client IP before protocol
dispatch, and release the slot when the connection closes. Skip
limiting when the client IP cannot be extracted (e.g. `net.Pipe`
connections used by integration app proxying) rather than
rejecting the connection. For HTTP, transfer the release into the
cleanup function that runs after the connection is served. For TCP
and MCP, release on handler return via defer.

Create the limiter unconditionally even when no
`connection_limits` are configured (the default), to stay
consistent with how every other Teleport service handles it.

Move `go c.expireSessions()` to after all fallible initialization
to avoid leaking the goroutine on error.

Add a v19 breaking-change entry to the changelog and update the
config reference to list Application alongside the other services.

Fixes https://github.com/gravitational/teleport/issues/7893