### PR TITLE
[v18] [tctl] introduce `tctl recordings download`

### DIFF
--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -49,7 +49,7 @@ informally referred to as "chunks."
 
 ### Database sessions
 
-Teleport captures database queries and a stream of audit events 
+Teleport captures database queries and a stream of audit events
 related to the database being accessed.
 
 ## Session recording configurations
@@ -140,7 +140,7 @@ The Proxy Service then establishes its own connection to the destination server 
 - For [OpenSSH servers](../../enroll-resources/server-access/openssh/openssh-agentless.mdx), the Proxy Service requests a certificate signed by the Teleport OpenSSH CA, which will be trusted by the OpenSSH server.
 
 With both sides of the connections decrypted, the Proxy Service acts as a pipe between the client
-and the destination server, performing RBAC checks, recording the session, and emitting audit events 
+and the destination server, performing RBAC checks, recording the session, and emitting audit events
 in the process as shown below:
 
 ![recording-proxy](../../../img/recording-proxy.svg)
@@ -256,6 +256,18 @@ This is sometimes surprising to Teleport users, because even though the recordin
 and audit log are stored in separate backends, both need to be operational in
 order to play recordings.
 
+## Download
+
+Session recordings can be downloaded from the cluster storage using the
+[`tctl recordings download`](../cli/tctl.mdx#tctl-recordings-download) command.
+
+```code
+$ tctl recordings download [--output-dir <output-dir>] <session_id>
+```
+
+All downloaded recordings are decrypted during the streaming process if session
+recording encryption is enabled.
+
 ## Upload completer
 
 Every Teleport process runs a service called the *upload completer* which periodically
@@ -338,3 +350,4 @@ defined when the key is first provisioned.
 - [SSH recording modes](../deployment/monitoring/audit.mdx)
 - [Session recording for desktops](../../enroll-resources/desktop-access/reference/sessions.mdx)
 - [Encrypted Session Recordings](../../enroll-resources/server-access/guides/encrypted-session-recordings/encrypted-session-recordings.mdx)
+- [Session recording summaries](../../identity-security/session-summaries.mdx)

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1536,6 +1536,19 @@ Flags:
 |---|---|---|
 |`--format`|`yaml`|Output format: 'yaml', 'json' or 'text'|
 
+## tctl recordings download
+
+Download session recordings from the cluster's recording storage to a local file.
+If you omit an output directory, recordings are saved to the current working directory.
+
+If session recording encryption is enabled in the cluster, recordings are decrypted during download.
+
+### Example
+
+```code
+$ tctl recordings download [--output-dir <output-dir>] <session_id>
+```
+
 ## tctl recordings encryption complete-rotation
 
 Completes an in-progress encryption key rotation.

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1637,7 +1637,7 @@ func (tc *TeleportClient) GetTargetNode(ctx context.Context, clt authclient.Clie
 		Labels:              tc.Labels,
 	})
 	switch {
-	//TODO(tross): DELETE IN v20.0.0
+	// TODO(tross): DELETE IN v20.0.0
 	case trace.IsNotImplemented(err):
 		resources, err := client.GetAllUnifiedResources(ctx, clt, &proto.ListUnifiedResourcesRequest{
 			Kinds:               []string{types.KindNode},
@@ -2570,7 +2570,7 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 		}
 	}
 
-	if err := player.Err(); err != nil {
+	if err := player.Err(); err != nil && !errors.Is(err, io.EOF) {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Backport of #62431 to branch/v18

Changelog: Added `tctl recordings download` command to download session recordings to local files without requiring direct access to the storage backend.


Test Plan:
 - [x] Tested `tctl recordings download <session_id>` to my local cluster
 - [x] Tested `tctl recordings download <session_id>` to my cloud tenant
 - [x] Tested `tsh play ./<session_id>.tar` on the downloaded file  