### PR TITLE
[v17] [tctl] introduce `tctl recordings download`

### DIFF
--- a/docs/pages/reference/architecture/session-recording.mdx
+++ b/docs/pages/reference/architecture/session-recording.mdx
@@ -46,7 +46,7 @@ informally referred to as "chunks."
 
 ### Database sessions
 
-Teleport captures database queries and a stream of audit events 
+Teleport captures database queries and a stream of audit events
 related to the database being accessed.
 
 ## Session recording configurations
@@ -205,6 +205,18 @@ audit log for session end events, which contain metadata about the recording.
 This is sometimes surprising to Teleport users, because even though the recordings
 and audit log are stored in separate backends, both need to be operational in
 order to play recordings.
+
+## Download
+
+Session recordings can be downloaded from the cluster storage using the
+[`tctl recordings download`](../cli/tctl.mdx#tctl-recordings-download) command.
+
+```code
+$ tctl recordings download [--output-dir <output-dir>] <session_id>
+```
+
+All downloaded recordings are decrypted during the streaming process if session
+recording encryption is enabled.
 
 ## Upload completer
 

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -394,6 +394,20 @@ $ tctl auth export --fingerprint=SHA256:8xu5kh1CbHCZRrGuitbQd4hM+d9V+I7YA1mUwA/2
 $ tctl auth export --type=tls-host
 ```
 
+## tctl recordings download
+
+Download session recordings from the cluster's recording storage to a local file.
+If you omit an output directory, recordings are saved to the current working directory.
+
+If session recording encryption is enabled in the cluster, recordings are decrypted during download.
+
+### Example
+
+```code
+$ tctl recordings download [--output-dir <output-dir>] <session_id>
+```
+
+
 ## tctl auth rotate
 
 Rotate certificate authorities in the cluster:

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1589,7 +1589,7 @@ func (tc *TeleportClient) GetTargetNode(ctx context.Context, clt authclient.Clie
 		Labels:              tc.Labels,
 	})
 	switch {
-	//TODO(tross): DELETE IN v20.0.0
+	// TODO(tross): DELETE IN v20.0.0
 	case trace.IsNotImplemented(err):
 		resources, err := client.GetAllUnifiedResources(ctx, clt, &proto.ListUnifiedResourcesRequest{
 			Kinds:               []string{types.KindNode},
@@ -2525,7 +2525,7 @@ func playSession(ctx context.Context, sessionID string, speed float64, streamer 
 		}
 	}
 
-	if err := player.Err(); err != nil {
+	if err := player.Err(); err != nil && !errors.Is(err, io.EOF) {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tctl/common/recordings_command.go
+++ b/tool/tctl/common/recordings_command.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -33,7 +34,10 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/tool/common"
 	commonclient "github.com/gravitational/teleport/tool/tctl/common/client"
 	tctlcfg "github.com/gravitational/teleport/tool/tctl/common/config"
@@ -47,6 +51,10 @@ type RecordingsCommand struct {
 	format string
 	// recordingsList implements the "tctl recordings ls" subcommand.
 	recordingsList *kingpin.CmdClause
+
+	// recordingsDownload implements the "tctl recordings download" subcommand.
+	recordingsDownload *kingpin.CmdClause
+
 	// fromUTC is the start time to use for the range of recordings listed by the recorded session listing command
 	fromUTC string
 	// toUTC is the start time to use for the range of recordings listed by the recorded session listing command
@@ -55,10 +63,15 @@ type RecordingsCommand struct {
 	maxRecordingsToShow int
 	// recordingsSince is a duration which sets the time into the past in which to list session recordings
 	recordingsSince string
+
+	// recordingsDownloadSessionID is the session ID to download recordings for
+	recordingsDownloadSessionID string
+	// recordingsDownloadOutputDir is the output directory to download session recordings to
+	recordingsDownloadOutputDir string
 }
 
 // Initialize allows RecordingsCommand to plug itself into the CLI parser
-func (c *RecordingsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
+func (c *RecordingsCommand) Initialize(app *kingpin.Application, t *tctlcfg.GlobalCLIFlags, config *servicecfg.Config) {
 	c.config = config
 	recordings := app.Command("recordings", "View and control session recordings.")
 	c.recordingsList = recordings.Command("ls", "List recorded sessions.")
@@ -67,6 +80,15 @@ func (c *RecordingsCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Glob
 	c.recordingsList.Flag("to-utc", fmt.Sprintf("End of time range in which recordings are listed. Format %s. Defaults to current time.", defaults.TshTctlSessionListTimeFormat)).StringVar(&c.toUTC)
 	c.recordingsList.Flag("limit", fmt.Sprintf("Maximum number of recordings to show. Default %s.", defaults.TshTctlSessionListLimit)).Default(defaults.TshTctlSessionListLimit).IntVar(&c.maxRecordingsToShow)
 	c.recordingsList.Flag("last", "Duration into the past from which session recordings should be listed. Format 5h30m40s").StringVar(&c.recordingsSince)
+
+	download := recordings.Command("download", "Download session recordings.")
+	download.Arg("session-id", "ID of the session to download recordings for.").Required().StringVar(&c.recordingsDownloadSessionID)
+	pwd, err := os.Getwd()
+	if err != nil {
+		pwd = "."
+	}
+	download.Flag("output-dir", "Directory to download session recordings to.").Short('o').Default(pwd).StringVar(&c.recordingsDownloadOutputDir)
+	c.recordingsDownload = download
 }
 
 // TryRun attempts to run subcommands like "recordings ls".
@@ -75,6 +97,8 @@ func (c *RecordingsCommand) TryRun(ctx context.Context, cmd string, clientFunc c
 	switch cmd {
 	case c.recordingsList.FullCommand():
 		commandFunc = c.ListRecordings
+	case c.recordingsDownload.FullCommand():
+		commandFunc = c.DownloadRecordings
 	default:
 		return false, nil
 	}
@@ -104,4 +128,74 @@ func (c *RecordingsCommand) ListRecordings(ctx context.Context, tc *authclient.C
 		return trace.Errorf("getting session events: %v", err)
 	}
 	return trace.Wrap(common.ShowSessions(recordings, c.format, os.Stdout))
+}
+
+func (c *RecordingsCommand) DownloadRecordings(ctx context.Context, tc *authclient.Client) (err error) {
+	sessionID, err := session.ParseID(c.recordingsDownloadSessionID)
+	if err != nil {
+		return trace.BadParameter("invalid session id")
+	}
+
+	e, err := createFileWriter(ctx, *sessionID, c.recordingsDownloadOutputDir)
+	if err != nil {
+		return trace.Wrap(err, "creating file downloader")
+	}
+	defer func() {
+		completeErr := e.Complete(ctx)
+		if err == nil && completeErr == nil {
+			return
+		}
+		localRemErr := os.Remove(filepath.Join(c.recordingsDownloadOutputDir, string(*sessionID)+".tar"))
+		// ignore file not found errors
+		if os.IsNotExist(localRemErr) {
+			localRemErr = nil
+		}
+		err = trace.NewAggregate(err, completeErr, localRemErr)
+	}()
+
+	recC, errC := tc.StreamSessionEvents(ctx, *sessionID, 0)
+loop:
+	for {
+		select {
+		case rec, ok := <-recC:
+			if !ok {
+				break loop
+			}
+			prepared, err := e.PrepareSessionEvent(rec)
+			if err != nil {
+				return trace.Wrap(err, "preparing recording event")
+			}
+			err = e.RecordEvent(ctx, prepared)
+			if err != nil {
+				return trace.Wrap(err, "recording session event")
+			}
+		case err := <-errC:
+			if err != nil && !trace.IsEOF(err) {
+				return trace.Wrap(err, "downloading session recordings")
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// createFileWriter creates a file-based session event writer that outputs to a file.
+func createFileWriter(ctx context.Context, sessionID session.ID, outputDir string) (*events.SessionWriter, error) {
+	fileStreamer, err := filesessions.NewStreamer(outputDir)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to create fileStreamer")
+	}
+
+	e, err := events.NewSessionWriter(
+		events.SessionWriterConfig{
+			SessionID: sessionID,
+			Component: "downloader",
+			// Use NoOpPreparer as events are already prepared by the server.
+			Preparer: &events.NoOpPreparer{},
+			Context:  ctx,
+			Clock:    clockwork.NewRealClock(),
+			Streamer: fileStreamer,
+		},
+	)
+	return e, trace.Wrap(err, "creating session writer")
 }


### PR DESCRIPTION
Backport of #62431 to branch/v17

Changelog: Added `tctl recordings download` command to download session recordings to local files without requiring direct access to the storage backend.

Test Plan:
 - manually tested locally