### PR TITLE
Docs: fix tags key in EC2 Discovery guides

### DIFF
--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
@@ -246,6 +246,8 @@ Static configuration while simpler at first, has less flexibility because enroll
     aws:
     - types: ["ec2"]
       regions: ["*"]
+      tags:
+        "env": "prod" # Match EC2 instances where tag:env=prod
       ssm:
         document_name: "AWS-RunShellScript"
       install:
@@ -266,8 +268,6 @@ Static configuration while simpler at first, has less flexibility because enroll
             # Only exact matches are supported.
             # Optional. If empty, no OUs are excluded.
             exclude: []
-        tags:
-            "env": "prod" # Match EC2 instances where tag:env=prod
   ```
   Adjust the keys under `spec.aws` to match your EC2 environment,
   specifically the tags you want to associate with the Discovery Service.
@@ -293,6 +293,8 @@ Static configuration while simpler at first, has less flexibility because enroll
     aws:
     - types: ["ec2"]
       regions: ["*"]
+      tags:
+        "env": "prod" # Match EC2 instances where tag:env=prod
       ssm:
         document_name: "AWS-RunShellScript"
       install:
@@ -312,10 +314,6 @@ Static configuration while simpler at first, has less flexibility because enroll
             # Only exact matches are supported.
             # Optional. If empty, no OUs are excluded.
             exclude: []
-        tags:
-            "env": "prod" # Match EC2 instances where tag:env=prod
-      tags:
-        "env": "prod" # Match EC2 instances where tag:env=prod
   ```
   
   Adjust the keys under `discovery_service.aws` to match your EC2 environment, 

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -57,13 +57,13 @@ Static configuration while simpler at first, has less flexibility because enroll
     aws:
     - types: ["ec2"]
       regions: ["us-east-1", "us-west-1"]
+      tags:
+        "env": "prod" # Match EC2 instances where tag:env=prod
       ssm:
         document_name: "AWS-RunShellScript"
       install:
         join_method: iam
         join_token: aws-discovery-iam-token
-      tags:
-        "env": "prod" # Match EC2 instances where tag:env=prod
   ```
   Adjust the keys under `spec.aws` to match your EC2 environment,
   specifically the regions and tags you want to associate with the Discovery Service.
@@ -90,15 +90,15 @@ Static configuration while simpler at first, has less flexibility because enroll
     discovery_group: <Var name="aws-prod" />
     aws:
     - types: ["ec2"]
-      regions: ["us-east-1","us-west-1"]
+      regions: ["us-east-1", "us-west-1"]
+      tags:
+        "env": "prod" # Match EC2 instances where tag:env=prod
       ssm:
         document_name: "AWS-RunShellScript"
       install:
           join_params:
             token_name: aws-discovery-iam-token
             method: iam
-      tags:
-        "env": "prod" # Match EC2 instances where tag:env=prod
   ```
   
   Adjust the keys under `discovery_service.aws` to match your EC2 environment, 

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
@@ -14,14 +14,14 @@ spec:
       document_name: "AWS-RunShellScript"
     # Add new entry after existing entries
   - types: ["ec2"]
-    regions: ["us-east-1","us-west-1"]
+    regions: ["us-east-1", "us-west-1"]
+    tags:
+      "env": "prod" # Match EC2 instances where tag:env=prod
     install:
       join_method: iam
       join_token: aws-discovery-iam-token
     ssm:
       document_name: "AWS-RunShellScript"
-    tags:
-      "env": "prod" # Match EC2 instances where tag:env=prod
     assume_role:
       role_arn: "<Var name="role ARN" />"
       external_id: "<Var name="optional external ID" />"
@@ -50,14 +50,14 @@ discovery_service:
       document_name: "AWS-RunShellScript"
     # Add new entry after existing entries
   - types: ["ec2"]
-    regions: ["us-east-1","us-west-1"]
+    regions: ["us-east-1", "us-west-1"]
+    tags:
+      "env": "prod" # Match EC2 instances where tag:env=prod
     install:
       join_method: iam
       join_token: aws-discovery-iam-token
     ssm:
       document_name: "AWS-RunShellScript"
-    tags:
-      "env": "prod" # Match EC2 instances where tag:env=prod
     assume_role_arn: "<Var name="role ARN" />"
     external_id: "<Var name="optional external ID" />"
   - types: ["ec2"]


### PR DESCRIPTION
Fixed indentation and moved it near the regions in all examples.

Filtering by tag, IMO, is a similar concern to filtering by region, so having them together makes sense.