### PR TITLE
Run Connect autoupdate integration tests on Windows

### DIFF
--- a/.github/workflows/integration-tests-win.yaml
+++ b/.github/workflows/integration-tests-win.yaml
@@ -26,7 +26,9 @@ jobs:
             changed:
               - '.github/workflows/integration-tests-win.yaml'
               - 'lib/autoupdate/tools/**.go'
+              - 'lib/teleterm/autoupdate/**.go'
               - 'lib/utils/packaging/**.go'
+              - 'integration/autoupdate/tools/**.go'
               - 'go.mod'
               - 'go.sum'
               - 'build.assets/Makefile'


### PR DESCRIPTION
Enables running integration tests added in https://github.com/gravitational/teleport/pull/63572.

The tests should also run whenever the corresponding test files are changed.