### PR TITLE
Fixes possible collisions when hashing immutable labels

### DIFF
--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -390,8 +390,10 @@ func HashImmutableLabels(labels *joiningv1.ImmutableLabels) string {
 		})
 
 		for _, v := range sorted {
-			_, _ = hash.Write([]byte(v.key))
-			_, _ = hash.Write([]byte(v.value))
+			entryHash := sha256.New()
+			_, _ = entryHash.Write([]byte(v.key))
+			_, _ = entryHash.Write([]byte(v.value))
+			_, _ = hash.Write(entryHash.Sum(nil))
 		}
 	}
 

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -693,9 +693,9 @@ func TestImmutableLabelHashCollision(t *testing.T) {
 		labelsB *joiningv1.ImmutableLabels
 	}{
 		{
-			// guards against keys and values being concatenated as they're hashed. e.g.
-			// foo:bar-baz-qux would become foobar-baz-qux which would collide with foo:bar-,baz:-qux
-			name: "simple concatenation",
+			// guards against map entries being naiively concatenated as they're hashed. e.g.
+			// aaa=bbbcccddd should not collide with aaa=bbb,ccc=ddd
+			name: "split label concatenation",
 			labelsA: &joiningv1.ImmutableLabels{
 				Ssh: map[string]string{
 					"aaa": "bbbcccddd",
@@ -709,6 +709,24 @@ func TestImmutableLabelHashCollision(t *testing.T) {
 				},
 			},
 		},
+		{
+			// guards against single entries being naiievely concatenated as they're hashed. e.g.
+			// aaa=bbb should not collide with aaab=bb
+			name: "single label concatenation",
+			labelsA: &joiningv1.ImmutableLabels{
+				Ssh: map[string]string{
+					"aaa": "bbb",
+				},
+			},
+
+			labelsB: &joiningv1.ImmutableLabels{
+				Ssh: map[string]string{
+					"aaab": "bb",
+				},
+			},
+		},
+		// TODO (eriktate): add test case for identical labels applied to different service types once immutable
+		// labels support more than SSH
 	}
 
 	for _, c := range cases {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -18,10 +18,12 @@ package joining_test
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
@@ -672,15 +674,15 @@ func TestImmutableLabelHashing(t *testing.T) {
 
 	// assert that the same labels match with their hash
 	initialHash := joining.HashImmutableLabels(labels)
-	require.True(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
+	require.True(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labels), initialHash))
 
 	// assert that changing a label value fails the hash check
 	labels.Ssh["hello"] = "other"
-	require.False(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
+	require.False(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labels), initialHash))
 
 	// assert that adding a label fails the hash check
 	labels.Ssh["three"] = "3"
-	require.False(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
+	require.False(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labels), initialHash))
 }
 
 func TestImmutableLabelHashCollision(t *testing.T) {
@@ -755,7 +757,7 @@ func TestImmutableLabelHashGolden(t *testing.T) {
 			hash: "5dd8fad69587f17535a4dea3ab41400914c3fbecd1972d4e194b1c18c0f4c4ff",
 		},
 		{
-			name: "multiple ssh label",
+			name: "multiple ssh labels",
 			labels: &joiningv1.ImmutableLabels{
 				Ssh: map[string]string{
 					"aaa": "bbb",
@@ -782,4 +784,46 @@ func TestImmutableLabelHashGolden(t *testing.T) {
 			assert.Equal(t, c.hash, hash)
 		})
 	}
+}
+
+func FuzzImmutableLabelHash(f *testing.F) {
+	f.Add("hello", "world", "foo", "bar", "baz", "qux", true)   // base case
+	f.Add("aaa", "bbbcccddd", "aaa", "bbb", "ccc", "ddd", true) // split label concatenation
+	f.Add("aaa", "bbb", "aaab", "bb", "", "", false)            // single label concatenation
+
+	f.Fuzz(func(t *testing.T, key1, value1, key2, value2, key3, value3 string, multiLabel bool) {
+		labelsA := &joiningv1.ImmutableLabels{
+			Ssh: map[string]string{
+				key1: value1,
+			},
+		}
+		labelsB := &joiningv1.ImmutableLabels{
+			Ssh: map[string]string{
+				key2: value2,
+			},
+		}
+		// assign a second label only if multiLabel is true
+		if multiLabel {
+			labelsB.Ssh[key3] = value3
+		}
+
+		// assert we can generate hashes for both labels without panicking
+		hashA := joining.HashImmutableLabels(labelsA)
+		require.NotEmpty(t, hashA)
+		hashB := joining.HashImmutableLabels(labelsB)
+		require.NotEmpty(t, hashB)
+
+		// assert that hashes are verified against their own labels
+		assert.True(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labelsA), hashA))
+		assert.True(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labelsB), hashB))
+
+		// assert that the same labels always result in the same hash and different labels always result in different hashes
+		assertFn := assert.False
+		if maps.Equal(labelsA.Ssh, labelsB.Ssh) {
+			assertFn = assert.True
+		}
+
+		assertFn(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labelsA), hashB))
+		assertFn(t, joining.VerifyImmutableLabelsHash(proto.CloneOf(labelsB), hashA))
+	})
 }


### PR DESCRIPTION
This PR fixes some possible collisions when hashing immutable labels to be included in host certs. It hashes each map entry and uses the result in generating the final labels hash rather than concatenating the keys and values themselves.

# Manual testing
- [x] Provision a scoped token assigning immutable labels: `tctl scoped tokens add --type=node --scope=/local --assign-scope=/local --ssh-labels=aaa=bbbcccddd`
- [x] Confirm nodes are still able to join and heartbeat with immutable labels
- [x] Restart the node and confirm it retains its immutable labels and heartbeats are successful
- [x] Stop the node and modify the immutable labels in process storage to be:
```json
{
  "immutable_labels": {
    "ssh": {
      "aaa": "bbb",
      "ccc": "ddd"
    }
  }
}
```
- [x] Restart the node and confirm it fails to register its inventory control stream with an auth error complaining about immutable labels not matching the cert's label hash

Shout out to @nklaassen for noticing this was possible :tada:
