### PR TITLE
Enable headless authentication for`tsh db ls` command

### DIFF
--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -71,10 +71,7 @@ func onListDatabases(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	profile, err := tc.ProfileStatus()
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	tc.AllowHeadless = true
 
 	var clusterClient *client.ClusterClient
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
@@ -87,6 +84,11 @@ func onListDatabases(cf *CLIConf) error {
 	defer clusterClient.Close()
 
 	servers, err := apiclient.GetAllResources[types.DatabaseServer](cf.Context, clusterClient.AuthClient, tc.ResourceFilter(types.KindDatabaseServer))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	profile, err := tc.ProfileStatus()
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -63,6 +64,9 @@ import (
 // onListDatabases implements "tsh db ls" command.
 func onListDatabases(cf *CLIConf) error {
 	if cf.ListAll {
+		if cf.Headless || cf.AuthConnector == constants.HeadlessConnector {
+			return trace.BadParameter("--all cannot be specified with --headless/--auth=headless")
+		}
 		return trace.Wrap(listDatabasesAllClusters(cf))
 	}
 

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -2299,4 +2300,102 @@ func TestMongoDBSeparatePortCommandError(t *testing.T) {
 	}, setHomePath(tshHome), setCmdRunner(noopCmdRunner))
 	require.NoError(t, err)
 	require.True(t, cmdExecuted.Load(), "expected the MongoDB command to have executed")
+}
+
+func TestDatabaseListHeadless(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	aliceUsername := "alice@example.com"
+	alice, err := types.NewUser(aliceUsername)
+	require.NoError(t, err)
+	alice.SetDatabaseNames([]string{"postgres"})
+	alice.SetRoles([]string{"access"})
+
+	// Create a Teleport process with a database
+	server, err := testserver.NewTeleportProcess(
+		t.TempDir(),
+		testserver.WithClusterName("test-cluster"),
+		testserver.WithBootstrap(alice),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.Auth.Enabled = true
+			cfg.Proxy.Enabled = true
+			cfg.SSH.Enabled = false
+
+			cfg.Auth.Preference = &types.AuthPreferenceV2{
+				Metadata: types.Metadata{
+					Labels: map[string]string{types.OriginLabel: types.OriginConfigFile},
+				},
+				Spec: types.AuthPreferenceSpecV2{
+					Type:         constants.Local,
+					SecondFactor: constants.SecondFactorOptional,
+					Webauthn: &types.Webauthn{
+						RPID: "127.0.0.1",
+					},
+					AllowHeadless: types.NewBoolOption(true),
+				},
+			}
+		}),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, server.Close())
+		require.NoError(t, server.Wait())
+	})
+
+	// Create database server manually. We do this to avoid creating it via cfg.Databases
+	// in NewTeleportProcess, which waits for the DatabasesReady event. In this test,
+	// DatabasesReady never fires because we aren't actually creating the the database
+	// that we are pointing the database service at.
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-db",
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+	})
+	require.NoError(t, err)
+	dbServer, err := types.NewDatabaseServerV3(types.Metadata{
+		Name: "test-db",
+	}, types.DatabaseServerSpecV3{
+		Version:  teleport.Version,
+		Hostname: "test-hostname",
+		HostID:   uuid.NewString(),
+		Database: database,
+	})
+	require.NoError(t, err)
+	_, err = server.GetAuthServer().UpsertDatabaseServer(ctx, dbServer)
+	require.NoError(t, err)
+
+	go func() {
+		// Ensure the context is canceled, so that Run calls don't block
+		defer cancel()
+		if err := approveAllAccessRequests(ctx, server.GetAuthServer()); err != nil {
+			assert.ErrorIs(t, err, context.Canceled, "unexpected error from approveAllAccessRequests")
+		}
+	}()
+
+	proxyAddr, err := server.ProxyWebAddr()
+	require.NoError(t, err)
+
+	captureStdout := &bytes.Buffer{}
+	err = Run(ctx, []string{
+		"db",
+		"ls",
+		"--proxy", proxyAddr.String(),
+		"--user", aliceUsername,
+		"--insecure",
+		"--headless",
+	},
+		setCopyStdout(captureStdout),
+		setHomePath(t.TempDir()),
+		func(cf *CLIConf) error {
+			cf.MockHeadlessLogin = mockHeadlessLogin(t, server.GetAuthServer(), alice)
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	stdoutStr := captureStdout.String()
+	require.Contains(t, stdoutStr, "test-db", "database should appear in output")
 }

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -2399,3 +2399,42 @@ func TestDatabaseListHeadless(t *testing.T) {
 	stdoutStr := captureStdout.String()
 	require.Contains(t, stdoutStr, "test-db", "database should appear in output")
 }
+
+func TestDatabaseListCLIFlags(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Args        []string
+		ErrTestFunc func(e error) bool
+	}{
+		{
+			Description: "should return bad parameter error when --headless and --all are specified",
+			Args: []string{
+				"db",
+				"ls",
+				"--proxy", "test-proxy",
+				"--user", "test-user",
+				"--headless",
+				"--all",
+			},
+			ErrTestFunc: trace.IsBadParameter,
+		},
+		{
+			Description: "should return bad parameter error when --auth=headless and --all are specified",
+			Args: []string{
+				"db",
+				"ls",
+				"--proxy", "test-proxy",
+				"--user", "test-user",
+				"--auth", "headless",
+				"--all",
+			},
+			ErrTestFunc: trace.IsBadParameter,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			err := Run(t.Context(), testCase.Args)
+			require.True(t, testCase.ErrTestFunc(err))
+		})
+	}
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2768,6 +2768,9 @@ func onLogout(cf *CLIConf) error {
 // onListNodes executes 'tsh ls' command.
 func onListNodes(cf *CLIConf) error {
 	if cf.ListAll {
+		if cf.Headless || cf.AuthConnector == constants.HeadlessConnector {
+			return trace.BadParameter("--all cannot be specified with --headless/--auth=headless")
+		}
 		return trace.Wrap(listNodesAllClusters(cf))
 	}
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8166,3 +8166,40 @@ func TestLogoutOneIdentity(t *testing.T) {
 		})
 	}
 }
+
+func TestListNodesCLIFlags(t *testing.T) {
+	testCases := []struct {
+		Description string
+		Args        []string
+		ErrTestFunc func(e error) bool
+	}{
+		{
+			Description: "should return bad parameter error when --headless and --all are specified",
+			Args: []string{
+				"ls",
+				"--proxy", "test-proxy",
+				"--user", "test-user",
+				"--headless",
+				"--all",
+			},
+			ErrTestFunc: trace.IsBadParameter,
+		},
+		{
+			Description: "should return bad parameter error when --auth=headless and --all are specified",
+			Args: []string{
+				"ls",
+				"--proxy", "test-proxy",
+				"--user", "test-user",
+				"--auth", "headless",
+				"--all",
+			},
+			ErrTestFunc: trace.IsBadParameter,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.Description, func(t *testing.T) {
+			err := Run(t.Context(), testCase.Args)
+			require.True(t, testCase.ErrTestFunc(err))
+		})
+	}
+}


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport/issues/29635.

This enables headless authentication for `tsh db ls`. Headless authentication for other subcommands of `tsh db` will follow.

Also note that this makes `tsh db ls` log the user in, if they are not already logged in.

Changelog: Enabled headless authentication for `tsh db ls` command.

---

Test plan:

- [x] `tsh db ls --headless` logs in using headless auth and produces correct output
- [x] `tsh db ls` produces correct output
- [x] `tsh db ls --all` produces correct output
- [x] `tsh db ls --headless --all` produces an error
- [x] `tsh db ls --auth=headless --all` produces an error
- [x] `tsh ls --headless` logs in using headless auth and produces correct output
- [x] `tsh ls` produces correct output
- [x] `tsh ls --all` produces correct output
- [x] `tsh ls --headless --all` produces an error
- [x] `tsh ls --auth=headless --all` produces an error