### PR TITLE
Docs: fix enroll mode in EC2 Discovery guides

### DIFF
--- a/build.assets/tooling/cmd/resource-ref-generator/resource_examples/discovery_config.yaml
+++ b/build.assets/tooling/cmd/resource-ref-generator/resource_examples/discovery_config.yaml
@@ -68,6 +68,14 @@ spec:
     # Optional section: install is used to provide parameters to the installer script.
     # Only applicable for EC2 discovery.
     install:
+      # enroll_mode is used to identify the method used to enroll the ec2 instance into Teleport.
+      # Only the value 1 is supported, which uses a script to install and enroll the instance into Teleport.
+      # Only applicable for EC2 discovery.
+      enroll_mode: 1
+      # Whether to install teleport on the EC2 instance.
+      # If false, it will enroll the EC2 instance as an agentless node.
+      # When using agentless, change the script_name to "default-agentless-installer" or create a custom script.
+      install_teleport: true
       # The token to use when joining the cluster
       join_token: "iam-join-token"
       # The method to use when joining the cluster

--- a/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
+++ b/docs/pages/enroll-resources/auto-discovery/servers/ec2-discovery/ec2-discovery-organization.mdx
@@ -251,6 +251,8 @@ Static configuration while simpler at first, has less flexibility because enroll
       ssm:
         document_name: "AWS-RunShellScript"
       install:
+        enroll_mode: 1
+        install_teleport: true
         join_method: iam
         join_token: aws-discovery-iam-token
       assume_role:
@@ -298,6 +300,8 @@ Static configuration while simpler at first, has less flexibility because enroll
       ssm:
         document_name: "AWS-RunShellScript"
       install:
+        enroll_mode: script
+        install_teleport: true
         join_method: iam
         join_token: aws-discovery-iam-token
       assume_role_name: <Var name="DiscoverEC2AssumedRole" />

--- a/docs/pages/includes/auto-discovery/ec2-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-config.mdx
@@ -62,6 +62,8 @@ Static configuration while simpler at first, has less flexibility because enroll
       ssm:
         document_name: "AWS-RunShellScript"
       install:
+        enroll_mode: 1
+        install_teleport: true
         join_method: iam
         join_token: aws-discovery-iam-token
   ```
@@ -96,9 +98,11 @@ Static configuration while simpler at first, has less flexibility because enroll
       ssm:
         document_name: "AWS-RunShellScript"
       install:
-          join_params:
-            token_name: aws-discovery-iam-token
-            method: iam
+        enroll_mode: script
+        install_teleport: true
+        join_params:
+          token_name: aws-discovery-iam-token
+          method: iam
   ```
   
   Adjust the keys under `discovery_service.aws` to match your EC2 environment, 

--- a/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
+++ b/docs/pages/includes/auto-discovery/ec2-cross-account-config.mdx
@@ -18,6 +18,8 @@ spec:
     tags:
       "env": "prod" # Match EC2 instances where tag:env=prod
     install:
+      enroll_mode: 1
+      install_teleport: true
       join_method: iam
       join_token: aws-discovery-iam-token
     ssm:
@@ -54,6 +56,8 @@ discovery_service:
     tags:
       "env": "prod" # Match EC2 instances where tag:env=prod
     install:
+      enroll_mode: script
+      install_teleport: true
       join_method: iam
       join_token: aws-discovery-iam-token
     ssm:

--- a/docs/pages/includes/discovery/discovery-config.yaml
+++ b/docs/pages/includes/discovery/discovery-config.yaml
@@ -67,6 +67,14 @@ discovery_service:
       # Optional section: install is used to provide parameters to the installer script.
       # Only applicable for EC2 discovery.
       install:
+        # enroll_mode is used to identify the method used to enroll the ec2 instance into Teleport.
+        # Only the value "script" is supported, which uses a script to install and enroll the instance into Teleport.
+        # Only applicable for EC2 discovery.
+        enroll_mode: script
+        # Whether to install teleport on the EC2 instance.
+        # If false, it will enroll the EC2 instance as an agentless node.
+        # When using agentless, change the script_name to "default-agentless-installer" or create a custom script.
+        install_teleport: true
         join_params:
           # token_name is the name of the Teleport invite token to use.
           # Optional, defaults to: "aws-discovery-iam-token".

--- a/docs/pages/includes/server-access/custom-installer-aws-dynamic.yaml
+++ b/docs/pages/includes/server-access/custom-installer-aws-dynamic.yaml
@@ -7,6 +7,8 @@ spec:
        - "env": "prod"
       regions: ["us-west1", "us-east1"]
       install:
+        enroll_mode: 1
+        install_teleport: true
         script_name: "default-installer"
       ssm:
         document_name: "AWS-RunShellScript"
@@ -15,6 +17,8 @@ spec:
        - "env": "devel"
       regions: ["us-west1", "us-east1"]
       install:
+        enroll_mode: 1
+        install_teleport: true
         script_name: "devel-installer"
       ssm:
         document_name: "AWS-RunShellScript"

--- a/docs/pages/includes/server-access/custom-installer-aws.yaml
+++ b/docs/pages/includes/server-access/custom-installer-aws.yaml
@@ -6,6 +6,8 @@ discovery_service:
        - "env": "prod"
       regions: ["us-west1", "us-east1"]
       install:
+        enroll_mode: script
+        install_teleport: true
         script_name: "default-installer"
       ssm:
         document_name: "AWS-RunShellScript"
@@ -14,6 +16,8 @@ discovery_service:
        - "env": "devel"
       regions: ["us-west1", "us-east1"]
       install:
+        enroll_mode: script
+        install_teleport: true
         script_name: "devel-installer"
       ssm:
         document_name: "AWS-RunShellScript"

--- a/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
+++ b/docs/pages/reference/infrastructure-as-code/teleport-resources/discovery-config.mdx
@@ -85,6 +85,14 @@ spec:
     # Optional section: install is used to provide parameters to the installer script.
     # Only applicable for EC2 discovery.
     install:
+      # enroll_mode is used to identify the method used to enroll the ec2 instance into Teleport.
+      # Only the value 1 is supported, which uses a script to install and enroll the instance into Teleport.
+      # Only applicable for EC2 discovery.
+      enroll_mode: 1
+      # Whether to install teleport on the EC2 instance.
+      # If false, it will enroll the EC2 instance as an agentless node.
+      # When using agentless, change the script_name to "default-agentless-installer" or create a custom script.
+      install_teleport: true
       # The token to use when joining the cluster
       join_token: "iam-join-token"
       # The method to use when joining the cluster


### PR DESCRIPTION
When not set, the enroll mode can be set to EICE if an integration is being used.

EICE is no longer supported (unless an env var is set, which is why we have to keep the code for v19).

This PR changes the docs to always be explicit about which enroll mode is being used.