### PR TITLE
proto/prehog: Sync with source of truth in cloud repo

### DIFF
--- a/gen/proto/go/prehog/v1/teleport.pb.go
+++ b/gen/proto/go/prehog/v1/teleport.pb.go
@@ -111,7 +111,7 @@ func (UserKind) EnumDescriptor() ([]byte, []int) {
 
 // UserOrigin is the origin of a user account.
 // Keep the values in sync with UserOrigin enum defined in
-// API events and prehogv1alpha.
+// Teleport OSS repository.
 type UserOrigin int32
 
 const (
@@ -400,15 +400,18 @@ type UserActivityRecord struct {
 	CertificatesIssued uint64 `protobuf:"varint,17,opt,name=certificates_issued,json=certificatesIssued,proto3" json:"certificates_issued,omitempty"`
 	// counter of SVIDs issued for each SPIFFE ID.
 	SpiffeIdsIssued []*SPIFFEIDRecord `protobuf:"bytes,18,rep,name=spiffe_ids_issued,json=spiffeIdsIssued,proto3" json:"spiffe_ids_issued,omitempty"`
-	// Indicates origin of user account.
+	// Indicates origin of this user account. Only
+	// recorded for the user login event.
 	UserOrigin UserOrigin `protobuf:"varint,19,opt,name=user_origin,json=userOrigin,proto3,enum=prehog.v1.UserOrigin" json:"user_origin,omitempty"`
 	// counter of Access Requests created by this user.
 	AccessRequestsCreated uint64 `protobuf:"varint,20,opt,name=access_requests_created,json=accessRequestsCreated,proto3" json:"access_requests_created,omitempty"`
 	// counter of Access Requests reviewed by this user.
 	AccessRequestsReviewed uint64 `protobuf:"varint,21,opt,name=access_requests_reviewed,json=accessRequestsReviewed,proto3" json:"access_requests_reviewed,omitempty"`
-	// counter of Access List review.
+	// counter of Access Lists reviewed by this user.
 	AccessListsReviewed uint64 `protobuf:"varint,22,opt,name=access_lists_reviewed,json=accessListsReviewed,proto3" json:"access_lists_reviewed,omitempty"`
-	// counter of roles or traits grant event based on Access List membership.
+	// counter of roles or traits granted to this user based on
+	// the Access List membership. The event is emitted during
+	// user login state calculation.
 	AccessListsGrants uint64 `protobuf:"varint,23,opt,name=access_lists_grants,json=accessListsGrants,proto3" json:"access_lists_grants,omitempty"`
 	// counter of successful SAML IdP authentication by this user.
 	SamlIdpSessions uint64 `protobuf:"varint,24,opt,name=saml_idp_sessions,json=samlIdpSessions,proto3" json:"saml_idp_sessions,omitempty"`

--- a/gen/proto/go/prehog/v1alpha/teleport.pb.go
+++ b/gen/proto/go/prehog/v1alpha/teleport.pb.go
@@ -42,7 +42,7 @@ const (
 
 // UserOrigin is the origin of a user account.
 // Keep the values in sync with UserOrigin enum defined in
-// API events and prehogv1.
+// Teleport OSS repository.
 type UserOrigin int32
 
 const (
@@ -515,6 +515,7 @@ const (
 	CTA_CTA_OKTA_USER_SYNC         CTA = 11
 	CTA_CTA_ENTRA_ID               CTA = 12
 	CTA_CTA_OKTA_SCIM              CTA = 13
+	CTA_CTA_USAGE_REPORT           CTA = 14
 )
 
 // Enum value maps for CTA.
@@ -534,6 +535,7 @@ var (
 		11: "CTA_OKTA_USER_SYNC",
 		12: "CTA_ENTRA_ID",
 		13: "CTA_OKTA_SCIM",
+		14: "CTA_USAGE_REPORT",
 	}
 	CTA_value = map[string]int32{
 		"CTA_UNSPECIFIED":            0,
@@ -550,6 +552,7 @@ var (
 		"CTA_OKTA_USER_SYNC":         11,
 		"CTA_ENTRA_ID":               12,
 		"CTA_OKTA_SCIM":              13,
+		"CTA_USAGE_REPORT":           14,
 	}
 )
 
@@ -1502,7 +1505,7 @@ type UserLoginEvent struct {
 	DeviceId string `protobuf:"bytes,3,opt,name=device_id,json=deviceId,proto3" json:"device_id,omitempty"`
 	// the required private key policy for this login.
 	RequiredPrivateKeyPolicy string `protobuf:"bytes,4,opt,name=required_private_key_policy,json=requiredPrivateKeyPolicy,proto3" json:"required_private_key_policy,omitempty"`
-	// UserOrigin specifies the origin of this user account.
+	// UserOrigin specifies the origin of the user specified in user_name.
 	//
 	// PostHog property: tp.user_origin
 	UserOrigin    UserOrigin `protobuf:"varint,5,opt,name=user_origin,json=userOrigin,proto3,enum=prehog.v1alpha.UserOrigin" json:"user_origin,omitempty"`
@@ -8883,7 +8886,7 @@ type SessionSummaryCreateEvent struct {
 	//
 	// PostHog property: tp.resource_name
 	ResourceName string `protobuf:"bytes,6,opt,name=resource_name,json=resourceName,proto3" json:"resource_name,omitempty"`
-	// is_cloud_default_model indicates wether the session summary was generated using
+	// is_cloud_default_model indicates whether the session summary was generated using
 	// the cloud default model.
 	//
 	// PostHog property: tp.ai.default_model
@@ -11564,7 +11567,7 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x17DISCOVER_STATUS_SUCCESS\x10\x01\x12\x1b\n" +
 	"\x17DISCOVER_STATUS_SKIPPED\x10\x02\x12\x19\n" +
 	"\x15DISCOVER_STATUS_ERROR\x10\x03\x12\x1b\n" +
-	"\x17DISCOVER_STATUS_ABORTED\x10\x04*\xd4\x02\n" +
+	"\x17DISCOVER_STATUS_ABORTED\x10\x04*\xea\x02\n" +
 	"\x03CTA\x12\x13\n" +
 	"\x0fCTA_UNSPECIFIED\x10\x00\x12\x16\n" +
 	"\x12CTA_AUTH_CONNECTOR\x10\x01\x12\x17\n" +
@@ -11580,7 +11583,8 @@ const file_prehog_v1alpha_teleport_proto_rawDesc = "" +
 	"\x12\x16\n" +
 	"\x12CTA_OKTA_USER_SYNC\x10\v\x12\x10\n" +
 	"\fCTA_ENTRA_ID\x10\f\x12\x11\n" +
-	"\rCTA_OKTA_SCIM\x10\r*\xb5\n" +
+	"\rCTA_OKTA_SCIM\x10\r\x12\x14\n" +
+	"\x10CTA_USAGE_REPORT\x10\x0e*\xb5\n" +
 	"\n" +
 	"\x15IntegrationEnrollKind\x12'\n" +
 	"#INTEGRATION_ENROLL_KIND_UNSPECIFIED\x10\x00\x12!\n" +

--- a/gen/proto/ts/prehog/v1/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1/teleport_pb.ts
@@ -205,7 +205,8 @@ export interface UserActivityRecord {
      */
     spiffeIdsIssued: SPIFFEIDRecord[];
     /**
-     * Indicates origin of user account.
+     * Indicates origin of this user account. Only
+     * recorded for the user login event.
      *
      * @generated from protobuf field: prehog.v1.UserOrigin user_origin = 19;
      */
@@ -223,13 +224,15 @@ export interface UserActivityRecord {
      */
     accessRequestsReviewed: bigint;
     /**
-     * counter of Access List review.
+     * counter of Access Lists reviewed by this user.
      *
      * @generated from protobuf field: uint64 access_lists_reviewed = 22;
      */
     accessListsReviewed: bigint;
     /**
-     * counter of roles or traits grant event based on Access List membership.
+     * counter of roles or traits granted to this user based on
+     * the Access List membership. The event is emitted during
+     * user login state calculation.
      *
      * @generated from protobuf field: uint64 access_lists_grants = 23;
      */
@@ -613,7 +616,7 @@ export enum UserKind {
 /**
  * UserOrigin is the origin of a user account.
  * Keep the values in sync with UserOrigin enum defined in
- * API events and prehogv1alpha.
+ * Teleport OSS repository.
  *
  * @generated from protobuf enum prehog.v1.UserOrigin
  */

--- a/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
+++ b/gen/proto/ts/prehog/v1alpha/teleport_pb.ts
@@ -76,7 +76,7 @@ export interface UserLoginEvent {
      */
     requiredPrivateKeyPolicy: string;
     /**
-     * UserOrigin specifies the origin of this user account.
+     * UserOrigin specifies the origin of the user specified in user_name.
      *
      * PostHog property: tp.user_origin
      *
@@ -3152,7 +3152,7 @@ export interface SessionSummaryCreateEvent {
      */
     resourceName: string;
     /**
-     * is_cloud_default_model indicates wether the session summary was generated using
+     * is_cloud_default_model indicates whether the session summary was generated using
      * the cloud default model.
      *
      * PostHog property: tp.ai.default_model
@@ -3841,7 +3841,7 @@ export interface HelloTeleportResponse {
 /**
  * UserOrigin is the origin of a user account.
  * Keep the values in sync with UserOrigin enum defined in
- * API events and prehogv1.
+ * Teleport OSS repository.
  *
  * @generated from protobuf enum prehog.v1alpha.UserOrigin
  */
@@ -4279,7 +4279,11 @@ export enum CTA {
     /**
      * @generated from protobuf enum value: CTA_OKTA_SCIM = 13;
      */
-    CTA_OKTA_SCIM = 13
+    CTA_OKTA_SCIM = 13,
+    /**
+     * @generated from protobuf enum value: CTA_USAGE_REPORT = 14;
+     */
+    CTA_USAGE_REPORT = 14
 }
 /**
  * IntegrationEnrollKind represents the types of integration that

--- a/proto/prehog/v1/teleport.proto
+++ b/proto/prehog/v1/teleport.proto
@@ -82,24 +82,6 @@ enum UserKind {
   USER_KIND_SYSTEM = 3;
 }
 
-// UserOrigin is the origin of a user account.
-// Keep the values in sync with UserOrigin enum defined in
-// API events and prehogv1alpha.
-enum UserOrigin {
-  // Indicates a legacy cluster emitting events without a defined user origin.
-  USER_ORIGIN_UNSPECIFIED = 0;
-  // Indicates a local user.
-  USER_ORIGIN_LOCAL = 1;
-  // Indicates an SSO user originated from the SAML or OIDC connector.
-  USER_ORIGIN_SSO = 2;
-  // Indicates a user originated from the Okta integration.
-  USER_ORIGIN_OKTA = 3;
-  // Indicates a user originated from the SCIM integration.
-  USER_ORIGIN_SCIM = 4;
-  // Indicates a user originated from the EntraID integration.
-  USER_ORIGIN_ENTRAID = 5;
-}
-
 // a set of activity counters for a single user; some old versions report
 // "ssh_port_sessions", counting both SSH port forwards and kubectl port-forward
 // connections in a single counter
@@ -147,20 +129,41 @@ message UserActivityRecord {
   uint64 certificates_issued = 17;
   // counter of SVIDs issued for each SPIFFE ID.
   repeated SPIFFEIDRecord spiffe_ids_issued = 18;
-  // Indicates origin of user account.
+  // Indicates origin of this user account. Only
+  // recorded for the user login event.
   UserOrigin user_origin = 19;
   // counter of Access Requests created by this user.
   uint64 access_requests_created = 20;
   // counter of Access Requests reviewed by this user.
   uint64 access_requests_reviewed = 21;
-  // counter of Access List review.
+  // counter of Access Lists reviewed by this user.
   uint64 access_lists_reviewed = 22;
-  // counter of roles or traits grant event based on Access List membership.
+  // counter of roles or traits granted to this user based on
+  // the Access List membership. The event is emitted during
+  // user login state calculation.
   uint64 access_lists_grants = 23;
   // counter of successful SAML IdP authentication by this user.
   uint64 saml_idp_sessions = 24;
   // counter of session summaries accessed by this user per session type and resource name.
   repeated SessionSummariesAccessedRecord session_summaries_accessed = 25;
+}
+
+// UserOrigin is the origin of a user account.
+// Keep the values in sync with UserOrigin enum defined in
+// Teleport OSS repository.
+enum UserOrigin {
+  // Indicates a legacy cluster emitting events without a defined user origin.
+  USER_ORIGIN_UNSPECIFIED = 0;
+  // Indicates a local user.
+  USER_ORIGIN_LOCAL = 1;
+  // Indicates an SSO user originated from the SAML or OIDC connector.
+  USER_ORIGIN_SSO = 2;
+  // Indicates a user originated from the Okta integration.
+  USER_ORIGIN_OKTA = 3;
+  // Indicates a user originated from the SCIM integration.
+  USER_ORIGIN_SCIM = 4;
+  // Indicates a user originated from the EntraID integration.
+  USER_ORIGIN_ENTRAID = 5;
 }
 
 // the kind of a "resource" (e.g. a node, a database, a desktop, etc.)
@@ -355,6 +358,7 @@ message SubmitUsageReportsRequest {
   // encoded as a separate tp.identity_security.summaries_generated PostHog event
   repeated IdentitySecuritySummariesGeneratedReport identity_security_summaries_report = 4;
 }
+
 message SubmitUsageReportsResponse {
   // randomly generated UUID for this specific batch, 16 bytes (in string order)
   //

--- a/proto/prehog/v1alpha/teleport.proto
+++ b/proto/prehog/v1alpha/teleport.proto
@@ -49,7 +49,7 @@ message UserLoginEvent {
   // the required private key policy for this login.
   string required_private_key_policy = 4;
 
-  // UserOrigin specifies the origin of this user account.
+  // UserOrigin specifies the origin of the user specified in user_name.
   //
   // PostHog property: tp.user_origin
   UserOrigin user_origin = 5;
@@ -57,7 +57,7 @@ message UserLoginEvent {
 
 // UserOrigin is the origin of a user account.
 // Keep the values in sync with UserOrigin enum defined in
-// API events and prehogv1.
+// Teleport OSS repository.
 enum UserOrigin {
   // Indicates a legacy cluster emitting events without a defined user origin.
   USER_ORIGIN_UNSPECIFIED = 0;
@@ -882,6 +882,7 @@ enum CTA {
   CTA_OKTA_USER_SYNC = 11;
   CTA_ENTRA_ID = 12;
   CTA_OKTA_SCIM = 13;
+  CTA_USAGE_REPORT = 14;
 }
 
 // a request forwarded to a kube cluster's API server (other than exec and
@@ -1834,7 +1835,7 @@ message SessionSummaryCreateEvent {
   // PostHog property: tp.resource_name
   string resource_name = 6;
 
-  // is_cloud_default_model indicates wether the session summary was generated using
+  // is_cloud_default_model indicates whether the session summary was generated using
   // the cloud default model.
   //
   // PostHog property: tp.ai.default_model


### PR DESCRIPTION

Sync the prehog proto files from the cloud repo as they are the source
of truth. These have diverged a little, largely in non-functional ways.
The CTA enum was missing `CTA_USAGE_REPORT`, now added. The rest is just
comments and some ordering.

This makes it easier to keep in sync in future as the files can just be
copied without needing to manually move changes across.

Regenerate the Go / Typescript code from the prehog proto from the
resync changes. Performed with:

    make grpc/host
