### PR TITLE
VNet: Add more debug logs to FQDN and TCP handler resolvers

### DIFF
--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -176,6 +176,7 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 		return nil, errNoMatch
 	}
 	if len(resp.Resources) == 0 {
+		log.DebugContext(ctx, "Found no matching app servers")
 		// Didn't find any matching app, forward the request upstream.
 		return nil, errNoMatch
 	}

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -162,7 +162,7 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 	if err != nil {
 		return trace.Wrap(err, "resolving target in undecidedHandler")
 	}
-	log := log.With("fqdn", h.cfg.fqdn)
+	log := log.With("fqdn", h.cfg.fqdn, "local_port", localPort)
 	if matchedTCPApp := resp.GetMatchedTcpApp(); matchedTCPApp != nil {
 		// If matched a TCP app, build a tcpAppHandler that will be used for this
 		// and all subsequent connections to this address.
@@ -212,6 +212,7 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		// SSH node that has already been established.
 		return sshHandler.handleTCPConnectorWithTargetConn(ctx, connector, targetConn, agent)
 	}
+	log.DebugContext(ctx, "Rejecting connection because no handler was found for FQDN", "resolve_fqdn_response", resp)
 	return trace.Errorf("rejecting connection to %s:%d", h.cfg.fqdn, localPort)
 }
 


### PR DESCRIPTION
This PR adds two debug log messages. The first one is in the FQDN resolver running in the user process. This message helps identify which cluster was queried for app servers. This can help identify cases where the wrong cluster was queried. It can happen, for example, when there's `root.example.com` and `leaf.example.com` and the root cluster has `example.com` added as custom DNS zone. In this case, when trying to reach `foo.leaf.example.com`, VNet will query the root cluster because the app FQDN will match the custom DNS zone added to the root.

I think this message will be logged for every attempt at an SSH connection, but I think this is fine.

The following is just an example of how the message looks like, not something that gets logged in the situation described above.

> `2026-02-12T12:56:16.542+01:00 DEBU [VNET]      Found no matching app servers profile:cluster.mirrors.link leaf_cluster:leaf.mirrors.link fqdn:foobarbaz.leaf.mirrors.link. vnet/fqdn_resolver.go:179`

The other log message is in the TCP handler resolver in the root process. `handleTCPConnector` contains multiple conditionals with some extra logic. The conditionals match on the response from the FQDN resolver. If no match is found, it's nice to be able to see what the FQDN resolver response was – this can help us debug the behavior of both resolvers.

> `2026-02-12T12:56:16.670+01:00 DEBU [VNET]      Rejecting connection because no handler was found for FQDN fqdn:foobarbaz.leaf.mirrors.link. local_port:443 resolve_fqdn_response:matched_cluster:{ipv4_cidr_range:"100.64.0.0/10" web_proxy_addr:"cluster.mirrors.link:443" profile:"cluster.mirrors.link" root_cluster:"cluster.mirrors.link" leaf_cluster:"leaf.mirrors.link"} vnet/tcp_handler_resolver.go:215`

To see both messages in action, attempt to curl a nonexistent leaf web app while VNet is active.