### PR TITLE
Fix Alt + arrow handling in Xterm.js 6.0

### DIFF
--- a/web/packages/teleport/src/lib/term/terminal.test.ts
+++ b/web/packages/teleport/src/lib/term/terminal.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import TtyTerminal from './terminal';
+import Tty from './tty';
+
+jest.mock('./tty');
+
+describe('Alt+Arrow sends escape sequences for word navigation', () => {
+  it.each([
+    // Escape codes don't render well in the terminal when running tests, hence we use arrays
+    // instead of objects to be able to use %j in test name to automatically escape the 2nd arg.
+    ['ArrowLeft', '\x1bb'],
+    ['ArrowRight', '\x1bf'],
+    ['ArrowUp', '\x1b[1;5A'],
+    ['ArrowDown', '\x1b[1;5B'],
+  ])('Alt+%s sends %j', (key, expectedSeq) => {
+    const { terminal, sendFn } = createTerminal();
+
+    dispatchKeydown(terminal, { key, altKey: true });
+
+    expect(sendFn).toHaveBeenCalledWith(expectedSeq);
+    terminal.destroy();
+  });
+
+  it('does not intercept Ctrl+Alt+Arrow', () => {
+    const { terminal, sendFn } = createTerminal();
+
+    dispatchKeydown(terminal, {
+      key: 'ArrowLeft',
+      altKey: true,
+      ctrlKey: true,
+    });
+
+    // sendFn may be called by xterm's default handling, but not with our Alt+arrow sequences.
+    expect(sendFn).not.toHaveBeenCalledWith('\x1bb');
+    expect(sendFn).not.toHaveBeenCalledWith('\x1b[1;5D');
+    terminal.destroy();
+  });
+});
+
+function createTerminal() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+
+  const tty = new Tty(undefined) as jest.Mocked<Tty>;
+  const sendFn = tty.send;
+
+  const terminal = new TtyTerminal(tty, {
+    el,
+    theme: {},
+  });
+  terminal.open();
+
+  return { terminal, sendFn, el };
+}
+
+function dispatchKeydown(
+  terminal: TtyTerminal,
+  opts: { key: string; altKey?: boolean; ctrlKey?: boolean }
+) {
+  const event = new KeyboardEvent('keydown', {
+    key: opts.key,
+    code: opts.key,
+    altKey: opts.altKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+  });
+  terminal.term.textarea.dispatchEvent(event);
+}

--- a/web/packages/teleport/src/lib/term/terminal.test.ts
+++ b/web/packages/teleport/src/lib/term/terminal.test.ts
@@ -29,8 +29,6 @@ describe('Alt+Arrow sends escape sequences for word navigation', () => {
     // instead of objects to be able to use %j in test name to automatically escape the 2nd arg.
     ['ArrowLeft', '\x1bb'],
     ['ArrowRight', '\x1bf'],
-    ['ArrowUp', '\x1b[1;5A'],
-    ['ArrowDown', '\x1b[1;5B'],
   ])('Alt+%s sends %j', (key, expectedSeq) => {
     const { terminal, sendFn } = createTerminal();
 
@@ -51,7 +49,6 @@ describe('Alt+Arrow sends escape sequences for word navigation', () => {
 
     // sendFn may be called by xterm's default handling, but not with our Alt+arrow sequences.
     expect(sendFn).not.toHaveBeenCalledWith('\x1bb');
-    expect(sendFn).not.toHaveBeenCalledWith('\x1b[1;5D');
     terminal.destroy();
   });
 });

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -141,6 +141,52 @@ export default class TtyTerminal implements TerminalSearcher {
     // subscribe to window resize events
     window.addEventListener('resize', this._debouncedResize);
 
+    // Xterm.js v6 removed the workaround that converted Alt+Arrow to Ctrl+Arrow sequences for word
+    // navigation (https://github.com/xtermjs/xterm.js/pull/5346). Re-add this behavior by sending
+    // the appropriate escape sequences, matching what VS Code does.
+    // https://github.com/microsoft/vscode/blob/5bb327de4bf14578c8c0bd1b553ee14dd2977e18/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts#L163-L182
+    //
+    // Alt+Left/Right always send ESC b / ESC f (readline word navigation), since the PTY is on a
+    // remote host and these sequences are universally understood by all shells.
+    this.registerCustomKeyEventHandler(e => {
+      // Only handle pure Alt+Arrow. Other modifier combinations (e.g. Ctrl+Alt+Arrow,
+      // Shift+Alt+Arrow) have their own distinct escape sequences that Xterm.js already handles.
+      if (
+        e.type !== 'keydown' ||
+        !e.altKey ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.shiftKey
+      ) {
+        return true;
+      }
+
+      let seq: string | undefined;
+      switch (e.key) {
+        case 'ArrowUp':
+          seq = '\x1b[1;5A';
+          break;
+        case 'ArrowDown':
+          seq = '\x1b[1;5B';
+          break;
+        case 'ArrowRight':
+          seq = '\x1bf';
+          break;
+        case 'ArrowLeft':
+          seq = '\x1bb';
+          break;
+      }
+
+      if (seq) {
+        this.term.input(seq, false /* wasUserInput */);
+        e.preventDefault();
+        // Event handled, do not process it in xterm.
+        return false;
+      }
+
+      return true;
+    });
+
     this.term.attachCustomKeyEventHandler(e => {
       for (const eventHandler of this.customKeyEventHandlers) {
         if (!eventHandler(e)) {

--- a/web/packages/teleport/src/lib/term/terminal.ts
+++ b/web/packages/teleport/src/lib/term/terminal.ts
@@ -146,8 +146,8 @@ export default class TtyTerminal implements TerminalSearcher {
     // the appropriate escape sequences, matching what VS Code does.
     // https://github.com/microsoft/vscode/blob/5bb327de4bf14578c8c0bd1b553ee14dd2977e18/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts#L163-L182
     //
-    // Alt+Left/Right always send ESC b / ESC f (readline word navigation), since the PTY is on a
-    // remote host and these sequences are universally understood by all shells.
+    // Terminal.app and iTerm2 have bindings only for Alt+Left/Right, so we follow their steps and
+    // send ESC b / ESC f (readline word navigation).
     this.registerCustomKeyEventHandler(e => {
       // Only handle pure Alt+Arrow. Other modifier combinations (e.g. Ctrl+Alt+Arrow,
       // Shift+Alt+Arrow) have their own distinct escape sequences that Xterm.js already handles.
@@ -163,12 +163,6 @@ export default class TtyTerminal implements TerminalSearcher {
 
       let seq: string | undefined;
       switch (e.key) {
-        case 'ArrowUp':
-          seq = '\x1b[1;5A';
-          break;
-        case 'ArrowDown':
-          seq = '\x1b[1;5B';
-          break;
         case 'ArrowRight':
           seq = '\x1bf';
           break;

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import 'jest-canvas-mock';
+
+import Logger, { NullService } from 'teleterm/logger';
+import { createMockConfigService } from 'teleterm/services/config/fixtures/mocks';
+import { MockPtyProcess } from 'teleterm/services/pty/fixtures/mocks';
+import { KeyboardShortcutsService } from 'teleterm/ui/services/keyboardShortcuts';
+
+import TtyTerminal from './ctrl';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+describe('Alt+Arrow sends escape sequences for word navigation', () => {
+  it.each([
+    // Escape codes don't render well in the terminal when running tests, hence we use arrays
+    // instead of objects to be able to use %j in test name to automatically escape the 2nd arg.
+    ['ArrowLeft', '\x1bb'],
+    ['ArrowRight', '\x1bf'],
+    ['ArrowUp', '\x1b[1;5A'],
+    ['ArrowDown', '\x1b[1;5B'],
+  ])('Alt+%s sends %j', (key, expectedSeq) => {
+    const { tty, writeFn } = createTerminal();
+
+    dispatchKeydown(tty, { key, altKey: true });
+
+    expect(writeFn).toHaveBeenCalledWith(expectedSeq);
+    tty.destroy();
+  });
+
+  it('does not intercept Ctrl+Alt+Arrow', () => {
+    const { tty, writeFn } = createTerminal();
+
+    dispatchKeydown(tty, { key: 'ArrowLeft', altKey: true, ctrlKey: true });
+
+    // writeFn may be called by xterm's default handling, but not with our Alt+arrow sequences.
+    expect(writeFn).not.toHaveBeenCalledWith('\x1bb');
+    expect(writeFn).not.toHaveBeenCalledWith('\x1b[1;5D');
+    tty.destroy();
+  });
+});
+
+function createTerminal() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+
+  const ptyProcess = new MockPtyProcess();
+  const writeFn = jest.spyOn(ptyProcess, 'write');
+  const configService = createMockConfigService({});
+  const keyboardShortcutsService: Partial<KeyboardShortcutsService> = {
+    getShortcutAction: jest.fn().mockReturnValue(undefined),
+  };
+
+  const tty = new TtyTerminal(
+    ptyProcess,
+    {
+      el,
+      fontSize: 12,
+      theme: {},
+      windowsPty: undefined,
+      openContextMenu: jest.fn(),
+    },
+    configService,
+    keyboardShortcutsService as KeyboardShortcutsService
+  );
+  tty.open();
+
+  return { tty, writeFn, el };
+}
+
+function dispatchKeydown(
+  tty: TtyTerminal,
+  opts: { key: string; altKey?: boolean; ctrlKey?: boolean }
+) {
+  const event = new KeyboardEvent('keydown', {
+    key: opts.key,
+    code: opts.key,
+    altKey: opts.altKey ?? false,
+    ctrlKey: opts.ctrlKey ?? false,
+  });
+  tty.term.textarea.dispatchEvent(event);
+}

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
@@ -35,8 +35,6 @@ describe('Alt+Arrow sends escape sequences for word navigation', () => {
     // instead of objects to be able to use %j in test name to automatically escape the 2nd arg.
     ['ArrowLeft', '\x1bb'],
     ['ArrowRight', '\x1bf'],
-    ['ArrowUp', '\x1b[1;5A'],
-    ['ArrowDown', '\x1b[1;5B'],
   ])('Alt+%s sends %j', (key, expectedSeq) => {
     const { tty, writeFn } = createTerminal();
 
@@ -53,7 +51,6 @@ describe('Alt+Arrow sends escape sequences for word navigation', () => {
 
     // writeFn may be called by xterm's default handling, but not with our Alt+arrow sequences.
     expect(writeFn).not.toHaveBeenCalledWith('\x1bb');
-    expect(writeFn).not.toHaveBeenCalledWith('\x1b[1;5D');
     tty.destroy();
   });
 });

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.test.ts
@@ -62,9 +62,10 @@ function createTerminal() {
   const ptyProcess = new MockPtyProcess();
   const writeFn = jest.spyOn(ptyProcess, 'write');
   const configService = createMockConfigService({});
-  const keyboardShortcutsService: Partial<KeyboardShortcutsService> = {
-    getShortcutAction: jest.fn().mockReturnValue(undefined),
-  };
+  const keyboardShortcutsService = new KeyboardShortcutsService(
+    'darwin',
+    configService
+  );
 
   const tty = new TtyTerminal(
     ptyProcess,
@@ -76,7 +77,7 @@ function createTerminal() {
       openContextMenu: jest.fn(),
     },
     configService,
-    keyboardShortcutsService as KeyboardShortcutsService
+    keyboardShortcutsService
   );
   tty.open();
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
@@ -142,6 +142,52 @@ export default class TtyTerminal implements TerminalSearcher {
       return true;
     });
 
+    // Xterm.js v6 removed the workaround that converted Alt+Arrow to Ctrl+Arrow sequences for word
+    // navigation (https://github.com/xtermjs/xterm.js/pull/5346). Re-add this behavior by sending
+    // the appropriate escape sequences, matching what VS Code does.
+    // https://github.com/microsoft/vscode/blob/5bb327de4bf14578c8c0bd1b553ee14dd2977e18/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts#L163-L182
+    //
+    // Alt+Left/Right always send ESC b / ESC f (readline word navigation), since these sequences
+    // are universally understood by all shells, regardless of the remote host's platform.
+    this.registerCustomKeyEventHandler(e => {
+      // Only handle pure Alt+Arrow. Other modifier combinations (e.g. Ctrl+Alt+Arrow,
+      // Shift+Alt+Arrow) have their own distinct escape sequences that Xterm.js already handles.
+      if (
+        e.type !== 'keydown' ||
+        !e.altKey ||
+        e.ctrlKey ||
+        e.metaKey ||
+        e.shiftKey
+      ) {
+        return true;
+      }
+
+      let seq: string | undefined;
+      switch (e.key) {
+        case 'ArrowUp':
+          seq = '\x1b[1;5A';
+          break;
+        case 'ArrowDown':
+          seq = '\x1b[1;5B';
+          break;
+        case 'ArrowRight':
+          seq = '\x1bf';
+          break;
+        case 'ArrowLeft':
+          seq = '\x1bb';
+          break;
+      }
+
+      if (seq) {
+        this.term.input(seq, false /* wasUserInput */);
+        e.preventDefault();
+        // Event handled, do not process it in xterm.
+        return false;
+      }
+
+      return true;
+    });
+
     this.term.attachCustomKeyEventHandler(e => {
       for (const eventHandler of this.customKeyEventHandlers) {
         if (!eventHandler(e)) {

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
@@ -147,8 +147,8 @@ export default class TtyTerminal implements TerminalSearcher {
     // the appropriate escape sequences, matching what VS Code does.
     // https://github.com/microsoft/vscode/blob/5bb327de4bf14578c8c0bd1b553ee14dd2977e18/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts#L163-L182
     //
-    // Alt+Left/Right always send ESC b / ESC f (readline word navigation), since these sequences
-    // are universally understood by all shells, regardless of the remote host's platform.
+    // Terminal.app and iTerm2 have bindings only for Alt+Left/Right, so we follow their steps and
+    // send ESC b / ESC f (readline word navigation).
     this.registerCustomKeyEventHandler(e => {
       // Only handle pure Alt+Arrow. Other modifier combinations (e.g. Ctrl+Alt+Arrow,
       // Shift+Alt+Arrow) have their own distinct escape sequences that Xterm.js already handles.
@@ -164,12 +164,6 @@ export default class TtyTerminal implements TerminalSearcher {
 
       let seq: string | undefined;
       switch (e.key) {
-        case 'ArrowUp':
-          seq = '\x1b[1;5A';
-          break;
-        case 'ArrowDown':
-          seq = '\x1b[1;5B';
-          break;
         case 'ArrowRight':
           seq = '\x1bf';
           break;


### PR DESCRIPTION
We bumped Xterm.js to 6.0 in #62565. That version included a breaking change where its built-in handling of Alt + arrow was removed and instead it asked Xterm.js users to implement this outside of Xterm.js by sending an escape sequence to the terminal.

The way it worked in Xterm.js 5.5 was that Alt + arrow was essentially mapped to Ctrl + arrow (https://github.com/xtermjs/xterm.js/pull/5346). [VSCode now does that too](https://github.com/microsoft/vscode/blob/5bb327de4bf14578c8c0bd1b553ee14dd2977e18/src/vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution.ts#L163-L182). Just like Xterm.js 5.5 before, VSCode sends a different code for Alt+Left/Right depending on whether the platform is macOS or not. From what I managed to find, this was meant to reflect what Terminal.app sends and what Terminal on Ubuntu sends. Terminal.app uses readline commands (see `forward-word` in [readline(3)](https://man7.org/linux/man-pages/man3/readline.3.html)) whereas Linux terminals use [Xterm CSI sequences](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-PC-Style-Function-Keys) for left/right.

However, platform-specific sequences don't seem to make much sense in the context of Web UI and Connect. In Connect, we use local shells where platform-specific sequences could make sense. However, Connect supports SSH-ing to remote hosts too. In that case, we don't know the platform of the remote host. The Web UI only connects to TTY sessions running on remote hosts. With this, I've decided to remove the platform check.

The readline sequences appear to be more widely supported, e.g. I can see CSI sequences leak to terminal when using sh on macOS and inputting Alt + up/down but left/right works fine. That's why ultimately I chose them over CSI sequences for left/right. 

I tested the new implementation on a variety of platforms.

| Client | Platform | TTY | Left | Right | Up | Down |
| --- | --- |       ---            | --- |  ---  | --- | --- |
| Connect | Windows | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |
| Connect | Windows | cmd.exe | ✅ | ✅ | Nothing | Nothing |
| Connect | Windows | pwsh.exe | ✅ | ✅ | Nothing | Nothing |
| Connect | Windows | bash.exe | ✅ | ✅ | History up | History down |
| Connect | Windows | wsl.exe | ✅ | ✅ | Nothing | Nothing |
| Connect | macOS | zsh | ✅ | ✅ | Nothing | Nothing |
| Connect | macOS | bash | ✅ | ✅ | Nothing | Nothing |
| Connect | macOS | Remote macOS host (zsh) | ✅ | ✅ | Nothing | Nothing |
| Connect | macOS | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |
| Connect | Ubuntu | zsh | ✅ | ✅ | Inputs `;5A` | Inputs `;5B` |
| Connect | Ubuntu | bash | ✅ | ✅ | Nothing | Nothing |
| Connect | Ubuntu | Remote macOS host (zsh) | ✅ | ✅ | Nothing | Nothing |
| Connect | Ubuntu | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |
| Web UI | Windows | Remote macOS host (zsh) | ✅ | ✅ | Nothing | Nothing |
| Web UI | Windows | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |
| Web UI | macOS | Remote macOS host (zsh) | ✅ | ✅ | Nothing | Nothing |
| Web UI | macOS | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |
| Web UI | Ubuntu | Remote macOS host (zsh) | ✅ | ✅ | Nothing | Nothing |
| Web UI | Ubuntu | Remote Linux host (bash) | ✅ | ✅ | Nothing | Nothing |

I cannot quite explain why zsh on Ubuntu misbehaves. FWIW, I wasn't able to get this to work even in regular Ubuntu Terminal, so maybe something's wrong with how I installed or ran zsh.

Edit: Ultimately we decided to provide bindings only for Alt + Left/Right arrow as emulators like iTerm2 or Terminal.app also only provide bindings for those keys but not Up/Down arrow.

---

No backport because Xterm.js 6.0 has not been backported to release branches.