### PR TITLE
[v18] Clarify multi-region blueprint recommendations

### DIFF
--- a/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
+++ b/docs/pages/zero-trust-access/deploy-a-cluster/deployments/multi-region-blueprint.mdx
@@ -11,11 +11,11 @@ enterprise: Support for multi-region deployments
 This page describes how to deploy a Teleport cluster in multiple regions to
 improve resiliency and sustain regional failure.
 
-<Admonition type="danger">
-This deployment drastically increases complexity and costs to provide
-multi-region resilience. Do not use this blueprint unless multi-region
-resilience is a requirement. We recommend the [High Availability
-Cluster](high-availability.mdx) for most deployments.
+<Admonition type="warning">
+Multi-region resilience drastically increases complexity and costs. Do not use
+this blueprint unless multi-region resilience is a requirement. We recommend
+following the [Deploying a High Availability Teleport
+Cluster](high-availability.mdx) guide for most deployments.
 
 Please follow this blueprint precisely with no modifications. If you modify any
 parts of this blueprint, we would not be able to support your deployment.
@@ -58,9 +58,10 @@ deployments. Teleport stores its state in a multi-region backend and uses
 [Proxy Peering](../reliability/proxy-peering.mdx) to connect users to resources
 hosted in a different region.
 
-The recommended multi-region backend
-is [the CockroachDB backend](../../../reference/deployment/backends.mdx)
-available in self-hosted Teleport Enterprise.
+The only option for a multi-region backend is [the CockroachDB
+backend](../../../reference/deployment/backends.mdx#cockroachdb) available in
+self-hosted Teleport Enterprise. We do not recommend or support any other
+backend for multi-region deployments.
 
 ![Architecture diagram](../../../../img/deploy-a-cluster/multi-region-blueprint.svg)
 


### PR DESCRIPTION
Backports #63656

Closes #62750

Adjust two recommendations in the multi-region blueprint guide per internal communication:

- Clarify that multi-region resilience in general is more expensive and complex than single-region deployments to avoid implying that individual technical choices spelled out in the blueprint are what lead to the increased cost.
- Strengthen the CockroachDB stipulation from recommended to required.