### PR TITLE
Log in the operator test if something caused a conflict

### DIFF
--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -36,7 +36,7 @@ import (
 	resources "github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
 
-const ConflictErrorMessage = ` An unexpected conflict happened. The resource changed since the last time it was edited.
+const ConflictErrorMessage = `An unexpected conflict happened. The resource changed since the last time it was edited.
 Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.`
 
 type ResourceTestingPrimitives[T reconcilers.Resource, K reconcilers.KubernetesCR[T]] interface {
@@ -123,7 +123,7 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 		require.NoError(t, err)
 
 		// Kubernetes and Teleport resources are in-sync
-		equal, diff := test.CompareTeleportAndKubernetesResource(tResource, kubeResource)
+		equal, diff := test.CompareTeleportAndKubernetesResource(reconciledResource, kubeResource)
 		require.True(t, equal, "Kubernetes and Teleport resources not sync-ed yet: %s", diff)
 	})
 

--- a/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
+++ b/integrations/operator/controllers/resources/testlib/teleport_reconciler_tests.go
@@ -22,17 +22,22 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integrations/operator/controllers/reconcilers"
-	"github.com/gravitational/teleport/integrations/operator/controllers/resources"
+	resources "github.com/gravitational/teleport/integrations/operator/controllers/resources"
 )
+
+const ConflictErrorMessage = ` An unexpected conflict happened. The resource changed since the last time it was edited.
+Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.`
 
 type ResourceTestingPrimitives[T reconcilers.Resource, K reconcilers.KubernetesCR[T]] interface {
 	// Adapter allows to recover the name revision and labels of a resource
@@ -71,9 +76,10 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 	err = test.CreateTeleportResource(ctx, resourceName)
 	require.NoError(t, err)
 
+	var tResource T
 	// Test setup: Wait for the resource to be served by Teleport, fail early if Teleport is broken.
 	FastEventuallyWithT(t, func(t *assert.CollectT) {
-		_, err := test.GetTeleportResource(ctx, resourceName)
+		tResource, err = test.GetTeleportResource(ctx, resourceName)
 		require.NoError(t, err, "Teleport resource still not served by Teleport, Teleport might be stale/with a broken cache.")
 	})
 
@@ -94,12 +100,23 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 			Name:      resourceName,
 		},
 	}
+	// First reconcile adds the finalizer
 	_, err = reconciler.Reconcile(ctx, req)
 	require.NoError(t, err)
+	// Second reconcile actually does the Teleport call.
+	_, err = reconciler.Reconcile(ctx, req)
+	if trace.IsCompareFailed(err) {
+		unexpectedResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
+		require.Failf(t, ConflictErrorMessage, cmp.Diff(tResource, unexpectedResource, protocmp.Transform()))
+	}
+	require.NoError(t, err)
+
+	var reconciledResource T
 
 	// Test setup: Check if both Teleport and Kube resources are in-sync.
 	FastEventuallyWithT(t, func(t *assert.CollectT) {
-		tResource, err := test.GetTeleportResource(ctx, resourceName)
+		reconciledResource, err = test.GetTeleportResource(ctx, resourceName)
 		require.NoError(t, err)
 
 		kubeResource, err := test.GetKubernetesResource(ctx, resourceName)
@@ -115,6 +132,11 @@ func ResourceUpdateTestSynchronous[T reconcilers.Resource, K reconcilers.Kuberne
 
 	// Test execution: Trigger reconciliation
 	_, err = reconciler.Reconcile(ctx, req)
+	if trace.IsCompareFailed(err) {
+		unexpectedResource, err := test.GetTeleportResource(ctx, resourceName)
+		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
+		require.Failf(t, ConflictErrorMessage, cmp.Diff(reconciledResource, unexpectedResource, protocmp.Transform()))
+	}
 	require.NoError(t, err)
 
 	var testPassed bool

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -339,6 +339,10 @@ func TestUserUpdate(t *testing.T) {
 	// Wait for the user to enter the cache
 	testlib.FastEventually(t, func() bool {
 		tUser, err = setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		// Fail if we see an unknown error
+		if err != nil {
+			require.True(t, trace.IsNotFound(err))
+		}
 		return !trace.IsNotFound(err)
 	})
 	require.NoError(t, err)
@@ -374,10 +378,7 @@ func TestUserUpdate(t *testing.T) {
 	if trace.IsCompareFailed(err) {
 		unexpectedUser, err := setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
 		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
-		require.Failf(t, `
-An unexpected conflict happened. The resource changed since the last time it was edited.
-Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.`,
-			cmp.Diff(tUser, unexpectedUser))
+		require.Failf(t, testlib.ConflictErrorMessage, cmp.Diff(tUser, unexpectedUser))
 	}
 	require.NoError(t, err)
 
@@ -418,7 +419,4 @@ Either the test is not waiting properly for changes to propagate in cache, or th
 func k8sCreateUser(ctx context.Context, t *testing.T, kc kclient.Client, user *v2.TeleportUser) {
 	err := kc.Create(ctx, user)
 	require.NoError(t, err)
-}
-
-func unexpectedChange(t *testing.T, before, after any) {
 }

--- a/integrations/operator/controllers/resources/user_controller_test.go
+++ b/integrations/operator/controllers/resources/user_controller_test.go
@@ -342,7 +342,6 @@ func TestUserUpdate(t *testing.T) {
 		return !trace.IsNotFound(err)
 	})
 	require.NoError(t, err)
-	oldRevision := tUser.GetRevision()
 
 	// The user is created in K8S
 	k8sUser := v2.TeleportUser{
@@ -372,14 +371,24 @@ func TestUserUpdate(t *testing.T) {
 	// In a real cluster we should receive the event of our own finalizer change
 	// and this wakes us for a second round.
 	_, err = reconciler.Reconcile(ctx, req)
+	if trace.IsCompareFailed(err) {
+		unexpectedUser, err := setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
+		require.Failf(t, `
+An unexpected conflict happened. The resource changed since the last time it was edited.
+Either the test is not waiting properly for changes to propagate in cache, or there is another resource editor messing with the test.`,
+			cmp.Diff(tUser, unexpectedUser))
+	}
 	require.NoError(t, err)
+
+	var reconciledUser types.User
 
 	// Wait for the new user to enter the cache, else the next reconciliation will cause conflicts.
 	testlib.FastEventually(t, func() bool {
-		newUser, err := setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		reconciledUser, err = setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
 		assert.NoError(t, err)
 		// only proceed when the revision changes
-		return newUser.GetRevision() != oldRevision
+		return reconciledUser.GetRevision() != tUser.GetRevision()
 	})
 	require.NoError(t, err)
 
@@ -397,6 +406,11 @@ func TestUserUpdate(t *testing.T) {
 	require.NoError(t, setup.K8sClient.Update(ctx, &k8sUserNewVersion))
 
 	_, err = reconciler.Reconcile(ctx, req)
+	if trace.IsCompareFailed(err) {
+		unexpectedUser, err := setup.TeleportClient.GetUser(ctx, tUser.GetName(), false)
+		require.NoError(t, err, "Retrieving the user after an unexpected conflict")
+		require.Failf(t, testlib.ConflictErrorMessage, cmp.Diff(reconciledUser, unexpectedUser))
+	}
 	require.NoError(t, err)
 	require.Equal(t, setup.OperatorName, tUser.GetCreatedBy().User.Name, "createdBy has not been erased")
 }
@@ -404,4 +418,7 @@ func TestUserUpdate(t *testing.T) {
 func k8sCreateUser(ctx context.Context, t *testing.T, kc kclient.Client, user *v2.TeleportUser) {
 	err := kc.Create(ctx, user)
 	require.NoError(t, err)
+}
+
+func unexpectedChange(t *testing.T, before, after any) {
 }


### PR DESCRIPTION
Some resources seem edited by Teleport or something else in the background. This breaks the operator tests and should not happen. This commit adds more logging if this is detected.

Part of: https://github.com/gravitational/teleport/issues/63759