### PR TITLE
Parse CA cluster name from custom OID

### DIFF
--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -635,6 +635,17 @@ var (
 	// ImmutableLabelHashASN1ExtensionOID is an extension OID that contains the
 	// immuable label hash used to verify immutable labels.
 	ImmutableLabelHashASN1ExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 2, 27}
+
+	// CAClusterNameExtensionOID records the cluster name in a Teleport CA
+	// certificate.
+	//
+	// Historically the cluster name is recorded in the certificate's "O=" field.
+	// This OID makes it possible to customize O= and still record the cluster
+	// name.
+	//
+	// Takes precedence, as the cluster name, over the O= field if both are
+	// present.
+	CAClusterNameExtensionOID = asn1.ObjectIdentifier{1, 3, 9999, 4, 1}
 )
 
 // Device Trust OIDs.

--- a/lib/tlsca/parsegen_test.go
+++ b/lib/tlsca/parsegen_test.go
@@ -1,0 +1,107 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tlsca_test
+
+import (
+	"crypto/x509/pkix"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestClusterName(t *testing.T) {
+	t.Parallel()
+
+	const exampleCluster = "zarquon"
+
+	tests := []struct {
+		name     string
+		pkixName pkix.Name
+		wantErr  string // takes precedence over want
+		want     string
+	}{
+		{
+			name: "cluster name in O",
+			pkixName: pkix.Name{
+				Organization: []string{exampleCluster},
+			},
+			want: exampleCluster,
+		},
+		{
+			name: "cluster name in OID",
+			pkixName: pkix.Name{
+				// Use Names, instead of ExtraNames, to mimic a parsed certificate.
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: tlsca.CAClusterNameExtensionOID, Value: exampleCluster},
+				},
+			},
+			want: exampleCluster,
+		},
+		{
+			name: "OID favored over O",
+			pkixName: pkix.Name{
+				Organization: []string{"badcluster"},
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: tlsca.CAClusterNameExtensionOID, Value: "goodcluster"},
+				},
+			},
+			want: "goodcluster",
+		},
+		{
+			name:     "no cluster name",
+			pkixName: pkix.Name{},
+			wantErr:  "missing cluster name",
+		},
+		{
+			name: "empty O cluster name",
+			pkixName: pkix.Name{
+				Organization: []string{""},
+			},
+			wantErr: "empty organization",
+		},
+		{
+			name: "empty OID",
+			pkixName: pkix.Name{
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: tlsca.CAClusterNameExtensionOID, Value: ""},
+				},
+			},
+			wantErr: "empty value",
+		},
+		{
+			name: "invalid OID value type",
+			pkixName: pkix.Name{
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: tlsca.CAClusterNameExtensionOID, Value: 0},
+				},
+			},
+			wantErr: "unexpected type",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := tlsca.ClusterName(test.pkixName)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "ClusterName() error mismatch")
+				return
+			}
+			assert.Equal(t, test.want, got, "Cluster name mismatch")
+		})
+	}
+}

--- a/lib/tlsca/parsegen_test.go
+++ b/lib/tlsca/parsegen_test.go
@@ -20,7 +20,7 @@ import (
 	"crypto/x509/pkix"
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/gravitational/teleport/lib/tlsca"
 )


### PR DESCRIPTION
Modify tls.ClusterName() to allow parsing the cluster name from a custom OID, as per [RFD 0237][1].

This is a fully backwards-compatible change.

[1]: https://github.com/gravitational/teleport/blob/master/rfd/0237-sub-ca-support.md#subject-customization

https://github.com/gravitational/teleport.e/issues/7675