### PR TITLE
[v18] Correct `force_reauth` to `force_authn` in SSO MFA docs

### DIFF
--- a/examples/resources/saml-connector-mfa.yaml
+++ b/examples/resources/saml-connector-mfa.yaml
@@ -22,8 +22,8 @@ spec:
     # entity_descriptor_url should point to an IdP configured app that handles MFA checks.
     # In most cases, this value should be different from the entity_descriptor_url above.
     entity_descriptor_url: https://example.okta.com/app/<MFA-APP-ID>/sso/saml/metadata
-    # force_reauth determines whether existing login sessions are accepted or if
+    # force_authn determines whether existing login sessions are accepted or if
     # re-authentication is always required. Defaults to "yes". This should only be
     # set to false if the app described above is setup to perform MFA checks on top
     # of active user sessions.
-    force_reauth: yes
+    force_authn: yes


### PR DESCRIPTION
Backport #63765 to branch/v18