### PR TITLE
Update `go-cassandra-native-protocol` library to reduce test flakiness.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -647,7 +647,7 @@ require (
 replace (
 	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
-	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2
+	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/gravitational/teleport/api => ./api

--- a/go.sum
+++ b/go.sum
@@ -1521,8 +1521,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2 h1:ygCC2LH+2TVWChc5x1AnjZsou48Kfq4NXYsfgdpnABs=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3 h1:GfAthsZxqifsBGdlYlHYnKYOXgFChWWoBRmdCWXfT98=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3/go.mod h1:wr7KfiF4QCea/0RHP+Zu1T6neCNNpw+rsXbzUbMuHfw=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbHOkWE7gRF/lMqvhcXKh2ek=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-mssqldb v1.8.1-teleport.2 h1:vzt5i39yPLCQ8FL19wUXq4+BcJR53NPimAIAOAIl4I0=

--- a/integrations/event-handler/go.mod
+++ b/integrations/event-handler/go.mod
@@ -409,7 +409,7 @@ replace (
 replace (
 	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
-	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2
+	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1

--- a/integrations/terraform-mwi/go.mod
+++ b/integrations/terraform-mwi/go.mod
@@ -545,7 +545,7 @@ replace (
 replace (
 	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
-	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2
+	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1

--- a/integrations/terraform-mwi/go.sum
+++ b/integrations/terraform-mwi/go.sum
@@ -737,8 +737,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2 h1:ygCC2LH+2TVWChc5x1AnjZsou48Kfq4NXYsfgdpnABs=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3 h1:GfAthsZxqifsBGdlYlHYnKYOXgFChWWoBRmdCWXfT98=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3/go.mod h1:wr7KfiF4QCea/0RHP+Zu1T6neCNNpw+rsXbzUbMuHfw=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbHOkWE7gRF/lMqvhcXKh2ek=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-mssqldb v1.8.1-teleport.2 h1:vzt5i39yPLCQ8FL19wUXq4+BcJR53NPimAIAOAIl4I0=

--- a/integrations/terraform/go.mod
+++ b/integrations/terraform/go.mod
@@ -543,7 +543,7 @@ replace (
 replace (
 	github.com/alecthomas/kingpin/v2 => github.com/gravitational/kingpin/v2 v2.1.11-0.20230515143221-4ec6b70ecd33
 	github.com/crewjam/saml => github.com/gravitational/saml v0.4.15-teleport.2
-	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2
+	github.com/datastax/go-cassandra-native-protocol => github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3
 	github.com/go-mysql-org/go-mysql => github.com/gravitational/go-mysql v1.9.1-teleport.4
 	github.com/gogo/protobuf => github.com/gravitational/protobuf v1.3.2-teleport.2
 	github.com/hinshun/vt10x => github.com/gravitational/vt10x v0.0.3-teleport.1

--- a/integrations/terraform/go.sum
+++ b/integrations/terraform/go.sum
@@ -834,8 +834,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2 h1:ygCC2LH+2TVWChc5x1AnjZsou48Kfq4NXYsfgdpnABs=
-github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.2/go.mod h1:6FzirJfdffakAVqmHjwVfFkpru/gNbIazUOK5rIhndc=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3 h1:GfAthsZxqifsBGdlYlHYnKYOXgFChWWoBRmdCWXfT98=
+github.com/gravitational/go-cassandra-native-protocol v0.0.0-teleport.3/go.mod h1:wr7KfiF4QCea/0RHP+Zu1T6neCNNpw+rsXbzUbMuHfw=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1 h1:nPfxiTH2Sr3J6zan280fbHOkWE7gRF/lMqvhcXKh2ek=
 github.com/gravitational/go-libfido2 v1.5.3-teleport.1/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/gravitational/go-mssqldb v1.8.1-teleport.2 h1:vzt5i39yPLCQ8FL19wUXq4+BcJR53NPimAIAOAIl4I0=


### PR DESCRIPTION
Related to #58857. Updates the `go-cassandra-native-protocol` library to include [a data race fix](https://github.com/gravitational/go-cassandra-native-protocol/pull/6). The data race was triggered while running unit and integration tests.

<hr>

### Manual testing

Not applicable, this change only affects integration/unit tests. The updated code is only used in tests.