### PR TITLE
[Connect] Provide empty resourceAccessId arr for Access Req dryrun

### DIFF
--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.test.tsx
@@ -268,6 +268,7 @@ test('after creating an access request, pending requests and specifiable fields 
     ],
     roles: ['apple', 'banana'],
     suggestedReviewers: ['bob'],
+    resourceAccessIds: [],
   });
   expect(result.current.requestedCount).toBe(2);
 
@@ -305,6 +306,7 @@ test('after creating an access request, pending requests and specifiable fields 
     // These fields gotten cleared after the first create.
     roles: [],
     suggestedReviewers: [],
+    resourceAccessIds: [],
   });
 });
 

--- a/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
+++ b/web/packages/teleterm/src/ui/AccessRequestCheckout/useAccessRequestCheckout.ts
@@ -297,7 +297,7 @@ export default function useAccessRequestCheckout() {
       assumeStartTime: req.start && Timestamp.fromDate(req.start),
       maxDuration: req.maxDuration && Timestamp.fromDate(req.maxDuration),
       requestTtl: req.requestTTL && Timestamp.fromDate(req.requestTTL),
-      resourceAccessIds: undefined,
+      resourceAccessIds: [],
     };
 
     // Don't attempt creating anything if there are no resources selected.


### PR DESCRIPTION
## Context
Remaining Resource Constraint-related PRs are postponed to batch together with Long-Term Access Request support for Connect. In the meantime, breaking out this fix to provide an empty arr for resourceAccessIds rather than `undefined`.
