### PR TITLE
Trim "v" prefix for all instance versions in inventory cache

### DIFF
--- a/lib/cache/inventory/inventory_cache.go
+++ b/lib/cache/inventory/inventory_cache.go
@@ -1039,11 +1039,13 @@ func (e *unifiedFilterEnvironment) GetVersion() string {
 		return ""
 	}
 	if e.ui.isInstance() {
-		return e.ui.instance.Spec.Version
+		// Trim "v" prefix if it's there
+		return strings.TrimPrefix(e.ui.instance.Spec.Version, "v")
 	}
 	// For bot instances, get version from latest heartbeat
 	if e.ui.bot.Status != nil && len(e.ui.bot.Status.LatestHeartbeats) > 0 {
-		return e.ui.bot.Status.LatestHeartbeats[0].Version
+		// Trim "v" prefix if it's there
+		return strings.TrimPrefix(e.ui.bot.Status.LatestHeartbeats[0].Version, "v")
 	}
 	return ""
 }

--- a/lib/cache/inventory/inventory_cache_test.go
+++ b/lib/cache/inventory/inventory_cache_test.go
@@ -1335,8 +1335,19 @@ func TestInventoryCacheSorting(t *testing.T) {
 		synctest.Wait()
 		require.True(t, inventoryCache.IsHealthy())
 
-		// Test sort by name ascending
+		// Version predicate filter should work whether the instance's version has "v" prefix or not
 		resp, err := inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
+			PageSize: 100,
+			Filter: &inventoryv1.ListUnifiedInstancesFilter{
+				PredicateExpression: `version == "18.0.0"`,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 2)
+		require.ElementsMatch(t, []string{"v18.0.0", "18.0.0"}, libslices.Map(resp.Items, getItemVersion))
+
+		// Test sort by name ascending
+		resp, err = inventoryCache.ListUnifiedInstances(ctx, &inventoryv1.ListUnifiedInstancesRequest{
 			PageSize: 100,
 			Sort:     inventoryv1.UnifiedInstanceSort_UNIFIED_INSTANCE_SORT_NAME,
 			Order:    inventoryv1.SortOrder_SORT_ORDER_ASCENDING,


### PR DESCRIPTION
## Purpose

There is an inconsistency in how we store versions for resources. In some cases, they will have a `"v"` prefix (eg. "v18.0.0"), and in other cases not (such as for bot instances). The `v` prefix is added by [this function](https://github.com/gravitational/teleport/blob/cf0adecf790066d5d384b32d42781f5a90a9a79f/lib/versioncontrol/versioncontrol.go#L37), however there are paths that never invoke it and thus may result in storing a resource with no version prefix in its version field.

This inconsistency means that the Instance Inventory UI version filtering may not work properly, if you have some instances with prefixes and others without, you'd have to run something like `version == "18.0.0" || version == "v18.0.0"` in order to get all of them in a single query.

This PR normalizes all instance versions in the inventory cache to have no prefix in order to prevent this and make filtering consistent.