### PR TITLE
[Web] Fetch status, context, and preferences concurrently on initial load

### DIFF
--- a/web/packages/teleport/src/User/UserContext.test.tsx
+++ b/web/packages/teleport/src/User/UserContext.test.tsx
@@ -29,10 +29,15 @@ import { Theme } from 'gen-proto-ts/teleport/userpreferences/v1/theme_pb';
 
 import cfg from 'teleport/config';
 import { KeysEnum } from 'teleport/services/storageService';
+import { clearCachedPreferences } from 'teleport/services/userPreferences';
 import { UserContextProvider } from 'teleport/User';
 import { useUser } from 'teleport/User/UserContext';
 
 enableMswServer();
+
+beforeEach(() => {
+  clearCachedPreferences();
+});
 
 function ThemeName() {
   const { preferences } = useUser();

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.test.tsx
@@ -21,6 +21,7 @@ import { render, screen, waitFor } from 'design/utils/testing';
 import api from 'teleport/services/api';
 import { ApiError } from 'teleport/services/api/parseError';
 import history from 'teleport/services/history';
+import userService from 'teleport/services/user';
 import session from 'teleport/services/websession';
 
 import Authenticated from './Authenticated';
@@ -43,8 +44,9 @@ describe('session', () => {
     jest.spyOn(session, 'ensureSession').mockImplementation();
     jest.spyOn(session, 'getInactivityTimeout').mockImplementation(() => 0);
     jest.spyOn(session, 'clear').mockImplementation();
-    jest.spyOn(api, 'get').mockResolvedValue(null);
+    jest.spyOn(api, 'get').mockResolvedValue({});
     jest.spyOn(api, 'delete').mockResolvedValue(null);
+    jest.spyOn(userService, 'fetchUserContext').mockResolvedValue(null);
     jest.spyOn(history, 'goToLogin').mockImplementation();
   });
 

--- a/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
+++ b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx
@@ -28,6 +28,8 @@ import { throttle } from 'shared/utils/highbar';
 import { StyledIndicator } from 'teleport/Main';
 import { ApiError } from 'teleport/services/api/parseError';
 import { storageService } from 'teleport/services/storageService';
+import userService from 'teleport/services/user';
+import { getUserPreferences } from 'teleport/services/userPreferences';
 import session from 'teleport/services/websession';
 
 import { ErrorDialog } from './ErrorDialogue';
@@ -58,6 +60,15 @@ const Authenticated: React.FC<PropsWithChildren> = ({ children }) => {
         session.clearBrowserSession(true /* rememberLocation */);
         return;
       }
+
+      // Prefetch user context and preferences. We do this here to speed up the initial load by fetching them concurrently.
+      userService.fetchUserContext().catch(err => {
+        // We merely log any error here, however if this fails, the actual UserContext component will attempt again and handle errors and show the error banner.
+        logger.error('Failed to prefetch user context', err);
+      });
+      getUserPreferences().catch(err => {
+        logger.error('Failed to prefetch user preferences', err);
+      });
 
       try {
         const result = await session.validateCookieAndSession();

--- a/web/packages/teleport/src/services/user/user.ts
+++ b/web/packages/teleport/src/services/user/user.ts
@@ -34,23 +34,26 @@ import {
   type UpdateUserVariables,
 } from './types';
 
-const cache = {
-  userContext: null as UserContext,
+const cache: { pendingUserContext: Promise<UserContext> | null } = {
+  pendingUserContext: null,
 };
 
 const service = {
   fetchUserContext(fromCache = true) {
-    if (fromCache && cache['userContext']) {
-      return Promise.resolve(cache['userContext']);
+    if (fromCache && cache.pendingUserContext) {
+      return cache.pendingUserContext;
     }
 
-    return api
+    // Keep track of any in-flight fetch so that we don't make this request multiple times.
+    cache.pendingUserContext = api
       .get(cfg.getUserContextUrl())
       .then(makeUserContext)
-      .then(userContext => {
-        cache['userContext'] = userContext;
-        return cache['userContext'];
+      .catch(err => {
+        cache.pendingUserContext = null;
+        throw err;
       });
+
+    return cache.pendingUserContext;
   },
 
   fetchAccessGraphFeatures(): Promise<object> {

--- a/web/packages/teleport/src/services/userPreferences/index.ts
+++ b/web/packages/teleport/src/services/userPreferences/index.ts
@@ -17,6 +17,7 @@
  */
 
 export {
+  clearCachedPreferences,
   getUserPreferences,
   updateUserPreferences,
   updateUserClusterPreferences,

--- a/web/packages/teleport/src/services/userPreferences/userPreferences.ts
+++ b/web/packages/teleport/src/services/userPreferences/userPreferences.ts
@@ -48,12 +48,29 @@ export interface BackendUserPreferences {
   keyboardLayout: number;
 }
 
-export async function getUserPreferences(): Promise<UserPreferences> {
-  const res: BackendUserPreferences = await api.get(
-    cfg.api.userPreferencesPath
-  );
+const cache: { pendingPreferences: Promise<UserPreferences> | null } = {
+  pendingPreferences: null,
+};
 
-  return convertBackendUserPreferences(res);
+export function clearCachedPreferences() {
+  cache.pendingPreferences = null;
+}
+
+export function getUserPreferences(fromCache = true): Promise<UserPreferences> {
+  if (fromCache && cache.pendingPreferences) {
+    return cache.pendingPreferences;
+  }
+
+  // Keep track of any in-flight fetch so that we don't make this request multiple times.
+  cache.pendingPreferences = api
+    .get(cfg.api.userPreferencesPath)
+    .then(convertBackendUserPreferences)
+    .catch(err => {
+      cache.pendingPreferences = null;
+      throw err;
+    });
+
+  return cache.pendingPreferences;
 }
 
 export async function getUserClusterPreferences(


### PR DESCRIPTION
## Purpose

Part of https://github.com/gravitational/teleport/issues/37896

This PR is part of a series of changes aimed at improving the initial load time for Web UI pages.

Currently on every page load we fetch `status`, `context`, and `preferences`, however we do these one after the other instead of concurrently. These changes ensure we fetch them at the same time and also prevent duplicate fetches.

Tested in Cloud staging, taking the average of 10 tries, the time to load a page before this change with no throttling went from `4927ms` down to `4209ms`. With "Slow 4G" throttling in Chrome dev tools, it went from `6273ms` to `5139ms`.