### PR TITLE
[v18] webui: add `accessListOwnersSource` to `PluginEntraIdSpec`

### DIFF
--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -486,6 +486,10 @@ export type PluginEntraIdSpec = {
    */
   defaultOwners: string[];
   /**
+   * accessListOwnersSource is the source of the Access List owners.
+   */
+  accessListOwnersSource: string;
+  /**
    * ssoConnectorId is the name of the SSO connector referenced
    * by the Entra ID plugin.
    */


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/63191 to branch/v18