### PR TITLE
Ignore session resumption SSE events sent from MCP servers and other non-MCP events

### DIFF
--- a/lib/utils/mcputils/errors.go
+++ b/lib/utils/mcputils/errors.go
@@ -26,6 +26,9 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// sseEventNoDataErr raise when a received SSE event has no data.
+var sseEventNoDataErr = errors.New("SSE event contains no data information")
+
 // IsOKCloseError checks if provided error is a common close error that
 // indicates the connection is ended.
 func IsOKCloseError(err error) bool {

--- a/lib/utils/mcputils/errors.go
+++ b/lib/utils/mcputils/errors.go
@@ -26,8 +26,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// sseEventNoDataErr raise when a received SSE event has no data.
-var sseEventNoDataErr = errors.New("SSE event contains no data information")
+// errSSEEventNoData raise when a received SSE event has no data.
+var errSSEEventNoData = errors.New("SSE event contains no data information")
 
 // IsOKCloseError checks if provided error is a common close error that
 // indicates the connection is ended.

--- a/lib/utils/mcputils/http.go
+++ b/lib/utils/mcputils/http.go
@@ -124,18 +124,19 @@ func (r *httpSSEResponseReplacer) Read(p []byte) (int, error) {
 		var err error
 		msg, err = r.ReadMessage(r.ctx)
 		if err != nil {
+			switch {
 			// Note that the underlying connection may be canceled by connection
 			// monitoring.
-			if utils.IsOKNetworkError(err) || errors.Is(err, context.Canceled) {
+			case utils.IsOKNetworkError(err) || errors.Is(err, context.Canceled):
 				return 0, io.EOF
-			}
-			// Skip malformed SSE events (e.g., events without data, or
-			// non-standard events.
-			if isReaderParseError(err) {
-				slog.DebugContext(r.ctx, "malformed SSE message received, ignoring it", "error", err)
+			case errors.Is(err, sseEventNoDataErr):
 				continue
+			case isReaderParseError(err):
+				slog.DebugContext(r.ctx, "non-MCP event received, ignoring it", "error", err)
+				continue
+			default:
+				return 0, trace.Wrap(err)
 			}
-			return 0, trace.Wrap(err)
 		}
 		break
 	}

--- a/lib/utils/mcputils/http.go
+++ b/lib/utils/mcputils/http.go
@@ -129,10 +129,11 @@ func (r *httpSSEResponseReplacer) Read(p []byte) (int, error) {
 			// monitoring.
 			case utils.IsOKNetworkError(err) || errors.Is(err, context.Canceled):
 				return 0, io.EOF
-			case errors.Is(err, sseEventNoDataErr):
+			case errors.Is(err, errSSEEventNoData):
+				slog.DebugContext(r.ctx, "empty data event received, ignoring it", "error", err)
 				continue
 			case isReaderParseError(err):
-				slog.DebugContext(r.ctx, "non-MCP event received, ignoring it", "error", err)
+				slog.WarnContext(r.ctx, "non-MCP event received, this can indicate a protocol that is currently not supported by Teleport or a malfunction on the MCP server", "error", err)
 				continue
 			default:
 				return 0, trace.Wrap(err)

--- a/lib/utils/mcputils/http_test.go
+++ b/lib/utils/mcputils/http_test.go
@@ -301,10 +301,10 @@ func TestReplaceHTTPResponseSSESkipUnsupportedEvents(t *testing.T) {
 
 type noopProcessor struct{}
 
-func (p *noopProcessor) ProcessResponse(_ context.Context, resp *JSONRPCResponse) mcp.JSONRPCMessage {
+func (p noopProcessor) ProcessResponse(_ context.Context, resp *JSONRPCResponse) mcp.JSONRPCMessage {
 	return resp
 }
 
-func (p *noopProcessor) ProcessNotification(_ context.Context, notif *JSONRPCNotification) mcp.JSONRPCMessage {
+func (p noopProcessor) ProcessNotification(_ context.Context, notif *JSONRPCNotification) mcp.JSONRPCMessage {
 	return notif
 }

--- a/lib/utils/mcputils/http_test.go
+++ b/lib/utils/mcputils/http_test.go
@@ -254,10 +254,11 @@ func makeHTTPServerWithInMemoryListener(t *testing.T, mcpServer *mcpserver.MCPSe
 	return listener
 }
 
-// TestReplaceHTTPResponseSSEIgnoreMalformedEvents ensures that when replacing
-// the HTTP SSE response, malformed events (such as without data) won't cause
-// the stream to fail, instead those events should be ignored.
-func TestReplaceHTTPResponseSSEIgnoreMalformedEvents(t *testing.T) {
+// TestReplaceHTTPResponseSSESkipUnsupportedEvents ensures that when replacing
+// the HTTP SSE response, events without data (such as Last-Event-ID from
+// SEP-1699) and non-MCP events won't cause the stream to fail, instead those
+// events should be skipped.
+func TestReplaceHTTPResponseSSESkipUnsupportedEvents(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -271,8 +272,11 @@ func TestReplaceHTTPResponseSSEIgnoreMalformedEvents(t *testing.T) {
 
 	// Construct SSE data with a malformed event followed by a message event.
 	var sseData bytes.Buffer
+	// Last-Event-ID event (from SEP-1699).
 	writeEvent(&sseData, Event{ID: "random-id"})
+	// Non-MCP message.
 	writeEvent(&sseData, Event{Name: "ping", Data: []byte("keepalive")})
+	// Regular message.
 	writeEvent(&sseData, Event{Name: "message", Data: responseJSON})
 
 	resp := &http.Response{

--- a/lib/utils/mcputils/sse.go
+++ b/lib/utils/mcputils/sse.go
@@ -182,7 +182,7 @@ func (r *SSEResponseReader) ReadMessage(ctx context.Context) (string, error) {
 		return "", trace.Wrap(err, "reading SSE server message")
 	}
 	if evt.Name != sseEventMessage {
-		return "", newReaderParseError(trace.BadParameter("unexpected event type %s", evt.Name))
+		return "", newReaderParseError(trace.BadParameter("unexpected event type %q", evt.Name))
 	}
 	return string(evt.Data), nil
 }

--- a/lib/utils/mcputils/sse.go
+++ b/lib/utils/mcputils/sse.go
@@ -191,7 +191,7 @@ func (r *SSEResponseReader) ReadMessage(ctx context.Context) (string, error) {
 	// Ref: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
 	// Ref: https://modelcontextprotocol.io/community/seps/1699-support-sse-polling-via-server-side-disconnect
 	if len(evt.Data) == 0 {
-		return "", sseEventNoDataErr
+		return "", errSSEEventNoData
 	}
 	if evt.Name != sseEventMessage {
 		return "", newReaderParseError(trace.BadParameter("unexpected event type %q", evt.Name))

--- a/lib/utils/mcputils/sse.go
+++ b/lib/utils/mcputils/sse.go
@@ -181,6 +181,18 @@ func (r *SSEResponseReader) ReadMessage(ctx context.Context) (string, error) {
 	} else if err != nil {
 		return "", trace.Wrap(err, "reading SSE server message")
 	}
+	// Per SSE spec events can have no data. For MCP events without data usually
+	// represent events with Last-Event-ID information used for session
+	// resumption (defined by SEP-1699).
+	//
+	// For those scenarios, since Teleport doesn't support session resumption
+	// yet, skip those events to avoid breaking the connection.
+	//
+	// Ref: https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+	// Ref: https://modelcontextprotocol.io/community/seps/1699-support-sse-polling-via-server-side-disconnect
+	if len(evt.Data) == 0 {
+		return "", sseEventNoDataErr
+	}
 	if evt.Name != sseEventMessage {
 		return "", newReaderParseError(trace.BadParameter("unexpected event type %q", evt.Name))
 	}


### PR DESCRIPTION
When using MCP Streamable HTTP, MCP servers can sometimes send SSE events that contain no data (`Last-Event-ID` from SEP-1699) and non-MCP events, causing the streamable connection to stop, leaving MCP clients stuck and eventually timing out due to no further messages being sent.

This PR improves this case by ignoring such messages and leaving the SSE stream going.

changelog: Fixed MCP clients' timeout and broken connections when the MCP server tries to resume the previous session.
 
<hr>

### Manual testing

- [x] MCP access (using `tsh mcp connect`).
  - [x] Streamable HTTP servers (`mcp+http://`).
  - [x] SSE servers (`mcp+sse://`).
  - [x] STDIO servers.

Servers used: [`everything` (NodeJS)](https://github.com/modelcontextprotocol/servers/blob/618cf4867bca1fa193553d94fb7f2b2cf47f2a04/src/everything/README.md) and [`time` (Python)](https://github.com/modelcontextprotocol/servers/tree/618cf4867bca1fa193553d94fb7f2b2cf47f2a04/src/time). 
Clients used: MCP inspector, Python SDK, and Claude Desktop.