### PR TITLE
[v17] Fix tsh kubectl short flag parsing

### DIFF
--- a/tool/tsh/common/kubectl_test.go
+++ b/tool/tsh/common/kubectl_test.go
@@ -20,6 +20,7 @@ package common
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/google/uuid"
@@ -263,6 +264,72 @@ func Test_overwriteKubeconfigFlagInEnv(t *testing.T) {
 		"KUBECONFIG=new-path",
 	}
 	require.Equal(t, wantEnv, overwriteKubeconfigInEnv(inputEnv, "new-path"))
+}
+
+func Test_insertDoubleDashAfterKubectl(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  []string
+		expect []string
+	}{
+		{
+			name:   "short flag before positional arg",
+			input:  []string{"kubectl", "-n", "default", "get", "pod"},
+			expect: []string{"kubectl", "--", "-n", "default", "get", "pod"},
+		},
+		{
+			name:   "long flag before positional arg",
+			input:  []string{"kubectl", "--namespace", "default", "get", "pod"},
+			expect: []string{"kubectl", "--", "--namespace", "default", "get", "pod"},
+		},
+		{
+			name:   "positional arg first",
+			input:  []string{"kubectl", "get", "pod", "-n", "default"},
+			expect: []string{"kubectl", "get", "pod", "-n", "default"},
+		},
+		{
+			name:   "global flags before kubectl",
+			input:  []string{"--debug", "kubectl", "-n", "default", "get", "pod"},
+			expect: []string{"--debug", "kubectl", "--", "-n", "default", "get", "pod"},
+		},
+		{
+			name:   "double dash already present",
+			input:  []string{"kubectl", "--", "-n", "default", "get", "pod"},
+			expect: []string{"kubectl", "--", "-n", "default", "get", "pod"},
+		},
+		{
+			name:   "no kubectl in args",
+			input:  []string{"ssh", "user@host"},
+			expect: []string{"ssh", "user@host"},
+		},
+		{
+			name:   "kubectl with no extra args",
+			input:  []string{"kubectl"},
+			expect: []string{"kubectl"},
+		},
+		{
+			name:   "kubectl as arg to another command",
+			input:  []string{"ssh", "jake@foo", "kubectl"},
+			expect: []string{"ssh", "jake@foo", "kubectl"},
+		},
+		{
+			name:   "kubectl as arg to another command with flags",
+			input:  []string{"ssh", "jake@foo", "kubectl", "-n", "default", "get", "pod"},
+			expect: []string{"ssh", "jake@foo", "kubectl", "-n", "default", "get", "pod"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			original := slices.Clone(test.input)
+			result := insertDoubleDashAfterKubectl(test.input)
+			require.Equal(t, test.expect, result)
+			// Verify original slice is not modified.
+			require.Equal(t, original, test.input)
+		})
+	}
 }
 
 func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1425,7 +1425,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 
 	// parse CLI commands+flags:
 	utils.UpdateAppUsageTemplate(app, args)
-	command, err := app.Parse(args)
+	command, err := app.Parse(insertDoubleDashAfterKubectl(args))
 	if errors.Is(err, kingpin.ErrExpectedCommand) {
 		if _, ok := cf.TSHConfig.Aliases[aliasCommand]; ok {
 			log.Debugf("Failing due to recursive alias %q. Aliases seen: %v", aliasCommand, ar.getSeenAliases())


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/63709 to branch/v17

Changelog: Fixed `tsh kubectl` failing when kubectl flags appear before positional arguments (e.g., `tsh kubectl -n default get pod`).