### PR TITLE
[v18] Add delay=none to indicator to fix flakey test

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.tsx
@@ -152,7 +152,7 @@ export function ListSessionRecordings({
 function RecordingsListLoading() {
   return (
     <Box textAlign="center" m={10} width="100%">
-      <Indicator />
+      <Indicator delay="none" />
     </Box>
   );
 }


### PR DESCRIPTION
Manually backport https://github.com/gravitational/teleport/pull/63814 to branch/v18 