### PR TITLE
[v18] Adding support for additional join methods to scoped tokens

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/token.pb.go
@@ -159,8 +159,18 @@ type ScopedTokenSpec struct {
 	// Immutable labels that should be applied to any resulting resources provisioned
 	// using this token.
 	ImmutableLabels *ImmutableLabels `protobuf:"bytes,5,opt,name=immutable_labels,json=immutableLabels,proto3" json:"immutable_labels,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+	Aws *AWS `protobuf:"bytes,6,opt,name=aws,proto3" json:"aws,omitempty"`
+	// The GCP-specific configuration used with the "gcp" join method.
+	Gcp *GCP `protobuf:"bytes,7,opt,name=gcp,proto3" json:"gcp,omitempty"`
+	// The Azure-specific configuration used with the "azure" join method.
+	Azure *Azure `protobuf:"bytes,8,opt,name=azure,proto3" json:"azure,omitempty"`
+	// The Azure Devops-specific configuration used with the "azure_devops" join method.
+	AzureDevops *AzureDevops `protobuf:"bytes,9,opt,name=azure_devops,json=azureDevops,proto3" json:"azure_devops,omitempty"`
+	// The Oracle-specific configuration used with the "oracle" join method.
+	Oracle        *Oracle `protobuf:"bytes,10,opt,name=oracle,proto3" json:"oracle,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ScopedTokenSpec) Reset() {
@@ -224,6 +234,41 @@ func (x *ScopedTokenSpec) GetUsageMode() string {
 func (x *ScopedTokenSpec) GetImmutableLabels() *ImmutableLabels {
 	if x != nil {
 		return x.ImmutableLabels
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAws() *AWS {
+	if x != nil {
+		return x.Aws
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetGcp() *GCP {
+	if x != nil {
+		return x.Gcp
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzure() *Azure {
+	if x != nil {
+		return x.Azure
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetAzureDevops() *AzureDevops {
+	if x != nil {
+		return x.AzureDevops
+	}
+	return nil
+}
+
+func (x *ScopedTokenSpec) GetOracle() *Oracle {
+	if x != nil {
+		return x.Oracle
 	}
 	return nil
 }
@@ -698,6 +743,684 @@ func (x *ImmutableLabels) GetSsh() map[string]string {
 	return nil
 }
 
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+type AWS struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AWS_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The TTL to use for AWS EC2 Instance Identity Documents used
+	// to join the cluster with this token. This should be a duration
+	// string such as "8h" or "6mo".
+	IidTtl string `protobuf:"bytes,2,opt,name=iid_ttl,json=iidTtl,proto3" json:"iid_ttl,omitempty"`
+	// Integration name which provides credentials for validating join attempts.
+	// Currently only in use for validating the AWS Organization ID in the IAM Join method.
+	Integration   string `protobuf:"bytes,3,opt,name=integration,proto3" json:"integration,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AWS) Reset() {
+	*x = AWS{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS) ProtoMessage() {}
+
+func (x *AWS) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS.ProtoReflect.Descriptor instead.
+func (*AWS) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *AWS) GetAllow() []*AWS_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AWS) GetIidTtl() string {
+	if x != nil {
+		return x.IidTtl
+	}
+	return ""
+}
+
+func (x *AWS) GetIntegration() string {
+	if x != nil {
+		return x.Integration
+	}
+	return ""
+}
+
+// The GCP-specific configuration used with the "gcp" join method.
+type GCP struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*GCP_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GCP) Reset() {
+	*x = GCP{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP) ProtoMessage() {}
+
+func (x *GCP) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP.ProtoReflect.Descriptor instead.
+func (*GCP) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GCP) GetAllow() []*GCP_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// The Azure-specific configuration used with the "azure" join method.
+type Azure struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*Azure_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Azure) Reset() {
+	*x = Azure{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure) ProtoMessage() {}
+
+func (x *Azure) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure.ProtoReflect.Descriptor instead.
+func (*Azure) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *Azure) GetAllow() []*Azure_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+type AzureDevops struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow []*AzureDevops_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	// The UUID of the Azure DevOps organization that this join token will grant access to.
+	// This is used to identify the correct issuer verification of the ID token.
+	// This is a required field.
+	OrganizationId string `protobuf:"bytes,2,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *AzureDevops) Reset() {
+	*x = AzureDevops{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops) ProtoMessage() {}
+
+func (x *AzureDevops) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops.ProtoReflect.Descriptor instead.
+func (*AzureDevops) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *AzureDevops) GetAllow() []*AzureDevops_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+func (x *AzureDevops) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
+// The Oracle-specific configuration used with the "oracle" join method.
+type Oracle struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of Rules for allowing use of this token. A node must match at least one
+	// allow rule in order to use this token.
+	Allow         []*Oracle_Rule `protobuf:"bytes,1,rep,name=allow,proto3" json:"allow,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Oracle) Reset() {
+	*x = Oracle{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Oracle) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Oracle) ProtoMessage() {}
+
+func (x *Oracle) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Oracle.ProtoReflect.Descriptor instead.
+func (*Oracle) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *Oracle) GetAllow() []*Oracle_Rule {
+	if x != nil {
+		return x.Allow
+	}
+	return nil
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with AWS join methods.
+type AWS_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The AWS account ID.
+	AwsAccount string `protobuf:"bytes,1,opt,name=aws_account,json=awsAccount,proto3" json:"aws_account,omitempty"`
+	// List of AWS regions a node is allowed to join from when using the
+	// EC2 join method.
+	AwsRegions []string `protobuf:"bytes,2,rep,name=aws_regions,json=awsRegions,proto3" json:"aws_regions,omitempty"`
+	// The ARN of the role the Auth Service will assume in order to call the
+	// EC2 API when using the EC2 join method.
+	AwsRole string `protobuf:"bytes,3,opt,name=aws_role,json=awsRole,proto3" json:"aws_role,omitempty"`
+	// The ARN of the joining identity for use with the IAM join method.
+	// Supports wildcards "*" and "?".
+	AwsArn string `protobuf:"bytes,4,opt,name=aws_arn,json=awsArn,proto3" json:"aws_arn,omitempty"`
+	// The organization ID that the joining AWS identity must belong to
+	// when using the IAM join method.
+	AwsOrganizationId string `protobuf:"bytes,5,opt,name=aws_organization_id,json=awsOrganizationId,proto3" json:"aws_organization_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *AWS_Rule) Reset() {
+	*x = AWS_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AWS_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AWS_Rule) ProtoMessage() {}
+
+func (x *AWS_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AWS_Rule.ProtoReflect.Descriptor instead.
+func (*AWS_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{9, 0}
+}
+
+func (x *AWS_Rule) GetAwsAccount() string {
+	if x != nil {
+		return x.AwsAccount
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsRegions() []string {
+	if x != nil {
+		return x.AwsRegions
+	}
+	return nil
+}
+
+func (x *AWS_Rule) GetAwsRole() string {
+	if x != nil {
+		return x.AwsRole
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsArn() string {
+	if x != nil {
+		return x.AwsArn
+	}
+	return ""
+}
+
+func (x *AWS_Rule) GetAwsOrganizationId() string {
+	if x != nil {
+		return x.AwsOrganizationId
+	}
+	return ""
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "gcp" join method.
+type GCP_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// A list of project IDs (e.g. `<example-id-123456>`).
+	ProjectIds []string `protobuf:"bytes,1,rep,name=project_ids,json=projectIds,proto3" json:"project_ids,omitempty"`
+	// A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+	Locations []string `protobuf:"bytes,2,rep,name=locations,proto3" json:"locations,omitempty"`
+	// A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+	ServiceAccounts []string `protobuf:"bytes,3,rep,name=service_accounts,json=serviceAccounts,proto3" json:"service_accounts,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *GCP_Rule) Reset() {
+	*x = GCP_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GCP_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GCP_Rule) ProtoMessage() {}
+
+func (x *GCP_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GCP_Rule.ProtoReflect.Descriptor instead.
+func (*GCP_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{10, 0}
+}
+
+func (x *GCP_Rule) GetProjectIds() []string {
+	if x != nil {
+		return x.ProjectIds
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetLocations() []string {
+	if x != nil {
+		return x.Locations
+	}
+	return nil
+}
+
+func (x *GCP_Rule) GetServiceAccounts() []string {
+	if x != nil {
+		return x.ServiceAccounts
+	}
+	return nil
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "azure" join method.
+type Azure_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The Azure subscription.
+	Subscription string `protobuf:"bytes,1,opt,name=subscription,proto3" json:"subscription,omitempty"`
+	// A list of Azure resource groups the node is allowed to join from.
+	ResourceGroups []string `protobuf:"bytes,2,rep,name=resource_groups,json=resourceGroups,proto3" json:"resource_groups,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *Azure_Rule) Reset() {
+	*x = Azure_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Azure_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Azure_Rule) ProtoMessage() {}
+
+func (x *Azure_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Azure_Rule.ProtoReflect.Descriptor instead.
+func (*Azure_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{11, 0}
+}
+
+func (x *Azure_Rule) GetSubscription() string {
+	if x != nil {
+		return x.Subscription
+	}
+	return ""
+}
+
+func (x *Azure_Rule) GetResourceGroups() []string {
+	if x != nil {
+		return x.ResourceGroups
+	}
+	return nil
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "azure_devops" join method.
+type AzureDevops_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The subject string that roughly uniquely identifies the workload. Example:
+	// `p://my-organization/my-project/my-pipeline`
+	// Mapped from the `sub` claim.
+	Sub string `protobuf:"bytes,1,opt,name=sub,proto3" json:"sub,omitempty"`
+	// The name of the AZDO project. Example:
+	// `my-project`.
+	// Mapped out of the `sub` claim.
+	ProjectName string `protobuf:"bytes,2,opt,name=project_name,json=projectName,proto3" json:"project_name,omitempty"`
+	// The name of the AZDO pipeline. Example:
+	// `my-pipeline`.
+	// Mapped out of the `sub` claim.
+	PipelineName string `protobuf:"bytes,3,opt,name=pipeline_name,json=pipelineName,proto3" json:"pipeline_name,omitempty"`
+	// The ID of the AZDO pipeline. Example:
+	// `271ef6f7-0000-0000-0000-4b54d9129990`
+	// Mapped from the `prj_id` claim.
+	ProjectId string `protobuf:"bytes,4,opt,name=project_id,json=projectId,proto3" json:"project_id,omitempty"`
+	// The ID of the AZDO pipeline definition. Example:
+	// `1`
+	// Mapped from the `def_id` claim.
+	DefinitionId string `protobuf:"bytes,5,opt,name=definition_id,json=definitionId,proto3" json:"definition_id,omitempty"`
+	// The URI of the repository the pipeline is using. Example:
+	// `https://github.com/gravitational/teleport.git`.
+	// Mapped from the `rpo_uri` claim.
+	RepositoryUri string `protobuf:"bytes,6,opt,name=repository_uri,json=repositoryUri,proto3" json:"repository_uri,omitempty"`
+	// The individual commit of the repository the pipeline is using. Example:
+	// `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+	// Mapped from the `rpo_ver` claim.
+	RepositoryVersion string `protobuf:"bytes,7,opt,name=repository_version,json=repositoryVersion,proto3" json:"repository_version,omitempty"`
+	// The reference of the repository the pipeline is using. Example:
+	// `refs/heads/main`.
+	// Mapped from the `rpo_ref` claim.
+	RepositoryRef string `protobuf:"bytes,8,opt,name=repository_ref,json=repositoryRef,proto3" json:"repository_ref,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AzureDevops_Rule) Reset() {
+	*x = AzureDevops_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AzureDevops_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AzureDevops_Rule) ProtoMessage() {}
+
+func (x *AzureDevops_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AzureDevops_Rule.ProtoReflect.Descriptor instead.
+func (*AzureDevops_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{12, 0}
+}
+
+func (x *AzureDevops_Rule) GetSub() string {
+	if x != nil {
+		return x.Sub
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectName() string {
+	if x != nil {
+		return x.ProjectName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetPipelineName() string {
+	if x != nil {
+		return x.PipelineName
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetProjectId() string {
+	if x != nil {
+		return x.ProjectId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetDefinitionId() string {
+	if x != nil {
+		return x.DefinitionId
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryUri() string {
+	if x != nil {
+		return x.RepositoryUri
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryVersion() string {
+	if x != nil {
+		return x.RepositoryVersion
+	}
+	return ""
+}
+
+func (x *AzureDevops_Rule) GetRepositoryRef() string {
+	if x != nil {
+		return x.RepositoryRef
+	}
+	return ""
+}
+
+// A rule that a joining node must match in order to use the associated token
+// with the "oracle" join method.
+type Oracle_Rule struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The OCID of the instance's tenancy. Required.
+	Tenancy string `protobuf:"bytes,1,opt,name=tenancy,proto3" json:"tenancy,omitempty"`
+	// A list of the OCIDs of compartments an instance is allowed to join from. Only direct
+	// parents are allowed, i.e. no nested compartments. If empty, any compartment is allowed.
+	ParentCompartments []string `protobuf:"bytes,2,rep,name=parent_compartments,json=parentCompartments,proto3" json:"parent_compartments,omitempty"`
+	// A list of regions an instance is allowed to join from. Both full region names ("us-phoenix-1")
+	// and abbreviations ("phx") are allowed. If empty, any region is allowed.
+	Regions []string `protobuf:"bytes,3,rep,name=regions,proto3" json:"regions,omitempty"`
+	// A list of the OCIDs of specific instances that are allowed to join. If empty, any instance
+	// matching the other fields in the rule is allowed. Limited to 100 instance OCIDs per rule.
+	Instances     []string `protobuf:"bytes,4,rep,name=instances,proto3" json:"instances,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Oracle_Rule) Reset() {
+	*x = Oracle_Rule{}
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Oracle_Rule) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Oracle_Rule) ProtoMessage() {}
+
+func (x *Oracle_Rule) ProtoReflect() protoreflect.Message {
+	mi := &file_teleport_scopes_joining_v1_token_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Oracle_Rule.ProtoReflect.Descriptor instead.
+func (*Oracle_Rule) Descriptor() ([]byte, []int) {
+	return file_teleport_scopes_joining_v1_token_proto_rawDescGZIP(), []int{13, 0}
+}
+
+func (x *Oracle_Rule) GetTenancy() string {
+	if x != nil {
+		return x.Tenancy
+	}
+	return ""
+}
+
+func (x *Oracle_Rule) GetParentCompartments() []string {
+	if x != nil {
+		return x.ParentCompartments
+	}
+	return nil
+}
+
+func (x *Oracle_Rule) GetRegions() []string {
+	if x != nil {
+		return x.Regions
+	}
+	return nil
+}
+
+func (x *Oracle_Rule) GetInstances() []string {
+	if x != nil {
+		return x.Instances
+	}
+	return nil
+}
+
 var File_teleport_scopes_joining_v1_token_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
@@ -710,7 +1433,7 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\bmetadata\x18\x04 \x01(\v2\x1c.teleport.header.v1.MetadataR\bmetadata\x12\x14\n" +
 	"\x05scope\x18\x05 \x01(\tR\x05scope\x12?\n" +
 	"\x04spec\x18\x06 \x01(\v2+.teleport.scopes.joining.v1.ScopedTokenSpecR\x04spec\x12E\n" +
-	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\xe6\x01\n" +
+	"\x06status\x18\a \x01(\v2-.teleport.scopes.joining.v1.ScopedTokenStatusR\x06status\"\x8d\x04\n" +
 	"\x0fScopedTokenSpec\x12%\n" +
 	"\x0eassigned_scope\x18\x01 \x01(\tR\rassignedScope\x12\x14\n" +
 	"\x05roles\x18\x02 \x03(\tR\x05roles\x12\x1f\n" +
@@ -718,7 +1441,13 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"joinMethod\x12\x1d\n" +
 	"\n" +
 	"usage_mode\x18\x04 \x01(\tR\tusageMode\x12V\n" +
-	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\"\xb6\x01\n" +
+	"\x10immutable_labels\x18\x05 \x01(\v2+.teleport.scopes.joining.v1.ImmutableLabelsR\x0fimmutableLabels\x121\n" +
+	"\x03aws\x18\x06 \x01(\v2\x1f.teleport.scopes.joining.v1.AWSR\x03aws\x121\n" +
+	"\x03gcp\x18\a \x01(\v2\x1f.teleport.scopes.joining.v1.GCPR\x03gcp\x127\n" +
+	"\x05azure\x18\b \x01(\v2!.teleport.scopes.joining.v1.AzureR\x05azure\x12J\n" +
+	"\fazure_devops\x18\t \x01(\v2'.teleport.scopes.joining.v1.AzureDevopsR\vazureDevops\x12:\n" +
+	"\x06oracle\x18\n" +
+	" \x01(\v2\".teleport.scopes.joining.v1.OracleR\x06oracle\"\xb6\x01\n" +
 	"\x0eHostCertParams\x12\x17\n" +
 	"\ahost_id\x18\x01 \x01(\tR\x06hostId\x12\x1b\n" +
 	"\tnode_name\x18\x02 \x01(\tR\bnodeName\x12\x12\n" +
@@ -750,7 +1479,51 @@ const file_teleport_scopes_joining_v1_token_proto_rawDesc = "" +
 	"\x03ssh\x18\x01 \x03(\v24.teleport.scopes.joining.v1.ImmutableLabels.SshEntryR\x03ssh\x1a6\n" +
 	"\bSshEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01BYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xab\x02\n" +
+	"\x03AWS\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.AWS.RuleR\x05allow\x12\x17\n" +
+	"\aiid_ttl\x18\x02 \x01(\tR\x06iidTtl\x12 \n" +
+	"\vintegration\x18\x03 \x01(\tR\vintegration\x1a\xac\x01\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vaws_account\x18\x01 \x01(\tR\n" +
+	"awsAccount\x12\x1f\n" +
+	"\vaws_regions\x18\x02 \x03(\tR\n" +
+	"awsRegions\x12\x19\n" +
+	"\baws_role\x18\x03 \x01(\tR\aawsRole\x12\x17\n" +
+	"\aaws_arn\x18\x04 \x01(\tR\x06awsArn\x12.\n" +
+	"\x13aws_organization_id\x18\x05 \x01(\tR\x11awsOrganizationId\"\xb3\x01\n" +
+	"\x03GCP\x12:\n" +
+	"\x05allow\x18\x01 \x03(\v2$.teleport.scopes.joining.v1.GCP.RuleR\x05allow\x1ap\n" +
+	"\x04Rule\x12\x1f\n" +
+	"\vproject_ids\x18\x01 \x03(\tR\n" +
+	"projectIds\x12\x1c\n" +
+	"\tlocations\x18\x02 \x03(\tR\tlocations\x12)\n" +
+	"\x10service_accounts\x18\x03 \x03(\tR\x0fserviceAccounts\"\x9a\x01\n" +
+	"\x05Azure\x12<\n" +
+	"\x05allow\x18\x01 \x03(\v2&.teleport.scopes.joining.v1.Azure.RuleR\x05allow\x1aS\n" +
+	"\x04Rule\x12\"\n" +
+	"\fsubscription\x18\x01 \x01(\tR\fsubscription\x12'\n" +
+	"\x0fresource_groups\x18\x02 \x03(\tR\x0eresourceGroups\"\x9e\x03\n" +
+	"\vAzureDevops\x12B\n" +
+	"\x05allow\x18\x01 \x03(\v2,.teleport.scopes.joining.v1.AzureDevops.RuleR\x05allow\x12'\n" +
+	"\x0forganization_id\x18\x02 \x01(\tR\x0eorganizationId\x1a\xa1\x02\n" +
+	"\x04Rule\x12\x10\n" +
+	"\x03sub\x18\x01 \x01(\tR\x03sub\x12!\n" +
+	"\fproject_name\x18\x02 \x01(\tR\vprojectName\x12#\n" +
+	"\rpipeline_name\x18\x03 \x01(\tR\fpipelineName\x12\x1d\n" +
+	"\n" +
+	"project_id\x18\x04 \x01(\tR\tprojectId\x12#\n" +
+	"\rdefinition_id\x18\x05 \x01(\tR\fdefinitionId\x12%\n" +
+	"\x0erepository_uri\x18\x06 \x01(\tR\rrepositoryUri\x12-\n" +
+	"\x12repository_version\x18\a \x01(\tR\x11repositoryVersion\x12%\n" +
+	"\x0erepository_ref\x18\b \x01(\tR\rrepositoryRef\"\xd3\x01\n" +
+	"\x06Oracle\x12=\n" +
+	"\x05allow\x18\x01 \x03(\v2'.teleport.scopes.joining.v1.Oracle.RuleR\x05allow\x1a\x89\x01\n" +
+	"\x04Rule\x12\x18\n" +
+	"\atenancy\x18\x01 \x01(\tR\atenancy\x12/\n" +
+	"\x13parent_compartments\x18\x02 \x03(\tR\x12parentCompartments\x12\x18\n" +
+	"\aregions\x18\x03 \x03(\tR\aregions\x12\x1c\n" +
+	"\tinstances\x18\x04 \x03(\tR\tinstancesBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
 	file_teleport_scopes_joining_v1_token_proto_rawDescOnce sync.Once
@@ -764,7 +1537,7 @@ func file_teleport_scopes_joining_v1_token_proto_rawDescGZIP() []byte {
 	return file_teleport_scopes_joining_v1_token_proto_rawDescData
 }
 
-var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_teleport_scopes_joining_v1_token_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
 var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*ScopedToken)(nil),            // 0: teleport.scopes.joining.v1.ScopedToken
 	(*ScopedTokenSpec)(nil),        // 1: teleport.scopes.joining.v1.ScopedTokenSpec
@@ -775,29 +1548,49 @@ var file_teleport_scopes_joining_v1_token_proto_goTypes = []any{
 	(*StaticScopedTokens)(nil),     // 6: teleport.scopes.joining.v1.StaticScopedTokens
 	(*StaticScopedTokensSpec)(nil), // 7: teleport.scopes.joining.v1.StaticScopedTokensSpec
 	(*ImmutableLabels)(nil),        // 8: teleport.scopes.joining.v1.ImmutableLabels
-	nil,                            // 9: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	(*v1.Metadata)(nil),            // 10: teleport.header.v1.Metadata
-	(*timestamppb.Timestamp)(nil),  // 11: google.protobuf.Timestamp
+	(*AWS)(nil),                    // 9: teleport.scopes.joining.v1.AWS
+	(*GCP)(nil),                    // 10: teleport.scopes.joining.v1.GCP
+	(*Azure)(nil),                  // 11: teleport.scopes.joining.v1.Azure
+	(*AzureDevops)(nil),            // 12: teleport.scopes.joining.v1.AzureDevops
+	(*Oracle)(nil),                 // 13: teleport.scopes.joining.v1.Oracle
+	nil,                            // 14: teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	(*AWS_Rule)(nil),               // 15: teleport.scopes.joining.v1.AWS.Rule
+	(*GCP_Rule)(nil),               // 16: teleport.scopes.joining.v1.GCP.Rule
+	(*Azure_Rule)(nil),             // 17: teleport.scopes.joining.v1.Azure.Rule
+	(*AzureDevops_Rule)(nil),       // 18: teleport.scopes.joining.v1.AzureDevops.Rule
+	(*Oracle_Rule)(nil),            // 19: teleport.scopes.joining.v1.Oracle.Rule
+	(*v1.Metadata)(nil),            // 20: teleport.header.v1.Metadata
+	(*timestamppb.Timestamp)(nil),  // 21: google.protobuf.Timestamp
 }
 var file_teleport_scopes_joining_v1_token_proto_depIdxs = []int32{
-	10, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
+	20, // 0: teleport.scopes.joining.v1.ScopedToken.metadata:type_name -> teleport.header.v1.Metadata
 	1,  // 1: teleport.scopes.joining.v1.ScopedToken.spec:type_name -> teleport.scopes.joining.v1.ScopedTokenSpec
 	5,  // 2: teleport.scopes.joining.v1.ScopedToken.status:type_name -> teleport.scopes.joining.v1.ScopedTokenStatus
 	8,  // 3: teleport.scopes.joining.v1.ScopedTokenSpec.immutable_labels:type_name -> teleport.scopes.joining.v1.ImmutableLabels
-	11, // 4: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
-	11, // 5: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
-	2,  // 6: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
-	3,  // 7: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
-	4,  // 8: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
-	10, // 9: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
-	7,  // 10: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
-	0,  // 11: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
-	9,  // 12: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	9,  // 4: teleport.scopes.joining.v1.ScopedTokenSpec.aws:type_name -> teleport.scopes.joining.v1.AWS
+	10, // 5: teleport.scopes.joining.v1.ScopedTokenSpec.gcp:type_name -> teleport.scopes.joining.v1.GCP
+	11, // 6: teleport.scopes.joining.v1.ScopedTokenSpec.azure:type_name -> teleport.scopes.joining.v1.Azure
+	12, // 7: teleport.scopes.joining.v1.ScopedTokenSpec.azure_devops:type_name -> teleport.scopes.joining.v1.AzureDevops
+	13, // 8: teleport.scopes.joining.v1.ScopedTokenSpec.oracle:type_name -> teleport.scopes.joining.v1.Oracle
+	21, // 9: teleport.scopes.joining.v1.SingleUseStatus.used_at:type_name -> google.protobuf.Timestamp
+	21, // 10: teleport.scopes.joining.v1.SingleUseStatus.reusable_until:type_name -> google.protobuf.Timestamp
+	2,  // 11: teleport.scopes.joining.v1.SingleUseStatus.host_cert_params:type_name -> teleport.scopes.joining.v1.HostCertParams
+	3,  // 12: teleport.scopes.joining.v1.UsageStatus.single_use:type_name -> teleport.scopes.joining.v1.SingleUseStatus
+	4,  // 13: teleport.scopes.joining.v1.ScopedTokenStatus.usage:type_name -> teleport.scopes.joining.v1.UsageStatus
+	20, // 14: teleport.scopes.joining.v1.StaticScopedTokens.metadata:type_name -> teleport.header.v1.Metadata
+	7,  // 15: teleport.scopes.joining.v1.StaticScopedTokens.spec:type_name -> teleport.scopes.joining.v1.StaticScopedTokensSpec
+	0,  // 16: teleport.scopes.joining.v1.StaticScopedTokensSpec.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
+	14, // 17: teleport.scopes.joining.v1.ImmutableLabels.ssh:type_name -> teleport.scopes.joining.v1.ImmutableLabels.SshEntry
+	15, // 18: teleport.scopes.joining.v1.AWS.allow:type_name -> teleport.scopes.joining.v1.AWS.Rule
+	16, // 19: teleport.scopes.joining.v1.GCP.allow:type_name -> teleport.scopes.joining.v1.GCP.Rule
+	17, // 20: teleport.scopes.joining.v1.Azure.allow:type_name -> teleport.scopes.joining.v1.Azure.Rule
+	18, // 21: teleport.scopes.joining.v1.AzureDevops.allow:type_name -> teleport.scopes.joining.v1.AzureDevops.Rule
+	19, // 22: teleport.scopes.joining.v1.Oracle.allow:type_name -> teleport.scopes.joining.v1.Oracle.Rule
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_teleport_scopes_joining_v1_token_proto_init() }
@@ -814,7 +1607,7 @@ func file_teleport_scopes_joining_v1_token_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_teleport_scopes_joining_v1_token_proto_rawDesc), len(file_teleport_scopes_joining_v1_token_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   10,
+			NumMessages:   20,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/api/proto/teleport/scopes/joining/v1/token.proto
+++ b/api/proto/teleport/scopes/joining/v1/token.proto
@@ -70,6 +70,21 @@ message ScopedTokenSpec {
   // Immutable labels that should be applied to any resulting resources provisioned
   // using this token.
   ImmutableLabels immutable_labels = 5;
+
+  // The AWS-specific configuration used with the "ec2" and "iam" join methods.
+  AWS aws = 6;
+
+  // The GCP-specific configuration used with the "gcp" join method.
+  GCP gcp = 7;
+
+  // The Azure-specific configuration used with the "azure" join method.
+  Azure azure = 8;
+
+  // The Azure Devops-specific configuration used with the "azure_devops" join method.
+  AzureDevops azure_devops = 9;
+
+  // The Oracle-specific configuration used with the "oracle" join method.
+  Oracle oracle = 10;
 }
 
 // The host certificate parameters that should be cached and leveraged for
@@ -153,4 +168,140 @@ message StaticScopedTokensSpec {
 message ImmutableLabels {
   // Labels that should be applied to SSH nodes.
   map<string, string> ssh = 1;
+}
+
+// The AWS-specific configuration used with the "ec2" and "iam" join methods.
+message AWS {
+  // A rule that a joining node must match in order to use the associated token
+  // with AWS join methods.
+  message Rule {
+    // The AWS account ID.
+    string aws_account = 1;
+    // List of AWS regions a node is allowed to join from when using the
+    // EC2 join method.
+    repeated string aws_regions = 2;
+    // The ARN of the role the Auth Service will assume in order to call the
+    // EC2 API when using the EC2 join method.
+    string aws_role = 3;
+    // The ARN of the joining identity for use with the IAM join method.
+    // Supports wildcards "*" and "?".
+    string aws_arn = 4;
+    // The organization ID that the joining AWS identity must belong to
+    // when using the IAM join method.
+    string aws_organization_id = 5;
+  }
+
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+
+  // The TTL to use for AWS EC2 Instance Identity Documents used
+  // to join the cluster with this token. This should be a duration
+  // string such as "8h" or "6mo".
+  string iid_ttl = 2;
+
+  // Integration name which provides credentials for validating join attempts.
+  // Currently only in use for validating the AWS Organization ID in the IAM Join method.
+  string integration = 3;
+}
+
+// The GCP-specific configuration used with the "gcp" join method.
+message GCP {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "gcp" join method.
+  message Rule {
+    // A list of project IDs (e.g. `<example-id-123456>`).
+    repeated string project_ids = 1;
+    // A list of regions (e.g. "us-west1") and/or zones (e.g. "us-west1-b").
+    repeated string locations = 2;
+    // A list of service account emails (e.g. `<project-number>-compute@developer.gserviceaccount.com`).
+    repeated string service_accounts = 3;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+}
+
+// The Azure-specific configuration used with the "azure" join method.
+message Azure {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure" join method.
+  message Rule {
+    // The Azure subscription.
+    string subscription = 1;
+    // A list of Azure resource groups the node is allowed to join from.
+    repeated string resource_groups = 2;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+}
+
+// The Azure Devops-specific configuration used with the "azure_devops" join method.
+message AzureDevops {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "azure_devops" join method.
+  message Rule {
+    // The subject string that roughly uniquely identifies the workload. Example:
+    // `p://my-organization/my-project/my-pipeline`
+    // Mapped from the `sub` claim.
+    string sub = 1;
+    // The name of the AZDO project. Example:
+    // `my-project`.
+    // Mapped out of the `sub` claim.
+    string project_name = 2;
+    // The name of the AZDO pipeline. Example:
+    // `my-pipeline`.
+    // Mapped out of the `sub` claim.
+    string pipeline_name = 3;
+    // The ID of the AZDO pipeline. Example:
+    // `271ef6f7-0000-0000-0000-4b54d9129990`
+    // Mapped from the `prj_id` claim.
+    string project_id = 4;
+    // The ID of the AZDO pipeline definition. Example:
+    // `1`
+    // Mapped from the `def_id` claim.
+    string definition_id = 5;
+    // The URI of the repository the pipeline is using. Example:
+    // `https://github.com/gravitational/teleport.git`.
+    // Mapped from the `rpo_uri` claim.
+    string repository_uri = 6;
+    // The individual commit of the repository the pipeline is using. Example:
+    // `e6b9eb29a288b27a3a82cc19c48b9d94b80aff36`.
+    // Mapped from the `rpo_ver` claim.
+    string repository_version = 7;
+    // The reference of the repository the pipeline is using. Example:
+    // `refs/heads/main`.
+    // Mapped from the `rpo_ref` claim.
+    string repository_ref = 8;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
+  // The UUID of the Azure DevOps organization that this join token will grant access to.
+  // This is used to identify the correct issuer verification of the ID token.
+  // This is a required field.
+  string organization_id = 2;
+}
+
+// The Oracle-specific configuration used with the "oracle" join method.
+message Oracle {
+  // A rule that a joining node must match in order to use the associated token
+  // with the "oracle" join method.
+  message Rule {
+    // The OCID of the instance's tenancy. Required.
+    string tenancy = 1;
+    // A list of the OCIDs of compartments an instance is allowed to join from. Only direct
+    // parents are allowed, i.e. no nested compartments. If empty, any compartment is allowed.
+    repeated string parent_compartments = 2;
+    // A list of regions an instance is allowed to join from. Both full region names ("us-phoenix-1")
+    // and abbreviations ("phx") are allowed. If empty, any region is allowed.
+    repeated string regions = 3;
+    // A list of the OCIDs of specific instances that are allowed to join. If empty, any instance
+    // matching the other fields in the rule is allowed. Limited to 100 instance OCIDs per rule.
+    repeated string instances = 4;
+  }
+  // A list of Rules for allowing use of this token. A node must match at least one
+  // allow rule in order to use this token.
+  repeated Rule allow = 1;
 }

--- a/api/types/duration.go
+++ b/api/types/duration.go
@@ -57,7 +57,7 @@ func (d *Duration) UnmarshalJSON(data []byte) error {
 		*d = Duration(0)
 		return nil
 	}
-	out, err := parseDuration(stringVar)
+	out, err := ParseDuration(stringVar)
 	if err != nil {
 		return trace.BadParameter("%s", err)
 	}
@@ -81,7 +81,7 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*d = Duration(0)
 		return nil
 	}
-	out, err := parseDuration(stringVar)
+	out, err := ParseDuration(stringVar)
 	if err != nil {
 		return trace.BadParameter("%s", err)
 	}
@@ -165,12 +165,12 @@ var unitMap = map[string]int64{
 	"y":  int64(time.Hour * 24 * 365),
 }
 
-// parseDuration parses a duration string.
+// ParseDuration parses a duration string.
 // A duration string is a possibly signed sequence of
 // decimal numbers, each with optional fraction and a unit suffix,
 // such as "300ms", "-1.5h" or "2h45m".
 // Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-func parseDuration(s string) (Duration, error) {
+func ParseDuration(s string) (Duration, error) {
 	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
 	orig := s
 	var d int64

--- a/api/types/fuzz_test.go
+++ b/api/types/fuzz_test.go
@@ -30,7 +30,7 @@ func FuzzParseDuration(f *testing.F) {
 
 	f.Fuzz(func(t *testing.T, s string) {
 		require.NotPanics(t, func() {
-			parseDuration(s)
+			ParseDuration(s)
 		})
 	})
 }

--- a/api/types/provisioning.go
+++ b/api/types/provisioning.go
@@ -145,6 +145,9 @@ type ProvisionToken interface {
 	SetLabels(map[string]string)
 	// GetAllowRules returns the list of allow rules
 	GetAllowRules() []*TokenRule
+	// GetAWSAllowRules returns the list of AWS-specific allow rules. GetAllowRules is kept for backwards compatibility,
+	// but GetAWSAllowRules should be preferred.
+	GetAWSAllowRules() []*TokenRule
 	// SetAllowRules sets the allow rules
 	SetAllowRules([]*TokenRule)
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
@@ -156,6 +159,12 @@ type ProvisionToken interface {
 	GetGithubRules() *ProvisionTokenSpecV2GitHub
 	// GetGitlabRules will return the GitLab rules within this token.
 	GetGitlabRules() *ProvisionTokenSpecV2GitLab
+	// GetAzure will return the Azure specific configuration for this token.
+	GetAzure() *ProvisionTokenSpecV2Azure
+	// GetAzureDevops will return the AzureDevops specific configuration for this token.
+	GetAzureDevops() *ProvisionTokenSpecV2AzureDevops
+	// GetOracle will return the Oracle specific configuration for this token.
+	GetOracle() *ProvisionTokenSpecV2Oracle
 	// GetAWSIIDTTL returns the TTL of EC2 IIDs
 	GetAWSIIDTTL() Duration
 	// GetJoinMethod returns joining method that must be used with this token.
@@ -512,9 +521,14 @@ func (p *ProvisionTokenV2) SetLabels(l map[string]string) {
 	p.Metadata.Labels = l
 }
 
-// GetAllowRules returns the list of allow rules
-func (p *ProvisionTokenV2) GetAllowRules() []*TokenRule {
+// GetAWSAllowRules returns the list of AWS-specific allow rules
+func (p *ProvisionTokenV2) GetAWSAllowRules() []*TokenRule {
 	return p.Spec.Allow
+}
+
+// GetAllowRules returns the list of allow rules.
+func (p *ProvisionTokenV2) GetAllowRules() []*TokenRule {
+	return p.GetAWSAllowRules()
 }
 
 // SetAllowRules sets the allow rules.
@@ -522,7 +536,7 @@ func (p *ProvisionTokenV2) SetAllowRules(rules []*TokenRule) {
 	p.Spec.Allow = rules
 }
 
-// GetGCPRules will return the GCP rules within this token.
+// GetGCPRules will return the GCP-specific configuration for this token.
 func (p *ProvisionTokenV2) GetGCPRules() *ProvisionTokenSpecV2GCP {
 	return p.Spec.GCP
 }
@@ -540,6 +554,21 @@ func (p *ProvisionTokenV2) GetGitlabRules() *ProvisionTokenSpecV2GitLab {
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (p *ProvisionTokenV2) GetAWSIIDTTL() Duration {
 	return p.Spec.AWSIIDTTL
+}
+
+// GetAzure the Azure specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzure() *ProvisionTokenSpecV2Azure {
+	return p.Spec.Azure
+}
+
+// GetAzureDevops will return the AzureDevops specific configuration for this token.
+func (p *ProvisionTokenV2) GetAzureDevops() *ProvisionTokenSpecV2AzureDevops {
+	return p.Spec.AzureDevops
+}
+
+// GetOracle will return the Oracle specific configuration for this token.
+func (p *ProvisionTokenV2) GetOracle() *ProvisionTokenSpecV2Oracle {
+	return p.Spec.Oracle
 }
 
 // GetJoinMethod returns joining method that must be used with this token.

--- a/buf.yaml
+++ b/buf.yaml
@@ -91,6 +91,8 @@ breaking:
     - api/proto/teleport/decision/v1alpha1
     # TODO(nklaassen): Remove ignore once the new join API is stable.
     - api/proto/teleport/join/v1
+    # TODO(eriktate): Remove ignore once the new scopes API is stable.
+    - api/proto/teleport/scopes
 
 plugins:
   - plugin:

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken.go
@@ -186,14 +186,14 @@ func updateTokenIAMJoin(ctx context.Context, req upsertIAMJoinTokenRequest, rule
 	uniqueRoles := utils.Deduplicate(allRoles)
 	existingToken.SetRoles(uniqueRoles)
 
-	for _, rule := range existingToken.GetAllowRules() {
+	for _, rule := range existingToken.GetAWSAllowRules() {
 		if rule.AWSAccount == req.accountID && rule.AWSARN == req.awsARN {
 
 			return nil, trace.AlreadyExists("rule already exists")
 		}
 	}
 
-	existingToken.SetAllowRules(append(existingToken.GetAllowRules(), rule))
+	existingToken.SetAllowRules(append(existingToken.GetAWSAllowRules(), rule))
 
 	return existingToken, nil
 }

--- a/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_jointoken_test.go
@@ -68,11 +68,11 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 
 		require.Equal(t, "t", iamToken.GetName())
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
-		require.Len(t, iamToken.GetAllowRules(), 1)
+		require.Len(t, iamToken.GetAWSAllowRules(), 1)
 		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		}, iamToken.GetAllowRules()[0])
+		}, iamToken.GetAWSAllowRules()[0])
 	})
 
 	t.Run("when token exist but is missing the required allow rule and system role, it is updated", func(t *testing.T) {
@@ -102,12 +102,12 @@ func TestUpsertIAMJoinToken(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, "t", iamToken.GetName())
-		require.Len(t, iamToken.GetAllowRules(), 1)
+		require.Len(t, iamToken.GetAWSAllowRules(), 1)
 		require.Contains(t, iamToken.GetRoles(), types.RoleDatabase)
 		require.Equal(t, &types.TokenRule{
 			AWSAccount: "123456789012",
 			AWSARN:     "arn:aws:sts::123456789012:assumed-role/myrole/*",
-		}, iamToken.GetAllowRules()[0])
+		}, iamToken.GetAWSAllowRules()[0])
 	})
 
 	t.Run("when token exist but has an invalid join method, it returns an error", func(t *testing.T) {

--- a/lib/join/azurejoin/azure.go
+++ b/lib/join/azurejoin/azure.go
@@ -38,10 +38,10 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/join/joinutils"
+	"github.com/gravitational/teleport/lib/join/provision"
 	liboidc "github.com/gravitational/teleport/lib/oidc"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -404,8 +404,8 @@ func claimsToIdentifiers(tokenClaims *AccessTokenClaims) (subscriptionID, resour
 	return "", "", trace.BadParameter("unexpected resource type: %q", resourceID.ResourceType.Type)
 }
 
-func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token *types.ProvisionTokenV2) error {
-	for _, rule := range token.Spec.Azure.Allow {
+func checkAzureAllowRules(vmID string, attrs *workloadidentityv1pb.JoinAttrsAzure, token provision.Token) error {
+	for _, rule := range token.GetAzure().Allow {
 		if rule.Subscription != attrs.Subscription {
 			continue
 		}
@@ -448,7 +448,7 @@ type CheckAzureRequestParams struct {
 	// AzureJoinConfig holds configurable options for Azure joining.
 	AzureJoinConfig *AzureJoinConfig
 	// Token is the token used for the incoming request.
-	Token *types.ProvisionTokenV2
+	Token provision.Token
 	// Challenge is the challenge that was issued.
 	Challenge string
 	// AttestedData is the Azure attested data that was returned by the joining

--- a/lib/join/azurejoin/join_azure_test.go
+++ b/lib/join/azurejoin/join_azure_test.go
@@ -45,6 +45,7 @@ import (
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/machineid/machineidv1"
@@ -52,6 +53,8 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -490,6 +493,29 @@ func TestJoinAzure(t *testing.T) {
 				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
 			})
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = a.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := a.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			mirID := tc.tokenManagedIdentityResourceID
 			if mirID == "" {
 				mirID = vmResourceID(defaultSubscription, defaultResourceGroup, defaultVMName)
@@ -527,6 +553,21 @@ func TestJoinAzure(t *testing.T) {
 			t.Run("new", func(t *testing.T) {
 				_, err = joinclient.Join(ctx, joinclient.JoinParams{
 					Token: tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient: nopClient,
+					AzureParams: joinclient.AzureParams{
+						ClientID:         tc.tokenVMID,
+						IMDSClient:       imdsClient,
+						IssuerHTTPClient: httpClient,
+					},
+				})
+				tc.assertError(t, err)
+			})
+			t.Run("scoped", func(t *testing.T) {
+				_, err = joinclient.Join(ctx, joinclient.JoinParams{
+					Token: "scoped_" + tc.requestTokenName,
 					ID: state.IdentityID{
 						Role: types.RoleInstance,
 					},
@@ -818,6 +859,29 @@ func TestJoinAzureClaims(t *testing.T) {
 				require.NoError(t, a.DeleteToken(ctx, token.GetName()))
 			})
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = a.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := a.DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			mirID := tc.tokenManagedIdentityResourceID
 			azrID := tc.tokenAzureResourceID
 			accessToken, err := makeToken(mirID, azrID, a.GetClock().Now())
@@ -867,6 +931,22 @@ func TestJoinAzureClaims(t *testing.T) {
 				// Try to join via the new join service.
 				_, err = joinclient.Join(ctx, joinclient.JoinParams{
 					Token: tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient: nopClient,
+					AzureParams: joinclient.AzureParams{
+						ClientID:         tc.tokenVMID,
+						IMDSClient:       imdsClient,
+						IssuerHTTPClient: httpClient,
+					},
+				})
+				tc.assertError(t, err)
+			})
+			t.Run("scoped", func(t *testing.T) {
+				// Try to join via the new join service.
+				_, err = joinclient.Join(ctx, joinclient.JoinParams{
+					Token: "scoped_" + tc.requestTokenName,
 					ID: state.IdentityID{
 						Role: types.RoleInstance,
 					},

--- a/lib/join/ec2join/ec2.go
+++ b/lib/join/ec2join/ec2.go
@@ -63,7 +63,7 @@ func ec2ClientFromConfig(cfg aws.Config) EC2Client {
 // checkEC2AllowRules checks that the iid matches at least one of the allow
 // rules of the given token.
 func checkEC2AllowRules(ctx context.Context, params *CheckEC2RequestParams, iid *imds.InstanceIdentityDocument) error {
-	allowRules := params.ProvisionToken.GetAllowRules()
+	allowRules := params.ProvisionToken.GetAWSAllowRules()
 	for _, rule := range allowRules {
 		// if this rule specifies an AWS account, the IID must match
 		if len(rule.AWSAccount) > 0 {

--- a/lib/join/iamjoin/iam.go
+++ b/lib/join/iamjoin/iam.go
@@ -282,7 +282,7 @@ func arnMatches(pattern, arn string) (bool, error) {
 // checkIAMAllowRules checks if the given identity matches any of the given
 // allowRules.
 func checkIAMAllowRules(ctx context.Context, identity *AWSIdentity, params *CheckIAMRequestParams, organizationIDFetcher *organizationsIDFetcher) error {
-	for _, rule := range params.ProvisionToken.GetAllowRules() {
+	for _, rule := range params.ProvisionToken.GetAWSAllowRules() {
 		// if this rule specifies an AWS account, the identity must match
 		if rule.AWSAccount != "" {
 			if rule.AWSAccount != identity.Account {

--- a/lib/join/join_gcp_test.go
+++ b/lib/join/join_gcp_test.go
@@ -27,12 +27,16 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authtest"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/join/gcp"
 	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/join/jointest"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 )
 
 type mockGCPTokenValidator struct {
@@ -222,6 +226,29 @@ func TestJoinGCP(t *testing.T) {
 			require.NoError(t, auth.CreateToken(ctx, token))
 			tc.request.Token = tc.name
 
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(tc.tokenSpec, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
+				},
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = auth.CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := auth.DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
 			nopClient, err := authServer.NewClient(authtest.TestNop())
 			require.NoError(t, err)
 
@@ -251,6 +278,23 @@ func TestJoinGCP(t *testing.T) {
 			t.Run("new joinclient", func(t *testing.T) {
 				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
 					Token:      tc.request.Token,
+					JoinMethod: types.JoinMethodGCP,
+					ID: state.IdentityID{
+						Role:     types.RoleInstance, // RoleNode is not allowed
+						NodeName: "testnode",
+					},
+					IDToken:    tc.request.IDToken,
+					AuthClient: nopClient,
+				})
+				tc.assertError(t, err)
+				if err != nil {
+					return
+				}
+			})
+
+			t.Run("scoped", func(t *testing.T) {
+				_, err := joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token:      "scoped_" + tc.request.Token,
 					JoinMethod: types.JoinMethodGCP,
 					ID: state.IdentityID{
 						Role:     types.RoleInstance, // RoleNode is not allowed

--- a/lib/join/jointest/scoped_token.go
+++ b/lib/join/jointest/scoped_token.go
@@ -1,0 +1,149 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package jointest
+
+import (
+	"cmp"
+
+	"github.com/gravitational/trace"
+
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// ScopedTokenFromProvisionTokenSpec is a test helper that creates a scoped token using a [types.ProvisionTokenSpecV2]
+// as a base. The override parameter can be used to provide override values that should be used instead of the base token
+// values. This is mostly useful for testing.
+func ScopedTokenFromProvisionTokenSpec(base types.ProvisionTokenSpecV2, override *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	roles := types.SystemRoles(base.Roles).StringSlice()
+	if len(roles) == 0 {
+		roles = override.GetSpec().GetRoles()
+	}
+
+	// scoped tokens can't be created without a join method, so we replicate ProvisionTokenV2.CheckAndSetDefaults() here
+	// for testing purposes
+	if base.JoinMethod == types.JoinMethodUnspecified {
+		base.JoinMethod = types.JoinMethodToken
+		if len(base.Allow) > 0 {
+			base.JoinMethod = types.JoinMethodEC2
+		}
+	}
+
+	scopedToken := &joiningv1.ScopedToken{
+		Kind:     types.KindScopedToken,
+		Version:  types.V1,
+		Scope:    override.GetScope(),
+		Metadata: override.GetMetadata(),
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: override.GetSpec().GetAssignedScope(),
+			JoinMethod:    cmp.Or(override.GetSpec().GetJoinMethod(), string(base.JoinMethod)),
+			Roles:         roles,
+			UsageMode:     override.GetSpec().GetUsageMode(),
+		},
+	}
+
+	switch base.JoinMethod {
+	case types.JoinMethodEC2:
+		allow := make([]*joiningv1.AWS_Rule, len(base.Allow))
+		for i, rule := range base.Allow {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:  allow,
+			IidTtl: base.AWSIIDTTL.Duration().String(),
+		}
+	case types.JoinMethodIAM:
+		allow := make([]*joiningv1.AWS_Rule, len(base.Allow))
+		for i, rule := range base.Allow {
+			allow[i] = &joiningv1.AWS_Rule{
+				AwsAccount:        rule.AWSAccount,
+				AwsRegions:        rule.AWSRegions,
+				AwsRole:           rule.AWSRole,
+				AwsArn:            rule.AWSARN,
+				AwsOrganizationId: rule.AWSOrganizationID,
+			}
+		}
+		scopedToken.Spec.Aws = &joiningv1.AWS{
+			Allow:       allow,
+			Integration: base.Integration,
+		}
+	case types.JoinMethodGCP:
+		allow := make([]*joiningv1.GCP_Rule, len(base.GCP.Allow))
+		for i, rule := range base.GCP.Allow {
+			allow[i] = &joiningv1.GCP_Rule{
+				ProjectIds:      rule.ProjectIDs,
+				Locations:       rule.Locations,
+				ServiceAccounts: rule.ServiceAccounts,
+			}
+		}
+		scopedToken.Spec.Gcp = &joiningv1.GCP{
+			Allow: allow,
+		}
+	case types.JoinMethodAzure:
+		allow := make([]*joiningv1.Azure_Rule, len(base.Azure.Allow))
+		for i, rule := range base.Azure.Allow {
+			allow[i] = &joiningv1.Azure_Rule{
+				Subscription:   rule.Subscription,
+				ResourceGroups: rule.ResourceGroups,
+			}
+		}
+		scopedToken.Spec.Azure = &joiningv1.Azure{
+			Allow: allow,
+		}
+	case types.JoinMethodAzureDevops:
+		allow := make([]*joiningv1.AzureDevops_Rule, len(base.AzureDevops.Allow))
+		for i, rule := range base.AzureDevops.Allow {
+			allow[i] = &joiningv1.AzureDevops_Rule{
+				Sub:               rule.Sub,
+				ProjectName:       rule.ProjectName,
+				PipelineName:      rule.PipelineName,
+				ProjectId:         rule.ProjectID,
+				DefinitionId:      rule.DefinitionID,
+				RepositoryUri:     rule.RepositoryURI,
+				RepositoryVersion: rule.RepositoryVersion,
+				RepositoryRef:     rule.RepositoryRef,
+			}
+		}
+		scopedToken.Spec.AzureDevops = &joiningv1.AzureDevops{
+			Allow:          allow,
+			OrganizationId: base.AzureDevops.OrganizationID,
+		}
+	case types.JoinMethodOracle:
+		allow := make([]*joiningv1.Oracle_Rule, len(base.Oracle.Allow))
+		for i, rule := range base.Oracle.Allow {
+			allow[i] = &joiningv1.Oracle_Rule{
+				Tenancy:            rule.Tenancy,
+				ParentCompartments: rule.ParentCompartments,
+				Regions:            rule.Regions,
+				Instances:          rule.Instances,
+			}
+		}
+		scopedToken.Spec.Oracle = &joiningv1.Oracle{
+			Allow: allow,
+		}
+	default:
+		return nil, trace.BadParameter("unsupported join method %q", base.JoinMethod)
+	}
+
+	return scopedToken, nil
+}

--- a/lib/join/oraclejoin/join_test.go
+++ b/lib/join/oraclejoin/join_test.go
@@ -44,6 +44,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/auth"
@@ -54,8 +56,10 @@ import (
 	"github.com/gravitational/teleport/lib/join/internal/messages"
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/join/joinclient/oracle"
+	"github.com/gravitational/teleport/lib/join/jointest"
 	"github.com/gravitational/teleport/lib/join/joinutils"
 	"github.com/gravitational/teleport/lib/join/oraclejoin"
+	"github.com/gravitational/teleport/lib/scopes/joining"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/testutils"
@@ -339,29 +343,66 @@ func TestJoinOracle(t *testing.T) {
 			imdsClient, err := newFakeHTTPClient(imdsListener.Addr())
 			require.NoError(t, err)
 
+			spec := types.ProvisionTokenSpecV2{
+				JoinMethod: types.JoinMethodOracle,
+				Roles:      []types.SystemRole{types.RoleNode},
+				Oracle: &types.ProvisionTokenSpecV2Oracle{
+					Allow: tc.allowRules,
+				},
+			}
 			token, err := types.NewProvisionTokenFromSpec(
 				tc.tokenName,
 				time.Now().Add(time.Minute),
-				types.ProvisionTokenSpecV2{
-					JoinMethod: types.JoinMethodOracle,
-					Roles:      []types.SystemRole{types.RoleNode},
-					Oracle: &types.ProvisionTokenSpecV2Oracle{
-						Allow: tc.allowRules,
-					},
-				},
+				spec,
 			)
 			require.NoError(t, err)
 			require.NoError(t, server.Auth().UpsertToken(t.Context(), token))
 
-			_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
-				Token: tc.requestTokenName,
-				ID: state.IdentityID{
-					Role: types.RoleInstance,
+			scopedToken, err := jointest.ScopedTokenFromProvisionTokenSpec(spec, &joiningv1.ScopedToken{
+				Scope: "/test",
+				Metadata: &headerv1.Metadata{
+					Name: "scoped_" + token.GetName(),
 				},
-				AuthClient:       nopClient,
-				OracleIMDSClient: imdsClient,
+				Spec: &joiningv1.ScopedTokenSpec{
+					AssignedScope: "/test/one",
+					UsageMode:     string(joining.TokenUsageModeUnlimited),
+				},
 			})
-			tc.assertion(t, err)
+			require.NoError(t, err)
+			_, err = server.Auth().CreateScopedToken(t.Context(), &joiningv1.CreateScopedTokenRequest{
+				Token: scopedToken,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				_, err := server.Auth().DeleteScopedToken(t.Context(), &joiningv1.DeleteScopedTokenRequest{
+					Name: scopedToken.GetMetadata().GetName(),
+				})
+				require.NoError(t, err)
+			})
+
+			t.Run("unscoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient:       nopClient,
+					OracleIMDSClient: imdsClient,
+				})
+				tc.assertion(t, err)
+			})
+
+			t.Run("scoped", func(t *testing.T) {
+				_, err = joinclient.Join(t.Context(), joinclient.JoinParams{
+					Token: "scoped_" + tc.requestTokenName,
+					ID: state.IdentityID{
+						Role: types.RoleInstance,
+					},
+					AuthClient:       nopClient,
+					OracleIMDSClient: imdsClient,
+				})
+				tc.assertion(t, err)
+			})
 		})
 	}
 }

--- a/lib/join/oraclejoin/rules.go
+++ b/lib/join/oraclejoin/rules.go
@@ -28,12 +28,8 @@ import (
 // CheckOracleAllowRules checks that a the oracle rules in a provision token
 // allow an OCI instance with the given claims to join the cluster.
 func CheckOracleAllowRules(claims *Claims, token provision.Token) error {
-	ptv2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return trace.Errorf("Oracle join method only supports ProvisionTokenV2")
-	}
 	instanceRegion := claims.Region()
-	for _, rule := range ptv2.Spec.Oracle.Allow {
+	for _, rule := range token.GetOracle().Allow {
 		if rule.Tenancy != claims.TenancyID {
 			// rule.Tenancy is required, if it doesn't match the instance skip this rule.
 			continue

--- a/lib/join/provision/token.go
+++ b/lib/join/provision/token.go
@@ -48,14 +48,22 @@ type Token interface {
 	// GetAssignedScope returns the scope that will be assigned to provisioned resources
 	// provisioned using the wrapped [joiningv1.ScopedToken].
 	GetAssignedScope() string
-	// GetAllowRules returns the list of allow rules.
-	GetAllowRules() []*types.TokenRule
-	// GetAWSIIDTTL returns the TTL of EC2 IIDs
-	GetAWSIIDTTL() types.Duration
 	// GetImmutableLabels returns labels that must be applied to resources
 	// provisioned with this token.
 	GetImmutableLabels() *joiningv1.ImmutableLabels
+	// GetAWSAllowRules returns the list of AWS-specific allow rules.
+	GetAWSAllowRules() []*types.TokenRule
+	// GetAWSIIDTTL returns the TTL of EC2 IIDs
+	GetAWSIIDTTL() types.Duration
 	// GetIntegration returns the integration name that provides credentials to validate allow rules.
 	// Currently, this is only used to validate the AWS Organization.
 	GetIntegration() string
+	// GetGCPRules returns the GCP-specific configuration for this token.
+	GetGCPRules() *types.ProvisionTokenSpecV2GCP
+	// GetAzure returns the Azure-specific configuration for this token.
+	GetAzure() *types.ProvisionTokenSpecV2Azure
+	// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+	GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops
+	// GetOracle returns the Oracle-specific configuration for this token.
+	GetOracle() *types.ProvisionTokenSpecV2Oracle
 }

--- a/lib/join/server_azure.go
+++ b/lib/join/server_azure.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azurejoin"
 	"github.com/gravitational/teleport/lib/join/internal/authz"
 	"github.com/gravitational/teleport/lib/join/internal/messages"
@@ -81,15 +80,10 @@ func (s *Server) handleAzureJoin(
 		return nil, trace.BadParameter("client did not send access token")
 	}
 
-	ptv2, ok := token.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, trace.BadParameter("Azure join method only supports ProvisionTokenV2, got %T", token)
-	}
-
 	// Verify the client's identity and make sure it matches an allow rule in the provision token.
 	claims, err := azurejoin.CheckAzureRequest(stream.Context(), azurejoin.CheckAzureRequestParams{
 		AzureJoinConfig: s.cfg.AuthService.GetAzureJoinConfig(),
-		Token:           ptv2,
+		Token:           token,
 		Challenge:       challenge,
 		AttestedData:    solution.AttestedData,
 		Intermediate:    solution.Intermediate,

--- a/lib/join/server_azuredevops.go
+++ b/lib/join/server_azuredevops.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gravitational/trace"
 
 	workloadidentityv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/workloadidentity/v1"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/join/azuredevops"
 	"github.com/gravitational/teleport/lib/join/provision"
 )
@@ -32,13 +31,8 @@ func (s *Server) validateAzureDevopsToken(
 	pt provision.Token,
 	idToken []byte,
 ) (any, *workloadidentityv1.JoinAttrs, error) {
-	ptv2, ok := pt.(*types.ProvisionTokenV2)
-	if !ok {
-		return nil, nil, trace.BadParameter("Azure Devops joining only supports ProvisionTokenV2, got %T", pt)
-	}
-
 	claims, err := azuredevops.CheckIDToken(ctx, &azuredevops.CheckIDTokenParams{
-		ProvisionToken: ptv2,
+		ProvisionToken: pt,
 		IDToken:        string(idToken),
 		Validator:      s.cfg.AuthService.GetAzureDevopsIDTokenValidator(),
 	})

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -35,10 +35,6 @@ var rolesSupportingScopes = types.SystemRoles{
 	types.RoleNode,
 }
 
-var joinMethodsSupportingScopes = map[string]struct{}{
-	string(types.JoinMethodToken): {},
-}
-
 // TokenUsageMode represents the possible usage modes of a scoped token.
 type TokenUsageMode string
 
@@ -48,6 +44,46 @@ const (
 	// TokenUsageModeUnlimited denotes a token that can provision any number of resources.
 	TokenUsageModeUnlimited = "unlimited"
 )
+
+func validateJoinMethod(token *joiningv1.ScopedToken) error {
+
+	switch types.JoinMethod(token.GetSpec().GetJoinMethod()) {
+	case types.JoinMethodToken:
+		if token.GetStatus().GetSecret() == "" {
+			return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
+		}
+	case types.JoinMethodEC2:
+		ttl := token.GetSpec().GetAws().GetIidTtl()
+		if _, err := types.ParseDuration(ttl); ttl != "" && err != nil {
+			return trace.BadParameter("invalid IID TTL value %q, must be empty or a valid duration string (e.g. 30m, 12h, 1mo)", ttl)
+		}
+		fallthrough
+	case types.JoinMethodIAM:
+		if len(token.GetSpec().GetAws().GetAllow()) == 0 {
+			return trace.BadParameter("aws configuration must be defined for a scoped token when using the ec2 or iam join methods")
+		}
+	case types.JoinMethodGCP:
+		if len(token.GetSpec().GetGcp().GetAllow()) == 0 {
+			return trace.BadParameter("gcp configuration must be defined for a scoped token when using the gcp join method")
+		}
+	case types.JoinMethodAzure:
+		if len(token.GetSpec().GetAzure().GetAllow()) == 0 {
+			return trace.BadParameter("azure configuration must be defined for a scoped token when using the azure join method")
+		}
+	case types.JoinMethodAzureDevops:
+		if len(token.GetSpec().GetAzureDevops().GetAllow()) == 0 {
+			return trace.BadParameter("azure_devops configuration must be defined for a scoped token when using the azure_devops join method")
+		}
+	case types.JoinMethodOracle:
+		if len(token.GetSpec().GetOracle().GetAllow()) == 0 {
+			return trace.BadParameter("oracle configuration must be defined for a scoped token when using the oracle join method")
+		}
+	default:
+		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
+	}
+
+	return nil
+}
 
 // StrongValidateToken checks if the scoped token is well-formed according to
 // all scoped token rules. This function *must* be used to validate any scoped
@@ -89,12 +125,8 @@ func StrongValidateToken(token *joiningv1.ScopedToken) error {
 		return trace.BadParameter("scoped token assigned scope must be descendant of its resource scope")
 	}
 
-	if _, ok := joinMethodsSupportingScopes[spec.JoinMethod]; !ok {
-		return trace.BadParameter("join method %q does not support scoping", spec.JoinMethod)
-	}
-
-	if token.GetStatus().GetSecret() == "" && types.JoinMethod(spec.JoinMethod) == types.JoinMethodToken {
-		return trace.BadParameter("secret value must be defined for a scoped token when using the token join method")
+	if err := validateJoinMethod(token); err != nil {
+		return trace.Wrap(err)
 	}
 
 	switch TokenUsageMode(spec.GetUsageMode()) {
@@ -148,8 +180,8 @@ func WeakValidateToken(token *joiningv1.ScopedToken) error {
 		return trace.BadParameter("scoped token must have at least one role")
 	}
 
-	if _, ok := joinMethodsSupportingScopes[token.GetSpec().GetJoinMethod()]; !ok {
-		return trace.BadParameter("join method %q does not support scoping", token.GetSpec().GetJoinMethod())
+	if err := validateJoinMethod(token); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return nil
@@ -295,25 +327,112 @@ func (t *Token) GetAssignedScope() string {
 	return t.scoped.GetSpec().GetAssignedScope()
 }
 
+// GetSecret returns the token's secret value.
+func (t *Token) GetSecret() (string, bool) {
+	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken
+}
+
 // GetAllowRules returns the list of allow rules.
-func (t *Token) GetAllowRules() []*types.TokenRule {
-	return nil
+func (t *Token) GetAWSAllowRules() []*types.TokenRule {
+	allow := make([]*types.TokenRule, len(t.scoped.GetSpec().GetAws().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAws().GetAllow() {
+		allow[i] = &types.TokenRule{
+			AWSAccount:        rule.GetAwsAccount(),
+			AWSRegions:        rule.GetAwsRegions(),
+			AWSRole:           rule.GetAwsRole(),
+			AWSARN:            rule.GetAwsArn(),
+			AWSOrganizationID: rule.GetAwsOrganizationId(),
+		}
+	}
+
+	return allow
 }
 
 // GetAWSIIDTTL returns the TTL of EC2 IIDs
 func (t *Token) GetAWSIIDTTL() types.Duration {
-	return types.NewDuration(0)
+	ttl, err := types.ParseDuration(t.scoped.GetSpec().GetAws().GetIidTtl())
+	if err != nil {
+		// if parsing fails for any reason (including an empty value) we fallback to the 5 minute default
+		return types.Duration(5 * time.Minute)
+	}
+
+	return ttl
 }
 
 // GetIntegration returns the Integration field which is used to provide
 // credentials that will be used when validating the AWS Organization if required by an IAM Token.
 func (t *Token) GetIntegration() string {
-	return ""
+	return t.scoped.GetSpec().GetAws().GetIntegration()
 }
 
-// GetSecret returns the token's secret value.
-func (t *Token) GetSecret() (string, bool) {
-	return t.scoped.GetStatus().GetSecret(), t.GetJoinMethod() == types.JoinMethodToken
+// GetGCPRules returns the GCP-specific configuration for this token.
+func (t *Token) GetGCPRules() *types.ProvisionTokenSpecV2GCP {
+	allow := make([]*types.ProvisionTokenSpecV2GCP_Rule, len(t.scoped.GetSpec().GetGcp().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetGcp().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2GCP_Rule{
+			ProjectIDs:      rule.GetProjectIds(),
+			Locations:       rule.GetLocations(),
+			ServiceAccounts: rule.GetServiceAccounts(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2GCP{
+		Allow: allow,
+	}
+}
+
+// GetAzure returns the Azure-specific configuration for this token.
+func (t *Token) GetAzure() *types.ProvisionTokenSpecV2Azure {
+	allow := make([]*types.ProvisionTokenSpecV2Azure_Rule, len(t.scoped.GetSpec().GetAzure().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzure().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Azure_Rule{
+			Subscription:   rule.GetSubscription(),
+			ResourceGroups: rule.GetResourceGroups(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Azure{
+		Allow: allow,
+	}
+}
+
+// GetAzureDevops returns the AzureDevops-specific configuration for this token.
+func (t *Token) GetAzureDevops() *types.ProvisionTokenSpecV2AzureDevops {
+	allow := make([]*types.ProvisionTokenSpecV2AzureDevops_Rule, len(t.scoped.GetSpec().GetAzureDevops().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetAzureDevops().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2AzureDevops_Rule{
+			Sub:               rule.GetSub(),
+			ProjectName:       rule.GetProjectName(),
+			PipelineName:      rule.GetPipelineName(),
+			ProjectID:         rule.GetProjectId(),
+			DefinitionID:      rule.GetDefinitionId(),
+			RepositoryURI:     rule.GetRepositoryUri(),
+			RepositoryVersion: rule.GetRepositoryVersion(),
+			RepositoryRef:     rule.GetRepositoryRef(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2AzureDevops{
+		Allow:          allow,
+		OrganizationID: t.scoped.GetSpec().GetAzureDevops().GetOrganizationId(),
+	}
+}
+
+// GetOracle returns the Oracle-specific configuration for this token.
+func (t *Token) GetOracle() *types.ProvisionTokenSpecV2Oracle {
+	allow := make([]*types.ProvisionTokenSpecV2Oracle_Rule, len(t.scoped.GetSpec().GetOracle().GetAllow()))
+	for i, rule := range t.scoped.GetSpec().GetOracle().GetAllow() {
+		allow[i] = &types.ProvisionTokenSpecV2Oracle_Rule{
+			Tenancy:            rule.GetTenancy(),
+			ParentCompartments: rule.GetParentCompartments(),
+			Regions:            rule.GetRegions(),
+			Instances:          rule.GetInstances(),
+		}
+	}
+
+	return &types.ProvisionTokenSpecV2Oracle{
+		Allow: allow,
+	}
 }
 
 // GetScopedToken attempts to return the underlying [*joiningv1.ScopedToken] backing a

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -31,477 +31,374 @@ import (
 )
 
 func TestValidateScopedToken(t *testing.T) {
+	// baseToken contains a valid scoped token using the token join method.
+	// It's used as a base for constructing scoped tokens in various valid
+	// and invalid states.
+	baseToken := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Scope:   "/aa/bb",
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "testtoken",
+		},
+		Spec: &joiningv1.ScopedTokenSpec{
+			Roles:         []string{types.RoleNode.String()},
+			AssignedScope: "/aa/bb",
+			JoinMethod:    string(types.JoinMethodToken),
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+			ImmutableLabels: &joiningv1.ImmutableLabels{
+				Ssh: map[string]string{
+					"one":   "1",
+					"two":   "2",
+					"three": "3",
+				},
+			},
+		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret",
+		},
+	}
 	cases := []struct {
 		name              string
-		token             *joiningv1.ScopedToken
+		modFn             func(*joiningv1.ScopedToken)
 		expectedStrongErr string
 		expectedWeakErr   string
 	}{
 		{
 			name: "invalid kind",
-			token: &joiningv1.ScopedToken{
-				Version: types.V1,
-				Scope:   "/aa",
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Kind = ""
 			},
 			expectedStrongErr: fmt.Sprintf("expected kind %v, got %q", types.KindScopedToken, ""),
 		},
 		{
 			name: "invalid version",
-			token: &joiningv1.ScopedToken{
-				Kind:  types.KindScopedToken,
-				Scope: "/aa",
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Version = ""
 			},
 			expectedStrongErr: fmt.Sprintf("expected version %v, got %q", types.V1, ""),
 		},
 		{
 			name: "invalid subkind",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Version: types.V1,
-				Scope:   "/aa",
-				SubKind: "subkind",
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.SubKind = "subkind"
 			},
 			expectedStrongErr: fmt.Sprintf("expected sub_kind %v, got %q", "", "subkind"),
 		},
 		{
 			name: "missing name",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Version: types.V1,
-				Scope:   "/aa",
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Metadata.Name = ""
 			},
 			expectedStrongErr: "missing name",
 		},
 		{
 			name: "missing spec",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Version: types.V1,
-				Scope:   "/aa",
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec = nil
 			},
 			expectedStrongErr: "spec must not be nil",
 			expectedWeakErr:   "validating scoped token assigned scope",
 		},
 		{
 			name: "missing scope",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Scope = ""
 			},
 			expectedStrongErr: "scoped token must have a scope assigned",
 			expectedWeakErr:   "validating scoped token resource scope",
 		},
 		{
 			name: "non-absolute scope",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Scope = "aa/bb"
 			},
 			expectedStrongErr: "validating scoped token resource scope",
 		},
 		{
 			name: "scope with invalid characters",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb}",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Scope = "/aa/bb}"
 			},
 			expectedStrongErr: "validating scoped token resource scope",
 			expectedWeakErr:   "validating scoped token resource scope",
 		},
 		{
 			name: "missing assigned scope",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:      []string{types.RoleNode.String()},
-					JoinMethod: string(types.JoinMethodToken),
-					UsageMode:  string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.AssignedScope = ""
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
 			expectedWeakErr:   "validating scoped token assigned scope",
 		},
 		{
 			name: "non-absolute assigned scope",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "aa/bb",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.AssignedScope = "aa/bb"
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
 		},
 		{
 			name: "assigned scope with invalid character",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "aa/bb}",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.AssignedScope = "aa/bb}"
 			},
 			expectedStrongErr: "validating scoped token assigned scope",
 			expectedWeakErr:   "validating scoped token assigned scope",
 		},
 		{
 			name: "assigned scope is not descendant of token scope",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "/bb/aa",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.AssignedScope = "/bb/aa"
 			},
 			expectedStrongErr: "scoped token assigned scope must be descendant of its resource scope",
 		},
 		{
 			name: "invalid join method",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "/aa/bb",
-					JoinMethod:    string(types.JoinMethodUnspecified),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodUnspecified)
 			},
 			expectedStrongErr: fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
 			expectedWeakErr:   fmt.Sprintf("join method %q does not support scoping", types.JoinMethodUnspecified),
 		},
 		{
 			name: "missing roles",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.Roles = nil
 			},
 			expectedStrongErr: "scoped token must have at least one role",
 			expectedWeakErr:   "scoped token must have at least one role",
 		},
 		{
 			name: "invalid roles",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{"random_role"},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.Roles = []string{"random_role"}
 			},
 			expectedStrongErr: "validating scoped token roles",
 		},
 		{
 			name: "unsupported roles",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String(), types.RoleInstance.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.Roles = []string{types.RoleNode.String(), types.RoleInstance.String()}
 			},
 			expectedStrongErr: fmt.Sprintf("role %q does not support scoping", types.RoleInstance),
 		},
 		{
-			name: "no secret with token join method",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-				},
-			},
-			expectedStrongErr: "secret value must be defined for a scoped token",
-		},
-		{
 			name: "invalid usage mode",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "/aa/bb",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     "invalid",
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.UsageMode = "invalid"
 			},
 			expectedStrongErr: "scoped token mode is not supported",
 		},
-		// TODO (eriktate): add a test case for a missing secret with non-token join method once scoped
-		// tokens support other join methods
 		{
 			name: "invalid labels key",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					AssignedScope: "/aa/bb",
-					Roles:         []string{types.RoleNode.String()},
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-					ImmutableLabels: &joiningv1.ImmutableLabels{
-						Ssh: map[string]string{
-							"one":  "1",
-							"two;": "2",
-						},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.ImmutableLabels = &joiningv1.ImmutableLabels{
+					Ssh: map[string]string{
+						"one":  "1",
+						"two;": "2",
 					},
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+				}
 			},
 			expectedStrongErr: "invalid immutable label key \"two;\"",
 		},
 		{
 			name: "setting ssh labels for role other than node",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleBot.String()},
-					AssignedScope: "/aa/bb",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-					ImmutableLabels: &joiningv1.ImmutableLabels{
-						Ssh: map[string]string{
-							"one":   "1",
-							"two":   "2",
-							"three": "3",
-						},
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.Roles = []string{types.RoleBot.String()}
+				tok.Spec.ImmutableLabels = &joiningv1.ImmutableLabels{
+					Ssh: map[string]string{
+						"one":   "1",
+						"two":   "2",
+						"three": "3",
 					},
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+				}
 			},
 			expectedStrongErr: "immutable ssh labels are only supported for tokens that allow the node role",
 		},
 		{
-			name: "valid scoped token",
-			token: &joiningv1.ScopedToken{
-				Kind:    types.KindScopedToken,
-				Scope:   "/aa/bb",
-				Version: types.V1,
-				Metadata: &headerv1.Metadata{
-					Name: "testtoken",
-				},
-				Spec: &joiningv1.ScopedTokenSpec{
-					Roles:         []string{types.RoleNode.String()},
-					AssignedScope: "/aa/bb",
-					JoinMethod:    string(types.JoinMethodToken),
-					UsageMode:     string(joining.TokenUsageModeUnlimited),
-					ImmutableLabels: &joiningv1.ImmutableLabels{
-						Ssh: map[string]string{
-							"one":   "1",
-							"two":   "2",
-							"three": "3",
+			name: "no secret with token join method",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Status = nil
+			},
+			expectedStrongErr: "secret value must be defined for a scoped token when using the token join method",
+			expectedWeakErr:   "secret value must be defined for a scoped token when using the token join method",
+		},
+		{
+			name: "ec2 token without aws configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+			},
+			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+		},
+		{
+			name: "ec2 token with invalid IID TTL",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
 						},
 					},
-				},
-				Status: &joiningv1.ScopedTokenStatus{
-					Secret: "secret",
-				},
+					IidTtl: "123", // no unit specified
+				}
+			},
+			expectedStrongErr: "invalid IID TTL value",
+			expectedWeakErr:   "invalid IID TTL value",
+		},
+		{
+			name: "iam token without aws configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
+			},
+			expectedStrongErr: "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+			expectedWeakErr:   "aws configuration must be defined for a scoped token when using the ec2 or iam join methods",
+		},
+		{
+			name: "gcp token without gcp configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodGCP)
+			},
+			expectedStrongErr: "gcp configuration must be defined for a scoped token when using the gcp join method",
+			expectedWeakErr:   "gcp configuration must be defined for a scoped token when using the gcp join method",
+		},
+		{
+			name: "azure token without azure configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzure)
+			},
+			expectedStrongErr: "azure configuration must be defined for a scoped token when using the azure join method",
+			expectedWeakErr:   "azure configuration must be defined for a scoped token when using the azure join method",
+		},
+		{
+			name: "azure_devops token without azure configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
+			},
+			expectedStrongErr: "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
+			expectedWeakErr:   "azure_devops configuration must be defined for a scoped token when using the azure_devops join method",
+		},
+		{
+			name: "oracle token without oracle configuration",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodOracle)
+			},
+			expectedStrongErr: "oracle configuration must be defined for a scoped token when using the oracle join method",
+			expectedWeakErr:   "oracle configuration must be defined for a scoped token when using the oracle join method",
+		},
+		{
+			name: "valid scoped token",
+		},
+		{
+			name: "valid ec2 scoped token with TTL",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+						},
+					},
+					IidTtl: "6mo",
+				}
+			},
+		},
+		{
+			name: "valid ec2 scoped token without TTL",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodEC2)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid iam scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodIAM)
+				tok.Spec.Aws = &joiningv1.AWS{
+					Allow: []*joiningv1.AWS_Rule{
+						{
+							AwsAccount: "1234567890",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid gcp scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodGCP)
+				tok.Spec.Gcp = &joiningv1.GCP{
+					Allow: []*joiningv1.GCP_Rule{
+						{
+							ProjectIds: []string{"1234567890"},
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid azure scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzure)
+				tok.Spec.Azure = &joiningv1.Azure{
+					Allow: []*joiningv1.Azure_Rule{
+						{
+							Subscription: "1234567890",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid azure_devops scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodAzureDevops)
+				tok.Spec.AzureDevops = &joiningv1.AzureDevops{
+					Allow: []*joiningv1.AzureDevops_Rule{
+						{
+							Sub: "1234567890",
+						},
+					},
+				}
+			},
+		},
+		{
+			name: "valid oracle scoped token",
+			modFn: func(tok *joiningv1.ScopedToken) {
+				tok.Spec.JoinMethod = string(types.JoinMethodOracle)
+				tok.Spec.Oracle = &joiningv1.Oracle{
+					Allow: []*joiningv1.Oracle_Rule{
+						{
+							Tenancy: "1234567890",
+						},
+					},
+				}
 			},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := joining.StrongValidateToken(c.token)
+			tok := proto.CloneOf(baseToken)
+			if c.modFn != nil {
+				c.modFn(tok)
+			}
+			err := joining.StrongValidateToken(tok)
 			if c.expectedStrongErr == "" {
 				assert.NoError(t, err)
 			} else {
 				assert.ErrorContains(t, err, c.expectedStrongErr)
 			}
 
-			err = joining.WeakValidateToken(c.token)
+			err = joining.WeakValidateToken(tok)
 			if c.expectedWeakErr == "" {
 				assert.NoError(t, err)
 			} else {

--- a/lib/web/join_tokens.go
+++ b/lib/web/join_tokens.go
@@ -376,7 +376,7 @@ func (h *Handler) createTokenForDiscoveryHandle(w http.ResponseWriter, r *http.R
 
 		if err == nil {
 			// check if the token found has the right rules
-			if t.GetJoinMethod() != types.JoinMethodIAM || !isSameRuleSet(req.Allow, t.GetAllowRules()) {
+			if t.GetJoinMethod() != types.JoinMethodIAM || !isSameRuleSet(req.Allow, t.GetAWSAllowRules()) {
 				return nil, trace.BadParameter("failed to create token: token with name %q already exists and does not have the expected allow rules", tokenName)
 			}
 

--- a/lib/web/ui/join_token.go
+++ b/lib/web/ui/join_token.go
@@ -74,7 +74,7 @@ func MakeJoinToken(token types.ProvisionToken) (*JoinToken, error) {
 		IsStatic:      token.IsStatic(),
 		IsCloudSystem: isCloudSystem,
 		Method:        token.GetJoinMethod(),
-		Allow:         token.GetAllowRules(),
+		Allow:         token.GetAWSAllowRules(),
 		Content:       string(content[:]),
 	}
 


### PR DESCRIPTION
Backports #63215, #63703, #63303, #63304, #64026  to branch/v18

# Manual testing
All manual token creation uses `tctl create <token_file>.yml`. This is the base format:
```yaml
kind: scoped_token
metadata:
  name: <method>-token
scope: /test
spec:
  assigned_scope: /test
  join_method: <ec2|iam|gcp|azure|oracle>
  roles:
  - Node
  usage_mode: unlimited
version: v1
```
## AWS
- [x] Create a scoped token that uses the `ec2` join method  by adding (re-tested with new `iid_ttl` field):
```yaml
spec:
  aws:
    allow:
      - aws_account: "112233445566"
    iid_ttl: 3mo # your instance must have been initialized within this time
```
- [x] Create a scoped token that uses the `iam` join method by adding:
```yaml
spec:
  aws:
    allow:
      - aws_account: "112233445566"
```
- [x] Provision an EC2 node using the scoped token.
- [x] Provision an IAM node using the scoped token.
## GCP
- [x] Create a scoped token that uses the `gcp` join method by adding:
```yaml
spec:
  gcp:
    allow:
      - project_ids: ["112233445566"]
```
- [x] Provision a GCP node using the scoped token.
## Azure
- [x] Create a scoped token that uses the `azure` join method by adding:
```yaml
spec:
  azure:
    allow:
      - subscription: "112233445566"
```
- [ ] ~Create a scoped token that uses the `azure_devops` join method `tctl scoped tokens add --type node --join-method azure_devops --scope /local --assign-scope /local`~
- [x] Provision an Azure node
- [ ] ~Provision a node using Azure DevOps~
## Oracle
- [x] Create a scoped token that uses the `oracle` join method by adding:
```yaml
spec:
  oracle:
    allow:
      - tenancy: "ocid1.tenancy.....aabbccdd"
```
- [x] Provision an Oracle node using the scoped token.

In order to setup the above tests I added a minimal backport of #63455 to my test build. All tests except for `ec2` were performed in cloud