### PR TITLE
Add modules to servicecfg.Config and helpers.InstanceConfig

### DIFF
--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/authclient"
-	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/srv/discovery"
 )
@@ -136,7 +135,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 // In those situations, ambient credentials (used by the AWS SDK) will provide access to the tenant's infra, which is not desired.
 // Setting IntegrationOnlyCredentials to true, will prevent usage of the ambient credentials.
 func (process *TeleportProcess) integrationOnlyCredentials() bool {
-	return process.Config.Auth.Enabled && modules.GetModules().Features().Cloud
+	return process.Config.Auth.Enabled && process.Config.Modules.Features().Cloud
 }
 
 // buildAccessGraphFromTAGOrFallbackToAuth builds the AccessGraphConfig from the Teleport Agent configuration or falls back to the Auth server's configuration.

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -66,12 +66,14 @@ func TestTeleportProcessIntegrationsOnly(t *testing.T) {
 					Auth: servicecfg.AuthConfig{
 						Enabled: tt.inputAuthEnabled,
 					},
+					Modules: &modulestest.Modules{
+						TestBuildType: modules.BuildEnterprise,
+						TestFeatures: modules.Features{
+							Cloud: tt.inputFeatureCloud,
+						},
+					},
 				},
 			}
-
-			modulestest.SetTestModules(t, modulestest.Modules{TestFeatures: modules.Features{
-				Cloud: tt.inputFeatureCloud,
-			}})
 
 			require.Equal(t, tt.integrationOnly, p.integrationOnlyCredentials())
 		})

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1487,9 +1487,10 @@ func TestEnterpriseServicesEnabled(t *testing.T) {
 			if tt.enterprise {
 				buildType = modules.BuildEnterprise
 			}
-			modulestest.SetTestModules(t, modulestest.Modules{
+
+			tt.config.Modules = &modulestest.Modules{
 				TestBuildType: buildType,
-			})
+			}
 
 			process := &TeleportProcess{
 				Config: tt.config,

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -211,8 +212,11 @@ type Config struct {
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
 
-	// FIPS means FedRAMP/FIPS compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested via the --fips flag.
 	FIPS bool
+
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 
 	// SkipVersionCheck means the version checking between server and client
 	// will be skipped.
@@ -660,6 +664,10 @@ func ApplyDefaults(cfg *Config) {
 
 	if cfg.LoggerLevel == nil {
 		cfg.LoggerLevel = new(slog.LevelVar)
+	}
+
+	if cfg.Modules == nil {
+		cfg.Modules = modules.GetModules()
 	}
 
 	// Remove insecure and (borderline insecure) cryptographic primitives from


### PR DESCRIPTION
Before these can be consumed in OSS, the enterprise modules need to be able to both override the global modules and update the configs so that tests and builds do not break during the transition.

Contributes to https://github.com/gravitational/teleport/issues/62799.