### PR TITLE
Fix sqlite error code checks

### DIFF
--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -1081,6 +1081,7 @@ func isConstraintError(err error) bool {
 	if ok := errors.As(err, &e); !ok {
 		return false
 	}
+	// Only return true if the constraint violation is from the primary key.
 	return e.Code() == sqlite3.SQLITE_CONSTRAINT_PRIMARYKEY
 }
 
@@ -1089,7 +1090,8 @@ func isLockedError(err error) bool {
 	if ok := errors.As(err, &e); !ok {
 		return false
 	}
-	return e.Code() == sqlite3.SQLITE_BUSY
+	// Return true for busy or any extended busy errors.
+	return e.Code()&0xFF == sqlite3.SQLITE_BUSY
 }
 
 func isReadonlyError(err error) bool {
@@ -1097,5 +1099,6 @@ func isReadonlyError(err error) bool {
 	if ok := errors.As(err, &e); !ok {
 		return false
 	}
-	return e.Code() == sqlite3.SQLITE_READONLY
+	// Return true for readonly or any extended readonly errors.
+	return e.Code()&0xFF == sqlite3.SQLITE_READONLY
 }


### PR DESCRIPTION
Locked, interrupted, and read only error checks were comparing against the error code. The check should return true for the base error code _and_ any extended error codes for that class of error. This is now correctly achieved by masking the error code and comparing with the base error code.

Note: the constraint error should only return true for primary key errors as that was done prior. As such it has not been updated to use the mask and check the base error coded.