### PR TITLE
Allow GitHub login for users whose roles come exclusively from access lists

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -50,8 +50,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// ErrGithubNoTeams results from a github user not belonging to any teams.
-var ErrGithubNoTeams = trace.BadParameter("user does not belong to any teams configured in connector; the configuration may have typos.")
+// ErrGithubNoRoles is returned when a user authenticated via GitHub has no roles assigned in Teleport.
+var ErrGithubNoRoles = trace.AccessDenied("GitHub user has no Teleport-assigned roles.")
 
 // InvalidClientRedirectErrorMessage is a string added to SSO login errors
 // caused by an invalid client redirect URL; the presence of this string is
@@ -644,6 +644,10 @@ func (a *Server) ValidateGithubAuthRedirect(ctx context.Context, diagCtx *SSODia
 		return nil, trace.Wrap(err)
 	}
 
+	if len(userState.GetRoles()) == 0 {
+		return nil, trace.Wrap(ErrGithubNoRoles)
+	}
+
 	// In test flow skip signing and creating web sessions.
 	if req.SSOTestFlow {
 		diagCtx.Info.Success = true
@@ -654,8 +658,14 @@ func (a *Server) ValidateGithubAuthRedirect(ctx context.Context, diagCtx *SSODia
 		}, nil
 	}
 
+	sessionRoles, err := services.FetchRoles(userState.GetRoles(), a, userState.GetTraits())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	sessionTTL := utils.MinTTL(sessionRoles.AdjustSessionTTL(apidefaults.MaxCertDuration), params.SessionTTL)
+
 	// Auth was successful, return session, certificate, etc. to caller.
-	return a.makeGithubAuthResponse(ctx, req, userState, userResp, params.SessionTTL)
+	return a.makeGithubAuthResponse(ctx, req, userState, userResp, sessionTTL)
 }
 
 func (a *Server) makeGithubAuthResponse(
@@ -663,7 +673,8 @@ func (a *Server) makeGithubAuthResponse(
 	req *types.GithubAuthRequest,
 	userState services.UserState,
 	githubUser *GithubUserResponse,
-	sessionTTL time.Duration) (*authclient.GithubAuthResponse, error) {
+	sessionTTL time.Duration,
+) (*authclient.GithubAuthResponse, error) {
 	auth := authclient.GithubAuthResponse{
 		Req:      GithubAuthRequestFromProto(req),
 		Identity: githubUser.makeExternalIdentity(req.ConnectorID),
@@ -910,9 +921,6 @@ func (a *Server) calculateGithubUser(ctx context.Context, diagCtx *SSODiagContex
 
 	// Calculate logins, kubegroups, roles, and traits.
 	p.Roles, p.KubeGroups, p.KubeUsers = connector.MapClaims(*claims)
-	if len(p.Roles) == 0 {
-		return nil, trace.Wrap(ErrGithubNoTeams)
-	}
 	p.Traits = map[string][]string{
 		constants.TraitLogins:     {p.Username},
 		constants.TraitKubeGroups: p.KubeGroups,

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -658,6 +658,7 @@ func (a *Server) ValidateGithubAuthRedirect(ctx context.Context, diagCtx *SSODia
 		}, nil
 	}
 
+	// Fetch the roles so the session TTL can be pre-constrained in the case no GitHub role is found.
 	sessionRoles, err := services.FetchRoles(userState.GetRoles(), a, userState.GetTraits())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -37,7 +37,10 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/accesslist"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/entitlements"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/auth/authtest"
@@ -312,7 +315,7 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 
 	diagCtx := &auth.SSODiagContext{}
 
-	_, err = a.CalculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
+	params, err := a.CalculateGithubUser(ctx, diagCtx, connector, &types.GithubClaims{
 		Username: "octocat",
 		OrganizationToTeams: map[string][]string{
 			"org1": {"team1", "team2"},
@@ -320,7 +323,8 @@ func TestCalculateGithubUserNoTeams(t *testing.T) {
 		},
 		Teams: []string{"team1", "team2", "team1"},
 	}, &types.GithubAuthRequest{})
-	require.ErrorIs(t, err, auth.ErrGithubNoTeams)
+	require.NoError(t, err)
+	require.Empty(t, params.Roles)
 }
 
 // Test that calculateGithubUser calls the login rule evaluator, evaluated
@@ -617,6 +621,329 @@ func TestBuildAPIEndpoint(t *testing.T) {
 			got, err := auth.BuildAPIEndpoint(tt.input)
 			require.NoError(t, err)
 			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGithubUserRoleMappingCombinations(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity: {Enabled: true},
+			},
+		},
+	})
+
+	ctx := t.Context()
+	tt := setupGithubContext(t)
+
+	accessRole, err := types.NewRole("access", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	_, err = tt.a.CreateRole(ctx, accessRole)
+	require.NoError(t, err)
+
+	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
+		TeamsToRoles: []types.TeamRolesMapping{{
+			Organization: "org1",
+			Team:         "teamx",
+			Roles:        []string{"access"},
+		}},
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		testName  string
+		claims    *types.GithubClaims
+		setup     func(t *testing.T, username string)
+		assertion func(t *testing.T, userState services.UserState, err error)
+	}{
+		{
+			testName: "SSO role mapping and access list role mapping",
+			claims: &types.GithubClaims{
+				Username:            "testuser1",
+				OrganizationToTeams: map[string][]string{"org1": {"teamx"}},
+				Teams:               []string{"teamx"},
+			},
+			setup: func(t *testing.T, username string) {
+				acl, err := accesslist.NewAccessList(
+					header.Metadata{Name: "test-acl-user1"},
+					accesslist.Spec{
+						Title:              "title",
+						Owners:             []accesslist.Owner{{Name: "owner"}},
+						Audit:              accesslist.Audit{NextAuditDate: time.Now().Add(24 * time.Hour)},
+						MembershipRequires: accesslist.Requires{},
+						OwnershipRequires:  accesslist.Requires{},
+						Grants:             accesslist.Grants{Roles: []string{"access"}},
+					},
+				)
+				require.NoError(t, err)
+
+				member, err := accesslist.NewAccessListMember(
+					header.Metadata{Name: username},
+					accesslist.AccessListMemberSpec{
+						AccessList: acl.GetName(),
+						Name:       username,
+						Joined:     time.Now(),
+						Expires:    time.Now().Add(24 * time.Hour),
+						Reason:     "test",
+						AddedBy:    "admin",
+					},
+				)
+				require.NoError(t, err)
+
+				_, _, err = tt.a.UpsertAccessListWithMembers(ctx, acl, []*accesslist.AccessListMember{member})
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					tt.a.DeleteAccessList(ctx, acl.GetName())
+				})
+			},
+			assertion: func(t *testing.T, userState services.UserState, err error) {
+				require.NoError(t, err)
+				require.Contains(t, userState.GetRoles(), "access")
+			},
+		},
+		{
+			testName: "SSO role mapping and no access list role mapping",
+			claims: &types.GithubClaims{
+				Username:            "testuser2",
+				OrganizationToTeams: map[string][]string{"org1": {"teamx"}},
+				Teams:               []string{"teamx"},
+			},
+			assertion: func(t *testing.T, userState services.UserState, err error) {
+				require.NoError(t, err)
+				require.Contains(t, userState.GetRoles(), "access")
+			},
+		},
+		{
+			testName: "no SSO role mapping and access list role mapping",
+			claims: &types.GithubClaims{
+				Username:            "testuser3",
+				OrganizationToTeams: map[string][]string{"org1": {"other-team"}},
+				Teams:               []string{"other-team"},
+			},
+			setup: func(t *testing.T, username string) {
+				acl, err := accesslist.NewAccessList(
+					header.Metadata{Name: "test-acl-user3"},
+					accesslist.Spec{
+						Title:  "title",
+						Owners: []accesslist.Owner{{Name: "owner"}},
+						Audit: accesslist.Audit{
+							NextAuditDate: time.Now().Add(365 * 24 * time.Hour),
+						},
+						MembershipRequires: accesslist.Requires{},
+						OwnershipRequires:  accesslist.Requires{},
+						Grants:             accesslist.Grants{Roles: []string{"access"}},
+					},
+				)
+				require.NoError(t, err)
+				member, err := accesslist.NewAccessListMember(
+					header.Metadata{Name: username},
+					accesslist.AccessListMemberSpec{
+						AccessList: acl.GetName(),
+						Name:       username,
+						Joined:     time.Now(),
+						Expires:    time.Now().Add(24 * time.Hour),
+						Reason:     "test",
+						AddedBy:    "admin",
+					},
+				)
+				require.NoError(t, err)
+
+				_, _, err = tt.a.UpsertAccessListWithMembers(ctx, acl, []*accesslist.AccessListMember{member})
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					tt.a.DeleteAccessList(ctx, acl.GetName())
+				})
+			},
+			assertion: func(t *testing.T, userState services.UserState, err error) {
+				require.NoError(t, err)
+				require.Contains(t, userState.GetRoles(), "access")
+			},
+		},
+		{
+			testName: "no SSO role mapping and no access list role mapping",
+			claims: &types.GithubClaims{
+				Username:            "testuser4",
+				OrganizationToTeams: map[string][]string{"org1": {"other-team"}},
+				Teams:               []string{"other-team"},
+			},
+			assertion: func(t *testing.T, userState services.UserState, err error) {
+				require.NoError(t, err)
+				require.Empty(t, userState.GetRoles())
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			diagCtx := &auth.SSODiagContext{}
+
+			params, err := tt.a.CalculateGithubUser(
+				ctx,
+				diagCtx,
+				connector,
+				test.claims,
+				&types.GithubAuthRequest{},
+			)
+			require.NoError(t, err)
+
+			user, err := tt.a.CreateGithubUser(ctx, params, false)
+			require.NoError(t, err)
+
+			if test.setup != nil {
+				test.setup(t, user.GetName())
+			}
+
+			require.NoError(t, tt.a.CallLoginHooks(ctx, user))
+
+			userState, err := tt.a.GetUserOrLoginState(ctx, user.GetName())
+
+			test.assertion(t, userState, err)
+		})
+	}
+}
+
+func TestGithubCallbackRoleValidation(t *testing.T) {
+	modulestest.SetTestModules(t, modulestest.Modules{
+		TestBuildType: modules.BuildEnterprise,
+		TestFeatures: modules.Features{
+			Entitlements: map[entitlements.EntitlementKind]modules.EntitlementInfo{
+				entitlements.Identity: {Enabled: true},
+			},
+		},
+	})
+
+	srv := newTestTLSServer(t)
+	ctx := context.Background()
+
+	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
+		ClientID:     "test-client-id",
+		ClientSecret: "test-client-secret",
+		RedirectURL:  "https://example.com/v1/webapi/github/callback",
+		Display:      "Sign in with GitHub",
+		TeamsToRoles: []types.TeamRolesMapping{
+			{
+				Organization: "org1",
+				Team:         "teamx",
+				Roles:        []string{"access"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	a := srv.Auth()
+	a.GithubUserAndTeamsOverride = func() (*auth.GithubUserResponse, []auth.GithubTeamResponse, error) {
+		return &auth.GithubUserResponse{
+				Login: "testuser1",
+			}, []auth.GithubTeamResponse{{
+				Name: "other-team",
+				Slug: "other-team",
+				Org:  auth.GithubOrgResponse{Login: "org1"},
+			}}, nil
+	}
+
+	_, err = auth.UpsertGithubConnector(ctx, a, connector)
+	require.NoError(t, err)
+
+	_, err = authtest.CreateRole(ctx, a, "access", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			// MaxSessionTTL less than default MinCertDuration to ensure session
+			// duration in constrained.
+			MaxSessionTTL: types.Duration(defaults.MinCertDuration / 2),
+		},
+	})
+	require.NoError(t, err)
+
+	proxyClient, err := srv.NewClient(authtest.TestBuiltin(types.RoleProxy))
+	require.NoError(t, err)
+
+	tests := []struct {
+		testName         string
+		createWebSession bool
+		setup            func(t *testing.T)
+		assertion        func(t *testing.T, resp *authclient.GithubAuthResponse, userState services.UserState, err error)
+	}{
+		{
+			testName: "user with no roles",
+			assertion: func(t *testing.T, resp *authclient.GithubAuthResponse, userState services.UserState, err error) {
+				require.Nil(t, resp)
+				require.Empty(t, userState.GetRoles())
+				require.ErrorIs(t, err, auth.ErrGithubNoRoles)
+			},
+		},
+		{
+			testName:         "user with roles from ACL",
+			createWebSession: true,
+			setup: func(t *testing.T) {
+				acl, err := accesslist.NewAccessList(
+					header.Metadata{Name: "test-acl-user1"},
+					accesslist.Spec{
+						Title:              "title",
+						Owners:             []accesslist.Owner{{Name: "owner"}},
+						Audit:              accesslist.Audit{NextAuditDate: time.Now().Add(24 * time.Hour)},
+						MembershipRequires: accesslist.Requires{},
+						OwnershipRequires:  accesslist.Requires{},
+						Grants:             accesslist.Grants{Roles: []string{"access"}},
+					},
+				)
+				require.NoError(t, err)
+
+				member, err := accesslist.NewAccessListMember(
+					header.Metadata{Name: "testuser1"},
+					accesslist.AccessListMemberSpec{
+						AccessList: acl.GetName(),
+						Name:       "testuser1",
+						Joined:     time.Now(),
+						Expires:    time.Now().Add(24 * time.Hour),
+						Reason:     "test",
+						AddedBy:    "admin",
+					},
+				)
+				require.NoError(t, err)
+
+				_, _, err = a.UpsertAccessListWithMembers(ctx, acl, []*accesslist.AccessListMember{member})
+				require.NoError(t, err)
+
+				t.Cleanup(func() {
+					a.DeleteAccessList(ctx, acl.GetName())
+				})
+			},
+			assertion: func(t *testing.T, resp *authclient.GithubAuthResponse, userState services.UserState, err error) {
+				require.NotNil(t, resp)
+				require.NoError(t, err)
+				require.Contains(t, userState.GetRoles(), "access")
+				require.WithinDuration(t, time.Now().Add(defaults.MinCertDuration/2), resp.Session.GetExpiryTime(), time.Second*5)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			req, err := proxyClient.CreateGithubAuthRequest(ctx, types.GithubAuthRequest{
+				ConnectorID:      connector.GetName(),
+				Type:             constants.Github,
+				CertTTL:          defaults.MinCertDuration,
+				CreateWebSession: tt.createWebSession,
+			})
+			require.NoError(t, err)
+
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			resp, err := proxyClient.ValidateGithubAuthCallback(ctx, url.Values{
+				"code":  []string{"test-code"},
+				"state": []string{req.StateToken},
+			})
+
+			userState, userErr := a.GetUserOrLoginState(ctx, "testuser1")
+			require.NoError(t, userErr)
+
+			tt.assertion(t, resp, userState, err)
 		})
 	}
 }

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -65,6 +65,8 @@ type githubContext struct {
 	c           *clockwork.FakeClock
 }
 
+// TODO(nixpig): Refactor to avoid using global modules.
+// See: https://github.com/gravitational/teleport/pull/63829#discussion_r3646729631
 func setupGithubContext(t *testing.T) *githubContext {
 	var tt githubContext
 	t.Cleanup(func() { tt.Close() })
@@ -818,7 +820,7 @@ func TestGithubCallbackRoleValidation(t *testing.T) {
 	})
 
 	srv := newTestTLSServer(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	connector, err := types.NewGithubConnector("github", types.GithubConnectorSpecV3{
 		ClientID:     "test-client-id",

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2569,7 +2569,7 @@ func (h *Handler) githubCallback(w http.ResponseWriter, r *http.Request, p httpr
 				}
 			}
 		}
-		if errors.Is(err, auth.ErrGithubNoTeams) {
+		if errors.Is(err, auth.ErrGithubNoRoles) {
 			return sso.LoginFailedUnauthorizedRedirectURL
 		}
 

--- a/web/packages/teleport/src/Login/LoginFailed.test.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.test.tsx
@@ -56,7 +56,7 @@ test('unauthorized error path shows unauthorized error', () => {
   );
   expect(
     screen.getByText(
-      'You are not authorized, please contact your SSO administrator.'
+      'You are not authorized. Please contact your Teleport administrator.'
     )
   ).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Login/LoginFailed.tsx
+++ b/web/packages/teleport/src/Login/LoginFailed.tsx
@@ -32,7 +32,7 @@ export function LoginFailed() {
         <LoginFailedComponent message="Unable to process SSO callback. The connector has a mapping to a role that does not exist. Please contact your SSO administrator." />
       </Route>
       <Route path={cfg.routes.loginErrorUnauthorized}>
-        <LoginFailedComponent message="You are not authorized, please contact your SSO administrator." />
+        <LoginFailedComponent message="You are not authorized. Please contact your Teleport administrator." />
       </Route>
       <Route path={cfg.routes.loginErrorEntraIDGroupsOverage}>
         <LoginFailedComponent message="Your account is a member of more than 150 Entra ID groups. Please contact your SSO administrator to configure Graph API access on the Teleport SAML connector." />


### PR DESCRIPTION
Users authenticating using GitHub who had no roles mapped from `teams_to_roles` mapping (but who would have had roles granted by access lists) were unable to login due to the 'zero roles' check happening immediately after authenticating.

This PR moves the 'zero roles' check to later in the flow after access lists have been evaluated. The error returned and the message displayed in the UI have also been updated to reflect that the failed authorization is due to missing roles in Teleport, rather than a potential GitHub connector misconfiguration. 

This is a prerequisite to relaxing the rules on creating GitHub connector without `teams_to_roles` mapping, which will come in a separate PR.

See: [RFD 0248 - Allow SSO login without connector-mapped roles](https://github.com/gravitational/rfd/blob/main/rfd/0248-sso-connector-without-role-mapping.md)

changelog: allow GitHub SSO login with only Teleport-assigned roles

## Manual Test Plan
### Test Environment

Local build deployed to cloud environment: https://jwardtest19.cloud.gravitational.io
Configured with GitHub SSO.

### Test Cases
- [x] User is able to login using GitHub SSO with roles from Teleport and no roles mapped from GitHub teams
- [x] User is able to login using GitHub SSO with no roles from Teleport and roles mapped from GitHub teams
- [x] User is able to login using GitHub SSO with roles from Teleport and roles mapped from GitHub teams
- [x] User is not authorised to login using GitHub SSO with no roles from Teleport and no roles mapped from GitHub teams
- [x] Session TTL is constrained by roles from Teleport when no roles granted by GitHub role mapping

