### PR TITLE
Add basic DynamoDB backend stream UT tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -117,6 +117,8 @@ linters:
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/gravitational/teleport/lib/utils/mcptest
               desc: testing packages should not be imported outside of _test.go files
+            - pkg: github.com/gravitational/teleport/lib/backend/dynamo/dynamodbtest
+              desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/testcontainers/testcontainers-go
               desc: testing packages should not be imported outside of _test.go files
             - pkg: github.com/testcontainers/testcontainers-go/modules/postgres

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -105,6 +105,9 @@ type Config struct {
 	EnableContinuousBackups bool `json:"continuous_backups,omitempty"`
 	// EnableAutoScaling is used to enable auto scaling policy.
 	EnableAutoScaling bool `json:"auto_scaling,omitempty"`
+	// HTTPClient is an optional HTTP client to use for AWS API calls.
+	// If not provided, a default client will be created.
+	HTTPClient *http.Client `json:"-"`
 }
 
 type billingMode string
@@ -141,7 +144,15 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	if cfg.RetryPeriod == 0 {
 		cfg.RetryPeriod = defaults.HighResPollingPeriod
 	}
-
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				MaxIdleConns:        defaults.HTTPMaxIdleConns,
+				MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
+			},
+		}
+	}
 	return nil
 }
 
@@ -235,15 +246,21 @@ var _ backend.Backend = &Backend{}
 // New returns new instance of DynamoDB backend.
 // It's an implementation of backend API's NewFunc
 func New(ctx context.Context, params backend.Params) (*Backend, error) {
-	l := slog.With(teleport.ComponentKey, BackendName)
-
 	var cfg *Config
 	if err := utils.ObjectToStruct(params, &cfg); err != nil {
 		return nil, trace.BadParameter("DynamoDB configuration is invalid: %v", err)
 	}
+	b, err := NewFromConfig(ctx, cfg)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return b, nil
+}
 
+// NewFromConfig returns new instance of DynamoDB backend based on provided Config struct.
+func NewFromConfig(ctx context.Context, cfg *Config) (*Backend, error) {
+	l := slog.With(teleport.ComponentKey, BackendName)
 	defer l.DebugContext(ctx, "AWS session is created.")
-
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -252,13 +269,7 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 
 	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(cfg.Region),
-		config.WithHTTPClient(&http.Client{
-			Transport: &http.Transport{
-				Proxy:               http.ProxyFromEnvironment,
-				MaxIdleConns:        defaults.HTTPMaxIdleConns,
-				MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
-			},
-		}),
+		config.WithHTTPClient(cfg.HTTPClient),
 		config.WithAPIOptions(awsmetrics.MetricsMiddleware()),
 		config.WithAPIOptions(dynamometrics.MetricsMiddleware(dynamometrics.Backend)),
 	}

--- a/lib/backend/dynamo/dynamodbtest/server.go
+++ b/lib/backend/dynamo/dynamodbtest/server.go
@@ -1,0 +1,95 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dynamodbtest
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// StreamARN is a constant ARN used for the mock stream.
+var StreamARN = "arn:aws:dynamodb:us-east-1:123456789012:table/TableName/stream/2025-02-12T12:00:00.000"
+
+// Server is a basic mock DynamoDB server.
+type Server struct {
+	mu           sync.RWMutex
+	streamArn    string
+	shardManager shardManager
+	tableName    string
+	Mux          *http.ServeMux
+}
+
+// NewMockDynamoDBServer creates a new mock DynamoDB server.
+func NewMockDynamoDBServer() *Server {
+	initialShardID := "shardId-" + uuid.NewString()
+	m := &Server{
+		tableName: "TableName",
+		streamArn: StreamARN,
+		shardManager: shardManager{
+			shards: make(map[string]*Shard),
+		},
+	}
+	m.shardManager.shards[initialShardID] = &Shard{
+		ID:                     initialShardID,
+		StartingSequenceNumber: 1,
+		Records:                make([]Item, 0),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", m.handleRequest)
+	m.Mux = mux
+	return m
+}
+
+type ShardState map[string]*Shard
+
+// SetShardState allows tests to directly set the Shard manager state.
+func (m *Server) SetShardState(shards ShardState) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shardManager.shards = shards
+}
+
+// UpsertShard adds or replaces a single shard.
+func (m *Server) UpsertShard(shard *Shard) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shardManager.shards[shard.ID] = shard
+}
+
+// AddRecord appends a stream record to an existing shard.
+func (m *Server) AddRecord(shardID string, record Item) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	shard := m.shardManager.shards[shardID]
+	shard.Records = append(shard.Records, record)
+}
+
+// CloseShard marks a shard as closed, setting the ending sequence number to
+// the last record's sequence number.
+func (m *Server) CloseShard(shardID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	shard := m.shardManager.shards[shardID]
+	shard.IsClosed = true
+	endingSeqNum := shard.getLastSequenceNumber()
+	shard.EndingSequenceNum = &endingSeqNum
+}

--- a/lib/backend/dynamo/dynamodbtest/shard.go
+++ b/lib/backend/dynamo/dynamodbtest/shard.go
@@ -1,0 +1,165 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dynamodbtest
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	streamtypes "github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
+	"github.com/google/uuid"
+)
+
+// CreateStreamRecord creates a DynamoDB stream record for testing.
+func CreateStreamRecord(itemName string, seqNum int64) Item {
+	return Item{
+		"eventID":   uuid.NewString(),
+		"eventName": "INSERT",
+		"dynamodb": map[string]any{
+			"Keys": map[string]any{
+				"FullPath": map[string]any{
+					"S": "teleport/test/" + itemName,
+				},
+			},
+			"NewImage": map[string]any{
+				"HashKey": map[string]any{"S": "teleport"},
+				"FullPath": map[string]any{
+					"S": "teleport/test/" + itemName,
+				},
+				"Value": map[string]any{
+					"B": base64.StdEncoding.EncodeToString([]byte("test-value")),
+				},
+			},
+			"SequenceNumber":              fmt.Sprintf("%d", seqNum),
+			"StreamViewType":              "NEW_IMAGE",
+			"ApproximateCreationDateTime": float64(time.Now().Unix()),
+		},
+	}
+}
+
+// Item represents a DynamoDB stream record
+type Item map[string]any
+
+// getSequenceNumber extracts the sequence number from a DynamoDB stream record.
+// Returns 0 if the sequence number cannot be extracted.
+func (item Item) getSequenceNumber() int64 {
+	dynamodbField := item["dynamodb"]
+
+	var dynamodb map[string]any
+	switch v := dynamodbField.(type) {
+	case Item:
+		dynamodb = v
+	case map[string]any:
+		dynamodb = v
+	default:
+		return 0
+	}
+
+	if seqStr, ok := dynamodb["SequenceNumber"].(string); ok {
+		seqNum, err := strconv.ParseInt(seqStr, 10, 64)
+		if err != nil {
+			panic(err)
+		}
+		return seqNum
+	}
+
+	return 0
+}
+
+// Shard represents a DynamoDB Stream Shard
+type Shard struct {
+	ID                     string
+	Records                []Item
+	StartingSequenceNumber int64
+	ParentShardID          string
+	EndingSequenceNum      *int64
+	IsClosed               bool // When true, GetRecords will return nil NextShardIterator
+}
+
+// getLastSequenceNumber returns the sequence number of the last assigned record.
+// Returns StartingSequenceNumber - 1 if no records have been assigned yet.
+func (s *Shard) getLastSequenceNumber() int64 {
+	if len(s.Records) == 0 {
+		return s.StartingSequenceNumber - 1
+	}
+
+	if seqNum := s.Records[len(s.Records)-1].getSequenceNumber(); seqNum > 0 {
+		return seqNum
+	}
+
+	return s.StartingSequenceNumber - 1
+}
+
+// shardManager manages DynamoDB Stream shards
+type shardManager struct {
+	shards map[string]*Shard
+}
+
+// encodeShardIterator creates an iterator string from iterator info
+func encodeShardIterator(info shardIteratorInfo) string {
+	return fmt.Sprintf("%s:%s:%d:%s", info.ShardID, info.IteratorType, info.SequenceNumber, uuid.NewString())
+}
+
+// decodeShardIterator parses an iterator string
+func decodeShardIterator(iterator string) (shardIteratorInfo, error) {
+	parts := strings.Split(iterator, ":")
+	if len(parts) != 4 {
+		return shardIteratorInfo{}, fmt.Errorf("invalid iterator format")
+	}
+
+	var parsedSeqNum int64
+	_, err := fmt.Sscanf(parts[2], "%d", &parsedSeqNum)
+	if err != nil && parts[1] != string(streamtypes.ShardIteratorTypeTrimHorizon) && parts[1] != string(streamtypes.ShardIteratorTypeLatest) {
+		return shardIteratorInfo{}, fmt.Errorf("invalid sequence number in iterator")
+	}
+
+	return shardIteratorInfo{
+		ShardID:        parts[0],
+		IteratorType:   streamtypes.ShardIteratorType(parts[1]),
+		SequenceNumber: parsedSeqNum,
+	}, nil
+}
+
+// shardIteratorInfo encodes information about where to start reading from a Shard
+type shardIteratorInfo struct {
+	ShardID      string
+	IteratorType streamtypes.ShardIteratorType
+	// SequenceNumber is record serries number used for AT_SEQUENCE_NUMBER and AFTER_SEQUENCE_NUMBER
+	SequenceNumber int64
+}
+
+// filterRecordsFromSequence filters Records based on sequence number
+func (m *Server) filterRecordsFromSequence(records []Item, seqNum int64, inclusive bool) []Item {
+	result := make([]Item, 0)
+	for _, record := range records {
+		recordSeq := record.getSequenceNumber()
+		if recordSeq == 0 {
+			continue
+		}
+		if inclusive && recordSeq >= seqNum {
+			result = append(result, record)
+		} else if !inclusive && recordSeq > seqNum {
+			result = append(result, record)
+		}
+	}
+	return result
+}

--- a/lib/backend/dynamo/dynamodbtest/web_handler.go
+++ b/lib/backend/dynamo/dynamodbtest/web_handler.go
@@ -1,0 +1,313 @@
+/*
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dynamodbtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	streamtypes "github.com/aws/aws-sdk-go-v2/service/dynamodbstreams/types"
+)
+
+const (
+	tabelAPIPrefix   = "DynamoDB_20120810."
+	streamsAPIPrefix = "DynamoDBStreams_20120810."
+)
+
+// handleRequest routes requests to the appropriate handler based on the X-Amz-Target header.
+func (m *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
+	target := r.Header.Get("X-Amz-Target")
+
+	switch {
+	case strings.HasPrefix(target, tabelAPIPrefix):
+		m.handleDynamoDBRequest(w, r, strings.TrimPrefix(target, tabelAPIPrefix))
+	case strings.HasPrefix(target, streamsAPIPrefix):
+		m.handleStreamsRequest(w, r, strings.TrimPrefix(target, streamsAPIPrefix))
+	default:
+		http.Error(w, "Unknown target", http.StatusBadRequest)
+	}
+}
+
+// handleDynamoDBRequest handles DynamoDB API requests.
+func (m *Server) handleDynamoDBRequest(w http.ResponseWriter, r *http.Request, operation string) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch operation {
+	case "DescribeTable":
+		m.handleDescribeTable(w, body)
+	case "CreateTable":
+		m.handleCreateTable(w, body)
+	case "DescribeTimeToLive":
+		m.handleDescribeTimeToLive(w, body)
+	default:
+		http.Error(w, "Unsupported operation", http.StatusNotImplemented)
+	}
+}
+
+// handleStreamsRequest handles DynamoDB Streams API requests.
+func (m *Server) handleStreamsRequest(w http.ResponseWriter, r *http.Request, operation string) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch operation {
+	case "DescribeStream":
+		m.handleDescribeStream(w, body)
+	case "GetShardIterator":
+		m.handleGetShardIterator(w, body)
+	case "GetRecords":
+		m.handleGetRecords(w, body)
+	default:
+		http.Error(w, "Unsupported operation", http.StatusNotImplemented)
+	}
+}
+
+// handleDescribeTable handles DescribeTable requests.
+func (m *Server) handleDescribeTable(w http.ResponseWriter, body []byte) {
+	m.writeResponse(w, map[string]any{
+		"Table": map[string]any{
+			"TableName":       m.tableName,
+			"TableStatus":     "ACTIVE",
+			"LatestStreamArn": m.streamArn,
+			"AttributeDefinitions": []map[string]string{
+				{"AttributeName": "HashKey", "AttributeType": "S"},
+				{"AttributeName": "FullPath", "AttributeType": "S"},
+			},
+			"StreamSpecification": map[string]any{
+				"StreamEnabled":  true,
+				"StreamViewType": "NEW_IMAGE",
+			},
+		},
+	})
+}
+
+// handleCreateTable handles CreateTable requests.
+func (m *Server) handleCreateTable(w http.ResponseWriter, body []byte) {
+	m.writeResponse(w, map[string]any{
+		"TableDescription": map[string]any{
+			"TableName":   m.tableName,
+			"TableStatus": "ACTIVE",
+		},
+	})
+}
+
+func (m *Server) handleDescribeTimeToLive(w http.ResponseWriter, body []byte) {
+	m.writeResponse(w, map[string]any{
+		"TimeToLiveDescription": map[string]any{
+			"TimeToLiveStatus": "ENABLED",
+			"AttributeName":    "Expires",
+		},
+	})
+}
+
+func (m *Server) handleDescribeStream(w http.ResponseWriter, body []byte) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	// Build list of all shards (both active and closed)
+	shards := make([]map[string]any, 0, len(m.shardManager.shards))
+	for shardID, shard := range m.shardManager.shards {
+		shardInfo := map[string]any{
+			"ShardId": shardID,
+		}
+
+		// Add parent Shard ID if this is a child Shard
+		if shard.ParentShardID != "" {
+			shardInfo["ParentShardId"] = shard.ParentShardID
+		}
+
+		seqRange := map[string]any{}
+		if shard.EndingSequenceNum != nil {
+			seqRange["EndingSequenceNumber"] = fmt.Sprintf("%d", *shard.EndingSequenceNum)
+		}
+		shardInfo["SequenceNumberRange"] = seqRange
+
+		shards = append(shards, shardInfo)
+	}
+
+	m.writeResponse(w, map[string]any{
+		"StreamDescription": map[string]any{
+			"StreamArn":    m.streamArn,
+			"StreamStatus": "ENABLED",
+			"Shards":       shards,
+		},
+	})
+}
+
+func (m *Server) writeError(w http.ResponseWriter, errorType, message string) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.WriteHeader(http.StatusBadRequest)
+	resp := map[string]string{
+		"__type":  errorType,
+		"message": message,
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		panic(err)
+	}
+}
+
+func (m *Server) writeResponse(w http.ResponseWriter, data any) {
+	w.Header().Set("Content-Type", "application/x-amz-json-1.0")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		panic(err)
+	}
+}
+
+func (m *Server) handleGetShardIterator(w http.ResponseWriter, body []byte) {
+	var req struct {
+		ShardID           string  `json:"ShardId"`
+		ShardIteratorType string  `json:"ShardIteratorType"`
+		SequenceNumber    *string `json:"SequenceNumber,omitempty"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		m.writeError(w, "ValidationException", err.Error())
+		return
+	}
+
+	m.mu.RLock()
+	shard, exists := m.shardManager.shards[req.ShardID]
+	m.mu.RUnlock()
+
+	if !exists {
+		m.writeError(w, "ResourceNotFoundException", fmt.Sprintf("Shard %s not found", req.ShardID))
+		return
+	}
+
+	// Parse sequence number if provided
+	var seqNum int64
+	if req.SequenceNumber != nil {
+		fmt.Sscanf(*req.SequenceNumber, "%d", &seqNum)
+	}
+
+	// For LATEST, position after all existing records
+	// Only records added AFTER the iterator is created will be returned
+	if req.ShardIteratorType == string(streamtypes.ShardIteratorTypeLatest) {
+		m.mu.RLock()
+		seqNum = shard.getLastSequenceNumber()
+		m.mu.RUnlock()
+	}
+
+	iteratorInfo := shardIteratorInfo{
+		ShardID:        req.ShardID,
+		IteratorType:   streamtypes.ShardIteratorType(req.ShardIteratorType),
+		SequenceNumber: seqNum,
+	}
+
+	iterator := encodeShardIterator(iteratorInfo)
+
+	m.writeResponse(w, map[string]any{
+		"ShardIterator": iterator,
+	})
+}
+
+func (m *Server) handleGetRecords(w http.ResponseWriter, body []byte) {
+	var req struct {
+		ShardIterator string `json:"ShardIterator"`
+	}
+
+	if err := json.Unmarshal(body, &req); err != nil {
+		m.writeError(w, "ValidationException", err.Error())
+		return
+	}
+
+	// Parse iterator
+	iteratorInfo, err := decodeShardIterator(req.ShardIterator)
+	if err != nil {
+		m.writeError(w, "ValidationException", "Invalid Shard iterator format")
+		return
+	}
+
+	m.mu.Lock()
+	shard, exists := m.shardManager.shards[iteratorInfo.ShardID]
+	if !exists {
+		m.mu.Unlock()
+		m.writeError(w, "ResourceNotFoundException", fmt.Sprintf("Shard %s not found", iteratorInfo.ShardID))
+		return
+	}
+
+	// Filter Records based on iterator type
+	var recordsToReturn []Item
+
+	switch iteratorInfo.IteratorType {
+	case streamtypes.ShardIteratorTypeTrimHorizon:
+		recordsToReturn = make([]Item, len(shard.Records))
+		copy(recordsToReturn, shard.Records)
+
+	case streamtypes.ShardIteratorTypeLatest:
+		recordsToReturn = m.filterRecordsFromSequence(shard.Records, iteratorInfo.SequenceNumber, false)
+
+	case streamtypes.ShardIteratorTypeAtSequenceNumber:
+		recordsToReturn = m.filterRecordsFromSequence(shard.Records, iteratorInfo.SequenceNumber, true)
+
+	case streamtypes.ShardIteratorTypeAfterSequenceNumber:
+		recordsToReturn = m.filterRecordsFromSequence(shard.Records, iteratorInfo.SequenceNumber, false)
+	default:
+		panic("iterator type is required")
+	}
+
+	newSeqNum := iteratorInfo.SequenceNumber
+	if len(recordsToReturn) > 0 {
+		if lastRecord := recordsToReturn[len(recordsToReturn)-1]; lastRecord != nil {
+			if seqNum := lastRecord.getSequenceNumber(); seqNum > 0 {
+				newSeqNum = seqNum
+			}
+		}
+	} else if iteratorInfo.IteratorType == streamtypes.ShardIteratorTypeLatest {
+		// For LATEST with no Records, update to last sequence
+		newSeqNum = shard.getLastSequenceNumber()
+	}
+
+	m.mu.Unlock()
+
+	// Generate next iterator - continue from where we left off
+	// TRIM_HORIZON and LATEST only apply to the initial iterator position.
+	// NextShardIterator should continue sequentially from the last returned record.
+	nextIteratorType := iteratorInfo.IteratorType
+	if iteratorInfo.IteratorType == streamtypes.ShardIteratorTypeTrimHorizon || iteratorInfo.IteratorType == streamtypes.ShardIteratorTypeLatest {
+		nextIteratorType = streamtypes.ShardIteratorTypeAfterSequenceNumber
+	}
+
+	response := map[string]any{
+		"Records": recordsToReturn,
+	}
+
+	// Only include NextShardIterator if the shard is not closed
+	if !shard.IsClosed {
+		nextIteratorInfo := shardIteratorInfo{
+			ShardID:        iteratorInfo.ShardID,
+			IteratorType:   nextIteratorType,
+			SequenceNumber: newSeqNum,
+		}
+		nextIterator := encodeShardIterator(nextIteratorInfo)
+		response["NextShardIterator"] = nextIterator
+	}
+
+	m.writeResponse(w, response)
+}

--- a/lib/backend/dynamo/stream_test.go
+++ b/lib/backend/dynamo/stream_test.go
@@ -1,0 +1,139 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dynamo_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/dynamo"
+	"github.com/gravitational/teleport/lib/backend/dynamo/dynamodbtest"
+)
+
+func TestStream(t *testing.T) {
+	t.Parallel()
+	mockServer := dynamodbtest.NewMockDynamoDBServer()
+	b := newTestBackend(t, mockServer)
+	w := newTestWatcher(t, b)
+
+	mockServer.SetShardState(dynamodbtest.ShardState{
+		"shard-1": {ID: "shard-1", StartingSequenceNumber: 1},
+	})
+	waitForWatcherInit(t, w)
+
+	t.Run("receives record added to existing shard", func(t *testing.T) {
+		mockServer.AddRecord("shard-1", dynamodbtest.CreateStreamRecord("item1", 1))
+		waitForEvent(t, w, "item1")
+	})
+
+	t.Run("receives many records", func(t *testing.T) {
+		mockServer.AddRecord("shard-1", dynamodbtest.CreateStreamRecord("item2", 2))
+		mockServer.AddRecord("shard-1", dynamodbtest.CreateStreamRecord("item3", 3))
+		waitForEvent(t, w, "item2")
+		waitForEvent(t, w, "item3")
+		ensureNoEvents(t, w)
+	})
+
+	t.Run("shard discovery after parent shard closed", func(t *testing.T) {
+		// TODO(smallinsky) Fix the underlying issue and enable this test.
+		t.Skip("Skipping due to bug where LATEST iterator omits the records from the new shard")
+
+		mockServer.UpsertShard(&dynamodbtest.Shard{
+			ID:                     "shard-2",
+			StartingSequenceNumber: 3,
+			ParentShardID:          "shard-1",
+		})
+		mockServer.CloseShard("shard-1")
+		mockServer.AddRecord("shard-2", dynamodbtest.CreateStreamRecord("item4", 4))
+		waitForEvent(t, w, "item4")
+		ensureNoEvents(t, w)
+	})
+}
+
+func newTestBackend(t *testing.T, mockServer *dynamodbtest.Server) *dynamo.Backend {
+	t.Helper()
+	b, err := dynamo.NewFromConfig(t.Context(), &dynamo.Config{
+		Region:           "us-east-1",
+		AccessKey:        "test-key",
+		SecretKey:        "test-secret",
+		TableName:        "TestTable",
+		RetryPeriod:      50 * time.Millisecond,
+		PollStreamPeriod: 50 * time.Millisecond,
+		BufferSize:       1000,
+		HTTPClient: &http.Client{
+			Transport: &muxToTransportWrapper{handler: mockServer.Mux},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { b.Close() })
+	return b
+}
+
+func newTestWatcher(t *testing.T, b *dynamo.Backend) backend.Watcher {
+	t.Helper()
+	w, err := b.NewWatcher(t.Context(), backend.Watch{Prefixes: []backend.Key{backend.NewKey("")}})
+	require.NoError(t, err)
+	return w
+}
+
+func ensureNoEvents(t *testing.T, w backend.Watcher) {
+	t.Helper()
+	select {
+	case event := <-w.Events():
+		t.Fatalf("unexpected event: %#v", event)
+	default:
+	}
+}
+
+func waitForWatcherInit(t *testing.T, w backend.Watcher) {
+	t.Helper()
+	select {
+	case event := <-w.Events():
+		require.Equal(t, types.OpInit, event.Type)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Did not receive init event in time")
+	}
+}
+
+func waitForEvent(t *testing.T, w backend.Watcher, item string) {
+	t.Helper()
+	select {
+	case event := <-w.Events():
+		require.Equal(t, types.OpPut, event.Type)
+		require.Equal(t, "/test/"+item, event.Item.Key.String())
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Did not receive put event in time: %v", item)
+	}
+}
+
+type muxToTransportWrapper struct {
+	handler http.Handler
+}
+
+func (rt *muxToTransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rec := httptest.NewRecorder()
+	rt.handler.ServeHTTP(rec, req)
+	return rec.Result(), nil
+}


### PR DESCRIPTION
### What

Add  basic shard stream test UT coverage for dynamoDB flow (Apart from HTTPClient injection only test code was added) 


### Why

DynamoDB backend is missing UT coverage where E2E test test only basic optimistic condition. 

Needed for: https://github.com/gravitational/teleport-private/issues/2362