### PR TITLE
[v17] app: Warn when proxy public_addr is missing

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2005,22 +2005,11 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	cfg.Apps.Enabled = true
 
 	// Warn if proxy_service is enabled in the same config but has no
-	// public_addr and at least one static app lacks its own
-	// public_addr. Without either, app FQDNs fall back to the
-	// cluster name and app access URLs may not resolve.
+	// public_addr. Without it, app access does not work.
 	if fc.Proxy.Enabled() && len(fc.Proxy.PublicAddr) == 0 {
-		var appsWithoutAddr []string
-		for _, app := range fc.Apps.Apps {
-			if app.PublicAddr == "" {
-				appsWithoutAddr = append(appsWithoutAddr, app.Name)
-			}
-		}
-		if len(appsWithoutAddr) > 0 {
-			slog.WarnContext(context.Background(),
-				"Apps may not be reachable: no public_addr on proxy_service or on the apps themselves",
-				"apps", appsWithoutAddr,
-			)
-		}
+		slog.WarnContext(context.Background(),
+			"app_service requires proxy_service.public_addr to route requests; app access will not work until it is set",
+		)
 	}
 
 	// Enable debugging application if requested.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2005,14 +2005,22 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	cfg.Apps.Enabled = true
 
 	// Warn if proxy_service is enabled in the same config but has no
-	// public_addr. Without it, app FQDNs fall back to the cluster
-	// name and app access URLs may not resolve.
+	// public_addr and at least one static app lacks its own
+	// public_addr. Without either, app FQDNs fall back to the
+	// cluster name and app access URLs may not resolve.
 	if fc.Proxy.Enabled() && len(fc.Proxy.PublicAddr) == 0 {
-		slog.WarnContext(context.Background(),
-			"proxy_service.public_addr is not set; app access URLs"+
-				" will use the cluster name as the domain suffix"+
-				" and may not be reachable",
-		)
+		var appsWithoutAddr []string
+		for _, app := range fc.Apps.Apps {
+			if app.PublicAddr == "" {
+				appsWithoutAddr = append(appsWithoutAddr, app.Name)
+			}
+		}
+		if len(appsWithoutAddr) > 0 {
+			slog.WarnContext(context.Background(),
+				"Apps may not be reachable: no public_addr on proxy_service or on the apps themselves",
+				"apps", appsWithoutAddr,
+			)
+		}
 	}
 
 	// Enable debugging application if requested.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -2004,6 +2004,17 @@ func applyAppsConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	// Apps are enabled.
 	cfg.Apps.Enabled = true
 
+	// Warn if proxy_service is enabled in the same config but has no
+	// public_addr. Without it, app FQDNs fall back to the cluster
+	// name and app access URLs may not resolve.
+	if fc.Proxy.Enabled() && len(fc.Proxy.PublicAddr) == 0 {
+		slog.WarnContext(context.Background(),
+			"proxy_service.public_addr is not set; app access URLs"+
+				" will use the cluster name as the domain suffix"+
+				" and may not be reachable",
+		)
+	}
+
 	// Enable debugging application if requested.
 	cfg.Apps.DebugApp = fc.Apps.DebugApp
 


### PR DESCRIPTION
When `app_service` is enabled and `proxy_service` has no `public_addr`,
app FQDNs silently fall back to the cluster name, producing
URLs that don't resolve. Log a warning at startup so admins
know to set `proxy_service.public_addr`.

Issue: https://github.com/gravitational/teleport/issues/4652
Backport: https://github.com/gravitational/teleport/pull/63683