### PR TITLE
Add a common MSW server for testing, update tests to use it

### DIFF
--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -39,6 +39,7 @@ import 'jest-styled-components';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { HttpResponse, JsonBodyType } from 'msw';
+import { setupServer } from 'msw/node';
 
 export const testQueryClient = new QueryClient({
   defaultOptions: {
@@ -131,6 +132,8 @@ export function createDeferredResponse<T extends JsonBodyType>(data: T) {
     resolve: () => resolve(),
   };
 }
+
+export const server = setupServer();
 
 export {
   act,

--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -135,6 +135,20 @@ export function createDeferredResponse<T extends JsonBodyType>(data: T) {
 
 export const server = setupServer();
 
+/**
+ * Registers MSW lifecycle hooks for the current test suite. Call this at the
+ * top level of every test file that uses `server.use()`.
+ *
+ * This is intentionally opt-in rather than global (via setupTests.ts) to
+ * avoid the overhead of patching fetch/XHR in the hundreds of test suites
+ * that don't use MSW.
+ */
+export function enableMswServer() {
+  beforeAll(() => server.listen());
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+}
+
 export {
   act,
   screen,

--- a/web/packages/shared/components/ErrorSuspenseWrapper/ErrorSuspenseWrapper.test.tsx
+++ b/web/packages/shared/components/ErrorSuspenseWrapper/ErrorSuspenseWrapper.test.tsx
@@ -19,19 +19,17 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { getErrorMessage, type FallbackProps } from 'react-error-boundary';
 
 import {
   createDeferredResponse,
   render,
   screen,
+  server,
   testQueryClient,
 } from 'design/utils/testing';
 
 import { ErrorSuspenseWrapper } from './ErrorSuspenseWrapper';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 afterEach(() => {

--- a/web/packages/shared/components/ErrorSuspenseWrapper/ErrorSuspenseWrapper.test.tsx
+++ b/web/packages/shared/components/ErrorSuspenseWrapper/ErrorSuspenseWrapper.test.tsx
@@ -23,6 +23,7 @@ import { getErrorMessage, type FallbackProps } from 'react-error-boundary';
 
 import {
   createDeferredResponse,
+  enableMswServer,
   render,
   screen,
   server,
@@ -31,12 +32,11 @@ import {
 
 import { ErrorSuspenseWrapper } from './ErrorSuspenseWrapper';
 
-beforeAll(() => server.listen());
+enableMswServer();
+
 afterEach(() => {
-  server.resetHandlers();
   testQueryClient.clear();
 });
-afterAll(() => server.close());
 
 function TestErrorComponent({ error, resetErrorBoundary }: FallbackProps) {
   return (

--- a/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
@@ -24,6 +24,7 @@ import { MemoryRouter, Route, Router } from 'react-router';
 import { darkTheme } from 'design/theme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -66,19 +67,13 @@ jest.mock('teleport/services/bot/bot', () => {
   };
 });
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.useRealTimers();
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('BotInstances', () => {
   it('Shows an empty state', async () => {

--- a/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
+++ b/web/packages/teleport/src/BotInstances/BotInstances.test.tsx
@@ -18,7 +18,6 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory } from 'history';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter, Route, Router } from 'react-router';
 
@@ -27,6 +26,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -65,8 +65,6 @@ jest.mock('teleport/services/bot/bot', () => {
     }),
   };
 });
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/BotInstances/Dashboard/BotInstanceDashboard.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Dashboard/BotInstanceDashboard.test.tsx
@@ -22,6 +22,7 @@ import { ComponentProps, PropsWithChildren } from 'react';
 import { darkTheme } from 'design/theme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -38,18 +39,12 @@ import {
 
 import { BotInstancesDashboard } from './BotInstanceDashboard';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('BotInstanceDashboard', () => {
   it('renders', async () => {

--- a/web/packages/teleport/src/BotInstances/Dashboard/BotInstanceDashboard.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Dashboard/BotInstanceDashboard.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { ComponentProps, PropsWithChildren } from 'react';
 
 import { darkTheme } from 'design/theme';
@@ -25,6 +24,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitForElementToBeRemoved,
@@ -37,8 +37,6 @@ import {
 } from 'teleport/test/helpers/botInstances';
 
 import { BotInstancesDashboard } from './BotInstanceDashboard';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
@@ -22,6 +22,7 @@ import { ComponentProps, PropsWithChildren } from 'react';
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -43,18 +44,12 @@ import {
 
 import { BotInstanceDetails } from './BotInstanceDetails';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('BotIntanceDetails', () => {
   it('Allows close action', async () => {

--- a/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
+++ b/web/packages/teleport/src/BotInstances/Details/BotInstanceDetails.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { ComponentProps, PropsWithChildren } from 'react';
 
 import darkTheme from 'design/theme/themes/darkTheme';
@@ -25,6 +24,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitForElementToBeRemoved,
@@ -42,8 +42,6 @@ import {
 } from 'teleport/test/helpers/botInstances';
 
 import { BotInstanceDetails } from './BotInstanceDetails';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import selectEvent from 'react-select-event';
 
@@ -27,6 +26,7 @@ import {
   act,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   within,
@@ -46,8 +46,6 @@ import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { ConfigureAccess } from './ConfigureAccess';
 import { GitHubK8sFlowProvider, useGitHubK8sFlow } from './useGitHubK8sFlow';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConfigureAccess.test.tsx
@@ -24,6 +24,7 @@ import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   act,
+  enableMswServer,
   render,
   screen,
   server,
@@ -47,9 +48,9 @@ import { TrackingProvider } from '../Shared/useTracking';
 import { ConfigureAccess } from './ConfigureAccess';
 import { GitHubK8sFlowProvider, useGitHubK8sFlow } from './useGitHubK8sFlow';
 
-beforeAll(() => {
-  server.listen();
+enableMswServer();
 
+beforeEach(() => {
   // Basic mock for all tests
   server.use(genWizardCiCdSuccess());
   server.use(fetchUnifiedResourcesSuccess());
@@ -59,8 +60,6 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  server.close();
-
   jest.useRealTimers();
   jest.resetAllMocks();
 });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { ComponentProps, PropsWithChildren } from 'react';
 import selectEvent from 'react-select-event';
 
@@ -27,6 +26,7 @@ import {
   act,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
 } from 'design/utils/testing';
@@ -42,8 +42,6 @@ import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { ConnectGitHub } from './ConnectGitHub';
 import { GitHubK8sFlowProvider } from './useGitHubK8sFlow';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/ConnectGitHub.test.tsx
@@ -24,6 +24,7 @@ import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   act,
+  enableMswServer,
   render,
   screen,
   server,
@@ -43,9 +44,9 @@ import { TrackingProvider } from '../Shared/useTracking';
 import { ConnectGitHub } from './ConnectGitHub';
 import { GitHubK8sFlowProvider } from './useGitHubK8sFlow';
 
-beforeAll(() => {
-  server.listen();
+enableMswServer();
 
+beforeEach(() => {
   // Basic mock for all tests
   server.use(genWizardCiCdSuccess());
   server.use(fetchUnifiedResourcesSuccess());
@@ -55,8 +56,6 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  server.close();
-
   jest.useRealTimers();
   jest.resetAllMocks();
 });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.test.tsx
@@ -24,6 +24,7 @@ import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   act,
+  enableMswServer,
   render,
   screen,
   server,
@@ -66,9 +67,9 @@ jest.mock('shared/components/FieldSelect/FieldSelectCreatable', () => {
   };
 });
 
-beforeAll(() => {
-  server.listen();
+enableMswServer();
 
+beforeEach(() => {
   // Basic mock for all tests
   server.use(genWizardCiCdSuccess());
   server.use(fetchUnifiedResourcesSuccess());
@@ -78,8 +79,6 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  server.close();
-
   jest.useRealTimers();
   jest.resetAllMocks();
 });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/Finish.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import selectEvent from 'react-select-event';
 
@@ -27,6 +26,7 @@ import {
   act,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
 } from 'design/utils/testing';
@@ -65,8 +65,6 @@ jest.mock('shared/components/FieldSelect/FieldSelectCreatable', () => {
     },
   };
 });
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/GitHubActionsK8s.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/GitHubActionsK8s.test.tsx
@@ -26,6 +26,7 @@ import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   act,
+  enableMswServer,
   render,
   screen,
   server,
@@ -47,9 +48,9 @@ import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { GitHubActionsK8sWithoutTracking } from './GitHubActionsK8s';
 
-beforeAll(() => {
-  server.listen();
+enableMswServer();
 
+beforeEach(() => {
   server.use(genWizardCiCdSuccess());
   server.use(userEventCaptureSuccess());
   server.use(fetchUnifiedResourcesSuccess());
@@ -58,8 +59,6 @@ beforeAll(() => {
 });
 
 afterAll(() => {
-  server.close();
-
   jest.useRealTimers();
   jest.resetAllMocks();
 });

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/GitHubActionsK8s.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/GitHubActionsK8s.test.tsx
@@ -18,7 +18,6 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory } from 'history';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import { Router } from 'react-router';
 import selectEvent from 'react-select-event';
@@ -29,6 +28,7 @@ import {
   act,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
 } from 'design/utils/testing';
@@ -46,8 +46,6 @@ import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { GitHubActionsK8sWithoutTracking } from './GitHubActionsK8s';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { ComponentProps, PropsWithChildren } from 'react';
 
 import darkTheme from 'design/theme/themes/darkTheme';
@@ -25,6 +24,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   within,
@@ -41,8 +41,6 @@ import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { KubernetesLabelsSelect } from './KubernetesLabelsSelect';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/KubernetesLabelsSelect.test.tsx
@@ -22,6 +22,7 @@ import { ComponentProps, PropsWithChildren } from 'react';
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -42,25 +43,18 @@ import { trackingTester } from '../Shared/trackingTester';
 import { TrackingProvider } from '../Shared/useTracking';
 import { KubernetesLabelsSelect } from './KubernetesLabelsSelect';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 beforeEach(() => {
   server.use(userEventCaptureSuccess());
 });
 
 afterEach(async () => {
-  server.resetHandlers();
-
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
 
 afterAll(() => {
-  server.close();
-
   jest.resetAllMocks();
 });
 

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
@@ -20,7 +20,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
-import { server, testQueryClient } from 'design/utils/testing';
+import { enableMswServer, server, testQueryClient } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport/index';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -30,9 +30,7 @@ import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 import { TrackingProvider } from '../Shared/useTracking';
 import { GitHubK8sFlowProvider, useGitHubK8sFlow } from './useGitHubK8sFlow';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 beforeEach(() => {
   server.use(userEventCaptureSuccess());
@@ -42,14 +40,10 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.useRealTimers();
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('useGitHubK8sFlow', () => {
   test('initial', async () => {

--- a/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
+++ b/web/packages/teleport/src/Bots/Add/GitHubActionsK8s/useGitHubK8sFlow.test.tsx
@@ -18,10 +18,9 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 
-import { testQueryClient } from 'design/utils/testing';
+import { server, testQueryClient } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport/index';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -30,8 +29,6 @@ import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 
 import { TrackingProvider } from '../Shared/useTracking';
 import { GitHubK8sFlowProvider, useGitHubK8sFlow } from './useGitHubK8sFlow';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
+++ b/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
@@ -19,6 +19,7 @@
 import { PropsWithChildren } from 'react';
 
 import {
+  enableMswServer,
   Providers,
   render,
   screen,
@@ -35,18 +36,12 @@ import { deleteBotError, deleteBotSuccess } from 'teleport/test/helpers/bots';
 
 import { DeleteDialog } from './DeleteDialog';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('DeleteDialog', () => {
   it('should render correctly', async () => {

--- a/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
+++ b/web/packages/teleport/src/Bots/Delete/DeleteDialog.test.tsx
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 
 import {
   Providers,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -34,8 +34,6 @@ import { defaultAccess, makeAcl } from 'teleport/services/user/makeAcl';
 import { deleteBotError, deleteBotSuccess } from 'teleport/test/helpers/bots';
 
 import { DeleteDialog } from './DeleteDialog';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
@@ -21,7 +21,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { UserEvent } from '@testing-library/user-event';
 import { createMemoryHistory } from 'history';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter, Route, Router } from 'react-router';
 
@@ -30,6 +29,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -64,8 +64,6 @@ import {
 } from 'teleport/test/helpers/tokens';
 
 import { BotDetails } from './BotDetails';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/BotDetails.test.tsx
@@ -27,6 +27,7 @@ import { MemoryRouter, Route, Router } from 'react-router';
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -65,18 +66,12 @@ import {
 
 import { BotDetails } from './BotDetails';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('BotDetails', () => {
   it('should show a page error state', async () => {

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
@@ -22,6 +22,7 @@ import { PropsWithChildren } from 'react';
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -39,18 +40,12 @@ import {
 
 import { InstancesPanel } from './InstancesPanel';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('InstancesPanel', () => {
   it('should show a fetch error state', async () => {

--- a/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
+++ b/web/packages/teleport/src/Bots/Details/InstancesPanel.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 
 import darkTheme from 'design/theme/themes/darkTheme';
@@ -25,6 +24,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   waitForElementToBeRemoved,
 } from 'design/utils/testing';
@@ -38,8 +38,6 @@ import {
 } from 'teleport/test/helpers/botInstances';
 
 import { InstancesPanel } from './InstancesPanel';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Edit/EditDialog.test.tsx
+++ b/web/packages/teleport/src/Bots/Edit/EditDialog.test.tsx
@@ -18,7 +18,6 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { UserEvent } from '@testing-library/user-event';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import selectEvent from 'react-select-event';
 
@@ -28,6 +27,7 @@ import {
   act,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitForElementToBeRemoved,
@@ -47,8 +47,6 @@ import {
 import { successGetRoles } from 'teleport/test/helpers/roles';
 
 import { EditDialog } from './EditDialog';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Bots/Edit/EditDialog.test.tsx
+++ b/web/packages/teleport/src/Bots/Edit/EditDialog.test.tsx
@@ -25,6 +25,7 @@ import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   act,
+  enableMswServer,
   render,
   screen,
   server,
@@ -48,18 +49,12 @@ import { successGetRoles } from 'teleport/test/helpers/roles';
 
 import { EditDialog } from './EditDialog';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('EditDialog', () => {
   it('should show a fetch error state', async () => {

--- a/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.test.tsx
+++ b/web/packages/teleport/src/Clusters/ManageCluster/ManageCluster.test.tsx
@@ -17,10 +17,15 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { MemoryRouter, Route } from 'react-router-dom';
 
-import { render, screen, waitFor } from 'design/utils/testing';
+import {
+  enableMswServer,
+  render,
+  screen,
+  server,
+  waitFor,
+} from 'design/utils/testing';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
 import cfg from 'teleport/config';
@@ -30,6 +35,8 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 
 import { clusterInfoFixture } from '../fixtures';
 import { ManageCluster } from './ManageCluster';
+
+enableMswServer();
 
 function renderElement(element, ctx) {
   return render(
@@ -46,24 +53,22 @@ function renderElement(element, ctx) {
 }
 
 describe('test ManageCluster component', () => {
-  const server = setupServer(
-    http.get(cfg.getClusterInfoPath('cluster-id'), () => {
-      return HttpResponse.json({
-        name: 'cluster-id',
-        lastConnected: new Date(),
-        status: 'active',
-        publicURL: 'cluster-id.teleport.com',
-        authVersion: 'v17.0.0',
-        proxyVersion: 'v17.0.0',
-        isCloud: false,
-        licenseExpiry: new Date(),
-      });
-    })
-  );
-
-  beforeAll(() => server.listen());
-  afterEach(() => server.resetHandlers());
-  afterAll(() => server.close());
+  beforeEach(() => {
+    server.use(
+      http.get(cfg.getClusterInfoPath('cluster-id'), () => {
+        return HttpResponse.json({
+          name: 'cluster-id',
+          lastConnected: new Date(),
+          status: 'active',
+          publicURL: 'cluster-id.teleport.com',
+          authVersion: 'v17.0.0',
+          proxyVersion: 'v17.0.0',
+          isCloud: false,
+          licenseExpiry: new Date(),
+        });
+      })
+    );
+  });
 
   test('fetches cluster information on load', async () => {
     const ctx = createTeleportContext();

--- a/web/packages/teleport/src/Console/DocumentDb/DocumentDb.test.tsx
+++ b/web/packages/teleport/src/Console/DocumentDb/DocumentDb.test.tsx
@@ -21,7 +21,7 @@ import { screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import 'jest-canvas-mock';
 
-import { act, render } from 'design/utils/testing';
+import { act, enableMswServer, render, server } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import { TestLayout } from 'teleport/Console/Console.story';
@@ -29,11 +29,18 @@ import ConsoleCtx from 'teleport/Console/consoleContext';
 import Tty from 'teleport/lib/term/tty';
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import type { Session } from 'teleport/services/session';
+import { fetchUnifiedResourcesSuccess } from 'teleport/test/helpers/resources';
 
 import { DocumentDb } from './DocumentDb';
 import { Status, useDbSession } from './useDbSession';
 
 jest.mock('./useDbSession');
+
+enableMswServer();
+
+beforeEach(() => {
+  server.use(fetchUnifiedResourcesSuccess());
+});
 
 const mockUseDbSession = useDbSession as jest.MockedFunction<
   typeof useDbSession

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -18,7 +18,7 @@
 
 import { MemoryRouter } from 'react-router';
 
-import { render, screen } from 'design/utils/testing';
+import { enableMswServer, render, screen, server } from 'design/utils/testing';
 import { Resource } from 'gen-proto-ts/teleport/userpreferences/v1/onboard_pb';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
@@ -38,6 +38,7 @@ import { FeaturesContextProvider } from 'teleport/FeaturesContext';
 import { createTeleportContext, getAcl } from 'teleport/mocks/contexts';
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
+import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
@@ -49,8 +50,11 @@ import { ResourceKind } from './Shared';
 import { getGuideTileId } from './testUtils';
 import { DiscoverUpdateProps, useDiscover } from './useDiscover';
 
+enableMswServer();
+
 beforeEach(() => {
   jest.restoreAllMocks();
+  server.use(userEventCaptureSuccess());
 });
 
 type createProps = {

--- a/web/packages/teleport/src/Instances/Instances.test.tsx
+++ b/web/packages/teleport/src/Instances/Instances.test.tsx
@@ -19,7 +19,6 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { createMemoryHistory } from 'history';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter, Route, Router } from 'react-router';
 
@@ -28,6 +27,7 @@ import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -46,8 +46,6 @@ import {
 } from 'teleport/test/helpers/instances';
 
 import { Instances } from './Instances';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Instances/Instances.test.tsx
+++ b/web/packages/teleport/src/Instances/Instances.test.tsx
@@ -25,6 +25,7 @@ import { MemoryRouter, Route, Router } from 'react-router';
 import darkTheme from 'design/theme/themes/darkTheme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -47,9 +48,9 @@ import {
 
 import { Instances } from './Instances';
 
-beforeAll(() => {
-  server.listen();
+enableMswServer();
 
+beforeAll(() => {
   global.IntersectionObserver = class IntersectionObserver {
     constructor() {}
     disconnect() {}
@@ -62,12 +63,9 @@ beforeAll(() => {
 });
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 it('having no permissions should show correct error', async () => {
   renderComponent({

--- a/web/packages/teleport/src/Main/Main.test.tsx
+++ b/web/packages/teleport/src/Main/Main.test.tsx
@@ -16,11 +16,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 
 import { ButtonPrimary } from 'design/Button';
 import { ListThin } from 'design/Icon';
-import { act, fireEvent, render, screen } from 'design/utils/testing';
+import {
+  act,
+  enableMswServer,
+  fireEvent,
+  render,
+  screen,
+  server,
+} from 'design/utils/testing';
 import { InfoGuideButton } from 'shared/components/SlidingSidePanel/InfoGuide/InfoGuide';
 import {
   autoRemoveDurationMs,
@@ -43,11 +51,28 @@ import { NavigationCategory } from 'teleport/Navigation';
 import { nodes } from 'teleport/Nodes/fixtures';
 import { sessions } from 'teleport/Sessions/fixtures';
 import TeleportContext from 'teleport/teleportContext';
+import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
+import { successGetUsersV2 } from 'teleport/test/helpers/users';
 import { TeleportFeature } from 'teleport/types';
 import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
 import { Main, MainProps } from './Main';
+
+enableMswServer();
+
+beforeEach(() => {
+  server.use(
+    userEventCaptureSuccess(),
+    successGetUsersV2([]),
+    http.get('/v1/webapi/sites/:clusterId/alerts', () =>
+      HttpResponse.json({ alerts: [] })
+    ),
+    http.get('/v1/webapi/sites/:clusterId/notifications', () =>
+      HttpResponse.json({ notifications: [] })
+    )
+  );
+});
 
 const setupContext = (): TeleportContext => {
   const ctx = new Context();

--- a/web/packages/teleport/src/ManagedUpdates/ManagedUpdates.test.tsx
+++ b/web/packages/teleport/src/ManagedUpdates/ManagedUpdates.test.tsx
@@ -20,6 +20,7 @@ import { http, HttpResponse } from 'msw';
 import { PropsWithChildren } from 'react';
 
 import {
+  enableMswServer,
   Providers,
   render,
   screen,
@@ -42,9 +43,7 @@ import {
 } from './fixtures';
 import { ManagedUpdates } from './ManagedUpdates';
 
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+enableMswServer();
 
 function makeWrapper(customAcl?: ReturnType<typeof makeAcl>) {
   return ({ children }: PropsWithChildren) => {

--- a/web/packages/teleport/src/ManagedUpdates/ManagedUpdates.test.tsx
+++ b/web/packages/teleport/src/ManagedUpdates/ManagedUpdates.test.tsx
@@ -17,10 +17,15 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 
-import { Providers, render, screen, waitFor } from 'design/utils/testing';
+import {
+  Providers,
+  render,
+  screen,
+  server,
+  waitFor,
+} from 'design/utils/testing';
 import { InfoGuidePanelProvider } from 'shared/components/SlidingSidePanel/InfoGuide';
 
 import cfg from 'teleport/config';
@@ -36,8 +41,6 @@ import {
   mockManagedUpdatesWithOrphaned,
 } from './fixtures';
 import { ManagedUpdates } from './ManagedUpdates';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());

--- a/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.test.tsx
@@ -21,6 +21,7 @@ import { generatePath, MemoryRouter } from 'react-router';
 
 import {
   createDeferredResponse,
+  enableMswServer,
   render,
   screen,
   server,
@@ -36,7 +37,8 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 import { ListSessionRecordingsRoute } from './ListSessionRecordingsRoute';
 import { getThumbnail, MOCK_EVENTS, MOCK_THUMBNAIL } from './mock';
 
-beforeAll(() => server.listen());
+enableMswServer();
+
 beforeEach(() => {
   server.use(
     getThumbnail(MOCK_THUMBNAIL),
@@ -54,12 +56,9 @@ beforeEach(() => {
     })
   );
 });
-afterEach(async () => {
-  server.resetHandlers();
-
+afterEach(() => {
   testQueryClient.clear();
 });
-afterAll(() => server.close());
 
 const listRecordingsUrl = generatePath(cfg.api.clusterEventsRecordingsPath, {
   clusterId: 'localhost',

--- a/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/ListSessionRecordingsRoute.test.tsx
@@ -17,13 +17,13 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { generatePath, MemoryRouter } from 'react-router';
 
 import {
   createDeferredResponse,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -35,8 +35,6 @@ import { createTeleportContext } from 'teleport/mocks/contexts';
 
 import { ListSessionRecordingsRoute } from './ListSessionRecordingsRoute';
 import { getThumbnail, MOCK_EVENTS, MOCK_THUMBNAIL } from './mock';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 beforeEach(() => {

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
@@ -17,11 +17,16 @@
  */
 
 import { format } from 'date-fns';
-import { setupServer } from 'msw/node';
 import { act } from 'react';
 import { MemoryRouter } from 'react-router';
 
-import { render, screen, testQueryClient, tick } from 'design/utils/testing';
+import {
+  render,
+  screen,
+  server,
+  testQueryClient,
+  tick,
+} from 'design/utils/testing';
 
 import cfg from 'teleport/config';
 import { ContextProvider } from 'teleport/index';
@@ -72,8 +77,6 @@ async function setupTest({
 
   return view;
 }
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
@@ -21,6 +21,7 @@ import { act } from 'react';
 import { MemoryRouter } from 'react-router';
 
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -36,6 +37,8 @@ import type { Recording } from 'teleport/services/recordings';
 import { getThumbnail, MOCK_THUMBNAIL, thumbnailError } from './mock';
 import { RecordingItem, type RecordingItemProps } from './RecordingItem';
 import { Density, ViewMode } from './ViewSwitcher';
+
+enableMswServer();
 
 const mockRecording: Recording = {
   sid: 'test-session',
@@ -78,18 +81,13 @@ async function setupTest({
   return view;
 }
 
-beforeAll(() => server.listen());
-
 beforeEach(() => {
   server.use(getThumbnail(MOCK_THUMBNAIL));
 });
 
-afterEach(async () => {
-  server.resetHandlers();
+afterEach(() => {
   testQueryClient.clear();
 });
-
-afterAll(() => server.close());
 
 test('renders recording item with basic information', async () => {
   await setupTest({});

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingThumbnail.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingThumbnail.test.tsx
@@ -16,19 +16,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { render, screen, server, testQueryClient } from 'design/utils/testing';
+import {
+  enableMswServer,
+  render,
+  screen,
+  server,
+  testQueryClient,
+} from 'design/utils/testing';
 
 import { getThumbnail, MOCK_THUMBNAIL } from './mock';
 import { RecordingThumbnail } from './RecordingThumbnail';
 
-beforeAll(() => server.listen());
+enableMswServer();
 
-afterEach(async () => {
-  server.resetHandlers();
+afterEach(() => {
   testQueryClient.clear();
 });
-
-afterAll(() => server.close());
 
 function setupTest(clusterId = 'localhost', sessionId = 'test-session') {
   return render(

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingThumbnail.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingThumbnail.test.tsx
@@ -16,14 +16,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setupServer } from 'msw/node';
-
-import { render, screen, testQueryClient } from 'design/utils/testing';
+import { render, screen, server, testQueryClient } from 'design/utils/testing';
 
 import { getThumbnail, MOCK_THUMBNAIL } from './mock';
 import { RecordingThumbnail } from './RecordingThumbnail';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
@@ -20,6 +20,7 @@ import { http, HttpResponse } from 'msw';
 import { generatePath, MemoryRouter } from 'react-router';
 
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -43,7 +44,8 @@ import { RecordingsList } from './RecordingsList';
 import type { RecordingsListState } from './state';
 import { Density, ViewMode } from './ViewSwitcher';
 
-beforeAll(() => server.listen());
+enableMswServer();
+
 beforeEach(() => {
   server.use(
     getThumbnail(MOCK_THUMBNAIL),
@@ -61,12 +63,9 @@ beforeEach(() => {
     })
   );
 });
-afterEach(async () => {
-  server.resetHandlers();
-
+afterEach(() => {
   testQueryClient.clear();
 });
-afterAll(() => server.close());
 
 const defaultState: RecordingsListState = {
   filters: {

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
@@ -17,12 +17,12 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { generatePath, MemoryRouter } from 'react-router';
 
 import {
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
 } from 'design/utils/testing';
@@ -42,8 +42,6 @@ import {
 import { RecordingsList } from './RecordingsList';
 import type { RecordingsListState } from './state';
 import { Density, ViewMode } from './ViewSwitcher';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 beforeEach(() => {

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -20,7 +20,12 @@ import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route } from 'react-router-dom';
 
-import { render, server, testQueryClient } from 'design/utils/testing';
+import {
+  enableMswServer,
+  render,
+  server,
+  testQueryClient,
+} from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import cfg from 'teleport/config';
@@ -42,18 +47,11 @@ jest.mock('teleport/lib/AuthenticatedWebSocket', () => ({
   AuthenticatedWebSocket: MockAuthenticatedWebSocket,
 }));
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(() => {
-  server.resetHandlers();
   testQueryClient.clear();
   jest.clearAllMocks();
-});
-
-afterAll(() => {
-  server.close();
 });
 
 const mockMetadata: SessionRecordingMetadata = {

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -18,10 +18,9 @@
 
 import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 import { MemoryRouter, Route } from 'react-router-dom';
 
-import { render, testQueryClient } from 'design/utils/testing';
+import { render, server, testQueryClient } from 'design/utils/testing';
 
 import { ContextProvider } from 'teleport';
 import cfg from 'teleport/config';
@@ -42,8 +41,6 @@ jest.spyOn(cfg, 'getSessionRecordingMetadataUrl').mockImplementation(() => {
 jest.mock('teleport/lib/AuthenticatedWebSocket', () => ({
   AuthenticatedWebSocket: MockAuthenticatedWebSocket,
 }));
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -16,23 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 import { MemoryRouter } from 'react-router';
 
 import {

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -19,6 +19,7 @@
 import { MemoryRouter } from 'react-router';
 
 import {
+  enableMswServer,
   fireEvent,
   render,
   screen,
@@ -39,6 +40,8 @@ import { successGetUsersV2 } from 'teleport/test/helpers/users';
 import { Users } from './Users';
 import { State } from './useUsers';
 
+enableMswServer();
+
 const defaultAcl: Access = {
   read: true,
   edit: true,
@@ -47,13 +50,9 @@ const defaultAcl: Access = {
   create: true,
 };
 
-beforeEach(() => server.listen());
 afterEach(() => {
-  server.resetHandlers();
-
   return testQueryClient.resetQueries();
 });
-afterAll(() => server.close());
 
 describe('invite collaborators integration', () => {
   const ctx = createTeleportContext();

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -16,13 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setupServer } from 'msw/node';
+/**
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import { MemoryRouter } from 'react-router';
 
 import {
   fireEvent,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -46,8 +63,6 @@ const defaultAcl: Access = {
   list: true,
   create: true,
 };
-
-const server = setupServer();
 
 beforeEach(() => server.listen());
 afterEach(() => {

--- a/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
@@ -23,6 +23,7 @@ import { MemoryRouter } from 'react-router';
 import { darkTheme } from 'design/theme';
 import { ConfiguredThemeProvider } from 'design/ThemeProvider';
 import {
+  enableMswServer,
   fireEvent,
   render,
   screen,
@@ -56,18 +57,12 @@ jest.mock('teleport/services/workloadIdentity/workloadIdentity', () => {
   };
 });
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('WorkloadIdentities', () => {
   it('Shows an empty state', async () => {

--- a/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
@@ -16,23 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Teleport
- * Copyright (C) 2025 Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 import { QueryClientProvider } from '@tanstack/react-query';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter } from 'react-router';

--- a/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
+++ b/web/packages/teleport/src/WorkloadIdentity/WorkloadIdentities.test.tsx
@@ -16,8 +16,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import { QueryClientProvider } from '@tanstack/react-query';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 import { MemoryRouter } from 'react-router';
 
@@ -27,6 +43,7 @@ import {
   fireEvent,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -55,8 +72,6 @@ jest.mock('teleport/services/workloadIdentity/workloadIdentity', () => {
     }),
   };
 });
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/components/BannerList/StandardBanner.test.tsx
+++ b/web/packages/teleport/src/components/BannerList/StandardBanner.test.tsx
@@ -16,11 +16,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { fireEvent, render, screen, theme } from 'design/utils/testing';
+import {
+  enableMswServer,
+  fireEvent,
+  render,
+  screen,
+  server,
+  theme,
+} from 'design/utils/testing';
 
 import { userEventService } from 'teleport/services/userEvent';
+import { userEventCaptureSuccess } from 'teleport/test/helpers/userEvents';
 
 import { StandardBanner } from './StandardBanner';
+
+enableMswServer();
+
+beforeEach(() => {
+  server.use(userEventCaptureSuccess());
+});
 
 describe('StandardBanner', () => {
   it('displays the supplied message', () => {

--- a/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
@@ -19,6 +19,7 @@
 import { http, HttpResponse } from 'msw';
 
 import {
+  enableMswServer,
   render,
   screen,
   server,
@@ -30,9 +31,7 @@ import { storageService } from 'teleport/services/storageService';
 
 import { FormIdentifierFirst } from './FormIdentifierFirst';
 
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
+enableMswServer();
 
 test('no user remembered in localstorage renders username input form', () => {
   storageService.setRememberedSsoUsername('');

--- a/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormIdentifierFirst.test.tsx
@@ -17,15 +17,18 @@
  */
 
 import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
 
-import { render, screen, userEvent, waitFor } from 'design/utils/testing';
+import {
+  render,
+  screen,
+  server,
+  userEvent,
+  waitFor,
+} from 'design/utils/testing';
 
 import { storageService } from 'teleport/services/storageService';
 
 import { FormIdentifierFirst } from './FormIdentifierFirst';
-
-const server = setupServer();
 
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
@@ -20,6 +20,7 @@ import { UserEvent } from '@testing-library/user-event';
 import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
 import {
+  enableMswServer,
   Providers,
   render,
   screen,
@@ -38,18 +39,12 @@ import {
 
 import { ResourceLockDialog } from './ResourceLockDialog';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('ResourceLockDialog', () => {
   it('should cancel', async () => {

--- a/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockDialog.test.tsx
@@ -17,13 +17,13 @@
  */
 
 import { UserEvent } from '@testing-library/user-event';
-import { setupServer } from 'msw/node';
 import { ComponentPropsWithoutRef, PropsWithChildren } from 'react';
 
 import {
   Providers,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -37,8 +37,6 @@ import {
 } from 'teleport/test/helpers/locks';
 
 import { ResourceLockDialog } from './ResourceLockDialog';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
@@ -16,13 +16,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { setupServer } from 'msw/node';
+/**
+ * Teleport
+ * Copyright (C) 2025 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import { PropsWithChildren } from 'react';
 
 import {
   Providers,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -33,8 +50,6 @@ import { TeleportProviderBasic } from 'teleport/mocks/providers';
 import { listV2LocksSuccess } from 'teleport/test/helpers/locks';
 
 import { ResourceLockIndicator } from './ResourceLockIndicator';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
@@ -19,6 +19,7 @@
 import { PropsWithChildren } from 'react';
 
 import {
+  enableMswServer,
   Providers,
   render,
   screen,
@@ -34,18 +35,12 @@ import { listV2LocksSuccess } from 'teleport/test/helpers/locks';
 
 import { ResourceLockIndicator } from './ResourceLockIndicator';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('ResourceUnlockDialog', () => {
   it('show a tooltip with details of a single lock', async () => {

--- a/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceLockIndicator.test.tsx
@@ -16,23 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/**
- * Teleport
- * Copyright (C) 2025 Gravitational, Inc.
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 import { PropsWithChildren } from 'react';
 
 import {

--- a/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.test.tsx
@@ -25,6 +25,7 @@ import {
 import { Router } from 'react-router';
 
 import {
+  enableMswServer,
   Providers,
   render,
   screen,
@@ -44,18 +45,12 @@ import {
 
 import { ResourceUnlockDialog } from './ResourceUnlockDialog';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('ResourceUnlockDialog', () => {
   it('should cancel', async () => {

--- a/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.test.tsx
+++ b/web/packages/teleport/src/lib/locks/ResourceUnlockDialog.test.tsx
@@ -17,7 +17,6 @@
  */
 
 import { createMemoryHistory } from 'history';
-import { setupServer } from 'msw/node';
 import {
   ComponentPropsWithoutRef,
   MouseEventHandler,
@@ -29,6 +28,7 @@ import {
   Providers,
   render,
   screen,
+  server,
   testQueryClient,
   userEvent,
   waitFor,
@@ -43,8 +43,6 @@ import {
 } from 'teleport/test/helpers/locks';
 
 import { ResourceUnlockDialog } from './ResourceUnlockDialog';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();

--- a/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
+++ b/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
@@ -20,7 +20,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
-import { server, testQueryClient } from 'design/utils/testing';
+import { enableMswServer, server, testQueryClient } from 'design/utils/testing';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
@@ -34,18 +34,12 @@ import {
 
 import { useResourceLock } from './useResourceLock';
 
-beforeAll(() => {
-  server.listen();
-});
+enableMswServer();
 
 afterEach(async () => {
-  server.resetHandlers();
   await testQueryClient.resetQueries();
-
   jest.clearAllMocks();
 });
-
-afterAll(() => server.close());
 
 describe('useResourceLock', () => {
   it('returns locks (empty)', async () => {

--- a/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
+++ b/web/packages/teleport/src/lib/locks/useResourceLock.test.tsx
@@ -18,10 +18,9 @@
 
 import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { setupServer } from 'msw/node';
 import { PropsWithChildren } from 'react';
 
-import { testQueryClient } from 'design/utils/testing';
+import { server, testQueryClient } from 'design/utils/testing';
 
 import { createTeleportContext } from 'teleport/mocks/contexts';
 import { TeleportProviderBasic } from 'teleport/mocks/providers';
@@ -34,8 +33,6 @@ import {
 } from 'teleport/test/helpers/locks';
 
 import { useResourceLock } from './useResourceLock';
-
-const server = setupServer();
 
 beforeAll(() => {
   server.listen();


### PR DESCRIPTION
@ravicious pointed out the MSW docs say (rather confusingly) 

> While we commend setting up request interception globally, as a part of your testing setup, you may also use setupServer in individual tests, if you want to. Just make sure to choose one pattern and follow it throughout your tests—multiple setupServer calls is not a good idea!

I'm debugging some flakey tests in `e`, where the loading state is shown instead of the finished state. I've added a common MSW server that all tests can use, in order to rule this out (I don't think it's the cause, but it doesn't hurt to have a common server)