### PR TITLE
Use a cargo cache for faster UI unit tests

### DIFF
--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -50,6 +50,18 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
 
+      - name: Cache Cargo WASM build
+        uses: actions/cache@v4
+        with:
+          path: |
+            /tmp/build/rust/registry
+            /tmp/build/rust/git
+            target/wasm32-unknown-unknown
+          key: cargo-wasm-${{ github.head_ref || github.ref_name }}-${{ hashFiles('Cargo.toml', 'Cargo.lock') }}
+          restore-keys: |
+            cargo-wasm-${{ github.head_ref || github.ref_name }}-
+            cargo-wasm-${{ github.base_ref }}-
+
       - name: Build WASM
         run: pnpm build-wasm
 


### PR DESCRIPTION
It's quite annoying to wait an extra ~3 minutes (OSS) or 7 minutes (e) every time you're running the UI unit tests for the WASM stuff to build, hopefully this makes things a bit faster