### PR TITLE
Fix escaped characters in Bedrock integration resource ARNs

### DIFF
--- a/tool/teleport/common/integration_configure.go
+++ b/tool/teleport/common/integration_configure.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
@@ -333,6 +334,10 @@ func onIntegrationConfSessionSummariesBedrock(ctx context.Context, params config
 		}
 		params.AccountID = aws.ToString(callerID.Account)
 	}
+
+	// shsprintf.EscapeDefaultContext incorrectly maps * to \*, which causes AWS API calls to fail.
+	// We need to unescape it before proceeding. \ is not a valid character in ARNs.
+	params.Resource = strings.ReplaceAll(params.Resource, "\\", "")
 
 	confReq := awsoidc.BedrockSessionSummariesIAMConfigureRequest{
 		IntegrationRole: params.Role,


### PR DESCRIPTION
The shsprintf.EscapeDefaultContext function incorrectly escapes * to \*, which causes AWS API calls to fail since backslashes are not valid in ARNs. This change strips escape characters from the resource parameter before making the API call.