### PR TITLE
Move queryClient.clear() to beforeEach in session recording tests

### DIFF
--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -45,7 +45,6 @@ export const testQueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
-      gcTime: 0,
     },
   },
 });

--- a/web/packages/design/src/utils/testing.tsx
+++ b/web/packages/design/src/utils/testing.tsx
@@ -45,6 +45,7 @@ export const testQueryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: false,
+      gcTime: 0,
     },
   },
 });

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingItem.test.tsx
@@ -82,11 +82,8 @@ async function setupTest({
 }
 
 beforeEach(() => {
-  server.use(getThumbnail(MOCK_THUMBNAIL));
-});
-
-afterEach(() => {
   testQueryClient.clear();
+  server.use(getThumbnail(MOCK_THUMBNAIL));
 });
 
 test('renders recording item with basic information', async () => {

--- a/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/list/RecordingsList.test.tsx
@@ -47,6 +47,8 @@ import { Density, ViewMode } from './ViewSwitcher';
 enableMswServer();
 
 beforeEach(() => {
+  testQueryClient.clear();
+
   server.use(
     getThumbnail(MOCK_THUMBNAIL),
     http.get(cfg.api.clustersPath, () => {
@@ -62,9 +64,6 @@ beforeEach(() => {
       ]);
     })
   );
-});
-afterEach(() => {
-  testQueryClient.clear();
 });
 
 const defaultState: RecordingsListState = {

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -49,8 +49,11 @@ jest.mock('teleport/lib/AuthenticatedWebSocket', () => ({
 
 enableMswServer();
 
-afterEach(() => {
+beforeEach(() => {
   testQueryClient.clear();
+});
+
+afterEach(() => {
   jest.clearAllMocks();
 });
 


### PR DESCRIPTION
Hopefully this will remove the flakiness of tests if we clear up queries immediately and clear before each instead of after each