### PR TITLE
[v18] Add unsetHeight to FeatureBox

### DIFF
--- a/web/packages/teleport/src/components/Layout/Layout.tsx
+++ b/web/packages/teleport/src/components/Layout/Layout.tsx
@@ -48,9 +48,12 @@ const FeatureHeaderTitle = styled(H1)`
 /**
  * Feature Box (container)
  */
-const FeatureBox = styled(Flex)<{ hideBottomSpacing?: boolean }>`
+const FeatureBox = styled(Flex)<{
+  hideBottomSpacing?: boolean;
+  unsetHeight?: boolean;
+}>`
   width: 100%;
-  height: 100%;
+  ${props => !props.unsetHeight && 'height: 100%;'}
   flex-direction: column;
   padding-left: ${props => props.theme.space[6]}px;
   padding-right: ${props => props.theme.space[6]}px;


### PR DESCRIPTION
The PR that changed `FeatureBox` (https://github.com/gravitational/teleport/pull/60480) wasn't backported so this change isn't in v18, but we need it as we use it in the session summaries setup UI. Backporting just that change manually.