### PR TITLE
Increase default `waitFor` timeout on CI from 1s to 5s

### DIFF
--- a/web/packages/build/jest/setupTests.ts
+++ b/web/packages/build/jest/setupTests.ts
@@ -21,6 +21,7 @@ import 'whatwg-fetch';
 import crypto from 'node:crypto';
 import path from 'node:path';
 
+import { configure as configureTestingLibrary } from '@testing-library/react';
 import failOnConsole from 'jest-fail-on-console';
 import { configMocks } from 'jsdom-testing-mocks';
 import { act } from 'react';
@@ -75,3 +76,10 @@ failOnConsole({
       message.includes(allowedMessageFragment)
     ),
 });
+
+if (process.env.CI) {
+  configureTestingLibrary({
+    // Change the default waitFor timeout from 1s to 5s.
+    asyncUtilTimeout: 5000,
+  });
+}

--- a/web/packages/teleport/src/Users/Users.test.tsx
+++ b/web/packages/teleport/src/Users/Users.test.tsx
@@ -307,7 +307,7 @@ describe('permission handling', () => {
 
     await screen.findByPlaceholderText('Search...');
 
-    expect(screen.getByTestId('create_new_users_button')).toBeDisabled();
+    expect(await screen.findByTestId('create_new_users_button')).toBeDisabled();
   });
 
   test('edit and reset options not available in the menu', async () => {
@@ -330,7 +330,9 @@ describe('permission handling', () => {
 
     await screen.findByPlaceholderText('Search...');
 
-    const optionsButton = screen.getByRole('button', { name: /options/i });
+    const optionsButton = await screen.findByRole('button', {
+      name: /options/i,
+    });
     fireEvent.click(optionsButton);
     const menuItems = screen.queryAllByRole('menuitem');
     expect(menuItems).toHaveLength(1);
@@ -362,7 +364,7 @@ describe('permission handling', () => {
 
     await screen.findByPlaceholderText('Search...');
 
-    expect(screen.getByText('tester')).toBeInTheDocument();
+    expect(await screen.findByText('tester')).toBeInTheDocument();
     const optionsButton = screen.getByRole('button', { name: /options/i });
     fireEvent.click(optionsButton);
     const menuItems = screen.queryAllByRole('menuitem');
@@ -401,7 +403,7 @@ describe('permission handling', () => {
 
     await screen.findByPlaceholderText('Search...');
 
-    expect(screen.getByText('tester')).toBeInTheDocument();
+    expect(await screen.findByText('tester')).toBeInTheDocument();
     const optionsButton = screen.getByRole('button', { name: /options/i });
     fireEvent.click(optionsButton);
     const menuItems = screen.queryAllByRole('menuitem');
@@ -440,7 +442,7 @@ describe('permission handling', () => {
     );
 
     await screen.findByPlaceholderText('Search...');
-    const userRow = screen.getByText('tester');
+    const userRow = await screen.findByText('tester');
     expect(userRow).toBeInTheDocument();
     expect(screen.queryByTestId('user-details-panel')).not.toBeInTheDocument();
 


### PR DESCRIPTION
This is an effort to battle some of the flakiness we're currently seeing which is hard to explain with anything else than CI being extra slow. The timeout is changed only on CI to avoid lengthening the feedback loop in dev env.

```
FAIL web/packages/teleport/src/User/UserContext.test.tsx
  ● user context - error state › should render with the settings from local storage

    Unable to find an element with the text: /theme: dark/i. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

    Ignored nodes: comments, script, style
    <body>
      <div>
        <div
          class="sc-gtssRx sc-jSFkmN sc-hmvlTF ybVmT kBCvSK fPHuDb"
        />
      </div>
    </body>

      116 |     );
      117 |
    > 118 |     const theme = await screen.findByText(/theme: dark/i);
          |                                ^
      119 |
      120 |     expect(theme).toBeInTheDocument();
      121 |   });

      at waitForWrapper (node_modules/.pnpm/@testing-library+dom@10.1.0/node_modules/@testing-library/dom/dist/wait-for.js:163:27)
      at node_modules/.pnpm/@testing-library+dom@10.1.0/node_modules/@testing-library/dom/dist/query-helpers.js:86:33
      at Object.findByText (web/packages/teleport/src/User/UserContext.test.tsx:118:32)
```