### PR TITLE
chore: update event handler docs to clarify session URL routing

### DIFF
--- a/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
+++ b/docs/pages/includes/helm-reference/zz_generated.event-handler.mdx
@@ -214,6 +214,9 @@ will trigger locking. By default, this is set to 1 minute.
 | `string` | `""` |
 
 `fluentd.sessionUrl` is the Fluentd URL where the session logs will be sent.
+The Event Handler appends `.<session-id>.log` to this URL for each session recording.
+Ensure that your log collector's tag matching or routing rules account for this suffix
+(e.g., use `session.*` as a match pattern in Fluentd or Fluent Bit).
 
 ### `fluentd.certificate`
 

--- a/docs/pages/includes/plugins/finish-event-handler-config.mdx
+++ b/docs/pages/includes/plugins/finish-event-handler-config.mdx
@@ -37,6 +37,12 @@ ca = "/home/bob/event-handler/ca.crt"
 cert = "/home/bob/event-handler/client.crt"
 key = "/home/bob/event-handler/client.key"
 url = "https://fluentd.example.com:8888/test.log"
+# The Event Handler appends `.<session-id>.log` to `session-url` when sending
+# session recording events. For example, if `session-url` is
+# `https://fluentd.example.com:8888/session`, the actual requests are sent to
+# paths like `/session.<session-id>.log`. Ensure that your log collector's
+# tag matching or routing rules account for this suffix (e.g., use `session.*`
+# as a match pattern in Fluentd or Fluent Bit).
 session-url = "https://fluentd.example.com:8888/session"
 
 [teleport]
@@ -87,6 +93,12 @@ teleport:
 
 fluentd:
   url: "https://fluentd.fluentd.svc.cluster.local/events.log"
+  # The Event Handler appends `.<session-id>.log` to `session-url` when sending
+  # session recording events. For example, if `session-url` is
+  # `https://fluentd.example.com:8888/session`, the actual requests are sent to
+  # paths like `/session.<session-id>.log`. Ensure that your log collector's
+  # tag matching or routing rules account for this suffix (e.g., use `session.*`
+  # as a match pattern in Fluentd or Fluent Bit).
   sessionUrl: "https://fluentd.fluentd.svc.cluster.local/session.log"
   certificate:
     secretName: "teleport-event-handler-client-tls"

--- a/examples/chart/event-handler/values.yaml
+++ b/examples/chart/event-handler/values.yaml
@@ -96,6 +96,9 @@ fluentd:
   # fluentd.url(string) -- is the Fluentd URL where the events will be sent.
   url: ""
   # fluentd.sessionUrl(string) -- is the Fluentd URL where the session logs will be sent.
+  # The Event Handler appends `.<session-id>.log` to this URL for each session recording.
+  # Ensure that your log collector's tag matching or routing rules account for this suffix
+  # (e.g., use `session.*` as a match pattern in Fluentd or Fluent Bit).
   sessionUrl: ""
   # fluentd.certificate -- contains the configuration for the plugin's Fluentd client certificates.
   # When `certManager.enabled` is true, `cert-manager` will use its own secrets, so this section is unused.

--- a/integrations/event-handler/README.md
+++ b/integrations/event-handler/README.md
@@ -27,7 +27,7 @@ You may specify configuration options via command line arguments, environment va
 | teleport-refresh-enabled  | Controls if the identity file should be reloaded from disk after the initial start on interval.       | FDFWD_TELEPORT_REFRESH_ENABLED  |
 | teleport-refresh-interval | How often to load the identity file from disk when teleport-refresh-enabled is specified. Default: 1m | FDFWD_TELEPORT_REFRESH_INTERVAL |
 | fluentd-url               | Fluentd URL                                                                                           | FDFWD_FLUENTD_URL               |
-| fluentd-session-url       | Fluentd session URL                                                                                   | FDFWD_FLUENTD_SESSION_URL       |
+| fluentd-session-url       | Fluentd session URL (base URL; `.<session-id>.log` is appended for each session)                      | FDFWD_FLUENTD_SESSION_URL       |
 | fluentd-ca                | Fluentd TLS CA file                                                                                   | FDFWD_FLUENTD_CA                |
 | fluentd-cert              | Fluentd TLS certificate file                                                                          | FDFWD_FLUENTD_CERT              |
 | fluentd-key               | Fluentd TLS key file                                                                                  | FDFWD_FLUENTD_KEY               |

--- a/integrations/event-handler/cli.go
+++ b/integrations/event-handler/cli.go
@@ -34,8 +34,9 @@ type FluentdConfig struct {
 	// FluentdURL fluentd url for audit log events
 	FluentdURL string `help:"fluentd url" required:"true" env:"FDFWD_FLUENTD_URL"`
 
-	// FluentdSessionURL
-	FluentdSessionURL string `help:"fluentd session url" required:"true" env:"FDFWD_FLUENTD_SESSION_URL"`
+	// FluentdSessionURL is the base URL for session recording events.
+	// The event handler appends .<session-id>.log to this URL for each session.
+	FluentdSessionURL string `help:"fluentd session url (.<session-id>.log is appended per session)" required:"true" env:"FDFWD_FLUENTD_SESSION_URL"`
 
 	// FluentdCert is a path to fluentd cert
 	FluentdCert string `help:"fluentd TLS certificate file" type:"existingfile" env:"FDFWD_FLUENTD_CERT,FDWRD_FLUENTD_CERT"`

--- a/integrations/event-handler/tpl/fluent.conf.tpl
+++ b/integrations/event-handler/tpl/fluent.conf.tpl
@@ -40,6 +40,8 @@
   @type stdout
 </match>
 
+# The Event Handler appends .<session-id>.log to the configured session URL,
+# so session events arrive with tags like session.<session-id>.log.
 <match session.*.log>
   @type stdout
 </match>

--- a/integrations/event-handler/tpl/teleport-event-handler.toml.tpl
+++ b/integrations/event-handler/tpl/teleport-event-handler.toml.tpl
@@ -7,6 +7,8 @@ ca = "{{index .CaCertPath}}"
 cert = "{{index .ClientCertPath}}"
 key = "{{index .ClientKeyPath}}"
 url = "https://localhost:8888/test.log"
+# Note: .<session-id>.log is appended to session-url for each session recording.
+# Ensure your log collector's tag matching accounts for this (e.g., session.* in Fluentd/Fluent Bit).
 session-url = "https://localhost:8888/session"
 
 [teleport]


### PR DESCRIPTION
Adds clarifying documentation that the [event handler will append](https://github.com/gravitational/teleport/blob/master/integrations/event-handler/session_events_job.go#L330) `.<<SESSION-UUID>>.log` to the `sessionUrl` setting, as it is non-apparent to the end user that this is what's happening.