### PR TITLE
[v18] Add UpsertScopedToken RPC & Add secret obfuscating server side

### DIFF
--- a/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service.pb.go
@@ -40,7 +40,9 @@ const (
 type GetScopedTokenRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Name is the name of the scoped token.
-	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// If true, include the token secret in the response.
+	WithSecret    bool `protobuf:"varint,2,opt,name=with_secret,json=withSecret,proto3" json:"with_secret,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -80,6 +82,13 @@ func (x *GetScopedTokenRequest) GetName() string {
 		return x.Name
 	}
 	return ""
+}
+
+func (x *GetScopedTokenRequest) GetWithSecret() bool {
+	if x != nil {
+		return x.WithSecret
+	}
+	return false
 }
 
 // GetScopedTokenResponse is the response to get a scoped token.
@@ -142,7 +151,9 @@ type ListScopedTokensRequest struct {
 	// Filter tokens that apply at least one of the provided roles.
 	Roles []string `protobuf:"bytes,5,rep,name=roles,proto3" json:"roles,omitempty"`
 	// Filter tokens that match all provided labels.
-	Labels        map[string]string `protobuf:"bytes,6,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Labels map[string]string `protobuf:"bytes,6,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// If true, include the token secrets in the response.
+	WithSecrets   bool `protobuf:"varint,7,opt,name=with_secrets,json=withSecrets,proto3" json:"with_secrets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -217,6 +228,13 @@ func (x *ListScopedTokensRequest) GetLabels() map[string]string {
 		return x.Labels
 	}
 	return nil
+}
+
+func (x *ListScopedTokensRequest) GetWithSecrets() bool {
+	if x != nil {
+		return x.WithSecrets
+	}
+	return false
 }
 
 // ListScopedTokensResponse is the response to list scoped tokens.
@@ -366,29 +384,29 @@ func (x *CreateScopedTokenResponse) GetToken() *ScopedToken {
 	return nil
 }
 
-// UpdateScopedTokenRequest is the request to update a scoped token.
-type UpdateScopedTokenRequest struct {
+// UpsertScopedTokenRequest is the request to upsert a scoped token.
+type UpsertScopedTokenRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Token is the scoped token to update.
+	// Token is the scoped token to upsert.
 	Token         *ScopedToken `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *UpdateScopedTokenRequest) Reset() {
-	*x = UpdateScopedTokenRequest{}
+func (x *UpsertScopedTokenRequest) Reset() {
+	*x = UpsertScopedTokenRequest{}
 	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *UpdateScopedTokenRequest) String() string {
+func (x *UpsertScopedTokenRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*UpdateScopedTokenRequest) ProtoMessage() {}
+func (*UpsertScopedTokenRequest) ProtoMessage() {}
 
-func (x *UpdateScopedTokenRequest) ProtoReflect() protoreflect.Message {
+func (x *UpsertScopedTokenRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -400,41 +418,41 @@ func (x *UpdateScopedTokenRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use UpdateScopedTokenRequest.ProtoReflect.Descriptor instead.
-func (*UpdateScopedTokenRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use UpsertScopedTokenRequest.ProtoReflect.Descriptor instead.
+func (*UpsertScopedTokenRequest) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_joining_v1_service_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *UpdateScopedTokenRequest) GetToken() *ScopedToken {
+func (x *UpsertScopedTokenRequest) GetToken() *ScopedToken {
 	if x != nil {
 		return x.Token
 	}
 	return nil
 }
 
-// UpdateScopedTokenResponse is the response to update a scoped token.
-type UpdateScopedTokenResponse struct {
+// UpsertScopedTokenResponse is the response to upsert a scoped token.
+type UpsertScopedTokenResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Token is the post-update scoped token.
+	// Token is the post-upsert scoped token.
 	Token         *ScopedToken `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *UpdateScopedTokenResponse) Reset() {
-	*x = UpdateScopedTokenResponse{}
+func (x *UpsertScopedTokenResponse) Reset() {
+	*x = UpsertScopedTokenResponse{}
 	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *UpdateScopedTokenResponse) String() string {
+func (x *UpsertScopedTokenResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*UpdateScopedTokenResponse) ProtoMessage() {}
+func (*UpsertScopedTokenResponse) ProtoMessage() {}
 
-func (x *UpdateScopedTokenResponse) ProtoReflect() protoreflect.Message {
+func (x *UpsertScopedTokenResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_teleport_scopes_joining_v1_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -446,12 +464,12 @@ func (x *UpdateScopedTokenResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use UpdateScopedTokenResponse.ProtoReflect.Descriptor instead.
-func (*UpdateScopedTokenResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use UpsertScopedTokenResponse.ProtoReflect.Descriptor instead.
+func (*UpsertScopedTokenResponse) Descriptor() ([]byte, []int) {
 	return file_teleport_scopes_joining_v1_service_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *UpdateScopedTokenResponse) GetToken() *ScopedToken {
+func (x *UpsertScopedTokenResponse) GetToken() *ScopedToken {
 	if x != nil {
 		return x.Token
 	}
@@ -554,18 +572,21 @@ var File_teleport_scopes_joining_v1_service_proto protoreflect.FileDescriptor
 
 const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\n" +
-	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"+\n" +
+	"(teleport/scopes/joining/v1/service.proto\x12\x1ateleport.scopes.joining.v1\x1a&teleport/scopes/joining/v1/token.proto\x1a\x1fteleport/scopes/v1/scopes.proto\"L\n" +
 	"\x15GetScopedTokenRequest\x12\x12\n" +
-	"\x04name\x18\x01 \x01(\tR\x04name\"W\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1f\n" +
+	"\vwith_secret\x18\x02 \x01(\bR\n" +
+	"withSecret\"W\n" +
 	"\x16GetScopedTokenResponse\x12=\n" +
-	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\xf7\x02\n" +
+	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"\x9a\x03\n" +
 	"\x17ListScopedTokensRequest\x12A\n" +
 	"\x0eresource_scope\x18\x01 \x01(\v2\x1a.teleport.scopes.v1.FilterR\rresourceScope\x12A\n" +
 	"\x0eassigned_scope\x18\x02 \x01(\v2\x1a.teleport.scopes.v1.FilterR\rassignedScope\x12\x16\n" +
 	"\x06cursor\x18\x03 \x01(\tR\x06cursor\x12\x14\n" +
 	"\x05limit\x18\x04 \x01(\rR\x05limit\x12\x14\n" +
 	"\x05roles\x18\x05 \x03(\tR\x05roles\x12W\n" +
-	"\x06labels\x18\x06 \x03(\v2?.teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntryR\x06labels\x1a9\n" +
+	"\x06labels\x18\x06 \x03(\v2?.teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntryR\x06labels\x12!\n" +
+	"\fwith_secrets\x18\a \x01(\bR\vwithSecrets\x1a9\n" +
 	"\vLabelsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"s\n" +
@@ -576,9 +597,9 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +
 	"\x19CreateScopedTokenResponse\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Y\n" +
-	"\x18UpdateScopedTokenRequest\x12=\n" +
+	"\x18UpsertScopedTokenRequest\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"Z\n" +
-	"\x19UpdateScopedTokenResponse\x12=\n" +
+	"\x19UpsertScopedTokenResponse\x12=\n" +
 	"\x05token\x18\x01 \x01(\v2'.teleport.scopes.joining.v1.ScopedTokenR\x05token\"J\n" +
 	"\x18DeleteScopedTokenRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x1a\n" +
@@ -588,7 +609,7 @@ const file_teleport_scopes_joining_v1_service_proto_rawDesc = "" +
 	"\x0eGetScopedToken\x121.teleport.scopes.joining.v1.GetScopedTokenRequest\x1a2.teleport.scopes.joining.v1.GetScopedTokenResponse\x12}\n" +
 	"\x10ListScopedTokens\x123.teleport.scopes.joining.v1.ListScopedTokensRequest\x1a4.teleport.scopes.joining.v1.ListScopedTokensResponse\x12\x80\x01\n" +
 	"\x11CreateScopedToken\x124.teleport.scopes.joining.v1.CreateScopedTokenRequest\x1a5.teleport.scopes.joining.v1.CreateScopedTokenResponse\x12\x80\x01\n" +
-	"\x11UpdateScopedToken\x124.teleport.scopes.joining.v1.UpdateScopedTokenRequest\x1a5.teleport.scopes.joining.v1.UpdateScopedTokenResponse\x12\x80\x01\n" +
+	"\x11UpsertScopedToken\x124.teleport.scopes.joining.v1.UpsertScopedTokenRequest\x1a5.teleport.scopes.joining.v1.UpsertScopedTokenResponse\x12\x80\x01\n" +
 	"\x11DeleteScopedToken\x124.teleport.scopes.joining.v1.DeleteScopedTokenRequest\x1a5.teleport.scopes.joining.v1.DeleteScopedTokenResponseBYZWgithub.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1;joiningv1b\x06proto3"
 
 var (
@@ -611,8 +632,8 @@ var file_teleport_scopes_joining_v1_service_proto_goTypes = []any{
 	(*ListScopedTokensResponse)(nil),  // 3: teleport.scopes.joining.v1.ListScopedTokensResponse
 	(*CreateScopedTokenRequest)(nil),  // 4: teleport.scopes.joining.v1.CreateScopedTokenRequest
 	(*CreateScopedTokenResponse)(nil), // 5: teleport.scopes.joining.v1.CreateScopedTokenResponse
-	(*UpdateScopedTokenRequest)(nil),  // 6: teleport.scopes.joining.v1.UpdateScopedTokenRequest
-	(*UpdateScopedTokenResponse)(nil), // 7: teleport.scopes.joining.v1.UpdateScopedTokenResponse
+	(*UpsertScopedTokenRequest)(nil),  // 6: teleport.scopes.joining.v1.UpsertScopedTokenRequest
+	(*UpsertScopedTokenResponse)(nil), // 7: teleport.scopes.joining.v1.UpsertScopedTokenResponse
 	(*DeleteScopedTokenRequest)(nil),  // 8: teleport.scopes.joining.v1.DeleteScopedTokenRequest
 	(*DeleteScopedTokenResponse)(nil), // 9: teleport.scopes.joining.v1.DeleteScopedTokenResponse
 	nil,                               // 10: teleport.scopes.joining.v1.ListScopedTokensRequest.LabelsEntry
@@ -627,17 +648,17 @@ var file_teleport_scopes_joining_v1_service_proto_depIdxs = []int32{
 	11, // 4: teleport.scopes.joining.v1.ListScopedTokensResponse.tokens:type_name -> teleport.scopes.joining.v1.ScopedToken
 	11, // 5: teleport.scopes.joining.v1.CreateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
 	11, // 6: teleport.scopes.joining.v1.CreateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 7: teleport.scopes.joining.v1.UpdateScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
-	11, // 8: teleport.scopes.joining.v1.UpdateScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 7: teleport.scopes.joining.v1.UpsertScopedTokenRequest.token:type_name -> teleport.scopes.joining.v1.ScopedToken
+	11, // 8: teleport.scopes.joining.v1.UpsertScopedTokenResponse.token:type_name -> teleport.scopes.joining.v1.ScopedToken
 	0,  // 9: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:input_type -> teleport.scopes.joining.v1.GetScopedTokenRequest
 	2,  // 10: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:input_type -> teleport.scopes.joining.v1.ListScopedTokensRequest
 	4,  // 11: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:input_type -> teleport.scopes.joining.v1.CreateScopedTokenRequest
-	6,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:input_type -> teleport.scopes.joining.v1.UpdateScopedTokenRequest
+	6,  // 12: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:input_type -> teleport.scopes.joining.v1.UpsertScopedTokenRequest
 	8,  // 13: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:input_type -> teleport.scopes.joining.v1.DeleteScopedTokenRequest
 	1,  // 14: teleport.scopes.joining.v1.ScopedJoiningService.GetScopedToken:output_type -> teleport.scopes.joining.v1.GetScopedTokenResponse
 	3,  // 15: teleport.scopes.joining.v1.ScopedJoiningService.ListScopedTokens:output_type -> teleport.scopes.joining.v1.ListScopedTokensResponse
 	5,  // 16: teleport.scopes.joining.v1.ScopedJoiningService.CreateScopedToken:output_type -> teleport.scopes.joining.v1.CreateScopedTokenResponse
-	7,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.UpdateScopedToken:output_type -> teleport.scopes.joining.v1.UpdateScopedTokenResponse
+	7,  // 17: teleport.scopes.joining.v1.ScopedJoiningService.UpsertScopedToken:output_type -> teleport.scopes.joining.v1.UpsertScopedTokenResponse
 	9,  // 18: teleport.scopes.joining.v1.ScopedJoiningService.DeleteScopedToken:output_type -> teleport.scopes.joining.v1.DeleteScopedTokenResponse
 	14, // [14:19] is the sub-list for method output_type
 	9,  // [9:14] is the sub-list for method input_type

--- a/api/gen/proto/go/teleport/scopes/joining/v1/service_grpc.pb.go
+++ b/api/gen/proto/go/teleport/scopes/joining/v1/service_grpc.pb.go
@@ -36,7 +36,7 @@ const (
 	ScopedJoiningService_GetScopedToken_FullMethodName    = "/teleport.scopes.joining.v1.ScopedJoiningService/GetScopedToken"
 	ScopedJoiningService_ListScopedTokens_FullMethodName  = "/teleport.scopes.joining.v1.ScopedJoiningService/ListScopedTokens"
 	ScopedJoiningService_CreateScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/CreateScopedToken"
-	ScopedJoiningService_UpdateScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/UpdateScopedToken"
+	ScopedJoiningService_UpsertScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/UpsertScopedToken"
 	ScopedJoiningService_DeleteScopedToken_FullMethodName = "/teleport.scopes.joining.v1.ScopedJoiningService/DeleteScopedToken"
 )
 
@@ -52,8 +52,8 @@ type ScopedJoiningServiceClient interface {
 	ListScopedTokens(ctx context.Context, in *ListScopedTokensRequest, opts ...grpc.CallOption) (*ListScopedTokensResponse, error)
 	// CreateScopedToken creates a new scoped token.
 	CreateScopedToken(ctx context.Context, in *CreateScopedTokenRequest, opts ...grpc.CallOption) (*CreateScopedTokenResponse, error)
-	// UpdateScopedToken updates a scoped token.
-	UpdateScopedToken(ctx context.Context, in *UpdateScopedTokenRequest, opts ...grpc.CallOption) (*UpdateScopedTokenResponse, error)
+	// UpsertScopedToken upserts a scoped token.
+	UpsertScopedToken(ctx context.Context, in *UpsertScopedTokenRequest, opts ...grpc.CallOption) (*UpsertScopedTokenResponse, error)
 	// DeleteScopedToken deletes a scoped token.
 	DeleteScopedToken(ctx context.Context, in *DeleteScopedTokenRequest, opts ...grpc.CallOption) (*DeleteScopedTokenResponse, error)
 }
@@ -96,10 +96,10 @@ func (c *scopedJoiningServiceClient) CreateScopedToken(ctx context.Context, in *
 	return out, nil
 }
 
-func (c *scopedJoiningServiceClient) UpdateScopedToken(ctx context.Context, in *UpdateScopedTokenRequest, opts ...grpc.CallOption) (*UpdateScopedTokenResponse, error) {
+func (c *scopedJoiningServiceClient) UpsertScopedToken(ctx context.Context, in *UpsertScopedTokenRequest, opts ...grpc.CallOption) (*UpsertScopedTokenResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(UpdateScopedTokenResponse)
-	err := c.cc.Invoke(ctx, ScopedJoiningService_UpdateScopedToken_FullMethodName, in, out, cOpts...)
+	out := new(UpsertScopedTokenResponse)
+	err := c.cc.Invoke(ctx, ScopedJoiningService_UpsertScopedToken_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -128,8 +128,8 @@ type ScopedJoiningServiceServer interface {
 	ListScopedTokens(context.Context, *ListScopedTokensRequest) (*ListScopedTokensResponse, error)
 	// CreateScopedToken creates a new scoped token.
 	CreateScopedToken(context.Context, *CreateScopedTokenRequest) (*CreateScopedTokenResponse, error)
-	// UpdateScopedToken updates a scoped token.
-	UpdateScopedToken(context.Context, *UpdateScopedTokenRequest) (*UpdateScopedTokenResponse, error)
+	// UpsertScopedToken upserts a scoped token.
+	UpsertScopedToken(context.Context, *UpsertScopedTokenRequest) (*UpsertScopedTokenResponse, error)
 	// DeleteScopedToken deletes a scoped token.
 	DeleteScopedToken(context.Context, *DeleteScopedTokenRequest) (*DeleteScopedTokenResponse, error)
 	mustEmbedUnimplementedScopedJoiningServiceServer()
@@ -151,8 +151,8 @@ func (UnimplementedScopedJoiningServiceServer) ListScopedTokens(context.Context,
 func (UnimplementedScopedJoiningServiceServer) CreateScopedToken(context.Context, *CreateScopedTokenRequest) (*CreateScopedTokenResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method CreateScopedToken not implemented")
 }
-func (UnimplementedScopedJoiningServiceServer) UpdateScopedToken(context.Context, *UpdateScopedTokenRequest) (*UpdateScopedTokenResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method UpdateScopedToken not implemented")
+func (UnimplementedScopedJoiningServiceServer) UpsertScopedToken(context.Context, *UpsertScopedTokenRequest) (*UpsertScopedTokenResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpsertScopedToken not implemented")
 }
 func (UnimplementedScopedJoiningServiceServer) DeleteScopedToken(context.Context, *DeleteScopedTokenRequest) (*DeleteScopedTokenResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteScopedToken not implemented")
@@ -232,20 +232,20 @@ func _ScopedJoiningService_CreateScopedToken_Handler(srv interface{}, ctx contex
 	return interceptor(ctx, in, info, handler)
 }
 
-func _ScopedJoiningService_UpdateScopedToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(UpdateScopedTokenRequest)
+func _ScopedJoiningService_UpsertScopedToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpsertScopedTokenRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(ScopedJoiningServiceServer).UpdateScopedToken(ctx, in)
+		return srv.(ScopedJoiningServiceServer).UpsertScopedToken(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: ScopedJoiningService_UpdateScopedToken_FullMethodName,
+		FullMethod: ScopedJoiningService_UpsertScopedToken_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(ScopedJoiningServiceServer).UpdateScopedToken(ctx, req.(*UpdateScopedTokenRequest))
+		return srv.(ScopedJoiningServiceServer).UpsertScopedToken(ctx, req.(*UpsertScopedTokenRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -288,8 +288,8 @@ var ScopedJoiningService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _ScopedJoiningService_CreateScopedToken_Handler,
 		},
 		{
-			MethodName: "UpdateScopedToken",
-			Handler:    _ScopedJoiningService_UpdateScopedToken_Handler,
+			MethodName: "UpsertScopedToken",
+			Handler:    _ScopedJoiningService_UpsertScopedToken_Handler,
 		},
 		{
 			MethodName: "DeleteScopedToken",

--- a/api/proto/teleport/scopes/joining/v1/service.proto
+++ b/api/proto/teleport/scopes/joining/v1/service.proto
@@ -32,8 +32,8 @@ service ScopedJoiningService {
   // CreateScopedToken creates a new scoped token.
   rpc CreateScopedToken(CreateScopedTokenRequest) returns (CreateScopedTokenResponse);
 
-  // UpdateScopedToken updates a scoped token.
-  rpc UpdateScopedToken(UpdateScopedTokenRequest) returns (UpdateScopedTokenResponse);
+  // UpsertScopedToken upserts a scoped token.
+  rpc UpsertScopedToken(UpsertScopedTokenRequest) returns (UpsertScopedTokenResponse);
 
   // DeleteScopedToken deletes a scoped token.
   rpc DeleteScopedToken(DeleteScopedTokenRequest) returns (DeleteScopedTokenResponse);
@@ -43,6 +43,9 @@ service ScopedJoiningService {
 message GetScopedTokenRequest {
   // Name is the name of the scoped token.
   string name = 1;
+
+  // If true, include the token secret in the response.
+  bool with_secret = 2;
 }
 
 // GetScopedTokenResponse is the response to get a scoped token.
@@ -70,6 +73,9 @@ message ListScopedTokensRequest {
 
   // Filter tokens that match all provided labels.
   map<string, string> labels = 6;
+
+  // If true, include the token secrets in the response.
+  bool with_secrets = 7;
 }
 
 // ListScopedTokensResponse is the response to list scoped tokens.
@@ -93,15 +99,15 @@ message CreateScopedTokenResponse {
   ScopedToken token = 1;
 }
 
-// UpdateScopedTokenRequest is the request to update a scoped token.
-message UpdateScopedTokenRequest {
-  // Token is the scoped token to update.
+// UpsertScopedTokenRequest is the request to upsert a scoped token.
+message UpsertScopedTokenRequest {
+  // Token is the scoped token to upsert.
   ScopedToken token = 1;
 }
 
-// UpdateScopedTokenResponse is the response to update a scoped token.
-message UpdateScopedTokenResponse {
-  // Token is the post-update scoped token.
+// UpsertScopedTokenResponse is the response to upsert a scoped token.
+message UpsertScopedTokenResponse {
+  // Token is the post-upsert scoped token.
   ScopedToken token = 1;
 }
 

--- a/lib/join/server.go
+++ b/lib/join/server.go
@@ -173,7 +173,8 @@ func (s *Server) getProvisionToken(ctx context.Context, name string) (provision.
 		}
 
 		res, err := s.cfg.ScopedTokenService.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
-			Name: name,
+			Name:       name,
+			WithSecret: true,
 		})
 		if err != nil {
 			scopedErr = err

--- a/lib/scopes/access/verbs.go
+++ b/lib/scopes/access/verbs.go
@@ -29,7 +29,7 @@ func isAllowedScopedRule(kind string, verb string) bool {
 		return isReadWriteNoSecrets(verb)
 	case types.KindScopedToken:
 		// scoped tokens can be read/written, and contain secrets.
-		return isReadWriteWithSecrets(verb)
+		return isReadWriteWithSecrets(verb) || isReadWriteNoSecrets(verb)
 	default:
 		return false
 	}

--- a/lib/scopes/joining/token.go
+++ b/lib/scopes/joining/token.go
@@ -184,6 +184,33 @@ func ValidateTokenForUse(token *joiningv1.ScopedToken) error {
 	return nil
 }
 
+// ValidateTokenUpdate checks for invalid updates between two tokens.
+// If the scope, usage mode, or secret was changed between two token updates,
+// a trace.BadParameter error is returned.
+func ValidateTokenUpdate(oldToken *joiningv1.ScopedToken, newToken *joiningv1.ScopedToken) error {
+	if newToken == nil {
+		return trace.BadParameter("new token is invalid")
+	}
+	// no old token to compare to so we assume that the new token is valid and no need for additional checks
+	if oldToken == nil {
+		return nil
+	}
+	tokenName := newToken.GetMetadata().GetName()
+	if oldToken.GetScope() != newToken.GetScope() {
+		return trace.BadParameter("cannot modify scope of existing scoped token %s with scope %s to %s", tokenName, oldToken.GetScope(), newToken.GetScope())
+	}
+
+	if oldToken.GetSpec().GetUsageMode() != newToken.GetSpec().GetUsageMode() {
+		return trace.BadParameter("cannot modify usage mode of existing scoped token %s from usage mode %s to %s", tokenName, oldToken.GetSpec().GetUsageMode(), newToken.GetSpec().GetUsageMode())
+	}
+
+	if oldToken.GetStatus().GetSecret() != newToken.GetStatus().GetSecret() {
+		return trace.BadParameter("cannot modify secret of existing scoped token %s", tokenName)
+	}
+
+	return nil
+}
+
 // Token wraps a [joiningv1.ScopedToken] such that it can be used to provision
 // resources.
 type Token struct {

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -531,3 +531,71 @@ func TestImmutableLabelHashing(t *testing.T) {
 	labels.Ssh["three"] = "3"
 	require.False(t, joining.VerifyImmutableLabelsHash(labels, initialHash))
 }
+
+func TestValidateTokenUpdate(t *testing.T) {
+	baseToken := &joiningv1.ScopedToken{
+		Kind:    types.KindScopedToken,
+		Version: types.V1,
+		Metadata: &headerv1.Metadata{
+			Name: "test-token",
+		},
+		Scope: "/test",
+		Spec: &joiningv1.ScopedTokenSpec{
+			AssignedScope: "/test/one",
+			JoinMethod:    string(types.JoinMethodToken),
+			Roles:         []string{types.RoleNode.String()},
+			UsageMode:     string(joining.TokenUsageModeUnlimited),
+		},
+		Status: &joiningv1.ScopedTokenStatus{
+			Secret: "secret-value",
+		},
+	}
+
+	for _, tc := range []struct {
+		name            string
+		modifyTokenFunc func(*joiningv1.ScopedToken)
+		wantErr         string
+	}{
+		{
+			name: "check scope change",
+			modifyTokenFunc: func(t *joiningv1.ScopedToken) {
+				t.Scope = "/other"
+				t.Spec.AssignedScope = "/other/one"
+			},
+			wantErr: "cannot modify scope of existing scoped token test-token with scope /test to /other",
+		},
+		{
+			name: "check usage mode change",
+			modifyTokenFunc: func(t *joiningv1.ScopedToken) {
+				t.Spec.UsageMode = string(joining.TokenUsageModeSingle)
+			},
+			wantErr: fmt.Sprintf("cannot modify usage mode of existing scoped token test-token from usage mode %s to %s", joining.TokenUsageModeUnlimited, joining.TokenUsageModeSingle),
+		},
+		{
+			name: "check secret change",
+			modifyTokenFunc: func(t *joiningv1.ScopedToken) {
+				t.Status.Secret = "new-secret-value"
+			},
+			wantErr: "cannot modify secret of existing scoped token test-token",
+		},
+		{
+			name: "valid update",
+			modifyTokenFunc: func(t *joiningv1.ScopedToken) {
+				t.Metadata.Labels = map[string]string{"env": "production"}
+				t.Spec.AssignedScope = "/test/one/two"
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			modified := proto.CloneOf(baseToken)
+			tc.modifyTokenFunc(modified)
+
+			err := joining.ValidateTokenUpdate(baseToken, modified)
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/lib/scopes/joining/token_test.go
+++ b/lib/scopes/joining/token_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"

--- a/lib/services/local/scoped_tokens.go
+++ b/lib/services/local/scoped_tokens.go
@@ -31,6 +31,7 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	scopesv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/scopes"
 	"github.com/gravitational/teleport/lib/scopes/joining"
@@ -39,7 +40,8 @@ import (
 )
 
 const (
-	scopedTokenPrefix = "scoped_token"
+	scopedTokenPrefix      = "scoped_token"
+	maxTokenUpsertAttempts = 4
 )
 
 // ScopedTokenService exposes backend functionality for working with scoped token resources.
@@ -137,8 +139,13 @@ func (s *ScopedTokenService) GetScopedToken(ctx context.Context, req *joiningv1.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	if err := joining.WeakValidateToken(token); err != nil {
 		return nil, trace.Wrap(err)
+	}
+
+	if !req.GetWithSecret() {
+		setScopedTokenWithoutSecret(token)
 	}
 	return &joiningv1.GetScopedTokenResponse{Token: token}, nil
 }
@@ -229,7 +236,9 @@ func (s *ScopedTokenService) ListScopedTokens(ctx context.Context, req *joiningv
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-
+		if !req.GetWithSecrets() {
+			setScopedTokenWithoutSecret(tokens...)
+		}
 		return &joiningv1.ListScopedTokensResponse{
 			Tokens: tokens,
 			Cursor: cursor,
@@ -292,6 +301,10 @@ func (s *ScopedTokenService) ListScopedTokens(ctx context.Context, req *joiningv
 		return nil, trace.Wrap(err)
 	}
 
+	if !req.GetWithSecrets() {
+		setScopedTokenWithoutSecret(tokens...)
+	}
+
 	return &joiningv1.ListScopedTokensResponse{
 		Tokens: tokens,
 		Cursor: cursor,
@@ -301,6 +314,82 @@ func (s *ScopedTokenService) ListScopedTokens(ctx context.Context, req *joiningv
 // DeleteScopedToken deletes a scoped token by name.
 func (s *ScopedTokenService) DeleteScopedToken(ctx context.Context, req *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error) {
 	return nil, trace.Wrap(s.svc.DeleteResource(ctx, req.GetName()))
+}
+
+// UpsertScopedToken updates or creates a scoped token. If updating an existing token, the scope and status must not be modified.
+func (s *ScopedTokenService) UpsertScopedToken(ctx context.Context, req *joiningv1.UpsertScopedTokenRequest) (*joiningv1.UpsertScopedTokenResponse, error) {
+	tokenUpsert := req.GetToken()
+
+	if err := joining.StrongValidateToken(tokenUpsert); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// We handle 4 retry attempts to try and handle some concurrency. Handling more retries than this
+	// indicates that something may be going wrong.
+	for attempt := range maxTokenUpsertAttempts {
+		if attempt != 0 {
+			select {
+			case <-time.After(retryutils.FullJitter(time.Duration(300*attempt) * time.Millisecond)):
+			case <-ctx.Done():
+				return nil, trace.Wrap(ctx.Err())
+			}
+		}
+
+		existingToken, err := s.svc.GetResource(ctx, tokenUpsert.GetMetadata().GetName())
+		if err != nil {
+			if !trace.IsNotFound(err) {
+				return nil, trace.Wrap(err)
+			}
+		}
+
+		// We enforce this validating the updates here in order for the access-control layer's checks to be sound.
+		// Changing this would require rethinking or additional changes to the access-control checks.
+		if err := joining.ValidateTokenUpdate(existingToken, tokenUpsert); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if existingToken != nil {
+			// Use conditional update with revision checking to ensure the token hasn't changed since we validated it.
+			// This prevents race conditions where the token could be deleted and recreated with
+			// different properties between our validation check and the write.
+			tokenUpsert.GetMetadata().Revision = existingToken.GetMetadata().GetRevision()
+			upsertedToken, err := s.svc.ConditionalUpdateResource(ctx, tokenUpsert)
+			if err != nil {
+				if trace.IsCompareFailed(err) {
+					continue
+				}
+				return nil, trace.Wrap(err)
+			}
+
+			return &joiningv1.UpsertScopedTokenResponse{
+				Token: upsertedToken,
+			}, nil
+		}
+
+		createdToken, err := s.svc.CreateResource(ctx, tokenUpsert)
+		if err != nil {
+			// This will only be true if we call upsert concurrently and there was no existing token.
+			// One of the concurrent calls will retry but as an update call.
+			if trace.IsAlreadyExists(err) {
+				continue
+			}
+			return nil, trace.Wrap(err)
+		}
+
+		return &joiningv1.UpsertScopedTokenResponse{
+			Token: createdToken,
+		}, nil
+	}
+
+	return nil, trace.LimitExceeded("exceeded max retries attempting to upsert scoped token - too many concurrent modifications")
+}
+
+func setScopedTokenWithoutSecret(token ...*joiningv1.ScopedToken) {
+	for _, t := range token {
+		if t != nil && t.Status != nil {
+			t.Status.Secret = ""
+		}
+	}
 }
 
 type scopedTokenParser struct {

--- a/lib/services/local/scoped_tokens_test.go
+++ b/lib/services/local/scoped_tokens_test.go
@@ -26,9 +26,11 @@ import (
 	"time"
 
 	gocmp "github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -80,11 +82,32 @@ func TestScopedTokenService(t *testing.T) {
 	}
 	assert.Empty(t, gocmp.Diff(token, created.Token, cmpOpts...))
 
+	updatedToken := proto.CloneOf(token)
+	updatedToken.Spec.AssignedScope = "/test/test"
+
+	updated, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{
+		Token: created.GetToken(),
+	})
+	require.NoError(t, err)
+
 	fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
 		Name: token.Metadata.Name,
 	})
 	require.NoError(t, err)
-	assert.Empty(t, gocmp.Diff(created.Token, fetched.Token, cmpOpts...))
+	require.Equal(t, fetched.Token.Spec.AssignedScope, updated.Token.Spec.AssignedScope)
+	require.Empty(t, fetched.Token.Status.Secret)
+
+	list, err := service.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{})
+	require.NoError(t, err)
+	require.Len(t, list.Tokens, 1)
+
+	fetched, err = service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+		Name:       token.Metadata.Name,
+		WithSecret: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, fetched.Token.Status.Secret)
+	assert.Empty(t, gocmp.Diff(updated.Token, fetched.Token, cmpOpts...))
 
 	_, err = service.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
 		Name: fetched.Token.Metadata.Name,
@@ -126,8 +149,10 @@ func TestScopedTokenService(t *testing.T) {
 	require.True(t, trace.IsNotFound(err))
 
 	fetchedActive, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
-		Name: activeRes.Token.Metadata.Name,
+		Name:       activeRes.Token.Metadata.Name,
+		WithSecret: true,
 	})
+
 	require.NoError(t, err)
 	assert.Empty(t, gocmp.Diff(activeRes.Token, fetchedActive.Token, cmpOpts...))
 }
@@ -213,8 +238,10 @@ func TestScopedTokenList(t *testing.T) {
 		expected []*joiningv1.ScopedToken
 	}{
 		{
-			name:     "all tokens (no filters)",
-			req:      &joiningv1.ListScopedTokensRequest{},
+			name: "all tokens (no filters)",
+			req: &joiningv1.ListScopedTokensRequest{
+				WithSecrets: true,
+			},
 			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4, stage, stage1, stage2},
 		},
 		{
@@ -224,6 +251,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/test",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4},
 		},
@@ -234,6 +262,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/test/aa",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test1, test3, test4},
 		},
@@ -244,6 +273,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 					Scope: "/test/bb",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test, test2},
 		},
@@ -254,6 +284,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/test",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4},
 		},
@@ -264,6 +295,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/test/aa",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test1, test3, test4},
 		},
@@ -274,6 +306,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_POLICIES_APPLICABLE_TO_SCOPE,
 					Scope: "/test/bb",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test, test2},
 		},
@@ -288,6 +321,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/stage/aa",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{stage1, stage2},
 		},
@@ -302,6 +336,7 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/stage/aa",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{stage2},
 		},
@@ -312,7 +347,8 @@ func TestScopedTokenList(t *testing.T) {
 					Mode:  scopesv1.Mode_MODE_RESOURCES_SUBJECT_TO_SCOPE,
 					Scope: "/test",
 				},
-				Roles: []string{types.RoleAuth.String()},
+				Roles:       []string{types.RoleAuth.String()},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{},
 		},
@@ -327,8 +363,16 @@ func TestScopedTokenList(t *testing.T) {
 				Labels: map[string]string{
 					"hello": "world",
 				},
+				WithSecrets: true,
 			},
 			expected: []*joiningv1.ScopedToken{test2},
+		},
+		{
+			name: "tokens have no secrets when WithSecrets is false",
+			req: &joiningv1.ListScopedTokensRequest{
+				WithSecrets: false,
+			},
+			expected: []*joiningv1.ScopedToken{test, test1, test2, test3, test4, stage, stage1, stage2},
 		},
 	}
 
@@ -342,10 +386,16 @@ func TestScopedTokenList(t *testing.T) {
 			slices.SortStableFunc(c.expected, sortFn)
 			slices.SortStableFunc(res.GetTokens(), sortFn)
 			require.Len(t, res.GetTokens(), len(c.expected))
+			cmpOpts := []gocmp.Option{
+				protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+				protocmp.Transform(),
+			}
+			if !req.WithSecrets {
+				cmpOpts = append(cmpOpts, protocmp.IgnoreFields(&joiningv1.ScopedTokenStatus{}, "secret"))
+			}
 			for i, token := range res.GetTokens() {
-				cmpOpts := []gocmp.Option{
-					protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
-					protocmp.Transform(),
+				if !req.WithSecrets {
+					assert.Empty(t, token.GetStatus().GetSecret())
 				}
 				assert.Empty(t, gocmp.Diff(c.expected[i], token, cmpOpts...))
 			}
@@ -526,5 +576,186 @@ func TestScopedTokenUse(t *testing.T) {
 		<-time.After(reuseDuration + time.Minute)
 		_, err = service.UseScopedToken(ctx, tok, testKey)
 		require.ErrorIs(t, err, joining.ErrTokenExhausted)
+	})
+}
+
+func TestScopedTokenUpsert(t *testing.T) {
+	t.Parallel()
+	bk, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+	service, err := local.NewScopedTokenService(backend.NewSanitizer(bk))
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	newToken := func() *joiningv1.ScopedToken {
+		return &joiningv1.ScopedToken{
+			Kind:    types.KindScopedToken,
+			Version: types.V1,
+			Metadata: &headerv1.Metadata{
+				Name: uuid.New().String(),
+			},
+			Scope: "/test",
+			Spec: &joiningv1.ScopedTokenSpec{
+				AssignedScope: "/test/one",
+				JoinMethod:    "token",
+				Roles:         []string{types.RoleNode.String()},
+				UsageMode:     string(joining.TokenUsageModeUnlimited),
+			},
+			Status: &joiningv1.ScopedTokenStatus{
+				Secret: "secret",
+			},
+		}
+	}
+	cmpOpts := []gocmp.Option{
+		protocmp.IgnoreFields(&headerv1.Metadata{}, "revision"),
+		protocmp.Transform(),
+	}
+
+	t.Run("upsert creates a new entry", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+
+		upsertedToken, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       upsertedToken.GetToken().GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, gocmp.Diff(upsertedToken.GetToken(), fetched.GetToken(), cmpOpts...))
+	})
+
+	t.Run("upsert updates existing entry", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		updated := proto.CloneOf(token)
+		updated.Metadata.Labels = map[string]string{"env": "test"}
+		updated.Spec.AssignedScope = "/test/one/two"
+
+		updatedToken, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
+		require.NoError(t, err)
+
+		fetched, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       token.GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, gocmp.Diff(updatedToken.GetToken(), fetched.GetToken(), cmpOpts...))
+	})
+
+	t.Run("upsert fails because the scope is changed", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		updated := proto.CloneOf(token)
+		updated.Scope = "/other"
+		updated.Spec.AssignedScope = "/other/one"
+
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
+		require.ErrorContains(t, err, "cannot modify scope of existing scoped token")
+	})
+
+	t.Run("upsert fails because the usage status is changed", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		updated := proto.CloneOf(token)
+		updated.Spec = proto.CloneOf(token.Spec)
+		updated.Spec.UsageMode = string(joining.TokenUsageModeSingle)
+
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
+		require.ErrorContains(t, err, "cannot modify usage mode of existing scoped token")
+	})
+
+	t.Run("upsert fails because the secret is changed", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		updated := proto.CloneOf(token)
+		updated.Status = proto.CloneOf(token.Status)
+		updated.Status.Secret = "new-secret"
+
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: updated})
+		require.ErrorContains(t, err, "cannot modify secret of existing scoped token")
+	})
+
+	t.Run("upsert succeeds when revisions don't match", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+
+		_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: token})
+		require.NoError(t, err)
+
+		fetched1, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       token.GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+
+		update1 := proto.CloneOf(fetched1.GetToken())
+		update1.Metadata.Labels = map[string]string{"env": "production"}
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: update1})
+		require.NoError(t, err)
+
+		// This should succeed as we set the revision before comparing
+		update2 := proto.CloneOf(fetched1.GetToken())
+		update2.GetMetadata().Revision = "somerev"
+		update2.Metadata.Labels = map[string]string{"env": "staging"}
+		_, err = service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: update2})
+		require.NoError(t, err, "upsert should succeed with retry on modification with stale revision")
+
+		// Verify that update2 succeeded and overwrote update1's label
+		final, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       token.GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "staging", final.GetToken().GetMetadata().GetLabels()["env"])
+	})
+
+	t.Run("concurrent upserts succeed", func(t *testing.T) {
+		t.Parallel()
+		token := newToken()
+
+		// Simulate 4 users concurrently upserting the same token with
+		// different labels. Every upsert should succeed thanks to the
+		// built-in retry logic.
+		const numUsers = 4
+
+		var wg errgroup.Group
+		for i := range numUsers {
+			wg.Go(func() error {
+				update := proto.CloneOf(token)
+				update.Metadata.Labels = map[string]string{
+					"user": fmt.Sprintf("user-%d", i),
+				}
+				_, err := service.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{Token: update})
+				return err
+			})
+		}
+		require.NoError(t, wg.Wait(), "concurrent upserts should all succeed")
+
+		// Verify the token still exists and is consistent.
+		final, err := service.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+			Name:       token.GetMetadata().GetName(),
+			WithSecret: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, final.GetToken())
+		// One of the concurrent writers must have won; the label should
+		// belong to one of the 4 users.
+		label := final.GetToken().GetMetadata().GetLabels()["user"]
+		require.Contains(t, []string{"user-0", "user-1", "user-2", "user-3"}, label)
 	})
 }

--- a/lib/services/scoped_tokens.go
+++ b/lib/services/scoped_tokens.go
@@ -41,4 +41,7 @@ type ScopedTokenService interface {
 	// DeleteScopedToken deletes a named scoped join token. Imlementations must guarantee that
 	// this returns trace.NotFound error if the token doesn't exist
 	DeleteScopedToken(ctx context.Context, req *joiningv1.DeleteScopedTokenRequest) (*joiningv1.DeleteScopedTokenResponse, error)
+
+	// UpsertScopedToken updates or creates a scoped join token. If updating an existing token, the scope and status must not be modified.
+	UpsertScopedToken(ctx context.Context, req *joiningv1.UpsertScopedTokenRequest) (*joiningv1.UpsertScopedTokenResponse, error)
 }

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -280,8 +280,9 @@ func (c *ScopedTokensCommand) Del(ctx context.Context, client *authclient.Client
 func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Client) error {
 	tokens, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*joiningv1.ScopedToken, string, error) {
 		res, err := client.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
-			Limit:  uint32(pageSize),
-			Cursor: pageKey,
+			Limit:       uint32(pageSize),
+			Cursor:      pageKey,
+			WithSecrets: c.withSecrets,
 		})
 		if err != nil {
 			return nil, "", trace.Wrap(err)


### PR DESCRIPTION
Backport #63681 to branch/v18

### Manual Test Plans
Full end to end feature won't be completed until https://github.com/gravitational/teleport/pull/63455 is merged in. Upsert test plans to be done when the above PR is merged in.

#### Secret Obfuscation with `tctl scoped tokens` command (List)

- [x] As the admin user (has `read` verb), run `tctl scoped tokens ls --with-secret` 
- [x] As the admin user, run `tctl scoped tokens ls` (no `--with-secret` flag)
- [x] As the reader user (has only `readnosecrets` verb), run `tctl scoped tokens ls` and verify the secret field is **empty** (used an identity file with a user that has list and readnosecrets verbs)
- [x] Run as a reader with only readnosecret `tctl scoped tokens ls --with-secret` and verify the command is **denied** (used an identity file with a user that has list and readnosecrets verbs)

Plans for **Get** and **Upsert** will be handled with the resources command located in #63455.

changelog: Added server side secret obfuscating for GetScopedTokens rpc and added UpsertScopedToken rpc
