### PR TITLE
Fix Desktop Connection Error When HostID Is Not a UUID

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -71,7 +71,6 @@ import "C"
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"net"
@@ -83,7 +82,6 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	tdpbv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/desktop/v1"
@@ -436,19 +434,6 @@ func (c *Client) startRustRDP(ctx context.Context, certDER, keyDER []byte) error
 		return trace.BadParameter("user key was nil")
 	}
 
-	hostID, err := uuid.Parse(c.cfg.HostID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	nextHostID := hostID[:]
-	cHostID := [4]C.uint32_t{}
-	for i := 0; i < len(cHostID); i++ {
-		const uint32Len = 4
-		cHostID[i] = (C.uint32_t)(binary.LittleEndian.Uint32(nextHostID[:uint32Len]))
-		nextHostID = nextHostID[uint32Len:]
-	}
-
 	res := C.client_run(
 		C.uintptr_t(c.handle),
 		C.CGOConnectParams{
@@ -469,7 +454,7 @@ func (c *Client) startRustRDP(ctx context.Context, certDER, keyDER []byte) error
 			allow_clipboard:         C.bool(c.cfg.AllowClipboard),
 			allow_directory_sharing: C.bool(c.cfg.AllowDirectorySharing),
 			show_desktop_wallpaper:  C.bool(c.cfg.ShowDesktopWallpaper),
-			client_id:               cHostID,
+			client_id:               hostIDToUint32Array[C.uint32_t](newHostID(c.cfg.HostID)),
 			keyboard_layout:         C.uint32_t(c.keyboardLayout),
 		},
 	)

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -454,7 +454,7 @@ func (c *Client) startRustRDP(ctx context.Context, certDER, keyDER []byte) error
 			allow_clipboard:         C.bool(c.cfg.AllowClipboard),
 			allow_directory_sharing: C.bool(c.cfg.AllowDirectorySharing),
 			show_desktop_wallpaper:  C.bool(c.cfg.ShowDesktopWallpaper),
-			client_id:               hostIDToUint32Array[C.uint32_t](newHostID(c.cfg.HostID)),
+			client_id:               rdpClientIDToUint32Array[C.uint32_t](newRDPClientID(c.cfg.HostID)),
 			keyboard_layout:         C.uint32_t(c.keyboardLayout),
 		},
 	)

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -125,14 +125,14 @@ func (c *Config) hasSizeOverride() bool { //nolint:unused // used in client.go t
 	return c.Width != 0 && c.Height != 0
 }
 
-type hostID [16]byte
+type rdpClientID [16]byte
 
 type uint32Like interface {
 	~uint32
 }
 
 //nolint:unused // only used in client.go which is ignored by linter
-func hostIDToUint32Array[T uint32Like](h hostID) [4]T {
+func rdpClientIDToUint32Array[T uint32Like](h rdpClientID) [4]T {
 	cArray := [4]T{}
 	for idx := range cArray {
 		cArray[idx] = T(binary.LittleEndian.Uint32(h[idx*4:]))
@@ -140,20 +140,20 @@ func hostIDToUint32Array[T uint32Like](h hostID) [4]T {
 	return cArray
 }
 
-func newHostID(id string) hostID {
+func newRDPClientID(id string) rdpClientID {
 	// In previous revisions of this code, we incorrectly assumed
-	// that hostID would always be a UUID. This is not always the case,
-	// however, we should continue to attempt to parse hostID as a UUID
+	// that rdpClientID would always be a UUID. This is not always the case,
+	// however, we should continue to attempt to parse rdpClientID as a UUID
 	// so that the client ID stays the same for existing users as this
 	// may affect RDP licensing.
 	// See https://github.com/gravitational/teleport/issues/63766
 	parsedUUID, err := uuid.Parse(id)
 	if err == nil {
-		return hostID(parsedUUID)
+		return rdpClientID(parsedUUID)
 	}
 
-	// Fall back to taking a hash of the hostID
+	// Fall back to taking a hash of the rdpClientID
 	hash := [16]byte{}
 	copy(hash[:], md5.New().Sum([]byte(id)))
-	return hostID(hash)
+	return rdpClientID(hash)
 }

--- a/lib/srv/desktop/rdp/rdpclient/client_common.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_common.go
@@ -21,10 +21,13 @@ package rdpclient
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/binary"
 	"image/png"
 	"log/slog"
 	"slices"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
@@ -120,4 +123,37 @@ func (c *Config) checkAndSetDefaults() error {
 // a given desktop.
 func (c *Config) hasSizeOverride() bool { //nolint:unused // used in client.go that is behind desktop_access_rdp build flag
 	return c.Width != 0 && c.Height != 0
+}
+
+type hostID [16]byte
+
+type uint32Like interface {
+	~uint32
+}
+
+//nolint:unused // only used in client.go which is ignored by linter
+func hostIDToUint32Array[T uint32Like](h hostID) [4]T {
+	cArray := [4]T{}
+	for idx := range cArray {
+		cArray[idx] = T(binary.LittleEndian.Uint32(h[idx*4:]))
+	}
+	return cArray
+}
+
+func newHostID(id string) hostID {
+	// In previous revisions of this code, we incorrectly assumed
+	// that hostID would always be a UUID. This is not always the case,
+	// however, we should continue to attempt to parse hostID as a UUID
+	// so that the client ID stays the same for existing users as this
+	// may affect RDP licensing.
+	// See https://github.com/gravitational/teleport/issues/63766
+	parsedUUID, err := uuid.Parse(id)
+	if err == nil {
+		return hostID(parsedUUID)
+	}
+
+	// Fall back to taking a hash of the hostID
+	hash := [16]byte{}
+	copy(hash[:], md5.New().Sum([]byte(id)))
+	return hostID(hash)
 }

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -96,33 +96,33 @@ func createConfig() Config {
 	}
 }
 
-func TestHostID(t *testing.T) {
-	nilID := hostID{}
+func TestRDPClientID(t *testing.T) {
+	nilID := rdpClientID{}
 	// The MD5 hash of an empty string
-	emptyHash := hostID([16]byte{0xD4, 0x1D, 0x8C, 0xD9, 0x8F, 0x00, 0xB2, 0x04, 0xE9, 0x80, 0x09, 0x98, 0xEC, 0xF8, 0x42, 0x7E})
+	emptyHash := rdpClientID([16]byte{0xD4, 0x1D, 0x8C, 0xD9, 0x8F, 0x00, 0xB2, 0x04, 0xE9, 0x80, 0x09, 0x98, 0xEC, 0xF8, 0x42, 0x7E})
 
-	invalidIDs := []hostID{nilID, emptyHash}
+	invalidIDs := []rdpClientID{nilID, emptyHash}
 	t.Run("from uuid", func(t *testing.T) {
 		// We must continue to attempt to parse strings
 		// as UUIDs first.
 		newUUID := uuid.New()
-		id := newHostID(newUUID.String())
+		id := newRDPClientID(newUUID.String())
 		parsed, err := uuid.FromBytes(id[:])
 		require.NoError(t, err)
-		// The hostID should just be a UUID under the hood.
+		// The rdpClientID should just be a UUID under the hood.
 		require.Equal(t, newUUID, parsed)
 	})
 
 	t.Run("from other string", func(t *testing.T) {
 		otherID := "some-other-identifier"
-		id := newHostID(otherID)
+		id := newRDPClientID(otherID)
 		// At make sure it's not nil or the empty hash.
 		require.NotContains(t, invalidIDs, id)
 	})
 
 	t.Run("empty string", func(t *testing.T) {
 		// Should match the empty hash.
-		require.Equal(t, newHostID(""), emptyHash)
+		require.Equal(t, newRDPClientID(""), emptyHash)
 	})
 
 	t.Run("uint32 conversion", func(t *testing.T) {
@@ -131,10 +131,10 @@ func TestHostID(t *testing.T) {
 		// Then represent each 32-bit word as little endian and we get:
 		expected := [4]uint32{0xd98c1dd4, 0x04b2008f, 0x980980e9, 0x7e42f8ec}
 
-		// Our [4]uint32 representation of the HostID should
+		// Our [4]uint32 representation of the rdpClientID should
 		// match the above. As a bonus, this will serve as a regression
 		// test to ensure that we don't switch hash algorithms by mistake.
-		got := hostIDToUint32Array[uint32](newHostID(""))
+		got := rdpClientIDToUint32Array[uint32](newRDPClientID(""))
 		require.Equal(t, expected, got)
 	})
 }

--- a/lib/srv/desktop/rdp/rdpclient/client_test.go
+++ b/lib/srv/desktop/rdp/rdpclient/client_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
@@ -93,4 +94,47 @@ func createConfig() Config {
 		Height:         1,
 		ClientProtocol: tdpb.ProtocolName,
 	}
+}
+
+func TestHostID(t *testing.T) {
+	nilID := hostID{}
+	// The MD5 hash of an empty string
+	emptyHash := hostID([16]byte{0xD4, 0x1D, 0x8C, 0xD9, 0x8F, 0x00, 0xB2, 0x04, 0xE9, 0x80, 0x09, 0x98, 0xEC, 0xF8, 0x42, 0x7E})
+
+	invalidIDs := []hostID{nilID, emptyHash}
+	t.Run("from uuid", func(t *testing.T) {
+		// We must continue to attempt to parse strings
+		// as UUIDs first.
+		newUUID := uuid.New()
+		id := newHostID(newUUID.String())
+		parsed, err := uuid.FromBytes(id[:])
+		require.NoError(t, err)
+		// The hostID should just be a UUID under the hood.
+		require.Equal(t, newUUID, parsed)
+	})
+
+	t.Run("from other string", func(t *testing.T) {
+		otherID := "some-other-identifier"
+		id := newHostID(otherID)
+		// At make sure it's not nil or the empty hash.
+		require.NotContains(t, invalidIDs, id)
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		// Should match the empty hash.
+		require.Equal(t, newHostID(""), emptyHash)
+	})
+
+	t.Run("uint32 conversion", func(t *testing.T) {
+		// The MD5 hash of an empty string is:
+		// d41d8cd9 8f00b204 e9800998 ecf8427e
+		// Then represent each 32-bit word as little endian and we get:
+		expected := [4]uint32{0xd98c1dd4, 0x04b2008f, 0x980980e9, 0x7e42f8ec}
+
+		// Our [4]uint32 representation of the HostID should
+		// match the above. As a bonus, this will serve as a regression
+		// test to ensure that we don't switch hash algorithms by mistake.
+		got := hostIDToUint32Array[uint32](newHostID(""))
+		require.Equal(t, expected, got)
+	})
 }


### PR DESCRIPTION
The RDP client needs to generate a hardware ID to present to the RDP server. Currently, we assume that the configured HostID is a UUID string that we can parse and use as the hardware ID. However, this is not always the case. Particularly, EC2 joined nodes tend to pass along their node name instead. This PR relaxes the UUID string requirement by falling back to simply taking a md5 of the host ID string if UUID parsing fails.

changelog: Fixed bug that causes Windows desktop connection errors on EC2 joined nodes.

closes #63766

Test plan:

- [X] Unit test coverage validates proper handling of UUID strings, non-UUID strings, and empty strings.
- [X] Manual validation of RDP client connection.