### PR TITLE
EC2 auto-discovery: add IAM permission issue types and descriptions

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -203,9 +203,29 @@ const (
 	TaskTypeDiscoverAzureVM = "discover-azure-vm"
 )
 
+// Permission-related Auto Discover EC2 issues identifiers.
+// This value is used to populate the UserTasks.Spec.IssueType for Discover EC2 tasks.
+// The Web UI will then use those identifiers to show detailed instructions on how to fix the issue.
+//
+// Permissions-related issues occur during the discovery phase when the integration's IAM role
+// lacks permissions to call AWS APIs, preventing Teleport from discovering EC2 instances.
+const (
+	// AutoDiscoverEC2IssuePermAccountDenied indicates the integration lacks
+	// permissions to discover EC2 instances within an account.
+	AutoDiscoverEC2IssuePermAccountDenied = "ec2-perm-account-denied"
+
+	// AutoDiscoverEC2IssuePermOrgDenied indicates the integration lacks
+	// permission to call Organizations APIs (ListRoots, ListChildren, ListAccountsForParent).
+	// This occurs when using organization-wide discovery.
+	AutoDiscoverEC2IssuePermOrgDenied = "ec2-perm-org-denied"
+)
+
 // List of Auto Discover EC2 issues identifiers.
 // This value is used to populate the UserTasks.Spec.IssueType for Discover EC2 tasks.
 // The Web UI will then use those identifiers to show detailed instructions on how to fix the issue.
+//
+// SSM-related issues occur during the installation phase when Teleport
+// attempts to install the agent on discovered EC2 instances via AWS Systems Manager.
 const (
 	// AutoDiscoverEC2IssueSSMInstanceNotRegistered is used to identify instances that failed to auto-enroll
 	// because they are not present in Amazon Systems Manager.
@@ -241,6 +261,8 @@ var DiscoverEC2IssueTypes = []string{
 	AutoDiscoverEC2IssueSSMInstanceUnsupportedOS,
 	AutoDiscoverEC2IssueSSMScriptFailure,
 	AutoDiscoverEC2IssueSSMInvocationFailure,
+	AutoDiscoverEC2IssuePermAccountDenied,
+	AutoDiscoverEC2IssuePermOrgDenied,
 }
 
 // List of Auto Discover EKS issues identifiers.
@@ -368,20 +390,80 @@ func validateDiscoverEC2TaskType(ut *usertasksv1.UserTask) error {
 	if ut.GetSpec().DiscoverEc2 == nil {
 		return trace.BadParameter("%s requires the discover_ec2 field", TaskTypeDiscoverEC2)
 	}
-	if ut.GetSpec().DiscoverEc2.AccountId == "" {
-		return trace.BadParameter("%s requires the discover_ec2.account_id field", TaskTypeDiscoverEC2)
-	}
-	if ut.GetSpec().DiscoverEc2.Region == "" {
-		return trace.BadParameter("%s requires the discover_ec2.region field", TaskTypeDiscoverEC2)
+
+	// Validate issue type for all tasks.
+	if !slices.Contains(DiscoverEC2IssueTypes, ut.GetSpec().GetIssueType()) {
+		return trace.BadParameter("invalid issue type %q, allowed values: %v", ut.GetSpec().GetIssueType(), DiscoverEC2IssueTypes)
 	}
 
+	// Permission issues occur before instance discovery (org/account level),
+	// so account ID, region, and instance list may all be empty.
+	if isPermissionIssueType(ut.GetSpec().GetIssueType()) {
+		return validateDiscoverEC2PermissionIssue(ut)
+	}
+	return validateDiscoverEC2InstallationIssue(ut)
+}
+
+func isPermissionIssueType(issueType string) bool {
+	switch issueType {
+	case AutoDiscoverEC2IssuePermAccountDenied,
+		AutoDiscoverEC2IssuePermOrgDenied:
+		return true
+	default:
+		return false
+	}
+}
+
+// validateDiscoverEC2PermissionIssue validates tasks for IAM permission errors
+// that occur before instance discovery. Account ID, region, and instances are
+// all optional since the error may occur at the organization or account level.
+func validateDiscoverEC2PermissionIssue(ut *usertasksv1.UserTask) error {
+	if err := validateDiscoverEC2TaskName(ut); err != nil {
+		return trace.Wrap(err)
+	}
+	// Permission issues are allowed to have empty instance lists, empty
+	// account ID, and empty region. If instances are present, validate them.
+	for instanceID, instanceIssue := range ut.GetSpec().GetDiscoverEc2().GetInstances() {
+		if err := validateDiscoverEC2Instance(instanceID, instanceIssue); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// validateDiscoverEC2InstallationIssue validates tasks for SSM installation
+// and join failures. Account ID, region, and at least one instance are required.
+func validateDiscoverEC2InstallationIssue(ut *usertasksv1.UserTask) error {
+	if ut.GetSpec().GetDiscoverEc2().GetAccountId() == "" {
+		return trace.BadParameter("%s requires the discover_ec2.account_id field", TaskTypeDiscoverEC2)
+	}
+	if ut.GetSpec().GetDiscoverEc2().GetRegion() == "" {
+		return trace.BadParameter("%s requires the discover_ec2.region field", TaskTypeDiscoverEC2)
+	}
+	if err := validateDiscoverEC2TaskName(ut); err != nil {
+		return trace.Wrap(err)
+	}
+	if len(ut.GetSpec().GetDiscoverEc2().GetInstances()) == 0 {
+		return trace.BadParameter("at least one instance is required")
+	}
+	for instanceID, instanceIssue := range ut.GetSpec().GetDiscoverEc2().GetInstances() {
+		if err := validateDiscoverEC2Instance(instanceID, instanceIssue); err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// validateDiscoverEC2TaskName validates that the task name matches the
+// deterministic name derived from its spec fields.
+func validateDiscoverEC2TaskName(ut *usertasksv1.UserTask) error {
 	expectedTaskName := TaskNameForDiscoverEC2(TaskNameForDiscoverEC2Parts{
-		Integration:     ut.Spec.Integration,
-		IssueType:       ut.Spec.IssueType,
-		AccountID:       ut.Spec.DiscoverEc2.AccountId,
-		Region:          ut.Spec.DiscoverEc2.Region,
-		SSMDocument:     ut.Spec.DiscoverEc2.SsmDocument,
-		InstallerScript: ut.Spec.DiscoverEc2.InstallerScript,
+		Integration:     ut.GetSpec().GetIntegration(),
+		IssueType:       ut.GetSpec().GetIssueType(),
+		AccountID:       ut.GetSpec().GetDiscoverEc2().GetAccountId(),
+		Region:          ut.GetSpec().GetDiscoverEc2().GetRegion(),
+		SSMDocument:     ut.GetSpec().GetDiscoverEc2().GetSsmDocument(),
+		InstallerScript: ut.GetSpec().GetDiscoverEc2().GetInstallerScript(),
 	})
 	if ut.Metadata.GetName() != expectedTaskName {
 		return trace.BadParameter("task name is pre-defined for discover-ec2 types, expected %q, got %q",
@@ -389,32 +471,26 @@ func validateDiscoverEC2TaskType(ut *usertasksv1.UserTask) error {
 			ut.Metadata.GetName(),
 		)
 	}
+	return nil
+}
 
-	if !slices.Contains(DiscoverEC2IssueTypes, ut.GetSpec().IssueType) {
-		return trace.BadParameter("invalid issue type state, allowed values: %v", DiscoverEC2IssueTypes)
+// validateDiscoverEC2Instance validates a single instance entry.
+func validateDiscoverEC2Instance(instanceID string, instance *usertasksv1.DiscoverEC2Instance) error {
+	if instanceID == "" {
+		return trace.BadParameter("instance id in discover_ec2.instances map is required")
 	}
-
-	if len(ut.Spec.DiscoverEc2.Instances) == 0 {
-		return trace.BadParameter("at least one instance is required")
+	if instance.GetInstanceId() == "" {
+		return trace.BadParameter("instance id in discover_ec2.instances field is required")
 	}
-	for instanceID, instanceIssue := range ut.Spec.DiscoverEc2.Instances {
-		if instanceID == "" {
-			return trace.BadParameter("instance id in discover_ec2.instances map is required")
-		}
-		if instanceIssue.InstanceId == "" {
-			return trace.BadParameter("instance id in discover_ec2.instances field is required")
-		}
-		if instanceID != instanceIssue.InstanceId {
-			return trace.BadParameter("instance id in discover_ec2.instances map and field are different")
-		}
-		if instanceIssue.DiscoveryConfig == "" {
-			return trace.BadParameter("discovery config in discover_ec2.instances field is required")
-		}
-		if instanceIssue.DiscoveryGroup == "" {
-			return trace.BadParameter("discovery group in discover_ec2.instances field is required")
-		}
+	if instanceID != instance.GetInstanceId() {
+		return trace.BadParameter("instance id in discover_ec2.instances map and field are different")
 	}
-
+	if instance.GetDiscoveryConfig() == "" {
+		return trace.BadParameter("discovery config in discover_ec2.instances field is required")
+	}
+	if instance.GetDiscoveryGroup() == "" {
+		return trace.BadParameter("discovery group in discover_ec2.instances field is required")
+	}
 	return nil
 }
 

--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -220,7 +220,7 @@ const (
 	AutoDiscoverEC2IssuePermOrgDenied = "ec2-perm-org-denied"
 )
 
-// List of Auto Discover EC2 issues identifiers.
+// SSM-related Auto Discover EC2 issues identifiers.
 // This value is used to populate the UserTasks.Spec.IssueType for Discover EC2 tasks.
 // The Web UI will then use those identifiers to show detailed instructions on how to fix the issue.
 //

--- a/lib/usertasks/descriptions/ec2-perm-account-denied.md
+++ b/lib/usertasks/descriptions/ec2-perm-account-denied.md
@@ -1,0 +1,45 @@
+# Missing AWS account permissions
+
+Teleport failed to discover EC2 instances because the integration's IAM role lacks the required permissions to discover AWS account resources.
+
+**How to fix:**
+
+Add the following permissions to the IAM role used by the integration:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2Discovery",
+      "Effect": "Allow",
+      "Action": [
+        "account:ListRegions",
+        "ec2:DescribeInstances",
+        "ssm:DescribeInstanceInformation",
+        "ssm:SendCommand",
+        "ssm:GetCommandInvocation",
+        "ssm:ListCommandInvocations"
+      ],
+      "Resource": ["*"]
+    }
+  ]
+}
+```
+
+**Alternative fix for account:ListRegions**
+
+`account:ListRegions` is only required if `regions: ["*"]` is used.
+
+If you prefer not to grant `account:ListRegions`, specify explicit region names in your matcher configuration instead of using `regions: ["*"]`. Explicitly listing regions means Teleport doesn't need to dynamically discover them via the API, thus not requiring that permission:
+
+```yaml
+regions:
+  - us-east-1
+  - us-west-2
+  - eu-west-1
+```
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.
+
+**Note:** IAM permission changes may take a few minutes to propagate in AWS. Teleport also polls for EC2 instances periodically, so the fix may not be reflected immediately. This task will automatically resolve once discovery succeeds.

--- a/lib/usertasks/descriptions/ec2-perm-account-denied.md
+++ b/lib/usertasks/descriptions/ec2-perm-account-denied.md
@@ -27,19 +27,6 @@ Add the following permissions to the IAM role used by the integration:
 }
 ```
 
-**Alternative fix for account:ListRegions**
-
-`account:ListRegions` is only required if `regions: ["*"]` is used.
-
-If you prefer not to grant `account:ListRegions`, specify explicit region names in your matcher configuration instead of using `regions: ["*"]`. Explicitly listing regions means Teleport doesn't need to dynamically discover them via the API, thus not requiring that permission:
-
-```yaml
-regions:
-  - us-east-1
-  - us-west-2
-  - eu-west-1
-```
-
 After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.
 
 **Note:** IAM permission changes may take a few minutes to propagate in AWS. Teleport also polls for EC2 instances periodically, so the fix may not be reflected immediately. This task will automatically resolve once discovery succeeds.

--- a/lib/usertasks/descriptions/ec2-perm-org-denied.md
+++ b/lib/usertasks/descriptions/ec2-perm-org-denied.md
@@ -1,0 +1,33 @@
+# Missing AWS organization permissions
+
+Teleport failed to discover EC2 instances because the integration's IAM role lacks the required permissions to discover AWS accounts in your organization.
+
+This error occurs when using organization-wide discovery, which requires Teleport to list accounts across your AWS organization.
+
+**How to fix:**
+
+Add the following permissions to the IAM role used by the integration:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "organizations:ListRoots",
+    "organizations:ListChildren",
+    "organizations:ListAccountsForParent"
+  ],
+  "Resource": ["*"]
+}
+```
+
+These permissions allow Teleport to:
+
+- `organizations:ListRoots` - Find the root of your organization
+- `organizations:ListChildren` - Navigate organizational units (OUs)
+- `organizations:ListAccountsForParent` - List accounts within each OU
+
+After applying the fix, mark this task as resolved. Teleport will retry discovery automatically.
+
+**Important:** The IAM Role must be configured in the AWS Organizations management account (or a delegated administrator account). These APIs can only be called from the management account, even with correct permissions.
+
+**Note:** IAM permission changes may take a few minutes to propagate in AWS. Teleport also polls for EC2 instances periodically, so the fix may not be reflected immediately. This task will automatically resolve once discovery succeeds.

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -206,7 +206,7 @@ function DetailsTab({ task }: { task: UserTaskDetail }) {
       <H3 mt={3}>Details</H3>
       <Markdown text={task.description || ''} enableLinks />
 
-      {impacted.count && (
+      {impacted.count > 0 && (
         <>
           <H3 mt={4}>Impacted resources ({impacted.count})</H3>
           <Table

--- a/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
+++ b/web/packages/teleport/src/Discover/Overview/UserTaskDrawer.tsx
@@ -206,12 +206,17 @@ function DetailsTab({ task }: { task: UserTaskDetail }) {
       <H3 mt={3}>Details</H3>
       <Markdown text={task.description || ''} enableLinks />
 
-      <H3 mt={4}>Impacted resources ({impacted.count})</H3>
-      <Table
-        data={impactsTable.data}
-        columns={impactsTable.columns}
-        emptyText="No impacted resources"
-      />
+      {impacted.count && (
+        <>
+          <H3 mt={4}>Impacted resources ({impacted.count})</H3>
+          <Table
+            data={impactsTable.data}
+            columns={impactsTable.columns}
+            emptyText="No impacted resources"
+          />
+        </>
+      )}
+
       <H3 mt={4}>Mark as Resolved</H3>
       <P>
         This issue will reappear if the underlying problem is not fixed.


### PR DESCRIPTION
This is a partial fix for Fixes https://github.com/gravitational/teleport/issues/62828.

API types, descriptions, validation, and web UI: everything that defines, validates, and displays the new permission issue types. No runtime behavior change.

Part 1 of splitting https://github.com/gravitational/teleport/pull/63099.

Introduces new permission-related UserTask issue types for EC2 auto-discovery (`ec2-perm-account-denied`, `ec2-perm-org-denied`) with:

- New issue type constants and validation in `api/types/usertasks`
- Relaxed validation for permission issues: empty `account_id`, `region`, and instances allowed (errors occur before discovery)
- Fenced code block support in Markdown component (renders policy JSON)
- Hide empty "Impacted resources" section for permission issues (author: @charlestp)

**No runtime behavior change** — nothing emits these issue types yet.

Part 2 will wire up detection and reporting from the discovery service.
