### PR TITLE
Capture stderr from ssh reexec process

### DIFF
--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -194,17 +194,17 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	}
 
 	// Capture stderr.
-	stderrr, stderrw, err := os.Pipe()
+	stderrR, stderrW, err := os.Pipe()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer stderrw.Close()
-	e.Cmd.Stderr = stderrw
+	defer stderrW.Close()
+	e.Cmd.Stderr = stderrW
 
 	e.waitForOutputStreams.Go(func() {
-		defer stderrr.Close()
+		defer stderrR.Close()
 
-		childErr, err := reexec.ReadChildError(stderrr)
+		childErr, err := reexec.ReadChildError(stderrR)
 		if err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
 			return

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -31,6 +31,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -133,6 +134,12 @@ type localExec struct {
 	// Ctx holds the *ServerContext.
 	Ctx *ServerContext
 
+	// waitForOutputStreams is closed when child reexec and shell processes have
+	// their stderr/stdout fully consumed by io.Copy goroutines. This is necessary
+	// due to the use of custom pipes, which exec.Cmd does not wait for closure of
+	// in Wait().
+	waitForOutputStreams sync.WaitGroup
+
 	pid int
 }
 
@@ -194,7 +201,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	defer stderrw.Close()
 	e.Cmd.Stderr = stderrw
 
-	go func() {
+	e.waitForOutputStreams.Go(func() {
 		defer stderrr.Close()
 
 		childErr, err := reexec.ReadChildError(stderrr)
@@ -209,7 +216,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 		if _, err := io.WriteString(channel, childErr); err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
 		}
-	}()
+	})
 
 	// Start the command.
 	err = e.Cmd.Start()
@@ -241,16 +248,16 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 		}
 		shellStdinW.Close()
 	}()
-	go func() {
+	e.waitForOutputStreams.Go(func() {
 		if _, err := io.Copy(channel, shellStdoutR); err != nil {
 			logger.WarnContext(ctx, "Failed to forward stdout from local command to SSH channel", "error", err)
 		}
-	}()
-	go func() {
+	})
+	e.waitForOutputStreams.Go(func() {
 		if _, err := io.Copy(channel.Stderr(), shellStderrR); err != nil {
 			logger.WarnContext(ctx, "Failed to forward stderr from local command to SSH channel", "error", err)
 		}
-	}()
+	})
 
 	logger.InfoContext(ctx, "Started local command execution")
 
@@ -265,6 +272,7 @@ func (e *localExec) Wait() *ExecResult {
 
 	// Block until the command is finished executing.
 	err := e.Cmd.Wait()
+	e.waitForOutputStreams.Wait()
 	if err != nil {
 		e.Ctx.Logger.DebugContext(e.Ctx.CancelContext(), "Local command failed", "error", err)
 	} else {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -41,6 +41,7 @@ import (
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/sshutils/reexec"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -160,24 +161,21 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	// side of each pipe after starting the command.
 	shellStdinR, shellStdinW, err := os.Pipe()
 	if err != nil {
-		ctxErr := e.Ctx.Close()
-		return nil, trace.NewAggregate(err, ctxErr)
+		return nil, trace.Wrap(err)
 	}
 	defer shellStdinR.Close()
 	e.Ctx.AddCloser(shellStdinW)
 
 	shellStdoutR, shellStdoutW, err := os.Pipe()
 	if err != nil {
-		ctxErr := e.Ctx.Close()
-		return nil, trace.NewAggregate(err, ctxErr)
+		return nil, trace.Wrap(err)
 	}
 	defer shellStdoutW.Close()
 	e.Ctx.AddCloser(shellStdoutR)
 
 	shellStderrR, shellStderrW, err := os.Pipe()
 	if err != nil {
-		ctxErr := e.Ctx.Close()
-		return nil, trace.NewAggregate(err, ctxErr)
+		return nil, trace.Wrap(err)
 	}
 	defer shellStderrW.Close()
 	e.Ctx.AddCloser(shellStderrR)
@@ -187,6 +185,31 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	// Capture stderr.
+	stderrr, stderrw, err := os.Pipe()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer stderrw.Close()
+	e.Cmd.Stderr = stderrw
+
+	go func() {
+		defer stderrr.Close()
+
+		childErr, err := reexec.ReadChildError(stderrr)
+		if err != nil {
+			logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
+			return
+		}
+		if childErr == "" {
+			return
+		}
+
+		if _, err := io.WriteString(channel, childErr); err != nil {
+			logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
+		}
+	}()
 
 	// Start the command.
 	err = e.Cmd.Start()
@@ -201,7 +224,6 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 			Code:    exitCode(err),
 		}, trace.ConvertSystemError(err)
 	}
-
 	// Close our half of the write pipe since it is only to be used by the child process.
 	// Not closing prevents being signaled when the child closes its half.
 	if err := e.Ctx.readyw.Close(); err != nil {

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -134,10 +134,9 @@ type localExec struct {
 	// Ctx holds the *ServerContext.
 	Ctx *ServerContext
 
-	// waitForOutputStreams is closed when child reexec and shell processes have
-	// their stderr/stdout fully consumed by io.Copy goroutines. This is necessary
-	// due to the use of custom pipes, which exec.Cmd does not wait for closure of
-	// in Wait().
+	// waitForOutputStreams tracks goroutines that copy stderr/stdout from child
+	// reexec and shell processes. This is necessary due to the use of custom pipes,
+	// which exec.Cmd does not wait for closure of in cmd.Wait().
 	waitForOutputStreams sync.WaitGroup
 
 	pid int
@@ -148,7 +147,7 @@ func (e *localExec) GetCommand() string {
 	return e.Command
 }
 
-// SetCommand gets the command string.
+// SetCommand sets the command string.
 func (e *localExec) SetCommand(command string) {
 	e.Command = command
 }
@@ -420,7 +419,7 @@ func (e *remoteExec) GetCommand() string {
 	return e.command
 }
 
-// SetCommand gets the command string.
+// SetCommand sets the command string.
 func (e *remoteExec) SetCommand(command string) {
 	e.command = command
 }

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -156,18 +156,34 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 		return nil, trace.Wrap(err)
 	}
 
-	// Create the command that will actually execute.
-	e.Cmd, err = ConfigureCommand(e.Ctx)
+	// Create pipes to capture stdio of the shell (grandchild) process, closing our
+	// side of each pipe after starting the command.
+	shellStdinR, shellStdinW, err := os.Pipe()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		ctxErr := e.Ctx.Close()
+		return nil, trace.NewAggregate(err, ctxErr)
 	}
+	defer shellStdinR.Close()
+	e.Ctx.AddCloser(shellStdinW)
 
-	// Connect stdout and stderr to the channel so the user can interact with the command.
-	e.Cmd.Stderr = channel.Stderr()
-	e.Cmd.Stdout = channel
+	shellStdoutR, shellStdoutW, err := os.Pipe()
+	if err != nil {
+		ctxErr := e.Ctx.Close()
+		return nil, trace.NewAggregate(err, ctxErr)
+	}
+	defer shellStdoutW.Close()
+	e.Ctx.AddCloser(shellStdoutR)
 
-	// Copy from the channel (client input) into stdin of the process.
-	inputWriter, err := e.Cmd.StdinPipe()
+	shellStderrR, shellStderrW, err := os.Pipe()
+	if err != nil {
+		ctxErr := e.Ctx.Close()
+		return nil, trace.NewAggregate(err, ctxErr)
+	}
+	defer shellStderrW.Close()
+	e.Ctx.AddCloser(shellStderrR)
+
+	// Create the command that will actually execute.
+	e.Cmd, err = ConfigureCommand(e.Ctx, shellStdinR, shellStdoutW, shellStderrW)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -185,6 +201,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 			Code:    exitCode(err),
 		}, trace.ConvertSystemError(err)
 	}
+
 	// Close our half of the write pipe since it is only to be used by the child process.
 	// Not closing prevents being signaled when the child closes its half.
 	if err := e.Ctx.readyw.Close(); err != nil {
@@ -195,11 +212,22 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 	// Save off the PID of the Teleport process under which the command is executing.
 	e.pid = e.Cmd.Process.Pid
 
+	// copy stdio between the channel and shell process.
 	go func() {
-		if _, err := io.Copy(inputWriter, channel); err != nil {
-			logger.WarnContext(ctx, "Failed to forward data from SSH channel to local command", "error", err)
+		if _, err := io.Copy(shellStdinW, channel); err != nil {
+			logger.WarnContext(ctx, "Failed to forward stdin from SSH channel to local command", "error", err)
 		}
-		inputWriter.Close()
+		shellStdinW.Close()
+	}()
+	go func() {
+		if _, err := io.Copy(channel, shellStdoutR); err != nil {
+			logger.WarnContext(ctx, "Failed to forward stdout from local command to SSH channel", "error", err)
+		}
+	}()
+	go func() {
+		if _, err := io.Copy(channel.Stderr(), shellStderrR); err != nil {
+			logger.WarnContext(ctx, "Failed to forward stderr from local command to SSH channel", "error", err)
+		}
 	}()
 
 	logger.InfoContext(ctx, "Started local command execution")

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -93,7 +93,12 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err := scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err := buildCommand(execCmd, usr, nil, nil)
+	stdio := stdio{
+		in:  os.Stdin,
+		out: os.Stdout,
+		err: os.Stderr,
+	}
+	cmd, err := buildCommand(execCmd, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -108,7 +113,7 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(execCmd, usr, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -123,7 +128,7 @@ func TestOSCommandPrep(t *testing.T) {
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
 
-	cmd, err = buildCommand(execCmd, usr, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "/bin/sh", cmd.Path)
@@ -136,7 +141,7 @@ func TestOSCommandPrep(t *testing.T) {
 	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"
-	cmd, err = buildCommand(execCmd, usr, nil, nil)
+	cmd, err = buildCommand(execCmd, usr, stdio, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, root, cmd.Dir)

--- a/lib/srv/exec_linux_test.go
+++ b/lib/srv/exec_linux_test.go
@@ -92,13 +92,11 @@ func TestOSCommandPrep(t *testing.T) {
 	// Empty command (simple shell).
 	execCmd, err := scx.ExecCommand()
 	require.NoError(t, err)
+	execCmd.stdin = os.Stdin
+	execCmd.stdout = os.Stdout
+	execCmd.stderr = os.Stderr
 
-	stdio := stdio{
-		in:  os.Stdin,
-		out: os.Stdout,
-		err: os.Stderr,
-	}
-	cmd, err := buildCommand(execCmd, usr, stdio, nil)
+	cmd, err := buildCommand(execCmd, usr, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -112,8 +110,11 @@ func TestOSCommandPrep(t *testing.T) {
 	scx.execRequest.SetCommand("ls -lh /etc")
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
+	execCmd.stdin = os.Stdin
+	execCmd.stdout = os.Stdout
+	execCmd.stderr = os.Stderr
 
-	cmd, err = buildCommand(execCmd, usr, stdio, nil)
+	cmd, err = buildCommand(execCmd, usr, nil)
 	require.NoError(t, err)
 
 	require.NotNil(t, cmd)
@@ -127,8 +128,11 @@ func TestOSCommandPrep(t *testing.T) {
 	scx.execRequest.SetCommand("top")
 	execCmd, err = scx.ExecCommand()
 	require.NoError(t, err)
+	execCmd.stdin = os.Stdin
+	execCmd.stdout = os.Stdout
+	execCmd.stderr = os.Stderr
 
-	cmd, err = buildCommand(execCmd, usr, stdio, nil)
+	cmd, err = buildCommand(execCmd, usr, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, "/bin/sh", cmd.Path)
@@ -141,7 +145,7 @@ func TestOSCommandPrep(t *testing.T) {
 	usr.HomeDir = "/wrong/place"
 	root := string(os.PathSeparator)
 	expectedEnv[2] = "HOME=/wrong/place"
-	cmd, err = buildCommand(execCmd, usr, stdio, nil)
+	cmd, err = buildCommand(execCmd, usr, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, root, cmd.Dir)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -63,10 +63,18 @@ import (
 	"github.com/gravitational/teleport/lib/utils/uds"
 )
 
+const (
+	// procLoginuid is the path to the current process's loginuid.
+	procLoginuid = "/proc/self/loginuid"
+	// procSessionID is the path to the current process's session ID.
+	procSessionID = "/proc/self/sessionid"
+)
+
 // FileFD is a file descriptor passed down from a parent process when
 // Teleport is re-executing itself.
 type FileFD = uintptr
 
+// Common FileFDs
 const (
 	// CommandFile is used to pass the command and arguments that the
 	// child process should execute from the parent process.
@@ -89,21 +97,45 @@ const (
 	// to pid 1 and "live forever". Killing the shell should not prevent processes
 	// preventing SIGHUP to be reassigned (ex. processes running with nohup).
 	TerminateFile
-	// Depcrecated: PTYFileDeprecated is a placeholder for the unused PTY file that
-	// was passed to the child process. The PTY should only be used in the
-	// the parent process but was left here for compatibility purposes.
-	PTYFileDeprecated
-	// TTYFile is a TTY the parent process passes to the child process.
-	TTYFile
-
 	// FirstExtraFile is the first file descriptor that will be valid when
 	// extra files are passed to child processes without a terminal.
 	FirstExtraFile FileFD = TerminateFile + 1
+)
 
-	// procLoginuid is the path to the current process's loginuid.
-	procLoginuid = "/proc/self/loginuid"
-	// procSessionID is the path to the current process's session ID.
-	procSessionID = "/proc/self/sessionid"
+// FileFDs for terminal based exec sessions.
+const (
+	// Deprecated: PTYFileDeprecated is a placeholder for the unused PTY file that
+	// was passed to the child process. The PTY should only be used in the
+	// the parent process but was left here for compatibility purposes.
+	PTYFileDeprecated = FirstExtraFile + iota
+	// TTYFile is a TTY the parent process passes to the child process.
+	TTYFile
+)
+
+// FileFDs for non-terminal based exec sessions.
+const (
+	// StdinFile is used to capture the stdin stream of the shell (grandchild) process.
+	StdinFile = FirstExtraFile + iota
+	// StdoutFile is used to capture the stdout stream of the shell (grandchild) process.
+	StdoutFile
+	// StderrFile is used to capture the stderr stream of the shell (grandchild) process.
+	StderrFile
+)
+
+// FileFDs for SFTP sessions.
+const (
+	// FileTransferOutFile is used to pass write transfer data to the sftp (grandchild) process.
+	FileTransferOutFile = FirstExtraFile + iota
+	// FileTransferOutFile is used to pass read transfer data from the sftp (grandchild) process.
+	FileTransferInFile
+	// AuditInFile is used to read audit events from the sftp (grandchild) process.
+	AuditInFile
+)
+
+// FileFDs for networking sessions.
+const (
+	// ListenerFile is a unix datagram socket listener.
+	ListenerFile = FirstExtraFile + iota
 )
 
 func fdName(f FileFD) string {
@@ -172,11 +204,6 @@ type ExecCommand struct {
 
 	// UaccMetadata contains metadata needed for user accounting.
 	UaccMetadata UaccMetadata `json:"uacc_meta"`
-
-	// ExtraFilesLen is the number of extra files that are inherited from
-	// the parent process. These files start at file descriptor 3 of the
-	// child process, and are only valid for processes without a terminal.
-	ExtraFilesLen int `json:"extra_files_len"`
 
 	// SetSELinuxContext is true when the SELinux context should be set
 	// for the child.
@@ -247,20 +274,6 @@ func RunCommand() (code int, err error) {
 	// ignore SIGQUIT signals.
 	signal.Ignore(syscall.SIGQUIT)
 
-	// If the command fails to launch, write the error to stdout for the parent process
-	// to digest. If we have a terminal, write it there for the user to see as well.
-	var tty *os.File
-	defer func() {
-		if err != nil && code == teleport.RemoteCommandFailure {
-			var w io.Writer = os.Stdout
-			if tty != nil {
-				w = io.MultiWriter(os.Stdout, tty)
-			}
-
-			fmt.Fprintf(w, "Failed to launch: %v.\r\n", err)
-		}
-	}()
-
 	// Parent sends the command payload in the third file descriptor.
 	cmdfd := os.NewFile(CommandFile, fdName(CommandFile))
 	if cmdfd == nil {
@@ -302,16 +315,6 @@ func RunCommand() (code int, err error) {
 
 	initLogger("reexec", logfd, c.LogConfig)
 
-	// If a terminal was requested, file descriptor 10 always points to the
-	// TTY. Extract it and set the controlling TTY. Otherwise, connect
-	// std{in,out,err} directly.
-	if c.Terminal {
-		tty = os.NewFile(TTYFile, fdName(TTYFile))
-		if tty == nil {
-			return teleport.RemoteCommandFailure, trace.BadParameter("tty not found")
-		}
-	}
-
 	auditdMsg := auditd.Message{
 		SystemUser:   c.Login,
 		TeleportUser: c.Username,
@@ -349,6 +352,41 @@ func RunCommand() (code int, err error) {
 		}
 	}
 
+	var tty *os.File
+	var shellStdio stdio
+	if c.Terminal {
+		// If this is an interactive session, use the tty file for grandchild stdio.
+		tty = os.NewFile(TTYFile, fdName(TTYFile))
+		if tty == nil {
+			return teleport.RemoteCommandFailure, trace.BadParameter("tty not found")
+		}
+		shellStdio.in = tty
+		shellStdio.out = tty
+		shellStdio.err = tty
+	} else if c.RequestType == sshutils.SubsystemRequest && c.Command == teleport.SFTPSubsystem {
+		// std{in/out} is not used by the SFTP sub process, just collect stderr.
+		shellStdio = stdio{
+			in:  bytes.NewReader([]byte{}),
+			out: io.Discard,
+			// Propagate sftp subprocess errors to the parent process.
+			err: os.Stderr,
+		}
+	} else {
+		// If this is a normal, non-interactive exec session, use the stdio pipes provided as extra files.
+		shellStdio.in = os.NewFile(StdinFile, fdName(StdinFile))
+		if shellStdio.in == nil {
+			return teleport.RemoteCommandFailure, trace.BadParameter("stdin not found")
+		}
+		shellStdio.out = os.NewFile(StdoutFile, fdName(StdoutFile))
+		if shellStdio.out == nil {
+			return teleport.RemoteCommandFailure, trace.BadParameter("stdout not found")
+		}
+		shellStdio.err = os.NewFile(StderrFile, fdName(StderrFile))
+		if shellStdio.err == nil {
+			return teleport.RemoteCommandFailure, trace.BadParameter("stderr not found")
+		}
+	}
+
 	// If PAM is enabled, open a PAM context. This has to be done before anything
 	// else because PAM is sometimes used to create the local user used to
 	// launch the shell under.
@@ -356,35 +394,29 @@ func RunCommand() (code int, err error) {
 	if c.PAMConfig != nil {
 		slog.DebugContext(ctx, "Opening PAM context")
 
-		// Connect std{in,out,err} to the TTY if a terminal has been allocated,
-		// otherwise discard std{out,err}. If this was not done, things like MOTD
-		// would be printed for non-interactive "exec" requests.
-		var stdin io.Reader
-		var stdout io.Writer
-		var stderr io.Writer
-		if tty != nil {
-			stdin = tty
-			stdout = tty
-			stderr = tty
-		} else {
-			stdin = os.Stdin
-			stdout = io.Discard
-			stderr = io.Discard
-		}
-
-		// Open the PAM context.
-		pamContext, err := pam.Open(&servicecfg.PAMConfig{
+		cfg := &servicecfg.PAMConfig{
 			ServiceName: c.PAMConfig.ServiceName,
 			UsePAMAuth:  c.PAMConfig.UsePAMAuth,
 			Login:       c.Login,
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the
 			// account/session.
-			Env:    c.PAMConfig.Environment,
-			Stdin:  stdin,
-			Stdout: stdout,
-			Stderr: stderr,
-		})
+			Env: c.PAMConfig.Environment,
+			// Connect std{in,out,err} to the TTY if a terminal has been allocated.
+			Stdin:  shellStdio.in,
+			Stdout: shellStdio.out,
+			Stderr: shellStdio.err,
+		}
+
+		// Discard std{out,err} for non-interactive requests. Otherwise, things like
+		// MOTD would be printed.
+		if !c.Terminal {
+			cfg.Stdout = io.Discard
+			cfg.Stderr = io.Discard
+		}
+
+		// Open the PAM context.
+		pamContext, err := pam.Open(cfg)
 		if err != nil {
 			return exitCode(err), trace.Wrap(err, "failed to open PAM context")
 		}
@@ -434,7 +466,7 @@ func RunCommand() (code int, err error) {
 	}
 
 	// Build the actual command that will launch the shell.
-	cmd, err := buildCommand(&c, localUser, tty, pamEnvironment)
+	cmd, err := buildCommand(&c, localUser, shellStdio, pamEnvironment)
 	if err != nil {
 		return teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
@@ -722,9 +754,10 @@ func RunNetworking() (code int, err error) {
 		pamContext, err := pam.Open(&servicecfg.PAMConfig{
 			ServiceName: c.PAMConfig.ServiceName,
 			Login:       c.Login,
-			Stdin:       os.Stdin,
-			Stdout:      io.Discard,
-			Stderr:      io.Discard,
+			// TODO (Joerger): add stdin?
+			Stdin:  os.Stdin,
+			Stdout: io.Discard,
+			Stderr: io.Discard,
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the
 			// account/session.
@@ -796,8 +829,7 @@ func RunNetworking() (code int, err error) {
 		return teleport.RemoteCommandFailure, trace.Wrap(err, "failed to set working directory for networking process: %s", workingDir)
 	}
 
-	// Build request listener from first extra file that was passed to command.
-	ffd := os.NewFile(FirstExtraFile, "listener")
+	ffd := os.NewFile(ListenerFile, "listener")
 	if ffd == nil {
 		return teleport.RemoteCommandFailure, trace.BadParameter("missing socket fd")
 	}
@@ -1068,6 +1100,12 @@ func RunAndExit(commandType string) {
 		code, err = teleport.RemoteCommandFailure, fmt.Errorf("unknown command type: %v", commandType)
 	}
 	if err != nil {
+		// Write the error to stderr, where it can be seen by the parent teleport process and
+		// propagated to the client.
+		if code == teleport.RemoteCommandFailure {
+			fmt.Fprintf(os.Stderr, "Failed to launch: %v.\r\n", err)
+		}
+
 		// The "operation not permitted" error is expected from a variety of operations if the
 		// teleport process is running as a non-root user and is trying to spawn a process for
 		// a different OS user.
@@ -1148,9 +1186,18 @@ func readUserEnv(localUser *user.User, path string) ([]string, error) {
 	return envs, trace.Wrap(err)
 }
 
+type stdio struct {
+	// stdin
+	in io.Reader
+	// stdout
+	out io.Writer
+	// stderr
+	err io.Writer
+}
+
 // buildCommand constructs a command that will execute the users shell. This
 // function is run by Teleport while it's re-executing.
-func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnvironment []string) (*exec.Cmd, error) {
+func buildCommand(c *ExecCommand, localUser *user.User, stdio stdio, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
 	isReexec := false
 
@@ -1230,14 +1277,12 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnviron
 	// after environment is fully built, set it to cmd
 	cmd.Env = *env
 
-	// If a terminal was requested, connect std{in,out,err} to the TTY and set
-	// the controlling TTY. Otherwise, connect std{in,out,err} to
-	// os.Std{in,out,err}.
-	if c.Terminal {
-		cmd.Stdin = tty
-		cmd.Stdout = tty
-		cmd.Stderr = tty
+	// set stdio. If a terminal was requested, the stdio fields all point to the same tty file.
+	cmd.Stdin = stdio.in
+	cmd.Stdout = stdio.out
+	cmd.Stderr = stdio.err
 
+	if c.Terminal {
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setsid:  true,
 			Setctty: true,
@@ -1245,28 +1290,26 @@ func buildCommand(c *ExecCommand, localUser *user.User, tty *os.File, pamEnviron
 			// set to our tty above.
 		}
 	} else {
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-
 		cmd.SysProcAttr = &syscall.SysProcAttr{
 			Setsid: true,
 		}
+	}
 
-		// If a terminal was not requested, and extra files were specified
-		// to be passed to the child, open them so that they can be passed
-		// to the grandchild.
-		if c.ExtraFilesLen > 0 {
-			cmd.ExtraFiles = make([]*os.File, c.ExtraFilesLen)
-			for i := range c.ExtraFilesLen {
-				fd := FirstExtraFile + uintptr(i)
-				f := os.NewFile(fd, strconv.Itoa(int(fd)))
-				if f == nil {
-					return nil, trace.NotFound("extra file %d not found", fd)
-				}
-				cmd.ExtraFiles[i] = f
-			}
+	// Pass extra files for SFTP to grandchild.
+	if c.RequestType == sshutils.SubsystemRequest && c.Command == teleport.SFTPSubsystem {
+		out := os.NewFile(FileTransferOutFile, strconv.Itoa(int(FileTransferOutFile)))
+		if out == nil {
+			return nil, trace.NotFound("read pipe out file not found")
 		}
+		in := os.NewFile(FileTransferInFile, strconv.Itoa(int(FileTransferInFile)))
+		if in == nil {
+			return nil, trace.NotFound("read pipe in file not found")
+		}
+		audit := os.NewFile(AuditInFile, strconv.Itoa(int(AuditInFile)))
+		if audit == nil {
+			return nil, trace.NotFound("read pipe audit file not found")
+		}
+		cmd.ExtraFiles = []*os.File{out, in, audit}
 	}
 
 	// Set the command's cwd to the user's $HOME, or "/" if
@@ -1333,9 +1376,6 @@ func ConfigureCommand(ctx *ServerContext, extraFiles ...*os.File) (*exec.Cmd, er
 	cmdmsg, err := ctx.ExecCommand()
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if !cmdmsg.Terminal {
-		cmdmsg.ExtraFilesLen = len(extraFiles)
 	}
 
 	go copyCommand(ctx.CancelContext(), ctx.cmdw, cmdmsg)

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -104,12 +104,8 @@ const (
 
 // FileFDs for terminal based exec sessions.
 const (
-	// Deprecated: PTYFileDeprecated is a placeholder for the unused PTY file that
-	// was passed to the child process. The PTY should only be used in the
-	// the parent process but was left here for compatibility purposes.
-	PTYFileDeprecated = FirstExtraFile + iota
 	// TTYFile is a TTY the parent process passes to the child process.
-	TTYFile
+	TTYFile = FirstExtraFile + iota
 )
 
 // FileFDs for non-terminal based exec sessions.

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -269,7 +269,7 @@ type UaccMetadata struct {
 // system state related to the process and/or thread for PAM and SELinux.
 // The process should exit after this function returns so the potentially
 // modified process and/or thread isn't used with a non-standard state.
-func RunCommand() (code int, err error) {
+func RunCommand() (execErr error, err error) {
 	ctx := context.Background()
 
 	// SIGQUIT is used by teleport to initiate graceful shutdown, waiting for
@@ -281,29 +281,29 @@ func RunCommand() (code int, err error) {
 	// Parent sends the command payload in the third file descriptor.
 	cmdfd := os.NewFile(CommandFile, fdName(CommandFile))
 	if cmdfd == nil {
-		return teleport.RemoteCommandFailure, trace.BadParameter("command pipe not found")
+		return nil, trace.BadParameter("command pipe not found")
 	}
 	logfd := os.NewFile(LogFile, fdName(LogFile))
 	if logfd == nil {
-		return teleport.RemoteCommandFailure, trace.BadParameter("log pipe not found")
+		return nil, trace.BadParameter("log pipe not found")
 	}
 	contfd := os.NewFile(ContinueFile, fdName(ContinueFile))
 	if contfd == nil {
-		return teleport.RemoteCommandFailure, trace.BadParameter("continue pipe not found")
+		return nil, trace.BadParameter("continue pipe not found")
 	}
 	readyfd := os.NewFile(ReadyFile, fdName(ReadyFile))
 	if readyfd == nil {
-		return teleport.RemoteCommandFailure, trace.BadParameter("ready pipe not found")
+		return nil, trace.BadParameter("ready pipe not found")
 	}
 	terminatefd := os.NewFile(TerminateFile, fdName(TerminateFile))
 	if terminatefd == nil {
-		return teleport.RemoteCommandFailure, trace.BadParameter("terminate pipe not found")
+		return nil, trace.BadParameter("terminate pipe not found")
 	}
 
 	// Read in the command payload.
 	var c ExecCommand
 	if err := json.NewDecoder(cmdfd).Decode(&c); err != nil {
-		return teleport.RemoteCommandFailure, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// If BPF is enabled, ensure that the ready file is closed if a
@@ -352,7 +352,7 @@ func RunCommand() (code int, err error) {
 	if c.RecordWithBPF {
 		loginUIDBytes, err = os.ReadFile(procLoginuid)
 		if err != nil {
-			return exitCode(err), trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -361,7 +361,7 @@ func RunCommand() (code int, err error) {
 		// If this is an interactive session, use the tty file for grandchild stdio.
 		tty = os.NewFile(TTYFile, fdName(TTYFile))
 		if tty == nil {
-			return teleport.RemoteCommandFailure, trace.BadParameter("tty not found")
+			return nil, trace.BadParameter("tty not found")
 		}
 		c.stdin = tty
 		c.stdout = tty
@@ -377,15 +377,15 @@ func RunCommand() (code int, err error) {
 		// If this is a normal, non-interactive exec session, use the stdio pipes provided as extra files.
 		c.stdin = os.NewFile(StdinFile, fdName(StdinFile))
 		if c.stdin == nil {
-			return teleport.RemoteCommandFailure, trace.BadParameter("stdin not found")
+			return nil, trace.BadParameter("stdin not found")
 		}
 		c.stdout = os.NewFile(StdoutFile, fdName(StdoutFile))
 		if c.stdout == nil {
-			return teleport.RemoteCommandFailure, trace.BadParameter("stdout not found")
+			return nil, trace.BadParameter("stdout not found")
 		}
 		c.stderr = os.NewFile(StderrFile, fdName(StderrFile))
 		if c.stderr == nil {
-			return teleport.RemoteCommandFailure, trace.BadParameter("stderr not found")
+			return nil, trace.BadParameter("stderr not found")
 		}
 	}
 
@@ -420,7 +420,7 @@ func RunCommand() (code int, err error) {
 		// Open the PAM context.
 		pamContext, err := pam.Open(cfg)
 		if err != nil {
-			return exitCode(err), trace.Wrap(err, "failed to open PAM context")
+			return nil, trace.Wrap(err, "failed to open PAM context")
 		}
 		defer pamContext.Close()
 
@@ -440,14 +440,14 @@ func RunCommand() (code int, err error) {
 		if uaccErr := uaccHandler.FailedLogin(c.Login, &c.UaccMetadata.RemoteAddr); uaccErr != nil {
 			slog.DebugContext(ctx, "unable to write failed login attempt to uacc", "error", uaccErr)
 		}
-		return teleport.RemoteCommandFailure, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Ensure this process has a unique audit login session ID (auid) set
 	// so Enhanced Session Recording can track events correctly.
 	if c.RecordWithBPF {
 		if err := setAuditSessionID(ctx, c, loginUIDBytes, localUser, readyfd); err != nil {
-			return exitCode(err), trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -470,7 +470,7 @@ func RunCommand() (code int, err error) {
 	// Build the actual command that will launch the shell.
 	cmd, err := buildCommand(&c, localUser, pamEnvironment)
 	if err != nil {
-		return teleport.RemoteCommandFailure, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	// Wait until the continue signal is received from Teleport signaling that
@@ -478,7 +478,7 @@ func RunCommand() (code int, err error) {
 	if c.RecordWithBPF {
 		err = waitForSignal(ctx, contfd, 10*time.Second)
 		if err != nil {
-			return teleport.RemoteCommandFailure, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 		slog.DebugContext(ctx, "Received continue signal")
 	}
@@ -497,7 +497,7 @@ func RunCommand() (code int, err error) {
 			cmd.SysProcAttr.Credential,
 			c.Login, &systemUser{u: localUser})
 		if err != nil {
-			return teleport.RemoteCommandFailure, trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -511,7 +511,7 @@ func RunCommand() (code int, err error) {
 	if c.SetSELinuxContext {
 		seContext, err := selinux.UserContext(c.Login)
 		if err != nil {
-			return teleport.RemoteCommandFailure, trace.Wrap(err, "failed to get SELinux context of login user")
+			return nil, trace.Wrap(err, "failed to get SELinux context of login user")
 		}
 
 		// SetExecLabel changes the SELinux exec context for the
@@ -523,21 +523,20 @@ func RunCommand() (code int, err error) {
 		// restrictive) SELinux context.
 		runtime.LockOSThread()
 		if err := ocselinux.SetExecLabel(seContext); err != nil {
-			return teleport.RemoteCommandFailure, trace.Wrap(err, "failed to set SELinux context")
+			return nil, trace.Wrap(err, "failed to set SELinux context")
 		}
 	}
 
 	// Start the command.
 	if err := cmd.Start(); err != nil {
-		return teleport.RemoteCommandFailure, trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	slog.DebugContext(ctx, "Started command")
 
 	parkerCancel()
 
-	err = waitForShell(terminatefd, cmd)
-
-	return exitCode(err), trace.Wrap(err)
+	execErr = waitForShell(terminatefd, cmd)
+	return trace.Wrap(execErr), nil
 }
 
 // setAuditSessionID ensures the audit login session ID is updated by
@@ -1090,7 +1089,13 @@ func RunAndExit(commandType string) {
 
 	switch commandType {
 	case teleport.ExecSubCommand:
-		code, err = RunCommand()
+		var execErr error
+		execErr, err = RunCommand()
+		if err != nil {
+			code = teleport.RemoteCommandFailure
+		} else {
+			code = exitCode(execErr)
+		}
 	case teleport.NetworkingSubCommand:
 		code, err = RunNetworking()
 	case teleport.CheckHomeDirSubCommand:

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -74,7 +74,7 @@ const (
 // Teleport is re-executing itself.
 type FileFD = uintptr
 
-// Common FileFDs
+// FileFDs used by all re-exec subcommands.
 const (
 	// CommandFile is used to pass the command and arguments that the
 	// child process should execute from the parent process.
@@ -99,7 +99,7 @@ const (
 	TerminateFile
 	// FirstExtraFile is the first file descriptor that will be valid when
 	// extra files are passed to child processes without a terminal.
-	FirstExtraFile FileFD = TerminateFile + 1
+	FirstExtraFile
 )
 
 // FileFDs for terminal based exec sessions.
@@ -126,7 +126,7 @@ const (
 const (
 	// FileTransferOutFile is used to pass write transfer data to the sftp (grandchild) process.
 	FileTransferOutFile = FirstExtraFile + iota
-	// FileTransferOutFile is used to pass read transfer data from the sftp (grandchild) process.
+	// FileTransferInFile is used to pass read transfer data from the sftp (grandchild) process.
 	FileTransferInFile
 	// AuditInFile is used to read audit events from the sftp (grandchild) process.
 	AuditInFile
@@ -145,6 +145,10 @@ func fdName(f FileFD) string {
 // ExecCommand contains the payload to "teleport exec" which will be used to
 // construct and execute a shell.
 type ExecCommand struct {
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+
 	// LogConfig is the log configuration for the child process.
 	LogConfig ExecLogConfig `json:"log_config"`
 
@@ -353,36 +357,34 @@ func RunCommand() (code int, err error) {
 	}
 
 	var tty *os.File
-	var shellStdio stdio
 	if c.Terminal {
 		// If this is an interactive session, use the tty file for grandchild stdio.
 		tty = os.NewFile(TTYFile, fdName(TTYFile))
 		if tty == nil {
 			return teleport.RemoteCommandFailure, trace.BadParameter("tty not found")
 		}
-		shellStdio.in = tty
-		shellStdio.out = tty
-		shellStdio.err = tty
+		c.stdin = tty
+		c.stdout = tty
+		c.stderr = tty
 	} else if c.RequestType == sshutils.SubsystemRequest && c.Command == teleport.SFTPSubsystem {
 		// std{in/out} is not used by the SFTP sub process, just collect stderr.
-		shellStdio = stdio{
-			in:  bytes.NewReader([]byte{}),
-			out: io.Discard,
-			// Propagate sftp subprocess errors to the parent process.
-			err: os.Stderr,
-		}
+		c.stdin = bytes.NewReader(nil)
+		c.stdout = io.Discard
+		// Propagate sftp subprocess errors to the parent process.
+		c.stderr = os.Stderr
+
 	} else {
 		// If this is a normal, non-interactive exec session, use the stdio pipes provided as extra files.
-		shellStdio.in = os.NewFile(StdinFile, fdName(StdinFile))
-		if shellStdio.in == nil {
+		c.stdin = os.NewFile(StdinFile, fdName(StdinFile))
+		if c.stdin == nil {
 			return teleport.RemoteCommandFailure, trace.BadParameter("stdin not found")
 		}
-		shellStdio.out = os.NewFile(StdoutFile, fdName(StdoutFile))
-		if shellStdio.out == nil {
+		c.stdout = os.NewFile(StdoutFile, fdName(StdoutFile))
+		if c.stdout == nil {
 			return teleport.RemoteCommandFailure, trace.BadParameter("stdout not found")
 		}
-		shellStdio.err = os.NewFile(StderrFile, fdName(StderrFile))
-		if shellStdio.err == nil {
+		c.stderr = os.NewFile(StderrFile, fdName(StderrFile))
+		if c.stderr == nil {
 			return teleport.RemoteCommandFailure, trace.BadParameter("stderr not found")
 		}
 	}
@@ -403,9 +405,9 @@ func RunCommand() (code int, err error) {
 			// account/session.
 			Env: c.PAMConfig.Environment,
 			// Connect std{in,out,err} to the TTY if a terminal has been allocated.
-			Stdin:  shellStdio.in,
-			Stdout: shellStdio.out,
-			Stderr: shellStdio.err,
+			Stdin:  c.stdin,
+			Stdout: c.stdout,
+			Stderr: c.stderr,
 		}
 
 		// Discard std{out,err} for non-interactive requests. Otherwise, things like
@@ -466,7 +468,7 @@ func RunCommand() (code int, err error) {
 	}
 
 	// Build the actual command that will launch the shell.
-	cmd, err := buildCommand(&c, localUser, shellStdio, pamEnvironment)
+	cmd, err := buildCommand(&c, localUser, pamEnvironment)
 	if err != nil {
 		return teleport.RemoteCommandFailure, trace.Wrap(err)
 	}
@@ -754,10 +756,9 @@ func RunNetworking() (code int, err error) {
 		pamContext, err := pam.Open(&servicecfg.PAMConfig{
 			ServiceName: c.PAMConfig.ServiceName,
 			Login:       c.Login,
-			// TODO (Joerger): add stdin?
-			Stdin:  os.Stdin,
-			Stdout: io.Discard,
-			Stderr: io.Discard,
+			Stdin:       os.Stdin,
+			Stdout:      io.Discard,
+			Stderr:      io.Discard,
 			// Set Teleport specific environment variables that PAM modules
 			// like pam_script.so can pick up to potentially customize the
 			// account/session.
@@ -1186,18 +1187,9 @@ func readUserEnv(localUser *user.User, path string) ([]string, error) {
 	return envs, trace.Wrap(err)
 }
 
-type stdio struct {
-	// stdin
-	in io.Reader
-	// stdout
-	out io.Writer
-	// stderr
-	err io.Writer
-}
-
-// buildCommand constructs a command that will execute the users shell. This
+// buildCommand constructs a command that will execute the user's shell. This
 // function is run by Teleport while it's re-executing.
-func buildCommand(c *ExecCommand, localUser *user.User, stdio stdio, pamEnvironment []string) (*exec.Cmd, error) {
+func buildCommand(c *ExecCommand, localUser *user.User, pamEnvironment []string) (*exec.Cmd, error) {
 	var cmd exec.Cmd
 	isReexec := false
 
@@ -1278,9 +1270,9 @@ func buildCommand(c *ExecCommand, localUser *user.User, stdio stdio, pamEnvironm
 	cmd.Env = *env
 
 	// set stdio. If a terminal was requested, the stdio fields all point to the same tty file.
-	cmd.Stdin = stdio.in
-	cmd.Stdout = stdio.out
-	cmd.Stderr = stdio.err
+	cmd.Stdin = c.stdin
+	cmd.Stdout = c.stdout
+	cmd.Stderr = c.stderr
 
 	if c.Terminal {
 		cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -1297,15 +1289,15 @@ func buildCommand(c *ExecCommand, localUser *user.User, stdio stdio, pamEnvironm
 
 	// Pass extra files for SFTP to grandchild.
 	if c.RequestType == sshutils.SubsystemRequest && c.Command == teleport.SFTPSubsystem {
-		out := os.NewFile(FileTransferOutFile, strconv.Itoa(int(FileTransferOutFile)))
+		out := os.NewFile(FileTransferOutFile, "FileTransferOutFile")
 		if out == nil {
 			return nil, trace.NotFound("read pipe out file not found")
 		}
-		in := os.NewFile(FileTransferInFile, strconv.Itoa(int(FileTransferInFile)))
+		in := os.NewFile(FileTransferInFile, "FileTransferInFile")
 		if in == nil {
 			return nil, trace.NotFound("read pipe in file not found")
 		}
-		audit := os.NewFile(AuditInFile, strconv.Itoa(int(AuditInFile)))
+		audit := os.NewFile(AuditInFile, "AuditInFile")
 		if audit == nil {
 			return nil, trace.NotFound("read pipe audit file not found")
 		}

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -265,7 +265,9 @@ type UaccMetadata struct {
 // system state related to the process and/or thread for PAM and SELinux.
 // The process should exit after this function returns so the potentially
 // modified process and/or thread isn't used with a non-standard state.
-func RunCommand() (execErr error, err error) {
+// Returns exitErr if the exec/shell command runs and exits successfully
+// or err if command fails to run.
+func RunCommand() (exitErr error, err error) {
 	ctx := context.Background()
 
 	// SIGQUIT is used by teleport to initiate graceful shutdown, waiting for
@@ -531,8 +533,8 @@ func RunCommand() (execErr error, err error) {
 
 	parkerCancel()
 
-	execErr = waitForShell(terminatefd, cmd)
-	return trace.Wrap(execErr), nil
+	exitErr = waitForShell(terminatefd, cmd)
+	return trace.Wrap(exitErr), nil
 }
 
 // setAuditSessionID ensures the audit login session ID is updated by
@@ -1051,7 +1053,7 @@ func getConnFile(conn net.Conn) (*os.File, error) {
 }
 
 // runCheckHomeDir checks if the active user's $HOME dir exists and is accessible.
-func runCheckHomeDir() (code int, err error) {
+func runCheckHomeDir() (code int) {
 	code = teleport.RemoteCommandSuccess
 	if err := hasAccessibleHomeDir(); err != nil {
 		switch {
@@ -1064,11 +1066,11 @@ func runCheckHomeDir() (code int, err error) {
 		}
 	}
 
-	return code, nil
+	return code
 }
 
 // runPark does nothing, forever.
-func runPark() (code int, err error) {
+func runPark() (code int) {
 	// Do not replace this with an empty select because there are no other
 	// goroutines running so it will panic.
 	for {
@@ -1077,7 +1079,7 @@ func runPark() (code int, err error) {
 }
 
 // RunAndExit will run the requested command and then exit. This wrapper
-// allows Run{Command,Forward} to use defers and makes sure error messages
+// allows Run{Command,Networking} to use defers and makes sure error messages
 // are consistent across both.
 func RunAndExit(commandType string) {
 	var code int
@@ -1095,9 +1097,9 @@ func RunAndExit(commandType string) {
 	case teleport.NetworkingSubCommand:
 		code, err = RunNetworking()
 	case teleport.CheckHomeDirSubCommand:
-		code, err = runCheckHomeDir()
+		code = runCheckHomeDir()
 	case teleport.ParkSubCommand:
-		code, err = runPark()
+		code = runPark()
 	default:
 		code, err = teleport.RemoteCommandFailure, fmt.Errorf("unknown command type: %v", commandType)
 	}
@@ -1292,15 +1294,15 @@ func buildCommand(c *ExecCommand, localUser *user.User, pamEnvironment []string)
 	if c.RequestType == sshutils.SubsystemRequest && c.Command == teleport.SFTPSubsystem {
 		out := os.NewFile(FileTransferOutFile, "FileTransferOutFile")
 		if out == nil {
-			return nil, trace.NotFound("read pipe out file not found")
+			return nil, trace.NotFound("FileTransferOutFile file not found")
 		}
 		in := os.NewFile(FileTransferInFile, "FileTransferInFile")
 		if in == nil {
-			return nil, trace.NotFound("read pipe in file not found")
+			return nil, trace.NotFound("FileTransferInFile file not found")
 		}
 		audit := os.NewFile(AuditInFile, "AuditInFile")
 		if audit == nil {
-			return nil, trace.NotFound("read pipe audit file not found")
+			return nil, trace.NotFound("AuditInFile file not found")
 		}
 		cmd.ExtraFiles = []*os.File{out, in, audit}
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1535,7 +1535,7 @@ func (s *session) startTerminal(ctx context.Context, scx *ServerContext) error {
 		s.term = term
 	}
 
-	if err := s.term.Run(ctx); err != nil {
+	if err := s.term.Run(ctx, s.io); err != nil {
 		s.logger.ErrorContext(ctx, "Unable to run shell command.", "error", err)
 		return trace.ConvertSystemError(err)
 	}

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -217,17 +217,17 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	}
 
 	// Capture stderr.
-	stderrr, stderrw, err := os.Pipe()
+	stderrR, stderrW, err := os.Pipe()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer stderrw.Close()
-	t.cmd.Stderr = stderrw
+	defer stderrW.Close()
+	t.cmd.Stderr = stderrW
 
 	t.waitForOutputStreams.Go(func() {
-		defer stderrr.Close()
+		defer stderrR.Close()
 
-		childErr, err := reexec.ReadChildError(stderrr)
+		childErr, err := reexec.ReadChildError(stderrR)
 		if err != nil {
 			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
 			return

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -201,24 +201,18 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	default:
 	}
 
-	var err error
-	// Create the command that will actually execute.
-	t.cmd, err = ConfigureCommand(t.serverContext)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
+	// Pass the TTY to the child since a terminal is attached.
 	// we need the lock here to protect from concurrent calls to Close()
 	t.mu.Lock()
 	tty := t.tty
 	t.mu.Unlock()
 
-	// Intentionally passing a nil value instead of the PTY. The child
-	// process does not need the PTY, but for compatibility purposes the
-	// first ExtraFiles is left for the PTY descriptor.
-	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, nil)
-	// Pass the TTY to the child since a terminal is attached.
-	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, tty)
+	var err error
+	// Create the command that will actually execute.
+	t.cmd, err = ConfigureCommand(t.serverContext, tty)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	// Capture stderr.
 	stderrr, stderrw, err := os.Pipe()

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -146,10 +146,9 @@ type terminal struct {
 	// the process running in the shell should be killed.
 	terminateFD *os.File
 
-	// waitForOutputStreams is closed when child reexec and shell processes have
-	// their stderr/stdout fully consumed by io.Copy goroutines. This is necessary
-	// due to the use of custom pipes, which exec.Cmd does not wait for closure of
-	// in Wait().
+	// waitForOutputStreams tracks goroutines that copy stderr/stdout from child
+	// reexec and shell processes. This is necessary due to the use of custom pipes,
+	// which exec.Cmd does not wait for closure of in cmd.Wait().
 	waitForOutputStreams sync.WaitGroup
 
 	pid int

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -146,9 +146,11 @@ type terminal struct {
 	// the process running in the shell should be killed.
 	terminateFD *os.File
 
-	// childStderrDone is closed when child process stderr is fully read and
-	// propagated to the SSH session stderr stream.
-	childStderrDone chan struct{}
+	// waitForOutputStreams is closed when child reexec and shell processes have
+	// their stderr/stdout fully consumed by io.Copy goroutines. This is necessary
+	// due to the use of custom pipes, which exec.Cmd does not wait for closure of
+	// in Wait().
+	waitForOutputStreams sync.WaitGroup
 
 	pid int
 
@@ -222,9 +224,7 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	defer stderrw.Close()
 	t.cmd.Stderr = stderrw
 
-	t.childStderrDone = make(chan struct{})
-	go func() {
-		defer close(t.childStderrDone)
+	t.waitForOutputStreams.Go(func() {
 		defer stderrr.Close()
 
 		childErr, err := reexec.ReadChildError(stderrr)
@@ -237,9 +237,9 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 		}
 
 		if _, err := io.WriteString(errorWriter, childErr); err != nil {
-			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
+			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to all parties", "error", err)
 		}
-	}()
+	})
 
 	// Close the TTY before returning to ensure that our half of the pipe is
 	// closed. This ensures that reading from the PTY will unblock when the
@@ -266,15 +266,7 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 // Wait will block until the terminal is complete.
 func (t *terminal) Wait() (*ExecResult, error) {
 	err := t.cmd.Wait()
-
-	// Wait a moment for the session stderr to propagate to connected parties. In the case of
-	// one or more parties being slow/blocking the stderr write, ensure the session still ends promptly.
-	select {
-	case <-t.childStderrDone:
-	case <-time.After(time.Second):
-		t.log.WarnContext(t.serverContext.cancelContext, "Failed to propagate child process stderr to client before ending the session")
-	}
-
+	t.waitForOutputStreams.Wait()
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -39,6 +39,7 @@ import (
 	"github.com/gravitational/teleport"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	rsession "github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/sshutils/reexec"
 )
 
 // LookupUser is used to mock the value returned by user.Lookup(string).
@@ -56,7 +57,7 @@ type Terminal interface {
 	AddParty(delta int)
 
 	// Run will run the terminal.
-	Run(ctx context.Context) error
+	Run(ctx context.Context, errorWriter io.Writer) error
 
 	// Wait will block until the terminal is complete.
 	Wait() (*ExecResult, error)
@@ -187,8 +188,9 @@ func (t *terminal) AddParty(delta int) {
 	t.wg.Add(delta)
 }
 
-// Run will run the terminal.
-func (t *terminal) Run(ctx context.Context) error {
+// Run will run the terminal. If the shell fails to start due to a [teleport.RemoteCommandFailure],
+// the error will be written to the given error writer.
+func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -213,6 +215,31 @@ func (t *terminal) Run(ctx context.Context) error {
 	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, nil)
 	// Pass the TTY to the child since a terminal is attached.
 	t.cmd.ExtraFiles = append(t.cmd.ExtraFiles, tty)
+
+	// Capture stderr.
+	stderrr, stderrw, err := os.Pipe()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer stderrw.Close()
+	t.cmd.Stderr = stderrw
+
+	go func() {
+		defer stderrr.Close()
+
+		childErr, err := reexec.ReadChildError(stderrr)
+		if err != nil {
+			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
+			return
+		}
+		if childErr == "" {
+			return
+		}
+
+		if _, err := io.WriteString(errorWriter, childErr); err != nil {
+			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
+		}
+	}()
 
 	// Close the TTY before returning to ensure that our half of the pipe is
 	// closed. This ensures that reading from the PTY will unblock when the
@@ -551,7 +578,7 @@ func (b *ptyBuffer) Write(p []byte) (n int, err error) {
 	return b.w.Write(p)
 }
 
-func (t *remoteTerminal) Run(ctx context.Context) error {
+func (t *remoteTerminal) Run(ctx context.Context, _ io.Writer) error {
 	// prepare the remote session by setting environment variables
 	t.prepareRemoteSession(ctx, t.session, t.ctx)
 

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -146,6 +146,10 @@ type terminal struct {
 	// the process running in the shell should be killed.
 	terminateFD *os.File
 
+	// childStderrDone is closed when child process stderr is fully read and
+	// propagated to the SSH session stderr stream.
+	childStderrDone chan struct{}
+
 	pid int
 
 	termType string
@@ -224,7 +228,9 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 	defer stderrw.Close()
 	t.cmd.Stderr = stderrw
 
+	t.childStderrDone = make(chan struct{})
 	go func() {
+		defer close(t.childStderrDone)
 		defer stderrr.Close()
 
 		childErr, err := reexec.ReadChildError(stderrr)
@@ -266,6 +272,15 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 // Wait will block until the terminal is complete.
 func (t *terminal) Wait() (*ExecResult, error) {
 	err := t.cmd.Wait()
+
+	// Wait a moment for the session stderr to propagate to connected parties. In the case of
+	// one or more parties being slow/blocking the stderr write, ensure the session still ends promptly.
+	select {
+	case <-t.childStderrDone:
+	case <-time.After(time.Second):
+		t.log.WarnContext(t.serverContext.cancelContext, "Failed to propagate child process stderr to client before ending the session")
+	}
+
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {

--- a/lib/srv/term_test.go
+++ b/lib/srv/term_test.go
@@ -20,6 +20,7 @@ package srv
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"os/user"
@@ -108,7 +109,7 @@ func TestTerminal_KillUnderlyingShell(t *testing.T) {
 	ctx := context.Background()
 
 	// Run sh
-	err = term.Run(ctx)
+	err = term.Run(ctx, io.Discard)
 	require.NoError(t, err)
 
 	errors := make(chan error)

--- a/lib/sshutils/reexec/reexec.go
+++ b/lib/sshutils/reexec/reexec.go
@@ -1,0 +1,45 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Package reexec contains a common implementation for teleport reexec commands.
+package reexec
+
+import (
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+)
+
+const maxRead = 4096
+
+// ReadChildError reads the child process's stderr pipe and returns it as a string.
+// If the stderr pipe is empty, an empty string and nil error is returned.
+func ReadChildError(stderr io.Reader) (string, error) {
+	// Read the error msg from stderr.
+	errMsg := new(strings.Builder)
+	if _, err := io.Copy(errMsg, io.LimitReader(stderr, maxRead)); err != nil {
+		return "", trace.Wrap(err, "Failed to read error message from child process")
+	}
+
+	// TODO(Joerger): Process the err msg from stderr to provide deeper insights into
+	// the cause of the session failure to add to the error message.
+	// e.g. user unknown because host user creation denied.
+
+	return errMsg.String(), nil
+}

--- a/lib/sshutils/reexec/reexec.go
+++ b/lib/sshutils/reexec/reexec.go
@@ -34,7 +34,7 @@ func ReadChildError(stderr io.Reader) (string, error) {
 	// Read the error msg from stderr.
 	errMsg := new(strings.Builder)
 	if _, err := io.Copy(errMsg, io.LimitReader(stderr, maxRead)); err != nil {
-		return "", trace.Wrap(err, "Failed to read error message from child process")
+		return "", trace.Wrap(err, "failed to read error message from child process")
 	}
 
 	// TODO(Joerger): Process the err msg from stderr to provide deeper insights into

--- a/lib/sshutils/reexec/reexec_test.go
+++ b/lib/sshutils/reexec/reexec_test.go
@@ -1,0 +1,80 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package reexec
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"testing/iotest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadChildError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		readErr    error
+		stderrIn   string
+		wantStderr string
+	}{
+		{
+			name:       "empty stderr",
+			stderrIn:   "",
+			wantStderr: "",
+		},
+		{
+			name:       "has stderr",
+			stderrIn:   "Failed to launch: test error.\r\n",
+			wantStderr: "Failed to launch: test error.\r\n",
+		},
+		{
+			name:       "stderr at max read limit",
+			stderrIn:   strings.Repeat("a", maxRead),
+			wantStderr: strings.Repeat("a", maxRead),
+		},
+		{
+			name:       "stderr over max read limit is truncated",
+			stderrIn:   strings.Repeat("a", maxRead) + "b",
+			wantStderr: strings.Repeat("a", maxRead),
+		},
+		{
+			name:    "read error",
+			readErr: errors.New("read failure"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.readErr != nil {
+				_, err := ReadChildError(iotest.ErrReader(tt.readErr))
+				require.ErrorIs(t, err, tt.readErr)
+				return
+			}
+
+			got, err := ReadChildError(strings.NewReader(tt.stderrIn))
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStderr, got)
+		})
+	}
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4584,12 +4584,17 @@ func convertSSHExitCode(tc *client.TeleportClient, err error) error {
 			// Already have an exitCodeError, return that.
 			return trace.Wrap(err)
 		}
-		if err != nil {
-			// Print the error here so we don't lose it when returning the exitCodeError.
-			fmt.Fprintln(tc.Stderr, utils.UserMessageFromError(err))
+
+		// If we get a basic SSH exit error with no unexpected msg or signal,
+		// convert it to an exitCodeError and return.
+		var sshExitErr *ssh.ExitError
+		if errors.As(err, &sshExitErr) && sshExitErr.Msg() == "" && sshExitErr.Signal() == "" {
+			return trace.Wrap(&common.ExitCodeError{Code: status})
 		}
-		err = &common.ExitCodeError{Code: status}
-		return trace.Wrap(err)
+
+		// For unexpected errors, print the error message before converting to an exitCodeError.
+		fmt.Fprintln(tc.Stderr, utils.UserMessageFromError(err))
+		return trace.Wrap(&common.ExitCodeError{Code: status})
 	}
 	return trace.Wrap(err)
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4579,6 +4579,10 @@ func onSSH(cf *CLIConf, initFunc ClientInitFunc) error {
 
 func convertSSHExitCode(tc *client.TeleportClient, err error) error {
 	if status := tc.ExitStatus(); status != 0 {
+		if err == nil {
+			return trace.Wrap(&common.ExitCodeError{Code: status})
+		}
+
 		var exitErr *common.ExitCodeError
 		if errors.As(err, &exitErr) {
 			// Already have an exitCodeError, return that.

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8298,3 +8298,128 @@ func TestListNodesCLIFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestReexecErrorPropagation(t *testing.T) {
+	ctx := t.Context()
+	connector := mockConnector(t)
+
+	createAgent(t)
+
+	// Use a non-existent OS user to force reexec failures in the node.
+	missingLogin := "does-not-exist"
+	nodeAccessMissingLogin, err := types.NewRole("node-access-missing-login", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:     []string{missingLogin},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+
+	userMissingLogin, err := types.NewUser("user-missing-login")
+	require.NoError(t, err)
+	userMissingLogin.SetRoles([]string{nodeAccessMissingLogin.GetName()})
+
+	sshHostname := "test-ssh-server"
+	rootServerOpts := []testserver.TestServerOptFunc{
+		testserver.WithBootstrap(connector, nodeAccessMissingLogin, userMissingLogin),
+		testserver.WithHostname(sshHostname),
+		testserver.WithConfig(func(cfg *servicecfg.Config) {
+			cfg.SSH.Enabled = true
+		}),
+	}
+	rootServer, err := testserver.NewTeleportProcess(t.TempDir(), rootServerOpts...)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, rootServer.Close())
+		require.NoError(t, rootServer.Wait())
+	})
+
+	authServer := rootServer.GetAuthServer()
+	proxyAddr, err := rootServer.ProxyWebAddr()
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		rootNodes, err := rootServer.GetAuthServer().GetNodes(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+		require.Len(t, rootNodes, 1)
+	}, 10*time.Second, 100*time.Millisecond)
+
+	homePath := t.TempDir()
+
+	recordingModes := []struct {
+		name    string
+		recMode string
+	}{
+		{
+			name:    "record at node",
+			recMode: types.RecordAtNode,
+		},
+		{
+			name:    "record at proxy",
+			recMode: types.RecordAtProxy,
+		},
+	}
+
+	sshCases := []struct {
+		name          string
+		tty           bool
+		remoteCommand []string
+	}{
+		{
+			name: "ssh shell",
+		},
+		{
+			name:          "ssh command",
+			remoteCommand: []string{"echo", "hello"},
+		},
+		{
+			name:          "ssh command w/ tty",
+			remoteCommand: []string{"echo", "hello"},
+			tty:           true,
+		},
+	}
+
+	for _, rm := range recordingModes {
+		t.Run(rm.name, func(t *testing.T) {
+			recCfg := types.DefaultSessionRecordingConfig()
+			recCfg.SetMode(rm.recMode)
+			_, err := authServer.UpsertSessionRecordingConfig(ctx, recCfg)
+			require.NoError(t, err)
+
+			err = Run(ctx, []string{
+				"login",
+				"--insecure",
+				"--proxy", proxyAddr.String(),
+			}, setHomePath(homePath), setMockSSOLogin(authServer, userMissingLogin, connector.GetName()))
+			require.NoError(t, err)
+
+			for _, sc := range sshCases {
+				t.Run(sc.name, func(t *testing.T) {
+					stdout := &output{buf: bytes.Buffer{}}
+
+					args := []string{"ssh", "--insecure"}
+					if sc.tty {
+						args = append(args, "--tty")
+					}
+					args = append(args, fmt.Sprintf("%s@%s", missingLogin, sshHostname))
+					args = append(args, sc.remoteCommand...)
+
+					err := Run(ctx, args,
+						setHomePath(homePath),
+						func(conf *CLIConf) error {
+							conf.OverrideStdout = stdout
+							return nil
+						},
+					)
+					require.Error(t, err)
+
+					// If there is a tty, we expect CRLF instead of just LF.
+					expectErr := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
+
+					// Check for exact match to catch regressions with new lines.
+					require.Equal(t, expectErr, stdout.String())
+				})
+			}
+		})
+	}
+}

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8346,20 +8346,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 
 	homePath := t.TempDir()
 
-	recordingModes := []struct {
-		name    string
-		recMode string
-	}{
-		{
-			name:    "record at node",
-			recMode: types.RecordAtNode,
-		},
-		{
-			name:    "record at proxy",
-			recMode: types.RecordAtProxy,
-		},
-	}
-
 	sshCases := []struct {
 		name          string
 		tty           bool
@@ -8386,41 +8372,31 @@ func TestReexecErrorPropagation(t *testing.T) {
 	}, setHomePath(homePath), setMockSSOLogin(authServer, userMissingLogin, connector.GetName()))
 	require.NoError(t, err)
 
-	for _, rm := range recordingModes {
-		t.Run(rm.name, func(t *testing.T) {
-			recCfg := types.DefaultSessionRecordingConfig()
-			recCfg.SetMode(rm.recMode)
-			_, err := authServer.UpsertSessionRecordingConfig(ctx, recCfg)
-			require.NoError(t, err)
+	for _, sc := range sshCases {
+		t.Run(sc.name, func(t *testing.T) {
+			t.Parallel()
+			stdout := &output{buf: bytes.Buffer{}}
 
-			for _, sc := range sshCases {
-				t.Run(sc.name, func(t *testing.T) {
-					t.Parallel()
-					stdout := &output{buf: bytes.Buffer{}}
-
-					args := []string{"ssh", "--insecure"}
-					if sc.tty {
-						args = append(args, "--tty")
-					}
-					args = append(args, fmt.Sprintf("%s@%s", missingLogin, sshHostname))
-					args = append(args, sc.remoteCommand...)
-
-					err := Run(ctx, args,
-						setHomePath(homePath),
-						func(conf *CLIConf) error {
-							conf.OverrideStdout = stdout
-							return nil
-						},
-					)
-					require.Error(t, err)
-
-					// If there is a tty, we expect CRLF instead of just LF.
-					expectErr := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
-
-					// Check for exact match to catch regressions with new lines.
-					require.Equal(t, expectErr, stdout.String())
-				})
+			args := []string{"ssh", "--insecure"}
+			if sc.tty {
+				args = append(args, "--tty")
 			}
+			args = append(args, fmt.Sprintf("%s@%s", missingLogin, sshHostname))
+			args = append(args, sc.remoteCommand...)
+
+			err := Run(ctx, args,
+				setHomePath(homePath),
+				func(conf *CLIConf) error {
+					conf.OverrideStdout = stdout
+					return nil
+				},
+			)
+			require.Error(t, err)
+
+			expectErr := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
+
+			// Check for exact match to catch regressions with new lines.
+			require.Equal(t, expectErr, stdout.String())
 		})
 	}
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8379,6 +8379,13 @@ func TestReexecErrorPropagation(t *testing.T) {
 		},
 	}
 
+	err = Run(ctx, []string{
+		"login",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+	}, setHomePath(homePath), setMockSSOLogin(authServer, userMissingLogin, connector.GetName()))
+	require.NoError(t, err)
+
 	for _, rm := range recordingModes {
 		t.Run(rm.name, func(t *testing.T) {
 			recCfg := types.DefaultSessionRecordingConfig()
@@ -8386,15 +8393,9 @@ func TestReexecErrorPropagation(t *testing.T) {
 			_, err := authServer.UpsertSessionRecordingConfig(ctx, recCfg)
 			require.NoError(t, err)
 
-			err = Run(ctx, []string{
-				"login",
-				"--insecure",
-				"--proxy", proxyAddr.String(),
-			}, setHomePath(homePath), setMockSSOLogin(authServer, userMissingLogin, connector.GetName()))
-			require.NoError(t, err)
-
 			for _, sc := range sshCases {
 				t.Run(sc.name, func(t *testing.T) {
+					t.Parallel()
 					stdout := &output{buf: bytes.Buffer{}}
 
 					args := []string{"ssh", "--insecure"}


### PR DESCRIPTION
Changes:
- Write reexec child process "Failed to launch: ..." errors to stderr instead of stdout.
- Isolate reexec child process stderr from the shell grandchild process stderr stream.
  - This enables the server to process the stderr before passing it on to the client, e.g. for audit events or for [adding context to the error for better UX](https://github.com/gravitational/teleport/pull/62314).
  - For non-interactive sessions without a tty, pass dedicated stdin/stdout/stderr pipes to the shell process rather than repurposing the child process's own FDs, which would break the stderr isolation desired.
- In proxy recording mode, forward the stderr from the remote node session over to the client. Previously, stderr was lost.
- Remove cryptic `ERROR: Process exited with status 255` error from the client as it did not provide anything but confusion for the user. The actual error is now written straight to stderr and the 255 exit code is ignored by the client. Other unexpected exit codes are still printed.

Minor changes:
- Remove the deprecated reexec PTY placeholder FD.
- Simplify the general reexec command construction path.

Part of https://github.com/gravitational/teleport/pull/62285#issuecomment-3850723494

Prerequisite for https://github.com/gravitational/teleport/pull/62314

<details>
<summary>Example output</summary>

Before:
```
> tsh ssh dne@server01
Failed to launch: user: unknown user dne.
ERROR: Process exited with status 255
```

After:
```
> tsh ssh dne@server01    
Failed to launch: user: unknown user dne.
```

</details>

<details>
<summary>Manual Test Plan</summary>

Last Run: 5fa10edd538b75247677d49d0bd33f46ceed0b69
- [x] Success cases
  - [x] `tsh ssh server01`
    - [x] session recorded
  - [x] `tsh ssh server01 ls`
  - [x] `tsh ssh --tty server01 ls`
    - [x] session recorded
- [x] Failure cases
  - [x] `tsh ssh dne@server01`
    - [x] session recorded
  - [x] `tsh ssh dne@server01 ls`
  - [x] `tsh ssh --tty dne@server01 ls`
    - [x] session recorded
- [x] Repeat all the tests above w/ proxy recording mode 
- [x] Repeat all the tests above w/ a PAM module w/ stdin/out/err

</details>