### PR TITLE
Tighten kinit file permissions

### DIFF
--- a/lib/srv/db/common/kerberos/kinit/kinit.go
+++ b/lib/srv/db/common/kerberos/kinit/kinit.go
@@ -222,17 +222,17 @@ func (k *kinitProvider) CreateClient(ctx context.Context, username string) (*cli
 		return nil, trace.Wrap(err)
 	}
 
-	err = os.WriteFile(certPath, certResult.certPEM, 0644)
+	err = os.WriteFile(certPath, certResult.certPEM, 0600)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	err = os.WriteFile(keyPath, certResult.keyPEM, 0644)
+	err = os.WriteFile(keyPath, certResult.keyPEM, 0600)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	err = os.WriteFile(userCAPath, k.buildAnchorsFileContents(certResult.caCert), 0644)
+	err = os.WriteFile(userCAPath, k.buildAnchorsFileContents(certResult.caCert), 0600)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
The Kerberos kinit client for database access temporarily writes a certificate (and its key and corresponding CA) to a temporary directory with world-reabable (and writable) permissions.

The permissions on the parent directory are correctly restricted to the current user only, so there is no exploit possible, this change just adds defense in depth by restricting the file permissions as well.