### PR TITLE
Status and Tag components to replace Label with updated colors for accessibility

### DIFF
--- a/web/packages/design/src/Label/Label.tsx
+++ b/web/packages/design/src/Label/Label.tsx
@@ -182,6 +182,10 @@ const kind = ({
   };
 };
 
+/**
+ * @deprecated Use `Status` from `design/Status` for semantic states
+ * (success, warning, danger) or `Tag` from `design/Tag` for neutral metadata.
+ */
 export type LabelKind =
   | 'primary'
   | 'secondary'
@@ -194,6 +198,10 @@ export type LabelKind =
   | 'outline-primary'
   | 'outline-success';
 
+/**
+ * @deprecated Use `StatusProps` from `design/Status` for semantic states
+ * (success, warning, danger) or `TagProps` from `design/Tag` for neutral metadata.
+ */
 export type LabelProps = {
   kind?: LabelKind;
   withHoverState?: boolean;
@@ -201,6 +209,10 @@ export type LabelProps = {
 } & SpaceProps &
   BorderProps;
 
+/**
+ * @deprecated Use `Status` from `design/Status` for semantic states
+ * (success, warning, danger) or `Tag` from `design/Tag` for neutral metadata.
+ */
 const Label = styled.div<LabelProps>`
   box-sizing: border-box;
   border-radius: 999px;
@@ -221,27 +233,35 @@ export default Label;
 
 type LabelPropsWithoutKind = Omit<LabelProps, 'kind'>;
 
+/** @deprecated Use `<Status kind="primary" variant="filled">` from `design/Status`. */
 export const Primary = (props: LabelPropsWithoutKind) => (
   <Label kind="primary" {...props} />
 );
+/** @deprecated Use `<Tag>` from `design/Tag`. */
 export const Secondary = (props: LabelPropsWithoutKind) => (
   <Label kind="secondary" {...props} />
 );
+/** @deprecated Use `<Status kind="warning" variant="filled">` from `design/Status`. */
 export const Warning = (props: LabelPropsWithoutKind) => (
   <Label kind="warning" {...props} />
 );
+/** @deprecated Use `<Status kind="danger" variant="filled">` from `design/Status`. */
 export const Danger = (props: LabelPropsWithoutKind) => (
   <Label kind="danger" {...props} />
 );
+/** @deprecated Use `<Tag variant="outline">` from `design/Tag`. */
 export const SecondaryOutlined = (props: LabelPropsWithoutKind) => (
   <Label kind="outline-secondary" {...props} />
 );
+/** @deprecated Use `<Status kind="success">` from `design/Status`. */
 export const SuccessOutlined = (props: LabelPropsWithoutKind) => (
   <Label kind="outline-success" {...props} />
 );
+/** @deprecated Use `<Status kind="warning">` from `design/Status`. */
 export const WarningOutlined = (props: LabelPropsWithoutKind) => (
   <Label kind="outline-warning" {...props} />
 );
+/** @deprecated Use `<Status kind="danger">` from `design/Status`. */
 export const DangerOutlined = (props: LabelPropsWithoutKind) => (
   <Label kind="outline-danger" {...props} />
 );

--- a/web/packages/design/src/Status/Status.story.tsx
+++ b/web/packages/design/src/Status/Status.story.tsx
@@ -1,0 +1,128 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Flex, Text } from 'design';
+
+import { Status, StatusKind, StatusVariant } from './Status';
+
+export default {
+  title: 'Design/Status',
+};
+
+const kinds: StatusKind[] = [
+  'success',
+  'warning',
+  'info',
+  'danger',
+  'neutral',
+  'primary',
+];
+
+const variants: StatusVariant[] = ['filled', 'filled-tonal', 'border'];
+
+export const AllVariants = () => (
+  <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
+    <Flex gap={6}>
+      <Text
+        typography="body2"
+        bold
+        css={{ width: '100px', textAlign: 'right' }}
+      >
+        {/* empty for alignment */}
+      </Text>
+      {variants.map(variant => (
+        <Text
+          key={variant}
+          typography="body2"
+          bold
+          css={{ width: '160px', textAlign: 'center' }}
+        >
+          {variant}
+        </Text>
+      ))}
+    </Flex>
+
+    {kinds.map(kind => (
+      <Flex key={kind} gap={6} alignItems="center">
+        <Text
+          typography="body2"
+          color="text.slightlyMuted"
+          css={{ width: '100px', textAlign: 'right' }}
+        >
+          {kind}
+        </Text>
+        {variants.map(variant => (
+          <Flex
+            key={variant}
+            css={{ width: '160px', justifyContent: 'center' }}
+          >
+            <Status kind={kind} variant={variant}>
+              {kind.charAt(0).toUpperCase() + kind.slice(1)}
+            </Status>
+          </Flex>
+        ))}
+      </Flex>
+    ))}
+  </Flex>
+);
+
+export const WithoutIcons = () => (
+  <Flex flexDirection="column" gap={6} p={4} bg="levels.surface">
+    <Flex gap={6}>
+      <Text
+        typography="body2"
+        bold
+        css={{ width: '100px', textAlign: 'right' }}
+      >
+        {/* empty for alignment */}
+      </Text>
+      {variants.map(variant => (
+        <Text
+          key={variant}
+          typography="body2"
+          bold
+          css={{ width: '160px', textAlign: 'center' }}
+        >
+          {variant}
+        </Text>
+      ))}
+    </Flex>
+
+    {kinds.map(kind => (
+      <Flex key={kind} gap={6} alignItems="center">
+        <Text
+          typography="body2"
+          color="text.slightlyMuted"
+          css={{ width: '100px', textAlign: 'right' }}
+        >
+          {kind}
+        </Text>
+        {variants.map(variant => (
+          <Flex
+            key={variant}
+            css={{ width: '160px', justifyContent: 'center' }}
+          >
+            <Status kind={kind} variant={variant} noIcon>
+              {kind.charAt(0).toUpperCase() + kind.slice(1)}
+            </Status>
+          </Flex>
+        ))}
+      </Flex>
+    ))}
+  </Flex>
+);

--- a/web/packages/design/src/Status/Status.test.tsx
+++ b/web/packages/design/src/Status/Status.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+
+import { render } from 'design/utils/testing';
+
+import { Status, StatusKind, StatusVariant } from './Status';
+
+describe('design/Status', () => {
+  const kinds: StatusKind[] = [
+    'success',
+    'warning',
+    'info',
+    'danger',
+    'neutral',
+    'primary',
+  ];
+
+  const variants: StatusVariant[] = ['filled', 'filled-tonal', 'border'];
+
+  it.each(kinds)('renders kind="%s"', kind => {
+    render(<Status kind={kind}>Label</Status>);
+    expect(screen.getByText('Label')).toBeInTheDocument();
+  });
+
+  it.each(variants)('renders variant="%s"', variant => {
+    render(
+      <Status kind="success" variant={variant}>
+        Label
+      </Status>
+    );
+    expect(screen.getByText('Label')).toBeInTheDocument();
+  });
+
+  it('renders a custom icon component', () => {
+    const CustomIcon = (props: any) => (
+      <span data-testid="custom-icon" {...props} />
+    );
+    render(
+      <Status kind="info" icon={CustomIcon}>
+        Info
+      </Status>
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('hides icon when noIcon is set', () => {
+    const CustomIcon = (props: any) => (
+      <span data-testid="custom-icon" {...props} />
+    );
+
+    render(
+      <Status kind="success" noIcon icon={CustomIcon}>
+        No Icon
+      </Status>
+    );
+
+    expect(screen.queryByTestId('custom-icon')).not.toBeInTheDocument();
+  });
+});

--- a/web/packages/design/src/Status/Status.tsx
+++ b/web/packages/design/src/Status/Status.tsx
@@ -1,0 +1,187 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type ComponentType, type HTMLAttributes, type ReactNode } from 'react';
+import styled, { css, useTheme } from 'styled-components';
+
+import { CircleCheck, CircleCross, Info, Question, Warning } from 'design/Icon';
+import type { IconProps } from 'design/Icon/Icon';
+import { pillBase } from 'design/pillStyles';
+import { space, type SpaceProps } from 'design/system';
+import type { Theme } from 'design/theme';
+
+export type StatusKind =
+  | 'success'
+  | 'warning'
+  | 'info'
+  | 'danger'
+  | 'neutral'
+  | 'primary';
+
+export type StatusVariant = 'filled' | 'filled-tonal' | 'border';
+
+interface KindColors {
+  solid: string;
+  tonal: string;
+  accent: string;
+}
+
+function getKindColors(theme: Theme, kind: StatusKind): KindColors {
+  const { interactive, dataVisualisation } = theme.colors;
+
+  switch (kind) {
+    case 'success':
+      return {
+        solid: interactive.solid.success.default,
+        tonal: interactive.tonal.success[1],
+        accent: dataVisualisation.tertiary.caribbean,
+      };
+    case 'warning':
+      return {
+        solid: interactive.solid.alert.default,
+        tonal: interactive.tonal.alert[2],
+        accent: dataVisualisation.tertiary.sunflower,
+      };
+    case 'info':
+      return {
+        solid: interactive.solid.accent.default,
+        tonal: interactive.tonal.informational[2],
+        accent: dataVisualisation.tertiary.picton,
+      };
+    case 'danger':
+      return {
+        solid: interactive.solid.danger.default,
+        tonal: interactive.tonal.danger[2],
+        accent: interactive.solid.danger.active,
+      };
+    case 'neutral':
+      return {
+        solid: theme.colors.text.muted,
+        tonal: interactive.tonal.neutral[1],
+        accent: theme.colors.text.slightlyMuted,
+      };
+    case 'primary':
+      return {
+        solid: interactive.solid.primary.default,
+        tonal: interactive.tonal.primary[0],
+        accent: dataVisualisation.tertiary.purple,
+      };
+  }
+}
+
+const defaultIcons: Record<StatusKind, ComponentType<IconProps>> = {
+  success: CircleCheck,
+  warning: Warning,
+  info: Info,
+  danger: CircleCross,
+  neutral: Question,
+  primary: CircleCheck,
+};
+
+function getIconColor(
+  colors: KindColors,
+  variant: StatusVariant,
+  theme: Theme
+): string {
+  if (variant === 'filled') {
+    return theme.colors.text.primaryInverse;
+  }
+  return colors.accent;
+}
+
+interface StyledStatusProps extends SpaceProps {
+  $kind: StatusKind;
+  $variant: StatusVariant;
+}
+
+function variantStyles({
+  $kind,
+  $variant,
+  theme,
+}: StyledStatusProps & { theme: Theme }) {
+  const c = getKindColors(theme, $kind);
+
+  switch ($variant) {
+    case 'filled':
+      return css`
+        background: ${c.solid};
+        color: ${theme.colors.text.primaryInverse};
+        border: 1px solid transparent;
+      `;
+    case 'filled-tonal':
+      return css`
+        background: ${c.tonal};
+        color: ${theme.colors.text.main};
+        border: 1px solid ${c.accent};
+      `;
+    case 'border':
+      return css`
+        background: transparent;
+        color: ${theme.colors.text.main};
+        border: 1px solid ${c.accent};
+      `;
+  }
+}
+
+const StyledStatus = styled.span<StyledStatusProps>`
+  ${pillBase}
+  cursor: default;
+  ${variantStyles}
+  ${space}
+`;
+
+export interface StatusProps
+  extends SpaceProps, Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+  kind: StatusKind;
+  variant?: StatusVariant;
+  // Provide a custom icon to override the default
+  icon?: ComponentType<IconProps>;
+  // Render the badge without an icon
+  noIcon?: boolean;
+  children: ReactNode;
+}
+
+export function Status({
+  kind,
+  variant = 'filled-tonal',
+  icon,
+  noIcon,
+  children,
+  ...rest
+}: StatusProps) {
+  const theme = useTheme() as Theme;
+
+  let iconElement: ReactNode = null;
+  if (!noIcon) {
+    const IconComponent = icon ?? defaultIcons[kind];
+    const colors = getKindColors(theme, kind);
+    iconElement = (
+      <IconComponent
+        size="small"
+        color={getIconColor(colors, variant, theme)}
+      />
+    );
+  }
+
+  return (
+    <StyledStatus $kind={kind} $variant={variant} {...rest}>
+      {iconElement}
+      {children}
+    </StyledStatus>
+  );
+}

--- a/web/packages/design/src/Status/index.ts
+++ b/web/packages/design/src/Status/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { Status } from './Status';
+export type { StatusKind, StatusVariant, StatusProps } from './Status';

--- a/web/packages/design/src/Tag/Tag.story.tsx
+++ b/web/packages/design/src/Tag/Tag.story.tsx
@@ -1,0 +1,67 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Flex, Text } from 'design';
+
+import { Tag } from './Tag';
+
+export default {
+  title: 'Design/Tag',
+};
+
+export const Variants = () => (
+  <Flex flexDirection="column" gap={4} p={4} bg="levels.surface">
+    <Text typography="body2" bold>
+      Subtle (default)
+    </Text>
+    <Flex gap={2} flexWrap="wrap">
+      <Tag>env: production</Tag>
+      <Tag>region: us-east-1</Tag>
+      <Tag>team: platform</Tag>
+    </Flex>
+
+    <Text typography="body2" bold>
+      Outline
+    </Text>
+    <Flex gap={2} flexWrap="wrap">
+      <Tag variant="outline">env: staging</Tag>
+      <Tag variant="outline">region: eu-west-1</Tag>
+      <Tag variant="outline">team: security</Tag>
+    </Flex>
+
+    <Text typography="body2" bold>
+      Dismissible
+    </Text>
+    <Flex gap={2} flexWrap="wrap">
+      <Tag onDismiss={() => {}}>removable-tag</Tag>
+      <Tag variant="outline" onDismiss={() => {}}>
+        also-removable
+      </Tag>
+    </Flex>
+
+    <Text typography="body2" bold>
+      Interactive (hover to see effect)
+    </Text>
+    <Flex gap={2} flexWrap="wrap">
+      <Tag onClick={() => {}}>clickable-tag</Tag>
+      <Tag variant="outline" onClick={() => {}}>
+        clickable-outline
+      </Tag>
+    </Flex>
+  </Flex>
+);

--- a/web/packages/design/src/Tag/Tag.test.tsx
+++ b/web/packages/design/src/Tag/Tag.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+
+import { fireEvent, render } from 'design/utils/testing';
+
+import { Tag } from './Tag';
+
+describe('design/Tag', () => {
+  it('does not render dismiss button by default', () => {
+    render(<Tag>tag</Tag>);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders dismiss button when onDismiss is provided', () => {
+    render(<Tag onDismiss={() => {}}>tag</Tag>);
+    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = jest.fn();
+    render(<Tag onDismiss={onDismiss}>tag</Tag>);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismiss click does not propagate to parent onClick', () => {
+    const onClick = jest.fn();
+    const onDismiss = jest.fn();
+    render(
+      <Tag onClick={onClick} onDismiss={onDismiss}>
+        tag
+      </Tag>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/design/src/Tag/Tag.tsx
+++ b/web/packages/design/src/Tag/Tag.tsx
@@ -1,0 +1,113 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { type HTMLAttributes, type ReactNode } from 'react';
+import styled, { css } from 'styled-components';
+
+import { Cross } from 'design/Icon';
+import { space, type SpaceProps } from 'design/system';
+
+import { pillBase } from '../pillStyles';
+
+export type TagVariant = 'subtle' | 'outline';
+
+export interface TagProps
+  extends SpaceProps, Omit<HTMLAttributes<HTMLSpanElement>, 'color'> {
+  variant?: TagVariant;
+  // When onDismiss is provided, a dismiss button is rendered and this function
+  // is called when clicked.
+  onDismiss?: () => void;
+  children: ReactNode;
+}
+
+interface StyledTagProps extends SpaceProps {
+  $variant: TagVariant;
+  $interactive: boolean;
+}
+
+const StyledTag = styled.span<StyledTagProps>`
+  ${pillBase}
+  cursor: default;
+  color: ${p => p.theme.colors.text.main};
+  border: 1px solid ${p => p.theme.colors.text.slightlyMuted};
+
+  background: ${p =>
+    p.$variant === 'subtle'
+      ? p.theme.colors.interactive.tonal.neutral[1]
+      : 'transparent'};
+
+  ${p =>
+    p.$interactive &&
+    css`
+      cursor: pointer;
+
+      &:hover {
+        background: ${p.theme.colors.interactive.tonal.neutral[2]};
+      }
+    `}
+
+  ${space}
+`;
+
+const DismissButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${p => p.theme.colors.text.muted};
+  border-radius: 50%;
+
+  &:hover {
+    color: ${p => p.theme.colors.text.main};
+  }
+`;
+
+export function Tag({
+  variant = 'subtle',
+  onDismiss,
+  onClick,
+  children,
+  ...rest
+}: TagProps) {
+  return (
+    <StyledTag
+      $variant={variant}
+      $interactive={!!onClick}
+      onClick={onClick}
+      {...rest}
+    >
+      {children}
+      {onDismiss && (
+        <DismissButton
+          type="button"
+          onClick={e => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          aria-label="Remove"
+        >
+          <Cross size="small" />
+        </DismissButton>
+      )}
+    </StyledTag>
+  );
+}

--- a/web/packages/design/src/Tag/index.ts
+++ b/web/packages/design/src/Tag/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export { Tag } from './Tag';
+export type { TagVariant, TagProps } from './Tag';

--- a/web/packages/design/src/index.ts
+++ b/web/packages/design/src/index.ts
@@ -47,8 +47,10 @@ import Menu, { MenuItem, MenuItemIcon } from './Menu';
 import { Pill } from './Pill';
 import Popover from './Popover';
 import { ResourceIcon } from './ResourceIcon';
+import { Status } from './Status';
 import { StepSlider } from './StepSlider';
 import { SyncStamp } from './SyncStamp';
+import { Tag } from './Tag';
 import Text, {
   H1,
   H2,
@@ -68,6 +70,7 @@ import TopNav from './TopNav';
 export { AnimatedProgressBar } from './AnimatedProgressBar';
 export {
   Alert,
+  Status,
   Banner,
   Box,
   Button,
@@ -112,6 +115,7 @@ export {
   Subtitle2,
   Subtitle3,
   SyncStamp,
+  Tag,
   Text,
   TextArea,
   Toggle,

--- a/web/packages/design/src/pillStyles.ts
+++ b/web/packages/design/src/pillStyles.ts
@@ -1,0 +1,36 @@
+/**
+ * Teleport
+ * Copyright (C) 2026 Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { css } from 'styled-components';
+
+// Shared base styles for pill-shaped inline elements (Status, Tag).
+// Provides consistent sizing, shape, and overflow behavior.
+export const pillBase = css`
+  display: inline-flex;
+  align-items: center;
+  gap: ${p => p.theme.space[1]}px;
+  padding: 2px ${p => p.theme.space[2]}px;
+  border-radius: 98px;
+  ${p => p.theme.typography.body3}
+  white-space: nowrap;
+  box-sizing: border-box;
+  overflow: hidden;
+  max-width: 100%;
+  min-width: 0;
+  vertical-align: middle;
+`;

--- a/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
+++ b/web/packages/teleport/src/Integrations/shared/StatusLabel.tsx
@@ -16,24 +16,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ComponentType } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 import { Box, Flex, Text } from 'design';
+import { Wrench } from 'design/Icon';
 import {
-  CircleCheck,
-  CircleCross,
-  Info,
-  Question,
-  Warning,
-  Wrench,
-} from 'design/Icon';
-import { IconSize } from 'design/Icon/Icon';
-import Label, {
-  DangerOutlined,
-  SecondaryOutlined,
-  WarningOutlined,
-} from 'design/Label/Label';
+  Status as StatusBadge,
+  StatusKind,
+  StatusVariant,
+} from 'design/Status';
 import { HoverTooltip } from 'design/Tooltip';
 import { pluralize } from 'shared/utils/text';
 
@@ -139,10 +131,6 @@ const SCANNING = (tooltip?: string) => ({
   tooltip,
 });
 
-const PrimaryOutlined = (props: { children: React.ReactNode }) => (
-  <Label kind="outline-primary" {...props} />
-);
-
 export function getStatus(item: IntegrationLike): {
   status: Status;
   label: string;
@@ -193,46 +181,45 @@ export function getStatus(item: IntegrationLike): {
 const StatusUI: Record<
   Status,
   {
-    Icon: ComponentType<{ size?: IconSize }>;
-    Label: ComponentType<{ children: React.ReactNode }>;
+    kind: StatusKind;
+    variant: StatusVariant;
+    icon?: React.ComponentType<any>;
   }
 > = {
   [Status.Healthy]: {
-    Icon: CircleCheck,
-    Label: SecondaryOutlined,
+    kind: 'success',
+    variant: 'border',
   },
   [Status.Draft]: {
-    Icon: Wrench,
-    Label: SecondaryOutlined,
+    kind: 'neutral',
+    variant: 'filled-tonal',
+    icon: Wrench,
   },
   [Status.Unknown]: {
-    Icon: Question,
-    Label: SecondaryOutlined,
+    kind: 'neutral',
+    variant: 'filled-tonal',
   },
   [Status.Failed]: {
-    Icon: CircleCross,
-    Label: DangerOutlined,
+    kind: 'danger',
+    variant: 'filled-tonal',
   },
   [Status.Issues]: {
-    Icon: Warning,
-    Label: WarningOutlined,
+    kind: 'warning',
+    variant: 'filled-tonal',
   },
   [Status.Scanning]: {
-    Icon: Info,
-    Label: PrimaryOutlined,
+    kind: 'info',
+    variant: 'filled-tonal',
   },
 };
 
 const statusLabel = (status: Status, label: string) => {
-  const { Icon, Label } = StatusUI[status];
+  const { kind, variant, icon } = StatusUI[status];
 
   return (
-    <Label aria-label="status">
-      <Flex alignItems="center" gap={1}>
-        <Icon size="small" />
-        {label}
-      </Flex>
-    </Label>
+    <StatusBadge kind={kind} variant={variant} icon={icon} aria-label="status">
+      {label}
+    </StatusBadge>
   );
 };
 


### PR DESCRIPTION
#63143

[Figma](https://www.figma.com/design/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?node-id=24485-13063&p=f)

Creating a new `StatusLabel` component with updated variants and colors based on the design. Deprecating the old `Label` component for now. There are too many uses to pile the refactors into 1 PR. I'll follow-up when I get time with refactors for the other `Label` use-cases. Once they're done, we can remove the old label, and possibly rename this to `Label` or just `Status`.

Starting with `Integrations/shared/StatusLabel` :

### Before:
<img width="1565" height="481" alt="Screenshot 2026-02-17 at 4 48 20 PM" src="https://github.com/user-attachments/assets/ca7874e6-3880-4d4d-aa27-fdb51b471879" />
<img width="844" height="582" alt="Screenshot 2026-02-17 at 4 49 27 PM" src="https://github.com/user-attachments/assets/2c125261-499a-446b-a2c4-e26471548ec8" />


### After:
<img width="1591" height="490" alt="Screenshot 2026-02-17 at 4 47 54 PM" src="https://github.com/user-attachments/assets/3fb0431e-6926-46cf-93b4-7a7fb6858743" />

<img width="1016" height="588" alt="Screenshot 2026-02-19 at 9 26 05 AM" src="https://github.com/user-attachments/assets/493b3683-f42c-48a5-a522-783b34b4b257" />
