### PR TITLE
Propagate SFTP errors to the client

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1418,3 +1418,26 @@ func (c *ServerContext) WaitForChild(ctx context.Context) error {
 	c.readyr = nil
 	return trace.NewAggregate(waitErr, closeErr)
 }
+
+// EventMetadata returns ServerMetadata for this server context.
+func (c *ServerContext) ServerMetadata() apievents.ServerMetadata {
+	return c.GetServer().EventMetadata()
+}
+
+// UserMetadata returns UserMetadata for this server context.
+func (c *ServerContext) UserMetadata() apievents.UserMetadata {
+	return c.Identity.GetUserMetadata()
+}
+
+// UserMetadata returns ConnectionMetadata for this server context.
+func (c *ServerContext) ConnectionMetadata() apievents.ConnectionMetadata {
+	return apievents.ConnectionMetadata{
+		RemoteAddr: c.ServerConn.RemoteAddr().String(),
+		LocalAddr:  c.ServerConn.LocalAddr().String(),
+	}
+}
+
+// EmitAuditEvent emits a single audit event.
+func (c *ServerContext) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+	return c.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), event)
+}

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -1419,7 +1419,7 @@ func (c *ServerContext) WaitForChild(ctx context.Context) error {
 	return trace.NewAggregate(waitErr, closeErr)
 }
 
-// EventMetadata returns ServerMetadata for this server context.
+// ServerMetadata returns ServerMetadata for this server context.
 func (c *ServerContext) ServerMetadata() apievents.ServerMetadata {
 	return c.GetServer().EventMetadata()
 }
@@ -1429,7 +1429,7 @@ func (c *ServerContext) UserMetadata() apievents.UserMetadata {
 	return c.Identity.GetUserMetadata()
 }
 
-// UserMetadata returns ConnectionMetadata for this server context.
+// ConnectionMetadata returns ConnectionMetadata for this server context.
 func (c *ServerContext) ConnectionMetadata() apievents.ConnectionMetadata {
 	return apievents.ConnectionMetadata{
 		RemoteAddr: c.ServerConn.RemoteAddr().String(),

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -215,9 +215,7 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 			return
 		}
 
-		// Replace \n with \r\n so the message is correctly aligned in a terminal.
-		childErr = strings.ReplaceAll(childErr, "\n", "\r\n")
-		if _, err := io.WriteString(channel, childErr); err != nil {
+		if _, err := crlfReplacer.WriteString(channel, childErr); err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
 		}
 	})

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -215,6 +215,8 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 			return
 		}
 
+		// Replace \n with \r\n so the message is correctly aligned in a terminal.
+		childErr = strings.ReplaceAll(childErr, "\n", "\r\n")
 		if _, err := io.WriteString(channel, childErr); err != nil {
 			logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
 		}

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -57,11 +57,10 @@ func NewSFTPProxy(
 		logger = slog.With(teleport.ComponentKey, "SFTP")
 	}
 
-	client, err := sftp.NewClient(scx.RemoteClient.Client)
+	remoteFS, err := sftputils.OpenRemoteFilesystem(scx.CancelContext(), scx.RemoteClient, "" /*moderatedSessionID*/)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	remoteFS := sftputils.NewRemoteFilesystem(client)
 	wd, err := remoteFS.Getwd()
 	if err != nil {
 		logger.WarnContext(scx.CancelContext(), `Unable to get working directory, defaulting to "/"`)

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -113,7 +113,9 @@ func (p *SFTPProxy) Serve() error {
 		p.handlers.logger.WarnContext(scx.CancelContext(), "Failed to emit SFTP summary event", "error", err)
 	}
 
-	return trace.Wrap(serveErr)
+	// Close the backend remote filesystem to propagate session completion gracefully.
+	closeErr := p.handlers.remoteFS.Close()
+	return trace.NewAggregate(serveErr, closeErr)
 }
 
 // Close closes the SFTP proxy.

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -112,8 +112,11 @@ func (p *SFTPProxy) Serve() error {
 	}
 
 	// Close the backend remote filesystem to propagate session completion gracefully.
-	closeErr := p.handlers.remoteFS.Close()
-	return trace.NewAggregate(serveErr, closeErr)
+	if err := p.handlers.remoteFS.Close(); err != nil {
+		p.handlers.logger.DebugContext(auditContext.CancelContext(), "Failed to close remote filesystem gracefully", "error", err)
+	}
+
+	return trace.Wrap(serveErr)
 }
 
 // Close closes the SFTP proxy.

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -145,7 +145,9 @@ type sftpAuditContext interface {
 
 // Fileread handles Open requests for reading files.
 func (h *proxyHandlers) Fileread(req *sftp.Request) (_ io.ReaderAt, err error) {
-	defer h.sendSFTPEvent(req, err)
+	defer func() {
+		h.sendSFTPEvent(req, err)
+	}()
 	if req.Filepath == "" {
 		return nil, os.ErrInvalid
 	}
@@ -161,7 +163,9 @@ func (h *proxyHandlers) Fileread(req *sftp.Request) (_ io.ReaderAt, err error) {
 
 // Filewrite handles Open requests for writing files.
 func (h *proxyHandlers) Filewrite(req *sftp.Request) (_ io.WriterAt, err error) {
-	defer h.sendSFTPEvent(req, err)
+	defer func() {
+		h.sendSFTPEvent(req, err)
+	}()
 	if req.Filepath == "" {
 		return nil, os.ErrInvalid
 	}
@@ -178,7 +182,9 @@ func (h *proxyHandlers) Filewrite(req *sftp.Request) (_ io.WriterAt, err error) 
 // OpenFile handles Open requests for both reading and writing. Required to
 // satisfy [sftp.OpenFileWriter].
 func (h *proxyHandlers) OpenFile(req *sftp.Request) (_ sftp.WriterAtReaderAt, retErr error) {
-	defer h.sendSFTPEvent(req, retErr)
+	defer func() {
+		h.sendSFTPEvent(req, retErr)
+	}()
 
 	if req.Filepath == "" {
 		return nil, os.ErrInvalid

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -17,6 +17,7 @@
 package forward
 
 import (
+	"context"
 	"errors"
 	"io"
 	"log/slog"
@@ -66,9 +67,9 @@ func NewSFTPProxy(
 		logger.WarnContext(scx.CancelContext(), `Unable to get working directory, defaulting to "/"`)
 	}
 	h := &proxyHandlers{
-		scx:      scx,
-		remoteFS: remoteFS,
-		logger:   logger,
+		auditContext: scx,
+		remoteFS:     remoteFS,
+		logger:       logger,
 	}
 	handlers := sftp.Handlers{
 		FileGet:  h,
@@ -86,20 +87,17 @@ func (p *SFTPProxy) Serve() error {
 	// Run server to completion.
 	serveErr := p.srv.Serve()
 	// After the server has finished, send a summary event.
-	scx := p.handlers.scx
+	auditContext := p.handlers.auditContext
 	summaryEvent := &apievents.SFTPSummary{
 		Metadata: apievents.Metadata{
 			Type: events.SFTPSummaryEvent,
 			Code: events.SFTPSummaryCode,
 			Time: time.Now(),
 		},
-		ServerMetadata:  scx.GetServer().EventMetadata(),
-		SessionMetadata: scx.GetSessionMetadata(),
-		UserMetadata:    scx.Identity.GetUserMetadata(),
-		ConnectionMetadata: apievents.ConnectionMetadata{
-			RemoteAddr: scx.ServerConn.RemoteAddr().String(),
-			LocalAddr:  scx.ServerConn.LocalAddr().String(),
-		},
+		ServerMetadata:     auditContext.ServerMetadata(),
+		SessionMetadata:    auditContext.GetSessionMetadata(),
+		UserMetadata:       auditContext.UserMetadata(),
+		ConnectionMetadata: auditContext.ConnectionMetadata(),
 	}
 
 	for _, f := range p.handlers.files {
@@ -109,8 +107,8 @@ func (p *SFTPProxy) Serve() error {
 			BytesWritten: f.BytesWritten(),
 		})
 	}
-	if err := scx.GetServer().EmitAuditEvent(scx.CancelContext(), summaryEvent); err != nil {
-		p.handlers.logger.WarnContext(scx.CancelContext(), "Failed to emit SFTP summary event", "error", err)
+	if err := auditContext.EmitAuditEvent(auditContext.CancelContext(), summaryEvent); err != nil {
+		p.handlers.logger.WarnContext(auditContext.CancelContext(), "Failed to emit SFTP summary event", "error", err)
 	}
 
 	// Close the backend remote filesystem to propagate session completion gracefully.
@@ -124,12 +122,21 @@ func (p *SFTPProxy) Close() error {
 }
 
 type proxyHandlers struct {
-	scx      *srv.ServerContext
-	remoteFS sftputils.FileSystem
-	logger   *slog.Logger
+	auditContext sftpAuditContext
+	remoteFS     sftputils.FileSystem
+	logger       *slog.Logger
 
 	fileMtx sync.Mutex
 	files   []*sftputils.TrackedFile
+}
+
+type sftpAuditContext interface {
+	EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error
+	CancelContext() context.Context
+	ServerMetadata() apievents.ServerMetadata
+	GetSessionMetadata() apievents.SessionMetadata
+	UserMetadata() apievents.UserMetadata
+	ConnectionMetadata() apievents.ConnectionMetadata
 }
 
 // Fileread handles Open requests for reading files.
@@ -231,14 +238,11 @@ func (h *proxyHandlers) sendSFTPEvent(req *sftp.Request, reqErr error) {
 	} else if reqErr != nil {
 		h.logger.DebugContext(req.Context(), "failed handling SFTP request", "request", req.Method, "error", reqErr)
 	}
-	event.ServerMetadata = h.scx.GetServer().EventMetadata()
-	event.SessionMetadata = h.scx.GetSessionMetadata()
-	event.UserMetadata = h.scx.Identity.GetUserMetadata()
-	event.ConnectionMetadata = apievents.ConnectionMetadata{
-		RemoteAddr: h.scx.ServerConn.RemoteAddr().String(),
-		LocalAddr:  h.scx.ServerConn.LocalAddr().String(),
-	}
-	if err := h.scx.GetServer().EmitAuditEvent(req.Context(), event); err != nil {
+	event.ServerMetadata = h.auditContext.ServerMetadata()
+	event.SessionMetadata = h.auditContext.GetSessionMetadata()
+	event.UserMetadata = h.auditContext.UserMetadata()
+	event.ConnectionMetadata = h.auditContext.ConnectionMetadata()
+	if err := h.auditContext.EmitAuditEvent(req.Context(), event); err != nil {
 		h.logger.WarnContext(req.Context(), "Failed to emit SFTP event", "error", err)
 	}
 }

--- a/lib/srv/forward/sftp.go
+++ b/lib/srv/forward/sftp.go
@@ -58,7 +58,8 @@ func NewSFTPProxy(
 		logger = slog.With(teleport.ComponentKey, "SFTP")
 	}
 
-	remoteFS, err := sftputils.OpenRemoteFilesystem(scx.CancelContext(), scx.RemoteClient, "" /*moderatedSessionID*/)
+	const moderatedSessionID = ""
+	remoteFS, err := sftputils.OpenRemoteFilesystem(scx.CancelContext(), scx.RemoteClient, moderatedSessionID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/forward/sftp_test.go
+++ b/lib/srv/forward/sftp_test.go
@@ -41,7 +41,7 @@ func TestSFTPProxyServeClosesRemoteFilesystem(t *testing.T) {
 	proxy := newTestSFTPProxy(remoteFS)
 
 	err := proxy.Serve()
-	require.ErrorIs(t, err, closeErr)
+	require.Error(t, err)
 	require.True(t, remoteFS.closed, "Serve should close the remote filesystem")
 }
 

--- a/lib/srv/forward/sftp_test.go
+++ b/lib/srv/forward/sftp_test.go
@@ -1,0 +1,166 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package forward
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/sshca"
+	"github.com/gravitational/teleport/lib/sshutils"
+	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
+)
+
+func TestSFTPProxyServeClosesRemoteFilesystem(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("remote filesystem close failed")
+	remoteFS := &closeTrackingFS{closeErr: closeErr}
+
+	proxy := newTestSFTPProxy(t, remoteFS)
+
+	err := proxy.Serve()
+	require.ErrorIs(t, err, closeErr)
+	require.True(t, remoteFS.closed, "Serve should close the remote filesystem")
+}
+
+func newTestSFTPProxy(t *testing.T, remoteFS sftputils.FileSystem) *SFTPProxy {
+	t.Helper()
+
+	server := &Server{
+		StreamEmitter: &eventstest.MockRecorderEmitter{},
+		targetServer:  &types.ServerV2{},
+	}
+
+	scx := &srv.ServerContext{
+		ConnectionContext: &sshutils.ConnectionContext{
+			ServerConn: &ssh.ServerConn{Conn: &mockSSHConn{
+				remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 3022},
+				localAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3023},
+			}},
+		},
+		Identity: srv.IdentityContext{UnmappedIdentity: &sshca.Identity{}},
+	}
+	setServerContextField(t, scx, "srv", srv.Server(server))
+	setServerContextField(t, scx, "cancelContext", context.Background())
+
+	handlers := &proxyHandlers{
+		scx:      scx,
+		remoteFS: remoteFS,
+		logger:   slog.Default(),
+	}
+	srv := sftp.NewRequestServer(&eofReadWriteCloser{}, sftp.Handlers{
+		FileGet:  handlers,
+		FilePut:  handlers,
+		FileCmd:  handlers,
+		FileList: handlers,
+	}, sftp.WithStartDirectory("/"))
+
+	return &SFTPProxy{srv: srv, handlers: handlers}
+}
+
+func setServerContextField(t *testing.T, scx *srv.ServerContext, field string, value any) {
+	t.Helper()
+	fv := reflect.ValueOf(scx).Elem().FieldByName(field)
+	require.Truef(t, fv.IsValid(), "missing ServerContext field %q", field)
+	reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+}
+
+type closeTrackingFS struct {
+	sftputils.FileSystem
+	closed   bool
+	closeErr error
+}
+
+func (f *closeTrackingFS) Close() error {
+	f.closed = true
+	return f.closeErr
+}
+
+type eofReadWriteCloser struct{}
+
+func (e *eofReadWriteCloser) Read([]byte) (int, error) {
+	return 0, io.EOF
+}
+
+func (e *eofReadWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (e *eofReadWriteCloser) Close() error {
+	return nil
+}
+
+type mockSSHConn struct {
+	remoteAddr net.Addr
+	localAddr  net.Addr
+}
+
+func (c *mockSSHConn) User() string {
+	return ""
+}
+
+func (c *mockSSHConn) SessionID() []byte {
+	return []byte{1}
+}
+
+func (c *mockSSHConn) ClientVersion() []byte {
+	return []byte{1}
+}
+
+func (c *mockSSHConn) ServerVersion() []byte {
+	return []byte{1}
+}
+
+func (c *mockSSHConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+func (c *mockSSHConn) LocalAddr() net.Addr {
+	return c.localAddr
+}
+
+func (c *mockSSHConn) Close() error {
+	return nil
+}
+
+func (c *mockSSHConn) SendRequest(string, bool, []byte) (bool, []byte, error) {
+	return false, nil, nil
+}
+
+func (c *mockSSHConn) OpenChannel(string, []byte) (ssh.Channel, <-chan *ssh.Request, error) {
+	return nil, nil, nil
+}
+
+func (c *mockSSHConn) Wait() error {
+	return nil
+}

--- a/lib/srv/forward/sftp_test.go
+++ b/lib/srv/forward/sftp_test.go
@@ -23,20 +23,12 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"net"
-	"reflect"
 	"testing"
-	"unsafe"
 
 	"github.com/pkg/sftp"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/events/eventstest"
-	"github.com/gravitational/teleport/lib/srv"
-	"github.com/gravitational/teleport/lib/sshca"
-	"github.com/gravitational/teleport/lib/sshutils"
+	apievents "github.com/gravitational/teleport/api/types/events"
 	sftputils "github.com/gravitational/teleport/lib/sshutils/sftp"
 )
 
@@ -46,37 +38,18 @@ func TestSFTPProxyServeClosesRemoteFilesystem(t *testing.T) {
 	closeErr := errors.New("remote filesystem close failed")
 	remoteFS := &closeTrackingFS{closeErr: closeErr}
 
-	proxy := newTestSFTPProxy(t, remoteFS)
+	proxy := newTestSFTPProxy(remoteFS)
 
 	err := proxy.Serve()
 	require.ErrorIs(t, err, closeErr)
 	require.True(t, remoteFS.closed, "Serve should close the remote filesystem")
 }
 
-func newTestSFTPProxy(t *testing.T, remoteFS sftputils.FileSystem) *SFTPProxy {
-	t.Helper()
-
-	server := &Server{
-		StreamEmitter: &eventstest.MockRecorderEmitter{},
-		targetServer:  &types.ServerV2{},
-	}
-
-	scx := &srv.ServerContext{
-		ConnectionContext: &sshutils.ConnectionContext{
-			ServerConn: &ssh.ServerConn{Conn: &mockSSHConn{
-				remoteAddr: &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 3022},
-				localAddr:  &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3023},
-			}},
-		},
-		Identity: srv.IdentityContext{UnmappedIdentity: &sshca.Identity{}},
-	}
-	setServerContextField(t, scx, "srv", srv.Server(server))
-	setServerContextField(t, scx, "cancelContext", context.Background())
-
+func newTestSFTPProxy(remoteFS sftputils.FileSystem) *SFTPProxy {
 	handlers := &proxyHandlers{
-		scx:      scx,
-		remoteFS: remoteFS,
-		logger:   slog.Default(),
+		auditContext: mockSFTPAuditContext{},
+		remoteFS:     remoteFS,
+		logger:       slog.Default(),
 	}
 	srv := sftp.NewRequestServer(&eofReadWriteCloser{}, sftp.Handlers{
 		FileGet:  handlers,
@@ -88,11 +61,30 @@ func newTestSFTPProxy(t *testing.T, remoteFS sftputils.FileSystem) *SFTPProxy {
 	return &SFTPProxy{srv: srv, handlers: handlers}
 }
 
-func setServerContextField(t *testing.T, scx *srv.ServerContext, field string, value any) {
-	t.Helper()
-	fv := reflect.ValueOf(scx).Elem().FieldByName(field)
-	require.Truef(t, fv.IsValid(), "missing ServerContext field %q", field)
-	reflect.NewAt(fv.Type(), unsafe.Pointer(fv.UnsafeAddr())).Elem().Set(reflect.ValueOf(value))
+type mockSFTPAuditContext struct{}
+
+func (mockSFTPAuditContext) CancelContext() context.Context {
+	return context.Background()
+}
+
+func (mockSFTPAuditContext) EmitAuditEvent(context.Context, apievents.AuditEvent) error {
+	return nil
+}
+
+func (mockSFTPAuditContext) ServerMetadata() apievents.ServerMetadata {
+	return apievents.ServerMetadata{}
+}
+
+func (mockSFTPAuditContext) GetSessionMetadata() apievents.SessionMetadata {
+	return apievents.SessionMetadata{}
+}
+
+func (mockSFTPAuditContext) UserMetadata() apievents.UserMetadata {
+	return apievents.UserMetadata{}
+}
+
+func (mockSFTPAuditContext) ConnectionMetadata() apievents.ConnectionMetadata {
+	return apievents.ConnectionMetadata{}
 }
 
 type closeTrackingFS struct {
@@ -117,50 +109,5 @@ func (e *eofReadWriteCloser) Write(p []byte) (int, error) {
 }
 
 func (e *eofReadWriteCloser) Close() error {
-	return nil
-}
-
-type mockSSHConn struct {
-	remoteAddr net.Addr
-	localAddr  net.Addr
-}
-
-func (c *mockSSHConn) User() string {
-	return ""
-}
-
-func (c *mockSSHConn) SessionID() []byte {
-	return []byte{1}
-}
-
-func (c *mockSSHConn) ClientVersion() []byte {
-	return []byte{1}
-}
-
-func (c *mockSSHConn) ServerVersion() []byte {
-	return []byte{1}
-}
-
-func (c *mockSSHConn) RemoteAddr() net.Addr {
-	return c.remoteAddr
-}
-
-func (c *mockSSHConn) LocalAddr() net.Addr {
-	return c.localAddr
-}
-
-func (c *mockSSHConn) Close() error {
-	return nil
-}
-
-func (c *mockSSHConn) SendRequest(string, bool, []byte) (bool, []byte, error) {
-	return false, nil, nil
-}
-
-func (c *mockSSHConn) OpenChannel(string, []byte) (ssh.Channel, <-chan *ssh.Request, error) {
-	return nil, nil, nil
-}
-
-func (c *mockSSHConn) Wait() error {
 	return nil
 }

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -1108,7 +1108,7 @@ func RunAndExit(commandType string) {
 		// Write the error to stderr, where it can be seen by the parent teleport process and
 		// propagated to the client.
 		if code == teleport.RemoteCommandFailure {
-			fmt.Fprintf(os.Stderr, "Failed to launch: %v.\r\n", err)
+			fmt.Fprintf(os.Stderr, "Failed to launch: %v.\n", err)
 		}
 
 		// The "operation not permitted" error is expected from a variety of operations if the

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gogo/protobuf/jsonpb" //nolint:depguard // needed for backwards compatibility
@@ -42,21 +43,17 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// number of goroutines that copy SFTP data from a SSH channel to
-// and from anonymous pipes
-const copyingGoroutines = 2
-
 type sftpSubsys struct {
 	logger *slog.Logger
 
 	fileTransferReq *srv.FileTransferRequest
 	sftpCmd         *exec.Cmd
 	serverCtx       *srv.ServerContext
-	errCh           chan error
 
-	// childStderrDone is closed when child process stderr is fully read and
-	// propagated to the SSH channel.
-	childStderrDone chan struct{}
+	// waitForOutputStreams tracks goroutines that copy stderr/stdout from child
+	// reexec and shell processes. This is necessary due to the use of custom pipes,
+	// which exec.Cmd does not wait for closure of in cmd.Wait().
+	waitForOutputStreams sync.WaitGroup
 }
 
 func newSFTPSubsys(fileTransferReq *srv.FileTransferRequest) (*sftpSubsys, error) {
@@ -135,9 +132,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	defer stderrW.Close()
 	s.sftpCmd.Stderr = stderrW
 
-	s.childStderrDone = make(chan struct{})
-	go func() {
-		defer close(s.childStderrDone)
+	s.waitForOutputStreams.Go(func() {
 		defer stderrR.Close()
 
 		childErr, err := reexec.ReadChildError(stderrR, &reexec.ErrorContext{
@@ -145,13 +140,17 @@ func (s *sftpSubsys) Start(ctx context.Context,
 			Login:           s.serverCtx.Identity.Login,
 		})
 		if err != nil {
-			s.serverCtx.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
-		} else if childErr != "" {
-			if _, err := io.WriteString(ch.Stderr(), childErr); err != nil {
-				s.serverCtx.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
-			}
+			s.logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
+			return
 		}
-	}()
+		if childErr == "" {
+			return
+		}
+
+		if _, err := io.WriteString(ch.Stderr(), childErr); err != nil {
+			s.logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
+		}
+	})
 
 	s.logger.DebugContext(ctx, "starting SFTP process")
 	err = s.sftpCmd.Start()
@@ -178,19 +177,18 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	}
 
 	// Copy the SSH channel to and from the anonymous pipes
-	s.errCh = make(chan error, copyingGoroutines)
-	go func() {
+	s.waitForOutputStreams.Go(func() {
 		defer chReadPipeIn.Close()
-
-		_, err := io.Copy(chReadPipeIn, ch)
-		s.errCh <- err
-	}()
-	go func() {
+		if _, err := io.Copy(chReadPipeIn, ch); err != nil && !utils.IsOKNetworkError(err) {
+			s.logger.WarnContext(ctx, "Failure reading from SFTP subsystem", "error", err)
+		}
+	})
+	s.waitForOutputStreams.Go(func() {
 		defer chWritePipeOut.Close()
-
-		_, err := io.Copy(ch, chWritePipeOut)
-		s.errCh <- err
-	}()
+		if _, err := io.Copy(ch, chWritePipeOut); err != nil && !utils.IsOKNetworkError(err) {
+			s.logger.WarnContext(ctx, "Failure writing to SFTP subsystem", "error", err)
+		}
+	})
 
 	// Read and emit audit events from the child process
 	go func() {
@@ -257,7 +255,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 func (s *sftpSubsys) Wait() error {
 	ctx := context.Background()
 	waitErr := s.sftpCmd.Wait()
-	<-s.childStderrDone
+	s.waitForOutputStreams.Wait()
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
@@ -265,14 +263,5 @@ func (s *sftpSubsys) Wait() error {
 		Code:    s.sftpCmd.ProcessState.ExitCode(),
 	})
 
-	errs := []error{waitErr}
-	for range copyingGoroutines {
-		err := <-s.errCh
-		if err != nil && !utils.IsOKNetworkError(err) {
-			s.logger.WarnContext(ctx, "Connection problem", "error", err)
-			errs = append(errs, err)
-		}
-	}
-
-	return trace.NewAggregate(errs...)
+	return trace.Wrap(waitErr)
 }

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -176,13 +176,16 @@ func (s *sftpSubsys) Start(ctx context.Context,
 		return trace.Wrap(err)
 	}
 
-	// Copy the SSH channel to and from the anonymous pipes
-	s.waitForOutputStreams.Go(func() {
+	// Copy the SSH channel to and from the anonymous pipes. The input copy from
+	// the SSH channel must not gate Wait(), or early child-process failures can
+	// deadlock waiting for the client to close the channel before we send the
+	// exit status.
+	go func() {
 		defer chReadPipeIn.Close()
 		if _, err := io.Copy(chReadPipeIn, ch); err != nil && !utils.IsOKNetworkError(err) {
 			s.logger.WarnContext(ctx, "Failure reading from SFTP subsystem", "error", err)
 		}
-	})
+	}()
 	s.waitForOutputStreams.Go(func() {
 		defer chWritePipeOut.Close()
 		if _, err := io.Copy(ch, chWritePipeOut); err != nil && !utils.IsOKNetworkError(err) {
@@ -255,6 +258,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 func (s *sftpSubsys) Wait() error {
 	ctx := context.Background()
 	waitErr := s.sftpCmd.Wait()
+	s.waitForOutputStreams.Wait()
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
@@ -262,6 +266,5 @@ func (s *sftpSubsys) Wait() error {
 		Code:    s.sftpCmd.ProcessState.ExitCode(),
 	})
 
-	s.waitForOutputStreams.Wait()
 	return trace.Wrap(waitErr)
 }

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -255,7 +255,6 @@ func (s *sftpSubsys) Start(ctx context.Context,
 func (s *sftpSubsys) Wait() error {
 	ctx := context.Background()
 	waitErr := s.sftpCmd.Wait()
-	s.waitForOutputStreams.Wait()
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{
@@ -263,5 +262,6 @@ func (s *sftpSubsys) Wait() error {
 		Code:    s.sftpCmd.ProcessState.ExitCode(),
 	})
 
+	s.waitForOutputStreams.Wait()
 	return trace.Wrap(waitErr)
 }

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -38,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv"
+	"github.com/gravitational/teleport/lib/sshutils/reexec"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -52,6 +53,10 @@ type sftpSubsys struct {
 	sftpCmd         *exec.Cmd
 	serverCtx       *srv.ServerContext
 	errCh           chan error
+
+	// childStderrDone is closed when child process stderr is fully read and
+	// propagated to the SSH channel.
+	childStderrDone chan struct{}
 }
 
 func newSFTPSubsys(fileTransferReq *srv.FileTransferRequest) (*sftpSubsys, error) {
@@ -121,8 +126,35 @@ func (s *sftpSubsys) Start(ctx context.Context,
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	s.sftpCmd.Stdout = os.Stdout
-	s.sftpCmd.Stderr = os.Stderr
+
+	// Capture stderr.
+	stderrR, stderrW, err := os.Pipe()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer stderrW.Close()
+	s.sftpCmd.Stderr = stderrW
+
+	s.childStderrDone = make(chan struct{})
+	go func() {
+		defer close(s.childStderrDone)
+		defer stderrR.Close()
+
+		childErr, err := reexec.ReadChildError(stderrR, &reexec.ErrorContext{
+			DecisionContext: s.serverCtx.Identity.AccessPermit.DecisionContext,
+			Login:           s.serverCtx.Identity.Login,
+		})
+		if err != nil {
+			s.serverCtx.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to read child process stderr", "error", err)
+		} else if childErr != "" {
+			if _, err := io.WriteString(ch.Stderr(), childErr); err != nil {
+				s.serverCtx.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to client", "error", err)
+			}
+		}
+	}()
+
+	// Ensure stderrR pipe is closed.
+	serverCtx.AddCloser(stderrR)
 
 	s.logger.DebugContext(ctx, "starting SFTP process")
 	err = s.sftpCmd.Start()
@@ -228,6 +260,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 func (s *sftpSubsys) Wait() error {
 	ctx := context.Background()
 	waitErr := s.sftpCmd.Wait()
+	<-s.childStderrDone
 	s.logger.DebugContext(ctx, "SFTP process finished")
 
 	s.serverCtx.SendExecResult(ctx, srv.ExecResult{

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -216,7 +216,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 				s.logger.WarnContext(ctx, "Unknown event type received from SFTP server process", "error", err, "event_type", event.GetType())
 			}
 
-			if err := serverCtx.GetServer().EmitAuditEvent(ctx, event); err != nil {
+			if err := serverCtx.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), event); err != nil {
 				s.logger.WarnContext(ctx, "Failed to emit SFTP event", "error", err)
 			}
 		}

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -153,9 +153,6 @@ func (s *sftpSubsys) Start(ctx context.Context,
 		}
 	}()
 
-	// Ensure stderrR pipe is closed.
-	serverCtx.AddCloser(stderrR)
-
 	s.logger.DebugContext(ctx, "starting SFTP process")
 	err = s.sftpCmd.Start()
 	if err != nil {

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -246,7 +246,7 @@ func (s *sftpSubsys) Start(ctx context.Context,
 				s.logger.WarnContext(ctx, "Unknown event type received from SFTP server process", "error", err, "event_type", event.GetType())
 			}
 
-			if err := serverCtx.GetServer().EmitAuditEvent(context.WithoutCancel(ctx), event); err != nil {
+			if err := serverCtx.GetServer().EmitAuditEvent(ctx, event); err != nil {
 				s.logger.WarnContext(ctx, "Failed to emit SFTP event", "error", err)
 			}
 		}

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -194,6 +194,9 @@ func (t *terminal) AddParty(delta int) {
 	t.wg.Add(delta)
 }
 
+// Replace \n with \r\n so the message is correctly aligned.
+var crlfReplacer = strings.NewReplacer("\r\n", "\r\n", "\n", "\r\n")
+
 // Run will run the terminal. If the shell fails to start due to a [teleport.RemoteCommandFailure],
 // the error will be written to the given error writer.
 func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
@@ -239,9 +242,7 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 			return
 		}
 
-		// Replace \n with \r\n so the message is correctly aligned in a terminal.
-		childErr = strings.ReplaceAll(childErr, "\n", "\r\n")
-		if _, err := io.WriteString(errorWriter, childErr); err != nil {
+		if _, err := crlfReplacer.WriteString(errorWriter, childErr); err != nil {
 			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to all parties", "error", err)
 		}
 	})

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"os/user"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -238,6 +239,8 @@ func (t *terminal) Run(ctx context.Context, errorWriter io.Writer) error {
 			return
 		}
 
+		// Replace \n with \r\n so the message is correctly aligned in a terminal.
+		childErr = strings.ReplaceAll(childErr, "\n", "\r\n")
 		if _, err := io.WriteString(errorWriter, childErr); err != nil {
 			t.serverContext.Logger.WarnContext(context.WithoutCancel(ctx), "Failed to propagate child process stderr to all parties", "error", err)
 		}

--- a/lib/sshutils/reexec/reexec.go
+++ b/lib/sshutils/reexec/reexec.go
@@ -71,7 +71,7 @@ func ReadChildError(stderr io.Reader, context *ErrorContext) (string, error) {
 		for _, d := range context.DecisionContext.HostUserCreationDeniedBy {
 			deniedBy = append(deniedBy, fmt.Sprintf("%v: %q", d.Kind, d.Name))
 		}
-		return fmt.Sprintf("%s: host user creation denied by the following resources: [%s]\r\n", strings.TrimRight(errMsg.String(), ".\r\n"), strings.Join(deniedBy, ", "))
+		return fmt.Sprintf("%s: host user creation denied by the following resources: [%s]\n", strings.TrimRight(errMsg.String(), ".\n"), strings.Join(deniedBy, ", "))
 	}
 
 	unknownUserError := user.UnknownUserError(context.Login)

--- a/lib/sshutils/reexec/reexec_test.go
+++ b/lib/sshutils/reexec/reexec_test.go
@@ -46,8 +46,8 @@ func TestReadChildError(t *testing.T) {
 		},
 		{
 			name:         "has stderr",
-			childErrIn:   "Failed to launch: test error.\r\n",
-			wantChildErr: "Failed to launch: test error.\r\n",
+			childErrIn:   "Failed to launch: test error.\n",
+			wantChildErr: "Failed to launch: test error.\n",
 		},
 		{
 			name:         "stderr at max read limit",
@@ -65,7 +65,7 @@ func TestReadChildError(t *testing.T) {
 		},
 		{
 			name:       "unknown user error with mixed host user creation decisions gets contextualized",
-			childErrIn: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec.\r\n",
+			childErrIn: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec.\n",
 			context: &ErrorContext{
 				Login: "teleport-test-user-does-not-exist-reexec",
 				DecisionContext: &decisionpb.SSHAccessPermitContext{
@@ -77,11 +77,11 @@ func TestReadChildError(t *testing.T) {
 					},
 				},
 			},
-			wantChildErr: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec: host user creation denied by the following resources: [role: \"deny-role\"]\r\n",
+			wantChildErr: "Failed to launch: user: unknown user teleport-test-user-does-not-exist-reexec: host user creation denied by the following resources: [role: \"deny-role\"]\n",
 		},
 		{
 			name:       "pam context error for unknown user gets contextualized",
-			childErrIn: "Failed to launch: failed to open PAM context: pam_start failed.\r\n",
+			childErrIn: "Failed to launch: failed to open PAM context: pam_start failed.\n",
 			context: &ErrorContext{
 				Login: "teleport-test-user-does-not-exist-pam",
 				DecisionContext: &decisionpb.SSHAccessPermitContext{
@@ -93,7 +93,7 @@ func TestReadChildError(t *testing.T) {
 					},
 				},
 			},
-			wantChildErr: "Failed to launch: failed to open PAM context: pam_start failed: host user creation denied by the following resources: [role: \"deny-role\"]\r\n",
+			wantChildErr: "Failed to launch: failed to open PAM context: pam_start failed: host user creation denied by the following resources: [role: \"deny-role\"]\n",
 		},
 	}
 

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -21,11 +21,9 @@ package sftp
 import (
 	"context"
 	"io"
-	"log/slog"
 	"os"
 	portablepath "path"
 	"strings"
-	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/pkg/sftp"
@@ -159,25 +157,10 @@ func (r *RemoteFS) Readlink(name string) (string, error) {
 }
 
 func (r *RemoteFS) Close() error {
-	if r.session == nil {
-		return trace.Wrap(r.Client.Close())
+	var sessionErr error
+	if r.session != nil {
+		sessionErr = r.session.Close()
 	}
 
-	// Wait (best effort) for the session to end on the remote side before closing the local side.
-	waitC := make(chan struct{})
-	go func() {
-		defer close(waitC)
-		if err := r.Client.Close(); err != nil {
-			slog.DebugContext(context.Background(), "Error closing sftp client", "error", err)
-		}
-		if err := r.session.Wait(); err != nil {
-			slog.DebugContext(context.Background(), "Error waiting for remote sftp session to end", "error", err)
-		}
-	}()
-	select {
-	case <-waitC:
-	case <-time.After(5 * time.Second):
-	}
-
-	return trace.Wrap(r.session.Close())
+	return trace.NewAggregate(sessionErr, r.Client.Close())
 }

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -158,12 +158,13 @@ func (r *RemoteFS) Readlink(name string) (string, error) {
 
 func (r *RemoteFS) Close() error {
 	clientErr := r.Client.Close()
-	var sessionErr error
-	if r.session != nil {
-		// Wait for the session to end on the server side before closing the client side.
-		if sessionErr = r.session.Wait(); sessionErr == nil {
-			sessionErr = r.session.Close()
-		}
+	if r.session == nil {
+		return trace.Wrap(clientErr)
 	}
-	return trace.NewAggregate(clientErr, sessionErr)
+
+	// Wait for the session to end on the server side before closing the client side.
+	waitErr := r.session.Wait()
+	closeErr := r.session.Close()
+
+	return trace.NewAggregate(clientErr, waitErr, closeErr)
 }

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -21,9 +21,11 @@ package sftp
 import (
 	"context"
 	"io"
+	"log/slog"
 	"os"
 	portablepath "path"
 	"strings"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/pkg/sftp"
@@ -157,14 +159,25 @@ func (r *RemoteFS) Readlink(name string) (string, error) {
 }
 
 func (r *RemoteFS) Close() error {
-	clientErr := r.Client.Close()
 	if r.session == nil {
-		return trace.Wrap(clientErr)
+		return trace.Wrap(r.Client.Close())
 	}
 
-	// Wait for the session to end on the server side before closing the client side.
-	waitErr := r.session.Wait()
-	closeErr := r.session.Close()
+	// Wait (best effort) for the session to end on the remote side before closing the local side.
+	waitC := make(chan struct{})
+	go func() {
+		defer close(waitC)
+		if err := r.Client.Close(); err != nil {
+			slog.DebugContext(context.Background(), "Error closing sftp client", "error", err)
+		}
+		if err := r.session.Wait(); err != nil {
+			slog.DebugContext(context.Background(), "Error waiting for remote sftp session to end", "error", err)
+		}
+	}()
+	select {
+	case <-waitC:
+	case <-time.After(5 * time.Second):
+	}
 
-	return trace.NewAggregate(clientErr, waitErr, closeErr)
+	return trace.Wrap(r.session.Close())
 }

--- a/lib/sshutils/sftp/remote.go
+++ b/lib/sshutils/sftp/remote.go
@@ -36,7 +36,7 @@ import (
 // the local file system
 type RemoteFS struct {
 	*sftp.Client
-	session io.Closer
+	session *tracessh.Session
 }
 
 // NewRemoteFilesystem creates a new FileSystem over SFTP.
@@ -99,6 +99,13 @@ func OpenRemoteFilesystem(ctx context.Context, sshClient *tracessh.Client, moder
 		sftp.UseConcurrentWrites(true),
 	)
 	if err != nil {
+		// After the subsystem request succeeds, the sftp server subprocess may still
+		// fail to initialize, resulting in an EOF error here. Check the stderr from
+		// the subsystem for a more actionable error.
+		var sb strings.Builder
+		if n, _ := io.Copy(&sb, pe); n > 0 {
+			return nil, trace.Errorf("%s", sb.String())
+		}
 		return nil, trace.Wrap(err)
 	}
 	return &RemoteFS{
@@ -150,9 +157,13 @@ func (r *RemoteFS) Readlink(name string) (string, error) {
 }
 
 func (r *RemoteFS) Close() error {
+	clientErr := r.Client.Close()
 	var sessionErr error
 	if r.session != nil {
-		sessionErr = r.session.Close()
+		// Wait for the session to end on the server side before closing the client side.
+		if sessionErr = r.session.Wait(); sessionErr == nil {
+			sessionErr = r.session.Close()
+		}
 	}
-	return trace.NewAggregate(sessionErr, r.Client.Close())
+	return trace.NewAggregate(clientErr, sessionErr)
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8443,6 +8443,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 		t.Parallel()
 		homePath := userMissingLoginHomePath
 
+		unkownUserReexecError := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
 		for _, tc := range []testCase{sshShell, sshCommand, sshCommandTTY} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -8453,17 +8454,44 @@ func TestReexecErrorPropagation(t *testing.T) {
 				require.ErrorAs(t, err, &exitCodeErr)
 				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
 
-				expectStdout := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
-
 				// Check for exact match to catch regressions with new lines.
-				require.Equal(t, expectStdout, stdout)
+				require.Equal(t, unkownUserReexecError, stdout)
 			})
 		}
+
+		t.Run("sftp", func(t *testing.T) {
+			stderr := &output{buf: bytes.Buffer{}}
+			err := Run(ctx, []string{
+				"scp",
+				"--insecure",
+				"-q",
+				"-d",
+				"--no-resume",
+				fmt.Sprintf("%s@%s:%s", missingLogin, sshHostname, "/placeholder"),
+				t.TempDir(),
+			},
+				setHomePath(homePath),
+				func(conf *CLIConf) error {
+					conf.overrideStderr = stderr
+					conf.Relogin = false
+					return nil
+				},
+			)
+			require.Error(t, err)
+			// Check for exact match to catch regressions with new lines.
+			require.Equal(t, unkownUserReexecError, err.Error())
+		})
 	})
 
 	t.Run("error with host user creation context", func(t *testing.T) {
 		t.Parallel()
 		homePath := userHostUserCreationContextHomePath
+
+		contextualReexecErrorMessage := fmt.Sprintf("Failed to launch: %s: host user creation denied by the following resources: [%s: %q]\r\n",
+			user.UnknownUserError(missingLogin),
+			types.KindRole,
+			roleNodeAccessMissingLogin.GetName(),
+		)
 
 		for _, tc := range []testCase{sshCommand} {
 			t.Run(tc.name, func(t *testing.T) {
@@ -8475,15 +8503,32 @@ func TestReexecErrorPropagation(t *testing.T) {
 				require.ErrorAs(t, err, &exitCodeErr)
 				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
 
-				expectStdout := fmt.Sprintf("Failed to launch: %s: host user creation denied by the following resources: [%s: %q]\r\n",
-					user.UnknownUserError(missingLogin),
-					types.KindRole,
-					roleNodeAccessMissingLogin.GetName(),
-				)
-
 				// Check for exact match to catch regressions with new lines.
-				require.Equal(t, expectStdout, stdout)
+				require.Equal(t, contextualReexecErrorMessage, stdout)
 			})
 		}
+
+		t.Run("sftp", func(t *testing.T) {
+			stderr := &output{buf: bytes.Buffer{}}
+			err := Run(ctx, []string{
+				"scp",
+				"--insecure",
+				"-q",
+				"-d",
+				"--no-resume",
+				fmt.Sprintf("%s@%s:%s", missingLogin, sshHostname, "/placeholder"),
+				t.TempDir(),
+			},
+				setHomePath(homePath),
+				func(conf *CLIConf) error {
+					conf.overrideStderr = stderr
+					conf.Relogin = false
+					return nil
+				},
+			)
+			require.Error(t, err)
+			// Check for exact match to catch regressions with new lines.
+			require.Equal(t, contextualReexecErrorMessage, err.Error())
+		})
 	})
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8479,7 +8479,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 			)
 			require.Error(t, err)
 			// Check for exact match to catch regressions with new lines.
-			require.Equal(t, unkownUserReexecError, err.Error())
+			require.Equal(t, strings.ReplaceAll(unkownUserReexecError, "\r\n", "\n"), err.Error())
 		})
 	})
 
@@ -8528,7 +8528,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 			)
 			require.Error(t, err)
 			// Check for exact match to catch regressions with new lines.
-			require.Equal(t, contextualReexecErrorMessage, err.Error())
+			require.Equal(t, strings.ReplaceAll(contextualReexecErrorMessage, "\r\n", "\n"), err.Error())
 		})
 	})
 }

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8443,7 +8443,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 		t.Parallel()
 		homePath := userMissingLoginHomePath
 
-		unkownUserReexecError := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
+		unknownUserReexecError := fmt.Sprintf("Failed to launch: %v.\r\n", user.UnknownUserError(missingLogin))
 		for _, tc := range []testCase{sshShell, sshCommand, sshCommandTTY} {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
@@ -8455,7 +8455,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 				require.Equal(t, teleport.RemoteCommandFailure, exitCodeErr.Code)
 
 				// Check for exact match to catch regressions with new lines.
-				require.Equal(t, unkownUserReexecError, stdout)
+				require.Equal(t, unknownUserReexecError, stdout)
 			})
 		}
 
@@ -8479,7 +8479,7 @@ func TestReexecErrorPropagation(t *testing.T) {
 			)
 			require.Error(t, err)
 			// Check for exact match to catch regressions with new lines.
-			require.Equal(t, strings.ReplaceAll(unkownUserReexecError, "\r\n", "\n"), err.Error())
+			require.Equal(t, strings.ReplaceAll(unknownUserReexecError, "\r\n", "\n"), err.Error())
 		})
 	})
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -8460,7 +8460,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 		}
 
 		t.Run("sftp", func(t *testing.T) {
-			stderr := &output{buf: bytes.Buffer{}}
 			err := Run(ctx, []string{
 				"scp",
 				"--insecure",
@@ -8472,7 +8471,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 			},
 				setHomePath(homePath),
 				func(conf *CLIConf) error {
-					conf.overrideStderr = stderr
 					conf.Relogin = false
 					return nil
 				},
@@ -8509,7 +8507,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 		}
 
 		t.Run("sftp", func(t *testing.T) {
-			stderr := &output{buf: bytes.Buffer{}}
 			err := Run(ctx, []string{
 				"scp",
 				"--insecure",
@@ -8521,7 +8518,6 @@ func TestReexecErrorPropagation(t *testing.T) {
 			},
 				setHomePath(homePath),
 				func(conf *CLIConf) error {
-					conf.overrideStderr = stderr
 					conf.Relogin = false
 					return nil
 				},


### PR DESCRIPTION
Changes:
- Capture SFTP exec reexec process stderr in the parent process.
- Propagate SFTP errors to the client via SSH channel's stderr.
- Fix issues around SFTP client / remoteFS closure which would lead to error/debug log spam in the success case and unexpected errors in the failure case.

Depends on https://github.com/gravitational/teleport/pull/63918

Part of https://github.com/gravitational/teleport/pull/62285#issuecomment-3850723494

<details>
<summary>Example output</summary>

Before:
```
> tsh scp dne@server01:sample.txt sample.txt
ERROR: error receiving version packet from server: server unexpectedly closed connection: unexpected EOF
```

After:
```
> tsh scp dne@server01:sample.txt sample.txt
ERROR: Failed to launch: user: unknown user dne
```

</details>

## Manual Test Plan

- [x] sftp success (no logs or errors)
  - [x] remote -> local
  - [x] local -> remote
- [x] sftp error propagated to client
  - [x] remote -> local
  - [x] local -> remote
- [x] Run above tests again in proxy recording mode