### PR TITLE
docs: correct aws ec2 joining intro

### DIFF
--- a/docs/pages/enroll-resources/agents/aws-ec2.mdx
+++ b/docs/pages/enroll-resources/agents/aws-ec2.mdx
@@ -10,8 +10,8 @@ tags:
 ---
 
 This guide explains how to use the **EC2 join method** to configure Teleport
-processes to join your Teleport cluster without sharing any secrets when they a
-re running in AWS.
+processes to join your Teleport cluster without sharing any secrets when they
+are running in AWS.
 
 The EC2 join method is only available in self-hosted Teleport deployments. There
 are two other AWS join methods available depending on your use case:


### PR DESCRIPTION
Spacing issue with a word