### PR TITLE
[v18] Add modules to servicecfg.Config and helpers.InstanceConfig

### DIFF
--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -305,6 +305,8 @@ type TeleInstance struct {
 
 	// Log specifies the instance logger
 	Log *slog.Logger
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 	InstanceListeners
 	Fds []*servicecfg.FileDescriptor
 	// ProcessProvider creates a Teleport process (OSS or Enterprise)
@@ -334,8 +336,9 @@ type InstanceConfig struct {
 	Logger *slog.Logger
 	// Ports is a collection of instance ports.
 	Listeners *InstanceListeners
-
-	Fds []*servicecfg.FileDescriptor
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
+	Fds     []*servicecfg.FileDescriptor
 }
 
 // NewInstance creates a new Teleport process instance.
@@ -357,6 +360,10 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 		cfg.Logger = slog.New(slog.DiscardHandler)
 	}
 
+	if cfg.Modules == nil {
+		cfg.Modules = modules.GetModules()
+	}
+
 	// generate instance secrets (keys):
 	if cfg.Priv == nil || cfg.Pub == nil {
 		privateKey, err := cryptosuites.GeneratePrivateKeyWithAlgorithm(cryptosuites.ECDSAP256)
@@ -371,8 +378,7 @@ func NewInstance(t *testing.T, cfg InstanceConfig) *TeleInstance {
 	fatalIf(err)
 
 	clock := cmp.Or(cfg.Clock, clockwork.NewRealClock())
-	// TODO(tross): replace modules.GetModules with cfg.Modules
-	authority, err := testauthority.NewKeygen(modules.GetModules().BuildType(), clock.Now)
+	authority, err := testauthority.NewKeygen(cfg.Modules.BuildType(), clock.Now)
 	fatalIf(err)
 
 	hostCert, err := authority.GenerateHostCert(sshca.HostCertificateRequest{
@@ -621,9 +627,8 @@ func (i *TeleInstance) GenerateConfig(t *testing.T, trustedSecrets []*InstanceSe
 
 	tconf.Kube.CheckImpersonationPermissions = nullImpersonationCheck
 
-	// TODO(tross): replace modules.GetModules with tconf.Modules
 	clock := cmp.Or(tconf.Clock, clockwork.NewRealClock())
-	keygen, err := testauthority.NewKeygen(modules.GetModules().BuildType(), clock.Now)
+	keygen, err := testauthority.NewKeygen(tconf.Modules.BuildType(), clock.Now)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/discovery_test.go
+++ b/lib/service/discovery_test.go
@@ -66,12 +66,14 @@ func TestTeleportProcessIntegrationsOnly(t *testing.T) {
 					Auth: servicecfg.AuthConfig{
 						Enabled: tt.inputAuthEnabled,
 					},
+					Modules: &modulestest.Modules{
+						TestBuildType: modules.BuildEnterprise,
+						TestFeatures: modules.Features{
+							Cloud: tt.inputFeatureCloud,
+						},
+					},
 				},
 			}
-
-			modulestest.SetTestModules(t, modulestest.Modules{TestFeatures: modules.Features{
-				Cloud: tt.inputFeatureCloud,
-			}})
 
 			require.Equal(t, tt.integrationOnly, p.integrationOnlyCredentials())
 		})

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -47,6 +47,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/imds"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/sshca"
@@ -211,8 +212,11 @@ type Config struct {
 	// Clock is used to control time in tests.
 	Clock clockwork.Clock
 
-	// FIPS means FedRAMP/FIPS compliant configuration was requested.
+	// FIPS means FedRAMP/FIPS compliant configuration was requested via the --fips flag.
 	FIPS bool
+
+	// Modules defines build time constraints and licensed features.
+	Modules modules.Modules
 
 	// SkipVersionCheck means the version checking between server and client
 	// will be skipped.
@@ -652,6 +656,10 @@ func ApplyDefaults(cfg *Config) {
 
 	if cfg.LoggerLevel == nil {
 		cfg.LoggerLevel = new(slog.LevelVar)
+	}
+
+	if cfg.Modules == nil {
+		cfg.Modules = modules.GetModules()
 	}
 
 	// Remove insecure and (borderline insecure) cryptographic primitives from


### PR DESCRIPTION
Backport #63824 to branch/v18

I've omitted the changes that consume the servicecfg.Config.Modules from the TeleportProcess to prevent issues discovered with teleport.e not overriding the modules appropriately.


## Manual Test Plan

### Test Environment

Cloud tests were performed against `timr-test3.cloud.gravitational.io`. Self-Hosted tests were done locally with a variety of license files.

### Test Cases

- [x] All pods in a brand new Cloud tenant start successfully. Auth is able to load the features from the license and populate the modules accordingly. Proxy is able to start up without a license provided.

Auth:

```
{"timestamp":"2026-02-20T20:50:28Z","level":"info","caller":"process/license.go:50","message":"Successfully loaded license.","license_file":"/var/lib/license/license.pem","license":"expires at 2126-01-27 20:50:03 +0000 UTC,reports usage,supports kubernetes,supports application access,supports database access,supports desktop access,is hosted by Gravitational"}
{"timestamp":"2026-02-20T20:50:28Z","level":"debug","caller":"modules/modules.go:62","message":"fetching features from Cloud","component":"enterprise/modules"}
{"timestamp":"2026-02-20T20:50:29Z","level":"debug","caller":"modules/modules.go:82","message":"successfully fetched features from Cloud","component":"enterprise/modules","features":"Kubernetes:true App:true DB:true OIDC:true SAML:true AccessControls:true AdvancedAccessWorkflows:true Cloud:true HSM:true Desktop:true IsUsageBased:true DeviceTrust:<enabled:true > AccessRequests:<> IdentityGovernance:true AccessList:<> AccessMonitoring:<> ProductType:PRODUCT_TYPE_EUB Policy:<enabled:true > ExternalAuditStorage:true SupportType:SUPPORT_TYPE_PREMIUM JoinActiveSessions:true MobileDeviceManagement:true entitlements:<key:\"AccessGraphDemoMode\" value:<> > entitlements:<key:\"AccessLists\" value:<enabled:true > > entitlements:<key:\"AccessMonitoring\" value:<enabled:true > > entitlements:<key:\"AccessRequests\" value:<enabled:true > > entitlements:<key:\"App\" value:<enabled:true > > entitlements:<key:\"ClientIPRestrictions\" value:<> > entitlements:<key:\"CloudAuditLogRetention\" value:<> > entitlements:<key:\"DB\" value:<enabled:true > > entitlements:<key:\"Desktop\" value:<enabled:true > > entitlements:<key:\"DeviceTrust\" value:<enabled:true > > entitlements:<key:\"ExternalAuditStorage\" value:<enabled:true > > entitlements:<key:\"FeatureHiding\" value:<> > entitlements:<key:\"HSM\" value:<enabled:true > > entitlements:<key:\"Identity\" value:<enabled:true > > entitlements:<key:\"JoinActiveSessions\" value:<enabled:true > > entitlements:<key:\"K8s\" value:<enabled:true > > entitlements:<key:\"LicenseAutoUpdate\" value:<> > entitlements:<key:\"MobileDeviceManagement\" value:<enabled:true > > entitlements:<key:\"OIDC\" value:<enabled:true > > entitlements:<key:\"OktaSCIM\" value:<enabled:true > > entitlements:<key:\"OktaUserSync\" value:<enabled:true > > entitlements:<key:\"Policy\" value:<enabled:true limit:1 > > entitlements:<key:\"SAML\" value:<enabled:true > > entitlements:<key:\"SessionLocks\" value:<enabled:true > > entitlements:<key:\"UnrestrictedManagedUpdates\" value:<> > entitlements:<key:\"UpsellAlert\" value:<> > entitlements:<key:\"UsageReporting\" value:<enabled:true > > entitlements:<key:\"WorkloadClusters\" value:<> > "}
```

Proxy:
```
{"timestamp":"2026-02-20T20:51:02Z","level":"info","caller":"service/connect.go:1369","message":"features loaded from auth server","component":"proc:1","pid":"6.1","identity":"Instance","features":"Kubernetes:true App:true DB:true OIDC:true SAML:true AccessControls:true AdvancedAccessWorkflows:true Cloud:true HSM:true Desktop:true RecoveryCodes:true Plugins:true AutomaticUpgrades:true IsUsageBased:true DeviceTrust:<enabled:true > AccessRequests:<> IdentityGovernance:true AccessGraph:true AccessList:<> AccessMonitoring:<enabled:true > ProductType:PRODUCT_TYPE_EUB Policy:<enabled:true > ExternalAuditStorage:true SupportType:SUPPORT_TYPE_PREMIUM JoinActiveSessions:true MobileDeviceManagement:true entitlements:<key:\"AccessGraphDemoMode\" value:<> > entitlements:<key:\"AccessLists\" value:<enabled:true > > entitlements:<key:\"AccessMonitoring\" value:<enabled:true > > entitlements:<key:\"AccessRequests\" value:<enabled:true > > entitlements:<key:\"App\" value:<enabled:true > > entitlements:<key:\"ClientIPRestrictions\" value:<> > entitlements:<key:\"CloudAuditLogRetention\" value:<> > entitlements:<key:\"DB\" value:<enabled:true > > entitlements:<key:\"Desktop\" value:<enabled:true > > entitlements:<key:\"DeviceTrust\" value:<enabled:true > > entitlements:<key:\"ExternalAuditStorage\" value:<enabled:true > > entitlements:<key:\"FeatureHiding\" value:<> > entitlements:<key:\"HSM\" value:<enabled:true > > entitlements:<key:\"Identity\" value:<enabled:true > > entitlements:<key:\"JoinActiveSessions\" value:<enabled:true > > entitlements:<key:\"K8s\" value:<enabled:true > > entitlements:<key:\"LicenseAutoUpdate\" value:<> > entitlements:<key:\"MobileDeviceManagement\" value:<enabled:true > > entitlements:<key:\"OIDC\" value:<enabled:true > > entitlements:<key:\"OktaSCIM\" value:<enabled:true > > entitlements:<key:\"OktaUserSync\" value:<enabled:true > > entitlements:<key:\"Policy\" value:<enabled:true limit:1 > > entitlements:<key:\"SAML\" value:<enabled:true > > entitlements:<key:\"SessionLocks\" value:<enabled:true > > entitlements:<key:\"UnrestrictedManagedUpdates\" value:<> > entitlements:<key:\"UpsellAlert\" value:<> > entitlements:<key:\"UsageReporting\" value:<enabled:true > > entitlements:<key:\"WorkloadClusters\" value:<> > AccessMonitoringConfigured:true "}
```

- [x] All pods in an existing Cloud tenant start successfully after upgrade. Auth is able to load the features from the license and populate the modules accordingly. Proxy is able to start up without a license provided.

Auth:
```
{"timestamp":"2026-02-20T21:04:39Z","level":"debug","caller":"modules/modules.go:62","message":"fetching features from Cloud","component":"enterprise/modules"}
{"timestamp":"2026-02-20T21:04:40Z","level":"debug","caller":"modules/modules.go:82","message":"successfully fetched features from Cloud","component":"enterprise/modules","features":"Kubernetes:true App:true DB:true OIDC:true SAML:true AccessControls:true AdvancedAccessWorkflows:true Cloud:true HSM:true Desktop:true IsUsageBased:true DeviceTrust:<enabled:true > AccessRequests:<> IdentityGovernance:true AccessList:<> AccessMonitoring:<> ProductType:PRODUCT_TYPE_EUB Policy:<enabled:true > ExternalAuditStorage:true SupportType:SUPPORT_TYPE_PREMIUM JoinActiveSessions:true MobileDeviceManagement:true entitlements:<key:\"AccessGraphDemoMode\" value:<> > entitlements:<key:\"AccessLists\" value:<enabled:true > > entitlements:<key:\"AccessMonitoring\" value:<enabled:true > > entitlements:<key:\"AccessRequests\" value:<enabled:true > > entitlements:<key:\"App\" value:<enabled:true > > entitlements:<key:\"ClientIPRestrictions\" value:<> > entitlements:<key:\"CloudAuditLogRetention\" value:<> > entitlements:<key:\"DB\" value:<enabled:true > > entitlements:<key:\"Desktop\" value:<enabled:true > > entitlements:<key:\"DeviceTrust\" value:<enabled:true > > entitlements:<key:\"ExternalAuditStorage\" value:<enabled:true > > entitlements:<key:\"FeatureHiding\" value:<> > entitlements:<key:\"HSM\" value:<enabled:true > > entitlements:<key:\"Identity\" value:<enabled:true > > entitlements:<key:\"JoinActiveSessions\" value:<enabled:true > > entitlements:<key:\"K8s\" value:<enabled:true > > entitlements:<key:\"LicenseAutoUpdate\" value:<> > entitlements:<key:\"MobileDeviceManagement\" value:<enabled:true > > entitlements:<key:\"OIDC\" value:<enabled:true > > entitlements:<key:\"OktaSCIM\" value:<enabled:true > > entitlements:<key:\"OktaUserSync\" value:<enabled:true > > entitlements:<key:\"Policy\" value:<enabled:true limit:1 > > entitlements:<key:\"SAML\" value:<enabled:true > > entitlements:<key:\"SessionLocks\" value:<enabled:true > > entitlements:<key:\"UnrestrictedManagedUpdates\" value:<> > entitlements:<key:\"UpsellAlert\" value:<> > entitlements:<key:\"UsageReporting\" value:<enabled:true > > entitlements:<key:\"WorkloadClusters\" value:<> > "}
```

Proxy:
```
{"timestamp":"2026-02-20T21:04:41Z","level":"info","caller":"service/connect.go:507","message":"Successfully obtained credentials to connect to the cluster.","component":"proc:1","pid":"6.1","identity":"Instance"}
{"timestamp":"2026-02-20T21:04:41Z","level":"info","caller":"service/connect.go:1369","message":"features loaded from auth server","component":"proc:1","pid":"6.1","identity":"Instance","features":"Kubernetes:true App:true DB:true OIDC:true SAML:true AccessControls:true AdvancedAccessWorkflows:true Cloud:true HSM:true Desktop:true RecoveryCodes:true Plugins:true AutomaticUpgrades:true IsUsageBased:true DeviceTrust:<enabled:true > AccessRequests:<> IdentityGovernance:true AccessGraph:true AccessList:<> AccessMonitoring:<enabled:true > ProductType:PRODUCT_TYPE_EUB Policy:<enabled:true > ExternalAuditStorage:true SupportType:SUPPORT_TYPE_PREMIUM JoinActiveSessions:true MobileDeviceManagement:true entitlements:<key:\"AccessGraphDemoMode\" value:<> > entitlements:<key:\"AccessLists\" value:<enabled:true > > entitlements:<key:\"AccessMonitoring\" value:<enabled:true > > entitlements:<key:\"AccessRequests\" value:<enabled:true > > entitlements:<key:\"App\" value:<enabled:true > > entitlements:<key:\"ClientIPRestrictions\" value:<> > entitlements:<key:\"CloudAuditLogRetention\" value:<> > entitlements:<key:\"DB\" value:<enabled:true > > entitlements:<key:\"Desktop\" value:<enabled:true > > entitlements:<key:\"DeviceTrust\" value:<enabled:true > > entitlements:<key:\"ExternalAuditStorage\" value:<enabled:true > > entitlements:<key:\"FeatureHiding\" value:<> > entitlements:<key:\"HSM\" value:<enabled:true > > entitlements:<key:\"Identity\" value:<enabled:true > > entitlements:<key:\"JoinActiveSessions\" value:<enabled:true > > entitlements:<key:\"K8s\" value:<enabled:true > > entitlements:<key:\"LicenseAutoUpdate\" value:<> > entitlements:<key:\"MobileDeviceManagement\" value:<enabled:true > > entitlements:<key:\"OIDC\" value:<enabled:true > > entitlements:<key:\"OktaSCIM\" value:<enabled:true > > entitlements:<key:\"OktaUserSync\" value:<enabled:true > > entitlements:<key:\"Policy\" value:<enabled:true limit:1 > > entitlements:<key:\"SAML\" value:<enabled:true > > entitlements:<key:\"SessionLocks\" value:<enabled:true > > entitlements:<key:\"UnrestrictedManagedUpdates\" value:<> > entitlements:<key:\"UpsellAlert\" value:<> > entitlements:<key:\"UsageReporting\" value:<enabled:true > > entitlements:<key:\"WorkloadClusters\" value:<> > AccessMonitoringConfigured:true "}
```

- [x] A Self-Hosted Auth server is able to load features from the license and does _not_ attempt to pull features from the Cloud API.