### PR TITLE
[v18] Configure `allow-proxy-conflict` in `teleport-update` using env var

### DIFF
--- a/lib/autoupdate/env_vars.go
+++ b/lib/autoupdate/env_vars.go
@@ -18,5 +18,10 @@
 
 package autoupdate
 
-// InstallSuffixEnvVar specifies the Teleport install suffix.
-const InstallSuffixEnvVar = "TELEPORT_INSTALL_SUFFIX"
+const (
+	// InstallSuffixEnvVar specifies the Teleport install suffix.
+	InstallSuffixEnvVar = "TELEPORT_INSTALL_SUFFIX"
+
+	// AllowProxyConflictEnvVar allows defining whether a proxy conflict is allowed via env var.
+	AllowProxyConflictEnvVar = "TELEPORT_ALLOW_PROXY_CONFLICT"
+)

--- a/tool/teleport-update/main.go
+++ b/tool/teleport-update/main.go
@@ -134,7 +134,7 @@ func Run(args []string) int {
 	enableCmd.Flag("overwrite", "Allow existing installed binaries and services to be overwritten.").
 		Short('o').BoolVar(&ccfg.AllowOverwrite)
 	enableCmd.Flag("allow-proxy-conflict", "Allow proxy addresses in teleport.yaml and update.yaml to conflict.").
-		BoolVar(&ccfg.AllowProxyConflict)
+		Envar(common.AllowProxyConflictEnvVar).BoolVar(&ccfg.AllowProxyConflict)
 	enableCmd.Flag("force-version", "Force the provided version instead of using the version provided by the Teleport cluster.").
 		Hidden().Short('f').Envar(updateVersionEnvVar).StringVar(&ccfg.ForceVersion)
 	enableCmd.Flag("force-flag", "Force the provided version flags instead of using the version flags provided by the Teleport cluster.").


### PR DESCRIPTION
Backport #63860 to branch/v18