### PR TITLE
feat(beams): Add stubbed `tsh` core sub-commands

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -202,6 +202,176 @@ Arguments:
 |---|---|---|
 |command|none (optional)|`az` command and subcommands arguments that are going to be forwarded to Azure CLI.|
 
+## tsh beams
+
+View, manage and run beam environments. Beams are convenient, sandboxed environments for experimenting with AI agents.
+
+Usage:
+
+```code
+$ tsh beams <command> [<flags>] [<args> ...]
+```
+
+## tsh beams add
+
+Start a new beam environment.
+
+Usage:
+
+```code
+$ tsh beams add [<flags>] [<name>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]wait`|`false`|Wait for the beam environment to become ready.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (optional)|Name for the new beam (optional).|
+
+## tsh beams allow
+
+Grant access to an external domain.
+
+Usage:
+
+```code
+$ tsh beams allow [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--domain`|none (required)|Domain to allow access to.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams deny
+
+Remove access to an external domain.
+
+Usage:
+
+```code
+$ tsh beams deny [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--domain`|none (required)|Domain to deny access to.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams ls
+
+List running beam environments.
+
+Usage:
+
+```code
+$ tsh beams ls [<flags>]
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--[no-]all`|`false`|List beams for all users.|
+|`-f`, `--format`|`text`|Format output (text, json, yaml).|
+
+## tsh beams mount
+
+Mount a local directory in a beam environment.
+
+Usage:
+
+```code
+$ tsh beams mount [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--dest`|none (required)|Mount location in the beam's filesystem.|
+|`--source`|none (required)|Path to a local directory.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams rm
+
+Delete a running beam environment.
+
+Usage:
+
+```code
+$ tsh beams rm <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to delete.|
+
+## tsh beams shell
+
+Start an interactive shell in a running beam environment.
+
+Usage:
+
+```code
+$ tsh beams shell <name>
+```
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams unmount
+
+Remove a mounted directory from a beam evironment.
+
+Usage:
+
+```code
+$ tsh beams unmount [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--dest`|none (required)|Mount location in the beam's filesystem.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
 ## tsh clusters
 
 List available Teleport clusters.
@@ -1689,4 +1859,3 @@ Flags:
 |`--label-selector`|none|A label-based selector for which workload identities to issue. Multiple labels can be provided using ','.|
 |`--name-selector`|none|The name of the workload identity to issue.|
 |`--output`|none|Path to the directory to write the SVID into.|
-

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5617,3 +5617,44 @@ func CalculateSSHLogins(identityPrincipals []string, allowedLogins []string) ([]
 	slices.Sort(logins)
 	return logins, nil
 }
+
+// ListBeams returns a list of beams, either for the current user or all users.
+func (tc *TeleportClient) ListBeams(ctx context.Context, allUsers bool) ([]any, error) {
+	return nil, trace.NotImplemented("TeleportClient.ListBeams is stubbed")
+}
+
+// AddBeam starts a new beam environment.
+func (tc *TeleportClient) AddBeam(ctx context.Context, name string, wait bool) (any, error) {
+	return nil, trace.NotImplemented("TeleportClient.AddBeam is stubbed")
+}
+
+// RemoveBeam deletes a running beam environment.
+func (tc *TeleportClient) RemoveBeam(ctx context.Context, name string) error {
+	return trace.NotImplemented("TeleportClient.RemoveBeam is stubbed")
+}
+
+// ShellBeam starts an interactive shell in a running beam environment.
+func (tc *TeleportClient) ShellBeam(ctx context.Context, name string) error {
+	return trace.NotImplemented("TeleportClient.ShellBeam is stubbed")
+}
+
+// MountBeam mounts a local directory in a beam environment.
+func (tc *TeleportClient) MountBeam(ctx context.Context, name, source, dest string) error {
+	return trace.NotImplemented("TeleportClient.MountBeam is stubbed")
+}
+
+// UnmountBeam removes a mounted directory from a beam environment.
+func (tc *TeleportClient) UnmountBeam(ctx context.Context, name, dest string) error {
+	return trace.NotImplemented("TeleportClient.UnmountBeam is stubbed")
+}
+
+// AllowBeamDomain grants access to an external domain.
+func (tc *TeleportClient) AllowBeamDomain(ctx context.Context, name, domain string) error {
+	return trace.NotImplemented("TeleportClient.AllowBeamDomain is stubbed")
+}
+
+// DenyBeamDomain removes access to an external domain.
+func (tc *TeleportClient) DenyBeamDomain(ctx context.Context, name, domain string) error {
+	return trace.NotImplemented("TeleportClient.DenyBeamDomain is stubbed")
+}
+

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -5,6 +5,14 @@ import (
 )
 
 type beamsCommands struct {
+	ls      *beamsListCommand
+	add     *beamsAddCommand
+	rm      *beamsRemoveCommand
+	shell   *beamsShellCommand
+	mount   *beamsMountCommand
+	unmount *beamsUnmountCommand
+	allow   *beamsAllowCommand
+	deny    *beamsDenyCommand
 }
 
 func newBeamsCommands(
@@ -13,6 +21,14 @@ func newBeamsCommands(
 	cmd := app.Command("beams", "View, manage and run beam environments. Beams are convenient, sandboxed environments for experimenting with AI agents.")
 	cmd.Alias("beam")
 	cmds := beamsCommands{
+		ls:      newBeamsListCommand(cmd),
+		add:     newBeamsAddCommand(cmd),
+		rm:      newBeamsRemoveCommand(cmd),
+		shell:   newBeamsShellCommand(cmd),
+		mount:   newBeamsMountCommand(cmd),
+		unmount: newBeamsUnmountCommand(cmd),
+		allow:   newBeamsAllowCommand(cmd),
+		deny:    newBeamsDenyCommand(cmd),
 	}
 	return cmds
 }

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -1,0 +1,18 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+)
+
+type beamsCommands struct {
+}
+
+func newBeamsCommands(
+	app *kingpin.Application,
+) beamsCommands {
+	cmd := app.Command("beams", "View, manage and run beam environments. Beams are convenient, sandboxed environments for experimenting with AI agents.")
+	cmd.Alias("beam")
+	cmds := beamsCommands{
+	}
+	return cmds
+}

--- a/tool/tsh/common/beams_add.go
+++ b/tool/tsh/common/beams_add.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsAddCommand struct {
+	*kingpin.CmdClause
+	name string
+	wait bool
+}
+
+func newBeamsAddCommand(parent *kingpin.CmdClause) *beamsAddCommand {
+	cmd := &beamsAddCommand{
+		CmdClause: parent.Command("add", "Start a new beam environment."),
+	}
+	cmd.Arg("name", "Name for the new beam (optional).").StringVar(&cmd.name)
+	cmd.Flag("wait", "Wait for the beam environment to become ready.").BoolVar(&cmd.wait)
+	return cmd
+}
+
+func (c *beamsAddCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = tc.AddBeam(ctx, c.name, c.wait)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_allow.go
+++ b/tool/tsh/common/beams_allow.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsAllowCommand struct {
+	*kingpin.CmdClause
+	name   string
+	domain string
+}
+
+func newBeamsAllowCommand(parent *kingpin.CmdClause) *beamsAllowCommand {
+	cmd := &beamsAllowCommand{
+		CmdClause: parent.Command("allow", "Grant access to an external domain."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("domain", "Domain to allow access to.").Required().StringVar(&cmd.domain)
+	return cmd
+}
+
+func (c *beamsAllowCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.AllowBeamDomain(ctx, c.name, c.domain)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_deny.go
+++ b/tool/tsh/common/beams_deny.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsDenyCommand struct {
+	*kingpin.CmdClause
+	name   string
+	domain string
+}
+
+func newBeamsDenyCommand(parent *kingpin.CmdClause) *beamsDenyCommand {
+	cmd := &beamsDenyCommand{
+		CmdClause: parent.Command("deny", "Remove access to an external domain."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("domain", "Domain to deny access to.").Required().StringVar(&cmd.domain)
+	return cmd
+}
+
+func (c *beamsDenyCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.DenyBeamDomain(ctx, c.name, c.domain)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_list.go
+++ b/tool/tsh/common/beams_list.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsListCommand struct {
+	*kingpin.CmdClause
+	format   string
+	allUsers bool
+}
+
+func newBeamsListCommand(parent *kingpin.CmdClause) *beamsListCommand {
+	cmd := &beamsListCommand{
+		CmdClause: parent.Command("ls", "List running beam environments."),
+	}
+	cmd.Alias("list")
+	cmd.Flag("format", "Format output (text, json, yaml).").
+		Short('f').
+		Default("text").
+		EnumVar(&cmd.format, "text", "json", "yaml")
+	cmd.Flag("all", "List beams for all users.").BoolVar(&cmd.allUsers)
+	return cmd
+}
+
+func (c *beamsListCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = tc.ListBeams(ctx, c.allUsers)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_mount.go
+++ b/tool/tsh/common/beams_mount.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsMountCommand struct {
+	*kingpin.CmdClause
+	name   string
+	source string
+	dest   string
+}
+
+func newBeamsMountCommand(parent *kingpin.CmdClause) *beamsMountCommand {
+	cmd := &beamsMountCommand{
+		CmdClause: parent.Command("mount", "Mount a local directory in a beam environment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("source", "Path to a local directory.").Required().StringVar(&cmd.source)
+	cmd.Flag("dest", "Mount location in the beam's filesystem.").Required().StringVar(&cmd.dest)
+	return cmd
+}
+
+func (c *beamsMountCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.MountBeam(ctx, c.name, c.source, c.dest)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_rm.go
+++ b/tool/tsh/common/beams_rm.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsRemoveCommand struct {
+	*kingpin.CmdClause
+	name string
+}
+
+func newBeamsRemoveCommand(parent *kingpin.CmdClause) *beamsRemoveCommand {
+	cmd := &beamsRemoveCommand{
+		CmdClause: parent.Command("rm", "Delete a running beam environment."),
+	}
+	cmd.Alias("remove")
+	cmd.Arg("name", "Name of the beam to delete.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsRemoveCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.RemoveBeam(ctx, c.name)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_shell.go
+++ b/tool/tsh/common/beams_shell.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsShellCommand struct {
+	*kingpin.CmdClause
+	name string
+}
+
+func newBeamsShellCommand(parent *kingpin.CmdClause) *beamsShellCommand {
+	cmd := &beamsShellCommand{
+		CmdClause: parent.Command("shell", "Start an interactive shell in a running beam environment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	return cmd
+}
+
+func (c *beamsShellCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.ShellBeam(ctx, c.name)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_unmount.go
+++ b/tool/tsh/common/beams_unmount.go
@@ -1,0 +1,34 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsUnmountCommand struct {
+	*kingpin.CmdClause
+	name string
+	dest string
+}
+
+func newBeamsUnmountCommand(parent *kingpin.CmdClause) *beamsUnmountCommand {
+	cmd := &beamsUnmountCommand{
+		CmdClause: parent.Command("unmount", "Remove a mounted directory from a beam evironment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("dest", "Mount location in the beam's filesystem.").Required().StringVar(&cmd.dest)
+	return cmd
+}
+
+func (c *beamsUnmountCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.UnmountBeam(ctx, c.name, c.dest)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1491,6 +1491,7 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	vnetUninstallServiceCommand := newVnetUninstallServiceCommand(app)
 
 	gitCmd := newGitCommands(app)
+	beamsCmd := newBeamsCommands(app)
 	pivCmd := newPIVCommands(app)
 	mcpCmd := newMCPCommands(app, &cf)
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1943,6 +1943,22 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = gitCmd.config.run(&cf)
 	case gitCmd.clone.FullCommand():
 		err = gitCmd.clone.run(&cf)
+	case beamsCmd.ls.FullCommand():
+		err = beamsCmd.ls.run(&cf)
+	case beamsCmd.add.FullCommand():
+		err = beamsCmd.add.run(&cf)
+	case beamsCmd.rm.FullCommand():
+		err = beamsCmd.rm.run(&cf)
+	case beamsCmd.shell.FullCommand():
+		err = beamsCmd.shell.run(&cf)
+	case beamsCmd.mount.FullCommand():
+		err = beamsCmd.mount.run(&cf)
+	case beamsCmd.unmount.FullCommand():
+		err = beamsCmd.unmount.run(&cf)
+	case beamsCmd.allow.FullCommand():
+		err = beamsCmd.allow.run(&cf)
+	case beamsCmd.deny.FullCommand():
+		err = beamsCmd.deny.run(&cf)
 	case pivCmd.agent.FullCommand():
 		err = pivCmd.agent.run(&cf)
 	case mcpCmd.dbStart.FullCommand():


### PR DESCRIPTION
## Summary
This change adds stubbed implementations of the core sub-commands for Beams.

## Changes
- Stubbed implementations for each command
- Updated the `tsh` CLI reference

## Demo
<img width="1007" height="744" alt="Screenshot 2026-02-18 at 14 22 02" src="https://github.com/user-attachments/assets/8c2f92fb-e550-44ad-98ea-096380d519dc" />
<img width="1007" height="744" alt="Screenshot 2026-02-18 at 14 22 11" src="https://github.com/user-attachments/assets/7de5743d-2e33-45b9-88ef-502c01045868" />
