### PR TITLE
feat(beams): Add stubbed `tsh` convenience sub-commands

### DIFF
--- a/docs/pages/reference/cli/tsh.mdx
+++ b/docs/pages/reference/cli/tsh.mdx
@@ -278,6 +278,53 @@ Arguments:
 |---|---|---|
 |name|none (required)|Name of the beam to target.|
 
+## tsh beams exec
+
+Run a command in a running beam environment.
+
+Usage:
+
+```code
+$ tsh beams exec [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--cmd`|none (required)|Command to execute in the environment.|
+|`--dir`|root (`/`)|Directory to run the command in (optional).|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams expose
+
+Serve an HTTP or TCP service running in a beam environment.
+
+Usage:
+
+```code
+$ tsh beams expose [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--mode`|`http`|Transport mode for the connection.|
+|`--port`|`8080`|Local beam environment port to expose.|
+|`--name`|none|Name of the exposed application (optional).|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
 ## tsh beams ls
 
 List running beam environments.
@@ -318,6 +365,52 @@ Arguments:
 |---|---|---|
 |name|none (required)|Name of the beam to target.|
 
+## tsh beams pull
+
+Copy a file from a running beam environment to the local filesystem.
+
+Usage:
+
+```code
+$ tsh beams pull [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--local`|none (required)|Local copy location.|
+|`--remote`|none (required)|Remote file to copy.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
+## tsh beams push
+
+Copy a local file to a running beam environment.
+
+Usage:
+
+```code
+$ tsh beams push [<flags>] <name>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--local`|none (required)|Local file to copy.|
+|`--remote`|none (required)|Remote copy location.|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|name|none (required)|Name of the beam to target.|
+
 ## tsh beams rm
 
 Delete a running beam environment.
@@ -333,6 +426,28 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |name|none (required)|Name of the beam to delete.|
+
+## tsh beams run
+
+Run a command in an ephemeral beam environment.
+
+Usage:
+
+```code
+$ tsh beams run <command>
+```
+
+Flags:
+
+|Flag|Default|Description|
+|---|---|---|
+|`--dir`|root (`/`)|Directory to run the command in (optional).|
+
+Arguments:
+
+|Argument|Default|Description|
+|---|---|---|
+|command|none (required)|Command to execute in the environment.|
 
 ## tsh beams shell
 
@@ -371,6 +486,16 @@ Arguments:
 |Argument|Default|Description|
 |---|---|---|
 |name|none (required)|Name of the beam to target.|
+
+## tsh beams vibe
+
+Start an ephemeral vibe-coding session in a sandboxed environment.
+
+Usage:
+
+```code
+$ tsh beams vibe [<flags>]
+```
 
 ## tsh clusters
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -5618,13 +5618,17 @@ func CalculateSSHLogins(identityPrincipals []string, allowedLogins []string) ([]
 	return logins, nil
 }
 
+type beam struct {
+	Name string
+}
+
 // ListBeams returns a list of beams, either for the current user or all users.
 func (tc *TeleportClient) ListBeams(ctx context.Context, allUsers bool) ([]any, error) {
 	return nil, trace.NotImplemented("TeleportClient.ListBeams is stubbed")
 }
 
 // AddBeam starts a new beam environment.
-func (tc *TeleportClient) AddBeam(ctx context.Context, name string, wait bool) (any, error) {
+func (tc *TeleportClient) AddBeam(ctx context.Context, name string, wait bool) (*beam, error) {
 	return nil, trace.NotImplemented("TeleportClient.AddBeam is stubbed")
 }
 
@@ -5648,6 +5652,11 @@ func (tc *TeleportClient) UnmountBeam(ctx context.Context, name, dest string) er
 	return trace.NotImplemented("TeleportClient.UnmountBeam is stubbed")
 }
 
+// ExposeBeam serves an HTTP or TCP service running in a beam environment.
+func (tc *TeleportClient) ExposeBeam(ctx context.Context, name, mode string, port int, serviceName string) error {
+	return trace.NotImplemented("TeleportClient.ExposeBeam is stubbed")
+}
+
 // AllowBeamDomain grants access to an external domain.
 func (tc *TeleportClient) AllowBeamDomain(ctx context.Context, name, domain string) error {
 	return trace.NotImplemented("TeleportClient.AllowBeamDomain is stubbed")
@@ -5658,3 +5667,7 @@ func (tc *TeleportClient) DenyBeamDomain(ctx context.Context, name, domain strin
 	return trace.NotImplemented("TeleportClient.DenyBeamDomain is stubbed")
 }
 
+// ExecBeam runs a command in a running beam environment.
+func (tc *TeleportClient) ExecBeam(ctx context.Context, name, command, dir string) (any, error) {
+	return nil, trace.NotImplemented("TeleportClient.ExecBeam is stubbed")
+}

--- a/tool/tsh/common/beams.go
+++ b/tool/tsh/common/beams.go
@@ -8,11 +8,17 @@ type beamsCommands struct {
 	ls      *beamsListCommand
 	add     *beamsAddCommand
 	rm      *beamsRemoveCommand
+	exec    *beamsExecCommand
 	shell   *beamsShellCommand
 	mount   *beamsMountCommand
 	unmount *beamsUnmountCommand
+	expose  *beamsExposeCommand
+	push    *beamsPushCommand
+	pull    *beamsPullCommand
 	allow   *beamsAllowCommand
 	deny    *beamsDenyCommand
+	vibe    *beamsVibeCommand
+	run     *beamsRunCommand
 }
 
 func newBeamsCommands(
@@ -24,11 +30,17 @@ func newBeamsCommands(
 		ls:      newBeamsListCommand(cmd),
 		add:     newBeamsAddCommand(cmd),
 		rm:      newBeamsRemoveCommand(cmd),
+		exec:    newBeamsExecCommand(cmd),
 		shell:   newBeamsShellCommand(cmd),
 		mount:   newBeamsMountCommand(cmd),
 		unmount: newBeamsUnmountCommand(cmd),
+		expose:  newBeamsExposeCommand(cmd),
+		push:    newBeamsPushCommand(cmd),
+		pull:    newBeamsPullCommand(cmd),
 		allow:   newBeamsAllowCommand(cmd),
 		deny:    newBeamsDenyCommand(cmd),
+		vibe:    newBeamsVibeCommand(cmd),
+		run:     newBeamsRunCommand(cmd),
 	}
 	return cmds
 }

--- a/tool/tsh/common/beams_exec.go
+++ b/tool/tsh/common/beams_exec.go
@@ -1,0 +1,36 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsExecCommand struct {
+	*kingpin.CmdClause
+	name string
+	cmd  string
+	dir  string
+}
+
+func newBeamsExecCommand(parent *kingpin.CmdClause) *beamsExecCommand {
+	cmd := &beamsExecCommand{
+		CmdClause: parent.Command("exec", "Run a command in a running beam environment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("cmd", "Command to execute in the environment.").Required().StringVar(&cmd.cmd)
+	cmd.Flag("dir", "Directory to run the command in (optional).").StringVar(&cmd.dir)
+	return cmd
+}
+
+func (c *beamsExecCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = tc.ExecBeam(ctx, c.name, c.cmd, c.dir)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_expose.go
+++ b/tool/tsh/common/beams_expose.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsExposeCommand struct {
+	*kingpin.CmdClause
+	name        string
+	mode        string
+	port        int
+	serviceName string
+}
+
+func newBeamsExposeCommand(parent *kingpin.CmdClause) *beamsExposeCommand {
+	cmd := &beamsExposeCommand{
+		CmdClause: parent.Command("expose", "Serve an HTTP or TCP service running in a beam environment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("mode", "Transport mode for the connection.").Default("http").StringVar(&cmd.mode)
+	cmd.Flag("port", "Local beam environment port to expose.").Default("8080").IntVar(&cmd.port)
+	cmd.Flag("name", "Name of the exposed application (optional).").StringVar(&cmd.serviceName)
+	return cmd
+}
+
+func (c *beamsExposeCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = tc.ExposeBeam(ctx, c.name, c.mode, c.port, c.serviceName)
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_pull.go
+++ b/tool/tsh/common/beams_pull.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsPullCommand struct {
+	*kingpin.CmdClause
+	name   string
+	remote string
+	local  string
+}
+
+func newBeamsPullCommand(parent *kingpin.CmdClause) *beamsPullCommand {
+	cmd := &beamsPullCommand{
+		CmdClause: parent.Command("pull", "Copy a file from a running beam environment to the local filesystem."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("remote", "Remote file to copy.").Required().StringVar(&cmd.remote)
+	cmd.Flag("local", "Local copy location.").Required().StringVar(&cmd.local)
+	return cmd
+}
+
+func (c *beamsPullCommand) run(cf *CLIConf) error {
+	// TODO: Use `tsh scp`
+
+	return trace.NotImplemented("`tsh beams pull` is stubbed")
+}

--- a/tool/tsh/common/beams_push.go
+++ b/tool/tsh/common/beams_push.go
@@ -1,0 +1,29 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsPushCommand struct {
+	*kingpin.CmdClause
+	name   string
+	local  string
+	remote string
+}
+
+func newBeamsPushCommand(parent *kingpin.CmdClause) *beamsPushCommand {
+	cmd := &beamsPushCommand{
+		CmdClause: parent.Command("push", "Copy a local file to a running beam environment."),
+	}
+	cmd.Arg("name", "Name of the beam to target.").Required().StringVar(&cmd.name)
+	cmd.Flag("local", "Local file to copy.").Required().StringVar(&cmd.local)
+	cmd.Flag("remote", "Remote copy location.").Required().StringVar(&cmd.remote)
+	return cmd
+}
+
+func (c *beamsPushCommand) run(cf *CLIConf) error {
+	// TODO: Use `tsh scp`
+
+	return trace.NotImplemented("`tsh beams push` is stubbed")
+}

--- a/tool/tsh/common/beams_run.go
+++ b/tool/tsh/common/beams_run.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsRunCommand struct {
+	*kingpin.CmdClause
+	command string
+	dir     string
+}
+
+func newBeamsRunCommand(parent *kingpin.CmdClause) *beamsRunCommand {
+	cmd := &beamsRunCommand{
+		CmdClause: parent.Command("run", "Run a command in an ephemaral beam environment."),
+	}
+	cmd.Arg("command", "Command to execute in the environment.").Required().StringVar(&cmd.command)
+	cmd.Flag("dir", "Directory to run the command in (optional).").StringVar(&cmd.dir)
+	return cmd
+}
+
+func (c *beamsRunCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	beam, err := tc.AddBeam(ctx, "", true)
+	if err != nil {
+		return trace.Wrap(err, "adding beam")
+	}
+
+	_, err = tc.ExecBeam(ctx, beam.Name, c.command, c.dir)
+	if err != nil {
+		return trace.Wrap(err, "executing beam command")
+	}
+
+	// TODO print command output
+
+	err = tc.RemoveBeam(ctx, beam.Name)
+	if err != nil {
+		return trace.Wrap(err, "removing beam")
+	}
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/beams_vibe.go
+++ b/tool/tsh/common/beams_vibe.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/gravitational/trace"
+)
+
+type beamsVibeCommand struct {
+	*kingpin.CmdClause
+}
+
+const helpLong = `Start an ephemeral vibe-coding session in a sandboxed environment.
+
+A convenience for;
+    tsh beams add my-beam --wait
+    tsh beams mount my-beam --source=./ --dest=/mnt/workspace
+    tsh beams expose my-beam --mode=http --port=8080
+    tsh beams shell my-beam
+    tsh beams unmount my-beam --dest=/mnt/workspace
+    tsh beams rm my-beam
+`
+
+func newBeamsVibeCommand(parent *kingpin.CmdClause) *beamsVibeCommand {
+	cmd := &beamsVibeCommand{
+		CmdClause: parent.Command("vibe", "Start an ephemeral vibe-coding session in a sandboxed environment."),
+	}
+	return cmd
+}
+
+func (c *beamsVibeCommand) run(cf *CLIConf) error {
+	ctx := cf.Context
+
+	tc, err := makeClient(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	beam, err := tc.AddBeam(ctx, "", true)
+	if err != nil {
+		return trace.Wrap(err, "adding beam")
+	}
+
+	err = tc.MountBeam(ctx, beam.Name, "./", "/mnt/workspace")
+	if err != nil {
+		return trace.Wrap(err, "mounting beam workspace")
+	}
+
+	err = tc.ExposeBeam(ctx, beam.Name, "http", 8080, "")
+	if err != nil {
+		return trace.Wrap(err, "exposing beam service")
+	}
+
+	err = tc.ShellBeam(ctx, beam.Name) // Returns when the shell session ends
+	if err != nil {
+		return trace.Wrap(err, "shelling to beam")
+	}
+
+	err = tc.UnmountBeam(ctx, beam.Name, "/mnt/workspace")
+	if err != nil {
+		return trace.Wrap(err, "unmounting beam workspace")
+	}
+
+	err = tc.RemoveBeam(ctx, beam.Name)
+	if err != nil {
+		return trace.Wrap(err, "removing beam")
+	}
+
+	return trace.Wrap(err)
+}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1949,16 +1949,28 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = beamsCmd.add.run(&cf)
 	case beamsCmd.rm.FullCommand():
 		err = beamsCmd.rm.run(&cf)
+	case beamsCmd.exec.FullCommand():
+		err = beamsCmd.exec.run(&cf)
 	case beamsCmd.shell.FullCommand():
 		err = beamsCmd.shell.run(&cf)
 	case beamsCmd.mount.FullCommand():
 		err = beamsCmd.mount.run(&cf)
 	case beamsCmd.unmount.FullCommand():
 		err = beamsCmd.unmount.run(&cf)
+	case beamsCmd.expose.FullCommand():
+		err = beamsCmd.expose.run(&cf)
+	case beamsCmd.push.FullCommand():
+		err = beamsCmd.push.run(&cf)
+	case beamsCmd.pull.FullCommand():
+		err = beamsCmd.pull.run(&cf)
 	case beamsCmd.allow.FullCommand():
 		err = beamsCmd.allow.run(&cf)
 	case beamsCmd.deny.FullCommand():
 		err = beamsCmd.deny.run(&cf)
+	case beamsCmd.vibe.FullCommand():
+		err = beamsCmd.vibe.run(&cf)
+	case beamsCmd.run.FullCommand():
+		err = beamsCmd.run.run(&cf)
 	case pivCmd.agent.FullCommand():
 		err = pivCmd.agent.run(&cf)
 	case mcpCmd.dbStart.FullCommand():


### PR DESCRIPTION
## Summary
This change adds stubbed implementations of the composite and convenience sub-commands for Beams. These commands are not in scope for the POC and may never be required.

## Changes
- Add sub-commands (exec, expose, pull, push, run, vibe)
- Updated the `tsh` CLI reference

## Demo
<img width="1015" height="744" alt="Screenshot 2026-02-18 at 15 29 51" src="https://github.com/user-attachments/assets/10307965-9a39-4e1d-89fa-933da5b1cbe7" />
