### PR TITLE
docs: updating IaC docs homepage and adding new IaC page

### DIFF
--- a/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/infrastructure-as-code.mdx
@@ -1,187 +1,166 @@
 ---
 title: Infrastructure as Code
-description: An introduction to managing Teleport with Infrastructure as Code tools, including Terraform and Kubernetes resources.
+description: Configure users, roles, authentication connectors, and more with tctl, Terraform, and Kubernetes resources.
+template: doc-page
+sidebar_label: Infrastructure as Code
 sidebar_position: 5
 tags:
  - infrastructure-as-code
  - conceptual
  - zero-trust
 ---
+import DocHero from "@site/src/components/Pages/Landing/DocHero";
+import Resources from "@site/src/components/Pages/Homepage/Resources";
 
-This section explains how to manage Teleport using infrastructure as code (IaC)
-tools.
+import iacImg from '@version/docs/img/dynamic-resources.png';
+import terraformSvg from "@site/src/components/Icon/svg/terraform.svg";
+import kubernetesClustersSvg from "@site/src/components/Icon/teleport-svg/kubernetes-clusters.svg";
+import cliSvg from "@site/src/components/Icon/teleport-svg/cli.svg";
+import userListSvg from "@site/src/components/Icon/svg/user-list.svg";
+import hardDrivesSvg from "@site/src/components/Icon/svg/hard-drives.svg";
+import kubernetesPurpleSvg from "@site/src/components/Icon/svg/kubernetes-purple.svg";
+import keyholePurpleSvg from "@site/src/components/Icon/svg/keyhole-purple.svg";
+import graphSvg from "@site/src/components/Icon/svg/graph.svg";
+import bookOpenSvg from "@site/src/components/Icon/teleport-svg/book-open.svg";
 
-Teleport provides three methods for managing Teleport with infrastructure as
-code tools: 
-- [Teleport Terraform provider](terraform-provider/terraform-provider.mdx)
-- [Teleport Kubernetes operator](teleport-operator/teleport-operator.mdx)
-- [`tctl` client tool](using-tctl.mdx)
+<DocHero
+  title="Managing Teleport with IaC"
+  image={iacImg}
+>
+  Use infrastructure as code tools to manage dynamic Teleport resources, including users, roles, and protected infrastructure. Dynamic resources are stored by the Auth Service and can be updated using the `tctl` CLI, Terraform, or the Kubernetes Operator.
 
-For instructions on managing users, roles, trusted clusters, and other resources
-with IaC tools, see [Managing Resources with Infrastructure as
-Code](managing-resources/managing-resources.mdx).
+  Some dynamic resources share fields with the static configuration file. Learn how Teleport [reconciles static and dynamic configuration](./static-and-dynamic-configuration.mdx) when these overlap.
+</DocHero>
 
-## How IaC works with Teleport
+<Resources
+  title="Getting started"
+  secondaryTitle="Step 1: Manage your Teleport cluster"
+  description="Teleport provides three methods for managing Teleport with infrastructure as code tools:"
+  desktopColumnsCount={3}
+  variant="doc"
+  titleSize="h2"
+  iconsSize="small"
+  descriptionsFontSize="lg"
+  resources={[
+    {
+      title: "Teleport Terraform Provider",
+      description: "Manage dynamic Teleport resources with Terraform.",
+      iconComponent: terraformSvg,
+      href: "./terraform-provider/",
+      links: [
+        {
+          title: "Get started",
+          href: "./terraform-provider/terraform-getting-started/"
+        },
+        {
+          title: "Setup guides",
+          href: "./terraform-provider/"
+        },
+        {
+          title: "Terraform reference",
+          href: "../../reference/infrastructure-as-code/terraform-provider/"
+        },
+        {
+          title: "Import Teleport resources",
+          href: "./terraform-provider/import-existing-resources/"
+        }
+      ]
+    },
+    {
+      title: "Teleport Kubernetes Operator",
+      description: `
+        Manage Teleport resources directly from Kubernetes using the <a href="https://kubernetes.io/docs/concepts/extend-kubernetes/operator/" rel="noopener noreferrer" target="_blank">operator pattern</a>.
+      `,
+      iconComponent: kubernetesClustersSvg,
+      href: "./teleport-operator/",
+      links: [
+        {
+          title: "Deploy with a cluster",
+          href: "./teleport-operator/teleport-operator-helm/"
+        },
+        {
+          title: "Deploy without a cluster",
+          href: "./teleport-operator/teleport-operator-standalone/"
+        },
+        {
+          title: "Secret lookup",
+          href: "./teleport-operator/secret-lookup/"
+        },
+        {
+          title: "Troubleshooting",
+          href: "./teleport-operator/#troubleshooting"
+        }
+      ]
+    },
+    {
+      title: "tctl client tool",
+      description: "Manage Teleport dynamic resources with <code>tctl</code> command-line tool.",
+      iconComponent: cliSvg,
+      href: "./using-tctl/",
+      links: [
+        {
+          title: "tctl CLI reference",
+          href: "../../reference/cli/tctl/"
+        },
+        {
+          title: "tctl get commands",
+          href: "../../reference/cli/tctl/#tctl-get"
+        },
+      ]
+    }
+  ]}
+/>
 
-There are two ways to configure a Teleport cluster:
-
-- **Static configuration file:** At startup, a Teleport process reads a
-  configuration file from the local filesystem (the default path is
-  `/etc/teleport.yaml`). Static configuration settings control aspects of a
-  cluster that are not expected to change frequently, like the ports that
-  services listen on. (See the [Configuration
-  Reference](../../reference/deployment/config.mdx) for all static configuration
-  options.)
-- **Dynamic resources:** Dynamic resources control aspects of your cluster that
-  are likely to change over time, such as roles, local users, and
-  Teleport-protected infrastructure resources.
-
-![Architecture of dynamic resources](../../../img/dynamic-resources.png)
-
-The Teleport Auth Service stores dynamic resources on its cluster state backend,
-and clients can authenticate to the Auth Service to read or write dynamic
-resources, depending on their permissions. Infrastructure as code tools can
-authenticate to a Teleport cluster to manage dynamic resources.
-
-## Reconciling static and dynamic configurations
-
-Some dynamic resources assign the same settings as fields within
-Teleport's static configuration file. For these fields, the Teleport Auth
-Service reconciles static and dynamic configurations on startup and when you
-create or remove a Teleport resource.
-
-While Teleport Enterprise Cloud does not expose the static configuration file to
-operators, they do use a static configuration file for certain settings.
-
-### Configuration resources that apply to static configuration fields
-
-There are four dynamic resources that share fields with the
-static configuration file:
-
-- `session_recording_config`
-- `cluster_auth_preference`
-- `cluster_networking_config`
-- `ui_config`
-
-#### `session_recording_config`
-
-|Dynamic resource field|Static configuration field|
-|---|---|
-|`spec.mode`|`auth_service.session_recording`|
-|`spec.proxy_checks_host_keys`|`auth_service.proxy_checks_host_keys`|
-
-#### `cluster_auth_preference`
-
-|Dynamic resource field|Static configuration field|
-|---|---|
-|`spec.type`|`auth_service.authentication.type`|
-|`spec.second_factor`|`auth_service.authentication.second_factor`|
-|`spec.second_factors`|`auth_service.authentication.second_factors`|
-|`spec.connector_name`|`auth_service.authentication.connector_name`
-|`spec.u2f`|`auth_service.authentication.u2f`|
-|`spec.disconnect_expired_cert`|`auth_service.disconnect_expired_cert`|
-|`spec.allow_local_auth`|`auth_service.authentication.local_auth`|
-|`spec.message_of_the_day`|`auth_service.message_of_the_day`|
-|`spec.locking_mode`|`auth_service.authentication.locking_mode`|
-|`spec.webauthn`|`auth_service.authentication.webauthn`|
-|`spec.require_session_mfa`|`auth_service.authentication.require_session_mfa`|
-|`spec.allow_passwordless`|`auth_service.authentication.passwordless`|
-|`spec.device_trust`|`auth_service.authentication.device_trust`|
-|`spec.idp`|`proxy_service.idp`|
-|`spec.allow_headless`|`auth_service.authentication.headless`|
-
-#### `cluster_networking_config`
-
-|Dynamic resource field|Static configuration field|
-|---|---|
-|`spec.client_idle_timeout`|`auth_service.client_idle_timeout`|
-|`spec.keep_alive_interval`|`auth_service.keep_alive_interval`|
-|`spec.keep_alive_count_max`|`auth_service.keep_alive_count_max`|
-|`spec.session_control_timeout`|`auth_service.session_control_timeout`|
-|`spec.idle_timeout_message`|`auth_service.client_idle_timeout_message`|
-|`spec.web_idle_timeout`|`auth_service.web_idle_timeout`|
-|`spec.proxy_listener_mode`|`auth_service.proxy_listener_mode`|
-|`spec.routing_strategy`|`auth_service.routing_strategy`|
-|`spec.tunnel_strategy`|`auth_service.tunnel_strategy`|
-|`spec.proxy_ping_interval`|`auth_service.proxy_ping_interval`|
-|`spec.case_insensitive_routing`|`auth_service.case_insensitive_routing`|
-
-#### `ui_config`
-
-| Dynamic resource field  | Static configuration field          |
-| ----------------------- | ----------------------------------- |
-| `spec.scrollback_lines` | `proxy_service.ui.scrollback_lines` |
-| `spec.show_resources`   | `proxy_service.ui.show_resources`   |
-
-## Origin labels
-
-The Teleport Auth Service applies the `teleport.dev/origin` label to
-configuration resources to indicate whether they originated from the static
-configuration file, a dynamic configuration resource, or the default value.
-
-Here are possible values of the `teleport.dev/origin` label:
-
-- `defaults`
-- `config-file`
-- `dynamic`
-- `terraform`
-- `kubernetes`
-
-When the Auth Service starts up, it looks up the values of static configuration
-fields that correspond to fields in dynamic configuration resources. If any of
-these have values, it creates the corresponding dynamic configuration resources
-and stores them in its backend.
-
-For any static configuration fields without a value, the Auth Service checks
-whether the backend contains the corresponding dynamic configuration resource.
-If not, it creates one with default values and the
-`teleport.dev/origin=defaults` label.
-
-If you attempt to create a dynamic configuration resource after the Auth Service
-has already loaded the configuration from a static configuration file, the Auth
-Service will return an error.
-
-If you remove a dynamic configuration resource, the Auth Service will restore
-its configuration fields to the default values and add the
-`teleport.dev/origin=defaults` label.
-
-<Admonition type="tip">
-
-Cloud-hosted Teleport deployments use configuration files, but these are not
-available for operators to modify. Users of Teleport Enterprise Cloud may see
-configuration resources with the `teleport.dev/origin=config-file` label.
-
-</Admonition>
-
-## Dynamic resource references
-
-Read the following reference guides for comprehensive lists of supported fields
-in Teleport dynamic resources:
-
-### tctl resources
-
-For reference guides to dynamic configuration resources available to apply using
-`tctl`, read the [Configuration Resource
-Reference](../../reference/infrastructure-as-code/teleport-resources/teleport-resources.mdx). There are also
-dedicated configuration resource references for
-[applications](../../enroll-resources/application-access/reference.mdx) and
-[databases](../../enroll-resources/database-access/reference/configuration.mdx).
-
-### Terraform resources and data sources
-
-For comprehensive reference guides for resources and data sources you can manage
-with the Teleport Terraform provider, see [Teleport Terraform Provider
-References](../../reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx).
-
-### Kubernetes operator resources 
-
-For comprehensive reference guides for resources you can manage with the
-Kubernetes operator, see [Teleport Kubernetes Operator Resource
-References](../../reference/infrastructure-as-code/operator-resources/operator-resources.mdx).
-
-## Other ways to use the dynamic resource API
-
-The Teleport Kubernetes Operator, Terraform provider, and `tctl` are all clients
-of the Teleport Auth Service's gRPC API. To build your own API client to extend
-Teleport for your organization's needs, read our [API
-guides](../api/api.mdx).
+<Resources
+  title=""
+  secondaryTitle="Step 2: Manage dynamic resources"
+  desktopColumnsCount={3}
+  variant="doc"
+  titleSize="h2"
+  iconsSize="small"
+  descriptionsFontSize="lg"
+  resources={[
+    {
+      title: "Access Lists",
+      description: "Create and manage Access Lists.",
+      href: "./managing-resources/access-list/",
+      iconComponent: userListSvg,
+    },
+    {
+      title: "Agentless OpenSSH servers",
+      description: "Register Agentless OpenSSH servers in Teleport.",
+      href: "./managing-resources/agentless-ssh-servers/",
+      iconComponent: hardDrivesSvg,
+    },
+    {
+      title: "Kubernetes OIDC joining",
+      description: "Join Kubernetes agents without secret tokens.",
+      href: "./managing-resources/kubernetes-oidc-join-token/",
+      iconComponent: kubernetesPurpleSvg,
+    },
+    {
+      title: "Login Rules (Kubernetes Operator)",
+      description: "Deploy Login Rules using the Kubernetes Operator.",
+      href: "./managing-resources/login-rules-operator/",
+      iconComponent: keyholePurpleSvg,
+    },
+    {
+      title: "Login Rules (Terraform Provider)",
+      description: "Deploy Login Rules using Terraform.",
+      href: "./managing-resources/login-rules-terraform/",
+      iconComponent: keyholePurpleSvg,
+    },
+    {
+      title: "Trusted clusters",
+      description: "Create and configure Teleport trusted clusters.",
+      href: "./managing-resources/trusted-cluster/",
+      iconComponent: graphSvg,
+    },
+    {
+      title: "Users and roles",
+      description: "Create and manage Teleport users and roles.",
+      href: "./managing-resources/user-and-role/",
+      iconComponent: bookOpenSvg,
+    },
+  ]}
+/>

--- a/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/managing-resources/managing-resources.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Managing Resources with Infrastructure as Code"
 sidebar_label: Managing Resources
-sidebar_position: 1
+sidebar_position: 2
 description: Provides instructions on managing specific dynamic resources with tctl and the Teleport Terraform provider and Kubernetes operator.
 template: "no-toc"
 tags:

--- a/docs/pages/zero-trust-access/infrastructure-as-code/static-and-dynamic-configuration.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/static-and-dynamic-configuration.mdx
@@ -1,0 +1,107 @@
+---
+title: Static and Dynamic Configuration
+description: Learn how Teleport reconciles static configuration files with dynamic resources managed through IaC tools.
+sidebar_position: 1
+tags:
+ - infrastructure-as-code
+ - conceptual
+ - zero-trust
+---
+
+Teleport supports two ways to configure a cluster:
+
+- **Static configuration file:** At startup, a Teleport process reads a configuration file from the local filesystem (the default path is `/etc/teleport.yaml`). Static configuration settings control aspects of a cluster that are not expected to change frequently, like the ports that services listen on. (See the [Configuration Reference](../../reference/deployment/config.mdx) for all static configuration options.)
+- **Dynamic resources:** Dynamic resources control aspects of your cluster that are likely to change over time, such as roles, local users, and Teleport-protected infrastructure resources.
+
+![The Teleport Auth Service stores dynamic resources on its cluster state backend, and clients can authenticate to the Auth Service to read or write dynamic resources, depending on their permissions. Infrastructure as code tools can authenticate to a Teleport cluster to manage dynamic resources.](../../../img/dynamic-resources.png)
+
+## Reconciling static and dynamic configurations
+
+Some dynamic resources assign the same settings as fields within Teleport's static configuration file. For these fields, the Teleport Auth Service reconciles static and dynamic configurations on startup and when you create or remove a Teleport resource.
+
+While Teleport Enterprise Cloud does not expose the static configuration file to operators, they do use a static configuration file for certain settings.
+
+There are several dynamic resources that share fields with the static configuration file:
+
+### session_recording_config
+
+| Dynamic resource field             | Static configuration field                 |
+|------------------------------------|--------------------------------------------|
+| `spec.node`                        | `auth_service.session_recording`           |
+| `spec.proxy_checks_host_keys`      | `auth_service.proxy_checks_host_keys`      |
+
+### cluster_auth_preference
+
+| Dynamic resource field        | Static configuration field                              |
+|-------------------------------|---------------------------------------------------------|
+| `spec.type`                   | `auth_service.authentication.type`                      |
+| `spec.second_factors`         | `auth_service.authentication.second_factors`            |
+| `spec.connector_name`         | `auth_service.authentication.connector_name`            |
+| `spec.disconnect_expired_cert`| `auth_service.disconnect_expired_cert`                  |
+| `spec.allow_local_auth`       | `auth_service.authentication.local_auth`                |
+| `spec.message_of_the_day`     | `auth_service.message_of_the_day`                       |
+| `spec.locking_mode`           | `auth_service.authentication.locking_mode`              |
+| `spec.webauthn`               | `auth_service.authentication.webauthn`                  |
+| `spec.require_session_mfa`    | `auth_service.authentication.require_session_mfa`       |
+| `spec.allow_passwordless`     | `auth_service.authentication.passwordless`              |
+| `spec.device_trust`           | `auth_service.authentication.device_trust`              |
+| `spec.idp`                    | `proxy_service.idp`                                     |
+| `spec.allow_headless`         | `auth_service.authentication.headless`                  |
+
+### cluster_networking_config
+
+| Dynamic resource field           | Static configuration field                   |
+|----------------------------------|----------------------------------------------|
+| `spec.client_idle_timeout`       | `auth_service.client_idle_timeout`           |
+| `spec.keep_alive_interval`       | `auth_service.keep_alive_interval`           |
+| `spec.keep_alive_count_max`      | `auth_service.keep_alive_count_max`          |
+| `spec.session_control_timeout`   | `auth_service.session_control_timeout`       |
+| `spec.idle_timeout_message`      | `auth_service.client_idle_timeout_message`   |
+| `spec.web_idle_timeout`          | `auth_service.web_idle_timeout`              |
+| `spec.proxy_listener_mode`       | `auth_service.proxy_listener_mode`           |
+| `spec.routing_strategy`          | `auth_service.routing_strategy`              |
+| `spec.tunnel_strategy`           | `auth_service.tunnel_strategy`               |
+| `spec.proxy_ping_interval`       | `auth_service.proxy_ping_interval`           |
+| `spec.case_insensitive_routing`  | `auth_service.case_insensitive_routing`      |
+
+### ui_config
+
+| Dynamic resource field        | Static configuration field                 |
+|-------------------------------|--------------------------------------------|
+| `spec.scrollback_lines`       | `proxy_service.ui.scrollback_lines`        |
+| `spec.show_resources`         | `proxy_service.ui.show_resources`          |
+
+## Origin labels
+
+The Teleport Auth Service applies the `teleport.dev/origin` label to configuration resources to indicate whether they originated from the static configuration file, a dynamic configuration resource, or the default value.
+
+Here are possible values of the teleport.dev/origin label:
+
+- `defaults`
+- `config-file`
+- `dynamic`
+- `terraform`
+- `kubernetes`
+
+When the Auth Service starts up, it looks up the values of static configuration fields that correspond to fields in dynamic configuration resources. If any of these have values, it creates the corresponding dynamic configuration resources and stores them in its backend.
+
+For any static configuration fields without a value, the Auth Service checks whether the backend contains the corresponding dynamic configuration resource. If not, it creates one with default values and the `teleport.dev/origin=defaults` label.
+
+If you attempt to create a dynamic configuration resource after the Auth Service has already loaded the configuration from a static configuration file, the Auth Service will return an error.
+
+If you remove a dynamic configuration resource, the Auth Service will restore its configuration fields to the default values and add the `teleport.dev/origin=defaults` label.
+
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Teleport Cloud deployments use configuration files, but these are not available for operators to modify. Users of Teleport Enterprise Cloud may see configuration resources with the `teleport.dev/origin=config-file` label.
+</Admonition>
+
+## Dynamic resource references
+
+Read the following reference guides for comprehensive lists of supported fields in Teleport dynamic resources:
+
+- **tctl resources:** See the [Configuration Resource Reference](../../reference/infrastructure-as-code/teleport-resources/teleport-resources.mdx) for dynamic configuration resources available to apply using tctl. There are also dedicated configuration resource references for applications and databases.
+- **Terraform resources and data sources:** The [Teleport Terraform Provider References](../../reference/infrastructure-as-code/terraform-provider/terraform-provider.mdx) covers resources and data sources you can manage with the Teleport Terraform provider.
+- **Kubernetes operator resources:** Read the [Teleport Kubernetes Operator Resource References](../../reference/infrastructure-as-code/operator-resources/operator-resources.mdx) for resources you can manage with the Kubernetes operator.

--- a/docs/pages/zero-trust-access/infrastructure-as-code/using-tctl.mdx
+++ b/docs/pages/zero-trust-access/infrastructure-as-code/using-tctl.mdx
@@ -2,7 +2,7 @@
 title: "Getting Started with tctl"
 sidebar_label: tctl Admin Tool
 description: Provides a conceptual overview of tctl, the Teleport administrative client tool.
-sidebar_position: 2
+sidebar_position: 3
 tags:
 - conceptual
 - platform-wide


### PR DESCRIPTION
This commit updates an IaC docs page and adds a new one.First, we redesigned the infrastructure as code
homepage at `/zero-trust-access/infrastructure-as-code/`. Second, we created a new page `how-iac-works-with-teleport.mdx`. Figma design for both can be 
[here](https://www.figma.com/design/VxtetU0SfDgD16KQANzAMU/Documentation?node-id=5098-32068&p=f&t=9pVWe0rPdS9MEJNc-0). This is a buddy PR.

EDIT: Based on feedback, the new page `how-iac-works-with-teleport.mdx` is, instead, going to be `static-and-dynamic-configuration.mdx`. This page has also been shifted to the bottom of the section.