### PR TITLE
[v18] Improve the happy path of Client Tools Managed Update re-execution

### DIFF
--- a/integration/autoupdate/tools/main_test.go
+++ b/integration/autoupdate/tools/main_test.go
@@ -127,11 +127,11 @@ func TestMain(m *testing.M) {
 	if err := updater.Update(ctx, testVersions[0]); err != nil {
 		log.Fatalf("failed to update: %v", err)
 	}
-	tshPath, err = updater.ToolPath(tools.DefaultClientTools()[0], testVersions[0])
+	tshPath, err = updater.SelectTool(tools.DefaultClientTools()[0], testVersions[0])
 	if err != nil {
 		log.Fatalf("failed to get tsh path: %v", err)
 	}
-	tctlPath, err = updater.ToolPath(tools.DefaultClientTools()[1], testVersions[0])
+	tctlPath, err = updater.SelectTool(tools.DefaultClientTools()[1], testVersions[0])
 	if err != nil {
 		log.Fatalf("failed to get tctl path: %v", err)
 	}

--- a/integration/autoupdate/tools/updater/modules.go
+++ b/integration/autoupdate/tools/updater/modules.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/accesslist"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/keys/hardwarekey"
 	"github.com/gravitational/teleport/entitlements"
@@ -44,6 +45,9 @@ const (
 	TestPassword = "UPDATER_TEST_PASSWORD"
 	// TestBuild is env var for setting test build type during the test.
 	TestBuild = "UPDATER_TEST_BUILD"
+	// TestRequireFastReExecOnly is an envvar to require "fast" (local-only)
+	// re-execution for client tools.
+	TestRequireFastReExecOnly = "UPDATER_TEST_FAST_REEXEC_ONLY"
 )
 
 func init() {
@@ -57,6 +61,14 @@ func init() {
 	parts := strings.Split(path, string(filepath.Separator))
 	if len(parts) > 2 {
 		tools.Version = parts[len(parts)-2]
+	}
+
+	if e := os.Getenv(TestRequireFastReExecOnly); e != "" {
+		b, err := apiutils.ParseBool(e)
+		if err != nil {
+			panic(err)
+		}
+		tools.FastReExecOnly = b
 	}
 }
 

--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -70,7 +70,7 @@ func TestUpdate(t *testing.T) {
 	_, err = cmd.Output()
 	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr)
-	require.Equal(t, exitErr.ExitCode(), tools.FastReExecOnlyExitCode)
+	require.Equal(t, tools.FastReExecOnlyExitCode, exitErr.ExitCode())
 	require.Contains(t, string(exitErr.Stderr), tools.FastReExecOnlyErrorMessage)
 
 	// Execute version command again with setting the new version which must

--- a/integration/autoupdate/tools/updater_test.go
+++ b/integration/autoupdate/tools/updater_test.go
@@ -59,6 +59,20 @@ func TestUpdate(t *testing.T) {
 
 	matchVersion(t, string(out), testVersions[0])
 
+	// Require that the re-execution fast path does not work with a different
+	// requested version.
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	cmd.Env = append(
+		os.Environ(),
+		teleportToolsVersion+"="+testVersions[1],
+		updater.TestRequireFastReExecOnly+"=true",
+	)
+	_, err = cmd.Output()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	require.Equal(t, exitErr.ExitCode(), tools.FastReExecOnlyExitCode)
+	require.Contains(t, string(exitErr.Stderr), tools.FastReExecOnlyErrorMessage)
+
 	// Execute version command again with setting the new version which must
 	// trigger re-execution of the same command after downloading requested version.
 	cmd = exec.CommandContext(ctx, tshPath, "version")
@@ -70,6 +84,20 @@ func TestUpdate(t *testing.T) {
 	require.NoError(t, err)
 
 	matchVersion(t, string(out), testVersions[1])
+
+	// Require that we successfully hit the fast path for re-execution after the
+	// first time.
+	cmd = exec.CommandContext(ctx, tshPath, "version")
+	cmd.Env = append(
+		os.Environ(),
+		teleportToolsVersion+"="+testVersions[1],
+		updater.TestRequireFastReExecOnly+"=true",
+	)
+	out, err = cmd.Output()
+	require.NoError(t, err)
+
+	matchVersion(t, string(out), testVersions[1])
+
 }
 
 // TestUpdateDifferentOSArch verifies the update logic for matching operating system

--- a/lib/autoupdate/tools/config.go
+++ b/lib/autoupdate/tools/config.go
@@ -184,7 +184,7 @@ func (t *Tool) IsEqual(toolsDir, version, os, arch string) bool {
 // GetToolsConfig reads the configuration file for client tools managed updates,
 // and acquires a filesystem lock until the configuration is read and deserialized.
 func GetToolsConfig(toolsDir string) (ctc *ClientToolsConfig, err error) {
-	unlock, err := utils.FSWriteLock(filepath.Join(toolsDir, lockFileName))
+	unlock, err := utils.FSReadLock(filepath.Join(toolsDir, lockFileName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/autoupdate/tools/config.go
+++ b/lib/autoupdate/tools/config.go
@@ -107,6 +107,19 @@ func (ctc *ClientToolsConfig) SelectVersion(toolsDir, version, os, arch string) 
 	return nil
 }
 
+// SelectVersion returns the tool with the given version if it's the most
+// recently used.
+func (ctc *ClientToolsConfig) SelectVersionIfMostRecent(toolsDir, version, os, arch string) *Tool {
+	if len(ctc.Tools) == 0 {
+		return nil
+	}
+	if !ctc.Tools[0].IsEqual(toolsDir, version, os, arch) {
+		return nil
+	}
+	tool := ctc.Tools[0]
+	return &tool
+}
+
 // HasVersion check that specific version present in collection.
 func (ctc *ClientToolsConfig) HasVersion(toolsDir, version, os, arch string) bool {
 	return slices.ContainsFunc(ctc.Tools, func(tool Tool) bool {

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -102,7 +102,7 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 	}
 
 	slog.DebugContext(ctx, "Attempting to local update", "current_profile_name", currentProfileName)
-	resp, err := updater.CheckLocal(ctx, currentProfileName)
+	resp, _, err := updater.CheckLocal(ctx, currentProfileName)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to check local teleport versions, client tools updates are disabled", "error", err)
 		return nil

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -19,6 +19,7 @@
 package tools
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"log/slog"
@@ -210,7 +211,7 @@ func updateAndReExec(ctx context.Context, updater *Updater, toolsVersion string,
 	code, err := updater.Exec(ctx, toolsVersion, args)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		slog.DebugContext(ctx, "Failed to re-exec client tool", "error", err, "code", code)
-		os.Exit(code)
+		os.Exit(cmp.Or(code, 1))
 	} else if err == nil {
 		os.Exit(code)
 	}

--- a/lib/autoupdate/tools/helper.go
+++ b/lib/autoupdate/tools/helper.go
@@ -22,6 +22,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -59,6 +60,20 @@ func newUpdater(toolsDir string) (*Updater, error) {
 
 	return NewUpdater(toolsDir, Version, WithBaseURL(baseURL)), nil
 }
+
+// FastReExecOnly is set by CTMU integration tests to test the re-execution fast
+// path; it's exported because integration tests live in a different package,
+// and it should only be set early because [CheckAndUpdateLocal] will read it
+// unsynchronously.
+var FastReExecOnly = false
+
+// The exit code and error message (written by [fmt.Fprintln] on [os.Stderr])
+// used if [FastReExecOnly] is set and [CheckAndUpdateLocal] needs a
+// re-execution but can't use the fast path. Only used in tests.
+const (
+	FastReExecOnlyExitCode     = 82
+	FastReExecOnlyErrorMessage = "expected fast re-exec"
+)
 
 // CheckAndUpdateLocal verifies if the TELEPORT_TOOLS_VERSION environment variable
 // is set and whether a version is defined (or explicitly disabled by setting it to "off").
@@ -121,6 +136,10 @@ func CheckAndUpdateLocal(ctx context.Context, currentProfileName string, reExecA
 	}
 
 	if resp.ReExec {
+		if FastReExecOnly {
+			fmt.Fprintln(os.Stderr, FastReExecOnlyErrorMessage)
+			os.Exit(FastReExecOnlyExitCode)
+		}
 		return trace.Wrap(updateAndReExec(ctx, updater, resp.Version, reExecArgs))
 	}
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -844,6 +844,12 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		DTAutoEnroll:       dtenroll.AutoEnroll,
 	}
 
+	// run early to enable debug logging if env var is set.
+	// this makes it possible to debug early startup functionality, particularly command aliases.
+	if _, err := initLogger(&cf, utils.LoggingForCLI, parseLoggingOptsFromEnv()); err != nil {
+		printInitLoggerError(err)
+	}
+
 	// We need to parse the arguments before executing managed updates to identify
 	// the profile name and the required version for the current cluster.
 	// All other commands and flags may change between versions, so full parsing
@@ -859,12 +865,6 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	name := utils.TryHost(strings.TrimPrefix(strings.ToLower(proxyArg), "https://"))
 	if err := autoupdatetools.CheckAndUpdateLocal(ctx, name, args); err != nil {
 		return trace.Wrap(err)
-	}
-
-	// run early to enable debug logging if env var is set.
-	// this makes it possible to debug early startup functionality, particularly command aliases.
-	if _, err := initLogger(&cf, utils.LoggingForCLI, parseLoggingOptsFromEnv()); err != nil {
-		printInitLoggerError(err)
 	}
 
 	moduleCfg := modules.GetModules()


### PR DESCRIPTION
Backport #63774 to branch/v18

Manual tests:
- [x] If the fast path is unavailable, updates proceed as normal
- [x] If the fast path is available, it's hit when updating from a version with this PR (a single `flock(LOCK_SH, ...)` as per `strace --follow-forks`)
- [x] When re-executing a version with this PR, the local configuration check uses the fast path (a single `flock(LOCK_SH, ...)`)
- [x] The performance of non-updating commands (`tsh version`, `tsh ssh`) is drastically improved if `.tsh` is on a remote filesystem

changelog: improved the performance of `tsh` and `tctl` when the profile directory is on a remote filesystem (NFS, SMB, etc.)
