### PR TITLE
chore: add in-process bufconn transport for authtest.TLSServer

### DIFF
--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -878,6 +879,20 @@ func WithAccessGraphConfig(config auth.AccessGraphConfig) TestTLSServerOption {
 	}
 }
 
+// WithBufconnListener configures the auth test server to use a gRPC bufconn
+// listener and dialer instead of loopback TCP. This is useful with synctest
+// where real TCP listeners are not durably blocking.
+func WithBufconnListener() TestTLSServerOption {
+	const testBufconnSize = 1024
+	return func(cfg *TLSServerConfig) {
+		listener := bufconn.Listen(testBufconnSize)
+		cfg.Listener = listener
+		cfg.AuthDialer = client.ContextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		})
+	}
+}
+
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *AuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
@@ -910,6 +925,8 @@ type TLSServerConfig struct {
 	Limiter *limiter.Config
 	// Listener is a listener to serve requests on
 	Listener net.Listener
+	// AuthDialer is a dialer to use when making auth clients.
+	AuthDialer client.ContextDialer
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
 }
@@ -979,9 +996,11 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 	tlsCert := tlsConfig.Certificates[0]
 
-	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if srv.Listener == nil {
+		srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
@@ -1144,7 +1163,8 @@ func (t *TLSServer) NewClientFromWebSession(sess types.WebSession) (*authclient.
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 
 	return authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1199,7 +1219,8 @@ func (t *TLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *authclie
 	}
 
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1222,7 +1243,8 @@ func (t *TLSServer) NewClientWithCert(clientCert tls.Certificate) (*authclient.C
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 	tlsConfig.Certificates = []tls.Certificate{clientCert}
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1253,6 +1275,7 @@ func (t *TLSServer) NewClient(identity TestIdentity) (*authclient.Client, error)
 	newClient, err := authclient.NewClient(client.Config{
 		DialInBackground: true,
 		Addrs:            []string{t.Addr().String()},
+		Dialer:           t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -5701,9 +5701,10 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 }
 
 type testTLSServerOptions struct {
-	cacheEnabled bool
-	accessGraph  *auth.AccessGraphConfig
-	clock        clockwork.Clock
+	cacheEnabled    bool
+	accessGraph     *auth.AccessGraphConfig
+	clock           clockwork.Clock
+	bufconnListener bool
 }
 
 type testTLSServerOption func(*testTLSServerOptions)
@@ -5723,6 +5724,11 @@ func withAccessGraphConfig(cfg auth.AccessGraphConfig) testTLSServerOption {
 func withClock(clock clockwork.Clock) testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.clock = clock
+	}
+}
+func withBufconnListener() testTLSServerOption {
+	return func(options *testTLSServerOptions) {
+		options.bufconnListener = true
 	}
 }
 
@@ -5750,6 +5756,9 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSSe
 	var tlsServerOpts []authtest.TestTLSServerOption
 	if options.accessGraph != nil {
 		tlsServerOpts = append(tlsServerOpts, authtest.WithAccessGraphConfig(*options.accessGraph))
+	}
+	if options.bufconnListener {
+		tlsServerOpts = append(tlsServerOpts, authtest.WithBufconnListener())
 	}
 	srv, err := as.NewTestTLSServer(tlsServerOpts...)
 	require.NoError(t, err)

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -137,16 +137,11 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 		if !ok {
 			return nil, trace.AccessDenied("missing peer info")
 		}
+
 		// Limit requests per second and simultaneous connection by client IP.
-		clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+		clientIP, err := clientIPFromPeer(peerInfo)
 		if err != nil {
-			// bufconn peers don't include host:port, so use a stable synthetic key
-			// for request/connection limiting in tests.
-			if peerInfo.Addr.Network() == "bufconn" && peerInfo.Addr.String() == "bufconn" {
-				clientIP = "bufconn"
-			} else {
-				return nil, trace.BadParameter("missing client IP")
-			}
+			return nil, trace.Wrap(err)
 		}
 		if err := l.RegisterRequestWithCustomRate(clientIP, customRate(info.FullMethod)); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")
@@ -167,9 +162,9 @@ func (l *Limiter) StreamServerInterceptor(srv any, serverStream grpc.ServerStrea
 		return trace.AccessDenied("missing peer info")
 	}
 	// Limit requests per second and simultaneous connection by client IP.
-	clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	clientIP, err := clientIPFromPeer(peerInfo)
 	if err != nil {
-		return trace.BadParameter("missing client IP")
+		return trace.Wrap(err)
 	}
 	if err := l.RegisterRequest(clientIP); err != nil {
 		return trace.LimitExceeded("rate limit exceeded")
@@ -179,6 +174,21 @@ func (l *Limiter) StreamServerInterceptor(srv any, serverStream grpc.ServerStrea
 	}
 	defer l.connectionLimiter.ReleaseConnection(clientIP)
 	return handler(srv, serverStream)
+}
+
+func clientIPFromPeer(peerInfo *peer.Peer) (string, error) {
+	clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	if err == nil {
+		return clientIP, nil
+	}
+
+	// bufconn peers don't include host:port, so use a stable synthetic key
+	// for request/connection limiting in tests.
+	if peerInfo.Addr.Network() == "bufconn" && peerInfo.Addr.String() == "bufconn" {
+		return "bufconn", nil
+	}
+
+	return "", trace.BadParameter("missing client IP")
 }
 
 // WrapListener returns a [Listener] that wraps the provided listener

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -140,7 +140,13 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 		// Limit requests per second and simultaneous connection by client IP.
 		clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
 		if err != nil {
-			return nil, trace.BadParameter("missing client IP")
+			// bufconn peers don't include host:port, so use a stable synthetic key
+			// for request/connection limiting in tests.
+			if peerInfo.Addr.Network() == "bufconn" && peerInfo.Addr.String() == "bufconn" {
+				clientIP = "bufconn"
+			} else {
+				return nil, trace.BadParameter("missing client IP")
+			}
 		}
 		if err := l.RegisterRequestWithCustomRate(clientIP, customRate(info.FullMethod)); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")


### PR DESCRIPTION
This change introduces an optional in-process bufconn listener/dialer in
authtest.TLSServer so tests can run reliably under testing/synctest
without depending on real TCP connections which aren't durably blocking
in the synctest bubble.

Converted TestCreateAccessListReminderNotifications as a demonstration.