### PR TITLE
Gracefully handle metadata/summaries failing to load when viewing a session recording

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -110,6 +110,14 @@ export function ViewSessionRecordingRoute({
     // This is to ensure that the player can still be rendered even if the session metadata
     // cannot be fetched, allowing users to still view the recording.
 
+    const recordingWithMetadataComponent = (
+      <RecordingWithMetadataComponent
+        clusterId={clusterId}
+        recordingType={recordingType}
+        sessionId={sid}
+      />
+    );
+
     if (RecordingWithSummaryComponent) {
       return (
         <Suspense fallback={<RecordingPlayerLoading />}>
@@ -124,11 +132,7 @@ export function ViewSessionRecordingRoute({
                 />
               }
             >
-              <RecordingWithMetadataComponent
-                clusterId={clusterId}
-                recordingType={recordingType}
-                sessionId={sid}
-              />
+              {recordingWithMetadataComponent}
             </ErrorBoundary>
           </ErrorBoundary>
         </Suspense>
@@ -138,11 +142,7 @@ export function ViewSessionRecordingRoute({
     return (
       <Suspense fallback={<RecordingPlayerLoading />}>
         <ErrorBoundary fallback={player}>
-          <RecordingWithMetadataComponent
-            clusterId={clusterId}
-            recordingType={recordingType}
-            sessionId={sid}
-          />
+          {recordingWithMetadataComponent}
         </ErrorBoundary>
       </Suspense>
     );

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -35,7 +35,6 @@ import {
 } from 'teleport/services/recordings/hooks';
 import {
   RECORDING_TYPES_WITH_METADATA,
-  RECORDING_TYPES_WITH_SUMMARIES,
   VALID_RECORDING_TYPES,
 } from 'teleport/services/recordings/recordings';
 import type { RecordingWithSummaryProps } from 'teleport/SessionRecordings/view/RecordingWithSummary';

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -102,6 +102,15 @@ export function ViewSessionRecordingRoute({
     );
   }
 
+  const recordingWithSummaryComponent = RecordingWithSummaryComponent ? (
+    <RecordingWithSummaryComponent
+      clusterId={clusterId}
+      sessionId={sid}
+      durationMs={durationMs}
+      recordingType={recordingType}
+    />
+  ) : null;
+
   if (RECORDING_TYPES_WITH_METADATA.includes(recordingType)) {
     // If the recording type is SSH, try to load the session metadata (ViewTerminalRecording)
     // and render the SSH player with the session metadata/summary.
@@ -118,20 +127,11 @@ export function ViewSessionRecordingRoute({
       />
     );
 
-    if (RecordingWithSummaryComponent) {
+    if (recordingWithSummaryComponent) {
       return (
         <Suspense fallback={<RecordingPlayerLoading />}>
           <ErrorBoundary fallback={player}>
-            <ErrorBoundary
-              fallback={
-                <RecordingWithSummaryComponent
-                  clusterId={clusterId}
-                  sessionId={sid}
-                  durationMs={durationMs}
-                  recordingType={recordingType}
-                />
-              }
-            >
+            <ErrorBoundary fallback={recordingWithSummaryComponent}>
               {recordingWithMetadataComponent}
             </ErrorBoundary>
           </ErrorBoundary>
@@ -148,16 +148,11 @@ export function ViewSessionRecordingRoute({
     );
   }
 
-  if (RecordingWithSummaryComponent) {
+  if (recordingWithSummaryComponent) {
     return (
       <Suspense fallback={<RecordingPlayerLoading />}>
         <ErrorBoundary fallback={player}>
-          <RecordingWithSummaryComponent
-            clusterId={clusterId}
-            sessionId={sid}
-            durationMs={durationMs}
-            recordingType={recordingType}
-          />
+          {recordingWithSummaryComponent}
         </ErrorBoundary>
       </Suspense>
     );

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -35,6 +35,7 @@ import {
 } from 'teleport/services/recordings/hooks';
 import {
   RECORDING_TYPES_WITH_METADATA,
+  RECORDING_TYPES_WITH_SUMMARIES,
   VALID_RECORDING_TYPES,
 } from 'teleport/services/recordings/recordings';
 import type { RecordingWithSummaryProps } from 'teleport/SessionRecordings/view/RecordingWithSummary';
@@ -125,12 +126,16 @@ export function ViewSessionRecordingRoute({
 
   if (RecordingWithSummaryComponent) {
     return (
-      <RecordingWithSummaryComponent
-        clusterId={clusterId}
-        sessionId={sid}
-        durationMs={durationMs}
-        recordingType={recordingType}
-      />
+      <Suspense fallback={<RecordingPlayerLoading />}>
+        <ErrorBoundary fallback={player}>
+          <RecordingWithSummaryComponent
+            clusterId={clusterId}
+            sessionId={sid}
+            durationMs={durationMs}
+            recordingType={recordingType}
+          />
+        </ErrorBoundary>
+      </Suspense>
     );
   }
 

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -110,6 +110,31 @@ export function ViewSessionRecordingRoute({
     // This is to ensure that the player can still be rendered even if the session metadata
     // cannot be fetched, allowing users to still view the recording.
 
+    if (RecordingWithSummaryComponent) {
+      return (
+        <Suspense fallback={<RecordingPlayerLoading />}>
+          <ErrorBoundary fallback={player}>
+            <ErrorBoundary
+              fallback={
+                <RecordingWithSummaryComponent
+                  clusterId={clusterId}
+                  sessionId={sid}
+                  durationMs={durationMs}
+                  recordingType={recordingType}
+                />
+              }
+            >
+              <RecordingWithMetadataComponent
+                clusterId={clusterId}
+                recordingType={recordingType}
+                sessionId={sid}
+              />
+            </ErrorBoundary>
+          </ErrorBoundary>
+        </Suspense>
+      );
+    }
+
     return (
       <Suspense fallback={<RecordingPlayerLoading />}>
         <ErrorBoundary fallback={player}>


### PR DESCRIPTION
When there's a custom `withSummaryComponent` (e), the component wasn't wrapped in an error boundary to fall back to the player if anything fails to load

This adds the fallback to the player

Fixes #63952

## Manual testing

### OSS

#### Desktop

- [x] Play, pause, seeking works

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/ffdf3b99-4e54-41f8-911c-b9c87eb6f77a" />

#### SSH

- [x] Play, pause, seeking works

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/34a8d05a-5cdf-4be7-b321-94daab33958d" />

- [x] Metadata + player shown correctly

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/2b4120ab-7655-4fa9-996f-cfd97c51276b" />

- [x] When missing metadata - player is shown

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/f694a94f-0b64-44a9-86cd-a89101d67f11" />

#### Database

- [x] Play, pause, seeking works

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/bd48392c-33ba-432a-b625-d5f1754ef38e" />

#### Kubernetes

- [x] Play, pause, seeking works

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/33f2aed1-bd89-484c-963c-f74e3a9ddfe1" />

- [x] Metadata + player shown correctly

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/002b2d7d-dd0f-4e76-98c8-6457afdd92cf" />

- [x] When missing metadata - player is shown

<img width="1608" height="1362" alt="image" src="https://github.com/user-attachments/assets/5ff2ec91-fe61-4202-ab56-71e8166a1eed" />

### Enterprise

- [x] Verified that before this fix, there was a white screen showed for desktop recordings
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/7d69a511-3819-4e32-85f3-943d62cb5cc2" />

#### Verified desktop recordings still display

- [x] Verified with an actual windows desktop recording that it plays back correctly using the old player
  - [x] Play, pause, seeking works
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/8bf48faa-5f34-4bc7-b195-a457a3288628" />

#### Verified that SSH recordings still display
- [x] Play, pause, seeking works
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/801bfc77-bf07-42ad-b4e2-2346d7e828e4" />

- [x] When enhanced summary is present
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/e83bb421-efa7-4ff3-adb5-91fa63dc08ed" />

- [x] When legacy summary is present
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/e83e7499-ffdf-4328-ab15-cb450f71eb48" />

- [x] When missing metadata + summary - player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/ed1479d2-7759-4c7b-9cc3-7d4772945cd7" />

- [x] When missing only summary - metadata + player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/23c6b6a6-df26-474b-9951-f970c26ab625" />

- [x] When missing only metadata - summary + player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/d1f2f3a2-ec48-419a-a17a-8e91591839dd" />

#### Verified that Kubernetes recordings still display
- [x] Play, pause, seeking works
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/c5ed0680-04b0-4146-a82e-328508807adc" />

- [x] When enhanced summary is present
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/711e4b50-3e52-4e49-933d-cc5a43020927" />

- [x] When legacy summary is present
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/591f7cba-ce7e-4ebf-a53d-6bbf726e2fc7" />

- [x] When missing metadata + summary - player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/3b2279f1-e136-447e-9fa9-5ef01179b7f3" />

- [x] When missing only metadata - summary + player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/4a0a4a11-4fb5-4005-a11d-bd6347f0e628" />

- [x] When missing only summary - metadata + player is shown
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/7207ab75-8d5c-469f-bbba-4b62c3eed0d9" />

#### Verified that Database recordings still display 
- [x] Play, pause, seek works
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/a8378a06-abb4-4ed3-bd0c-5463df92fb39" />

- [x] When legacy summary is present
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/3091d422-64b9-4505-a51e-dc9719e3c0fd" />

- [x] When missing summary (they don't have metadata generated yet)
<img width="1532" height="1027" alt="image" src="https://github.com/user-attachments/assets/7440bd0d-7c8d-4e7d-8a7f-a6b74e987219" />

Note - due to the assumption that if metadata fails to load it would be because of a possible proxy upgrade situation where one proxy returned a 404 for the new endpoint added, we'd fall back to just showing the player. I updated this and tested that if the metadata fails to load, we try to load the summary and show that anyway, and if they both fail to load, we fall back to the player.

changelog: Fixed an issue where desktop session recordings would show a white screen instead of the recording player, and fixed an issue where if a session's metadata failed to load and the session had a summary it didn't display the summary