### PR TITLE
docs: update docs homepage video

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -59,7 +59,7 @@ import listBulletsSvg from "@site/src/components/Icon/teleport-svg/list-bullets.
 />
 
 <GetStarted
-  youtubeVideoId="BJWbSqiDLeU"
+  youtubeVideoId="O0YOPpWsn8M"
   steps={[
     {
       title: "Step 1: Deploy a Teleport cluster",


### PR DESCRIPTION
This PR updates the docs homepage youtube video id from the old open source demo from a few years ago to the newer community edition demo.