### PR TITLE
[terraform] fix data sources

### DIFF
--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -24,6 +24,7 @@ import (
     {{- protoImport . }}
     {{- end }}
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -81,10 +82,21 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "{{.Kind}}")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/gen/plural_data_source.go.tpl
+++ b/integrations/terraform/gen/plural_data_source.go.tpl
@@ -117,7 +117,11 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	{{else if .ConvertPackagePath -}}
 	{{.VarName}} := convert.{{ if .ConvertToProtoFunc }}{{.ConvertToProtoFunc}}{{ else }}ToProto{{ end }}({{.VarName}}I)
 	{{else}}
-	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
+	{{.VarName}}, ok := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Errorf("Can not convert %T to {{.TypeName}}", {{.VarName}}I), "{{.Kind}}"))
+		return
+	}
 	{{- end}}
 	diags = {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -24,6 +24,7 @@ import (
     {{- protoImport . }}
     {{- end }}
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -59,10 +60,21 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "{{.Kind}}")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	{{if .IsPlainStruct -}}

--- a/integrations/terraform/gen/singular_data_source.go.tpl
+++ b/integrations/terraform/gen/singular_data_source.go.tpl
@@ -80,7 +80,11 @@ func (r dataSourceTeleport{{.Name}}) Read(ctx context.Context, req tfsdk.ReadDat
 	{{if .IsPlainStruct -}}
 	{{.VarName}} := {{.VarName}}I
 	{{else -}}
-	{{.VarName}} := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
+	{{.VarName}}, ok := {{.VarName}}I.(*{{.ProtoPackage}}.{{.TypeName}})
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading {{.Name}}", trace.Errorf("Can not convert %T to {{.TypeName}}", {{.VarName}}I), "{{.Kind}}"))
+		return
+	}
 	{{end -}}
 	diags := {{.SchemaPackage}}.Copy{{.TypeName}}ToTerraform(ctx, {{.VarName}}, &state)
 	resp.Diagnostics.Append(diags...)

--- a/integrations/terraform/provider/data_source_teleport_access_list.go
+++ b/integrations/terraform/provider/data_source_teleport_access_list.go
@@ -22,6 +22,7 @@ import (
 
 	convert "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportAccessList) Read(ctx context.Context, req tfsdk.ReadDa
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "access_list")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_access_list_member.go
+++ b/integrations/terraform/provider/data_source_teleport_access_list_member.go
@@ -22,6 +22,7 @@ import (
 
 	convert "github.com/gravitational/teleport/api/types/accesslist/convert/v1"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -71,10 +72,21 @@ func (r dataSourceTeleportMember) Read(ctx context.Context, req tfsdk.ReadDataSo
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "access_list_member")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_access_monitoring_rule.go
+++ b/integrations/terraform/provider/data_source_teleport_access_monitoring_rule.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportAccessMonitoringRule) Read(ctx context.Context, req tf
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "access_monitoring_rule")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_app.go
+++ b/integrations/terraform/provider/data_source_teleport_app.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportApp) Read(ctx context.Context, req tfsdk.ReadDataSourc
 	}
 
 	
-	app := appI.(*apitypes.AppV3)
+	app, ok := appI.(*apitypes.AppV3)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading App", trace.Errorf("Can not convert %T to AppV3", appI), "app"))
+		return
+	}
 	diags = tfschema.CopyAppV3ToTerraform(ctx, app, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_app.go
+++ b/integrations/terraform/provider/data_source_teleport_app.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportApp) Read(ctx context.Context, req tfsdk.ReadDataSourc
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "app")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_app_auth_config.go
+++ b/integrations/terraform/provider/data_source_teleport_app_auth_config.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportAppAuthConfig) Read(ctx context.Context, req tfsdk.Rea
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "app_auth_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_auth_preference.go
+++ b/integrations/terraform/provider/data_source_teleport_auth_preference.go
@@ -75,7 +75,11 @@ func (r dataSourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Re
 		AttrTypes: objType.AttributeTypes(),
 	}
 
-	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)
+	authPreference, ok := authPreferenceI.(*apitypes.AuthPreferenceV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading AuthPreference", trace.Errorf("Can not convert %T to AuthPreferenceV2", authPreferenceI), "cluster_auth_preference"))
+		return
+	}
 	diags := tfschema.CopyAuthPreferenceV2ToTerraform(ctx, authPreference, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_auth_preference.go
+++ b/integrations/terraform/provider/data_source_teleport_auth_preference.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportAuthPreference) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "cluster_auth_preference")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	authPreference := authPreferenceI.(*apitypes.AuthPreferenceV2)

--- a/integrations/terraform/provider/data_source_teleport_autoupdate_config.go
+++ b/integrations/terraform/provider/data_source_teleport_autoupdate_config.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportAutoUpdateConfig) Read(ctx context.Context, req tfsdk.
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "autoupdate_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	autoUpdateConfig := autoUpdateConfigI

--- a/integrations/terraform/provider/data_source_teleport_autoupdate_version.go
+++ b/integrations/terraform/provider/data_source_teleport_autoupdate_version.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportAutoUpdateVersion) Read(ctx context.Context, req tfsdk
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "autoupdate_version")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	autoUpdateVersion := autoUpdateVersionI

--- a/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
@@ -75,7 +75,11 @@ func (r dataSourceTeleportClusterMaintenanceConfig) Read(ctx context.Context, re
 		AttrTypes: objType.AttributeTypes(),
 	}
 
-	clusterMaintenanceConfig := clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)
+	clusterMaintenanceConfig, ok := clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterMaintenanceConfig", trace.Errorf("Can not convert %T to ClusterMaintenanceConfigV1", clusterMaintenanceConfigI), "cluster_maintenance_config"))
+		return
+	}
 	diags := tfschema.CopyClusterMaintenanceConfigV1ToTerraform(ctx, clusterMaintenanceConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_maintenance_config.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportClusterMaintenanceConfig) Read(ctx context.Context, re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "cluster_maintenance_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	clusterMaintenanceConfig := clusterMaintenanceConfigI.(*apitypes.ClusterMaintenanceConfigV1)

--- a/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
@@ -75,7 +75,11 @@ func (r dataSourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req
 		AttrTypes: objType.AttributeTypes(),
 	}
 
-	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
+	clusterNetworkingConfig, ok := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ClusterNetworkingConfig", trace.Errorf("Can not convert %T to ClusterNetworkingConfigV2", clusterNetworkingConfigI), "cluster_networking_config"))
+		return
+	}
 	diags := tfschema.CopyClusterNetworkingConfigV2ToTerraform(ctx, clusterNetworkingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
+++ b/integrations/terraform/provider/data_source_teleport_cluster_networking_config.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportClusterNetworkingConfig) Read(ctx context.Context, req
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "cluster_networking_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	clusterNetworkingConfig := clusterNetworkingConfigI.(*apitypes.ClusterNetworkingConfigV2)

--- a/integrations/terraform/provider/data_source_teleport_database.go
+++ b/integrations/terraform/provider/data_source_teleport_database.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportDatabase) Read(ctx context.Context, req tfsdk.ReadData
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "db")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_database.go
+++ b/integrations/terraform/provider/data_source_teleport_database.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportDatabase) Read(ctx context.Context, req tfsdk.ReadData
 	}
 
 	
-	database := databaseI.(*apitypes.DatabaseV3)
+	database, ok := databaseI.(*apitypes.DatabaseV3)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Database", trace.Errorf("Can not convert %T to DatabaseV3", databaseI), "db"))
+		return
+	}
 	diags = tfschema.CopyDatabaseV3ToTerraform(ctx, database, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_device_trust.go
+++ b/integrations/terraform/provider/data_source_teleport_device_trust.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportDeviceV1) Read(ctx context.Context, req tfsdk.ReadData
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "device")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_discovery_config.go
+++ b/integrations/terraform/provider/data_source_teleport_discovery_config.go
@@ -22,6 +22,7 @@ import (
 
 	convert "github.com/gravitational/teleport/api/types/discoveryconfig/convert/v1"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportDiscoveryConfig) Read(ctx context.Context, req tfsdk.R
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "discovery_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/data_source_teleport_dynamic_windows_desktop.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportDynamicWindowsDesktop) Read(ctx context.Context, req t
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "dynamic_windows_desktop")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_dynamic_windows_desktop.go
+++ b/integrations/terraform/provider/data_source_teleport_dynamic_windows_desktop.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportDynamicWindowsDesktop) Read(ctx context.Context, req t
 	}
 
 	
-	desktop := desktopI.(*apitypes.DynamicWindowsDesktopV1)
+	desktop, ok := desktopI.(*apitypes.DynamicWindowsDesktopV1)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading DynamicWindowsDesktop", trace.Errorf("Can not convert %T to DynamicWindowsDesktopV1", desktopI), "dynamic_windows_desktop"))
+		return
+	}
 	diags = tfschema.CopyDynamicWindowsDesktopV1ToTerraform(ctx, desktop, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_github_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_github_connector.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportGithubConnector) Read(ctx context.Context, req tfsdk.R
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "github")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_github_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_github_connector.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportGithubConnector) Read(ctx context.Context, req tfsdk.R
 	}
 
 	
-	githubConnector := githubConnectorI.(*apitypes.GithubConnectorV3)
+	githubConnector, ok := githubConnectorI.(*apitypes.GithubConnectorV3)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading GithubConnector", trace.Errorf("Can not convert %T to GithubConnectorV3", githubConnectorI), "github"))
+		return
+	}
 	diags = tfschema.CopyGithubConnectorV3ToTerraform(ctx, githubConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_health_check_config.go
+++ b/integrations/terraform/provider/data_source_teleport_health_check_config.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportHealthCheckConfig) Read(ctx context.Context, req tfsdk
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "health_check_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_inference_model.go
+++ b/integrations/terraform/provider/data_source_teleport_inference_model.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportInferenceModel) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "inference_model")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_inference_policy.go
+++ b/integrations/terraform/provider/data_source_teleport_inference_policy.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportInferencePolicy) Read(ctx context.Context, req tfsdk.R
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "inference_policy")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_inference_secret.go
+++ b/integrations/terraform/provider/data_source_teleport_inference_secret.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportInferenceSecret) Read(ctx context.Context, req tfsdk.R
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "inference_secret")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_installer.go
+++ b/integrations/terraform/provider/data_source_teleport_installer.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportInstaller) Read(ctx context.Context, req tfsdk.ReadDat
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "installer")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_installer.go
+++ b/integrations/terraform/provider/data_source_teleport_installer.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportInstaller) Read(ctx context.Context, req tfsdk.ReadDat
 	}
 
 	
-	installer := installerI.(*apitypes.InstallerV1)
+	installer, ok := installerI.(*apitypes.InstallerV1)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Installer", trace.Errorf("Can not convert %T to InstallerV1", installerI), "installer"))
+		return
+	}
 	diags = tfschema.CopyInstallerV1ToTerraform(ctx, installer, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_integration.go
+++ b/integrations/terraform/provider/data_source_teleport_integration.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportIntegration) Read(ctx context.Context, req tfsdk.ReadD
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "integration")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_integration.go
+++ b/integrations/terraform/provider/data_source_teleport_integration.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportIntegration) Read(ctx context.Context, req tfsdk.ReadD
 	}
 
 	
-	integration := integrationI.(*apitypes.IntegrationV1)
+	integration, ok := integrationI.(*apitypes.IntegrationV1)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Integration", trace.Errorf("Can not convert %T to IntegrationV1", integrationI), "integration"))
+		return
+	}
 	diags = tfschema.CopyIntegrationV1ToTerraform(ctx, integration, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_login_rule.go
+++ b/integrations/terraform/provider/data_source_teleport_login_rule.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportLoginRule) Read(ctx context.Context, req tfsdk.ReadDat
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "login_rule")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_oidc_connector.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportOIDCConnector) Read(ctx context.Context, req tfsdk.Rea
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "oidc")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_oidc_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_oidc_connector.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportOIDCConnector) Read(ctx context.Context, req tfsdk.Rea
 	}
 
 	
-	oidcConnector := oidcConnectorI.(*apitypes.OIDCConnectorV3)
+	oidcConnector, ok := oidcConnectorI.(*apitypes.OIDCConnectorV3)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OIDCConnector", trace.Errorf("Can not convert %T to OIDCConnectorV3", oidcConnectorI), "oidc"))
+		return
+	}
 	diags = tfschema.CopyOIDCConnectorV3ToTerraform(ctx, oidcConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/data_source_teleport_okta_import_rule.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportOktaImportRule) Read(ctx context.Context, req tfsdk.Re
 	}
 
 	
-	oktaImportRule := oktaImportRuleI.(*apitypes.OktaImportRuleV1)
+	oktaImportRule, ok := oktaImportRuleI.(*apitypes.OktaImportRuleV1)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading OktaImportRule", trace.Errorf("Can not convert %T to OktaImportRuleV1", oktaImportRuleI), "okta_import_rule"))
+		return
+	}
 	diags = tfschema.CopyOktaImportRuleV1ToTerraform(ctx, oktaImportRule, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_okta_import_rule.go
+++ b/integrations/terraform/provider/data_source_teleport_okta_import_rule.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportOktaImportRule) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "okta_import_rule")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_provision_token.go
+++ b/integrations/terraform/provider/data_source_teleport_provision_token.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportProvisionToken) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "token")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_provision_token.go
+++ b/integrations/terraform/provider/data_source_teleport_provision_token.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportProvisionToken) Read(ctx context.Context, req tfsdk.Re
 	}
 
 	
-	provisionToken := provisionTokenI.(*apitypes.ProvisionTokenV2)
+	provisionToken, ok := provisionTokenI.(*apitypes.ProvisionTokenV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading ProvisionToken", trace.Errorf("Can not convert %T to ProvisionTokenV2", provisionTokenI), "token"))
+		return
+	}
 	diags = token.CopyProvisionTokenV2ToTerraform(ctx, provisionToken, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_role.go
+++ b/integrations/terraform/provider/data_source_teleport_role.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportRole) Read(ctx context.Context, req tfsdk.ReadDataSour
 	}
 
 	
-	role := roleI.(*apitypes.RoleV6)
+	role, ok := roleI.(*apitypes.RoleV6)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Role", trace.Errorf("Can not convert %T to RoleV6", roleI), "role"))
+		return
+	}
 	diags = tfschema.CopyRoleV6ToTerraform(ctx, role, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_role.go
+++ b/integrations/terraform/provider/data_source_teleport_role.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportRole) Read(ctx context.Context, req tfsdk.ReadDataSour
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "role")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_saml_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_saml_connector.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.Rea
 	}
 
 	
-	samlConnector := samlConnectorI.(*apitypes.SAMLConnectorV2)
+	samlConnector, ok := samlConnectorI.(*apitypes.SAMLConnectorV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SAMLConnector", trace.Errorf("Can not convert %T to SAMLConnectorV2", samlConnectorI), "saml"))
+		return
+	}
 	diags = tfschema.CopySAMLConnectorV2ToTerraform(ctx, samlConnector, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_saml_connector.go
+++ b/integrations/terraform/provider/data_source_teleport_saml_connector.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportSAMLConnector) Read(ctx context.Context, req tfsdk.Rea
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "saml")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_server.go
+++ b/integrations/terraform/provider/data_source_teleport_server.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -66,10 +67,21 @@ func (r dataSourceTeleportServer) Read(ctx context.Context, req tfsdk.ReadDataSo
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "node")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_server.go
+++ b/integrations/terraform/provider/data_source_teleport_server.go
@@ -94,7 +94,11 @@ func (r dataSourceTeleportServer) Read(ctx context.Context, req tfsdk.ReadDataSo
 	}
 
 	
-	server := serverI.(*apitypes.ServerV2)
+	server, ok := serverI.(*apitypes.ServerV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading Server", trace.Errorf("Can not convert %T to ServerV2", serverI), "node"))
+		return
+	}
 	diags = tfschema.CopyServerV2ToTerraform(ctx, server, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/data_source_teleport_session_recording_config.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportSessionRecordingConfig) Read(ctx context.Context, req 
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "session_recording_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)

--- a/integrations/terraform/provider/data_source_teleport_session_recording_config.go
+++ b/integrations/terraform/provider/data_source_teleport_session_recording_config.go
@@ -75,7 +75,11 @@ func (r dataSourceTeleportSessionRecordingConfig) Read(ctx context.Context, req 
 		AttrTypes: objType.AttributeTypes(),
 	}
 
-	sessionRecordingConfig := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
+	sessionRecordingConfig, ok := sessionRecordingConfigI.(*apitypes.SessionRecordingConfigV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading SessionRecordingConfig", trace.Errorf("Can not convert %T to SessionRecordingConfigV2", sessionRecordingConfigI), "session_recording_config"))
+		return
+	}
 	diags := tfschema.CopySessionRecordingConfigV2ToTerraform(ctx, sessionRecordingConfig, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_static_host_user.go
+++ b/integrations/terraform/provider/data_source_teleport_static_host_user.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportStaticHostUser) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "static_host_user")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/data_source_teleport_trusted_cluster.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportTrustedCluster) Read(ctx context.Context, req tfsdk.Re
 	}
 
 	
-	trustedCluster := trustedClusterI.(*apitypes.TrustedClusterV2)
+	trustedCluster, ok := trustedClusterI.(*apitypes.TrustedClusterV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading TrustedCluster", trace.Errorf("Can not convert %T to TrustedClusterV2", trustedClusterI), "trusted_cluster"))
+		return
+	}
 	diags = tfschema.CopyTrustedClusterV2ToTerraform(ctx, trustedCluster, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_trusted_cluster.go
+++ b/integrations/terraform/provider/data_source_teleport_trusted_cluster.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportTrustedCluster) Read(ctx context.Context, req tfsdk.Re
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "trusted_cluster")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_user.go
+++ b/integrations/terraform/provider/data_source_teleport_user.go
@@ -22,6 +22,7 @@ import (
 
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportUser) Read(ctx context.Context, req tfsdk.ReadDataSour
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "user")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/provider/data_source_teleport_user.go
+++ b/integrations/terraform/provider/data_source_teleport_user.go
@@ -93,7 +93,11 @@ func (r dataSourceTeleportUser) Read(ctx context.Context, req tfsdk.ReadDataSour
 	}
 
 	
-	user := userI.(*apitypes.UserV2)
+	user, ok := userI.(*apitypes.UserV2)
+	if !ok {
+		resp.Diagnostics.Append(diagFromWrappedErr("Error reading User", trace.Errorf("Can not convert %T to UserV2", userI), "user"))
+		return
+	}
 	diags = tfschema.CopyUserV2ToTerraform(ctx, user, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/integrations/terraform/provider/data_source_teleport_vnet_config.go
+++ b/integrations/terraform/provider/data_source_teleport_vnet_config.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -57,10 +58,21 @@ func (r dataSourceTeleportVnetConfig) Read(ctx context.Context, req tfsdk.ReadDa
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "vnet_config")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	vnetConfig := vnetConfigI

--- a/integrations/terraform/provider/data_source_teleport_workload_identity.go
+++ b/integrations/terraform/provider/data_source_teleport_workload_identity.go
@@ -22,6 +22,7 @@ import (
 
 	
 	"github.com/gravitational/trace"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -65,10 +66,21 @@ func (r dataSourceTeleportWorkloadIdentity) Read(ctx context.Context, req tfsdk.
 		return
 	}
 
-	var state types.Object
-	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
-	if resp.Diagnostics.HasError() {
+	// TODO: This is a non-idiomatic approach to initializing the state of the
+	// data source. It is a workaround to avoid initializing all omitted fields
+	// to null values. State should be initialized using `req.Config.Get` once
+	// `Copy<resource>ToTerraform` is able to properly handle null values.
+	objType, ok := req.Config.Schema.AttributeType().(types.ObjectType)
+	if !ok {
+		resp.Diagnostics.AddError("Error reading schema attribute types", "workload_identity")
 		return
+	}
+
+	state := types.Object{
+		Unknown:   false,
+		Null:      false,
+		Attrs:     make(map[string]attr.Value),
+		AttrTypes: objType.AttributeTypes(),
 	}
 
 	// Todo: Remove after updating terraform-plugin to >=v1.5.0.

--- a/integrations/terraform/testlib/fixtures/user_data_source.tf
+++ b/integrations/terraform/testlib/fixtures/user_data_source.tf
@@ -1,0 +1,7 @@
+data "teleport_user" "test" {
+  kind    = "user"
+  version = "v2"
+  metadata = {
+    name = "test"
+  }
+}

--- a/integrations/terraform/testlib/role_test.go
+++ b/integrations/terraform/testlib/role_test.go
@@ -19,6 +19,7 @@ package testlib
 import (
 	"context"
 	"regexp"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -27,7 +28,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils"
 )
 
 func (s *TerraformSuiteOSS) TestRoleDataSource() {
@@ -44,8 +47,50 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 	}
 
 	role := &types.RoleV6{
+		Kind:    "role",
+		Version: "v8",
 		Metadata: types.Metadata{
 			Name: "test",
+		},
+		Spec: types.RoleSpecV6{
+			Options: types.RoleOptions{
+				CertificateFormat:       "standard",
+				ClientIdleTimeout:       types.NewDuration(time.Hour),
+				CreateDatabaseUser:      types.NewBoolOption(false),
+				CreateDesktopUser:       types.NewBoolOption(false),
+				DesktopClipboard:        types.NewBoolOption(true),
+				DesktopDirectorySharing: types.NewBoolOption(true),
+				BPF: []string{
+					"command",
+					"network",
+				},
+				ForwardAgent:  true,
+				MaxSessionTTL: types.NewDuration(time.Hour * 30),
+				PinSourceIP:   false,
+				RecordSession: &types.RecordSession{
+					Default: constants.SessionRecordingModeBestEffort,
+					Desktop: types.NewBoolOption(true),
+				},
+				SSHFileCopy: types.NewBoolOption(true),
+			},
+			Allow: types.RoleConditions{
+				Logins: []string{"anonymous"},
+				AppLabels: types.Labels{
+					"env": utils.Strings{"test"},
+				},
+				KubernetesLabels: types.Labels{
+					"env": utils.Strings{"test"},
+				},
+				KubernetesResources: []types.KubernetesResource{
+					{
+						APIGroup:  "*",
+						Kind:      "*",
+						Name:      "*",
+						Namespace: "*",
+						Verbs:     []string{"*"},
+					},
+				},
+			},
 		},
 	}
 	err := role.CheckAndSetDefaults()
@@ -66,6 +111,32 @@ func (s *TerraformSuiteOSS) TestRoleDataSource() {
 					resource.TestCheckResourceAttr(name, "kind", "role"),
 					resource.TestCheckResourceAttr(name, "version", "v8"),
 					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+
+					resource.TestCheckResourceAttr(name, "spec.options.cert_format", "standard"),
+					resource.TestCheckResourceAttr(name, "spec.options.client_idle_timeout", "1h0m0s"),
+					resource.TestCheckResourceAttr(name, "spec.options.create_db_user", "false"),
+					resource.TestCheckResourceAttr(name, "spec.options.create_desktop_user", "false"),
+					resource.TestCheckResourceAttr(name, "spec.options.desktop_clipboard", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.desktop_directory_sharing", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.enhanced_recording.0", "command"),
+					resource.TestCheckResourceAttr(name, "spec.options.enhanced_recording.1", "network"),
+					resource.TestCheckResourceAttr(name, "spec.options.forward_agent", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.max_session_ttl", "30h0m0s"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.default", "best_effort"),
+					resource.TestCheckResourceAttr(name, "spec.options.record_session.desktop", "true"),
+					resource.TestCheckResourceAttr(name, "spec.options.ssh_file_copy", "true"),
+
+					// Regular false boolean values should be omitted
+					resource.TestCheckNoResourceAttr(name, "spec.options.pin_source_ip"),
+
+					resource.TestCheckResourceAttr(name, "spec.allow.logins.0", "anonymous"),
+					resource.TestCheckResourceAttr(name, "spec.allow.app_labels.env.0", "test"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_labels.env.0", "test"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_resources.0.api_group", "*"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_resources.0.kind", "*"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_resources.0.name", "*"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_resources.0.namespace", "*"),
+					resource.TestCheckResourceAttr(name, "spec.allow.kubernetes_resources.0.verbs.0", "*"),
 				),
 			},
 		},

--- a/integrations/terraform/testlib/user_test.go
+++ b/integrations/terraform/testlib/user_test.go
@@ -18,11 +18,95 @@ package testlib
 
 import (
 	"context"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/wrappers"
 )
+
+func (s *TerraformSuiteOSS) TestUserDataSource() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.T().Cleanup(cancel)
+
+	checkUserDestroyed := func(state *terraform.State) error {
+		_, err := s.client.GetUser(ctx, "test", false)
+		if trace.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	expires := time.Date(2035, 10, 12, 0, 0, 0, 0, time.UTC)
+	user := &types.UserV2{
+		Metadata: types.Metadata{
+			Name:    "test",
+			Expires: &expires,
+		},
+		Spec: types.UserSpecV2{
+			Roles: []string{"terraform-provider"},
+			Traits: wrappers.Traits{
+				"logins": []string{"example"},
+				"env":    []string{"example"},
+			},
+			OIDCIdentities: []types.ExternalIdentity{
+				{
+					ConnectorID: "oidc",
+					Username:    "example",
+				},
+			},
+			GithubIdentities: []types.ExternalIdentity{
+				{
+					ConnectorID: "github",
+					Username:    "example",
+				},
+			},
+			SAMLIdentities: []types.ExternalIdentity{
+				{
+					ConnectorID: "saml",
+					Username:    "example",
+				},
+			},
+		},
+	}
+	err := user.CheckAndSetDefaults()
+	require.NoError(s.T(), err)
+
+	_, err = s.client.CreateUser(ctx, user)
+	require.NoError(s.T(), err)
+
+	name := "data.teleport_user.test"
+
+	resource.Test(s.T(), resource.TestCase{
+		ProtoV6ProviderFactories: s.terraformProviders,
+		CheckDestroy:             checkUserDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: s.getFixture("user_data_source.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(name, "kind", "user"),
+					resource.TestCheckResourceAttr(name, "version", "v2"),
+					resource.TestCheckResourceAttr(name, "metadata.name", "test"),
+					resource.TestCheckResourceAttr(name, "metadata.expires", "2035-10-12T00:00:00Z"),
+					resource.TestCheckResourceAttr(name, "spec.roles.0", "terraform-provider"),
+					resource.TestCheckResourceAttr(name, "spec.traits.logins.0", "example"),
+					resource.TestCheckResourceAttr(name, "spec.traits.env.0", "example"),
+					resource.TestCheckResourceAttr(name, "spec.oidc_identities.0.connector_id", "oidc"),
+					resource.TestCheckResourceAttr(name, "spec.oidc_identities.0.username", "example"),
+					resource.TestCheckResourceAttr(name, "spec.github_identities.0.connector_id", "github"),
+					resource.TestCheckResourceAttr(name, "spec.github_identities.0.username", "example"),
+					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.connector_id", "saml"),
+					resource.TestCheckResourceAttr(name, "spec.saml_identities.0.username", "example"),
+				),
+			},
+		},
+	})
+}
 
 func (s *TerraformSuiteOSS) TestUser() {
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This PR fixes an issue that prevents the Terraform provider from populating nested values in data sources.

### Details
Previously, the datasource `Read` function uses the `Config.Get` function to read initial state from the provided terraform config files. Omitted values are set to `null`. When calling `Copy<resource>ToTerraform` to copy the Teleport resource to the terraform state, nested values are not cleared of their `null` value.

This is not a perfect solution. A more proper solution would require fixing the generated `Copy<resource>ToTerraform` function to clear `null` values when expected. However, this requires a larger change to https://github.com/gravitational/protoc-gen-terraform.

### Testing

```hcl
# example.tf
data "teleport_user" "example" {
  version = "v2"
  metadata = {
    name = "example"
  }
}

output "user" {
  value = data.teleport_user.example
}
```

Behavior before the change:
```console
$ terraform plan
...
+ user = {
  + id       = "example"
  + kind     = null
  + metadata = {
      + description = null
      + expires     = null
      + labels      = null
      + name        = "example"
      + namespace   = null
      + revision    = null
    }
  + spec     = null
  + status   = null
  + sub_kind = null
  + version  = "v2"
}
```

Behavior after the change:
```console
$ terraform plan
...
+ user = {
  + id       = "example"
  + kind     = "user"
  + metadata = {
      + description = null
      + expires     = null
      + labels      = null
      + name        = "example"
      + namespace   = "default"
      + revision    = "219fb36a-7abe-458e-a45e-037a5ba39ba3"
    }
  + spec     = {
      + github_identities  = null
      + oidc_identities    = null
      + roles              = [
          + "access",
          + "auditor",
          + "editor",
          + "reviewer",
        ]
      + saml_identities    = null
      + traits             = {
          + env            = [
              + "demo",
            ]
          + logins         = [
              + "root",
            ]
          + "team/on-call" = [
              + "true",
            ]
        }
      + trusted_device_ids = null
    }
  + status   = {
      + mfa_weakest_device = 3
      + password_state     = 1
    }
  + sub_kind = null
  + version  = "v2"
}
```

Additional test coverage included in https://github.com/gravitational/teleport/pull/64288

Changelog: Fixed an issue that prevented the Terraform provider from populating nested values in data sources.