### PR TITLE
Add basic support for `bound_keypair` joining for standard agent types

### DIFF
--- a/lib/auth/storage/storage.go
+++ b/lib/auth/storage/storage.go
@@ -297,7 +297,7 @@ func (p *ProcessStorage) ReadRDPLicense(ctx context.Context, key *types.RDPLicen
 
 // ReadBoundKeypairItem reads an arbitrary key with the bound keypair prefix
 func (p *ProcessStorage) ReadBoundKeypairItem(ctx context.Context, name string) ([]byte, error) {
-	item, err := p.BackendStorage.Get(ctx, backend.NewKey(boundKeypairPrefix, name))
+	item, err := p.stateStorage.Get(ctx, backend.NewKey(boundKeypairPrefix, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -310,7 +310,7 @@ func (p *ProcessStorage) WriteBoundKeypairItem(ctx context.Context, name string,
 		Key:   backend.NewKey(boundKeypairPrefix, name),
 		Value: data,
 	}
-	_, err := p.BackendStorage.Put(ctx, item)
+	_, err := p.stateStorage.Put(ctx, item)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/auth/storage/storage.go
+++ b/lib/auth/storage/storage.go
@@ -57,6 +57,9 @@ const (
 	teleportPrefix = "teleport"
 	// lastKnownVersion is a key for storing version of teleport
 	lastKnownVersion = "last-known-version"
+	// boundKeypairPrefix is a key prefix for the agent's bound keypair state,
+	// if any
+	boundKeypairPrefix = "bound-keypair"
 )
 
 // stateBackend implements abstraction over local or remote storage backend methods
@@ -290,6 +293,28 @@ func (p *ProcessStorage) ReadRDPLicense(ctx context.Context, key *types.RDPLicen
 		return nil, trace.Wrap(err)
 	}
 	return license.Data, nil
+}
+
+// ReadBoundKeypairItem reads an arbitrary key with the bound keypair prefix
+func (p *ProcessStorage) ReadBoundKeypairItem(ctx context.Context, name string) ([]byte, error) {
+	item, err := p.BackendStorage.Get(ctx, backend.NewKey(boundKeypairPrefix, name))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return item.Value, nil
+}
+
+// WriteBoundKeypairItem writes a (key, value) into the bound keypair prefix.
+func (p *ProcessStorage) WriteBoundKeypairItem(ctx context.Context, name string, data []byte) error {
+	item := backend.Item{
+		Key:   backend.NewKey(boundKeypairPrefix, name),
+		Value: data,
+	}
+	_, err := p.BackendStorage.Put(ctx, item)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // ReadLocalIdentityForRole reads, parses and returns the given pub/pri key +

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -3167,6 +3167,16 @@ func applyTokenConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 				},
 			}
 		}
+
+		if fc.JoinParams.BoundKeypair != (BoundKeypairParams{}) {
+			cfg.JoinParams = servicecfg.JoinParams{
+				BoundKeypair: servicecfg.BoundKeypairParams{
+					RegistrationSecretValue: fc.JoinParams.BoundKeypair.RegistrationSecretValue,
+					RegistrationSecretPath:  fc.JoinParams.BoundKeypair.RegistrationSecretPath,
+					StaticPrivateKeyPath:    fc.JoinParams.BoundKeypair.StaticPrivateKeyPath,
+				},
+			}
+		}
 	}
 
 	return nil

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -3620,6 +3620,7 @@ func TestJoinParams(t *testing.T) {
 		expectToken      string
 		expectJoinMethod types.JoinMethod
 		expectError      bool
+		expectParsed     *servicecfg.JoinParams
 	}{
 		{
 			desc: "empty",
@@ -3687,6 +3688,60 @@ teleport:
 `,
 			expectError: true,
 		},
+		{
+			desc: "bound keypair with registration secret value",
+			input: `
+teleport:
+  join_params:
+    token_name: example
+    method: bound_keypair
+    bound_keypair:
+      registration_secret_value: "example-secret"
+`,
+			expectToken:      "example",
+			expectJoinMethod: types.JoinMethodBoundKeypair,
+			expectParsed: &servicecfg.JoinParams{
+				BoundKeypair: servicecfg.BoundKeypairParams{
+					RegistrationSecretValue: "example-secret",
+				},
+			},
+		},
+		{
+			desc: "bound keypair with registration secret path",
+			input: `
+teleport:
+  join_params:
+    token_name: example
+    method: bound_keypair
+    bound_keypair:
+      registration_secret_path: "/path/to/secret"
+`,
+			expectToken:      "example",
+			expectJoinMethod: types.JoinMethodBoundKeypair,
+			expectParsed: &servicecfg.JoinParams{
+				BoundKeypair: servicecfg.BoundKeypairParams{
+					RegistrationSecretPath: "/path/to/secret",
+				},
+			},
+		},
+		{
+			desc: "bound keypair with static keypair path",
+			input: `
+teleport:
+  join_params:
+    token_name: example
+    method: bound_keypair
+    bound_keypair:
+      static_key_path: "/path/to/secret"
+`,
+			expectToken:      "example",
+			expectJoinMethod: types.JoinMethodBoundKeypair,
+			expectParsed: &servicecfg.JoinParams{
+				BoundKeypair: servicecfg.BoundKeypairParams{
+					StaticPrivateKeyPath: "/path/to/secret",
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			conf, err := ReadConfig(strings.NewReader(tc.input))
@@ -3705,6 +3760,10 @@ teleport:
 			require.NoError(t, err)
 			require.Equal(t, tc.expectToken, token)
 			require.Equal(t, tc.expectJoinMethod, cfg.JoinMethod)
+
+			if tc.expectParsed != nil {
+				require.Empty(t, cmp.Diff(cfg.JoinParams, *tc.expectParsed))
+			}
 		})
 	}
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -512,11 +512,31 @@ type JoinParams struct {
 	TokenSecret string           `yaml:"token_secret,omitempty"`
 	Method      types.JoinMethod `yaml:"method"`
 	Azure       AzureJoinParams  `yaml:"azure,omitempty"`
+	BoundKeypair BoundKeypairParams `yaml:"bound_keypair"`
 }
 
 // AzureJoinParams configures the parameters specific to the Azure join method.
 type AzureJoinParams struct {
 	ClientID string `yaml:"client_id"`
+}
+
+// BoundKeypairParams contains parameters specific to bound keypair joining.
+type BoundKeypairParams struct {
+	// RegistrationSecretValue is an explicit registration secret value, used to
+	// authenticate the initial join with a bound keypair token. It becomes
+	// inert once used.
+	RegistrationSecretValue string `yaml:"registration_secret_value"`
+
+	// RegistrationSecretPath is a path to a file on the local disk containing a
+	// registration secret. It is incompatible with RegistrationSecretValue.
+	RegistrationSecretPath string `yaml:"registration_secret_path"`
+
+	// StaticPrivateKeyPath is a path to a file on the local disk containing a
+	// static keypair to be used for bound keypair joining. Static keys are
+	// immmutable and are not managed automatically. They must be preregistered,
+	// do not support automatic keypair rotation, and must be used with a token
+	// set to use `insecure` recovery mode.
+	StaticPrivateKeyPath string `yaml:"static_key_path"`
 }
 
 // ConnectionRate configures rate limiter

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -508,11 +508,11 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 
 // JoinParams configures the parameters for Simplified Node Joining.
 type JoinParams struct {
-	TokenName   string           `yaml:"token_name"`
-	TokenSecret string           `yaml:"token_secret,omitempty"`
-	Method      types.JoinMethod `yaml:"method"`
-	Azure       AzureJoinParams  `yaml:"azure,omitempty"`
-	BoundKeypair BoundKeypairParams `yaml:"bound_keypair"`
+	TokenName    string             `yaml:"token_name"`
+	TokenSecret  string             `yaml:"token_secret,omitempty"`
+	Method       types.JoinMethod   `yaml:"method"`
+	Azure        AzureJoinParams    `yaml:"azure,omitempty"`
+	BoundKeypair BoundKeypairParams `yaml:"bound_keypair,omitempty"`
 }
 
 // AzureJoinParams configures the parameters specific to the Azure join method.
@@ -533,7 +533,7 @@ type BoundKeypairParams struct {
 
 	// StaticPrivateKeyPath is a path to a file on the local disk containing a
 	// static keypair to be used for bound keypair joining. Static keys are
-	// immmutable and are not managed automatically. They must be preregistered,
+	// immutable and are not managed automatically. They must be preregistered,
 	// do not support automatic keypair rotation, and must be used with a token
 	// set to use `insecure` recovery mode.
 	StaticPrivateKeyPath string `yaml:"static_key_path"`

--- a/lib/config/fileconf_test.go
+++ b/lib/config/fileconf_test.go
@@ -1607,6 +1607,88 @@ func TestBackoffConfig(t *testing.T) {
 	}
 }
 
+func TestBoundKeypairConfig(t *testing.T) {
+	testCases := []struct {
+		desc             string
+		mutate           func(cfgMap)
+		expectJoinParams JoinParams
+	}{
+		{
+			desc:             "empty",
+			mutate:           func(cfg cfgMap) {},
+			expectJoinParams: JoinParams{},
+		},
+		{
+			desc: "bound keypair registration secret value",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["join_params"] = cfgMap{
+					"token_name": "example",
+					"method":     "bound_keypair",
+					"bound_keypair": cfgMap{
+						"registration_secret_value": "reg-secret",
+					},
+				}
+			},
+			expectJoinParams: JoinParams{
+				TokenName: "example",
+				Method:    types.JoinMethodBoundKeypair,
+				BoundKeypair: BoundKeypairParams{
+					RegistrationSecretValue: "reg-secret",
+				},
+			},
+		},
+		{
+			desc: "bound keypair registration secret path",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["join_params"] = cfgMap{
+					"token_name": "example",
+					"method":     "bound_keypair",
+					"bound_keypair": cfgMap{
+						"registration_secret_path": "/path/to/secret",
+					},
+				}
+			},
+			expectJoinParams: JoinParams{
+				TokenName: "example",
+				Method:    types.JoinMethodBoundKeypair,
+				BoundKeypair: BoundKeypairParams{
+					RegistrationSecretPath: "/path/to/secret",
+				},
+			},
+		},
+		{
+			desc: "bound keypair registration static key path",
+			mutate: func(cfg cfgMap) {
+				cfg["teleport"].(cfgMap)["join_params"] = cfgMap{
+					"token_name": "example",
+					"method":     "bound_keypair",
+					"bound_keypair": cfgMap{
+						"static_key_path": "/path/to/key",
+					},
+				}
+			},
+			expectJoinParams: JoinParams{
+				TokenName: "example",
+				Method:    types.JoinMethodBoundKeypair,
+				BoundKeypair: BoundKeypairParams{
+					StaticPrivateKeyPath: "/path/to/key",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			text := bytes.NewBuffer(editConfig(t, tc.mutate))
+
+			cfg, err := ReadConfig(text)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectJoinParams, cfg.JoinParams)
+		})
+	}
+}
+
 func TestMakeSampleFileConfig(t *testing.T) {
 	t.Run("Default roles", func(t *testing.T) {
 		fc, err := MakeSampleFileConfig(SampleFlags{

--- a/lib/service/bound_keypair_adapter.go
+++ b/lib/service/bound_keypair_adapter.go
@@ -1,0 +1,48 @@
+/*
+ * Teleport
+ * Copyright (C) 2023  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"context"
+
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
+	"github.com/gravitational/teleport/lib/auth/storage"
+)
+
+// boundKeypairStorageAdapter returns a storage interface implementation for
+// bound keypair joining backed by the local agent storage.
+func (p *TeleportProcess) boundKeypairStorageAdapter() boundkeypair.FS {
+	return &boundKeypairAdapter{
+		storage: p.storage,
+	}
+}
+
+// boundKeypairAdapter satisfies the boundkeypair.FS interface and is suitable
+// for managing persistence of bound keypair keys using agent local storage.
+type boundKeypairAdapter struct {
+	storage *storage.ProcessStorage
+}
+
+func (a *boundKeypairAdapter) Read(ctx context.Context, name string) ([]byte, error) {
+	return a.storage.ReadBoundKeypairItem(ctx, name)
+}
+
+func (a *boundKeypairAdapter) Write(ctx context.Context, name string, value []byte) error {
+	return a.storage.WriteBoundKeypairItem(ctx, name, value)
+}

--- a/lib/service/bound_keypair_adapter.go
+++ b/lib/service/bound_keypair_adapter.go
@@ -1,6 +1,6 @@
 /*
  * Teleport
- * Copyright (C) 2023  Gravitational, Inc.
+ * Copyright (C) 2026  Gravitational, Inc.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by

--- a/lib/service/bound_keypair_adapter_test.go
+++ b/lib/service/bound_keypair_adapter_test.go
@@ -1,0 +1,81 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package service
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
+	"github.com/gravitational/teleport/lib/auth/storage"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundKeypairStorageAdapter(t *testing.T) {
+	ctx := t.Context()
+	tempDir := t.TempDir()
+
+	backend, err := memory.New(memory.Config{})
+	require.NoError(t, err)
+
+	processStorage, err := storage.NewProcessStorage(
+		ctx,
+		filepath.Join(tempDir, teleport.ComponentProcess),
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		backend.Close()
+		processStorage.Close()
+	})
+
+	process := &TeleportProcess{
+		Supervisor: &LocalSupervisor{
+			exitContext: t.Context(),
+		},
+		backend: backend,
+		storage: processStorage,
+		logger:  logtest.NewLogger(),
+	}
+
+	adapter := process.boundKeypairStorageAdapter()
+
+	state := boundkeypair.NewEmptyFSClientState(adapter)
+
+	// Fake a new keypair request, this should update the client state and make
+	// it non-empty.
+	signer, err := state.RequestNewKeypair(ctx,
+		cryptosuites.StaticAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1),
+	)
+	require.NoError(t, err)
+
+	// Set the new key as active and store it. The state should have a nonempty
+	// key.
+	require.NoError(t, state.SetActiveKey(signer))
+	require.NoError(t, state.Store(ctx))
+	require.NotEmpty(t, state.PrivateKeyBytes)
+
+	loadedState, err := boundkeypair.LoadClientState(ctx, adapter)
+	require.NoError(t, err)
+
+	require.Equal(t, state.PrivateKeyBytes, loadedState.PrivateKeyBytes)
+}

--- a/lib/service/bound_keypair_adapter_test.go
+++ b/lib/service/bound_keypair_adapter_test.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
@@ -27,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/teleport/lib/cryptosuites"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
-	"github.com/stretchr/testify/require"
 )
 
 func TestBoundKeypairStorageAdapter(t *testing.T) {

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -726,7 +726,7 @@ func (process *TeleportProcess) legacyJoinWithHostUUID(role types.SystemRole, ho
 // initBoundKeypairClientState attempts to initialize or load an existing bound
 // keypair client state. This state could be static or stored in the local
 // process storage.
-func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.ClientState, error) {
+func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.ClientState, string, error) {
 	cfg := process.Config.JoinParams.BoundKeypair
 
 	staticKey, err := cfg.StaticPrivateKeyBytes()
@@ -737,12 +737,12 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 			"error", err,
 		)
 	} else if staticKey != nil {
-		return boundkeypair.NewStaticClientState(staticKey), nil
+		return boundkeypair.NewStaticClientState(staticKey), "", nil
 	}
 
 	registrationSecret, err := cfg.RegistrationSecret()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, "", trace.Wrap(err)
 	}
 
 	adapter := process.boundKeypairStorageAdapter()
@@ -761,10 +761,10 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 				"could be loaded and no registration secret was configured",
 			"error", err,
 		)
-		return nil, trace.Wrap(err, "loading bound keypair client state")
+		return nil, "", trace.Wrap(err, "loading bound keypair client state")
 	}
 
-	return state, nil
+	return state, registrationSecret, nil
 }
 
 func (process *TeleportProcess) makeJoinParams(
@@ -811,12 +811,13 @@ func (process *TeleportProcess) makeJoinParams(
 		}
 	}
 	if joinParams.JoinMethod == types.JoinMethodBoundKeypair {
-		boundKeypairState, err := process.initBoundKeypairClientState()
+		boundKeypairState, regSecret, err := process.initBoundKeypairClientState()
 		if err != nil {
 			return nil, trace.Wrap(err, "initializing bound keypair client state")
 		}
 
 		joinParams.BoundKeypairState = boundKeypairState
+		joinParams.BoundKeypairRegistrationSecret = regSecret
 	}
 	return joinParams, nil
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -815,8 +815,6 @@ func (process *TeleportProcess) makeJoinParams(
 			return nil, trace.Wrap(err, "initializing bound keypair client state")
 		}
 
-		// TODO: this was accidental but I think is actually the correct way to
-		// do this, and we should refactor joinParams to make this real.
 		joinParams.BoundKeypairState = boundKeypairState
 	}
 	return joinParams, nil

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -758,7 +758,8 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 		process.logger.ErrorContext(
 			process.ExitContext(),
 			"Could not complete bound keypair joining: no local credentials "+
-				"are available and no registration secret was configured",
+				"could be loaded and no registration secret was configured",
+			"error", err,
 		)
 		return nil, trace.Wrap(err, "loading bound keypair client state")
 	}

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/auth/join/boundkeypair"
 	"github.com/gravitational/teleport/lib/auth/state"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -722,6 +723,49 @@ func (process *TeleportProcess) legacyJoinWithHostUUID(role types.SystemRole, ho
 	return identity, trace.Wrap(err)
 }
 
+// initBoundKeypairClientState attempts to initialize or load an existing bound
+// keypair client state. This state could be static or stored in the local
+// process storage.
+func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.ClientState, error) {
+	cfg := process.Config.JoinParams.BoundKeypair
+
+	staticKey, err := cfg.StaticPrivateKeyBytes()
+	if err != nil {
+		process.logger.WarnContext(
+			process.ExitContext(),
+			"Could not load the configured bound keypair static key, will attempt to fall back to a standard keypair",
+			"error", err,
+		)
+	} else if staticKey != nil {
+		return boundkeypair.NewStaticClientState(staticKey), nil
+	}
+
+	registrationSecret, err := cfg.RegistrationSecret()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	adapter := process.boundKeypairStorageAdapter()
+	state, err := boundkeypair.LoadClientState(process.GracefulExitContext(), adapter)
+	if trace.IsNotFound(err) && registrationSecret != "" {
+		process.logger.InfoContext(
+			process.ExitContext(),
+			"No existing bound keypair client state found, will attempt to "+
+				"join with configured registration secret",
+		)
+		state = boundkeypair.NewEmptyFSClientState(adapter)
+	} else if err != nil {
+		process.logger.ErrorContext(
+			process.ExitContext(),
+			"Could not complete bound keypair joining: no local credentials "+
+				"are available and no registration secret was configured",
+		)
+		return nil, trace.Wrap(err, "loading bound keypair client state")
+	}
+
+	return state, nil
+}
+
 func (process *TeleportProcess) makeJoinParams(
 	id state.IdentityID,
 	additionalPrincipals []string,
@@ -764,6 +808,16 @@ func (process *TeleportProcess) makeJoinParams(
 		joinParams.AzureParams = joinclient.AzureParams{
 			ClientID: process.Config.JoinParams.Azure.ClientID,
 		}
+	}
+	if joinParams.JoinMethod == types.JoinMethodBoundKeypair {
+		boundKeypairState, err := process.initBoundKeypairClientState()
+		if err != nil {
+			return nil, trace.Wrap(err, "initializing bound keypair client state")
+		}
+
+		// TODO: this was accidental but I think is actually the correct way to
+		// do this, and we should refactor joinParams to make this real.
+		joinParams.BoundKeypairState = boundKeypairState
 	}
 	return joinParams, nil
 }

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -740,20 +740,27 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 		return boundkeypair.NewStaticClientState(staticKey), "", nil
 	}
 
-	registrationSecret, err := cfg.RegistrationSecret()
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
 	adapter := process.boundKeypairStorageAdapter()
 	state, err := boundkeypair.LoadClientState(process.GracefulExitContext(), adapter)
-	if trace.IsNotFound(err) && registrationSecret != "" {
+	if trace.IsNotFound(err) {
+		registrationSecret, err := cfg.RegistrationSecret()
+		if err != nil {
+			process.logger.ErrorContext(
+				process.ExitContext(),
+				"Could not complete bound keypair joining: no local credentials "+
+					"could be loaded and no registration secret was configured",
+				"error", err,
+			)
+
+			return nil, "", trace.Wrap(err, "loading bound keypair registration secret")
+		}
+
 		process.logger.InfoContext(
 			process.ExitContext(),
 			"No existing bound keypair client state found, will attempt to "+
 				"join with configured registration secret",
 		)
-		state = boundkeypair.NewEmptyFSClientState(adapter)
+		return boundkeypair.NewEmptyFSClientState(adapter), registrationSecret, nil
 	} else if err != nil {
 		process.logger.ErrorContext(
 			process.ExitContext(),
@@ -764,7 +771,7 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 		return nil, "", trace.Wrap(err, "loading bound keypair client state")
 	}
 
-	return state, registrationSecret, nil
+	return state, "", nil
 }
 
 func (process *TeleportProcess) makeJoinParams(

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -753,6 +753,8 @@ func (process *TeleportProcess) initBoundKeypairClientState() (boundkeypair.Clie
 			)
 
 			return nil, "", trace.Wrap(err, "loading bound keypair registration secret")
+		} else if registrationSecret == "" {
+			return nil, "", trace.BadParameter("no existing bound keypair credentials and no registration secret configured")
 		}
 
 		process.logger.InfoContext(

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -23,6 +23,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
@@ -33,8 +36,6 @@ import (
 	"github.com/gravitational/teleport/lib/join/joinclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
-	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/ssh"
 )
 
 func TestMakeJoinParams_BoundKeypair(t *testing.T) {

--- a/lib/service/connect_test.go
+++ b/lib/service/connect_test.go
@@ -1,0 +1,173 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth/state"
+	"github.com/gravitational/teleport/lib/auth/storage"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/join/joinclient"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils/log/logtest"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
+)
+
+func TestMakeJoinParams_BoundKeypair(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	staticKey, err := cryptosuites.GenerateKey(ctx,
+		cryptosuites.StaticAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1),
+		cryptosuites.BoundKeypairJoining)
+	require.NoError(t, err)
+
+	sshPubKey, err := ssh.NewPublicKey(staticKey.Public())
+	require.NoError(t, err)
+
+	publicKeyBytes := ssh.MarshalAuthorizedKey(sshPubKey)
+
+	privateKeyBytes, err := keys.MarshalPrivateKey(staticKey)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	regSecretPath := filepath.Join(dir, "reg-secret")
+	staticKeyPath := filepath.Join(dir, "static-key")
+
+	require.NoError(t, os.WriteFile(regSecretPath, []byte("reg-secret"), 0600))
+	require.NoError(t, os.WriteFile(staticKeyPath, privateKeyBytes, 0600))
+
+	for _, tt := range []struct {
+		name             string
+		mutateConfig     func(*servicecfg.Config)
+		assertError      require.ErrorAssertionFunc
+		assertJoinParams func(t *testing.T, params *joinclient.JoinParams)
+	}{
+		{
+			name:        "bound keypair not configured",
+			assertError: require.NoError,
+			assertJoinParams: func(t *testing.T, params *joinclient.JoinParams) {
+				require.Nil(t, params.BoundKeypairState)
+			},
+		},
+		{
+			name: "bound keypair registration secret value configured",
+			mutateConfig: func(c *servicecfg.Config) {
+				c.JoinMethod = types.JoinMethodBoundKeypair
+				c.JoinParams.BoundKeypair.RegistrationSecretValue = "test"
+			},
+			assertError: require.NoError,
+			assertJoinParams: func(t *testing.T, params *joinclient.JoinParams) {
+				require.Equal(t, "test", params.BoundKeypairRegistrationSecret)
+				require.NotNil(t, params.BoundKeypairState)
+
+				// Should be initialized but empty.
+				require.Empty(t, params.BoundKeypairState.GetClientParams("").PreviousJoinState)
+			},
+		},
+		{
+			name: "bound keypair registration secret path configured",
+			mutateConfig: func(c *servicecfg.Config) {
+				c.JoinMethod = types.JoinMethodBoundKeypair
+				c.JoinParams.BoundKeypair.RegistrationSecretPath = regSecretPath
+			},
+			assertError: require.NoError,
+			assertJoinParams: func(t *testing.T, params *joinclient.JoinParams) {
+				require.Equal(t, "reg-secret", params.BoundKeypairRegistrationSecret)
+				require.NotNil(t, params.BoundKeypairState)
+
+				// Should be initialized but empty.
+				require.Empty(t, params.BoundKeypairState.GetClientParams("").PreviousJoinState)
+			},
+		},
+		{
+			name: "bound keypair static key configured",
+			mutateConfig: func(c *servicecfg.Config) {
+				c.JoinMethod = types.JoinMethodBoundKeypair
+				c.JoinParams.BoundKeypair.StaticPrivateKeyPath = staticKeyPath
+			},
+			assertError: require.NoError,
+			assertJoinParams: func(t *testing.T, params *joinclient.JoinParams) {
+				require.Empty(t, params.BoundKeypairRegistrationSecret)
+
+				// Should be initialized and nonempty.
+				state := params.BoundKeypairState
+				require.NotNil(t, state)
+
+				// It should be possible to fetch the signer by its public key
+				signer, err := state.GetSigner(publicKeyBytes)
+				require.NoError(t, err)
+				require.NotNil(t, signer)
+
+				// Previous join state should still be empty.
+				require.Empty(t, params.BoundKeypairState.GetClientParams("").PreviousJoinState)
+
+				// RequestNewKeypair should fail (impl doesn't support rotation)
+				_, err = state.RequestNewKeypair(ctx, cryptosuites.StaticAlgorithmSuite(types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1))
+				require.ErrorContains(t, err, "do not support automatic rotation")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			backend, err := memory.New(memory.Config{})
+			require.NoError(t, err)
+
+			processStorage, err := storage.NewProcessStorage(
+				ctx,
+				filepath.Join(tempDir, teleport.ComponentProcess),
+			)
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				backend.Close()
+				processStorage.Close()
+			})
+
+			process := &TeleportProcess{
+				Supervisor: &LocalSupervisor{
+					exitContext:         t.Context(),
+					gracefulExitContext: t.Context(),
+				},
+				Config:  servicecfg.MakeDefaultConfig(),
+				backend: backend,
+				storage: processStorage,
+				logger:  logtest.NewLogger(),
+			}
+			process.Config.SetToken("example")
+
+			if tt.mutateConfig != nil {
+				tt.mutateConfig(process.Config)
+			}
+
+			params, err := process.makeJoinParams(state.IdentityID{}, []string{}, []string{})
+			tt.assertError(t, err)
+			tt.assertJoinParams(t, params)
+		})
+	}
+}

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -463,12 +463,79 @@ func DisableLongRunningServices(cfg *Config) {
 
 // JoinParams is a set of extra parameters for joining the auth server.
 type JoinParams struct {
-	Azure AzureJoinParams
+	Azure        AzureJoinParams
+	BoundKeypair BoundKeypairParams
 }
 
 // AzureJoinParams is the parameters specific to the azure join method.
 type AzureJoinParams struct {
 	ClientID string
+}
+
+// BoundKeypairParams contains parameters specific to bound keypair joining.
+type BoundKeypairParams struct {
+	// RegistrationSecretValue is an explicit registration secret value, used to
+	// authenticate the initial join with a bound keypair token. It becomes
+	// inert once used.
+	RegistrationSecretValue string
+
+	// RegistrationSecretPath is a path to a file on the local disk containing a
+	// registration secret. It is incompatible with RegistrationSecretValue.
+	RegistrationSecretPath string
+
+	// StaticPrivateKeyPath is a path to a file on the local disk containing a
+	// static keypair to be used for bound keypair joining. Static keys are
+	// immmutable and are not managed automatically. They must be preregistered,
+	// do not support automatic keypair rotation, and must be used with a token
+	// set to use `insecure` recovery mode.
+	StaticPrivateKeyPath string
+}
+
+// RegistrationSecret returns the currently configured bound keypair
+// registration secret, if any. Registration secrets are optional, and only used
+// at first join when no existing identity can be used to authenticate the join
+// request, no pregenerated key exists, and no static key is configured.
+func (b *BoundKeypairParams) RegistrationSecret() (string, error) {
+	if b.RegistrationSecretValue != "" && b.RegistrationSecretPath != "" {
+		return "", trace.BadParameter("only one of `registration_secret` and `registration_secret_path` may be specified")
+	}
+
+	// TODO: Consider whether or not to support environment variable config. Is
+	// there precedent for agents?
+
+	switch {
+	case b.RegistrationSecretPath != "":
+		bytes, err := os.ReadFile(b.RegistrationSecretPath)
+		if err != nil {
+			return "", trace.ConvertSystemError(err)
+		}
+
+		return strings.TrimSpace(string(bytes)), nil
+	case b.RegistrationSecretValue != "":
+		return b.RegistrationSecretValue, nil
+	default:
+		return "", nil
+	}
+}
+
+// StaticPrivateKeyBytes returns the configured static private key if one has
+// been configured. If not nil, this value should be used to initialize a
+// bound keypair `StaticClientState` instead of the process-stored state. Static
+// keys do not support automatic rotation or join state verification. 
+func (b *BoundKeypairParams) StaticPrivateKeyBytes() ([]byte, error) {
+	if b.StaticPrivateKeyPath != "" {
+		bytes, err := os.ReadFile(b.StaticPrivateKeyPath)
+		if err != nil {
+			return nil, trace.Wrap(err, "reading static key from %s", b.StaticPrivateKeyPath)
+		}
+
+		return bytes, nil
+	}
+
+	// TODO: Consider env var support
+
+	// No static key configured, nothing to return.
+	return nil, nil
 }
 
 // CachePolicy sets caching policy for proxies and nodes

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -500,8 +500,8 @@ func (b *BoundKeypairParams) RegistrationSecret() (string, error) {
 		return "", trace.BadParameter("only one of `registration_secret` and `registration_secret_path` may be specified")
 	}
 
-	// TODO: Consider whether or not to support environment variable config. Is
-	// there precedent for agents?
+	// Note: no env var support like in tbot, we could consider adding it in the
+	// future.
 
 	switch {
 	case b.RegistrationSecretPath != "":
@@ -532,7 +532,8 @@ func (b *BoundKeypairParams) StaticPrivateKeyBytes() ([]byte, error) {
 		return bytes, nil
 	}
 
-	// TODO: Consider env var support
+	// Note: no env var support like in tbot, may consider adding it in the
+	// future.
 
 	// No static key configured, nothing to return.
 	return nil, nil

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -485,7 +485,7 @@ type BoundKeypairParams struct {
 
 	// StaticPrivateKeyPath is a path to a file on the local disk containing a
 	// static keypair to be used for bound keypair joining. Static keys are
-	// immmutable and are not managed automatically. They must be preregistered,
+	// immutable and are not managed automatically. They must be preregistered,
 	// do not support automatic keypair rotation, and must be used with a token
 	// set to use `insecure` recovery mode.
 	StaticPrivateKeyPath string
@@ -521,7 +521,7 @@ func (b *BoundKeypairParams) RegistrationSecret() (string, error) {
 // StaticPrivateKeyBytes returns the configured static private key if one has
 // been configured. If not nil, this value should be used to initialize a
 // bound keypair `StaticClientState` instead of the process-stored state. Static
-// keys do not support automatic rotation or join state verification. 
+// keys do not support automatic rotation or join state verification.
 func (b *BoundKeypairParams) StaticPrivateKeyBytes() ([]byte, error) {
 	if b.StaticPrivateKeyPath != "" {
 		bytes, err := os.ReadFile(b.StaticPrivateKeyPath)

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -690,6 +691,106 @@ func TestSetLogLevel(t *testing.T) {
 
 			c.SetLogLevel(test.logLevel)
 			require.Equal(t, test.logLevel, c.LoggerLevel.Level())
+		})
+	}
+}
+
+func TestBoundKeypairConfig(t *testing.T) {
+	dir := t.TempDir()
+	regSecretPath := filepath.Join(dir, "reg-secret")
+	staticKeyPath := filepath.Join(dir, "static-key")
+
+	require.NoError(t, os.WriteFile(regSecretPath, []byte("reg-secret"), 0600))
+	require.NoError(t, os.WriteFile(staticKeyPath, []byte("static-key"), 0600))
+
+	tests := []struct {
+		name   string
+		config BoundKeypairParams
+		assert func(cfg BoundKeypairParams)
+	}{
+		{
+			name: "registration secret value",
+			config: BoundKeypairParams{
+				RegistrationSecretValue: "reg-secret",
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.RegistrationSecret()
+				require.NoError(t, err)
+				require.Equal(t, "reg-secret", secret)
+			},
+		},
+		{
+			name: "registration secret path",
+			config: BoundKeypairParams{
+				RegistrationSecretPath: regSecretPath,
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.RegistrationSecret()
+				require.NoError(t, err)
+				require.Equal(t, "reg-secret", secret)
+			},
+		},
+		{
+			name: "registration secret path does not exist",
+			config: BoundKeypairParams{
+				RegistrationSecretPath: filepath.Join(dir, "invalid-reg-secret"),
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.RegistrationSecret()
+				require.ErrorContains(t, err, "no such file")
+				require.Empty(t, secret)
+			},
+		},
+		{
+			name:   "empty",
+			config: BoundKeypairParams{},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.RegistrationSecret()
+				require.NoError(t, err)
+				require.Empty(t, secret)
+			},
+		},
+		{
+			name: "error if ambiguous",
+			config: BoundKeypairParams{
+				RegistrationSecretValue: "foo",
+				RegistrationSecretPath:  "bar",
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.RegistrationSecret()
+				require.ErrorContains(t, err, "only one")
+				require.Empty(t, secret)
+			},
+		},
+		{
+			name: "static key path",
+			config: BoundKeypairParams{
+				StaticPrivateKeyPath: staticKeyPath,
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.StaticPrivateKeyBytes()
+				require.NoError(t, err)
+				require.Equal(t, []byte("static-key"), secret)
+			},
+		},
+		{
+			name: "static key path does not exist",
+			config: BoundKeypairParams{
+				StaticPrivateKeyPath: filepath.Join(dir, "invalid-static-key"),
+			},
+			assert: func(cfg BoundKeypairParams) {
+				secret, err := cfg.StaticPrivateKeyBytes()
+				require.ErrorContains(t, err, "no such file")
+				require.Empty(t, secret)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			test.assert(test.config)
 		})
 	}
 }


### PR DESCRIPTION
This adds basic support for bound keypair joining for all agent types. This provides benefits in certain situations, for example:
- Bound keypair registration secrets are single-use, unlike `token`. In rare cases, users may want to provide a credential that can only join one node.
- Bound keypair allows preregistration of the node's public key, eliminating shared secrets.

Notably, agents are still issued long-lived, effectively permanent credentials (10yr) after their first registration. This means many benefits of bound keypair joining are not relevant once joined; agents should effectively never need to perform a recovery as their primary credentials are valid for the life of the agent.

This PR adds client-side support to the agent join process, allowing agents to store new bound keypair credential material in their local state storage (alongside other credentials, like their usual long-lived certs), load various bound keypair-related fields from YAML config, and pass the required parameters along to the `joinclient` so it can complete bound keypair challenges at join time.

This feature is split into several PRs:
- Proto changes: https://github.com/gravitational/teleport/pull/64234
- Join client interface refactor to better support agents: https://github.com/gravitational/teleport/pull/64235
- Support agent UUIDs and other non-bot fixes in the join method itself: https://github.com/gravitational/teleport/pull/64351
- Add bound keypair support to agents (this PR)

changelog: Standard Teleport agents can now join using the `bound_keypair` join method

## Manual test plan

### Test environment

To adequately test the bound keypair storage adapter, this should be tested both on a traditional node (e.g. standard binary in a Docker container) and in Kubernetes (with the kubernetes secret backend).

See the test plan in #64351 for more detailed test env setup instructions.

### Test cases

- [x] Agent can join with bound keypair + registration secret on a standalone host. Backend should be populated.
- [x] Agent can join with bound keypair + registration secret in Kubernetes using the Kubenetes secret backend. The secret should contain the bound keypair credentials.
- [x] Agents can still join with other join methods (e.g. token)
- [x] Agent cannot join using the legacy join service (requires agent binary with hack to force use of the legacy join service, or otherwise triggering a join failure that results in a call to the legacy join service)
- [x] Agent can successfully repeat bound keypair joining to refresh certificates when needed. This can be done by updating the token roles (e.g. adding app service) and then adding a new service to the agent, forcing it to request new certs with the added role.