### PR TITLE
Move error boundary to a child of theme provider so it displays properly

### DIFF
--- a/web/packages/teleport/src/Teleport.tsx
+++ b/web/packages/teleport/src/Teleport.tsx
@@ -92,9 +92,9 @@ const Teleport: React.FC<Props> = props => {
   }, []);
 
   return (
-    <CatchError>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <CatchError>
           <LayoutContextProvider>
             <Router history={history}>
               <Suspense fallback={null}>
@@ -121,9 +121,9 @@ const Teleport: React.FC<Props> = props => {
               </Suspense>
             </Router>
           </LayoutContextProvider>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </CatchError>
+        </CatchError>
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 };
 


### PR DESCRIPTION
As it stands, the global error boundary for the app is the first thing we render, which causes white screens to show instead of the error. This is because the error boundary uses styled components/the theme, so it would error and show a white screen instead of the error (as the theme provider was a child of the error boundary, and the displaying of the error could not read values from the theme).

<img width="1693" height="1422" alt="image" src="https://github.com/user-attachments/assets/a9862d5a-6fc4-4889-9fdb-0b0a4b312fc2" />

<img width="1693" height="1422" alt="image" src="https://github.com/user-attachments/assets/a180ce59-d319-43af-8eba-42552b4d4833" />

### Manual testing

- [x] Verified that before this, when an error was thrown (like a session recording summary failing to load), the screen would be white and we'd get a `Cannot read properties of undefined (reading '2')` error in the console (not related to the actual error thrown)
- [x] After this fix, we display the correct error in the UI, no white screen, and only the actual error that occurred is shown in the console

changelog: Fixed an issue where the UI would display a white screen and no error when an error occurred