### PR TITLE
[v18] Restart DiscoveryConfig watcher in Discovery Service

### DIFF
--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -38,7 +38,7 @@ import (
 const databaseEventPrefix = "db/"
 
 func (s *Server) startDatabaseWatchers() error {
-	if len(s.databaseFetchers) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.databaseFetchers) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -423,7 +423,8 @@ type Server struct {
 
 	// dynamicMatcherWatcher is an initialized Watcher for DiscoveryConfig resources.
 	// Each new event must update the existing resources.
-	dynamicMatcherWatcher types.Watcher
+	dynamicMatcherWatcher   types.Watcher
+	dynamicMatcherWatcherMu sync.Mutex
 
 	// dynamicDatabaseFetchers holds the current Database Fetchers for the Dynamic Matchers (those coming from DiscoveryConfig resource).
 	// The key is the DiscoveryConfig name.
@@ -534,20 +535,12 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.startDynamicMatchersWatcher(s.ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
+	s.startDynamicMatchersWatcher(s.ctx)
 
 	return s, nil
 }
 
-// startDynamicMatchersWatcher starts a watcher for DiscoveryConfig events.
-// After initialization, it starts a goroutine that receives and handles events.
-func (s *Server) startDynamicMatchersWatcher(ctx context.Context) error {
-	if s.DiscoveryGroup == "" {
-		return nil
-	}
-
+func (s *Server) runDynamicMatchersWatcher(ctx context.Context) error {
 	watcher, err := s.AccessPoint.NewWatcher(ctx, types.Watch{
 		Kinds: []types.WatchKind{{
 			Kind: types.KindDiscoveryConfig,
@@ -567,14 +560,46 @@ func (s *Server) startDynamicMatchersWatcher(ctx context.Context) error {
 		return trace.Wrap(watcher.Error())
 	}
 
+	s.dynamicMatcherWatcherMu.Lock()
 	s.dynamicMatcherWatcher = watcher
+	s.dynamicMatcherWatcherMu.Unlock()
 
 	if err := s.loadExistingDynamicDiscoveryConfigs(); err != nil {
 		return trace.Wrap(err)
 	}
 
-	go s.startDynamicWatcherUpdater()
+	s.startDynamicWatcherUpdater()
 	return nil
+}
+
+// startDynamicMatchersWatcher starts a watcher for DiscoveryConfig events.
+// Does not block and runs until the provided context is done.
+// Restarts on watcher errors, with a 1 minute delay between retries.
+func (s *Server) startDynamicMatchersWatcher(ctx context.Context) {
+	if s.DiscoveryGroup == "" {
+		return
+	}
+
+	s.Log.DebugContext(ctx, "Starting DiscoveryConfig watcher")
+	go func() {
+		for {
+			if err := s.runDynamicMatchersWatcher(ctx); err != nil {
+				s.Log.ErrorContext(ctx, "DiscoveryConfig watcher failed", "error", err)
+			}
+
+			select {
+			case <-s.ctx.Done():
+				// Break the loop if server's context is done.
+				s.Log.DebugContext(ctx, "Shutting down DiscoveryConfig watcher", "error", s.ctx.Err())
+				return
+
+			case <-s.clock.After(1 * time.Minute):
+				// runDynamicMatchersWatcher might fail due to a transient error in the watcher.
+				// Wait 1 minute before retrying.
+				s.Log.InfoContext(ctx, "Restarting DiscoveryConfig watcher", "error", s.ctx.Err())
+			}
+		}
+	}()
 }
 
 // publicProxyAddress returns the public proxy address to use for installation scripts.
@@ -1657,6 +1682,8 @@ func (s *Server) Start() error {
 // loadExistingDynamicDiscoveryConfigs loads all the dynamic discovery configs for the current discovery group
 // and setups their matchers.
 func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
+	hasDynamicMatchers := false
+	discoveryConfigsMap := make(map[string]*discoveryconfig.DiscoveryConfig)
 	// Add all existing DiscoveryConfigs as matchers.
 	nextKey := ""
 	for {
@@ -1674,13 +1701,23 @@ func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
 				s.Log.WarnContext(s.ctx, "Failed to update dynamic matchers for discovery config", "discovery_config", dc.GetName(), "error", err)
 				continue
 			}
-			s.dynamicDiscoveryConfig[dc.GetName()] = dc
+			discoveryConfigsMap[dc.GetName()] = dc
+			hasDynamicMatchers = true
 		}
 		if respNextKey == "" {
 			break
 		}
 		nextKey = respNextKey
 	}
+
+	s.dynamicDiscoveryConfigMu.Lock()
+	s.dynamicDiscoveryConfig = discoveryConfigsMap
+	s.dynamicDiscoveryConfigMu.Unlock()
+
+	if hasDynamicMatchers {
+		s.notifyDiscoveryConfigChanged()
+	}
+
 	return nil
 }
 
@@ -1930,11 +1967,15 @@ func (s *Server) Stop() {
 	if s.gcpWatcher != nil {
 		s.gcpWatcher.Stop()
 	}
+
+	s.dynamicMatcherWatcherMu.Lock()
 	if s.dynamicMatcherWatcher != nil {
 		if err := s.dynamicMatcherWatcher.Close(); err != nil {
 			s.Log.WarnContext(s.ctx, "Dynamic matcher watcher closing error", "error", err)
 		}
 	}
+	s.dynamicMatcherWatcherMu.Unlock()
+
 	if s.gcpClients != nil {
 		_ = s.gcpClients.Close()
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -421,11 +421,6 @@ type Server struct {
 	// databaseFetchers holds all database fetchers.
 	databaseFetchers []common.Fetcher
 
-	// dynamicMatcherWatcher is an initialized Watcher for DiscoveryConfig resources.
-	// Each new event must update the existing resources.
-	dynamicMatcherWatcher   types.Watcher
-	dynamicMatcherWatcherMu sync.Mutex
-
 	// dynamicDatabaseFetchers holds the current Database Fetchers for the Dynamic Matchers (those coming from DiscoveryConfig resource).
 	// The key is the DiscoveryConfig name.
 	dynamicDatabaseFetchers   map[string][]common.Fetcher
@@ -549,9 +544,12 @@ func (s *Server) runDynamicMatchersWatcher(ctx context.Context) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	defer watcher.Close()
 
 	// Wait for OpInit event so the watcher is ready.
 	select {
+	case <-ctx.Done():
+		return trace.Wrap(ctx.Err())
 	case event := <-watcher.Events():
 		if event.Type != types.OpInit {
 			return trace.BadParameter("failed to watch for DiscoveryConfig: received an unexpected event while waiting for the initial OpInit")
@@ -560,16 +558,11 @@ func (s *Server) runDynamicMatchersWatcher(ctx context.Context) error {
 		return trace.Wrap(watcher.Error())
 	}
 
-	s.dynamicMatcherWatcherMu.Lock()
-	s.dynamicMatcherWatcher = watcher
-	s.dynamicMatcherWatcherMu.Unlock()
-
 	if err := s.loadExistingDynamicDiscoveryConfigs(); err != nil {
 		return trace.Wrap(err)
 	}
 
-	s.startDynamicWatcherUpdater()
-	return nil
+	return trace.Wrap(s.startDynamicWatcherUpdater(ctx, watcher))
 }
 
 // startDynamicMatchersWatcher starts a watcher for DiscoveryConfig events.
@@ -588,15 +581,15 @@ func (s *Server) startDynamicMatchersWatcher(ctx context.Context) {
 			}
 
 			select {
-			case <-s.ctx.Done():
+			case <-ctx.Done():
 				// Break the loop if server's context is done.
-				s.Log.DebugContext(ctx, "Shutting down DiscoveryConfig watcher", "error", s.ctx.Err())
+				s.Log.DebugContext(ctx, "Shutting down DiscoveryConfig watcher", "error", ctx.Err())
 				return
 
 			case <-s.clock.After(1 * time.Minute):
 				// runDynamicMatchersWatcher might fail due to a transient error in the watcher.
 				// Wait 1 minute before retrying.
-				s.Log.InfoContext(ctx, "Restarting DiscoveryConfig watcher", "error", s.ctx.Err())
+				s.Log.InfoContext(ctx, "Restarting DiscoveryConfig watcher", "error", ctx.Err())
 			}
 		}
 	}()
@@ -1725,17 +1718,19 @@ func (s *Server) loadExistingDynamicDiscoveryConfigs() error {
 // Before consuming changes, it iterates over all DiscoveryConfigs and
 // For deleted resources, it deletes the matchers.
 // For new/updated resources, it replaces the set of fetchers.
-func (s *Server) startDynamicWatcherUpdater() {
+func (s *Server) startDynamicWatcherUpdater(ctx context.Context, dynamicMatcherWatcher types.Watcher) error {
 	// Consume DiscoveryConfig events to update Matchers as they change.
 	for {
 		select {
-		case event := <-s.dynamicMatcherWatcher.Events():
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		case event := <-dynamicMatcherWatcher.Events():
 			switch event.Type {
 			case types.OpPut:
 				dc, ok := event.Resource.(*discoveryconfig.DiscoveryConfig)
 				if !ok {
-					s.Log.WarnContext(s.ctx, "Dynamic matcher watcher: unexpected resource type", "expected", logutils.TypeAttr(dc), "got", logutils.TypeAttr(event.Resource))
-					return
+					s.Log.WarnContext(ctx, "Skipping unexpected resource type", "expected", logutils.TypeAttr(dc), "got", logutils.TypeAttr(event.Resource))
+					continue
 				}
 
 				if dc.GetDiscoveryGroup() != s.DiscoveryGroup {
@@ -1766,8 +1761,8 @@ func (s *Server) startDynamicWatcherUpdater() {
 					continue
 				}
 
-				if err := s.upsertDynamicMatchers(s.ctx, dc); err != nil {
-					s.Log.WarnContext(s.ctx, "Failed to update dynamic matchers for discovery config", "discovery_config", dc.GetName(), "error", err)
+				if err := s.upsertDynamicMatchers(ctx, dc); err != nil {
+					s.Log.WarnContext(ctx, "Failed to update dynamic matchers for discovery config", "discovery_config", dc.GetName(), "error", err)
 					continue
 				}
 				s.dynamicDiscoveryConfigMu.Lock()
@@ -1791,13 +1786,10 @@ func (s *Server) startDynamicWatcherUpdater() {
 				s.dynamicDiscoveryConfigMu.Unlock()
 				s.notifyDiscoveryConfigChanged()
 			default:
-				s.Log.WarnContext(s.ctx, "Skipping unknown event type %s", "got", event.Type)
+				s.Log.WarnContext(ctx, "Skipping unknown event type %s", "got", event.Type)
 			}
-		case <-s.dynamicMatcherWatcher.Done():
-			if err := s.dynamicMatcherWatcher.Error(); err != nil {
-				s.Log.WarnContext(s.ctx, "Dynamic matcher watcher error", "error", err)
-			}
-			return
+		case <-dynamicMatcherWatcher.Done():
+			return trace.Wrap(dynamicMatcherWatcher.Error())
 		}
 	}
 }
@@ -1967,14 +1959,6 @@ func (s *Server) Stop() {
 	if s.gcpWatcher != nil {
 		s.gcpWatcher.Stop()
 	}
-
-	s.dynamicMatcherWatcherMu.Lock()
-	if s.dynamicMatcherWatcher != nil {
-		if err := s.dynamicMatcherWatcher.Close(); err != nil {
-			s.Log.WarnContext(s.ctx, "Dynamic matcher watcher closing error", "error", err)
-		}
-	}
-	s.dynamicMatcherWatcherMu.Unlock()
 
 	if s.gcpClients != nil {
 		_ = s.gcpClients.Close()

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -975,108 +975,139 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 }
 
 type fakeAccessPointWithWatcher struct {
-	authclient.DiscoveryAccessPoint
+	*mockAuthServer
 
-	discoveryConfigWatcherMu sync.RWMutex
-	discoveryConfigWatcher   types.Watcher
+	discoveryConfigMu      sync.RWMutex
+	discoveryConfigWatcher *mockWatcher
+	discoveryConfigStore   []*discoveryconfig.DiscoveryConfig
+}
+
+func (f *fakeAccessPointWithWatcher) createDiscoveryConfig(discoveryConfig *discoveryconfig.DiscoveryConfig) {
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
+
+	f.discoveryConfigStore = append(f.discoveryConfigStore, discoveryConfig)
+
+	f.discoveryConfigWatcher.events <- types.Event{
+		Type:     types.OpPut,
+		Resource: discoveryConfig,
+	}
+}
+func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
+	return f.discoveryConfigWatcher.Close()
+}
+
+func (f *fakeAccessPointWithWatcher) ListDiscoveryConfigs(ctx context.Context, pageSize int, nextKey string) ([]*discoveryconfig.DiscoveryConfig, string, error) {
+	f.discoveryConfigMu.RLock()
+	defer f.discoveryConfigMu.RUnlock()
+
+	return f.discoveryConfigStore, "", nil
 }
 
 func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
-	watcher, err := f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
+	f.discoveryConfigMu.Lock()
+	defer f.discoveryConfigMu.Unlock()
 
-	f.discoveryConfigWatcherMu.Lock()
-	defer f.discoveryConfigWatcherMu.Unlock()
-	f.discoveryConfigWatcher = watcher
+	for _, kind := range watch.Kinds {
+		switch kind.Kind {
+		case types.KindDiscoveryConfig:
+			eventsCh := make(chan types.Event, 1)
+			eventsCh <- types.Event{
+				Type: types.OpInit,
+			}
 
-	return watcher, err
-}
+			f.discoveryConfigWatcher = &mockWatcher{
+				events: eventsCh,
+				done:   make(chan struct{}),
+			}
+			return f.discoveryConfigWatcher, nil
 
-func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
-	f.discoveryConfigWatcherMu.Lock()
-	defer f.discoveryConfigWatcherMu.Unlock()
-	return f.discoveryConfigWatcher.Close()
+		default:
+			return &mockWatcher{
+				events: make(chan types.Event, 1),
+				done:   make(chan struct{}),
+			}, nil
+		}
+	}
+
+	return nil, trace.BadParameter("missing watch kinds in NewWatcher")
 }
 
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
 // it restarts and continues to pick up new Discovery Configs matchers.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
-	fakeClock := clockwork.NewFakeClock()
+	const discoveryGroup = "discovery-group"
 
-	// Create and start test auth server.
-	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
-		Dir:   t.TempDir(),
-		Clock: fakeClock,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+	synctest.Test(t, func(t *testing.T) {
+		bk, err := memory.New(memory.Config{})
+		require.NoError(t, err)
 
-	tlsServer, err := testAuthServer.NewTestTLSServer()
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+		mockAuthServer := &mockAuthServer{
+			events: local.NewEventsService(bk),
+		}
 
-	// Auth client for discovery service.
-	identity := authtest.TestServerID(types.RoleDiscovery, "hostID")
-	authClient, err := tlsServer.NewClient(identity)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+		mockAccessPoint := &fakeAccessPointWithWatcher{
+			mockAuthServer: mockAuthServer,
+		}
 
-	accessPoint := &fakeAccessPointWithWatcher{
-		DiscoveryAccessPoint: getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
-	}
+		server, err := New(t.Context(), &Config{
+			ClusterFeatures: func() proto.Features { return proto.Features{} },
+			AccessPoint:     mockAccessPoint,
+			Matchers:        Matchers{},
+			Emitter:         &mockEmitter{},
+			Log:             logtest.NewLogger(),
+			DiscoveryGroup:  discoveryGroup,
+		})
+		require.NoError(t, err)
+		require.NoError(t, server.Start())
+		t.Cleanup(server.Stop)
 
-	// Start discovery server
-	server, err := New(t.Context(), &Config{
-		ClusterFeatures: func() proto.Features { return proto.Features{} },
-		AccessPoint:     accessPoint,
-		Matchers:        Matchers{},
-		Emitter:         authClient,
-		Log:             logtest.NewLogger(),
-		DiscoveryGroup:  "discovery-group",
-		clock:           fakeClock,
-	})
-	require.NoError(t, err)
+		// Wait for the server to start discovering resources.
+		synctest.Wait()
 
-	go server.Start()
-	t.Cleanup(server.Stop)
+		// 1. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers.
+		discoveryConfigA, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-a"},
+			discoveryconfig.Spec{
+				DiscoveryGroup: discoveryGroup,
+			},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(discoveryConfigA)
 
-	// 1. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers.
-	discoveryConfigA, err := discoveryconfig.NewDiscoveryConfig(
-		header.Metadata{Name: "dc-a"},
-		discoveryconfig.Spec{
-			DiscoveryGroup: "discovery-group",
-		},
-	)
-	require.NoError(t, err)
-	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigA)
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
+		// Wait until the event is processed.
+		synctest.Wait()
+
 		server.dynamicDiscoveryConfigMu.RLock()
-		defer server.dynamicDiscoveryConfigMu.RUnlock()
-		return len(server.dynamicDiscoveryConfig) == 1
-	}, 5*time.Second, 50*time.Millisecond)
+		require.Len(t, server.dynamicDiscoveryConfig, 1)
+		server.dynamicDiscoveryConfigMu.RUnlock()
 
-	// 2. Break the watcher
-	accessPoint.closeDiscoveryConfigWatcher()
+		// 2. Break the watcher
+		mockAccessPoint.closeDiscoveryConfigWatcher()
 
-	// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
-	discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(
-		header.Metadata{Name: "dc-b"},
-		discoveryconfig.Spec{
-			DiscoveryGroup: "discovery-group",
-		},
-	)
-	require.NoError(t, err)
-	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigB)
-	require.NoError(t, err)
+		// When the watcher breaks, it will restart after 1 minute.
+		// Sleep a little longer to ensure the watcher had time to restart.
+		time.Sleep(2 * time.Minute)
 
-	// DynamicMatcher watcher waits 1 minute before restarting, but in tests we can speed this up by advancing the fake clock.
-	fakeClock.Advance(2 * time.Minute)
+		// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
+		discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(
+			header.Metadata{Name: "dc-b"},
+			discoveryconfig.Spec{
+				DiscoveryGroup: discoveryGroup,
+			},
+		)
+		require.NoError(t, err)
+		go mockAccessPoint.createDiscoveryConfig(discoveryConfigB)
 
-	require.Eventually(t, func() bool {
+		// Wait until the event is processed.
+		synctest.Wait()
+
 		server.dynamicDiscoveryConfigMu.RLock()
-		defer server.dynamicDiscoveryConfigMu.RUnlock()
-		return len(server.dynamicDiscoveryConfig) == 2
-	}, 5*time.Second, 50*time.Millisecond)
+		require.Len(t, server.dynamicDiscoveryConfig, 2)
+		server.dynamicDiscoveryConfigMu.RUnlock()
+	})
 }
 
 func TestDiscoveryServerConcurrency(t *testing.T) {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -921,6 +921,9 @@ func TestDiscoveryServer(t *testing.T) {
 					want := *tc.wantDiscoveryConfigStatus
 					got := storedDiscoveryConfig.Status
 
+					if want.DiscoveredResources > 0 && storedDiscoveryConfig.Status.DiscoveredResources == 0 {
+						return false
+					}
 					require.Equal(t, want.State, got.State)
 					require.Equal(t, want.DiscoveredResources, got.DiscoveredResources)
 					require.Equal(t, want.ErrorMessage, got.ErrorMessage)
@@ -969,6 +972,86 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 	}, 10*time.Second, 50*time.Millisecond)
 
 	return existingTasks
+}
+
+// This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
+// it restarts and continues to pick up new Discovery Configs matchers.
+func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
+	fakeClock := clockwork.NewFakeClock()
+
+	// Create and start test auth server.
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: fakeClock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	tlsServer, err := testAuthServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	// Auth client for discovery service.
+	identity := authtest.TestServerID(types.RoleDiscovery, "hostID")
+	authClient, err := tlsServer.NewClient(identity)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+	// Start discovery server
+	server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
+		ClusterFeatures: func() proto.Features { return proto.Features{} },
+		AccessPoint:     getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+		Matchers:        Matchers{},
+		Emitter:         authClient,
+		Log:             logtest.NewLogger(),
+		DiscoveryGroup:  "discovery-group",
+		clock:           fakeClock,
+	})
+	require.NoError(t, err)
+
+	go server.Start()
+	t.Cleanup(server.Stop)
+
+	// 1. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers.
+	discoveryConfigA, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: "dc-a"},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "discovery-group",
+		},
+	)
+	require.NoError(t, err)
+	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigA)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		server.dynamicDiscoveryConfigMu.RLock()
+		defer server.dynamicDiscoveryConfigMu.RUnlock()
+		return len(server.dynamicDiscoveryConfig) == 1
+	}, 5*time.Second, 50*time.Millisecond)
+
+	// 2. Break the watcher
+	server.dynamicDiscoveryConfigMu.Lock()
+	server.dynamicMatcherWatcher.Close()
+	server.dynamicDiscoveryConfigMu.Unlock()
+
+	// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
+	discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: "dc-b"},
+		discoveryconfig.Spec{
+			DiscoveryGroup: "discovery-group",
+		},
+	)
+	require.NoError(t, err)
+	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(t.Context(), discoveryConfigB)
+	require.NoError(t, err)
+
+	// DynamicMatcher watcher waits 1 minute before restarting, but in tests we can speed this up by advancing the fake clock.
+	fakeClock.Advance(2 * time.Minute)
+
+	require.Eventually(t, func() bool {
+		server.dynamicDiscoveryConfigMu.RLock()
+		defer server.dynamicDiscoveryConfigMu.RUnlock()
+		return len(server.dynamicDiscoveryConfig) == 2
+	}, 5*time.Second, 50*time.Millisecond)
 }
 
 func TestDiscoveryServerConcurrency(t *testing.T) {

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -974,6 +974,29 @@ func fetchAllUserTasks(t *testing.T, userTasksClt services.UserTasks, minUserTas
 	return existingTasks
 }
 
+type fakeAccessPointWithWatcher struct {
+	authclient.DiscoveryAccessPoint
+
+	discoveryConfigWatcherMu sync.RWMutex
+	discoveryConfigWatcher   types.Watcher
+}
+
+func (f *fakeAccessPointWithWatcher) NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error) {
+	watcher, err := f.DiscoveryAccessPoint.NewWatcher(ctx, watch)
+
+	f.discoveryConfigWatcherMu.Lock()
+	defer f.discoveryConfigWatcherMu.Unlock()
+	f.discoveryConfigWatcher = watcher
+
+	return watcher, err
+}
+
+func (f *fakeAccessPointWithWatcher) closeDiscoveryConfigWatcher() error {
+	f.discoveryConfigWatcherMu.Lock()
+	defer f.discoveryConfigWatcherMu.Unlock()
+	return f.discoveryConfigWatcher.Close()
+}
+
 // This test exercises the dynamic matcher watcher and ensures that if there's a failure in the watcher,
 // it restarts and continues to pick up new Discovery Configs matchers.
 func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
@@ -997,10 +1020,14 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
 
+	accessPoint := &fakeAccessPointWithWatcher{
+		DiscoveryAccessPoint: getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+	}
+
 	// Start discovery server
-	server, err := New(authz.ContextWithUser(context.Background(), identity.I), &Config{
+	server, err := New(t.Context(), &Config{
 		ClusterFeatures: func() proto.Features { return proto.Features{} },
-		AccessPoint:     getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+		AccessPoint:     accessPoint,
 		Matchers:        Matchers{},
 		Emitter:         authClient,
 		Log:             logtest.NewLogger(),
@@ -1029,9 +1056,7 @@ func TestDiscoveryServer_dynamicMatcherRestart(t *testing.T) {
 	}, 5*time.Second, 50*time.Millisecond)
 
 	// 2. Break the watcher
-	server.dynamicDiscoveryConfigMu.Lock()
-	server.dynamicMatcherWatcher.Close()
-	server.dynamicDiscoveryConfigMu.Unlock()
+	accessPoint.closeDiscoveryConfigWatcher()
 
 	// 3. Send a new Discovery Config and ensure it gets loaded into the dynamic matchers. In this case it will require the watcher to have restarted.
 	discoveryConfigB, err := discoveryconfig.NewDiscoveryConfig(

--- a/lib/srv/discovery/kube_integration_watcher.go
+++ b/lib/srv/discovery/kube_integration_watcher.go
@@ -49,7 +49,7 @@ import (
 // EKS watchers can do that and they behave differently from non-integration ones - we install agent on the
 // discovered clusters, instead of just proxying them.
 func (s *Server) startKubeIntegrationWatchers() error {
-	if len(s.getKubeIntegrationFetchers()) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.getKubeIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -35,7 +35,7 @@ import (
 const kubeEventPrefix = "kube/"
 
 func (s *Server) startKubeWatchers() error {
-	if len(s.getKubeNonIntegrationFetchers()) == 0 && s.dynamicMatcherWatcher == nil {
+	if len(s.getKubeNonIntegrationFetchers()) == 0 && s.DiscoveryGroup == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Backport #63060 to branch/v18

changelog: Fixed an issue that caused Discovery Service to stop working for Discovery Configs, also affecting AWS OIDC resource enrollments created from the UI.

Demo / manual testing:
<img width="1576" height="736" alt="image" src="https://github.com/user-attachments/assets/e97325f6-236e-45cb-b386-2ce01b53f9b6" />
