### PR TITLE
TDPB Translation Tests and Bug Fixes

### DIFF
--- a/lib/srv/desktop/tdp/protocol/tdpb/translate.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate.go
@@ -526,6 +526,7 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 	case legacy.SharedDirectoryListRequest:
 		return []tdp.Message{&SharedDirectoryRequest{
 			CompletionId: m.CompletionID,
+			DirectoryId:  m.DirectoryID,
 			Operation: &tdpbv1.SharedDirectoryRequest_List_{
 				List: &tdpbv1.SharedDirectoryRequest_List{
 					Path: m.Path,
@@ -557,6 +558,7 @@ func TranslateToModern(msg tdp.Message) ([]tdp.Message, error) {
 		return []tdp.Message{&SharedDirectoryResponse{
 			CompletionId: m.CompletionID,
 			ErrorCode:    m.ErrCode,
+			Operation:    &tdpbv1.SharedDirectoryResponse_Truncate_{},
 		}}, nil
 	default:
 		return nil, trace.Errorf("Could not translate to TDPB. Encountered unexpected message type %T", m)

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate_test.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate_test.go
@@ -1,0 +1,203 @@
+package tdpb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
+	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/legacy"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslation(t *testing.T) {
+	// Tests "core" messages which can be translated in both directions
+	// (TDPB -> TDP as well as TDP -> TDPB).
+	clipboard := []byte("some data")
+	pdu := []byte("some pdu")
+	response := []byte("some response")
+	cases := []tdp.Message{
+		legacy.ClientScreenSpec{
+			Width: 1920, Height: 1080,
+		},
+		legacy.MouseWheel{
+			Axis:  legacy.HorizontalWheelAxis,
+			Delta: -100,
+		},
+		legacy.MouseWheel{
+			Axis:  legacy.VerticalWheelAxis,
+			Delta: 123,
+		},
+		legacy.MouseButton{
+			Button: legacy.LeftMouseButton,
+			State:  legacy.ButtonNotPressed,
+		},
+		legacy.MouseButton{
+			Button: legacy.RightMouseButton,
+			State:  legacy.ButtonNotPressed,
+		},
+		legacy.MouseButton{
+			Button: legacy.MiddleMouseButton,
+			State:  legacy.ButtonPressed,
+		},
+		legacy.SyncKeys{
+			ScrollLockState: legacy.ButtonNotPressed,
+			NumLockState:    legacy.ButtonNotPressed,
+			CapsLockState:   legacy.ButtonNotPressed,
+			KanaLockState:   legacy.ButtonNotPressed,
+		},
+		legacy.SyncKeys{
+			ScrollLockState: legacy.ButtonPressed,
+			NumLockState:    legacy.ButtonPressed,
+			CapsLockState:   legacy.ButtonPressed,
+			KanaLockState:   legacy.ButtonPressed,
+		},
+		legacy.KeyboardButton{
+			KeyCode: 10,
+			State:   legacy.ButtonPressed,
+		},
+		legacy.KeyboardButton{
+			KeyCode: 23,
+			State:   legacy.ButtonNotPressed,
+		},
+		legacy.Alert{Severity: legacy.SeverityError, Message: "error"},
+		legacy.Alert{Severity: legacy.SeverityWarning, Message: "warn"},
+		legacy.Alert{Severity: legacy.SeverityInfo, Message: "info"},
+		legacy.ClipboardData(clipboard),
+		legacy.RDPFastPathPDU(pdu),
+		legacy.RDPResponsePDU(response),
+		legacy.SharedDirectoryCreateRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			FileType:     3,
+			Path:         "create req",
+		},
+		legacy.SharedDirectoryInfoRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			Path:         "info req",
+		},
+		legacy.SharedDirectoryDeleteRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			Path:         "delete req",
+		},
+		legacy.SharedDirectoryTruncateRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			Path:         "truncate req",
+			EndOfFile:    3,
+		},
+		legacy.SharedDirectoryListRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			Path:         "list req",
+		},
+		legacy.SharedDirectoryWriteRequest{
+			CompletionID:    1,
+			DirectoryID:     2,
+			WriteDataLength: 3,
+			Offset:          4,
+			WriteData:       []byte("aaa"),
+		},
+		legacy.SharedDirectoryReadRequest{
+			CompletionID: 1,
+			DirectoryID:  2,
+			Path:         "read req",
+			Offset:       3,
+			Length:       4,
+		},
+		legacy.SharedDirectoryInfoResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+			Fso: legacy.FileSystemObject{
+				LastModified: 3,
+				Size:         4,
+				IsEmpty:      1,
+				Path:         "create response",
+			},
+		},
+		legacy.SharedDirectoryCreateResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+			Fso: legacy.FileSystemObject{
+				LastModified: 3,
+				Size:         4,
+				IsEmpty:      1,
+				Path:         "create response",
+			},
+		},
+		legacy.SharedDirectoryDeleteResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+		},
+		legacy.SharedDirectoryListResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+			FsoList: []legacy.FileSystemObject{
+				{
+					LastModified: 3,
+					Size:         2,
+					IsEmpty:      1,
+					Path:         "fso 1",
+				},
+				{
+					LastModified: 4,
+					Size:         5,
+					IsEmpty:      0,
+					Path:         "fso 2",
+				},
+			},
+		},
+		legacy.SharedDirectoryReadResponse{
+			CompletionID:   1,
+			ErrCode:        2,
+			ReadDataLength: 3,
+			ReadData:       []byte("aaa"),
+		},
+		legacy.SharedDirectoryWriteResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+			BytesWritten: 3,
+		},
+		legacy.SharedDirectoryMoveResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+		},
+		legacy.SharedDirectoryTruncateResponse{
+			CompletionID: 1,
+			ErrCode:      2,
+		},
+		legacy.SharedDirectoryAcknowledge{
+			DirectoryID: 1,
+			ErrCode:     2,
+		},
+		legacy.SharedDirectoryAnnounce{
+			DirectoryID: 1,
+			Name:        "directory",
+		},
+		legacy.Ping{
+			UUID: uuid.New(),
+		},
+		legacy.LatencyStats{
+			ClientLatency: 1,
+			ServerLatency: 2,
+		},
+	}
+
+	// Let's play a game of telephone. Translate each message
+	// to TDPB and back. We should get the exact same input message.
+	for _, msg := range cases {
+		t.Run(fmt.Sprintf("translate %T", msg), func(t *testing.T) {
+			modern, err := TranslateToModern(msg)
+			require.NoError(t, err)
+			require.Len(t, modern, 1)
+			legacyMsgs, err := TranslateToLegacy(modern[0])
+			require.NoError(t, err)
+			require.Len(t, legacyMsgs, 1)
+
+			require.Equal(t, msg, legacyMsgs[0])
+		})
+
+	}
+}

--- a/lib/srv/desktop/tdp/protocol/tdpb/translate_test.go
+++ b/lib/srv/desktop/tdp/protocol/tdpb/translate_test.go
@@ -1,3 +1,19 @@
+// Teleport
+// Copyright (C) 2026 Gravitational, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package tdpb
 
 import (
@@ -5,9 +21,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp/protocol/legacy"
-	"github.com/stretchr/testify/require"
 )
 
 func TestTranslation(t *testing.T) {
@@ -30,21 +47,21 @@ func TestTranslation(t *testing.T) {
 		},
 		legacy.MouseButton{
 			Button: legacy.LeftMouseButton,
-			State:  legacy.ButtonNotPressed,
+			State:  legacy.ButtonPressed,
 		},
 		legacy.MouseButton{
 			Button: legacy.RightMouseButton,
-			State:  legacy.ButtonNotPressed,
+			State:  legacy.ButtonPressed,
 		},
 		legacy.MouseButton{
 			Button: legacy.MiddleMouseButton,
 			State:  legacy.ButtonPressed,
 		},
 		legacy.SyncKeys{
-			ScrollLockState: legacy.ButtonNotPressed,
-			NumLockState:    legacy.ButtonNotPressed,
-			CapsLockState:   legacy.ButtonNotPressed,
-			KanaLockState:   legacy.ButtonNotPressed,
+			ScrollLockState: legacy.ButtonPressed,
+			NumLockState:    legacy.ButtonPressed,
+			CapsLockState:   legacy.ButtonPressed,
+			KanaLockState:   legacy.ButtonPressed,
 		},
 		legacy.SyncKeys{
 			ScrollLockState: legacy.ButtonPressed,
@@ -58,7 +75,7 @@ func TestTranslation(t *testing.T) {
 		},
 		legacy.KeyboardButton{
 			KeyCode: 23,
-			State:   legacy.ButtonNotPressed,
+			State:   legacy.ButtonPressed,
 		},
 		legacy.Alert{Severity: legacy.SeverityError, Message: "error"},
 		legacy.Alert{Severity: legacy.SeverityWarning, Message: "warn"},
@@ -185,19 +202,18 @@ func TestTranslation(t *testing.T) {
 		},
 	}
 
-	// Let's play a game of telephone. Translate each message
-	// to TDPB and back. We should get the exact same input message.
+	// Translate each message to TDPB and back. Then check
+	// the resulting message for equality with the original.
 	for _, msg := range cases {
 		t.Run(fmt.Sprintf("translate %T", msg), func(t *testing.T) {
 			modern, err := TranslateToModern(msg)
 			require.NoError(t, err)
 			require.Len(t, modern, 1)
+
 			legacyMsgs, err := TranslateToLegacy(modern[0])
 			require.NoError(t, err)
 			require.Len(t, legacyMsgs, 1)
-
 			require.Equal(t, msg, legacyMsgs[0])
 		})
-
 	}
 }

--- a/web/packages/shared/libs/tdp/codec.ts
+++ b/web/packages/shared/libs/tdp/codec.ts
@@ -860,7 +860,7 @@ export class TdpbCodec implements Codec {
   encodeMouseWheelScroll(axis: ScrollAxis, delta: number): Message {
     return this.marshal({
       oneofKind: 'mouseWheel',
-      mouseWheel: { axis: axis.valueOf() - 1, delta: Math.round(delta) },
+      mouseWheel: { axis: axis.valueOf() + 1, delta: Math.round(delta) },
     });
   }
 

--- a/web/packages/teleport/src/lib/tdp/playerClient.ts
+++ b/web/packages/teleport/src/lib/tdp/playerClient.ts
@@ -177,7 +177,7 @@ export class PlayerClient extends TdpClient {
       }
 
       // Handle TDPB recordings by switching to the TDPB codec
-      if (json.tdpb_message !== undefined) {
+      if (json.tdpb_message) {
         await super.processMessage(
           base64ToArrayBuffer(json.tdpb_message),
           this.tdpbCodec


### PR DESCRIPTION
This PR includes a few small fixes for regressions as a result of TDPB work, including:
- Fix mouse wheel scroll for TDPB clients.
- Fix null check in player client.
- Fix incorrect construction of shared directory truncate events during translation.
- Fix missing directory ID field in shared directory list message. (This passed manual testing because the web client doesn't actually inspect this field yet).

I've also added translation tests for the majority of TDP/TDPB messages to increase our confidence in the translation layer.