### PR TITLE
Deflake `profileWatcher.test.ts`

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -54,6 +54,8 @@ func (s *Storage) ListRootClusters() ([]*Cluster, error) {
 
 	clusters := make([]*Cluster, 0, len(pfNames))
 	for _, name := range pfNames {
+		// TODO(ravicious): Handle a possible scenario where one of the clusters gets removed between
+		// client.Store.ListProfiles and Storage.fromProfile. See https://github.com/gravitational/teleport/pull/63975
 		cluster, _, err := s.fromProfile(name, "")
 		if cluster == nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
I was helping Ryan with flaky tests yesterday and in the process I've also triggered some other flaky tests. Interestingly, this one I could trigger pretty reliably just by running `pnpm test`, without having to run a second test suite in parallel or anything like that.

This PR takes care of the following failure:

```
 FAIL  web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.test.ts
  ● yields a "removed" change when cluster disappears

    ENOENT: no such file or directory, open '/var/folders/j8/lsxv55ks0z954233q0y6nk000000gn/T/profile-watcher-testqk4Sdf/testCR8v2z/teleport-local.com/cluster.json'

      72 |     return Promise.all(
      73 |       paths.map(async singlePath => {
    > 74 |         const file = await fs.readFile(
         |                      ^
      75 |           path.join(tshDir, singlePath, 'cluster.json'),
      76 |           {
      77 |             encoding: 'utf-8',

      at web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.test.ts:74:22
          at async Promise.all (index 0)
      at watchProfiles (web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.ts:79:26)
      at Object.<anonymous> (web/packages/teleterm/src/mainProcess/profileWatcher/profileWatcher.test.ts:161:21)
```

This is because this code first does `fs.readdir` and then `fs.readFile` on each file in the dir. But this is not atomic and in the `yields a "removed" change when cluster disappears` test we actually fire `void tshClientMock.removeCluster()` without awaiting to test the generator function `watchProfiles`. This causes a race condition where if a cluster is removed between `fs.readdir` and `fs.readFile`, `fs.readFile` fails with `ENOENT`.

The fix is to just ignore `ENOENT` at this point in the mock implementation of `listRootClusters` because it can be pretty much caused only by said race condition.

The real implementation of `listRootClusters` used in the app which calls the `ListRootClusters` RPC is susceptible to the same problem, because it also [first reads all files from the folder followed by reading the files one by one](https://github.com/gravitational/teleport/blob/3286cdcefc1f03c144ce614f266a11c8c3aad6ec/lib/teleterm/clusters/storage.go#L50-L63). But in the real app we generally don't issue requests to remove a cluster at the same time as a request to list them all. Though with the `~/.tsh` dir now shared between tsh and Connect, as well as the profile watcher being in place, this can happen in the real app. 🤔