### PR TITLE
[v18] Gracefully handle metadata/summaries failing to load when viewing a session recording

### DIFF
--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.test.tsx
@@ -16,9 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import type { ComponentType } from 'react';
 import { MemoryRouter, Route } from 'react-router-dom';
 
 import { render, testQueryClient } from 'design/utils/testing';
@@ -31,6 +33,7 @@ import {
   type RecordingType,
   type SessionRecordingMetadata,
 } from 'teleport/services/recordings';
+import type { RecordingWithSummaryProps } from 'teleport/SessionRecordings/view/RecordingWithSummary';
 
 import { createMetadataHandler } from './mock';
 import { ViewSessionRecordingRoute } from './ViewSessionRecordingRoute';
@@ -81,14 +84,19 @@ jest.mock('./RecordingPlayer', () => ({
   ),
 }));
 
-function setupTest(initialEntry?: string) {
+function setupTest(
+  initialEntry?: string,
+  customSummaryComponent?: ComponentType<RecordingWithSummaryProps>
+) {
   const ctx = createTeleportContext();
 
   return render(
     <MemoryRouter initialEntries={initialEntry ? [initialEntry] : undefined}>
       <ContextProvider ctx={ctx}>
         <Route path={cfg.routes.player}>
-          <ViewSessionRecordingRoute />
+          <ViewSessionRecordingRoute
+            withSummaryComponent={customSummaryComponent}
+          />
         </Route>
       </ContextProvider>
     </MemoryRouter>
@@ -158,6 +166,43 @@ test('renders non-SSH recordings correctly', async () => {
         durationMs: 3600000,
       }
     )
+  );
+
+  expect(
+    await screen.findByText(
+      'RecordingPlayer: test-cluster/test-session/3600000/desktop'
+    )
+  ).toBeInTheDocument();
+});
+
+test('falls back to the player when the custom summary component fails to load', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+
+  server.use(createMetadataHandler({ ...mockMetadata, type: 'desktop' }, []));
+
+  function CustomSummaryComponent() {
+    useSuspenseQuery({
+      queryKey: ['fail'],
+      queryFn: () => {
+        throw new Error('Failed to load summary');
+      },
+    });
+
+    return null;
+  }
+
+  setupTest(
+    cfg.getPlayerRoute(
+      {
+        clusterId: 'test-cluster',
+        sid: 'test-session',
+      },
+      {
+        recordingType: 'desktop',
+        durationMs: 3600000,
+      }
+    ),
+    CustomSummaryComponent
   );
 
   expect(

--- a/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
+++ b/web/packages/teleport/src/SessionRecordings/view/ViewSessionRecordingRoute.tsx
@@ -102,6 +102,15 @@ export function ViewSessionRecordingRoute({
     );
   }
 
+  const recordingWithSummaryComponent = RecordingWithSummaryComponent ? (
+    <RecordingWithSummaryComponent
+      clusterId={clusterId}
+      sessionId={sid}
+      durationMs={durationMs}
+      recordingType={recordingType}
+    />
+  ) : null;
+
   if (RECORDING_TYPES_WITH_METADATA.includes(recordingType)) {
     // If the recording type is SSH, try to load the session metadata (ViewTerminalRecording)
     // and render the SSH player with the session metadata/summary.
@@ -110,27 +119,42 @@ export function ViewSessionRecordingRoute({
     // This is to ensure that the player can still be rendered even if the session metadata
     // cannot be fetched, allowing users to still view the recording.
 
+    const recordingWithMetadataComponent = (
+      <RecordingWithMetadataComponent
+        clusterId={clusterId}
+        recordingType={recordingType}
+        sessionId={sid}
+      />
+    );
+
+    if (recordingWithSummaryComponent) {
+      return (
+        <Suspense fallback={<RecordingPlayerLoading />}>
+          <ErrorBoundary fallback={player}>
+            <ErrorBoundary fallback={recordingWithSummaryComponent}>
+              {recordingWithMetadataComponent}
+            </ErrorBoundary>
+          </ErrorBoundary>
+        </Suspense>
+      );
+    }
+
     return (
       <Suspense fallback={<RecordingPlayerLoading />}>
         <ErrorBoundary fallback={player}>
-          <RecordingWithMetadataComponent
-            clusterId={clusterId}
-            recordingType={recordingType}
-            sessionId={sid}
-          />
+          {recordingWithMetadataComponent}
         </ErrorBoundary>
       </Suspense>
     );
   }
 
-  if (RecordingWithSummaryComponent) {
+  if (recordingWithSummaryComponent) {
     return (
-      <RecordingWithSummaryComponent
-        clusterId={clusterId}
-        sessionId={sid}
-        durationMs={durationMs}
-        recordingType={recordingType}
-      />
+      <Suspense fallback={<RecordingPlayerLoading />}>
+        <ErrorBoundary fallback={player}>
+          {recordingWithSummaryComponent}
+        </ErrorBoundary>
+      </Suspense>
     );
   }
 


### PR DESCRIPTION
Backport #63949 to branch/v18

## Manual testing

### OSS

#### Desktop

- [x] Play, pause, seeking works

#### SSH

- [x] Play, pause, seeking works
- [x] Metadata + player shown correctly
- [x] When missing metadata - player is shown

#### Database

- [x] Play, pause, seeking works

#### Kubernetes

- [x] Play, pause, seeking works
- [x] Metadata + player shown correctly
- [x] When missing metadata - player is shown

### Enterprise

- [x] Verified that before this fix, there was a white screen showed for desktop recordings

#### Verified desktop recordings still display

- [x] Verified with an actual windows desktop recording that it plays back correctly using the old player
  - [x] Play, pause, seeking works

#### Verified that SSH recordings still display
- [x] Play, pause, seeking works
- [x] When enhanced summary is present
- [x] When legacy summary is present
- [x] When missing metadata + summary - player is shown
- [x] When missing only summary - metadata + player is shown
- [x] When missing only metadata - summary + player is shown

#### Verified that Kubernetes recordings still display

- [x] Play, pause, seeking works
- [x] When enhanced summary is present
- [x] When legacy summary is present
- [x] When missing metadata + summary - player is shown
- [x] When missing only metadata - summary + player is shown
- [x] When missing only summary - metadata + player is shown

#### Verified that Database recordings still display 

- [x] Play, pause, seek works
- [x] When legacy summary is present
- [x] When missing summary (they don't have metadata generated yet)

changelog: Fixed an issue where desktop session recordings would show a white screen instead of the recording player, and fixed an issue where if a session's metadata failed to load and the session had a summary it didn't display the summary