### PR TITLE
[v18][vnet] fix: preserve leaf web app access

### DIFF
--- a/lib/vnet/fqdn_resolver.go
+++ b/lib/vnet/fqdn_resolver.go
@@ -17,9 +17,13 @@
 package vnet
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"iter"
+	"log/slog"
+	"slices"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -64,110 +68,201 @@ func (r *fqdnResolver) ResolveFQDN(ctx context.Context, fqdn string) (*vnetv1.Re
 			return nil, errNoTCPHandler
 		}
 	}
-	// First try to resolve a matching TCP or web app. A matching app is more
-	// specific than the cluster match we do for SSH, and checking for a
-	// matching app first maintains backward compatibility because apps were
-	// supported before SSH.
-	resp, err := r.tryResolveApp(ctx, profileNames, fqdn)
+
+	var matchedClusters []clusterResolutionCandidate
+	for candidate := range r.clusterResolutionCandidates(ctx, profileNames, fqdn) {
+		// First check if there's a matching app in this cluster.
+		result, err := r.resolveAppInfoForCluster(ctx, candidate, fqdn)
+		switch {
+		case err == nil:
+			// Found a matching app, return it immediately.
+			return result, nil
+		case !errors.Is(err, errNoMatch):
+			return nil, err
+		}
+
+		// SSH servers match at any subdomain of the cluster name. For example,
+		// a query for "foo.bar.teleport.example.com" should match the cluster
+		// "teleport.example.com" so that it may resolve for an SSH node named
+		// "foo.bar".
+		//
+		// This doesn't return immediately so that an app found in a later
+		// cluster still takes precedence.
+		if isDescendantSubdomain(fqdn, candidate.clusterName) {
+			matchedClusters = append(matchedClusters, candidate)
+		}
+	}
+
+	if len(matchedClusters) == 0 {
+		return nil, errNoTCPHandler
+	}
+
+	result, err := r.resolveClusterMatch(ctx, log, matchedClusters)
 	switch {
 	case err == nil:
-		return resp, nil
-	case !errors.Is(err, errNoMatch):
-		return nil, err
+		return result, nil
+	case errors.Is(err, errNoMatch):
+		return nil, errNoTCPHandler
+	default:
+		return nil, trace.Wrap(err)
 	}
-	resp, err = r.tryResolveSSH(ctx, profileNames, fqdn)
-	switch {
-	case err == nil:
-		return resp, nil
-	case !errors.Is(err, errNoMatch):
-		return nil, err
-	}
-	return nil, errNoTCPHandler
 }
 
 var errNoMatch = errors.New("no match for queried FQDN")
 
-func (r *fqdnResolver) tryResolveApp(ctx context.Context, profileNames []string, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
-	for _, profileName := range profileNames {
-		clusterClient, err := r.clusterClientForAppFQDN(ctx, profileName, fqdn)
-		if err != nil {
-			if errors.Is(err, errNoMatch) {
-				continue
-			}
-			// The user might be logged out from this one cluster (and retryWithRelogin isn't working). Log
-			// the error but don't return it so that DNS resolution will be forwarded upstream instead of
-			// failing, to avoid breaking e.g. web app access (we don't know if this is a web or TCP app yet
-			// because we can't log in).
-			log.ErrorContext(ctx, "Failed to get teleport client.", "error", err)
-			continue
-		}
-
-		leafClusterName := ""
-		clusterName := clusterClient.ClusterName()
-		if clusterName != "" && clusterName != clusterClient.RootClusterName() {
-			leafClusterName = clusterName
-		}
-
-		return r.resolveAppInfoForCluster(ctx, clusterClient, profileName, leafClusterName, fqdn)
-	}
-	return nil, errNoMatch
+type clusterResolutionCandidate struct {
+	client          ClusterClient
+	profileName     string
+	rootClusterName string
+	leafClusterName string
+	clusterName     string
 }
 
-func (r *fqdnResolver) clusterClientForAppFQDN(ctx context.Context, profileName, fqdn string) (ClusterClient, error) {
-	rootClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
-	if err != nil {
-		log.ErrorContext(ctx, "Failed to get root cluster client, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
-	}
-
-	if isDescendantSubdomain(fqdn, profileName) {
-		// The queried FQDN is a subdomain of this cluster proxy address.
-		return rootClient, nil
-	}
-
-	leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
-	if err != nil {
-		// Good chance we're here because the user is not logged in to the profile.
-		log.ErrorContext(ctx, "Failed to list leaf clusters, apps in this cluster will not be resolved.", "profile", profileName, "error", err)
-		return nil, errNoMatch
-	}
-
-	// Prefix with an empty string to represent the root cluster.
-	allClusters := append([]string{""}, leafClusters...)
-	for _, leafClusterName := range allClusters {
-		clusterClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to get cluster client, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-
-		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to get VNet config, apps in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
-			continue
-		}
-		for _, zone := range clusterConfig.appDNSZones() {
-			if isDescendantSubdomain(fqdn, zone) {
-				return clusterClient, nil
+// clusterResolutionCandidates yields all clusterResolutionCandidates for a
+// queried FQDN. A clusterResolutionCandidate essentially identifies a specific
+// Teleport cluster, and includes a client for the cluster and some metadata
+// that may be helpful for deciding if the queried FQDN should really resolve
+// to a match in that cluster.
+//
+// It does a first-pass filter to avoid yielding any clusters that definitely
+// won't match for the queried FQDN, using only cached information without
+// doing any actual queries to the cluster.
+func (r *fqdnResolver) clusterResolutionCandidates(ctx context.Context, profileNames []string, fqdn string) iter.Seq[clusterResolutionCandidate] {
+	return func(yield func(clusterResolutionCandidate) bool) {
+		for _, profileName := range profileNames {
+			for candidate := range r.clusterResolutionCandidatesInProfile(ctx, profileName, fqdn) {
+				if !yield(candidate) {
+					return
+				}
 			}
 		}
 	}
-	return nil, errNoMatch
+}
+
+// clusterResolutionCandidatesInProfile yields all clusterResolutionCandidates
+// in a specific profile for a queried FQDN.
+//
+// It does a first-pass filter to avoid yielding any clusters that definitely
+// won't match for the queried FQDN, using only cached information without
+// doing any actual queries to the cluster.
+//
+// A cluster candidate will be yielded in the following cases:
+//
+//  1. If fqdn is a direct (one-level) subdomain of the profileName it may
+//     match an app in the root cluster or any leaf cluster.
+//  2. If fqdn is any subdomain of the cluster name it may match an SSH node
+//     in that cluster.
+//  3. If fqdn is any subdomain of any of the app DNS zones for the cluster
+//     (this includes the proxy public_addr and any configured custom DNS
+//     zones)
+func (r *fqdnResolver) clusterResolutionCandidatesInProfile(ctx context.Context, profileName string, fqdn string) iter.Seq[clusterResolutionCandidate] {
+	return func(yield func(clusterResolutionCandidate) bool) {
+		// A direct subdomain of the root cluster proxy public addr (which is
+		// the profileName) may be a web app in a leaf cluster, which needs to
+		// be reachable at <app-name>.<root-proxy-public-addr>. It also may be
+		// an app in the root cluster, so we can/must yield every client before
+		// checking configured DNS zones.
+		shouldYieldAllCandidates := isDirectSubdomain(fqdn, profileName)
+
+		shouldYieldCandidate := func(candidate clusterResolutionCandidate) bool {
+			if shouldYieldAllCandidates {
+				return true
+			}
+
+			if isDescendantSubdomain(fqdn, candidate.clusterName) {
+				// This may match an SSH server, must yield the client.
+				return true
+			}
+
+			clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, candidate.client)
+			if err != nil {
+				log.ErrorContext(ctx, "Failed to get VNet config, apps in this cluster may not be resolved.", "profile", profileName, "leaf_cluster", candidate.leafClusterName, "error", err)
+				return false
+			}
+			for _, zone := range clusterConfig.appDNSZones() {
+				if isDescendantSubdomain(fqdn, zone) {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		rootClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
+		if err != nil {
+			log.ErrorContext(ctx, "Failed to get root cluster client, resources in this cluster will not be resolved.", "profile", profileName, "error", err)
+			return
+		}
+		rootClusterName := rootClient.ClusterName()
+
+		leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
+		if err != nil {
+			// Good chance we're here because the user is not logged in to the profile.
+			log.ErrorContext(ctx, "Failed to list leaf clusters, resources in leaves of this cluster will not be resolved.", "profile", profileName, "error", err)
+			// Don't return so that the root cluster may still work even if
+			// leaf cluster listing is broken.
+			leafClusters = nil
+		}
+
+		// Prefix with an empty string to represent the root cluster.
+		// GetCachedClient will return the root client if given an empty string for leafClusterName.
+		leafClusters = append([]string{""}, leafClusters...)
+
+		for _, leafClusterName := range leafClusters {
+			clusterClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
+			if err != nil {
+				log.ErrorContext(ctx, "Failed to get cluster client, resources in this cluster will not be resolved.", "profile", profileName, "leaf_cluster", leafClusterName, "error", err)
+				continue
+			}
+
+			candidate := clusterResolutionCandidate{
+				client:          clusterClient,
+				profileName:     profileName,
+				rootClusterName: rootClusterName,
+				leafClusterName: leafClusterName,
+				clusterName:     clusterClient.ClusterName(),
+			}
+
+			if !shouldYieldCandidate(candidate) {
+				continue
+			}
+
+			if !yield(candidate) {
+				return
+			}
+		}
+	}
 }
 
 func (r *fqdnResolver) resolveAppInfoForCluster(
 	ctx context.Context,
-	clusterClient ClusterClient,
-	profileName, leafClusterName, fqdn string,
+	candidate clusterResolutionCandidate,
+	fqdn string,
 ) (*vnetv1.ResolveFQDNResponse, error) {
-	log := log.With("profile", profileName, "leaf_cluster", leafClusterName, "fqdn", fqdn)
+	log := log.With("profile", candidate.profileName, "leaf_cluster", candidate.leafClusterName, "fqdn", fqdn)
+
 	// An app public_addr could technically be fully-qualified or not, match either way.
 	expr := fmt.Sprintf(`resource.spec.public_addr == "%s" || resource.spec.public_addr == "%s"`,
 		strings.TrimSuffix(fqdn, "."), fqdn)
-	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, clusterClient.CurrentCluster(), &proto.ListResourcesRequest{
+
+	// If candidate is a leaf cluster and fqdn possibly points to a leaf
+	// cluster app, also query for the app by name.
+	//
+	// Apps in leaf clusters are reachable through the root cluster at
+	// <app-name>.<root-proxy-addr>. They can only be queried in the leaf
+	// cluster by name. The root proxy address is always the profile name, so
+	// any queried FQDN that is a direct subdomain of the profile name may be
+	// for a web app in a leaf cluster.
+	var potentialAppName string
+	if candidate.leafClusterName != "" && isDirectSubdomain(fqdn, candidate.profileName) {
+		potentialAppName = strings.TrimSuffix(fqdn, "."+fullyQualify(candidate.profileName))
+		expr += fmt.Sprintf(` || name == "%s"`, potentialAppName)
+	}
+
+	resp, err := apiclient.GetResourcePage[types.AppServer](ctx, candidate.client.CurrentCluster(), &proto.ListResourcesRequest{
 		ResourceType:        types.KindAppServer,
 		PredicateExpression: expr,
-		Limit:               1,
+		Limit:               10,
 	})
 	if err != nil {
 		// Don't return an unexpected error so we can try to find the app in different clusters or forward the
@@ -179,13 +274,48 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 		// Didn't find any matching app, forward the request upstream.
 		return nil, errNoMatch
 	}
+
+	selectBestAppMatch := func() (*types.AppV3, error) {
+		var matchedWebApp *types.AppV3
+		for _, resource := range resp.Resources {
+			app, ok := resource.GetApp().(*types.AppV3)
+			if !ok {
+				return nil, trace.BadParameter("expected *types.AppV3, got %T", resource.GetApp())
+			}
+			matchedByPublicAddr := fullyQualify(app.GetPublicAddr()) == fqdn
+			matchedByName := app.GetName() == potentialAppName
+			if !matchedByName && !matchedByPublicAddr {
+				// This shouldn't happen if the backend query worked correctly.
+				log.WarnContext(ctx, "Query returned an app that did not match by name or public_addr",
+					"name", app.GetName(), "public_addr", app.GetPublicAddr())
+				continue
+			}
+			if app.IsTCP() {
+				if matchedByPublicAddr {
+					// Greedily prefer to match an arbitrary TCP app by public addr.
+					return app, nil
+				}
+				// Skip TCP apps that only matched by name, VNet only handles
+				// TCP apps that match a public addr.
+			} else {
+				matchedWebApp = app
+			}
+		}
+		if matchedWebApp != nil {
+			return matchedWebApp, nil
+		}
+		// Didn't find any matching app.
+		return nil, errNoMatch
+	}
+
+	app, err := selectBestAppMatch()
+	if err != nil {
+		return nil, err
+	}
+
 	// At this point we have found a matching app in the cluster, any error is
 	// unexpected and is preventing access to the app and should be returned to
 	// the user.
-	app, ok := resp.Resources[0].GetApp().(*types.AppV3)
-	if !ok {
-		return nil, trace.BadParameter("expected *types.AppV3, got %T", resp.Resources[0].GetApp())
-	}
 	if !app.IsTCP() {
 		log.InfoContext(ctx, "Query matched a web app")
 		// If not a TCP app this must be a web app and we can return early.
@@ -195,12 +325,12 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 			},
 		}, nil
 	}
-	clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, clusterClient)
+	clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, candidate.client)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to get cluster VNet config for matching app", "error", err)
 		return nil, trace.Wrap(err, "getting cached cluster VNet config for matching app")
 	}
-	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, profileName)
+	dialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, candidate.profileName)
 	if err != nil {
 		log.ErrorContext(ctx, "Failed to get cluster dial options", "error", err)
 		return nil, trace.Wrap(err, "getting dial options for matching app")
@@ -208,11 +338,11 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 	log.InfoContext(ctx, "Query matched a TCP app")
 	appInfo := &vnetv1.AppInfo{
 		AppKey: &vnetv1.AppKey{
-			Profile:     profileName,
-			LeafCluster: leafClusterName,
+			Profile:     candidate.profileName,
+			LeafCluster: candidate.leafClusterName,
 			Name:        app.GetName(),
 		},
-		Cluster:       clusterClient.ClusterName(),
+		Cluster:       candidate.clusterName,
 		App:           app,
 		Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
 		DialOptions:   dialOpts,
@@ -228,76 +358,38 @@ func (r *fqdnResolver) resolveAppInfoForCluster(
 
 // VNet SSH handles SSH hostnames matching "<hostname>.<cluster_name>.", where
 // the <cluster-name> may be the name of a root or leaf cluster.
-// tryResolveSSH checks if fqdn matches that pattern for any known cluster
-// and if so returns a match. We never actually query for whether or not a
-// matching SSH node exists, we just attempt to dial it when the client
-// connects to the assigned IP.
-func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string, fqdn string) (*vnetv1.ResolveFQDNResponse, error) {
-	for _, profileName := range profileNames {
-		log := log.With("profile", profileName)
-		rootClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, "")
-		if err != nil {
-			log.ErrorContext(ctx, "Failed to get root cluster client, SSH nodes in this cluster will not be resolved", "error", err)
-			continue
-		}
-		rootClusterName := rootClient.ClusterName()
-		log = log.With("root_cluster", rootClusterName)
-		leafClusters, err := r.cfg.leafClusterCache.getLeafClusters(ctx, rootClient)
-		if err != nil {
-			// Good chance we're here because the user is not logged in to the profile.
-			log.ErrorContext(ctx, "Failed to list leaf clusters, SSH nodes in this cluster will not be resolved", "error", err)
-			continue
-		}
-		rootDialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, profileName)
+// We never actually query for whether or not a matching SSH node exists, we
+// just attempt to dial it when the client connects to the assigned IP.
+func (r *fqdnResolver) resolveClusterMatch(ctx context.Context, log *slog.Logger, matchedClusters []clusterResolutionCandidate) (*vnetv1.ResolveFQDNResponse, error) {
+	// Longer cluster name matches are preferred, this is so that
+	// node.leaf.example.com will preferentially resolve to a match in
+	// leaf.example.com if there is another cluster named example.com
+	slices.SortFunc(matchedClusters, func(a, b clusterResolutionCandidate) int {
+		return cmp.Compare(len(b.clusterName), len(a.clusterName))
+	})
+	for _, matchedCluster := range matchedClusters {
+		rootDialOpts, err := r.cfg.clientApplication.GetDialOptions(ctx, matchedCluster.profileName)
 		if err != nil {
 			log.ErrorContext(ctx, "Failed to get cluster dial options, SSH nodes in this cluster will not be resolved", "error", err)
 			continue
 		}
-		for _, leafClusterName := range leafClusters {
-			log := log.With("leaf_cluster", leafClusterName)
-			if !isDescendantSubdomain(fqdn, leafClusterName) {
-				continue
-			}
-			leafClient, err := r.cfg.clientApplication.GetCachedClient(ctx, profileName, leafClusterName)
-			if err != nil {
-				log.ErrorContext(ctx, "Failed to get cluster client, SSH nodes in this cluster will not be resolved", "error", err)
-				return nil, errNoMatch
-			}
-			clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, leafClient)
-			if err != nil {
-				log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)
-				return nil, errNoMatch
-			}
-			log.InfoContext(ctx, "Query matched a leaf cluster subdomain and may later resolve to an app or SSH node")
-			return &vnetv1.ResolveFQDNResponse{
-				Match: &vnetv1.ResolveFQDNResponse_MatchedCluster{
-					MatchedCluster: &vnetv1.MatchedCluster{
-						WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
-						Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
-						Profile:       profileName,
-						RootCluster:   rootClusterName,
-						LeafCluster:   leafClusterName,
-					},
-				},
-			}, nil
-		}
-		// Didn't match any leaf, check if it's in the root cluster.
-		if !isDescendantSubdomain(fqdn, rootClusterName) {
-			continue
-		}
-		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, rootClient)
+
+		clusterConfig, err := r.cfg.clusterConfigCache.GetClusterConfig(ctx, matchedCluster.client)
 		if err != nil {
 			log.ErrorContext(ctx, "Failed to get VNet config, SSH nodes in this cluster will not be resolved", "error", err)
-			return nil, errNoMatch
+			continue
 		}
-		log.InfoContext(ctx, "Query matched a root cluster subdomain and may later resolve to an app or SSH node")
+
+		log.InfoContext(ctx, "Query matched a cluster subdomain and may later resolve to an app or SSH node",
+			"cluster_name", matchedCluster.clusterName)
 		return &vnetv1.ResolveFQDNResponse{
 			Match: &vnetv1.ResolveFQDNResponse_MatchedCluster{
 				MatchedCluster: &vnetv1.MatchedCluster{
 					WebProxyAddr:  rootDialOpts.GetWebProxyAddr(),
 					Ipv4CidrRange: clusterConfig.IPv4CIDRRange,
-					Profile:       profileName,
-					RootCluster:   rootClusterName,
+					Profile:       matchedCluster.profileName,
+					RootCluster:   matchedCluster.rootClusterName,
+					LeafCluster:   matchedCluster.leafClusterName,
 				},
 			},
 		}, nil
@@ -308,6 +400,15 @@ func (r *fqdnResolver) tryResolveSSH(ctx context.Context, profileNames []string,
 // isDescendantSubdomain checks if fqdn is a subdomain of zone.
 func isDescendantSubdomain(fqdn, zone string) bool {
 	return strings.HasSuffix(fqdn, "."+fullyQualify(zone))
+}
+
+// isDirectSubdomain checks if fqdn is a direct single-level subdomain of zone.
+func isDirectSubdomain(fqdn, zone string) bool {
+	trimmed := strings.TrimSuffix(fqdn, "."+fullyQualify(zone))
+	if trimmed == fqdn {
+		return false
+	}
+	return !strings.ContainsRune(trimmed, '.')
 }
 
 // fullyQualify returns a fully-qualified domain name from [domain].

--- a/lib/vnet/tcp_handler_resolver.go
+++ b/lib/vnet/tcp_handler_resolver.go
@@ -190,6 +190,7 @@ func (h *undecidedHandler) handleTCPConnector(ctx context.Context, localPort uin
 		// Attempt a dial to the target SSH node to see if it exists.
 		target := computeDialTarget(matchedCluster, h.cfg.fqdn)
 		agent := newSSHAgent()
+		log.DebugContext(ctx, "Attempting TCP dial to target SSH node", "target", target)
 		targetConn, err := h.cfg.sshProvider.dial(ctx, target, agent)
 		if err != nil {
 			if trace.IsConnectionProblem(err) {

--- a/lib/vnet/vnet_test.go
+++ b/lib/vnet/vnet_test.go
@@ -33,7 +33,6 @@ import (
 	"net"
 	"os"
 	"slices"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -65,6 +64,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/services"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -335,9 +335,22 @@ func (n noUpstreamNameservers) UpstreamNameservers(ctx context.Context) ([]strin
 }
 
 type appSpec struct {
-	// publicAddr is used both as the name of the app and its public address in the final spec.
+	// name is optional and will default to publicAddr if unset
+	name       string
 	publicAddr string
+	isWebApp   bool
 	tcpPorts   []*types.PortRange
+}
+
+func (s *appSpec) getName() string {
+	return cmp.Or(s.name, s.publicAddr)
+}
+
+func (s *appSpec) getURI() string {
+	if s.isWebApp {
+		return "http://" + s.publicAddr
+	}
+	return "tcp://" + s.publicAddr
 }
 
 type nodeSpec struct {
@@ -675,8 +688,7 @@ func (c *fakeClusterClient) SessionSSHKeyRing(ctx context.Context, user string, 
 	return k, false, nil
 }
 
-// fakeAuthClient is a fake auth client that answers GetResources requests with a static list of apps and
-// basic/faked predicate filtering.
+// fakeAuthClient is a fake auth client that answers GetResources requests with a static list of apps.
 type fakeAuthClient struct {
 	authclient.ClientI
 	clusterSpec     testClusterSpec
@@ -685,37 +697,44 @@ type fakeAuthClient struct {
 }
 
 func (c *fakeAuthClient) GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+	filter, err := services.MatchResourceFilterFromListResourceRequest(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	resp := &proto.ListResourcesResponse{}
 	for _, app := range c.clusterSpec.apps {
-		// Poor-man's predicate expression filter.
-		if !strings.Contains(req.PredicateExpression, app.publicAddr) {
-			continue
-		}
-		spec := &types.AppV3{
+		appServer := &types.AppServerV3{
+			Kind: types.KindAppServer,
 			Metadata: types.Metadata{
-				Name: app.publicAddr,
+				Name: app.getName(),
 			},
-			Spec: types.AppSpecV3{
-				PublicAddr: app.publicAddr,
-				URI:        "tcp://" + app.publicAddr,
+			Spec: types.AppServerSpecV3{
+				App: &types.AppV3{
+					Metadata: types.Metadata{
+						Name: app.getName(),
+					},
+					Spec: types.AppSpecV3{
+						PublicAddr: app.publicAddr,
+						URI:        app.getURI(),
+					},
+				},
 			},
+		}
+		if len(app.tcpPorts) != 0 {
+			appServer.Spec.App.SetTCPPorts(app.tcpPorts)
 		}
 
-		if len(app.tcpPorts) != 0 {
-			spec.SetTCPPorts(app.tcpPorts)
+		match, err := services.MatchResourceByFilters(appServer, filter, nil /* seenMap */)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if !match {
+			continue
 		}
 
 		resp.Resources = append(resp.Resources, &proto.PaginatedResource{
 			Resource: &proto.PaginatedResource_AppServer{
-				AppServer: &types.AppServerV3{
-					Kind: types.KindAppServer,
-					Metadata: types.Metadata{
-						Name: app.publicAddr,
-					},
-					Spec: types.AppServerSpecV3{
-						App: spec,
-					},
-				},
+				AppServer: appServer,
 			},
 		})
 	}
@@ -779,6 +798,11 @@ func TestDialFakeApp(t *testing.T) {
 							{Port: 4242},
 						},
 					},
+					{
+						name:       "webroot",
+						publicAddr: "webroot.root1.example.com",
+						isWebApp:   true,
+					},
 				},
 				customDNSZones: []string{
 					"myzone.example.com",
@@ -794,6 +818,18 @@ func TestDialFakeApp(t *testing.T) {
 									{Port: 1337},
 									{Port: 4242},
 								},
+							},
+							{
+								// Important: leaf web apps are reachable at
+								// their public_addr if the user logs in
+								// directly to the leaf, and they must also be
+								// reachable at <name>.<root-proxy-public-addr>
+								// if the user is logged in to the root.
+								// In this case webleaf.root1.example.com must
+								// be reachable.
+								name:       "webleaf",
+								publicAddr: "webleaf.leaf1.example.com",
+								isWebApp:   true,
 							},
 						},
 					},
@@ -985,6 +1021,14 @@ func TestDialFakeApp(t *testing.T) {
 		}
 	})
 
+	lookupShouldFailFast := func(t *testing.T, host string) {
+		t.Helper()
+		lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+		_, err := p.lookupHost(lookupCtx, host)
+		require.Error(t, err)
+	}
+
 	t.Run("invalid FQDN", func(t *testing.T) {
 		t.Parallel()
 		invalidTestCases := []string{
@@ -994,10 +1038,7 @@ func TestDialFakeApp(t *testing.T) {
 		for _, fqdn := range invalidTestCases {
 			t.Run(fqdn, func(t *testing.T) {
 				t.Parallel()
-				ctx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
-				defer cancel()
-				_, err := p.lookupHost(ctx, fqdn)
-				require.Error(t, err)
+				lookupShouldFailFast(t, fqdn)
 			})
 		}
 	})
@@ -1017,6 +1058,29 @@ func TestDialFakeApp(t *testing.T) {
 			return int(route.TargetPort) == port
 		}), "no certs are supposed to be requested for target port %d in app %s", port, app)
 		require.Equal(t, uint32(1), clientApp.onInvalidLocalPortCallCount.Load(), "unexpected number of calls to OnInvalidLocalPort")
+	})
+
+	// Test that VNet does not resolve known web app addrs to VNet IP
+	// addresses. The expected behavior is for VNet to forward these requests
+	// to upstream nameservers so that clients can go around VNet and the
+	// browser hit the proxy public IP directly.
+	t.Run("web", func(t *testing.T) {
+		t.Parallel()
+		for _, addr := range []string{
+			"webroot.root1.example.com",
+			"webleaf.leaf1.example.com",
+			"webleaf.root1.example.com", // leaf web app name as subdomain of root proxy addr must work.
+		} {
+			t.Run(addr, func(t *testing.T) {
+				t.Parallel()
+
+				// For the test we've configured VNet with no upstream
+				// nameservers, so we expect the DNS lookup to fail.
+				// net.Resolver.LookupHost takes a while to fail unless we
+				// provide a short context.
+				lookupShouldFailFast(t, addr)
+			})
+		}
 	})
 }
 
@@ -1054,7 +1118,7 @@ func TestOnNewAppConnection(t *testing.T) {
 		clusters: map[string]testClusterSpec{
 			"root1.example.com": {
 				apps: []appSpec{
-					{publicAddr: "echo1"},
+					{publicAddr: "echo1.root1.example.com"},
 				},
 				cidrRange:    "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{},
@@ -1115,15 +1179,15 @@ func testWithAlgorithmSuite(t *testing.T, suite types.SignatureAlgorithmSuite) {
 		clusters: map[string]testClusterSpec{
 			"root.example.com": {
 				apps: []appSpec{
-					{publicAddr: "echo1"},
-					{publicAddr: "echo2"},
+					{publicAddr: "echo1.root.example.com"},
+					{publicAddr: "echo2.root.example.com"},
 				},
 				cidrRange: "192.168.2.0/24",
 				leafClusters: map[string]testClusterSpec{
 					"leaf.example.com": {
 						apps: []appSpec{
-							{publicAddr: "echo1"},
-							{publicAddr: "echo2"},
+							{publicAddr: "echo1.leaf.example.com"},
+							{publicAddr: "echo2.leaf.example.com"},
 						},
 						cidrRange: "192.168.2.0/24",
 					},
@@ -1469,6 +1533,180 @@ func TestSSH(t *testing.T) {
 		for i := range connections - 1 {
 			require.NotEqual(t, checkedHostCerts[i], checkedHostCerts[i+1])
 		}
+	})
+}
+
+// TestPriority tests resolution priority in case a query may match multiple targets:
+//
+//  1. A matching TCP app gets first priority (resolves to a VNet IP and is reachable)
+//  2. A matching web app gets second priority (no address should be resolved)
+//  3. A matching SSH host gets third priority (any subdomain of the cluster
+//     should resolve if it's not an app, only reachable if there's an SSH node)
+//
+// Between multiple clusters:
+//
+//  1. Any app in a root cluster gets priority over apps in leaf clusters that also match
+//  2. If falling back to a cluster/SSH match, longest matching cluster name wins
+//  3. If the same app public_addr is present in multiple root clusters, resolution is arbitrary.
+func TestPriority(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	clock := clockwork.NewFakeClockAt(time.Now())
+
+	const (
+		rootCIDR = "192.168.10.0/24"
+		leafCIDR = "192.168.20.0/24"
+	)
+
+	homePath := t.TempDir()
+	clientApp := newFakeClientApp(ctx, t, &fakeClientAppConfig{
+		clusters: map[string]testClusterSpec{
+			"example.com": {
+				apps: []appSpec{
+					{name: "dual-web", publicAddr: "dual.example.com", isWebApp: true},
+					{name: "dual-tcp", publicAddr: "dual.example.com"},
+					{name: "shared-root", publicAddr: "shared.apps.shared.test"},
+				},
+				nodes: map[string]nodeSpec{
+					"node": {},
+				},
+				cidrRange:      rootCIDR,
+				customDNSZones: []string{"apps.shared.test"},
+				leafClusters: map[string]testClusterSpec{
+					"leaf.example.com": {
+						apps: []appSpec{
+							{name: "webwins", publicAddr: "webwins.leaf.example.com", isWebApp: true},
+							{name: "shared-leaf", publicAddr: "shared.apps.shared.test"},
+						},
+						nodes: map[string]nodeSpec{
+							"webwins": {},
+							"node":    {},
+						},
+						cidrRange:      leafCIDR,
+						customDNSZones: []string{"apps.shared.test"},
+					},
+				},
+			},
+		},
+		clock:                   clock,
+		signatureAlgorithmSuite: types.SignatureAlgorithmSuite_SIGNATURE_ALGORITHM_SUITE_BALANCED_V1,
+	})
+
+	p := newTestPack(t, ctx, testPackConfig{
+		fakeClientApp: clientApp,
+		clock:         clock,
+		homePath:      homePath,
+	})
+
+	assertConnInCIDR := func(t *testing.T, conn net.Conn, expectCIDR string) {
+		t.Helper()
+		remoteAddr, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		require.NoError(t, err)
+		remoteIP := net.ParseIP(remoteAddr)
+		require.NotNil(t, remoteIP)
+
+		_, expectNet, err := net.ParseCIDR(expectCIDR)
+		require.NoError(t, err)
+		remoteIPSuffix := remoteIP[len(remoteIP)-4:]
+		assert.True(t, expectNet.Contains(remoteIPSuffix), "expected CIDR range %s does not include remote IP %s", expectNet, remoteIPSuffix)
+	}
+
+	dialAndAssertCIDR := func(t *testing.T, host string, port int, expectCIDR string) net.Conn {
+		t.Helper()
+		conn, err := p.dialHost(ctx, host, port)
+		require.NoError(t, err)
+		assertConnInCIDR(t, conn, expectCIDR)
+		return conn
+	}
+
+	lookupShouldFailFast := func(t *testing.T, host string) {
+		t.Helper()
+		lookupCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+		_, err := p.lookupHost(lookupCtx, host)
+		require.Error(t, err)
+	}
+
+	knownHosts, err := os.ReadFile(keypaths.VNetKnownHostsPath(homePath))
+	require.NoError(t, err)
+	marker, hosts, hostCAPubKey, _, _, err := ssh.ParseKnownHosts(knownHosts)
+	require.NoError(t, err)
+	require.Equal(t, "cert-authority", marker)
+	require.Equal(t, []string{"*"}, hosts)
+
+	sshUserKey, err := os.ReadFile(keypaths.VNetClientSSHKeyPath(homePath))
+	require.NoError(t, err)
+	sshUserSigner, err := ssh.ParsePrivateKey(sshUserKey)
+	require.NoError(t, err)
+
+	t.Run("tcp app beats web app", func(t *testing.T) {
+		t.Parallel()
+
+		conn := dialAndAssertCIDR(t, "dual.example.com", 80, rootCIDR)
+		t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+		testEchoConnection(t, conn)
+
+		routes := clientApp.RequestedRouteToApps("dual.example.com")
+		require.Len(t, routes, 1)
+		route := routes[0]
+		expectedRoute := &proto.RouteToApp{
+			ClusterName: "example.com",
+			Name:        "dual-tcp",
+			PublicAddr:  "dual.example.com",
+			URI:         "tcp://dual.example.com",
+		}
+		assert.Equal(t, expectedRoute, route)
+	})
+
+	t.Run("web app beats SSH cluster match", func(t *testing.T) {
+		t.Parallel()
+
+		lookupShouldFailFast(t, "webwins.leaf.example.com")
+		assert.Empty(t, clientApp.RequestedRouteToApps("webwins.leaf.example.com"))
+	})
+
+	t.Run("cluster SSH fallback longest match wins", func(t *testing.T) {
+		t.Parallel()
+
+		conn := dialAndAssertCIDR(t, "node.leaf.example.com", 22, leafCIDR)
+		t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+
+		certChecker := ssh.CertChecker{
+			IsHostAuthority: func(auth ssh.PublicKey, address string) bool {
+				return sshutils.KeysEqual(auth, hostCAPubKey)
+			},
+			Clock: clock.Now,
+		}
+		clientConfig := &ssh.ClientConfig{
+			User:            "testuser",
+			Auth:            []ssh.AuthMethod{ssh.PublicKeys(sshUserSigner)},
+			HostKeyCallback: certChecker.CheckHostKey,
+		}
+
+		sshConn, chans, reqs, err := ssh.NewClientConn(conn, net.JoinHostPort("node.leaf.example.com", "22"), clientConfig)
+		require.NoError(t, err)
+		defer sshConn.Close()
+
+		testConnectionToSshEchoServer(t, sshConn, chans, reqs)
+	})
+
+	t.Run("root app beats leaf app when both match", func(t *testing.T) {
+		t.Parallel()
+
+		conn := dialAndAssertCIDR(t, "shared.apps.shared.test", 80, rootCIDR)
+		t.Cleanup(func() { assert.NoError(t, conn.Close()) })
+		testEchoConnection(t, conn)
+
+		routes := clientApp.RequestedRouteToApps("shared.apps.shared.test")
+		require.Len(t, routes, 1)
+		route := routes[0]
+		expectedRoute := &proto.RouteToApp{
+			ClusterName: "example.com",
+			Name:        "shared-root",
+			PublicAddr:  "shared.apps.shared.test",
+			URI:         "tcp://shared.apps.shared.test",
+		}
+		assert.Equal(t, expectedRoute, route)
 	})
 }
 


### PR DESCRIPTION
Backport #63823 to branch/v18

## Manual Test Plan

Setup: a root and leaf cluster, with at least one web app in the leaf cluster that is **not** present in the root cluster. The `dumper` debug app works if you make sure it doesn't exist in the root.

- [x] With VNet turned on, web app access to the leaf app (while logged into the root) works
- [x] Normal TCP app access continues to work in root and leaf clusters
- [x] VNet SSH access continues to work in root and leaf clusters

Changelog: fixed web app access in leaf clusters when VNet is enabled