### PR TITLE
Add diagram to SSH Getting Started guide

### DIFF
--- a/docs/pages/enroll-resources/server-access/getting-started.mdx
+++ b/docs/pages/enroll-resources/server-access/getting-started.mdx
@@ -35,6 +35,24 @@ per the instructions in this guide. Do not run the SSH Service as a Kubernetes
 pod, as there is no guarantee that the SSH Service pod is running on a server
 that a user intends to access.
 
+```mermaid
+architecture-beta
+    group priv(carbon-virtual-private-cloud)[Private Network]
+    group priv2(carbon-virtual-private-cloud)[Teleport Cloud or Private Network]
+    group server(carbon-bare-metal-server)[Linux Server] in priv
+
+    service audit_log(carbon-ibm-db2)[Teleport Audit Log] in priv2
+    service auth(teleport-logo-purple)[Teleport Auth Service] in priv2
+    service client(carbon-user)[SSH Client]
+    service proxy(teleport-logo-purple)[Teleport Proxy Service]
+    service ssh_service(teleport-logo-purple)[Teleport SSH Service] in server
+
+    ssh_service:L --> R:proxy
+    client:R --> L:proxy
+    proxy:B <--> T:auth
+    auth:R --> L:audit_log
+```
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)


### PR DESCRIPTION
Closes #61573

Add a diagram showing how the components introduced in the How it Works section relate to one another. Use the newly enabled MermaidJS plugin for Docusaurus along with our allowed icon sets (which include a custom Teleport icon). See gravitational/docs-website#552.