### PR TITLE
Fix Teleport Connect WASM Inlining

### DIFF
--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -112,6 +112,19 @@ const config = defineConfig(env => {
         reactPlugin(env.mode),
         cspPlugin(getConnectCsp(env.mode === 'development')),
         tsConfigPathsPlugin,
+        {
+          // The wasm module is embedded into the main app earlier in the build.
+          // Exclude it here, otherwise rollup still emits it as a static asset
+          // by default.
+          name: 'drop-wasm-assets',
+          generateBundle(_, bundle) {
+            for (const file of Object.keys(bundle)) {
+              if (file.endsWith('.wasm')) {
+                delete bundle[file];
+              }
+            }
+          },
+        },
       ],
       define: {
         'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),

--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -113,9 +113,8 @@ const config = defineConfig(env => {
         cspPlugin(getConnectCsp(env.mode === 'development')),
         tsConfigPathsPlugin,
         {
-          // The wasm module is embedded into the main app earlier in the build.
-          // Exclude it here, otherwise rollup still emits it as a static asset
-          // by default.
+          // The IronRDP wasm module is embedded into the renderer app earlier in the build.
+          // Exclude it here, otherwise rollup still emits it as a static asset by default.
           name: 'drop-wasm-assets',
           generateBundle(_, bundle) {
             for (const file of Object.keys(bundle)) {

--- a/web/packages/teleterm/electron.vite.config.mts
+++ b/web/packages/teleterm/electron.vite.config.mts
@@ -91,6 +91,7 @@ const config = defineConfig(env => {
       },
     },
     renderer: {
+      assetsInclude: ['**/shared/libs/ironrdp/**/*.wasm'],
       root: '.',
       build: {
         outDir: path.resolve(outputDirectory, 'renderer'),


### PR DESCRIPTION
It appears #63503 broke Teleport Connect by neglecting to update teleterm's Vite config to support inlining the WASM module.
