### PR TITLE
EC2 auto-discovery:  emit IAM permission errors as UserTasks

### DIFF
--- a/api/types/usertasks/object.go
+++ b/api/types/usertasks/object.go
@@ -398,13 +398,16 @@ func validateDiscoverEC2TaskType(ut *usertasksv1.UserTask) error {
 
 	// Permission issues occur before instance discovery (org/account level),
 	// so account ID, region, and instance list may all be empty.
-	if isPermissionIssueType(ut.GetSpec().GetIssueType()) {
+	if IsPermissionIssueType(ut.GetSpec().GetIssueType()) {
 		return validateDiscoverEC2PermissionIssue(ut)
 	}
 	return validateDiscoverEC2InstallationIssue(ut)
 }
 
-func isPermissionIssueType(issueType string) bool {
+// IsPermissionIssueType reports whether the given issue type represents an
+// IAM permission error (account-level or org-level). Permission issues have
+// relaxed validation: they may have empty account ID, region, and instances.
+func IsPermissionIssueType(issueType string) bool {
 	switch issueType {
 	case AutoDiscoverEC2IssuePermAccountDenied,
 		AutoDiscoverEC2IssuePermOrgDenied:

--- a/lib/loglimit/keyed_limiter.go
+++ b/lib/loglimit/keyed_limiter.go
@@ -1,0 +1,108 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package loglimit
+
+import (
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+const (
+	// defaultKeyedSweepMultiplier is the default sweep cadence relative to
+	// the smallest retained window (sweep every 3× the minimum window).
+	defaultKeyedSweepMultiplier = 3
+	// defaultKeyedStaleMultiplier is the default retention relative to each
+	// key's admitted window (retain for 2× the window before eviction).
+	defaultKeyedStaleMultiplier = 2
+)
+
+// KeyedLimiterConfig configures a [KeyedLimiter]. All fields are optional;
+// zero values select sensible defaults.
+type KeyedLimiterConfig struct {
+	Clock clockwork.Clock
+	// SweepInterval sets a fixed cadence for opportunistic stale-entry
+	// sweeps. Sweeps piggyback on [KeyedLimiter.Allow] calls, so they
+	// only run when the limiter is actively used. When zero (the default),
+	// cadence is derived from SweepMultiplier × the smallest retained
+	// window.
+	SweepInterval time.Duration
+	// SweepMultiplier derives sweep cadence as SweepMultiplier × the
+	// smallest retained window when SweepInterval is zero. Ignored when
+	// SweepInterval is set. Defaults to 3.
+	SweepMultiplier int
+	// StaleMultiplier controls how long an admitted key is retained:
+	// StaleMultiplier × the key's last admitted window. After that
+	// duration the entry is eligible for eviction. A zero or negative
+	// value causes immediate eviction. Defaults to 2.
+	StaleMultiplier int
+}
+
+// checkAndSetDefaults fills zero-valued fields with production defaults.
+func (c *KeyedLimiterConfig) checkAndSetDefaults() {
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	if c.SweepMultiplier <= 0 {
+		c.SweepMultiplier = defaultKeyedSweepMultiplier
+	}
+	if c.StaleMultiplier <= 0 {
+		c.StaleMultiplier = defaultKeyedStaleMultiplier
+	}
+}
+
+// KeyedLimiter suppresses repeated admissions for the same key within a
+// caller-supplied window. All time comparisons are boundary-inclusive
+// (>=), so a key becomes eligible for re-admission exactly when its
+// window elapses.
+type KeyedLimiter struct {
+	*limiter
+}
+
+// NewKeyedLimiter creates a [KeyedLimiter] with the given configuration.
+// Zero-valued config fields are replaced with sensible defaults.
+func NewKeyedLimiter(config KeyedLimiterConfig) *KeyedLimiter {
+	config.checkAndSetDefaults()
+
+	return &KeyedLimiter{
+		limiter: newLimiter(limiterConfig{
+			clock:                 config.Clock,
+			sweepInterval:         config.SweepInterval,
+			sweepMultiplier:       config.SweepMultiplier,
+			staleMultiplier:       config.StaleMultiplier,
+			allowAtWindowBoundary: true,
+			sweepAtBoundary:       true,
+			staleAtBoundary:       true,
+		}),
+	}
+}
+
+// Allow reports whether key should be admitted for the given window.
+//
+// Empty keys are valid and behave like a shared global bucket.
+// Non-positive windows are always admitted and do not retain key state
+// (but may still trigger an opportunistic stale sweep).
+//
+// For a positive window, a key is admitted when it has never been seen
+// or when now >= lastAllowedAt + lastAllowedWindow (boundary-inclusive).
+// On admission, both timestamp and stored window are updated. On
+// suppression, state is unchanged.
+func (l *KeyedLimiter) Allow(key string, window time.Duration) bool {
+	return l.limiter.allow(key, window)
+}

--- a/lib/loglimit/keyed_limiter_test.go
+++ b/lib/loglimit/keyed_limiter_test.go
@@ -1,0 +1,178 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package loglimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyedLimiterSuppressesWithinWindow(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+	require.False(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(9 * time.Second)
+	require.False(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(1 * time.Second)
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+}
+
+func TestKeyedLimiterSupportsVariableWindows(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(10 * time.Second)
+	require.True(t, limiter.Allow("ec2", 20*time.Second))
+
+	fakeClock.Advance(19 * time.Second)
+	require.False(t, limiter.Allow("ec2", 20*time.Second))
+
+	fakeClock.Advance(1 * time.Second)
+	require.True(t, limiter.Allow("ec2", 20*time.Second))
+}
+
+func TestKeyedLimiterSuppressedCallDoesNotRefreshStoredState(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 5*time.Second))
+
+	fakeClock.Advance(4 * time.Second)
+	require.False(t, limiter.Allow("ec2", 30*time.Second))
+
+	fakeClock.Advance(1 * time.Second)
+	require.True(t, limiter.Allow("ec2", 5*time.Second))
+}
+
+func TestKeyedLimiterSuppressedCallDoesNotShrinkStoredWindow(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 30*time.Second))
+
+	fakeClock.Advance(10 * time.Second)
+	require.False(t, limiter.Allow("ec2", 5*time.Second))
+
+	fakeClock.Advance(19 * time.Second)
+	require.False(t, limiter.Allow("ec2", 30*time.Second))
+
+	fakeClock.Advance(1 * time.Second)
+	require.True(t, limiter.Allow("ec2", 30*time.Second))
+}
+
+func TestKeyedLimiterSuppressionBoundaryIsInclusiveAtWindowEnd(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(9*time.Second + 999*time.Millisecond)
+	require.False(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(1 * time.Millisecond)
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+}
+
+func TestKeyedLimiterTracksStatePerKeyIndependently(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("short", 5*time.Second))
+	require.True(t, limiter.Allow("long", 20*time.Second))
+
+	fakeClock.Advance(15 * time.Second)
+	require.True(t, limiter.Allow("short", 5*time.Second))
+	require.False(t, limiter.Allow("long", 20*time.Second))
+}
+
+func TestKeyedLimiterAllowsEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("", 10*time.Second))
+	require.False(t, limiter.Allow("", 10*time.Second))
+}
+
+func TestKeyedLimiterNonPositiveWindowAlwaysAllowsWithoutRetention(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{Clock: fakeClock})
+
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+
+	require.True(t, limiter.Allow("ec2", 0))
+	require.False(t, limiter.Allow("ec2", 10*time.Second))
+
+	require.True(t, limiter.Allow("ec2", -time.Second))
+	require.False(t, limiter.Allow("ec2", 10*time.Second))
+
+	fakeClock.Advance(10 * time.Second)
+	require.True(t, limiter.Allow("ec2", 10*time.Second))
+}
+
+func TestKeyedLimiterCustomMultipliers(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := NewKeyedLimiter(KeyedLimiterConfig{
+		Clock:           fakeClock,
+		SweepMultiplier: 2,
+		StaleMultiplier: 3,
+	})
+
+	require.True(t, limiter.Allow("A", 10*time.Second))
+
+	// Key should be retained for staleMultiplier * window = 30s.
+	// Sweep cadence = sweepMultiplier * minWindow = 2*10s = 20s.
+	// At t=20s: sweep runs, but A is not stale yet (30s threshold).
+	fakeClock.Advance(20 * time.Second)
+	require.True(t, limiter.Allow("trigger", 10*time.Second))
+	_, aExists := limiter.limiter.windows["A"]
+	require.True(t, aExists, "A should still be retained before stale threshold")
+
+	// At t=40s: another sweep runs (20s since last), A is stale (40s > 30s).
+	fakeClock.Advance(20 * time.Second)
+	require.True(t, limiter.Allow("trigger2", 10*time.Second))
+	_, aExists = limiter.limiter.windows["A"]
+	require.False(t, aExists, "A should be evicted after stale threshold + sweep")
+}

--- a/lib/loglimit/limiter.go
+++ b/lib/loglimit/limiter.go
@@ -1,0 +1,249 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package loglimit
+
+import (
+	"maps"
+	"sync"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+// limiter tracks per-key admission windows and performs opportunistic
+// stale-entry sweeps. It is the shared engine behind both [LogLimiter]
+// and [KeyedLimiter].
+type limiter struct {
+	config limiterConfig
+
+	mu          sync.Mutex
+	windows     map[string]window
+	lastSweep   time.Time
+	sweepWindow time.Duration
+}
+
+// limiterConfig holds tuning knobs for admission, sweep cadence, and
+// staleness. Boundary flags control whether comparisons use >= (true)
+// or > (false).
+type limiterConfig struct {
+	clock clockwork.Clock
+
+	// sweepInterval defines fixed cadence for opportunistic stale sweeps.
+	// When zero, sweep cadence is derived from sweepMultiplier and the
+	// current minimum retained window.
+	sweepInterval time.Duration
+	// sweepMultiplier derives sweep cadence as
+	// sweepMultiplier * minimumRetainedWindow when sweepInterval is zero.
+	// Ignored when sweepInterval is set.
+	sweepMultiplier int
+	// staleMultiplier controls how long an admitted key is retained:
+	// staleMultiplier * lastAllowedWindow. A zero or negative value
+	// causes immediate eviction.
+	staleMultiplier int
+
+	// allowAtWindowBoundary controls window expiry comparison. When true,
+	// the exact boundary (now == windowEnd) counts as expired (>=).
+	// When false, only strictly after counts (>).
+	allowAtWindowBoundary bool
+	// sweepAtBoundary controls sweep-due comparison. When true, the exact
+	// boundary (now == sweepAt) triggers a sweep (>=). When false, only
+	// strictly after triggers (>).
+	sweepAtBoundary bool
+	// staleAtBoundary controls staleness comparison. When true, the exact
+	// boundary (now == staleAt) counts as stale (>=). When false, only
+	// strictly after counts (>).
+	staleAtBoundary bool
+}
+
+// window records the last admission time and duration for a single key.
+type window struct {
+	lastAllowedAt     time.Time
+	lastAllowedWindow time.Duration
+}
+
+// newLimiter initializes a limiter with empty per-key state. The sweep
+// timeline is anchored lazily on the first call to allow.
+func newLimiter(config limiterConfig) *limiter {
+	return &limiter{
+		config:  config,
+		windows: make(map[string]window),
+	}
+}
+
+// allow reports whether key should be admitted for allowWindow and updates
+// per-key state on admission. Calls with non-positive windows are always
+// admitted and do not retain key state (but may still trigger a sweep).
+// Opportunistic stale sweeps may run on every call depending on sweep cadence.
+func (l *limiter) allow(key string, allowWindow time.Duration) bool {
+	now := l.config.clock.Now()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Anchor sweep timeline on first call.
+	if l.lastSweep.IsZero() {
+		l.lastSweep = now
+	}
+
+	if allowWindow <= 0 {
+		l.maybeSweep(now)
+		return true
+	}
+
+	storedWindow, ok := l.windows[key]
+	if ok && !l.windowExpired(now, storedWindow) {
+		l.maybeSweep(now)
+		return false
+	}
+
+	l.windows[key] = window{
+		lastAllowedAt:     now,
+		lastAllowedWindow: allowWindow,
+	}
+	l.updateSweepWindowAfterAllow(ok, storedWindow.lastAllowedWindow, allowWindow)
+
+	l.maybeSweep(now)
+	return true
+}
+
+// windowExpired reports whether the admitted window has elapsed as of now.
+// When allowAtWindowBoundary is true the exact boundary (now == windowEnd)
+// counts as expired; otherwise only strictly after counts.
+func (l *limiter) windowExpired(now time.Time, window window) bool {
+	windowEnd := window.lastAllowedAt.Add(window.lastAllowedWindow)
+	if l.config.allowAtWindowBoundary {
+		return !now.Before(windowEnd)
+	}
+
+	return now.After(windowEnd)
+}
+
+// maybeSweep opportunistically evicts stale keys when the sweep cadence is due.
+// It recalculates sweepWindow from retained entries after each sweep.
+func (l *limiter) maybeSweep(now time.Time) {
+	sweepInterval := l.currentSweepInterval()
+	if sweepInterval <= 0 || !l.sweepDue(now, sweepInterval) {
+		return
+	}
+
+	for key, window := range l.windows {
+		if l.windowStale(now, window) {
+			delete(l.windows, key)
+		}
+	}
+
+	l.sweepWindow = minimumRetainedWindow(l.windows)
+	l.lastSweep = now
+}
+
+// currentSweepInterval returns the active sweep cadence.
+// A fixed interval takes precedence; otherwise cadence is derived from the
+// current minimum retained window and sweepMultiplier.
+func (l *limiter) currentSweepInterval() time.Duration {
+	if l.config.sweepInterval > 0 {
+		return l.config.sweepInterval
+	}
+	if l.config.sweepMultiplier <= 0 || l.sweepWindow <= 0 {
+		return 0
+	}
+
+	return time.Duration(l.config.sweepMultiplier) * l.sweepWindow
+}
+
+// updateSweepWindowAfterAllow updates the tracked minimum retained window after
+// allowing a key. This keeps the sweep cadence aligned with the smallest retained
+// window. When a fixed sweepInterval is configured, this is a no-op.
+//
+// If re-admitting a retained key widens what used to be the minimum window,
+// recompute the minimum from all retained entries.
+func (l *limiter) updateSweepWindowAfterAllow(entryExisted bool, previousWindow, newWindow time.Duration) {
+	if l.config.sweepInterval > 0 {
+		return
+	}
+
+	if l.sweepWindow <= 0 || newWindow < l.sweepWindow {
+		l.sweepWindow = newWindow
+		return
+	}
+
+	// If we just widened the current minimum, recompute it from retained entries.
+	if entryExisted && previousWindow == l.sweepWindow && newWindow > previousWindow {
+		l.sweepWindow = minimumRetainedWindow(l.windows)
+	}
+}
+
+// sweepDue reports whether a sweep should run as of now for sweepInterval.
+// When sweepAtBoundary is true the exact boundary (now == sweepAt) triggers
+// a sweep; otherwise only strictly after triggers.
+func (l *limiter) sweepDue(now time.Time, sweepInterval time.Duration) bool {
+	sweepAt := l.lastSweep.Add(sweepInterval)
+	if l.config.sweepAtBoundary {
+		return !now.Before(sweepAt)
+	}
+
+	return now.After(sweepAt)
+}
+
+// windowStale reports whether a retained key is stale and should be evicted.
+// A key is retained for staleMultiplier * lastAllowedWindow after its last
+// admission. A non-positive retention duration causes immediate eviction.
+// When staleAtBoundary is true the exact boundary (now == staleAt) counts
+// as stale; otherwise only strictly after counts.
+func (l *limiter) windowStale(now time.Time, window window) bool {
+	retainedDuration := time.Duration(l.config.staleMultiplier) * window.lastAllowedWindow
+	if retainedDuration <= 0 {
+		return true
+	}
+
+	staleAt := window.lastAllowedAt.Add(retainedDuration)
+	if l.config.staleAtBoundary {
+		return !now.Before(staleAt)
+	}
+
+	return now.After(staleAt)
+}
+
+// clone returns a thread-safe snapshot copy of limiter state.
+func (l *limiter) clone() *limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return &limiter{
+		config:      l.config,
+		windows:     maps.Clone(l.windows),
+		lastSweep:   l.lastSweep,
+		sweepWindow: l.sweepWindow,
+	}
+}
+
+// minimumRetainedWindow returns the smallest positive retained window.
+// Returns zero when there are no positive windows.
+func minimumRetainedWindow(windows map[string]window) time.Duration {
+	var minWindow time.Duration
+	for _, window := range windows {
+		if window.lastAllowedWindow <= 0 {
+			continue
+		}
+		if minWindow <= 0 || window.lastAllowedWindow < minWindow {
+			minWindow = window.lastAllowedWindow
+		}
+	}
+
+	return minWindow
+}

--- a/lib/loglimit/limiter_test.go
+++ b/lib/loglimit/limiter_test.go
@@ -1,0 +1,155 @@
+/*
+ * Teleport
+ * Copyright (C) 2026  Gravitational, Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package loglimit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterSweepCleansUpStaleWindows(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	limiter := newLimiter(limiterConfig{
+		clock:                 clock,
+		sweepMultiplier:       3,
+		staleMultiplier:       2,
+		allowAtWindowBoundary: false,
+		sweepAtBoundary:       false,
+		staleAtBoundary:       false,
+	})
+
+	require.True(t, limiter.allow("A", time.Minute))
+	require.Len(t, limiter.windows, 1)
+
+	// Simulate frequent calls that occur between key "A" going
+	// stale and the sweep interval being reached.
+	for elapsed := time.Duration(0); elapsed < 5*time.Minute; elapsed += time.Minute {
+		clock.Advance(time.Minute)
+		limiter.allow("B", time.Minute)
+	}
+
+	require.Len(t, limiter.windows, 1, "stale window for A should have been swept")
+	require.Contains(t, limiter.windows, "B", "only the fresh B window should remain")
+}
+
+func TestLimiterZeroOrNegativeAllowWindowStillRunsSweep(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := newLimiter(limiterConfig{
+		clock:                 clock,
+		sweepInterval:         10 * time.Second,
+		sweepMultiplier:       2,
+		staleMultiplier:       2,
+		allowAtWindowBoundary: true,
+		sweepAtBoundary:       true,
+		staleAtBoundary:       true,
+	})
+
+	require.True(t, limiter.allow("A", 5*time.Second))
+
+	clock.Advance(10 * time.Second)
+	require.True(t, limiter.allow("cleanup", 0))
+
+	_, existsAtBoundary := limiter.windows["A"]
+	require.False(t, existsAtBoundary)
+
+	clock.Advance(10 * time.Second)
+	require.True(t, limiter.allow("cleanup", -time.Second))
+}
+
+func TestLimiterDerivedSweepIntervalTracksMinimumRetainedWindow(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := newLimiter(limiterConfig{
+		clock:                 clock,
+		sweepMultiplier:       2,
+		staleMultiplier:       2,
+		allowAtWindowBoundary: true,
+		sweepAtBoundary:       true,
+		staleAtBoundary:       true,
+	})
+
+	require.True(t, limiter.allow("short", 5*time.Second))
+	require.True(t, limiter.allow("long", 60*time.Second))
+
+	clock.Advance(10 * time.Second)
+	require.True(t, limiter.allow("trigger", 60*time.Second))
+
+	_, shortExists := limiter.windows["short"]
+	require.False(t, shortExists)
+	require.Equal(t, 60*time.Second, limiter.sweepWindow)
+}
+
+func TestLimiterFixedSweepIntervalIgnoresCallerWindowMix(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := newLimiter(limiterConfig{
+		clock:                 clock,
+		sweepInterval:         10 * time.Second,
+		sweepMultiplier:       100,
+		staleMultiplier:       2,
+		allowAtWindowBoundary: true,
+		sweepAtBoundary:       true,
+		staleAtBoundary:       true,
+	})
+
+	require.True(t, limiter.allow("short", 5*time.Second))
+	require.True(t, limiter.allow("long", 60*time.Second))
+
+	clock.Advance(10 * time.Second)
+	require.True(t, limiter.allow("trigger", 60*time.Second))
+
+	_, shortExists := limiter.windows["short"]
+	require.False(t, shortExists)
+
+	require.Equal(t, 10*time.Second, limiter.currentSweepInterval())
+}
+
+func TestLimiterSweepWindowWidensOnReAdmission(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+	limiter := newLimiter(limiterConfig{
+		clock:                 clock,
+		sweepMultiplier:       2,
+		staleMultiplier:       2,
+		allowAtWindowBoundary: true,
+		sweepAtBoundary:       true,
+		staleAtBoundary:       true,
+	})
+
+	require.True(t, limiter.allow("A", 5*time.Second))
+	require.True(t, limiter.allow("B", 5*time.Second))
+	require.Equal(t, 5*time.Second, limiter.sweepWindow)
+
+	// Re-admit A with a wider window after its original window expires.
+	clock.Advance(5 * time.Second)
+	require.True(t, limiter.allow("A", 20*time.Second))
+
+	// sweepWindow should recompute to B's 5s (the remaining minimum), not A's new 20s.
+	require.Equal(t, 5*time.Second, limiter.sweepWindow)
+}

--- a/lib/loglimit/loglimit.go
+++ b/lib/loglimit/loglimit.go
@@ -21,9 +21,7 @@ package loglimit
 import (
 	"context"
 	"log/slog"
-	"maps"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -33,8 +31,7 @@ import (
 const (
 	// timeWindow is the time window over which logs are deduplicated.
 	timeWindow = time.Minute
-	// sweepInterval is how often the window mapping should be checked
-	// for stale entries.
+	// sweepInterval is how often the window mapping should be checked for stale entries.
 	sweepInterval = timeWindow * 3
 	// staleDuration is the amount of time an entry can exist in the
 	// window mapping before being evicted.
@@ -43,14 +40,11 @@ const (
 
 // Config contains the log limiter config.
 type Config struct {
-	// MessageSubstrings contains a list of substrings belonging to the
-	// logs that should be deduplicated.
+	// MessageSubstrings contains a list of substrings belonging to the logs that should be deduplicated.
 	MessageSubstrings []string
-	// Clock is a clock to override in tests, set to real time clock
-	// by default.
+	// Clock is a clock to override in tests, set to real time clock by default.
 	Clock clockwork.Clock
-	// Handler is the wrapped Handler that processes any messages that
-	// should be sampled.
+	// Handler is the wrapped Handler that processes any messages that should be sampled.
 	Handler slog.Handler
 }
 
@@ -73,15 +67,8 @@ func (c *Config) checkAndSetDefaults() error {
 type LogLimiter struct {
 	// config is the log limiter config.
 	config Config
-	// mu synchronizes access to `windows`.
-	mu sync.Mutex
-	// windows is a mapping from log substring to an active
-	// time window.
-	windows map[string]time.Time
-
-	// lastSweep indicates the last time the full windows mapping
-	// was sweeped and purged of expired entries.
-	lastSweep time.Time
+	// limiter stores fixed-window suppression state for matched substrings.
+	limiter *limiter
 }
 
 // Enabled implements slog.Handler.
@@ -96,39 +83,7 @@ func (l *LogLimiter) Handle(ctx context.Context, record slog.Record) error {
 		return trace.Wrap(l.config.Handler.Handle(ctx, record))
 	}
 
-	shouldLog := func(now time.Time) bool {
-		l.mu.Lock()
-		defer func() {
-			// Periodically attempt to clean up the last seen mapping.
-			if now.After(l.lastSweep.Add(sweepInterval)) {
-				for key, lastSeen := range l.windows {
-					if now.After(lastSeen.Add(staleDuration)) {
-						delete(l.windows, key)
-					}
-				}
-				l.lastSweep = l.config.Clock.Now()
-			}
-
-			l.mu.Unlock()
-		}()
-		lastSeen, ok := l.windows[messageSubstring]
-
-		switch {
-		case !ok:
-			// If this is the first occurrence, log the entry and save it.
-			l.windows[messageSubstring] = now
-			return true
-		case now.After(lastSeen.Add(timeWindow)):
-			// If this is NOT the first occurrence BUT the last occurrence,
-			// has expired, then permit the log entry and update the window.
-			l.windows[messageSubstring] = l.config.Clock.Now()
-			return true
-		default:
-			return false
-		}
-	}(l.config.Clock.Now())
-
-	if shouldLog {
+	if l.limiter.allow(messageSubstring, timeWindow) {
 		return trace.Wrap(l.config.Handler.Handle(ctx, record))
 	}
 
@@ -138,31 +93,30 @@ func (l *LogLimiter) Handle(ctx context.Context, record slog.Record) error {
 
 // WithAttrs implements slog.Handler.
 func (l *LogLimiter) WithAttrs(attrs []slog.Attr) slog.Handler {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
+	// slog.Handler values are immutable; derived handlers must behave as
+	// independent values. We clone suppression state at derivation time so the
+	// new handler starts with the same snapshot but then diverges independently.
 	return &LogLimiter{
 		config: Config{
 			MessageSubstrings: l.config.MessageSubstrings,
 			Clock:             l.config.Clock,
 			Handler:           l.config.Handler.WithAttrs(attrs),
 		},
-		windows: maps.Clone(l.windows),
+		limiter: l.limiter.clone(),
 	}
 }
 
 // WithGroup implements slog.Handler.
 func (l *LogLimiter) WithGroup(name string) slog.Handler {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
+	// Keep the same clone semantics as WithAttrs: copy current limiter state,
+	// then let parent/child handlers evolve independently.
 	return &LogLimiter{
 		config: Config{
 			MessageSubstrings: l.config.MessageSubstrings,
 			Clock:             l.config.Clock,
 			Handler:           l.config.Handler.WithGroup(name),
 		},
-		windows: maps.Clone(l.windows),
+		limiter: l.limiter.clone(),
 	}
 }
 
@@ -173,8 +127,16 @@ func New(config Config) (*LogLimiter, error) {
 	}
 
 	l := &LogLimiter{
-		config:  config,
-		windows: make(map[string]time.Time, len(config.MessageSubstrings)),
+		config: config,
+		limiter: newLimiter(limiterConfig{
+			clock:                 config.Clock,
+			sweepInterval:         sweepInterval,
+			sweepMultiplier:       int(sweepInterval / timeWindow),
+			staleMultiplier:       int(staleDuration / timeWindow),
+			allowAtWindowBoundary: false,
+			sweepAtBoundary:       false,
+			staleAtBoundary:       false,
+		}),
 	}
 
 	return l, nil

--- a/lib/loglimit/loglimit_test.go
+++ b/lib/loglimit/loglimit_test.go
@@ -29,39 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSweepCleansUpStaleEntries(t *testing.T) {
-	t.Parallel()
-
-	clock := clockwork.NewFakeClock()
-
-	var sink bytes.Buffer
-	logLimiter, err := New(Config{
-		MessageSubstrings: []string{"A", "B"},
-		Clock:             clock,
-		Handler:           slog.NewTextHandler(&sink, &slog.HandlerOptions{}),
-	})
-	require.NoError(t, err)
-
-	logger := slog.New(logLimiter)
-
-	logger.InfoContext(t.Context(), "A log 1")
-	require.Len(t, logLimiter.windows, 1)
-
-	// Simulate frequent calls that occur between the entry going stale
-	// and the sweep interval being reached.
-	//
-	// Advance in small increments, logging a deduplicated "B" message
-	// each time. After enough time has passed the "A" entry is stale
-	// and the sweep is overdue.
-	for elapsed := time.Duration(0); elapsed < staleDuration+sweepInterval; elapsed += timeWindow {
-		clock.Advance(timeWindow)
-		logger.InfoContext(t.Context(), "B log")
-	}
-
-	require.Len(t, logLimiter.windows, 1, "stale entry for A should have been swept")
-	require.Contains(t, logLimiter.windows, "B", "only the fresh B entry should remain")
-}
-
 func TestLogLimiter(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -205,4 +172,89 @@ msg="C log 1"
 			tc.logsAssert(t, loggedFirstBatch, loggedSecondBatch)
 		})
 	}
+}
+
+func TestLogLimiterSuppressionBoundaryIsStrictlyAfterWindowEnd(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+
+	var sink bytes.Buffer
+	logLimiter, err := New(Config{
+		MessageSubstrings: []string{"A"},
+		Clock:             clock,
+		Handler: slog.NewTextHandler(&sink, &slog.HandlerOptions{
+			AddSource: false,
+			Level:     nil,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+					return slog.Attr{}
+				}
+
+				return a
+			},
+		}),
+	})
+	require.NoError(t, err)
+
+	logger := slog.New(logLimiter)
+
+	logger.InfoContext(t.Context(), "A log 1")
+
+	clock.Advance(time.Minute - time.Millisecond)
+	logger.InfoContext(t.Context(), "A log 2")
+
+	clock.Advance(time.Millisecond)
+	logger.InfoContext(t.Context(), "A log 3")
+
+	clock.Advance(time.Millisecond)
+	logger.InfoContext(t.Context(), "A log 4")
+
+	assert.Equal(t, `msg="A log 1"
+msg="A log 4"
+`, sink.String())
+}
+
+func TestLogLimiterWithAttrsCloneStateDivergesIndependently(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 23, 0, 0, 0, 0, time.UTC))
+
+	var sink bytes.Buffer
+	logLimiter, err := New(Config{
+		MessageSubstrings: []string{"A"},
+		Clock:             clock,
+		Handler: slog.NewTextHandler(&sink, &slog.HandlerOptions{
+			AddSource: false,
+			Level:     nil,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey || a.Key == slog.LevelKey {
+					return slog.Attr{}
+				}
+
+				return a
+			},
+		}),
+	})
+	require.NoError(t, err)
+
+	base := slog.New(logLimiter)
+	child := base.With("component", "child")
+
+	// Prime base state, then derive child so both start from the same snapshot.
+	base.InfoContext(t.Context(), "A from base")
+
+	// Child allows once from the cloned snapshot; base suppresses because it's
+	// still in the original window.
+	child.InfoContext(t.Context(), "A from child")
+	base.InfoContext(t.Context(), "A from base again")
+
+	// Child now suppresses independently in its own limiter state.
+	child.InfoContext(t.Context(), "A from child again")
+
+	logged := sink.String()
+	assert.Contains(t, logged, `msg="A from base"`)
+	assert.Contains(t, logged, `msg="A from child" component=child`)
+	assert.NotContains(t, logged, "A from base again")
+	assert.NotContains(t, logged, "A from child again")
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/gcp"
 	gcpimds "github.com/gravitational/teleport/lib/cloud/imds/gcp"
 	"github.com/gravitational/teleport/lib/cryptosuites"
+	"github.com/gravitational/teleport/lib/loglimit"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/readonly"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
@@ -78,7 +79,31 @@ import (
 
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
-const noDiscoveryConfig = ""
+const (
+	noDiscoveryConfig = ""
+
+	// ec2IAMWarningMinSuppression is the minimum duration a repeated EC2 IAM
+	// permission warning will be suppressed.
+	ec2IAMWarningMinSuppression = 15 * time.Minute
+
+	// ec2IAMWarningSuppressionMultiplier scales the poll interval to produce
+	// the suppression window.
+	ec2IAMWarningSuppressionMultiplier = 3
+
+	// ec2IAMWarningSweepMultiplier defines how many suppression windows
+	// must pass before a garbage collection sweep occurs. It multiplies
+	// against the suppression duration to determine the sweep interval.
+	// This tells the system when it's safe to delete the warning from
+	// its internal memory map.
+	ec2IAMWarningSweepMultiplier = 3
+
+	// ec2IAMWarningStaleMultiplier defines how many suppression windows
+	// a warning key must sit inactive before becoming stale. It
+	// multiplies against the suppression duration to determine this
+	// inactivity threshold. This tells the system how long to keep the
+	// warning in memory before deleting it.
+	ec2IAMWarningStaleMultiplier = 2
+)
 
 // Matchers contains all matchers used by discovery service
 type Matchers struct {
@@ -92,6 +117,27 @@ type Matchers struct {
 	Kubernetes []types.KubernetesMatcher
 	// AccessGraph is the configuration for the Access Graph Cloud sync.
 	AccessGraph *types.AccessGraphSync
+}
+
+type ec2IAMWarningKey struct {
+	integration string
+	accountID   string
+	region      string
+	issueType   string
+}
+
+// String returns a pipe-delimited composite key with each component quoted,
+// so pipe characters in field values do not collide with the delimiter.
+func (k ec2IAMWarningKey) String() string {
+	return fmt.Sprintf("%q|%q|%q|%q", k.integration, k.accountID, k.region, k.issueType)
+}
+
+func ec2IAMWarningSuppressionWindow(pollInterval time.Duration) time.Duration {
+	return max(pollInterval*ec2IAMWarningSuppressionMultiplier, ec2IAMWarningMinSuppression)
+}
+
+func ec2IAMWarningSweepInterval(pollInterval time.Duration) time.Duration {
+	return ec2IAMWarningSuppressionWindow(pollInterval) * ec2IAMWarningSweepMultiplier
 }
 
 func (m Matchers) IsEmpty() bool {
@@ -442,9 +488,14 @@ type Server struct {
 	awsRDSResourcesStatus awsResourcesStatus
 	awsEKSResourcesStatus awsResourcesStatus
 	awsEC2Tasks           awsEC2Tasks
-	awsEKSTasks awsEKSTasks
-	awsRDSTasks        awsRDSTasks
-	azureVMStatus      atomic.Pointer[resourceStatusMap]
+
+	// ec2IAMWarningLimiter rate-limits EC2 IAM permission warnings keyed by
+	// integration, account, region, and issue type.
+	ec2IAMWarningLimiter *loglimit.KeyedLimiter
+
+	awsEKSTasks   awsEKSTasks
+	awsRDSTasks   awsRDSTasks
+	azureVMStatus atomic.Pointer[resourceStatusMap]
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -482,6 +533,11 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		awsEC2ResourcesStatus:   newAWSResourceStatusCollector(types.AWSMatcherEC2),
 		awsRDSResourcesStatus:   newAWSResourceStatusCollector(types.AWSMatcherRDS),
 		awsEKSResourcesStatus:   newAWSResourceStatusCollector(types.AWSMatcherEKS),
+		ec2IAMWarningLimiter: loglimit.NewKeyedLimiter(loglimit.KeyedLimiterConfig{
+			Clock:           cfg.clock,
+			SweepInterval:   ec2IAMWarningSweepInterval(cfg.PollInterval),
+			StaleMultiplier: ec2IAMWarningStaleMultiplier,
+		}),
 	}
 	s.discardUnsupportedMatchers(&s.Matchers)
 
@@ -630,40 +686,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		server.WithPollInterval[*server.EC2DiscoveryResult](s.PollInterval),
 		server.WithTriggerFetchC[*server.EC2DiscoveryResult](s.newDiscoveryConfigChangedSub()),
 		server.WithPreFetchHookFn(s.ec2WatcherIterationStarted),
-		server.WithPostFetchHookFn[*server.EC2DiscoveryResult](s.upsertTasksForAWSEC2FailedEnrollments),
-		// Report IAM permission errors in the watcher pipeline, close to where
-		// they originate, rather than downstream in handleEC2Discovery.
-		server.WithPerInstanceHookFn(func(results []*server.EC2DiscoveryResult) {
-			for _, result := range results {
-				if result == nil {
-					continue
-				}
-				for _, permErr := range result.PermissionErrors {
-					s.Log.WarnContext(s.ctx, "IAM permission error during EC2 discovery",
-						"issue_type", permErr.IssueType,
-						"integration", permErr.Integration,
-						"account_id", permErr.AccountID,
-						"region", permErr.Region,
-						"discovery_config", permErr.DiscoveryConfigName,
-						"error", permErr.Err,
-					)
-					s.awsEC2Tasks.addFailedEnrollment(
-						awsEC2TaskKey{
-							accountID:   permErr.AccountID,
-							integration: permErr.Integration,
-							issueType:   permErr.IssueType,
-							region:      permErr.Region,
-						},
-						nil, // Permission issues have no instance data.
-					)
-				}
-				select {
-				case s.ec2Watcher.InstancesC <- result:
-				case <-s.ctx.Done():
-					return
-				}
-			}
-		}),
+		server.WithPerInstanceTapFn(s.handleEC2WatcherResults),
 		server.WithClock[*server.EC2DiscoveryResult](s.clock),
 	)
 	s.ec2Watcher.SetFetchers(noDiscoveryConfig, staticFetchers)
@@ -700,6 +723,74 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	s.kubeFetchers = append(s.kubeFetchers, kubeFetchers...)
 
 	return nil
+}
+
+// handleEC2WatcherResults processes EC2 watcher results before
+// downstream enrollment handling runs. It conditionally logs
+// rate-limited IAM permission warnings, while unconditionally
+// queuing those permission errors as failed enrollments for later
+// user-task upserts.
+func (s *Server) handleEC2WatcherResults(results []*server.EC2DiscoveryResult) {
+	for _, result := range results {
+		if result == nil {
+			continue
+		}
+		for _, permErr := range result.PermissionErrors {
+			if permErr == nil {
+				continue
+			}
+			if s.shouldLogEC2IAMPermissionWarning(permErr) {
+				// discovery_config is logged as informational context and is intentionally absent from the rate-limiting key.
+				// The first config observed within a suppression window is the one shown in the emitted warning.
+				s.Log.WarnContext(s.ctx, "IAM permission error during EC2 discovery",
+					"issue_type", permErr.IssueType,
+					"integration", permErr.Integration,
+					"account_id", permErr.AccountID,
+					"region", permErr.Region,
+					"discovery_config", permErr.DiscoveryConfigName,
+					"error", permErr.Err,
+				)
+			}
+
+			// This is called every poll, regardless of the suppression logic.
+			s.awsEC2Tasks.addFailedPermissionEnrollment(
+				awsEC2TaskKey{
+					// Intentionally do not include DiscoveryConfigName in the task key. Permission errors are
+					// account/region scoped and usually shared by all discovery configs using the same credentials.
+					accountID:   permErr.AccountID,
+					integration: permErr.Integration,
+					issueType:   permErr.IssueType,
+					region:      permErr.Region,
+				},
+			)
+		}
+	}
+}
+
+// shouldLogEC2IAMPermissionWarning reports whether an EC2 IAM permission warning
+// should be logged. Identical warnings with the same integration, account, region,
+// and issue type are rate-limited to prevent log spam during repeated discovery polls.
+//
+// Suppression and stale-entry sweeping are delegated to [loglimit.KeyedLimiter],
+// which must be initialized before this method is called.
+func (s *Server) shouldLogEC2IAMPermissionWarning(permErr *server.EC2IAMPermissionError) bool {
+	if permErr == nil {
+		return false
+	}
+	if s.ec2IAMWarningLimiter == nil {
+		return true
+	}
+
+	suppressionWindow := ec2IAMWarningSuppressionWindow(s.PollInterval)
+
+	key := ec2IAMWarningKey{
+		integration: permErr.Integration,
+		accountID:   permErr.AccountID,
+		region:      permErr.Region,
+		issueType:   permErr.IssueType,
+	}
+
+	return s.ec2IAMWarningLimiter.Allow(key.String(), suppressionWindow)
 }
 
 func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC2DiscoveryResult]) {
@@ -1399,10 +1490,6 @@ func (s *Server) handleEC2Discovery() {
 				continue
 			}
 
-			// Permission errors are handled in the watcher pipeline via
-			// WithPerInstanceHookFn, close to where they originate.
-
-			// Process discovered instances.
 			for _, instances := range result.Instances {
 				s.Log.DebugContext(s.ctx, "EC2 instances discovered, starting installation", "account_id", instances.AccountID, "instances", genEC2InstancesLogStr(instances.Instances))
 
@@ -1415,6 +1502,8 @@ func (s *Server) handleEC2Discovery() {
 					s.logHandleInstancesErr(err)
 				}
 			}
+
+			s.upsertTasksForAWSEC2FailedEnrollments()
 		case <-s.ctx.Done():
 			s.ec2Watcher.Stop()
 			return

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -395,8 +395,8 @@ type Server struct {
 	// nodeWatcher is a node watcher.
 	nodeWatcher *services.GenericWatcher[types.Server, readonly.Server]
 
-	// ec2Watcher periodically retrieves EC2 instances.
-	ec2Watcher *server.Watcher[*server.EC2Instances]
+	// ec2Watcher periodically retrieves EC2 instances and permission errors.
+	ec2Watcher *server.Watcher[*server.EC2DiscoveryResult]
 	// ec2Installer is used to start the installation process on discovered EC2 nodes
 	ec2Installer ssmInstaller
 	// gcpWatcher periodically retrieves GCP virtual machines.
@@ -442,9 +442,9 @@ type Server struct {
 	awsRDSResourcesStatus awsResourcesStatus
 	awsEKSResourcesStatus awsResourcesStatus
 	awsEC2Tasks           awsEC2Tasks
-	awsEKSTasks           awsEKSTasks
-	awsRDSTasks           awsRDSTasks
-	azureVMStatus         atomic.Pointer[resourceStatusMap]
+	awsEKSTasks awsEKSTasks
+	awsRDSTasks        awsRDSTasks
+	azureVMStatus      atomic.Pointer[resourceStatusMap]
 
 	// caRotationCh receives nodes that need to have their CAs rotated.
 	caRotationCh chan []types.Server
@@ -627,10 +627,44 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	s.ec2Watcher = server.NewWatcher(
 		s.ctx,
 		server.WithMissedRotation(s.caRotationCh),
-		server.WithPollInterval[*server.EC2Instances](s.PollInterval),
-		server.WithTriggerFetchC[*server.EC2Instances](s.newDiscoveryConfigChangedSub()),
+		server.WithPollInterval[*server.EC2DiscoveryResult](s.PollInterval),
+		server.WithTriggerFetchC[*server.EC2DiscoveryResult](s.newDiscoveryConfigChangedSub()),
 		server.WithPreFetchHookFn(s.ec2WatcherIterationStarted),
-		server.WithClock[*server.EC2Instances](s.clock),
+		server.WithPostFetchHookFn[*server.EC2DiscoveryResult](s.upsertTasksForAWSEC2FailedEnrollments),
+		// Report IAM permission errors in the watcher pipeline, close to where
+		// they originate, rather than downstream in handleEC2Discovery.
+		server.WithPerInstanceHookFn(func(results []*server.EC2DiscoveryResult) {
+			for _, result := range results {
+				if result == nil {
+					continue
+				}
+				for _, permErr := range result.PermissionErrors {
+					s.Log.WarnContext(s.ctx, "IAM permission error during EC2 discovery",
+						"issue_type", permErr.IssueType,
+						"integration", permErr.Integration,
+						"account_id", permErr.AccountID,
+						"region", permErr.Region,
+						"discovery_config", permErr.DiscoveryConfigName,
+						"error", permErr.Err,
+					)
+					s.awsEC2Tasks.addFailedEnrollment(
+						awsEC2TaskKey{
+							accountID:   permErr.AccountID,
+							integration: permErr.Integration,
+							issueType:   permErr.IssueType,
+							region:      permErr.Region,
+						},
+						nil, // Permission issues have no instance data.
+					)
+				}
+				select {
+				case s.ec2Watcher.InstancesC <- result:
+				case <-s.ctx.Done():
+					return
+				}
+			}
+		}),
+		server.WithClock[*server.EC2DiscoveryResult](s.clock),
 	)
 	s.ec2Watcher.SetFetchers(noDiscoveryConfig, staticFetchers)
 
@@ -668,7 +702,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	return nil
 }
 
-func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC2Instances]) {
+func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC2DiscoveryResult]) {
 	if len(fetchers) == 0 {
 		return
 	}
@@ -677,7 +711,7 @@ func (s *Server) ec2WatcherIterationStarted(fetchers []server.Fetcher[*server.EC
 
 	awsResultGroups := libslices.FilterMapUnique(
 		fetchers,
-		func(f server.Fetcher[*server.EC2Instances]) (awsResourceGroup, bool) {
+		func(f server.Fetcher[*server.EC2DiscoveryResult]) (awsResourceGroup, bool) {
 			include := f.GetDiscoveryConfigName() != "" && f.IntegrationName() != ""
 			resourceGroup := awsResourceGroup{
 				discoveryConfigName: f.GetDiscoveryConfigName(),
@@ -730,7 +764,7 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 }
 
 // awsServerFetchersFromMatchers converts Matchers into a set of AWS EC2 Fetchers.
-func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []types.AWSMatcher, discoveryConfigName string) ([]server.Fetcher[*server.EC2Instances], error) {
+func (s *Server) awsServerFetchersFromMatchers(ctx context.Context, matchers []types.AWSMatcher, discoveryConfigName string) ([]server.Fetcher[*server.EC2DiscoveryResult], error) {
 	serverMatchers, _ := splitMatchers(matchers, func(matcherType string) bool {
 		return matcherType == types.AWSMatcherEC2
 	})
@@ -1360,19 +1394,27 @@ func (s *Server) handleEC2Discovery() {
 
 	for {
 		select {
-		case instances := <-s.ec2Watcher.InstancesC:
-			s.Log.DebugContext(s.ctx, "EC2 instances discovered, starting installation", "account_id", instances.AccountID, "instances", genEC2InstancesLogStr(instances.Instances))
-
-			s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
-				discoveryConfigName: instances.DiscoveryConfigName,
-				integration:         instances.Integration,
-			}, len(instances.Instances))
-
-			if err := s.handleEC2Instances(instances); err != nil {
-				s.logHandleInstancesErr(err)
+		case result := <-s.ec2Watcher.InstancesC:
+			if result == nil {
+				continue
 			}
 
-			s.upsertTasksForAWSEC2FailedEnrollments()
+			// Permission errors are handled in the watcher pipeline via
+			// WithPerInstanceHookFn, close to where they originate.
+
+			// Process discovered instances.
+			for _, instances := range result.Instances {
+				s.Log.DebugContext(s.ctx, "EC2 instances discovered, starting installation", "account_id", instances.AccountID, "instances", genEC2InstancesLogStr(instances.Instances))
+
+				s.awsEC2ResourcesStatus.incrementFound(awsResourceGroup{
+					discoveryConfigName: instances.DiscoveryConfigName,
+					integration:         instances.Integration,
+				}, len(instances.Instances))
+
+				if err := s.handleEC2Instances(instances); err != nil {
+					s.logHandleInstancesErr(err)
+				}
+			}
 		case <-s.ctx.Done():
 			s.ec2Watcher.Stop()
 			return

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"net/http"
 	"net/url"
@@ -103,6 +104,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	libevents "github.com/gravitational/teleport/lib/events"
 	libstream "github.com/gravitational/teleport/lib/itertools/stream"
+	"github.com/gravitational/teleport/lib/loglimit"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local"
@@ -119,6 +121,179 @@ import (
 func TestMain(m *testing.M) {
 	modules.SetInsecureTestMode(true)
 	os.Exit(m.Run())
+}
+
+func TestShouldLogEC2IAMPermissionWarning(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 20, 0, 0, 0, 0, time.UTC))
+	pollInterval := 5 * time.Minute
+	srv := &Server{
+		Config: &Config{clock: fakeClock, PollInterval: pollInterval},
+		ec2IAMWarningLimiter: loglimit.NewKeyedLimiter(loglimit.KeyedLimiterConfig{
+			Clock:           fakeClock,
+			SweepInterval:   ec2IAMWarningSweepInterval(pollInterval),
+			StaleMultiplier: ec2IAMWarningStaleMultiplier,
+		}),
+	}
+
+	baseErr := &server.EC2IAMPermissionError{
+		Integration:         "my-integration",
+		AccountID:           "123456789012",
+		Region:              "eu-west-2",
+		IssueType:           usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+		DiscoveryConfigName: "dc-1",
+		Err:                 trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances"),
+	}
+
+	t.Run("first call allowed", func(t *testing.T) {
+		require.True(t, srv.shouldLogEC2IAMPermissionWarning(baseErr))
+	})
+
+	t.Run("duplicate suppressed", func(t *testing.T) {
+		require.False(t, srv.shouldLogEC2IAMPermissionWarning(baseErr))
+	})
+
+	t.Run("different error same key suppressed", func(t *testing.T) {
+		sameContextDifferentErr := &server.EC2IAMPermissionError{
+			Integration:         baseErr.Integration,
+			AccountID:           baseErr.AccountID,
+			Region:              baseErr.Region,
+			IssueType:           baseErr.IssueType,
+			DiscoveryConfigName: baseErr.DiscoveryConfigName,
+			Err:                 trace.AccessDenied("User is not authorized to perform: account:ListRegions"),
+		}
+		require.False(t, srv.shouldLogEC2IAMPermissionWarning(sameContextDifferentErr))
+	})
+
+	t.Run("different region allowed", func(t *testing.T) {
+		differentRegion := &server.EC2IAMPermissionError{
+			Integration:         baseErr.Integration,
+			AccountID:           baseErr.AccountID,
+			Region:              "us-west-2",
+			IssueType:           baseErr.IssueType,
+			DiscoveryConfigName: baseErr.DiscoveryConfigName,
+			Err:                 trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances"),
+		}
+		require.True(t, srv.shouldLogEC2IAMPermissionWarning(differentRegion))
+	})
+
+	t.Run("different config same key suppressed", func(t *testing.T) {
+		sameKeyDifferentConfig := &server.EC2IAMPermissionError{
+			Integration:         baseErr.Integration,
+			AccountID:           baseErr.AccountID,
+			Region:              baseErr.Region,
+			IssueType:           baseErr.IssueType,
+			DiscoveryConfigName: "dc-2",
+			Err:                 trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances"),
+		}
+		require.False(t, srv.shouldLogEC2IAMPermissionWarning(sameKeyDifferentConfig))
+	})
+
+	t.Run("suppressed within window", func(t *testing.T) {
+		fakeClock.Advance(10 * time.Minute)
+		require.False(t, srv.shouldLogEC2IAMPermissionWarning(baseErr))
+	})
+
+	t.Run("allowed after window expires", func(t *testing.T) {
+		fakeClock.Advance(5 * time.Minute)
+		require.True(t, srv.shouldLogEC2IAMPermissionWarning(baseErr))
+	})
+
+	t.Run("nil returns false", func(t *testing.T) {
+		require.False(t, srv.shouldLogEC2IAMPermissionWarning(nil))
+	})
+}
+
+func TestShouldLogEC2IAMPermissionWarning_StaleSweep(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 20, 0, 0, 0, 0, time.UTC))
+	pollInterval := 5 * time.Minute
+	srv := &Server{
+		Config: &Config{clock: fakeClock, PollInterval: pollInterval},
+		ec2IAMWarningLimiter: loglimit.NewKeyedLimiter(loglimit.KeyedLimiterConfig{
+			Clock:           fakeClock,
+			SweepInterval:   ec2IAMWarningSweepInterval(pollInterval),
+			StaleMultiplier: ec2IAMWarningStaleMultiplier,
+		}),
+	}
+
+	makeErr := func(suffix string) *server.EC2IAMPermissionError {
+		return &server.EC2IAMPermissionError{
+			Integration:         "my-integration",
+			AccountID:           "123456789012",
+			Region:              "eu-west-2",
+			IssueType:           fmt.Sprintf("%s-%s", usertasks.AutoDiscoverEC2IssuePermAccountDenied, suffix),
+			DiscoveryConfigName: "dc-1",
+			Err:                 trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances"),
+		}
+	}
+
+	require.True(t, srv.shouldLogEC2IAMPermissionWarning(makeErr("old")))
+
+	// Advance beyond stale duration so first key becomes evictable.
+	fakeClock.Advance(31 * time.Minute)
+	require.True(t, srv.shouldLogEC2IAMPermissionWarning(makeErr("new")))
+
+	// Trigger sweep after sweep interval has elapsed.
+	fakeClock.Advance(15 * time.Minute)
+	require.True(t, srv.shouldLogEC2IAMPermissionWarning(makeErr("sweep")))
+	require.True(t, srv.shouldLogEC2IAMPermissionWarning(makeErr("old")))
+}
+
+func TestEC2IAMWarningKeyStringIsUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	// These would collide with a naive NUL-joined serialization.
+	keyA := ec2IAMWarningKey{
+		integration: "my-int\x00suffix",
+		accountID:   "123456789012",
+		region:      "us-west-2",
+		issueType:   usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+	}
+	keyB := ec2IAMWarningKey{
+		integration: "my-int",
+		accountID:   "suffix\x00123456789012",
+		region:      "us-west-2",
+		issueType:   usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+	}
+
+	require.NotEqual(t, keyA.String(), keyB.String())
+}
+
+func TestHandleEC2WatcherResults_NilGuards(t *testing.T) {
+	t.Parallel()
+
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2026, time.March, 20, 0, 0, 0, 0, time.UTC))
+	pollInterval := 5 * time.Minute
+	srv := &Server{
+		Config: &Config{
+			clock:        fakeClock,
+			PollInterval: pollInterval,
+			Log:          slog.Default(),
+		},
+		ctx: t.Context(),
+		ec2IAMWarningLimiter: loglimit.NewKeyedLimiter(loglimit.KeyedLimiterConfig{
+			Clock:           fakeClock,
+			SweepInterval:   ec2IAMWarningSweepInterval(pollInterval),
+			StaleMultiplier: ec2IAMWarningStaleMultiplier,
+		}),
+	}
+
+	t.Run("nil result skipped", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			srv.handleEC2WatcherResults([]*server.EC2DiscoveryResult{nil})
+		})
+	})
+
+	t.Run("nil permission error skipped", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			srv.handleEC2WatcherResults([]*server.EC2DiscoveryResult{
+				{PermissionErrors: []*server.EC2IAMPermissionError{nil}},
+			})
+		})
+	})
 }
 
 type mockSSMClient struct {
@@ -139,13 +314,32 @@ type mockEmitter struct {
 	eventHandler func(*testing.T, events.AuditEvent, *Server)
 	server       *Server
 	t            *testing.T
+	mu           sync.Mutex
+	emitted      []events.AuditEvent
 }
 
 func (me *mockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+	me.mu.Lock()
+	me.emitted = append(me.emitted, event)
+	me.mu.Unlock()
+
 	if me.eventHandler != nil {
 		me.eventHandler(me.t, event, me.server)
 	}
 	return nil
+}
+
+func (me *mockEmitter) EmittedByType(eventType string) []events.AuditEvent {
+	me.mu.Lock()
+	defer me.mu.Unlock()
+
+	var filtered []events.AuditEvent
+	for _, evt := range me.emitted {
+		if evt.GetType() == eventType {
+			filtered = append(filtered, evt)
+		}
+	}
+	return filtered
 }
 
 type mockUsageReporter struct {
@@ -184,10 +378,15 @@ type mockEC2Client struct {
 	err    error
 }
 
+// Compile-time check that the mock satisfies the API used by discovery tests.
+var _ ec2.DescribeInstancesAPIClient = (*mockEC2Client)(nil)
+
 func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
+	// Unlike the server package mock, this integration-style test mock returns
+	// pre-shaped outputs so tests can focus on discovery service behavior.
 	return m.output, nil
 }
 
@@ -1416,6 +1615,359 @@ func TestDiscoveryServerConcurrency(t *testing.T) {
 
 		return len(allNodes) != 1
 	}, 2*time.Second, 50*time.Millisecond)
+}
+
+func TestEC2PermissionTaskAuditCadence_CreateThenUpdate(t *testing.T) {
+	t.Parallel()
+	const defaultDiscoveryGroup = "dc001"
+
+	ctx := context.Background()
+	logger := logtest.NewLogger()
+	fakeClock := clockwork.NewFakeClock()
+
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: fakeClock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	tlsServer, err := testAuthServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	identity := authtest.TestServerID(types.RoleDiscovery, "hostID")
+	authClient, err := tlsServer.NewClient(identity)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+	discoveryConfigName := "dc-ec2-audit-cadence"
+	discoveryCfg, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryConfigName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{
+				{
+					Types:       []string{"ec2"},
+					Regions:     []string{"us-west-2"},
+					Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+					Integration: "my-integration",
+					Params: &types.InstallerParams{
+						EnrollMode: types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+					},
+					SSM: &types.AWSSSM{DocumentName: "document"},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, discoveryCfg.CheckAndSetDefaults())
+	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, discoveryCfg)
+	require.NoError(t, err)
+
+	awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{Name: "my-integration"}, &types.AWSOIDCIntegrationSpecV1{
+		RoleARN: "arn:aws:iam::123456789012:role/teleport",
+	})
+	require.NoError(t, err)
+	testAuthServer.AuthServer.IntegrationsTokenGenerator = &mockIntegrationsTokenGenerator{
+		integrations: map[string]types.Integration{
+			awsOIDCIntegration.GetName(): awsOIDCIntegration,
+		},
+	}
+	_, err = tlsServer.Auth().CreateIntegration(ctx, awsOIDCIntegration)
+	require.NoError(t, err)
+
+	emitter := &mockEmitter{}
+	fakeConfigProvider := mocks.AWSConfigProvider{
+		OIDCIntegrationClient: tlsServer.Auth(),
+	}
+
+	discoveryServer, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
+		GetEC2Client: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{err: trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances")}, nil
+		},
+		GetSSMClient: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (server.SSMClient, error) {
+			return &mockSSMClient{}, nil
+		},
+		AWSConfigProvider: &fakeConfigProvider,
+		AWSFetchersClients: &mockFetchersClients{
+			AWSConfigProvider: fakeConfigProvider,
+		},
+		ClusterFeatures:  func() proto.Features { return proto.Features{} },
+		KubernetesClient: fake.NewClientset(),
+		AccessPoint:      getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+		Matchers:         Matchers{},
+		Emitter:          emitter,
+		Log:              logger,
+		DiscoveryGroup:   defaultDiscoveryGroup,
+		clock:            fakeClock,
+		PollInterval:     5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	listUserTasks := func() ([]*usertasksv1.UserTask, error) {
+		var allTasks []*usertasksv1.UserTask
+		nextToken := ""
+		for {
+			tasks, nextTokenResp, err := tlsServer.Auth().UserTasks.ListUserTasks(ctx, 0, nextToken, &usertasksv1.ListUserTasksFilters{})
+			if err != nil {
+				return nil, err
+			}
+			allTasks = append(allTasks, tasks...)
+			if nextTokenResp == "" {
+				return allTasks, nil
+			}
+			nextToken = nextTokenResp
+		}
+	}
+	listUserTaskAuditEvents := func() ([]events.AuditEvent, error) {
+		events, _, err := testAuthServer.AuditLog.SearchEvents(ctx, libevents.SearchEventsRequest{
+			From:       time.Time{},
+			To:         fakeClock.Now().Add(24 * time.Hour),
+			EventTypes: []string{libevents.UserTaskCreateEvent, libevents.UserTaskUpdateEvent},
+			Limit:      1000,
+			Order:      types.EventOrderAscending,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return events, nil
+	}
+
+	go discoveryServer.Start()
+	t.Cleanup(discoveryServer.Stop)
+	discoveryServer.notifyDiscoveryConfigChanged()
+
+	var taskName string
+	require.Eventually(t, func() bool {
+		fakeClock.Advance(discoveryServer.PollInterval)
+
+		tasks, err := listUserTasks()
+		if err != nil {
+			return false
+		}
+		for _, task := range tasks {
+			if task.GetSpec().GetIssueType() != usertasks.AutoDiscoverEC2IssuePermAccountDenied {
+				continue
+			}
+			taskName = task.GetMetadata().GetName()
+			return taskName != ""
+		}
+		return false
+	}, 10*time.Second, 50*time.Millisecond)
+
+	advancesRemaining := 3
+	require.Eventually(t, func() bool {
+		if advancesRemaining > 0 {
+			fakeClock.Advance(discoveryServer.PollInterval)
+			advancesRemaining--
+		}
+		auditEvents, err := listUserTaskAuditEvents()
+		if err != nil {
+			return false
+		}
+
+		sawCreate := false
+		for _, evt := range auditEvents {
+			switch event := evt.(type) {
+			case *events.UserTaskCreate:
+				if event.ResourceMetadata.Name == taskName {
+					sawCreate = true
+				}
+			case *events.UserTaskUpdate:
+				if sawCreate && event.ResourceMetadata.Name == taskName {
+					return true
+				}
+			}
+		}
+
+		return false
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+func TestEC2PermissionOrgDenied_TaskScopeAndAuditCadence(t *testing.T) {
+	t.Parallel()
+	const defaultDiscoveryGroup = "dc001"
+
+	ctx := context.Background()
+	logger := logtest.NewLogger()
+	fakeClock := clockwork.NewFakeClock()
+
+	testAuthServer, err := authtest.NewAuthServer(authtest.AuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: fakeClock,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, testAuthServer.Close()) })
+
+	tlsServer, err := testAuthServer.NewTestTLSServer()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, tlsServer.Close()) })
+
+	identity := authtest.TestServerID(types.RoleDiscovery, "hostID")
+	authClient, err := tlsServer.NewClient(identity)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, authClient.Close()) })
+
+	discoveryConfigName := "dc-ec2-org-denied-cadence"
+	discoveryCfg, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: discoveryConfigName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{
+				{
+					Types:       []string{"ec2"},
+					Regions:     []string{"us-west-2", "us-east-1"},
+					Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+					Integration: "my-integration",
+					Params: &types.InstallerParams{
+						EnrollMode: types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+					},
+					SSM: &types.AWSSSM{DocumentName: "document"},
+					AssumeRole: &types.AssumeRole{
+						RoleName: "MyRole",
+					},
+					Organization: &types.AWSOrganizationMatcher{
+						OrganizationID: "o-abcdefghij",
+						OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+							Include: []string{types.Wildcard},
+						},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.NoError(t, discoveryCfg.CheckAndSetDefaults())
+	_, err = tlsServer.Auth().DiscoveryConfigs.CreateDiscoveryConfig(ctx, discoveryCfg)
+	require.NoError(t, err)
+
+	awsOIDCIntegration, err := types.NewIntegrationAWSOIDC(types.Metadata{Name: "my-integration"}, &types.AWSOIDCIntegrationSpecV1{
+		RoleARN: "arn:aws:iam::123456789012:role/teleport",
+	})
+	require.NoError(t, err)
+	testAuthServer.AuthServer.IntegrationsTokenGenerator = &mockIntegrationsTokenGenerator{
+		integrations: map[string]types.Integration{
+			awsOIDCIntegration.GetName(): awsOIDCIntegration,
+		},
+	}
+	_, err = tlsServer.Auth().CreateIntegration(ctx, awsOIDCIntegration)
+	require.NoError(t, err)
+
+	emitter := &mockEmitter{}
+	fakeConfigProvider := mocks.AWSConfigProvider{
+		OIDCIntegrationClient: tlsServer.Auth(),
+	}
+
+	discoveryServer, err := New(authz.ContextWithUser(ctx, identity.I), &Config{
+		GetEC2Client: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{output: &ec2.DescribeInstancesOutput{}}, nil
+		},
+		GetSSMClient: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (server.SSMClient, error) {
+			return &mockSSMClient{}, nil
+		},
+		GetAWSOrganizationsClient: func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+			return &mockOrganizationsClient{err: trace.AccessDenied("User is not authorized to perform: organizations:ListRoots")}, nil
+		},
+		AWSConfigProvider: &fakeConfigProvider,
+		AWSFetchersClients: &mockFetchersClients{
+			AWSConfigProvider: fakeConfigProvider,
+		},
+		ClusterFeatures:  func() proto.Features { return proto.Features{} },
+		KubernetesClient: fake.NewClientset(),
+		AccessPoint:      getDiscoveryAccessPointWithEKSEnroller(tlsServer.Auth(), authClient, authClient.IntegrationAWSOIDCClient()),
+		Matchers:         Matchers{},
+		Emitter:          emitter,
+		Log:              logger,
+		DiscoveryGroup:   defaultDiscoveryGroup,
+		clock:            fakeClock,
+		PollInterval:     5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	listUserTasks := func() ([]*usertasksv1.UserTask, error) {
+		var allTasks []*usertasksv1.UserTask
+		nextToken := ""
+		for {
+			tasks, nextTokenResp, err := tlsServer.Auth().UserTasks.ListUserTasks(ctx, 0, nextToken, &usertasksv1.ListUserTasksFilters{})
+			if err != nil {
+				return nil, err
+			}
+			allTasks = append(allTasks, tasks...)
+			if nextTokenResp == "" {
+				return allTasks, nil
+			}
+			nextToken = nextTokenResp
+		}
+	}
+	listUserTaskAuditEvents := func() ([]events.AuditEvent, error) {
+		events, _, err := testAuthServer.AuditLog.SearchEvents(ctx, libevents.SearchEventsRequest{
+			From:       time.Time{},
+			To:         fakeClock.Now().Add(24 * time.Hour),
+			EventTypes: []string{libevents.UserTaskCreateEvent, libevents.UserTaskUpdateEvent},
+			Limit:      1000,
+			Order:      types.EventOrderAscending,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return events, nil
+	}
+
+	go discoveryServer.Start()
+	t.Cleanup(discoveryServer.Stop)
+	discoveryServer.notifyDiscoveryConfigChanged()
+
+	var orgDeniedTaskName string
+	require.Eventually(t, func() bool {
+		fakeClock.Advance(discoveryServer.PollInterval)
+
+		tasks, err := listUserTasks()
+		if err != nil {
+			return false
+		}
+
+		orgDeniedTasks := 0
+		for _, task := range tasks {
+			if task.GetSpec().GetIssueType() == usertasks.AutoDiscoverEC2IssuePermOrgDenied {
+				orgDeniedTasks++
+				orgDeniedTaskName = task.GetMetadata().GetName()
+				if task.GetSpec().GetDiscoverEc2().GetRegion() != "" {
+					return false
+				}
+			}
+		}
+		return orgDeniedTasks == 1 && orgDeniedTaskName != ""
+	}, 10*time.Second, 50*time.Millisecond)
+	require.NotEmpty(t, orgDeniedTaskName)
+
+	advancesRemaining := 3
+	require.Eventually(t, func() bool {
+		if advancesRemaining > 0 {
+			fakeClock.Advance(discoveryServer.PollInterval)
+			advancesRemaining--
+		}
+		auditEvents, err := listUserTaskAuditEvents()
+		if err != nil {
+			return false
+		}
+
+		sawCreate := false
+		for _, evt := range auditEvents {
+			switch event := evt.(type) {
+			case *events.UserTaskCreate:
+				if event.ResourceMetadata.Name == orgDeniedTaskName {
+					sawCreate = true
+				}
+			case *events.UserTaskUpdate:
+				if sawCreate && event.ResourceMetadata.Name == orgDeniedTaskName {
+					return true
+				}
+			}
+		}
+
+		return false
+	}, 10*time.Second, 50*time.Millisecond)
 }
 
 func newMockKubeService(name, namespace, externalName string, labels, annotations map[string]string, ports []corev1.ServicePort) *corev1.Service {
@@ -3525,6 +4077,7 @@ func TestAzureVMDiscovery(t *testing.T) {
 				require.Empty(t, cmp.Diff(expectedTask, tasks[0],
 					protocmp.Transform(),
 					protocmp.IgnoreFields(&headerv1.Metadata{}, "expires", "revision"),
+					protocmp.IgnoreFields(&usertasksv1.UserTask{}, "status"),
 					protocmp.IgnoreFields(&usertasksv1.DiscoverAzureVMInstance{}, "sync_time"),
 				))
 			},
@@ -4192,10 +4745,25 @@ type eksClustersEnroller interface {
 
 type combinedDiscoveryClient struct {
 	*auth.Server
+	client authclient.ClientI
 	eksClustersEnroller
 	discoveryConfigStatusUpdater interface {
 		UpdateDiscoveryConfigStatus(context.Context, string, discoveryconfig.Status) (*discoveryconfig.DiscoveryConfig, error)
 	}
+}
+
+func (d *combinedDiscoveryClient) UpsertUserTask(ctx context.Context, req *usertasksv1.UserTask) (*usertasksv1.UserTask, error) {
+	if d.client != nil {
+		return d.client.UserTasksServiceClient().UpsertUserTask(ctx, req)
+	}
+	return d.Server.UserTasks.UpsertUserTask(ctx, req)
+}
+
+func (d *combinedDiscoveryClient) GetUserTask(ctx context.Context, name string) (*usertasksv1.UserTask, error) {
+	if d.client != nil {
+		return d.client.UserTasksServiceClient().GetUserTask(ctx, name)
+	}
+	return d.Server.UserTasks.GetUserTask(ctx, name)
 }
 
 func (d *combinedDiscoveryClient) EnrollEKSClusters(ctx context.Context, req *integrationpb.EnrollEKSClustersRequest, _ ...grpc.CallOption) (*integrationpb.EnrollEKSClustersResponse, error) {
@@ -4213,11 +4781,11 @@ func (d *combinedDiscoveryClient) UpdateDiscoveryConfigStatus(ctx context.Contex
 }
 
 func getDiscoveryAccessPointWithEKSEnroller(authServer *auth.Server, authClient authclient.ClientI, eksEnroller eksClustersEnroller) authclient.DiscoveryAccessPoint {
-	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: eksEnroller, discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
+	return &combinedDiscoveryClient{Server: authServer, client: authClient, eksClustersEnroller: eksEnroller, discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
 }
 
 func getDiscoveryAccessPoint(authServer *auth.Server, authClient authclient.ClientI) authclient.DiscoveryAccessPoint {
-	return &combinedDiscoveryClient{Server: authServer, eksClustersEnroller: authClient.IntegrationAWSOIDCClient(), discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
+	return &combinedDiscoveryClient{Server: authServer, client: authClient, eksClustersEnroller: authClient.IntegrationAWSOIDCClient(), discoveryConfigStatusUpdater: authClient.DiscoveryConfigClient()}
 }
 
 type fakeAccessPoint struct {
@@ -4499,4 +5067,3 @@ func TestGenInstancesLogStr(t *testing.T) {
 		})
 	}
 }
-

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redis/armredis/v3"
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/account"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/eks"
@@ -50,6 +51,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticache"
 	"github.com/aws/aws-sdk-go-v2/service/memorydb"
 	"github.com/aws/aws-sdk-go-v2/service/opensearch"
+	"github.com/aws/aws-sdk-go-v2/service/organizations"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdstypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
@@ -110,6 +112,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/server"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	libutils "github.com/gravitational/teleport/lib/utils"
+	liborganizations "github.com/gravitational/teleport/lib/utils/aws/organizations"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 )
 
@@ -178,10 +181,41 @@ func (m *mockUsageReporter) DiscoveryFetchEventCount() int {
 
 type mockEC2Client struct {
 	output *ec2.DescribeInstancesOutput
+	err    error
 }
 
 func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
 	return m.output, nil
+}
+
+type mockRegionsLister struct {
+	err error
+}
+
+func (m *mockRegionsLister) ListRegions(ctx context.Context, input *account.ListRegionsInput, opts ...func(*account.Options)) (*account.ListRegionsOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &account.ListRegionsOutput{}, nil
+}
+
+type mockOrganizationsClient struct {
+	err error
+}
+
+func (m *mockOrganizationsClient) ListRoots(ctx context.Context, input *organizations.ListRootsInput, opts ...func(*organizations.Options)) (*organizations.ListRootsOutput, error) {
+	return nil, m.err
+}
+
+func (m *mockOrganizationsClient) ListChildren(ctx context.Context, input *organizations.ListChildrenInput, opts ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {
+	return nil, m.err
+}
+
+func (m *mockOrganizationsClient) ListAccountsForParent(ctx context.Context, input *organizations.ListAccountsForParentInput, opts ...func(*organizations.Options)) (*organizations.ListAccountsForParentOutput, error) {
+	return nil, m.err
 }
 
 func genEC2InstanceIDs(n int) []string {
@@ -340,12 +374,84 @@ func TestDiscoveryServer(t *testing.T) {
 	)
 	require.NoError(t, err)
 
+	dcForEC2IAMErrorTestName := uuid.NewString()
+	dcForEC2IAMErrorTest, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: dcForEC2IAMErrorTestName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"us-west-2"},
+				Tags:    map[string]utils.Strings{"*": {"*"}},
+				SSM:     &types.AWSSSM{DocumentName: "document"},
+				Params: &types.InstallerParams{
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				Integration: "my-integration",
+			}},
+		},
+	)
+	require.NoError(t, err)
+
+	dcForEC2IAMListRegionsErrorName := uuid.NewString()
+	dcForEC2IAMListRegionsError, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: dcForEC2IAMListRegionsErrorName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"*"},
+				Tags:    map[string]utils.Strings{"*": {"*"}},
+				SSM:     &types.AWSSSM{DocumentName: "document"},
+				Params: &types.InstallerParams{
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				Integration: "my-integration",
+			}},
+		},
+	)
+	require.NoError(t, err)
+
+	dcForEC2IAMOrganizationsErrorName := uuid.NewString()
+	dcForEC2IAMOrganizationsError, err := discoveryconfig.NewDiscoveryConfig(
+		header.Metadata{Name: dcForEC2IAMOrganizationsErrorName},
+		discoveryconfig.Spec{
+			DiscoveryGroup: defaultDiscoveryGroup,
+			AWS: []types.AWSMatcher{{
+				Types:   []string{"ec2"},
+				Regions: []string{"us-east-1"},
+				Tags:    map[string]utils.Strings{"*": {"*"}},
+				SSM:     &types.AWSSSM{DocumentName: "document"},
+				Params: &types.InstallerParams{
+					InstallTeleport: true,
+					EnrollMode:      types.InstallParamEnrollMode_INSTALL_PARAM_ENROLL_MODE_SCRIPT,
+				},
+				Integration: "my-integration",
+				AssumeRole: &types.AssumeRole{
+					RoleName: "TeleportDiscovery",
+				},
+				Organization: &types.AWSOrganizationMatcher{
+					OrganizationID: "o-1234567890",
+					OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+						Include: []string{"*"},
+					},
+				},
+			}},
+		},
+	)
+	require.NoError(t, err)
+
 	tcs := []struct {
 		name          string
 		requiresProxy bool
 		// presentInstances is a list of servers already present in teleport.
 		presentInstances          []types.Server
 		foundEC2Instances         []ec2types.Instance
+		ec2ClientErr              error
+		regionsListerErr          error
+		organizationsClientErr    error
 		ssm                       *mockSSMClient
 		emitter                   *mockEmitter
 		discoveryConfig           *discoveryconfig.DiscoveryConfig
@@ -786,6 +892,64 @@ func TestDiscoveryServer(t *testing.T) {
 				require.Equal(t, defaultDiscoveryGroup, taskInstance.DiscoveryGroup)
 			},
 		},
+		{
+			name:              "IAM permission error creates UserTask for ec2:DescribeInstances",
+			presentInstances:  []types.Server{},
+			foundEC2Instances: []ec2types.Instance{},
+			ec2ClientErr:      trace.AccessDenied("User is not authorized to perform: ec2:DescribeInstances"),
+			emitter:           &mockEmitter{},
+			discoveryConfig:   dcForEC2IAMErrorTest,
+			staticMatchers:    Matchers{},
+			userTasksDiscoverCheck: func(t *testing.T, userTasksClt services.UserTasks) {
+				existingTasks := fetchAllUserTasks(t, userTasksClt, 1, 0)
+				existingTask := existingTasks[0]
+
+				require.Equal(t, "OPEN", existingTask.GetSpec().State)
+				require.Equal(t, "my-integration", existingTask.GetSpec().Integration)
+				require.Equal(t, "ec2-perm-account-denied", existingTask.GetSpec().IssueType)
+				require.Equal(t, "us-west-2", existingTask.GetSpec().GetDiscoverEc2().GetRegion())
+			},
+		},
+		{
+			name:              "IAM permission error creates UserTask for account:ListRegions",
+			presentInstances:  []types.Server{},
+			foundEC2Instances: []ec2types.Instance{},
+			regionsListerErr:  trace.AccessDenied("User is not authorized to perform: account:ListRegions"),
+			emitter:           &mockEmitter{},
+			discoveryConfig:   dcForEC2IAMListRegionsError,
+			staticMatchers:    Matchers{},
+			userTasksDiscoverCheck: func(t *testing.T, userTasksClt services.UserTasks) {
+				existingTasks := fetchAllUserTasks(t, userTasksClt, 1, 0)
+				existingTask := existingTasks[0]
+
+				require.Equal(t, "OPEN", existingTask.GetSpec().State)
+				require.Equal(t, "my-integration", existingTask.GetSpec().Integration)
+				require.Equal(t, "ec2-perm-account-denied", existingTask.GetSpec().IssueType)
+				// ListRegions errors occur at the account level, before we know which regions
+				// are available, so the region should be empty.
+				require.Empty(t, existingTask.GetSpec().GetDiscoverEc2().GetRegion())
+			},
+		},
+		{
+			name:                   "IAM permission error creates UserTask for organizations APIs",
+			presentInstances:       []types.Server{},
+			foundEC2Instances:      []ec2types.Instance{},
+			organizationsClientErr: trace.AccessDenied("User is not authorized to perform: organizations:ListRoots"),
+			emitter:                &mockEmitter{},
+			discoveryConfig:        dcForEC2IAMOrganizationsError,
+			staticMatchers:         Matchers{},
+			userTasksDiscoverCheck: func(t *testing.T, userTasksClt services.UserTasks) {
+				existingTasks := fetchAllUserTasks(t, userTasksClt, 1, 0)
+				existingTask := existingTasks[0]
+
+				require.Equal(t, "OPEN", existingTask.GetSpec().State)
+				require.Equal(t, "my-integration", existingTask.GetSpec().Integration)
+				require.Equal(t, "ec2-perm-org-denied", existingTask.GetSpec().IssueType)
+				// Organization-level errors occur before we know which regions to discover,
+				// so the region should be empty.
+				require.Empty(t, existingTask.GetSpec().GetDiscoverEc2().GetRegion())
+			},
+		},
 	}
 
 	for _, tc := range tcs {
@@ -802,6 +966,7 @@ func TestDiscoveryServer(t *testing.T) {
 						},
 					},
 				},
+				err: tc.ec2ClientErr,
 			}
 
 			// Create and start test auth server.
@@ -877,6 +1042,12 @@ func TestDiscoveryServer(t *testing.T) {
 				},
 				GetSSMClient: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (server.SSMClient, error) {
 					return tc.ssm, nil
+				},
+				GetAWSRegionsLister: func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+					return &mockRegionsLister{err: tc.regionsListerErr}, nil
+				},
+				GetAWSOrganizationsClient: func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+					return &mockOrganizationsClient{err: tc.organizationsClientErr}, nil
 				},
 				AWSConfigProvider: &fakeConfigProvider,
 				AWSFetchersClients: &mockFetchersClients{
@@ -4328,3 +4499,4 @@ func TestGenInstancesLogStr(t *testing.T) {
 		})
 	}
 }
+

--- a/lib/srv/discovery/status.go
+++ b/lib/srv/discovery/status.go
@@ -410,7 +410,14 @@ type awsEC2Tasks struct {
 	issuesSyncQueue map[awsEC2TaskKey]struct{}
 }
 
-// awsEC2TaskKey identifies a UserTask group.
+// awsEC2TaskKey identifies a unique UserTask group for EC2
+// discovery errors.
+//
+// Note: DiscoveryConfigName is intentionally excluded from the
+// key. EC2 permission and execution issues are account and
+// region scoped, so failures from multiple discovery configs
+// sharing the same credentials or installation parameters
+// deduplicate into a single UserTask.
 type awsEC2TaskKey struct {
 	integration     string
 	issueType       string
@@ -430,14 +437,21 @@ func (d *awsEC2Tasks) reset() {
 	d.issuesSyncQueue = make(map[awsEC2TaskKey]struct{})
 }
 
-// addFailedEnrollment adds an enrollment failure of a given instance.
+// addFailedEnrollment records an EC2 enrollment failure.
+//
+// For permission issue types, instance may be nil because those failures are
+// account/region scoped and can occur before any instance metadata is known.
+// For non-permission issue types, nil instances are ignored.
 func (d *awsEC2Tasks) addFailedEnrollment(g awsEC2TaskKey, instance *usertasksv1.DiscoverEC2Instance) {
-	// Only failures associated with an Integration are reported.
-	// There's no major blocking for showing non-integration User Tasks, but this keeps scope smaller.
+	// Only failures with non-empty Integration are reported. UserTask validation
+	// requires an Integration, so ambient-credential failures are intentionally skipped.
 	if g.integration == "" {
 		return
 	}
 	if g.issueType == "" {
+		return
+	}
+	if instance == nil && !usertasks.IsPermissionIssueType(g.issueType) {
 		return
 	}
 
@@ -463,6 +477,12 @@ func (d *awsEC2Tasks) addFailedEnrollment(g awsEC2TaskKey, instance *usertasksv1
 		d.issuesSyncQueue = make(map[awsEC2TaskKey]struct{})
 	}
 	d.issuesSyncQueue[g] = struct{}{}
+}
+
+// addFailedPermissionEnrollment records an EC2 permission failure
+// with no associated instance data.
+func (d *awsEC2Tasks) addFailedPermissionEnrollment(g awsEC2TaskKey) {
+	d.addFailedEnrollment(g, nil)
 }
 
 // awsEKSTasks contains the Discover EKS User Tasks that must be reported to the user.
@@ -675,7 +695,11 @@ func (s *taskUpdater) mergeUpsertDiscoverEC2Task(taskGroup awsEC2TaskKey, failed
 	case err != nil:
 		return trace.Wrap(err)
 	default:
-		mergeExistingInstances(s, currentUserTask.Spec.DiscoverEc2.Instances, failedInstances.Instances)
+		// Permission errors produce no instance data, so their instance list is empty.
+		// Skip merging to avoid carrying stale instance data forward from a previous task.
+		if len(failedInstances.Instances) > 0 {
+			mergeExistingInstances(s, currentUserTask.Spec.DiscoverEc2.Instances, failedInstances.Instances)
+		}
 	}
 
 	// If the DiscoveryService is stopped, or the issue does not happen again

--- a/lib/srv/discovery/status_test.go
+++ b/lib/srv/discovery/status_test.go
@@ -241,6 +241,52 @@ func TestMergeUpsertUserTask(t *testing.T) {
 	}
 }
 
+func TestMergeUpsertDiscoverEC2Task_DoesNotMergePermissionInstances(t *testing.T) {
+	t.Parallel()
+
+	syncTime := timestamppb.New(time.Now())
+	taskGroup := awsEC2TaskKey{
+		integration: "my-int",
+		issueType:   usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+		accountID:   "unknown-account-test",
+		region:      "",
+	}
+
+	existingTask, err := usertasks.NewDiscoverEC2UserTask(
+		&usertasksv1.UserTaskSpec{
+			Integration: taskGroup.integration,
+			TaskType:    usertasks.TaskTypeDiscoverEC2,
+			IssueType:   taskGroup.issueType,
+			State:       usertasks.TaskStateOpen,
+			DiscoverEc2: &usertasksv1.DiscoverEC2{
+				AccountId: taskGroup.accountID,
+				Region:    taskGroup.region,
+				Instances: map[string]*usertasksv1.DiscoverEC2Instance{
+					"i-old": {
+						InstanceId:      "i-old",
+						DiscoveryConfig: "dc-1",
+						DiscoveryGroup:  "group-1",
+						SyncTime:        syncTime,
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	updater, ap := newTaskUpdater(t, existingTask)
+
+	require.NoError(t, updater.mergeUpsertDiscoverEC2Task(taskGroup, &usertasksv1.DiscoverEC2{
+		AccountId: taskGroup.accountID,
+		Region:    taskGroup.region,
+		Instances: map[string]*usertasksv1.DiscoverEC2Instance{},
+	}))
+
+	got, err := ap.GetUserTask(updater.ctx, existingTask.GetMetadata().GetName())
+	require.NoError(t, err)
+	require.Empty(t, got.GetSpec().GetDiscoverEc2().GetInstances())
+}
+
 type mocktaskUpdaterAccessPoint struct {
 	types.Semaphores
 
@@ -448,8 +494,8 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 		issueType:       usertasks.AutoDiscoverEC2IssuePermAccountDenied,
 		accountID:       "",
 		region:          "",
-		ssmDocument:     "doc",
-		installerScript: "script",
+		ssmDocument:     "",
+		installerScript: "",
 	}
 
 	syncTime := timestamppb.New(time.Now())
@@ -481,6 +527,7 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 		name     string
 		mutate   func(tasks *awsEC2Tasks)
 		expected map[awsEC2TaskKey]*usertasksv1.DiscoverEC2
+		queue    map[awsEC2TaskKey]struct{}
 	}{
 		{
 			name: "empty integration is ignored",
@@ -506,6 +553,7 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
 				testEC2Key: ec2Data(testEC2Key, "i-1"),
 			},
+			queue: map[awsEC2TaskKey]struct{}{testEC2Key: {}},
 		},
 		{
 			name: "adds multiple instances to same key",
@@ -516,6 +564,7 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
 				testEC2Key: ec2Data(testEC2Key, "i-1", "i-2"),
 			},
+			queue: map[awsEC2TaskKey]struct{}{testEC2Key: {}},
 		},
 		{
 			name: "different keys create separate entries",
@@ -527,23 +576,22 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 				testEC2Key:    ec2Data(testEC2Key, "i-1"),
 				testEC2KeyAlt: ec2Data(testEC2KeyAlt, "i-2"),
 			},
+			queue: map[awsEC2TaskKey]struct{}{testEC2Key: {}, testEC2KeyAlt: {}},
 		},
 		{
-			name: "nil instance creates task entry without instances (permission issues)",
+			name: "permission issue creates task entry without instances",
 			mutate: func(tasks *awsEC2Tasks) {
-				tasks.addFailedEnrollment(testEC2KeyPermIssue, nil)
+				tasks.addFailedPermissionEnrollment(testEC2KeyPermIssue)
 			},
 			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
 				testEC2KeyPermIssue: ec2Data(testEC2KeyPermIssue),
 			},
+			queue: map[awsEC2TaskKey]struct{}{testEC2KeyPermIssue: {}},
 		},
 		{
-			name: "nil instance with non-permission issue still creates entry",
+			name: "nil instance with non-permission issue is ignored",
 			mutate: func(tasks *awsEC2Tasks) {
 				tasks.addFailedEnrollment(testEC2Key, nil)
-			},
-			expected: map[awsEC2TaskKey]*usertasksv1.DiscoverEC2{
-				testEC2Key: ec2Data(testEC2Key),
 			},
 		},
 	}
@@ -553,6 +601,7 @@ func TestAWSEC2Tasks_AddFailedEnrollment(t *testing.T) {
 			tasks := &awsEC2Tasks{}
 			tt.mutate(tasks)
 			require.Empty(t, cmp.Diff(tt.expected, tasks.instancesIssues, protocmp.Transform()))
+			require.Equal(t, tt.queue, tasks.issuesSyncQueue)
 		})
 	}
 }

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -20,6 +20,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
@@ -34,6 +36,7 @@ import (
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	libcloudaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	"github.com/gravitational/teleport/lib/labels"
@@ -81,6 +84,17 @@ type EC2Instances struct {
 
 	// EnrollMode is the mode used to enroll the instance into Teleport.
 	EnrollMode types.InstallParamEnrollMode
+}
+
+// EC2DiscoveryResult contains the results of EC2 instance discovery,
+// including both successfully discovered instances and any permission errors.
+type EC2DiscoveryResult struct {
+	// Instances contains the discovered EC2 instances grouped by region/account.
+	Instances []*EC2Instances
+	// PermissionErrors contains IAM permission errors encountered during discovery.
+	// These are returned as data rather than causing the discovery to fail,
+	// allowing partial results when some regions/accounts are inaccessible.
+	PermissionErrors []*EC2IAMPermissionError
 }
 
 // EC2Instance represents an AWS EC2 instance that has been
@@ -200,8 +214,8 @@ type MatcherToEC2FetcherParams struct {
 }
 
 // MatchersToEC2InstanceFetchers converts a list of AWS EC2 Matchers into a list of AWS EC2 Fetchers.
-func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToEC2FetcherParams) ([]Fetcher[*EC2Instances], error) {
-	var ret []Fetcher[*EC2Instances]
+func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToEC2FetcherParams) ([]Fetcher[*EC2DiscoveryResult], error) {
+	var ret []Fetcher[*EC2DiscoveryResult]
 	for _, matcher := range matcherParams.Matchers {
 		fetcher := newEC2InstanceFetcher(ec2FetcherConfig{
 			Matcher:                matcher,
@@ -215,6 +229,72 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToE
 		ret = append(ret, fetcher)
 	}
 	return ret, nil
+}
+
+// EC2IAMPermissionError represents an IAM permission error during EC2 discovery.
+// This is used to report missing permissions so that UserTasks can be created.
+// It implements the error interface so it can be returned and checked with errors.As.
+type EC2IAMPermissionError struct {
+	Integration         string
+	AccountID           string
+	Region              string
+	IssueType           string
+	DiscoveryConfigName string
+	Err                 error
+}
+
+// Error implements the error interface with full context.
+func (e *EC2IAMPermissionError) Error() string {
+	if e.Region != "" {
+		return fmt.Sprintf("IAM permission error (%s) for account %s in region %s: %v",
+			e.IssueType, e.AccountID, e.Region, e.Err)
+	}
+	return fmt.Sprintf("IAM permission error (%s) for account %s: %v",
+		e.IssueType, e.AccountID, e.Err)
+}
+
+// Unwrap returns the underlying error for use with errors.Is/As.
+func (e *EC2IAMPermissionError) Unwrap() error {
+	return e.Err
+}
+
+// collectError checks if the error is an EC2IAMPermissionError and if so,
+// appends it to the PermissionErrors slice and returns true.
+// Returns false if the error is not a permission error.
+func (r *EC2DiscoveryResult) collectError(err error) bool {
+	var iamErr *EC2IAMPermissionError
+	if errors.As(err, &iamErr) {
+		r.PermissionErrors = append(r.PermissionErrors, iamErr)
+		return true
+	}
+	return false
+}
+
+// HasInstances returns true if any instances were discovered.
+func (r *EC2DiscoveryResult) HasInstances() bool {
+	return len(r.Instances) > 0
+}
+
+// HasErrors returns true if any permission errors were encountered.
+func (r *EC2DiscoveryResult) HasErrors() bool {
+	return len(r.PermissionErrors) > 0
+}
+
+// IsEmpty returns true if no instances were discovered and no errors occurred.
+func (r *EC2DiscoveryResult) IsEmpty() bool {
+	return !r.HasInstances() && !r.HasErrors()
+}
+
+// accountIDFromRoleARN extracts the AWS account ID from a role ARN.
+// Returns an empty string if the ARN is empty or invalid.
+func accountIDFromRoleARN(roleARN string) string {
+	if roleARN == "" {
+		return ""
+	}
+	if parsed, err := arn.Parse(roleARN); err == nil {
+		return parsed.AccountID
+	}
+	return ""
 }
 
 type ec2FetcherConfig struct {
@@ -368,8 +448,10 @@ func ssmRunCommandParameters(ctx context.Context, cfg ec2FetcherConfig) (map[str
 	return ssmRunCommandParametersForCustomDocuments(cfg), nil
 }
 
-// GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes
-func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []types.Server, rotation bool) ([]*EC2Instances, error) {
+// GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes.
+// This method filters existing nodes based on cached instances from the last GetInstances call.
+// It does not make AWS API calls, so no permission errors can occur.
+func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []types.Server, rotation bool) ([]*EC2DiscoveryResult, error) {
 	ssmRunParams, err := ssmRunCommandParameters(ctx, f.ec2FetcherConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -423,7 +505,7 @@ func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []t
 		return nil, trace.NotFound("no ec2 instances found")
 	}
 
-	return chunkInstances(instancesByRegion), nil
+	return []*EC2DiscoveryResult{{Instances: chunkInstances(instancesByRegion)}}, nil
 }
 
 // chunkInstances splits instances into chunks of 50.
@@ -472,10 +554,15 @@ func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, awsOpts []awsco
 		if err != nil {
 			convertedErr := libcloudaws.ConvertRequestFailureError(err)
 			if trace.IsAccessDenied(convertedErr) {
-				return nil, trace.BadParameter("Missing account:ListRegions permission in IAM Role, which is required to iterate over all regions. " +
-					"Add this permission to the IAM Role, or enumerate all the regions in the AWS matcher.")
+				return nil, &EC2IAMPermissionError{
+					Integration:         f.Matcher.Integration,
+					IssueType:           usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+					DiscoveryConfigName: f.DiscoveryConfigName,
+					AccountID:           accountIDFromRoleARN(f.Matcher.AssumeRole.RoleARN),
+					Err:                 convertedErr,
+				}
 			}
-			return nil, convertedErr
+			return nil, trace.Wrap(convertedErr)
 		}
 
 		for _, region := range page.Regions {
@@ -513,8 +600,13 @@ func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Contex
 	if err != nil {
 		convertedErr := libcloudaws.ConvertRequestFailureError(err)
 		if trace.IsAccessDenied(convertedErr) {
-			// TODO(marco): create UserTask to alert users about missing permissions.
-			return nil, trace.BadParameter("discovering instances under an organization requires the following permissions: [%s], add those to the IAM Role used by the Discovery Service", strings.Join(organizations.RequiredAPIs(), ", "))
+			return nil, &EC2IAMPermissionError{
+				Integration:         f.Matcher.Integration,
+				IssueType:           usertasks.AutoDiscoverEC2IssuePermOrgDenied,
+				DiscoveryConfigName: f.DiscoveryConfigName,
+				AccountID:           accountIDFromRoleARN(f.Matcher.AssumeRole.RoleARN),
+				Err:                 convertedErr,
+			}
 		}
 
 		return nil, trace.Wrap(convertedErr)
@@ -575,19 +667,31 @@ func (f *ec2InstanceFetcher) allAssumeRoles(ctx context.Context) ([]assumeRoleWi
 }
 
 // GetInstances fetches all EC2 instances matching configured filters.
-func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([]*EC2Instances, error) {
+// Returns an EC2DiscoveryResult containing discovered instances and any permission errors.
+// Org-level permission errors (from allAssumeRoles) cause immediate failure since no discovery
+// is possible without org access. Account/region-level errors are collected and returned
+// alongside any successfully discovered instances.
+func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([]*EC2DiscoveryResult, error) {
 	ssmRunParams, err := ssmRunCommandParameters(ctx, f.ec2FetcherConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	f.cachedInstances.clear()
-	var allInstances []*EC2Instances
+	result := &EC2DiscoveryResult{}
 
 	accountRolesToAssume, err := f.allAssumeRoles(ctx)
 	if err != nil {
+		// Org-level permission errors are blocking - we can't discover anything
+		// without access to list accounts in the organization.
+		if result.collectError(err) {
+			return []*EC2DiscoveryResult{result}, nil
+		}
 		return nil, trace.Wrap(err)
 	}
+
+	// Preallocate slices based on expected number of accounts.
+	result.Instances = make([]*EC2Instances, 0, len(accountRolesToAssume))
 
 	for _, assumeRole := range accountRolesToAssume {
 		awsOpts := []awsconfig.OptionsFn{
@@ -597,6 +701,10 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 
 		regions, err := f.matcherRegions(ctx, awsOpts)
 		if err != nil {
+			// Account-level permission errors are collected - we continue with other accounts.
+			if result.collectError(err) {
+				continue
+			}
 			f.Logger.WarnContext(ctx, "Failed to get regions for EC2 discovery",
 				"assume_role_arn", assumeRole.RoleARN,
 				"error", err,
@@ -613,6 +721,10 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 				ssmRunParams: ssmRunParams,
 			})
 			if err != nil {
+				// Region-level permission errors are collected - we continue with other regions.
+				if result.collectError(err) {
+					continue
+				}
 				f.Logger.WarnContext(ctx, "Failed to get instances for EC2 discovery",
 					"region", region,
 					"assume_role_arn", assumeRole.RoleARN,
@@ -621,15 +733,17 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 				continue
 			}
 
-			allInstances = append(allInstances, regionInstances...)
+			result.Instances = append(result.Instances, regionInstances...)
 		}
 	}
 
-	if len(allInstances) == 0 {
+	// Return NotFound only if we have no instances AND no permission errors.
+	// Permission errors are valuable information even without instances.
+	if len(result.Instances) == 0 && len(result.PermissionErrors) == 0 {
 		return nil, trace.NotFound("no ec2 instances found")
 	}
 
-	return allInstances, nil
+	return []*EC2DiscoveryResult{result}, nil
 }
 
 type getInstancesInRegionParams struct {
@@ -656,7 +770,18 @@ func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params ge
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, libcloudaws.ConvertRequestFailureError(err)
+			convertedErr := libcloudaws.ConvertRequestFailureError(err)
+			if trace.IsAccessDenied(convertedErr) {
+				return nil, &EC2IAMPermissionError{
+					Integration:         f.Matcher.Integration,
+					Region:              params.region,
+					IssueType:           usertasks.AutoDiscoverEC2IssuePermAccountDenied,
+					DiscoveryConfigName: f.DiscoveryConfigName,
+					AccountID:           accountIDFromRoleARN(params.assumeRole.RoleARN),
+					Err:                 convertedErr,
+				}
+			}
+			return nil, trace.Wrap(convertedErr)
 		}
 
 		for _, res := range page.Reservations {

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -20,6 +20,9 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -231,9 +234,7 @@ func MatchersToEC2InstanceFetchers(ctx context.Context, matcherParams MatcherToE
 	return ret, nil
 }
 
-// EC2IAMPermissionError represents an IAM permission error during EC2 discovery.
-// This is used to report missing permissions so that UserTasks can be created.
-// It implements the error interface so it can be returned and checked with errors.As.
+// EC2IAMPermissionError is a structured IAM permission error from EC2 discovery.
 type EC2IAMPermissionError struct {
 	Integration         string
 	AccountID           string
@@ -243,58 +244,127 @@ type EC2IAMPermissionError struct {
 	Err                 error
 }
 
-// Error implements the error interface with full context.
+// Error formats the permission error as a human-readable string, including the
+// integration and region (if set), issue type, account ID, and underlying error.
 func (e *EC2IAMPermissionError) Error() string {
-	if e.Region != "" {
-		return fmt.Sprintf("IAM permission error (%s) for account %s in region %s: %v",
-			e.IssueType, e.AccountID, e.Region, e.Err)
+	integrationPrefix := ""
+	if e.Integration != "" {
+		integrationPrefix = fmt.Sprintf("integration %s: ", e.Integration)
 	}
-	return fmt.Sprintf("IAM permission error (%s) for account %s: %v",
-		e.IssueType, e.AccountID, e.Err)
+
+	if e.Region != "" {
+		return fmt.Sprintf("%sIAM permission error (%s) for account %s in region %s: %v",
+			integrationPrefix, e.IssueType, e.AccountID, e.Region, e.Err)
+	}
+
+	return fmt.Sprintf("%sIAM permission error (%s) for account %s: %v",
+		integrationPrefix, e.IssueType, e.AccountID, e.Err)
 }
 
-// Unwrap returns the underlying error for use with errors.Is/As.
+// Unwrap returns the underlying error that triggered the permission failure.
+// This is typically an AWS SDK request error.
 func (e *EC2IAMPermissionError) Unwrap() error {
 	return e.Err
 }
 
-// collectError checks if the error is an EC2IAMPermissionError and if so,
-// appends it to the PermissionErrors slice and returns true.
-// Returns false if the error is not a permission error.
+// collectError collects err if it wraps a permission error. Returns
+// true if collected, false otherwise.
 func (r *EC2DiscoveryResult) collectError(err error) bool {
 	var iamErr *EC2IAMPermissionError
 	if errors.As(err, &iamErr) {
 		r.PermissionErrors = append(r.PermissionErrors, iamErr)
 		return true
 	}
+
 	return false
 }
 
-// HasInstances returns true if any instances were discovered.
+// HasInstances reports whether any EC2Instances groups were discovered.
+// Note: a group may itself have an empty list of Instances.
 func (r *EC2DiscoveryResult) HasInstances() bool {
 	return len(r.Instances) > 0
 }
 
-// HasErrors returns true if any permission errors were encountered.
+// HasErrors reports whether any IAM permission errors were collected during discovery.
 func (r *EC2DiscoveryResult) HasErrors() bool {
 	return len(r.PermissionErrors) > 0
 }
 
-// IsEmpty returns true if no instances were discovered and no errors occurred.
+// IsEmpty reports whether no instances were discovered and no IAM
+// permission errors were collected.
 func (r *EC2DiscoveryResult) IsEmpty() bool {
 	return !r.HasInstances() && !r.HasErrors()
 }
 
-// accountIDFromRoleARN extracts the AWS account ID from a role ARN.
-// Returns an empty string if the ARN is empty or invalid.
-func accountIDFromRoleARN(roleARN string) string {
+// accountIDFromRoleARN extracts the AWS account ID from a role ARN,
+// returning an empty string (without error) when roleARN is empty.
+func accountIDFromRoleARN(roleARN string) (string, error) {
 	if roleARN == "" {
-		return ""
+		return "", nil
 	}
-	if parsed, err := arn.Parse(roleARN); err == nil {
-		return parsed.AccountID
+
+	parsed, err := arn.Parse(roleARN)
+	if err != nil {
+		return "", trace.Wrap(err)
 	}
-	return ""
+
+	if parsed.AccountID == "" {
+		return "", trace.BadParameter("role ARN does not contain account ID")
+	}
+
+	return parsed.AccountID, nil
+}
+
+// accountIDFromRoleARNOrWarn returns the AWS account ID from
+// roleARN when available. If roleARN is non-empty but is invalid
+// (parse failure or missing account ID), a warning is logged and
+// a synthetic account ID is returned. If roleARN is empty (expected
+// when using ambient credentials rather than an explicit
+// assume-role ARN), a synthetic ID is returned without warning.
+//
+// Synthetic account IDs are deterministic for the same (roleARN,
+// integration, region) scope and are only used for issue
+// grouping/deduplication. They must not be interpreted as real
+// AWS account IDs.
+func accountIDFromRoleARNOrWarn(ctx context.Context, logger *slog.Logger, roleARN, integration, region string) string {
+	accountID, err := accountIDFromRoleARN(roleARN)
+	if accountID != "" {
+		return accountID
+	}
+	fallbackAccountID := syntheticAccountID(roleARN, integration, region)
+
+	if err != nil {
+		logger.WarnContext(ctx, "Could not parse account ID from assume role ARN; using synthetic account grouping key for EC2 permission reporting",
+			"role_arn", roleARN,
+			"integration", integration,
+			"region", region,
+			"fallback_account_id", fallbackAccountID,
+			"error", err,
+		)
+	}
+
+	return fallbackAccountID
+}
+
+// syntheticAccountID returns a deterministic fallback account ID derived from
+// roleARN, integration, and region when the real account ID cannot be resolved.
+// This prevents unrelated permission errors from being merged into the same
+// UserTask when account ID is unavailable.
+func syntheticAccountID(roleARN, integration, region string) string {
+	// DiscoveryConfigName is intentionally excluded so permission tasks deduplicate
+	// across configs that share the same credential scope.
+	//
+	// Encode each field as length + value to preserve boundaries, positions, and empty values.
+	scope := make([]byte, 0, len(roleARN)+len(integration)+len(region)+12)
+	for _, part := range [...]string{roleARN, integration, region} {
+		var size [4]byte
+		binary.BigEndian.PutUint32(size[:], uint32(len(part)))
+		scope = append(scope, size[:]...)
+		scope = append(scope, part...)
+	}
+
+	scopeHash := sha256.Sum256(scope)
+	return "unknown-account-" + hex.EncodeToString(scopeHash[:12])
 }
 
 type ec2FetcherConfig struct {
@@ -321,7 +391,7 @@ type ec2InstanceFetcher struct {
 }
 
 type instancesCache struct {
-	sync.Mutex
+	sync.RWMutex
 	instances map[cachedInstanceKey]struct{}
 }
 
@@ -338,8 +408,8 @@ func (ic *instancesCache) clear() {
 }
 
 func (ic *instancesCache) exists(accountID, instanceID string) bool {
-	ic.Lock()
-	defer ic.Unlock()
+	ic.RLock()
+	defer ic.RUnlock()
 	_, ok := ic.instances[cachedInstanceKey{accountID: accountID, instanceID: instanceID}]
 	return ok
 }
@@ -380,6 +450,10 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 		Values: []string{string(ec2types.InstanceStateNameRunning)},
 	}}
 
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
 	if _, ok := cfg.Matcher.Tags[types.Wildcard]; !ok {
 		for key, val := range cfg.Matcher.Tags {
 			tagFilters = append(tagFilters, ec2types.Filter{
@@ -388,15 +462,11 @@ func newEC2InstanceFetcher(cfg ec2FetcherConfig) *ec2InstanceFetcher {
 			})
 		}
 	} else {
-		slog.DebugContext(context.Background(), "Not setting any tag filters as there is a '*:...' tag present and AWS doesn't allow globbing on keys")
+		cfg.Logger.DebugContext(context.Background(), "Not setting any tag filters as there is a '*:...' tag present and AWS doesn't allow globbing on keys")
 	}
 
 	if cfg.Matcher.AssumeRole == nil {
 		cfg.Matcher.AssumeRole = &types.AssumeRole{}
-	}
-
-	if cfg.Logger == nil {
-		cfg.Logger = slog.Default()
 	}
 
 	return &ec2InstanceFetcher{
@@ -448,9 +518,11 @@ func ssmRunCommandParameters(ctx context.Context, cfg ec2FetcherConfig) (map[str
 	return ssmRunCommandParametersForCustomDocuments(cfg), nil
 }
 
-// GetMatchingInstances returns a list of EC2 instances from a list of matching Teleport nodes.
-// This method filters existing nodes based on cached instances from the last GetInstances call.
-// It does not make AWS API calls, so no permission errors can occur.
+// GetMatchingInstances returns a list of EC2 instances from a
+// list of matching Teleport nodes. This method filters existing
+// nodes based on cached instances from the last GetInstances
+// call. It does not make AWS API calls, so no permission errors
+// can occur.
 func (f *ec2InstanceFetcher) GetMatchingInstances(ctx context.Context, nodes []types.Server, rotation bool) ([]*EC2DiscoveryResult, error) {
 	ssmRunParams, err := ssmRunCommandParameters(ctx, f.ec2FetcherConfig)
 	if err != nil {
@@ -531,12 +603,17 @@ func chunkInstances(instancesByRegion map[string]EC2Instances) []*EC2Instances {
 	return instColl
 }
 
-func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, awsOpts []awsconfig.OptionsFn) ([]string, error) {
+type matcherRegionsParams struct {
+	awsOpts       []awsconfig.OptionsFn
+	assumeRoleARN string
+}
+
+func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, params matcherRegionsParams) ([]string, error) {
 	if !f.Matcher.IsRegionWildcard() {
 		return f.Matcher.Regions, nil
 	}
 
-	regionsListerClient, err := f.RegionsListerGetter(ctx, awsOpts...)
+	regionsListerClient, err := f.RegionsListerGetter(ctx, params.awsOpts...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -554,13 +631,14 @@ func (f *ec2InstanceFetcher) matcherRegions(ctx context.Context, awsOpts []awsco
 		if err != nil {
 			convertedErr := libcloudaws.ConvertRequestFailureError(err)
 			if trace.IsAccessDenied(convertedErr) {
-				return nil, &EC2IAMPermissionError{
+				accountID := accountIDFromRoleARNOrWarn(ctx, f.Logger, params.assumeRoleARN, f.Matcher.Integration, "")
+				return nil, trace.Wrap(&EC2IAMPermissionError{
 					Integration:         f.Matcher.Integration,
 					IssueType:           usertasks.AutoDiscoverEC2IssuePermAccountDenied,
 					DiscoveryConfigName: f.DiscoveryConfigName,
-					AccountID:           accountIDFromRoleARN(f.Matcher.AssumeRole.RoleARN),
+					AccountID:           accountID,
 					Err:                 convertedErr,
-				}
+				})
 			}
 			return nil, trace.Wrap(convertedErr)
 		}
@@ -600,13 +678,14 @@ func (f *ec2InstanceFetcher) fetchAccountIDsUnderOrganization(ctx context.Contex
 	if err != nil {
 		convertedErr := libcloudaws.ConvertRequestFailureError(err)
 		if trace.IsAccessDenied(convertedErr) {
-			return nil, &EC2IAMPermissionError{
+			accountID := accountIDFromRoleARNOrWarn(ctx, f.Logger, f.Matcher.AssumeRole.RoleARN, f.Matcher.Integration, "")
+			return nil, trace.Wrap(&EC2IAMPermissionError{
 				Integration:         f.Matcher.Integration,
 				IssueType:           usertasks.AutoDiscoverEC2IssuePermOrgDenied,
 				DiscoveryConfigName: f.DiscoveryConfigName,
-				AccountID:           accountIDFromRoleARN(f.Matcher.AssumeRole.RoleARN),
+				AccountID:           accountID,
 				Err:                 convertedErr,
-			}
+			})
 		}
 
 		return nil, trace.Wrap(convertedErr)
@@ -668,9 +747,9 @@ func (f *ec2InstanceFetcher) allAssumeRoles(ctx context.Context) ([]assumeRoleWi
 
 // GetInstances fetches all EC2 instances matching configured filters.
 // Returns an EC2DiscoveryResult containing discovered instances and any permission errors.
-// Org-level permission errors (from allAssumeRoles) cause immediate failure since no discovery
-// is possible without org access. Account/region-level errors are collected and returned
-// alongside any successfully discovered instances.
+// Org-level permission errors (from allAssumeRoles) cause immediate failure since no
+// discovery is possible without org access. Account/region-level errors are
+// collected and returned alongside any successful discovered instances.
 func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([]*EC2DiscoveryResult, error) {
 	ssmRunParams, err := ssmRunCommandParameters(ctx, f.ec2FetcherConfig)
 	if err != nil {
@@ -699,7 +778,10 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 			awsconfig.WithAssumeRole(assumeRole.RoleARN, assumeRole.ExternalID),
 		}
 
-		regions, err := f.matcherRegions(ctx, awsOpts)
+		regions, err := f.matcherRegions(ctx, matcherRegionsParams{
+			awsOpts:       awsOpts,
+			assumeRoleARN: assumeRole.RoleARN,
+		})
 		if err != nil {
 			// Account-level permission errors are collected - we continue with other accounts.
 			if result.collectError(err) {
@@ -772,14 +854,15 @@ func (f *ec2InstanceFetcher) getInstancesInRegion(ctx context.Context, params ge
 		if err != nil {
 			convertedErr := libcloudaws.ConvertRequestFailureError(err)
 			if trace.IsAccessDenied(convertedErr) {
-				return nil, &EC2IAMPermissionError{
+				accountID := accountIDFromRoleARNOrWarn(ctx, f.Logger, params.assumeRole.RoleARN, f.Matcher.Integration, params.region)
+				return nil, trace.Wrap(&EC2IAMPermissionError{
 					Integration:         f.Matcher.Integration,
 					Region:              params.region,
 					IssueType:           usertasks.AutoDiscoverEC2IssuePermAccountDenied,
 					DiscoveryConfigName: f.DiscoveryConfigName,
-					AccountID:           accountIDFromRoleARN(params.assumeRole.RoleARN),
+					AccountID:           accountID,
 					Err:                 convertedErr,
-				}
+				})
 			}
 			return nil, trace.Wrap(convertedErr)
 		}

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -37,6 +38,7 @@ import (
 
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/usertasks"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/cloud/awsconfig"
 	liborganizations "github.com/gravitational/teleport/lib/utils/aws/organizations"
@@ -47,10 +49,16 @@ type mockEC2Client struct {
 	err    error
 }
 
+// Compile-time check that the mock satisfies the same API surface used by the
+// EC2 fetcher tests.
+var _ ec2.DescribeInstancesAPIClient = (*mockEC2Client)(nil)
+
 func (m *mockEC2Client) DescribeInstances(ctx context.Context, input *ec2.DescribeInstancesInput, opts ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
 	if m.err != nil {
 		return nil, m.err
 	}
+	// This mock intentionally applies AWS-side filtering semantics so the unit
+	// tests validate fetcher filter behavior, not only happy-path wiring.
 	var output ec2.DescribeInstancesOutput
 	for _, res := range m.output.Reservations {
 		var instances []ec2types.Instance
@@ -805,6 +813,173 @@ func TestEC2WatcherWithMixedResults(t *testing.T) {
 	}
 }
 
+func TestEC2WatcherWithOrganizationListRegionsAccessDeniedUsesPerAccountScope(t *testing.T) {
+	t.Parallel()
+
+	organizationID := "o-abcdefghij"
+	matchers := []types.AWSMatcher{
+		{
+			Params: &types.InstallerParams{
+				InstallTeleport: true,
+			},
+			Types:       []string{"ec2"},
+			Regions:     []string{types.Wildcard},
+			Tags:        map[string]utils.Strings{"teleport": {"yes"}},
+			SSM:         &types.AWSSSM{},
+			Integration: "my-integration",
+			AssumeRole: &types.AssumeRole{
+				RoleName: "MyRole",
+			},
+			Organization: &types.AWSOrganizationMatcher{
+				OrganizationID: organizationID,
+				OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+					Include: []string{types.Wildcard},
+				},
+			},
+		},
+	}
+
+	organizationsGetter := func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+		return &mockOrganizationsClient{
+			organizationID: organizationID,
+			rootOUID:       "r-123",
+			ouItems: map[string]ouItem{
+				"r-123": {
+					innerOUs: []string{},
+					innerAccounts: []string{
+						"000000000001",
+						"000000000002",
+					},
+				},
+			},
+		}, nil
+	}
+
+	regionsListerGetter := func(ctx context.Context, opts ...awsconfig.OptionsFn) (account.ListRegionsAPIClient, error) {
+		return &mockAWSAccountClient{
+			responseError: trace.AccessDenied("User is not authorized to perform: account:ListRegions"),
+		}, nil
+	}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+		Matchers: matchers,
+		PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+			return "proxy.example.com:3080", nil
+		},
+		EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{output: &ec2.DescribeInstancesOutput{}}, nil
+		},
+		RegionsListerGetter:    regionsListerGetter,
+		AWSOrganizationsGetter: organizationsGetter,
+	})
+	require.NoError(t, err)
+
+	watcher := NewWatcher[*EC2DiscoveryResult](t.Context())
+	watcher.SetFetchers("", fetchers)
+
+	go watcher.Run()
+
+	select {
+	case result := <-watcher.InstancesC:
+		require.NotNil(t, result)
+		require.Empty(t, result.Instances)
+		require.Len(t, result.PermissionErrors, 2)
+
+		var gotAccountIDs []string
+		for _, permErr := range result.PermissionErrors {
+			require.Equal(t, usertasks.AutoDiscoverEC2IssuePermAccountDenied, permErr.IssueType)
+			require.Equal(t, "my-integration", permErr.Integration)
+			require.Empty(t, permErr.Region)
+			gotAccountIDs = append(gotAccountIDs, permErr.AccountID)
+		}
+
+		require.ElementsMatch(t, []string{"000000000001", "000000000002"}, gotAccountIDs)
+	case <-t.Context().Done():
+		require.Fail(t, "context canceled")
+	}
+
+	select {
+	case result := <-watcher.InstancesC:
+		require.Fail(t, "unexpected result: %v", result)
+	default:
+	}
+}
+
+func TestEC2WatcherWithOrgAccessDenied(t *testing.T) {
+	t.Parallel()
+
+	organizationID := "o-abcdefghij"
+	matchers := []types.AWSMatcher{
+		{
+			Params: &types.InstallerParams{
+				InstallTeleport: true,
+			},
+			Types:   []string{"ec2"},
+			Regions: []string{"us-west-2"},
+			Tags:    map[string]utils.Strings{"teleport": {"yes"}},
+			SSM:     &types.AWSSSM{},
+			AssumeRole: &types.AssumeRole{
+				RoleName: "MyRole",
+			},
+			Integration: "my-integration",
+			Organization: &types.AWSOrganizationMatcher{
+				OrganizationID: organizationID,
+				OrganizationalUnits: &types.AWSOrganizationUnitsMatcher{
+					Include: []string{types.Wildcard},
+				},
+			},
+		},
+	}
+
+	organizationsGetter := func(ctx context.Context, opts ...awsconfig.OptionsFn) (liborganizations.OrganizationsClient, error) {
+		return &mockAccessDeniedOrganizationsClient{}, nil
+	}
+
+	fetchers, err := MatchersToEC2InstanceFetchers(t.Context(), MatcherToEC2FetcherParams{
+		Matchers: matchers,
+		PublicProxyAddrGetter: func(ctx context.Context) (string, error) {
+			return "proxy.example.com:3080", nil
+		},
+		EC2ClientGetter: func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
+			return &mockEC2Client{output: &ec2.DescribeInstancesOutput{}}, nil
+		},
+		AWSOrganizationsGetter: organizationsGetter,
+	})
+	require.NoError(t, err)
+
+	watcher := NewWatcher[*EC2DiscoveryResult](t.Context())
+	watcher.SetFetchers("", fetchers)
+
+	go watcher.Run()
+
+	select {
+	case result := <-watcher.InstancesC:
+		require.NotNil(t, result)
+		require.Empty(t, result.Instances)
+		require.Len(t, result.PermissionErrors, 1)
+		require.Equal(t, usertasks.AutoDiscoverEC2IssuePermOrgDenied, result.PermissionErrors[0].IssueType)
+		require.Equal(t, "my-integration", result.PermissionErrors[0].Integration)
+	case <-t.Context().Done():
+		require.Fail(t, "context canceled")
+	}
+}
+
+// mockAccessDeniedOrganizationsClient returns AccessDenied from
+// ListRoots, simulating an org-level permission failure.
+type mockAccessDeniedOrganizationsClient struct{}
+
+func (m *mockAccessDeniedOrganizationsClient) ListRoots(ctx context.Context, input *organizations.ListRootsInput, opts ...func(*organizations.Options)) (*organizations.ListRootsOutput, error) {
+	return nil, trace.AccessDenied("not authorized to perform: organizations:ListRoots")
+}
+
+func (m *mockAccessDeniedOrganizationsClient) ListChildren(ctx context.Context, input *organizations.ListChildrenInput, opts ...func(*organizations.Options)) (*organizations.ListChildrenOutput, error) {
+	return nil, trace.AccessDenied("not authorized to perform: organizations:ListChildren")
+}
+
+func (m *mockAccessDeniedOrganizationsClient) ListAccountsForParent(ctx context.Context, input *organizations.ListAccountsForParentInput, opts ...func(*organizations.Options)) (*organizations.ListAccountsForParentOutput, error) {
+	return nil, trace.AccessDenied("not authorized to perform: organizations:ListAccountsForParent")
+}
+
 func TestMatchersToEC2InstanceFetchers(t *testing.T) {
 	ec2ClientGetter := func(ctx context.Context, region string, opts ...awsconfig.OptionsFn) (ec2.DescribeInstancesAPIClient, error) {
 		return nil, errors.New("ec2 client getter invocation must not fail when creating fetchers")
@@ -985,6 +1160,121 @@ func TestToEC2Instances(t *testing.T) {
 	}
 }
 
+func TestAccountIDFromRoleARN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		roleARN       string
+		wantAccountID string
+		wantErr       require.ErrorAssertionFunc
+	}{
+		{
+			name:          "empty ARN",
+			roleARN:       "",
+			wantAccountID: "",
+			wantErr:       require.NoError,
+		},
+		{
+			name:          "valid ARN",
+			roleARN:       "arn:aws:iam::123456789012:role/teleport",
+			wantAccountID: "123456789012",
+			wantErr:       require.NoError,
+		},
+		{
+			name:          "invalid ARN",
+			roleARN:       "invalid-arn",
+			wantAccountID: "",
+			wantErr:       require.Error,
+		},
+		{
+			name:          "ARN without account ID",
+			roleARN:       "arn:aws:iam:::role/teleport",
+			wantAccountID: "",
+			wantErr:       require.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountID, err := accountIDFromRoleARN(tt.roleARN)
+			tt.wantErr(t, err)
+			require.Equal(t, tt.wantAccountID, accountID)
+		})
+	}
+}
+
+func TestSyntheticAccountIDIsUnambiguous(t *testing.T) {
+	t.Parallel()
+
+	base := syntheticAccountID("invalid-arn", "my-int", "us-west-2")
+	require.NotEmpty(t, base)
+	require.Contains(t, base, "unknown-account-")
+
+	// Fallback account IDs are deterministic for the same scope.
+	require.Equal(t, base, syntheticAccountID("invalid-arn", "my-int", "us-west-2"))
+
+	// Field boundaries are preserved even when values contain delimiters.
+	delimiterCollisionLeft := syntheticAccountID("scope-a|scope-b", "my-int", "")
+	delimiterCollisionRight := syntheticAccountID("scope-a", "scope-b|my-int", "")
+	require.NotEqual(t, delimiterCollisionLeft, delimiterCollisionRight)
+
+	// Empty fields retain positional meaning.
+	integrationOnlyScope := syntheticAccountID("", "my-int", "")
+	roleOnlyScope := syntheticAccountID("my-int", "", "")
+	require.NotEqual(t, integrationOnlyScope, roleOnlyScope)
+
+	// Distinct scopes must remain distinct even when the same non-empty values
+	// appear shifted between positions.
+	integrationRegionScope := syntheticAccountID("", "my-int", "us-west-2")
+	roleIntegrationScope := syntheticAccountID("my-int", "us-west-2", "")
+	require.NotEqual(t, integrationRegionScope, roleIntegrationScope)
+}
+
+func TestAccountIDFromRoleARNOrWarn(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.Default()
+	ctx := context.Background()
+
+	valid := accountIDFromRoleARNOrWarn(ctx, logger, "arn:aws:iam::123456789012:role/teleport", "my-int", "us-west-2")
+	require.Equal(t, "123456789012", valid)
+
+	invalid := accountIDFromRoleARNOrWarn(ctx, logger, "invalid-arn", "my-int", "us-west-2")
+	require.NotEmpty(t, invalid)
+	require.Contains(t, invalid, "unknown-account-")
+
+	// Fallback account IDs are deterministic for the same scope.
+	invalidAgain := accountIDFromRoleARNOrWarn(ctx, logger, "invalid-arn", "my-int", "us-west-2")
+	require.Equal(t, invalid, invalidAgain)
+
+	emptyRole := accountIDFromRoleARNOrWarn(ctx, logger, "", "my-int", "us-west-2")
+	require.NotEmpty(t, emptyRole)
+	require.Contains(t, emptyRole, "unknown-account-")
+
+	noScope := accountIDFromRoleARNOrWarn(ctx, logger, "", "", "")
+	require.NotEmpty(t, noScope)
+	require.Contains(t, noScope, "unknown-account-")
+
+	// Region remains part of fallback scoping when account ID is unknown.
+	otherRegion := accountIDFromRoleARNOrWarn(ctx, logger, "", "my-int", "us-east-1")
+	require.NotEqual(t, emptyRole, otherRegion)
+
+	// Integration remains part of fallback scoping when account ID is unknown.
+	otherIntegration := accountIDFromRoleARNOrWarn(ctx, logger, "", "other-int", "us-west-2")
+	require.NotEqual(t, emptyRole, otherIntegration)
+
+	// Field boundaries are preserved even when values contain delimiters.
+	delimiterCollisionLeft := accountIDFromRoleARNOrWarn(ctx, logger, "scope-a|scope-b", "my-int", "")
+	delimiterCollisionRight := accountIDFromRoleARNOrWarn(ctx, logger, "scope-a", "scope-b|my-int", "")
+	require.NotEqual(t, delimiterCollisionLeft, delimiterCollisionRight)
+
+	// Empty fields retain positional meaning.
+	integrationOnlyScope := accountIDFromRoleARNOrWarn(ctx, logger, "", "my-int", "")
+	roleOnlyScope := accountIDFromRoleARNOrWarn(ctx, logger, "my-int", "", "")
+	require.NotEqual(t, integrationOnlyScope, roleOnlyScope)
+}
+
 func TestSSMRunCommandParameters(t *testing.T) {
 	for _, tt := range []struct {
 		name           string
@@ -1113,7 +1403,7 @@ func TestSSMRunCommandParameters(t *testing.T) {
 func TestEC2IAMPermissionError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("implements error interface with context", func(t *testing.T) {
+	t.Run("with region and integration", func(t *testing.T) {
 		underlyingErr := errors.New("access denied")
 		permErr := &EC2IAMPermissionError{
 			Integration:         "my-integration",
@@ -1124,15 +1414,15 @@ func TestEC2IAMPermissionError(t *testing.T) {
 			Err:                 underlyingErr,
 		}
 
-		// Error message should include context
 		errMsg := permErr.Error()
+		require.Contains(t, errMsg, "my-integration")
 		require.Contains(t, errMsg, "123456789012")
 		require.Contains(t, errMsg, "us-west-2")
 		require.Contains(t, errMsg, "ec2-perm-account-denied")
 		require.Contains(t, errMsg, "access denied")
 	})
 
-	t.Run("error without region", func(t *testing.T) {
+	t.Run("without region", func(t *testing.T) {
 		underlyingErr := errors.New("org access denied")
 		permErr := &EC2IAMPermissionError{
 			Integration: "my-integration",
@@ -1142,19 +1432,34 @@ func TestEC2IAMPermissionError(t *testing.T) {
 		}
 
 		errMsg := permErr.Error()
+		require.Contains(t, errMsg, "my-integration")
 		require.Contains(t, errMsg, "123456789012")
 		require.Contains(t, errMsg, "ec2-perm-org-denied")
 		require.NotContains(t, errMsg, "region")
 	})
 
-	t.Run("unwrap returns underlying error", func(t *testing.T) {
+	t.Run("unwrap", func(t *testing.T) {
 		underlyingErr := errors.New("access denied")
 		permErr := &EC2IAMPermissionError{Err: underlyingErr}
 
 		require.ErrorIs(t, permErr, underlyingErr)
 	})
 
-	t.Run("errors.As finds permission error", func(t *testing.T) {
+	t.Run("without integration", func(t *testing.T) {
+		permErr := &EC2IAMPermissionError{
+			AccountID: "123456789012",
+			Region:    "us-west-2",
+			IssueType: "ec2-perm-account-denied",
+			Err:       errors.New("access denied"),
+		}
+
+		errMsg := permErr.Error()
+		require.NotContains(t, errMsg, "integration")
+		require.Contains(t, errMsg, "123456789012")
+		require.Contains(t, errMsg, "us-west-2")
+	})
+
+	t.Run("errors.As through trace.Wrap", func(t *testing.T) {
 		underlyingErr := errors.New("access denied")
 		permErr := &EC2IAMPermissionError{
 			AccountID: "123456789012",
@@ -1162,7 +1467,6 @@ func TestEC2IAMPermissionError(t *testing.T) {
 			Err:       underlyingErr,
 		}
 
-		// Wrap the error
 		wrappedErr := trace.Wrap(permErr)
 
 		var found *EC2IAMPermissionError
@@ -1174,7 +1478,7 @@ func TestEC2IAMPermissionError(t *testing.T) {
 func TestEC2DiscoveryResultCollectError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("collects permission error", func(t *testing.T) {
+	t.Run("direct permission error", func(t *testing.T) {
 		result := &EC2DiscoveryResult{}
 		permErr := &EC2IAMPermissionError{
 			AccountID: "123456789012",
@@ -1188,7 +1492,7 @@ func TestEC2DiscoveryResultCollectError(t *testing.T) {
 		require.Equal(t, "123456789012", result.PermissionErrors[0].AccountID)
 	})
 
-	t.Run("collects wrapped permission error", func(t *testing.T) {
+	t.Run("wrapped permission error", func(t *testing.T) {
 		result := &EC2DiscoveryResult{}
 		permErr := &EC2IAMPermissionError{
 			AccountID: "123456789012",
@@ -1202,7 +1506,7 @@ func TestEC2DiscoveryResultCollectError(t *testing.T) {
 		require.Len(t, result.PermissionErrors, 1)
 	})
 
-	t.Run("does not collect non-permission error", func(t *testing.T) {
+	t.Run("non-permission error ignored", func(t *testing.T) {
 		result := &EC2DiscoveryResult{}
 		regularErr := errors.New("some other error")
 
@@ -1212,47 +1516,3 @@ func TestEC2DiscoveryResultCollectError(t *testing.T) {
 	})
 }
 
-func TestEC2DiscoveryResultHelpers(t *testing.T) {
-	t.Parallel()
-
-	t.Run("HasInstances", func(t *testing.T) {
-		empty := &EC2DiscoveryResult{}
-		require.False(t, empty.HasInstances())
-
-		withInstances := &EC2DiscoveryResult{
-			Instances: []*EC2Instances{{Region: "us-west-2"}},
-		}
-		require.True(t, withInstances.HasInstances())
-	})
-
-	t.Run("HasErrors", func(t *testing.T) {
-		empty := &EC2DiscoveryResult{}
-		require.False(t, empty.HasErrors())
-
-		withErrors := &EC2DiscoveryResult{
-			PermissionErrors: []*EC2IAMPermissionError{{AccountID: "123"}},
-		}
-		require.True(t, withErrors.HasErrors())
-	})
-
-	t.Run("IsEmpty", func(t *testing.T) {
-		empty := &EC2DiscoveryResult{}
-		require.True(t, empty.IsEmpty())
-
-		withInstances := &EC2DiscoveryResult{
-			Instances: []*EC2Instances{{Region: "us-west-2"}},
-		}
-		require.False(t, withInstances.IsEmpty())
-
-		withErrors := &EC2DiscoveryResult{
-			PermissionErrors: []*EC2IAMPermissionError{{AccountID: "123"}},
-		}
-		require.False(t, withErrors.IsEmpty())
-
-		withBoth := &EC2DiscoveryResult{
-			Instances:        []*EC2Instances{{Region: "us-west-2"}},
-			PermissionErrors: []*EC2IAMPermissionError{{AccountID: "123"}},
-		}
-		require.False(t, withBoth.IsEmpty())
-	})
-}

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -1515,4 +1515,3 @@ func TestEC2DiscoveryResultCollectError(t *testing.T) {
 		require.Empty(t, result.PermissionErrors)
 	})
 }
-

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -104,9 +104,9 @@ func WithClock[Instances any](clock clockwork.Clock) Option[Instances] {
 }
 
 // WithMissedRotation sets the missed rotation channel.
-// Specialized for EC2Instances since this functionality is specific to EC2 servers.
-func WithMissedRotation(missedRotation <-chan []types.Server) Option[*EC2Instances] {
-	return func(w *Watcher[*EC2Instances]) {
+// Specialized for EC2DiscoveryResult since this functionality is specific to EC2 servers.
+func WithMissedRotation(missedRotation <-chan []types.Server) Option[*EC2DiscoveryResult] {
+	return func(w *Watcher[*EC2DiscoveryResult]) {
 		w.missedRotation = missedRotation
 	}
 }

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -89,6 +89,15 @@ func WithPerInstanceHookFn[Instances any](callback func(groups []Instances)) Opt
 	}
 }
 
+// WithPerInstanceTapFn sets an optional callback for each fetcher's batch of fetched
+// instance groups. It will be called once per fetcher. This callback observes results before
+// forwarding, but does not replace normal channel writes to InstancesC.
+func WithPerInstanceTapFn[Instances any](callback func(groups []Instances)) Option[Instances] {
+	return func(w *Watcher[Instances]) {
+		w.perInstanceTapFn = callback
+	}
+}
+
 // WithPostFetchHookFn sets an optional callback to be called after the fetch round is finished.
 func WithPostFetchHookFn[Instances any](f func()) Option[Instances] {
 	return func(w *Watcher[Instances]) {
@@ -127,6 +136,7 @@ type Watcher[Instances any] struct {
 	preFetchHookFn     func(fetchers []Fetcher[Instances])
 	postFetchHookFn    func()
 	triggerFetchHookFn func()
+	perInstanceTapFn   func(instances []Instances)
 	perInstanceHookFn  func(instances []Instances)
 }
 
@@ -181,6 +191,9 @@ func (w *Watcher[Instances]) sendInstancesOrLogError(instancesColl []Instances, 
 		}
 		slog.ErrorContext(context.Background(), "Failed to fetch instances", "error", err)
 		return
+	}
+	if w.perInstanceTapFn != nil {
+		w.perInstanceTapFn(instancesColl)
 	}
 	w.perInstanceHookFn(instancesColl)
 }

--- a/lib/srv/server/watcher_test.go
+++ b/lib/srv/server/watcher_test.go
@@ -321,6 +321,87 @@ func TestWatcherHooks(t *testing.T) {
 	}
 }
 
+func TestWatcherPerInstanceTap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tap with default forwarding sends to InstancesC", func(t *testing.T) {
+		t.Parallel()
+
+		w := NewWatcher[mockInstance](t.Context(),
+			WithPerInstanceTapFn[mockInstance](func(instances []mockInstance) {
+				assert.Len(t, instances, 1)
+				assert.Equal(t, "i-1", instances[0].ID)
+			}),
+		)
+
+		done := make(chan struct{})
+		go func() {
+			w.sendInstancesOrLogError([]mockInstance{{ID: "i-1"}}, nil)
+			close(done)
+		}()
+
+		select {
+		case got := <-w.InstancesC:
+			assert.Equal(t, "i-1", got.ID)
+		case <-time.After(time.Second):
+			t.Fatal("expected forwarded instance on InstancesC")
+		}
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("sendInstancesOrLogError did not return")
+		}
+	})
+
+	t.Run("tap with replacing hook runs tap then hook without default forwarding", func(t *testing.T) {
+		t.Parallel()
+
+		order := make([]string, 0, 2)
+		w := NewWatcher[mockInstance](t.Context(),
+			WithPerInstanceTapFn[mockInstance](func(instances []mockInstance) {
+				assert.Len(t, instances, 1)
+				assert.Equal(t, "i-2", instances[0].ID)
+				order = append(order, "tap")
+			}),
+			WithPerInstanceHookFn[mockInstance](func(instances []mockInstance) {
+				assert.Len(t, instances, 1)
+				assert.Equal(t, "i-2", instances[0].ID)
+				order = append(order, "hook")
+			}),
+		)
+
+		w.sendInstancesOrLogError([]mockInstance{{ID: "i-2"}}, nil)
+
+		assert.Equal(t, []string{"tap", "hook"}, order)
+		select {
+		case got := <-w.InstancesC:
+			t.Fatalf("did not expect default forwarding, got instance %v", got)
+		default:
+		}
+	})
+
+	t.Run("error path does not run tap or hook", func(t *testing.T) {
+		t.Parallel()
+
+		tapCalled := false
+		hookCalled := false
+		w := NewWatcher[mockInstance](t.Context(),
+			WithPerInstanceTapFn[mockInstance](func([]mockInstance) {
+				tapCalled = true
+			}),
+			WithPerInstanceHookFn[mockInstance](func([]mockInstance) {
+				hookCalled = true
+			}),
+		)
+
+		w.sendInstancesOrLogError(nil, trace.BadParameter("boom"))
+
+		assert.False(t, tapCalled)
+		assert.False(t, hookCalled)
+	})
+}
+
 func TestWatcherShutdown(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/62828

Changelog: Surface IAM permission errors from EC2 auto-discovery as UserTasks for account-level and organization-level permission failures, helping users identify and resolve missing IAM permissions.

---

## End-to-end flow

Permission errors reuse the existing UserTask upsert pipeline (`mergeUpsertDiscoverEC2Task`) that already handles SSM installation failures, same grouping key, same distributed locking, same TTL strategy.

### 1. EC2 watcher discovers permission errors

During each poll cycle, `ec2InstanceFetcher.GetInstances` calls AWS APIs (`DescribeInstances`, `account:ListRegions`, `organizations:ListAccounts`). Access-denied errors are wrapped as `EC2IAMPermissionError` and collected in `EC2DiscoveryResult.PermissionErrors` instead of failing the entire discovery. Successful instances from other accounts/regions are still returned alongside the errors.

### 2. Discovery server processes results

`handleEC2WatcherResults` receives results via `WithPerInstanceTapFn` before instances are forwarded to the enrollment handler. For each permission error it:

- rate-limits log warnings via `KeyedLimiter` (per integration/account/region/issue-type, suppressed for `max(pollInterval*3, 15m)`)
- queues the error as a failed enrollment via `addFailedPermissionEnrollment`

### 3. Failed enrollments are flushed to UserTasks

After each poll cycle, `upsertTasksForAWSEC2FailedEnrollments` iterates the sync queue and calls `mergeUpsertDiscoverEC2Task`, which:

- builds a deterministic task name from (integration, issue type, account, region)
- acquires a distributed semaphore (keyed by task name) to prevent concurrent discovery services from racing on the same UserTask
- fetches any existing task, merges state, and upserts (skipping instance merge for permission issues since they have no instance data)
- sets a TTL of `2 * PollInterval` (same as all other UserTask types) , each poll re-upserts with a fresh expiration, so the task auto-expires when the error stops recurring

### 4. UserTask is created

The task is stored with IssueType of `ec2-perm-account-denied` or `ec2-perm-org-denied`. Validation is relaxed for permission issues: empty account ID, region, and instances are allowed since these errors occur before any instance metadata is known. The Web UI lists tasks per integration and uses the issue type to show targeted remediation instructions.

The (new) `loglimit.KeyedLimiter` is extracted from the existing `LogLimiter` internals to rate-limit warning logs without coupling to `slog.Handler`.

---

## Manual Test Plan

### Test Environment
 - Where: Teleport Cloud (staging): https://carlisia-4.cloud.gravitational.io

### Test Cases

- [x] **Happy path -- full permissions, no permission UserTasks**
  - [x] Apply discovery config targeting EC2 instances with your creator tag
  - [x] Verify instances are discovered: `dtctl get nodes --format=json | jq '.[]'`
  - [x] Verify NO permission-related UserTasks exist: `dtctl get user_tasks --format=json | jq '.[] | select(.spec.issue_type | startswith("ec2-perm"))'` returns empty
  - [x] Existing SSM-related UserTasks (if any) still have correct issue types
- [x] **Deny ec2:DescribeInstances creates `ec2-perm-account-denied` UserTask**
  - [x] Attach IAM deny policy for `ec2:DescribeInstances` to the integration role
  - [x] Apply discovery config targeting your region
  - [x] Verify UserTask created with `issue_type=ec2-perm-account-denied` and region populated
  - [x] Verify discovery service logs contain `IAM permission error during EC2 discovery` warning with correct context fields
  - [x] Remove deny policy and destroy discovery config before next test
- [ ] **Deny account:ListRegions creates `ec2-perm-account-denied` UserTask**
  - [ ] Attach IAM deny policy for `account:ListRegions` to the integration role
  - [ ] Apply discovery config with `regions = ["*"]`
  - [ ] Wait 2-3 minutes for discovery cycle
  - [ ] Verify UserTask created with `issue_type=ec2-perm-account-denied` and empty region field
  - [ ] Remove deny policy and destroy discovery config before next test
- [ ] **Deny Organizations APIs creates `ec2-perm-org-denied` UserTask** (manual -- no Terraform for org matcher)
  - [ ] Only if your account is in an AWS Organization
  - [ ] Create discovery config with Organization matcher via `dtctl create`
  - [ ] Attach IAM deny policy for `organizations:ListRoots`, `organizations:ListChildren`, `organizations:ListAccountsForParent`
  - [ ] Wait 2-3 minutes for discovery cycle
  - [ ] Verify UserTask created with `issue_type=ec2-perm-org-denied` and empty region
  - [ ] Remove deny policy and destroy discovery config before next test
- [ ] **Partial failures -- instances discovered alongside permission errors** (validated by unit tests)
  - [ ] Apply discovery config with full permissions
  - [ ] Verify instances discovered and no permission UserTasks
  - [ ] Add deny policy for `ec2:DescribeInstances` in a DIFFERENT region (not the one your instances are in)
  - [ ] Verify instances from the accessible region are still discovered
  - [ ] Verify permission UserTask created for the denied region