### PR TITLE
docs: correct token example in jamf guide

### DIFF
--- a/docs/pages/identity-governance/device-trust/jamf-integration.mdx
+++ b/docs/pages/identity-governance/device-trust/jamf-integration.mdx
@@ -111,6 +111,7 @@ teleport:
   # Necessary to write devices back to Teleport.
   proxy_server: (=clusterDefaults.clusterName=):443 # CHANGEME
   join_params:
+    method: "token"
     token_name: "/tmp/token"
 
 jamf_service:


### PR DESCRIPTION
Included `method` that is required under `join_params` for Teleport configuration example.

If not included  you get this error attempting to run:

```bash
ERROR: join method must be one of azure, azure_devops, bitbucket, circleci, ec2, gcp, github, gitlab, iam, kubernetes, spacelift, token, tpm, terraform_cloud, oracle, bound_keypair, env0
```