### PR TITLE
[v18] Server Discovery: handle failure when proxy is unreachable

### DIFF
--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -882,7 +882,7 @@ func TestSSMRunCommandParameters(t *testing.T) {
 			},
 			errCheck: require.NoError,
 			expectedParams: map[string]string{
-				"commands": "curl -s -L https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token",
+				"commands": `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token"`,
 			},
 		},
 		{
@@ -905,7 +905,7 @@ func TestSSMRunCommandParameters(t *testing.T) {
 			},
 			errCheck: require.NoError,
 			expectedParams: map[string]string{
-				"commands": "export TELEPORT_INSTALL_SUFFIX=cluster-green; curl -s -L https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token",
+				"commands": `export TELEPORT_INSTALL_SUFFIX=cluster-green; bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com/v1/webapi/scripts/installer/default-installer | bash -s my-token"`,
 			},
 		},
 		{

--- a/lib/srv/server/installer_script.go
+++ b/lib/srv/server/installer_script.go
@@ -133,7 +133,7 @@ func installerScript(ctx context.Context, params *types.InstallerParams, opts ..
 		RawQuery: scriptURLQuery.Encode(),
 	}
 
-	installationScript := fmt.Sprintf("curl -s -L %s | bash -s %s",
+	installationScript := fmt.Sprintf(`bash -c "set -o pipefail; curl --silent --show-error --location %s | bash -s %s"`,
 		scriptURL.String(),
 		shsprintf.EscapeDefaultContext(params.JoinToken),
 	)

--- a/lib/srv/server/installer_script_test.go
+++ b/lib/srv/server/installer_script_test.go
@@ -48,14 +48,14 @@ func TestInstallerScript(t *testing.T) {
 			name:           "basic",
 			req:            basicParams,
 			errCheck:       require.NoError,
-			expectedScript: "curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 		{
 			name:                   "with nonce to ensure script is unique",
 			req:                    basicParams,
 			withOptions:            []scriptOption{withNonceComment()},
 			errCheck:               require.NoError,
-			expectedScriptContains: "curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token # ",
+			expectedScriptContains: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token" #`,
 		},
 		{
 			name: "with azure clientid",
@@ -68,7 +68,7 @@ func TestInstallerScript(t *testing.T) {
 			},
 			withOptions:            []scriptOption{withNonceComment()},
 			errCheck:               require.NoError,
-			expectedScriptContains: "curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName?azure-client-id=my-id | bash -s my-token # ",
+			expectedScriptContains: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName?azure-client-id=my-id | bash -s my-token" #`,
 		},
 		{
 			name: "with suffix installation",
@@ -78,7 +78,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: "export TELEPORT_INSTALL_SUFFIX=suffix; curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX=suffix; bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 		{
 			name: "with update group",
@@ -88,7 +88,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: "export TELEPORT_UPDATE_GROUP=updateGroup; curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `export TELEPORT_UPDATE_GROUP=updateGroup; bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 		{
 			name: "with install suffix and update group",
@@ -99,7 +99,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: "export TELEPORT_INSTALL_SUFFIX=suffix TELEPORT_UPDATE_GROUP=updateGroup; curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `export TELEPORT_INSTALL_SUFFIX=suffix TELEPORT_UPDATE_GROUP=updateGroup; bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 		{
 			name: "missing public proxy address but getter was set up",
@@ -114,7 +114,7 @@ func TestInstallerScript(t *testing.T) {
 				}),
 			},
 			errCheck:       require.NoError,
-			expectedScript: "curl -s -L https://proxy2.example.com/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy2.example.com/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 		{
 			name: "proxy addr is missing but getter returns an error",
@@ -147,7 +147,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: "curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s token\\$\\(sh\\)",
+			expectedScript: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s token\$\(sh\)"`,
 		},
 		{
 			name: "with script name that needs escaping",
@@ -157,7 +157,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: `curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName%5C$%5C%28sh%5C%29 | bash -s my-token`,
+			expectedScript: `bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName%5C$%5C%28sh%5C%29 | bash -s my-token"`,
 		},
 		{
 			name: "with HTTP Proxy settings set",
@@ -171,7 +171,7 @@ func TestInstallerScript(t *testing.T) {
 				return req
 			},
 			errCheck:       require.NoError,
-			expectedScript: "export HTTP_PROXY=http://local-squid:3128 HTTPS_PROXY=http://local-squid:3128 NO_PROXY=http://intranet.local; curl -s -L https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token",
+			expectedScript: `export HTTP_PROXY=http://local-squid:3128 HTTPS_PROXY=http://local-squid:3128 NO_PROXY=http://intranet.local; bash -c "set -o pipefail; curl --silent --show-error --location https://proxy.example.com:443/v1/webapi/scripts/installer/scriptName | bash -s my-token"`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Backport #63767 to branch/v18

changelog: Fixed correct reporting of server discovery enrollment failures when the Proxy is not accessible from the target server.

Demo:
AWS EC2 Discovery has the new command:

<img width="1352" height="600" alt="image" src="https://github.com/user-attachments/assets/07fc7475-1a2d-42d9-ace3-07f2b6a0f55f" />
