### PR TITLE
Add bot RFD validation

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -313,6 +313,24 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Checkout shared-workflows
+        uses: actions/checkout@v6
+        with:
+          repository: gravitational/shared-workflows
+          path: .github/shared-workflows
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
+
+      - name: Generate GitHub Token
+        id: generate_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.REVIEWERS_APP_ID }}
+          private-key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+
+      - name: Validate RFD
+        id: validate_rfd
+        run: cd .github/shared-workflows/bot && go run main.go -workflow=rfd -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"
+        
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
When linting RFDs the bot is now invoked to ensure that the following items from RFD 0 are enforced.

- All RFD numbers are properly zero padded to avoid collisions (rfd/123-foo vs. rfd/0123-bar)
- All RFD branches must be in the form rfd/$number-your-title
- The RFD exists at /rfd/$number-your-title.md

The bot only enforces the above on _new_ RFDs. Any edits to existing RFDs are skipped. To make the transition easier the bot can be disarmed with a `/excluderfd` comment from and admin.