### PR TITLE
Bump the bot to workflows/v0.0.3

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -37,7 +37,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
 
       - name: Setup base cache
         uses: actions/cache/restore@v5
@@ -95,7 +95,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
 
       - name: Build Binaries
         id: build_branch

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -43,7 +43,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
 
       - name: Find excluded tests
         id: find_excluded

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -39,7 +39,7 @@ jobs:
         with:
           repository: gravitational/shared-workflows
           path: .github/shared-workflows
-          ref: 664e788d45a7f56935cf63094b4fb52a41b12015 # workflows/v0.0.2
+          ref: dd8f30e8fd5dd1d1655b9d27049e5d0f6f4f9ef2 # workflows/v0.0.3
       - name: Installing Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
Diff of v0.0.2 and v0.0.3 is [here](https://github.com/gravitational/shared-workflows/compare/workflows/v0.0.2..workflows/v0.0.3).

This is a preemptive change to get all existing workflows on the latest version of the bot. Future changes to existing workflows or new workflows will be making use of v0.0.3.