### PR TITLE
docs: set block as bash to avoid emoticon display in host user creation test

### DIFF
--- a/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/enroll-resources/server-access/guides/host-user-creation.mdx
@@ -282,7 +282,7 @@ which serves a similar purpose. Ensure that the correct directive is used based 
 When you connect to a remote Node via `tsh`, and host user creation is enabled, the
 Teleport SSH Service will automatically create a user on the host:
 
-```code
+```bash
 $ tsh login
 $ tsh ssh nginxrestarter@develnode
 $ grep "nginxrestarter" /etc/passwd


### PR DESCRIPTION
Due to the `:x:` usage in the `code` block that  can display as emoticons like ❌ .  Updated to `bash` and reported docs-website [issue](https://github.com/gravitational/docs-website/issues/554) for the emoticon rendering.