### PR TITLE
Add initial AGENTS.md file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any L
 - Do **not** stage, commit, or open PRs containing LLM-authored code or text. If you created files, clearly mark them as prototypes and remove them before any commit.
 
 ## Review Guidelines
-- Focus only on critical security and reliability issues.
-- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a security / reliability failure
+- Focus only on critical security, reliability, performance, and scalability issues.
+- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a signfiicant failure
 
 ### What to Look For
 - Authentication/authorization bypasses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any L
 
 ## Review Guidelines
 - Focus only on critical security, reliability, performance, and scalability issues.
-- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a signficant failure
+- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a significant failure
 
 ### What to Look For
 - Authentication/authorization bypasses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Mission
+Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any LLM-produced code or content must **not** be committed to the repository.
+
+## Absolute Rules
+- **No LLM-written code may be committed.** This includes direct code, generated tests, configs, migrations, scripts, or documentation intended for production use.
+- LLM work is for **experimentation and throwaway prototypes** only. If a change is worth keeping, a human must rewrite or re-implement it from scratch before committing.
+- Do **not** stage, commit, or open PRs containing LLM-authored code or text. If you created files, clearly mark them as prototypes and remove them before any commit.
+
+## Review Guidelines
+- Focus only on critical security and reliability issues.
+- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a security / reliability failure
+
+### What to Look For
+- Authentication/authorization bypasses
+- Secret leakage, unsafe logging, or credential exposure
+- Unsafe defaults in security-sensitive areas
+- Injection risks (SQL, command, template, path traversal, SSRF)
+- Insecure crypto usage or key handling
+- Privilege escalation or sandbox escapes
+- Data corruption, durability failures, or irreversible loss scenarios
+- Concurrency hazards that can cause outages or data races
+- Reliability regressions: crash loops, panics, deadlocks, unbounded retries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Use Codex/LLMs to explore ideas, prototypes, and design alternatives only. Any L
 
 ## Review Guidelines
 - Focus only on critical security, reliability, performance, and scalability issues.
-- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a signfiicant failure
+- Ignore style, performance micro-optimizations, and readability nits unless they are tied to a signficant failure
 
 ### What to Look For
 - Authentication/authorization bypasses


### PR DESCRIPTION
## Overview

Teleport does not use LLMs to write production code.

We do want LLMs to be good at reviewing our code for security and reliability issues.

A well maintained AGENTS.md file can help us implement both of these goals.

Today, Codex PR reviews can provide valuable findings, but are a little noisy still. By keeping an AGENTS.md file with specific guidelines for LLM reviews we may be able to get more out of the PR review bots.

## Testing

Since we should not be using LLMs to write production code already, this should have no impact on development workflows today.

After rolling this out, there are a couple of things worth testing:

1. Does this interfere with engineer's ability to prototype / test ideas with LLMs?
2. Does this improve the quality of PR review findings, and reduce false positives?

Both are fuzzy enough that we will need to test them qualitatively over time. We don't have good quantitative measures yet.