### PR TITLE
Automatically update Go patch version using Renovate 🤖 🆙 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "gitAuthor": "Renovate Bot <dev@goteleport.com>",
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "labels": [
+    "dependencies",
+    "go"
+  ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/bower_components/**",
+    "**/vendor/**",
+    "**/__tests__/**",
+    "**/test/**",
+    "**/tests/**",
+    "**/__fixtures__/**"
+  ],
+  "schedule": [
+    "at any time"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)go\\.mod$/"
+      ],
+      "matchStrings": [
+        "(?m)^go\\s+(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\\s*$",
+        "(?m)^toolchain\\s+go(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\\s*$"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^build\\.assets/versions\\.mk$/"
+      ],
+      "matchStrings": [
+        "GOLANG_VERSION\\s*\\?=\\s*go(?<currentValue>[^\\s\\n]+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^docs/config\\.json$/"
+      ],
+      "matchStrings": [
+        "\"golang\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^build\\.assets/Dockerfile-grpcbox$/"
+      ],
+      "matchStrings": [
+        "FROM docker\\.io/golang:(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "groupName": "Go version",
+      "groupSlug": "go-version",
+      "prHourlyLimit": 5,
+      "recreateWhen": "always",
+      "rangeStrategy": "bump",
+      "prBodyNotes": [
+        "Changelog: Updated Go to {{{newValue}}}."
+      ],
+      "commitMessageTopic": "Go toolchain version"
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,18 @@
   ],
   "packageRules": [
     {
+      "matchBaseBranches": [
+        "branch/v18"
+      ],
+      "commitMessagePrefix": "[v18] "
+    },
+    {
+      "matchBaseBranches": [
+        "branch/v17"
+      ],
+      "commitMessagePrefix": "[v17] "
+    },
+    {
       "matchManagers": [
         "custom.regex"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -108,7 +108,6 @@
       "groupName": "Go version",
       "groupSlug": "go-version",
       "prHourlyLimit": 5,
-      "recreateWhen": "always",
       "prBodyNotes": [
         "Changelog: Updated Go to {{{newValue}}}."
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "baseBranchPatterns": [
+    "master",
+    "branch/v18",
+    "branch/v17"
+  ],
   "extends": [
     "config:recommended"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended"
   ],
-  "gitAuthor": "Renovate Bot <dev@goteleport.com>",
   "enabledManagers": [
     "custom.regex"
   ],
@@ -19,9 +18,6 @@
     "**/test/**",
     "**/tests/**",
     "**/__fixtures__/**"
-  ],
-  "schedule": [
-    "at any time"
   ],
   "customManagers": [
     {
@@ -82,11 +78,37 @@
       "matchDepNames": [
         "go"
       ],
+      "separateMultipleMinor": true,
+      "separateMinorPatch": true
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "enabled": true,
       "groupName": "Go version",
       "groupSlug": "go-version",
       "prHourlyLimit": 5,
       "recreateWhen": "always",
-      "rangeStrategy": "bump",
       "prBodyNotes": [
         "Changelog: Updated Go to {{{newValue}}}."
       ],

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,9 +1,9 @@
 # This workflow runs Renovate to keep the Go toolchain version up to date.
-# It is scheduled to run daily and can also be triggered manually.
+# It is scheduled to run weekly and can also be triggered manually.
 name: Renovate
 on:
   schedule:
-    - cron: '0 7 * * *' # Every day at 7 AM UTC
+    - cron: '0 7 * * 1' # Every Monday at 7 AM UTC
   workflow_dispatch: {}
 
 # Renovate needs the following permissions in order to write branches, pull requests and issues.

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,29 @@
+# This workflow runs Renovate to keep the Go toolchain version up to date.
+# It is scheduled to run daily and can also be triggered manually.
+name: Renovate
+on:
+  schedule:
+    - cron: '0 7 * * *' # Every day at 7 AM UTC
+  workflow_dispatch: {}
+
+# Renovate needs the following permissions in order to write branches, pull requests and issues.
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@d65ef9e20512193cc070238b49c3873a361cd50c # v46.1.1
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -3,7 +3,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 7 * * 1' # Every Monday at 7 AM UTC
+    - cron: '0 7 * * 3' # Every Wednesday at 7 AM UTC
   workflow_dispatch: {}
 
 # Renovate needs the following permissions in order to write branches, pull requests and issues.


### PR DESCRIPTION
How about we just automate this step from now on? Had some spare time between CI runs and running tests. Why not just crank this out while I wait? lol

**This change only makes Renovate update Go patch versions.**

## Backport?

No backport needed since this workflow runs on a schedule on `master` branch. It is configured to run against our release branches as defined in the config.

## Demo

<img width="1002" height="256" alt="Screenshot 2026-02-20 at 3 34 02 PM" src="https://github.com/user-attachments/assets/ca6c5d03-71e0-4be5-a09f-6cfc97533ca2" />

Example PRs:

1. `master` branch: https://github.com/cthach/teleport/pull/5
2. `branch/v18`: https://github.com/cthach/teleport/pull/8
3. `branch/v17`:  https://github.com/cthach/teleport/pull/9

The corresponding workflow that ran it: https://github.com/cthach/teleport/actions/runs/22239639765

This is my first CI change, so any suggestions welcome!
