### PR TITLE
app: Clean up orphaned app servers on startup

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -468,25 +468,34 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	return nil
 }
 
-// cleanupOrphanedAppServers deletes app server heartbeat records
-// belonging to this host that no longer correspond to a running app.
-// This handles the case where an app is removed from config and the
-// agent is reloaded: the old heartbeat record is orphaned because no
-// process deletes it, and it lingers until TTL expiry.
+// cleanupOrphanedAppServers deletes app server heartbeat
+// records belonging to this host that no longer correspond
+// to a running app.
+//
+// When an app is removed from config and the agent is
+// reloaded via SIGHUP, the removed app's heartbeat record
+// is not deleted. It lingers in the auth backend until TTL
+// expiry (up to 15 minutes). This method runs on startup
+// to clean up those orphaned records immediately.
+//
+// For agents with dynamic apps (ResourceMatchers), cleanup
+// waits for the first successful reconciliation so that
+// s.apps includes dynamic apps before deciding what is
+// orphaned. If reconciliation does not complete within a
+// timeout, cleanup is skipped entirely to avoid mistakenly
+// deleting valid dynamic app records.
 func (s *Server) cleanupOrphanedAppServers(ctx context.Context) {
-	// If the resource watcher is active, wait for the first
-	// reconciliation so s.apps includes dynamic apps. Without
-	// this, cleanup would incorrectly delete heartbeat records
-	// for dynamic apps not yet reconciled. Use a timeout so
-	// cleanup still runs if the watcher never delivers an
-	// initial resource set (e.g. auth is slow at startup).
+	// Bail out if reconciliation does not complete within a
+	// reasonable time. Without a full picture of dynamic apps
+	// we could mistakenly delete valid records.
 	if s.watcher != nil {
 		timer := time.NewTimer(2 * time.Minute)
 		defer timer.Stop()
 		select {
 		case <-s.reconcileDone:
 		case <-timer.C:
-			s.log.WarnContext(ctx, "Timed out waiting for first reconciliation before orphan cleanup, proceeding with static apps only.")
+			s.log.WarnContext(ctx, "Timed out waiting for first reconciliation, skipping orphan cleanup.")
+			return
 		case <-s.closeContext.Done():
 			return
 		case <-ctx.Done():
@@ -511,11 +520,10 @@ func (s *Server) cleanupOrphanedAppServers(ctx context.Context) {
 		return
 	}
 
-	if s.closeContext.Err() != nil {
-		return
-	}
-
 	for _, server := range servers {
+		if s.closeContext.Err() != nil {
+			return
+		}
 		if server.GetHostID() != s.c.HostID {
 			continue
 		}

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -475,8 +475,9 @@ func (s *Server) Start(ctx context.Context) (err error) {
 // When an app is removed from config and the agent is
 // reloaded via SIGHUP, the removed app's heartbeat record
 // is not deleted. It lingers in the auth backend until TTL
-// expiry (up to 15 minutes). This method runs on startup
-// to clean up those orphaned records immediately.
+// expiry (up to [apidefaults.ServerAnnounceTTL]). This
+// method runs on startup to clean up those orphaned records
+// immediately.
 //
 // For agents with dynamic apps (ResourceMatchers), cleanup
 // waits for the first successful reconciliation so that

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -26,6 +26,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -154,6 +155,12 @@ type Server struct {
 
 	// watcher monitors changes to application resources.
 	watcher *services.GenericWatcher[types.Application, readonly.Application]
+
+	// reconcileDone is closed after the first successful
+	// reconciliation cycle completes. It is only signaled
+	// when a resource watcher is active (s.watcher != nil).
+	reconcileDone     chan struct{}
+	reconcileDoneOnce sync.Once
 }
 
 // monitoredApps is a collection of applications from different sources
@@ -207,9 +214,10 @@ func New(ctx context.Context, c *Config) (*Server, error) {
 		monitoredApps: monitoredApps{
 			static: c.Apps,
 		},
-		reconcileCh:  make(chan struct{}),
-		closeFunc:    closeFunc,
-		closeContext: closeContext,
+		reconcileCh:   make(chan struct{}),
+		reconcileDone: make(chan struct{}),
+		closeFunc:     closeFunc,
+		closeContext:  closeContext,
 	}
 
 	s.c.ConnectionsHandler.SetApplicationsProvider(s.GetAppByPublicAddress)
@@ -453,7 +461,83 @@ func (s *Server) Start(ctx context.Context) (err error) {
 		}()
 	}
 
+	// Clean up orphaned app server records left behind by a previous
+	// instance (e.g. after SIGHUP reload removed an app from config).
+	go s.cleanupOrphanedAppServers(ctx)
+
 	return nil
+}
+
+// cleanupOrphanedAppServers deletes app server heartbeat records
+// belonging to this host that no longer correspond to a running app.
+// This handles the case where an app is removed from config and the
+// agent is reloaded: the old heartbeat record is orphaned because no
+// process deletes it, and it lingers until TTL expiry.
+func (s *Server) cleanupOrphanedAppServers(ctx context.Context) {
+	// If the resource watcher is active, wait for the first
+	// reconciliation so s.apps includes dynamic apps. Without
+	// this, cleanup would incorrectly delete heartbeat records
+	// for dynamic apps not yet reconciled. Use a timeout so
+	// cleanup still runs if the watcher never delivers an
+	// initial resource set (e.g. auth is slow at startup).
+	if s.watcher != nil {
+		timer := time.NewTimer(2 * time.Minute)
+		defer timer.Stop()
+		select {
+		case <-s.reconcileDone:
+		case <-timer.C:
+			s.log.WarnContext(ctx, "Timed out waiting for first reconciliation before orphan cleanup, proceeding with static apps only.")
+		case <-s.closeContext.Done():
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+
+	// Snapshot the current app set before the RPC call. close()
+	// clears s.apps under the write lock before canceling
+	// closeContext, so snapshotting early ensures we see the full
+	// set even if close() runs during GetApplicationServers.
+	s.mu.RLock()
+	currentApps := make(map[string]bool, len(s.apps))
+	for name := range s.apps {
+		currentApps[name] = true
+	}
+	s.mu.RUnlock()
+
+	servers, err := s.c.AuthClient.GetApplicationServers(ctx, apidefaults.Namespace)
+	if err != nil {
+		s.log.WarnContext(ctx, "Failed to list app servers for orphan cleanup.", "error", err)
+		return
+	}
+
+	if s.closeContext.Err() != nil {
+		return
+	}
+
+	for _, server := range servers {
+		if server.GetHostID() != s.c.HostID {
+			continue
+		}
+		// Skip app servers managed by other components (e.g. AWS
+		// OIDC integration servers upserted by the proxy web
+		// handler). In all-in-one deployments these share our
+		// HostID but are not part of the app service's app set.
+		if server.GetApp().GetIntegration() != "" {
+			continue
+		}
+		name := server.GetApp().GetName()
+		if currentApps[name] {
+			continue
+		}
+		if err := s.removeAppServer(ctx, name); err != nil {
+			if !trace.IsNotFound(err) {
+				s.log.WarnContext(ctx, "Failed to remove orphaned app server.", "app", name, "error", err)
+			}
+			continue
+		}
+		s.log.InfoContext(ctx, "Removed orphaned app server on startup.", "app", name)
+	}
 }
 
 // Close will shut the server down and unblock any resources.
@@ -537,7 +621,7 @@ func (s *Server) close(ctx context.Context) error {
 	// Signal to any blocking go routine that it should exit.
 	s.closeFunc()
 
-	// Stop the database resource watcher.
+	// Stop the application resource watcher.
 	if s.watcher != nil {
 		s.watcher.Close()
 	}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -158,6 +159,11 @@ type suiteConfig struct {
 	Rewrite *types.Rewrite
 	// Login is used to specify "login" trait in the jwt token
 	Login string
+	// ManualStart skips calling Start() automatically so the
+	// caller can inject state before starting the server.
+	ManualStart bool
+	// HostUUID overrides the generated host UUID when set.
+	HostUUID string
 }
 
 type fakeConnMonitor struct{}
@@ -176,7 +182,10 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	s.clock = clockwork.NewFakeClock()
 	s.dataDir = t.TempDir()
-	s.hostUUID = uuid.New().String()
+	s.hostUUID = config.HostUUID
+	if s.hostUUID == "" {
+		s.hostUUID = uuid.New().String()
+	}
 	s.login = config.Login
 
 	var err error
@@ -413,20 +422,22 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	})
 	require.NoError(t, err)
 
-	err = s.appServer.Start(s.closeContext)
-	require.NoError(t, err)
+	if !config.ManualStart {
+		err = s.appServer.Start(s.closeContext)
+		require.NoError(t, err)
 
-	// Explicitly send a heartbeat for any statically defined apps.
-	for _, app := range apps {
-		select {
-		case sender := <-inventoryHandle.Sender():
-			appServer, err := s.appServer.getServerInfo(app)
-			require.NoError(t, err)
-			require.NoError(t, sender.Send(s.closeContext, &proto.InventoryHeartbeat{
-				AppServer: appServer,
-			}))
-		case <-time.After(20 * time.Second):
-			t.Fatal("timed out waiting for inventory handle sender")
+		// Explicitly send a heartbeat for any statically defined apps.
+		for _, app := range apps {
+			select {
+			case sender := <-inventoryHandle.Sender():
+				appServer, err := s.appServer.getServerInfo(app)
+				require.NoError(t, err)
+				require.NoError(t, sender.Send(s.closeContext, &proto.InventoryHeartbeat{
+					AppServer: appServer,
+				}))
+			case <-time.After(20 * time.Second):
+				t.Fatal("timed out waiting for inventory handle sender")
+			}
 		}
 	}
 
@@ -1362,6 +1373,90 @@ func (c *testCloud) GetAWSSigninURL(_ context.Context, _ AWSSigninRequest) (*AWS
 	return &AWSSigninResponse{
 		SigninURL: "https://signin.aws.amazon.com",
 	}, nil
+}
+
+// TestCleanupOrphanedAppServers verifies that orphaned app server
+// records from a previous instance are deleted on startup.
+func TestCleanupOrphanedAppServers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		resourceMatchers []services.ResourceMatcher
+	}{
+		{
+			name: "static apps only",
+		},
+		{
+			name: "with resource matchers",
+			resourceMatchers: []services.ResourceMatcher{
+				{Labels: types.Labels{"group": []string{"a"}}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			app0, err := makeStaticApp("app0", maps.Clone(staticLabels))
+			require.NoError(t, err)
+
+			s := SetUpSuiteWithConfig(t, suiteConfig{
+				Apps:             types.Apps{app0},
+				ResourceMatchers: test.resourceMatchers,
+				ManualStart:      true,
+			})
+
+			// Plant an orphaned app server record with this host ID
+			// before starting the server.
+			orphanApp, err := types.NewAppV3(types.Metadata{
+				Name: "orphan",
+			}, types.AppSpecV3{
+				URI: "localhost:9999",
+			})
+			require.NoError(t, err)
+			orphanServer, err := types.NewAppServerV3FromApp(orphanApp, "test", s.hostUUID)
+			require.NoError(t, err)
+			_, err = s.tlsServer.Auth().UpsertApplicationServer(t.Context(), orphanServer)
+			require.NoError(t, err)
+
+			// Plant an app server record for app0 with this host ID
+			// to verify that cleanup preserves running apps' records.
+			app0Server, err := types.NewAppServerV3FromApp(app0, "test", s.hostUUID)
+			require.NoError(t, err)
+			_, err = s.tlsServer.Auth().UpsertApplicationServer(t.Context(), app0Server)
+			require.NoError(t, err)
+
+			// Plant an app server record with a different host ID to
+			// verify that cleanup does not delete other hosts' records.
+			otherServer, err := types.NewAppServerV3FromApp(orphanApp, "test", "other-host-id")
+			require.NoError(t, err)
+			_, err = s.tlsServer.Auth().UpsertApplicationServer(t.Context(), otherServer)
+			require.NoError(t, err)
+
+			// Start the server. The cleanup goroutine runs
+			// asynchronously after Start returns.
+			err = s.appServer.Start(s.closeContext)
+			require.NoError(t, err)
+
+			// The orphaned record for this host should be deleted.
+			// The record for the other host must remain.
+			require.EventuallyWithT(t, func(t *assert.CollectT) {
+				servers, err := s.authClient.GetApplicationServers(s.closeContext, defaults.Namespace)
+				if !assert.NoError(t, err) {
+					return
+				}
+				var names []string
+				for _, srv := range servers {
+					names = append(names, srv.GetHostID()+"/"+srv.GetApp().GetName())
+				}
+				assert.NotContains(t, names, s.hostUUID+"/orphan", "orphan for this host should have been cleaned up")
+				assert.Contains(t, names, s.hostUUID+"/app0", "running app record should be preserved")
+				assert.Contains(t, names, "other-host-id/orphan", "orphan for other host should remain")
+			}, 10*time.Second, 100*time.Millisecond)
+		})
+	}
 }
 
 var (

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -19,7 +19,6 @@
 package app
 
 import (
-	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -163,8 +162,6 @@ type suiteConfig struct {
 	// ManualStart skips calling Start() automatically so the
 	// caller can inject state before starting the server.
 	ManualStart bool
-	// HostUUID overrides the generated host UUID when set.
-	HostUUID string
 }
 
 type fakeConnMonitor struct{}
@@ -183,7 +180,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	s.clock = clockwork.NewFakeClock()
 	s.dataDir = t.TempDir()
-	s.hostUUID = cmp.Or(config.HostUUID, uuid.New().String())
+	s.hostUUID = uuid.New().String()
 	s.login = config.Login
 
 	var err error

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -19,6 +19,7 @@
 package app
 
 import (
+	"cmp"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
@@ -39,7 +40,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/go-jose/go-jose/v3/jwt"
-	"github.com/google/go-cmp/cmp"
+	gocmp "github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
@@ -182,10 +183,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 
 	s.clock = clockwork.NewFakeClock()
 	s.dataDir = t.TempDir()
-	s.hostUUID = config.HostUUID
-	if s.hostUUID == "" {
-		s.hostUUID = uuid.New().String()
-	}
+	s.hostUUID = cmp.Or(config.HostUUID, uuid.New().String())
 	s.login = config.Login
 
 	var err error
@@ -422,25 +420,6 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	})
 	require.NoError(t, err)
 
-	if !config.ManualStart {
-		err = s.appServer.Start(s.closeContext)
-		require.NoError(t, err)
-
-		// Explicitly send a heartbeat for any statically defined apps.
-		for _, app := range apps {
-			select {
-			case sender := <-inventoryHandle.Sender():
-				appServer, err := s.appServer.getServerInfo(app)
-				require.NoError(t, err)
-				require.NoError(t, sender.Send(s.closeContext, &proto.InventoryHeartbeat{
-					AppServer: appServer,
-				}))
-			case <-time.After(20 * time.Second):
-				t.Fatal("timed out waiting for inventory handle sender")
-			}
-		}
-	}
-
 	t.Cleanup(func() {
 		s.appServer.Close()
 
@@ -448,6 +427,27 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		// actions to proceed
 		s.appServer.Wait()
 	})
+
+	if config.ManualStart {
+		return s
+	}
+
+	err = s.appServer.Start(s.closeContext)
+	require.NoError(t, err)
+
+	// Explicitly send a heartbeat for any statically defined apps.
+	for _, app := range apps {
+		select {
+		case sender := <-inventoryHandle.Sender():
+			appServer, err := s.appServer.getServerInfo(app)
+			require.NoError(t, err)
+			require.NoError(t, sender.Send(s.closeContext, &proto.InventoryHeartbeat{
+				AppServer: appServer,
+			}))
+		case <-time.After(20 * time.Second):
+			t.Fatal("timed out waiting for inventory handle sender")
+		}
+	}
 
 	return s
 }
@@ -515,7 +515,7 @@ func TestStart(t *testing.T) {
 	require.NoError(t, err)
 
 	sort.Sort(types.AppServers(servers))
-	require.Empty(t, cmp.Diff([]types.AppServer{serverAWS, serverAWSWithIntegration, serverFoo}, servers,
+	require.Empty(t, gocmp.Diff([]types.AppServer{serverAWS, serverAWSWithIntegration, serverFoo}, servers,
 		cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Expires"), cmpopts.IgnoreFields(types.AppServerSpecV3{}, "ComponentFeatures")))
 
 	// Check the expiry time is correct.
@@ -589,7 +589,7 @@ func TestShutdown(t *testing.T) {
 				if !assert.Len(t, appServers, 1) {
 					return
 				}
-				if !assert.Empty(t, cmp.Diff(appServers[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Expires"))) {
+				if !assert.Empty(t, gocmp.Diff(appServers[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision", "Expires"))) {
 					return
 				}
 			}, 10*time.Second, 100*time.Millisecond)
@@ -608,7 +608,7 @@ func TestShutdown(t *testing.T) {
 				appServersAfterShutdown, err := s.authClient.GetApplicationServers(ctx, defaults.Namespace)
 				require.NoError(t, err)
 				require.Len(t, appServersAfterShutdown, 1)
-				require.Empty(t, cmp.Diff(appServersAfterShutdown[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
+				require.Empty(t, gocmp.Diff(appServersAfterShutdown[0].GetApp(), app0, cmpopts.IgnoreFields(types.Metadata{}, "Revision")))
 			} else {
 				require.EventuallyWithT(t, func(t *assert.CollectT) {
 					appServersAfterShutdown, err := s.authClient.GetApplicationServers(ctx, defaults.Namespace)
@@ -1165,7 +1165,7 @@ func TestRequestAuditEvents(t *testing.T) {
 						AppName:       app.Metadata.Name,
 					},
 				}
-				require.Empty(t, cmp.Diff(
+				require.Empty(t, gocmp.Diff(
 					expectedEvent,
 					event,
 					cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
@@ -1189,7 +1189,7 @@ func TestRequestAuditEvents(t *testing.T) {
 					Method:     "GET",
 					Path:       "/",
 				}
-				require.Empty(t, cmp.Diff(
+				require.Empty(t, gocmp.Diff(
 					expectedEvent,
 					event,
 					cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),
@@ -1242,7 +1242,7 @@ func TestRequestAuditEvents(t *testing.T) {
 			AppName:       app.Metadata.Name,
 		},
 	}
-	require.Empty(t, cmp.Diff(
+	require.Empty(t, gocmp.Diff(
 		expectedEvent,
 		searchEvents[0],
 		cmpopts.IgnoreTypes(apievents.ServerMetadata{}, apievents.SessionMetadata{}, apievents.UserMetadata{}, apievents.ConnectionMetadata{}),

--- a/lib/srv/app/watcher.go
+++ b/lib/srv/app/watcher.go
@@ -53,8 +53,11 @@ func (s *Server) startReconciler(ctx context.Context) error {
 			case <-s.reconcileCh:
 				if err := reconciler.Reconcile(ctx); err != nil {
 					s.log.ErrorContext(ctx, "Failed to reconcile.", "error", err)
-				} else if s.c.OnReconcile != nil {
-					s.c.OnReconcile(s.getApps())
+				} else {
+					s.reconcileDoneOnce.Do(func() { close(s.reconcileDone) })
+					if s.c.OnReconcile != nil {
+						s.c.OnReconcile(s.getApps())
+					}
 				}
 			case <-ctx.Done():
 				s.log.DebugContext(ctx, "Reconciler done.")


### PR DESCRIPTION
Delete stale app server heartbeat records in the backend on startup so that
removed apps disappear immediately instead of lingering until TTL expiry (up to
15 minutes).

On SIGHUP reload, Teleport forks a new child process and the parent shuts down
without deleting its heartbeat records (to avoid a gap before the child starts
heartbeating). If an app was removed from config, the child never heartbeats it,
so the old record lingers until TTL expiry. 

This PR adds a cleanup step on startup that lists all app server records for
this host and deletes any that do not correspond to a currently running app. For
agents with dynamic apps (ResourceMatchers), cleanup waits for the first
successful reconciliation so that dynamic app records are not mistakenly
deleted. Integration-managed app servers (e.g. AWS OIDC) that share the host
UUID in all-in-one deployments are skipped. Cleanup is best-effort: if the auth
server is unreachable, it logs a warning and continues without blocking startup.

Issue: https://github.com/gravitational/teleport/issues/63771

## Manual Test Plan

### Test Environment

Local macOS, single-process enterprise Teleport (auth + proxy + app service)
with two static apps configured.

### Test 1: Orphaned app cleaned up on SIGHUP reload (with fix)

Start Teleport with both apps configured. Verify both appear in `tctl apps ls`.
Comment out `app-b` in config and send SIGHUP to reload. Wait a few seconds
for the child process to start, then run `tctl apps ls`.

- [x] Only `app-a` appears. `app-b` is cleaned up by the new child process.
- [x] Log contains: `Removed orphaned app server on startup. app:app-b`.

### Test 2: Regression baseline (without fix)

Build from master (before the fix) and repeat Test 1.

- [x] `app-b` still appears after SIGHUP reload and lingers until TTL expiry (~15 minutes).

### Test 3: Clean restart does not break anything (with fix)

Start Teleport with both apps, stop with Ctrl-C, remove `app-b` from config,
restart. (A clean shutdown sets `deleteResources=true`, so orphans may not
exist, but the startup cleanup path should not cause issues.)

- [x] Only `app-a` appears after restart.