### PR TITLE
app: Fix flaky TestAuthorizeWithLocks

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -110,9 +110,10 @@ type Suite struct {
 	appAWS                *types.AppV3
 	appAWSWithIntegration *types.AppV3
 
-	user       types.User
-	role       types.Role
-	serverPort string
+	user        types.User
+	role        types.Role
+	serverPort  string
+	lockWatcher *services.LockWatcher
 
 	login string
 }
@@ -339,7 +340,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	// Generate certificate for AWS console application with integration
 	s.awsConsoleCertificateWithIntegration = s.generateCertificate(t, s.user, "aws-integration.example.com", "arn:aws:iam::123456789012:role/readonly")
 
-	lockWatcher, err := services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
+	s.lockWatcher, err = services.NewLockWatcher(s.closeContext, services.LockWatcherConfig{
 		ResourceWatcherConfig: services.ResourceWatcherConfig{
 			Component: teleport.ComponentApp,
 			Client:    s.authClient,
@@ -349,12 +350,12 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	authorizer, err := authz.NewAuthorizer(authz.AuthorizerOpts{
 		ClusterName: "cluster-name",
 		AccessPoint: s.authClient,
-		LockWatcher: lockWatcher,
+		LockWatcher: s.lockWatcher,
 	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		lockWatcher.Close()
+		s.lockWatcher.Close()
 	})
 
 	apps := types.Apps{s.appFoo.Copy(), s.appAWS.Copy(), s.appAWSWithIntegration.Copy()}
@@ -1049,15 +1050,36 @@ func TestAuthorize(t *testing.T) {
 // a matching lock in force.
 func TestAuthorizeWithLocks(t *testing.T) {
 	s := SetUpSuite(t)
+
+	// Subscribe to the lock watcher before upserting so we can wait for the
+	// event deterministically.
+	lockWatch, err := s.lockWatcher.Subscribe(s.closeContext)
+	require.NoError(t, err)
+	defer lockWatch.Close()
+
 	// Create a lock targeting the user.
 	lock, err := types.NewLock("test-lock", types.LockSpecV2{
 		Target: types.LockTarget{User: s.user.GetName()},
 	})
 	require.NoError(t, err)
-	s.tlsServer.Auth().UpsertLock(s.closeContext, lock)
+	err = s.tlsServer.Auth().UpsertLock(s.closeContext, lock)
+	require.NoError(t, err)
 	defer func() {
-		s.tlsServer.Auth().DeleteLock(s.closeContext, lock.GetName())
+		err := s.tlsServer.Auth().DeleteLock(s.closeContext, lock.GetName())
+		assert.NoError(t, err)
 	}()
+
+	// Wait for the lock watcher to process the event before making the
+	// request. This follows the same subscribe-then-wait pattern used in
+	// lib/authz/permissions_test.go (upsertLockWithPutEvent).
+	require.Eventually(t, func() bool {
+		select {
+		case event := <-lockWatch.Events():
+			return event.Type == types.OpPut && event.Resource.GetName() == lock.GetName()
+		case <-lockWatch.Done():
+			return false
+		}
+	}, 2*time.Second, 100*time.Millisecond)
 
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)
@@ -1065,30 +1087,6 @@ func TestAuthorizeWithLocks(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "Forbidden", strings.TrimSpace(string(buf)))
 	})
-}
-
-// TestGetConfigForClient verifies that only the CAs of the requested cluster are returned.
-func TestGetConfigForClient(t *testing.T) {
-	// TODO(r0mant): Implement this.
-	t.Skip("Not Implemented")
-}
-
-// TestRewriteRequest verifies that requests are rewritten to include JWT headers.
-func TestRewriteRequest(t *testing.T) {
-	// TODO(r0mant): Implement this.
-	t.Skip("Not Implemented")
-}
-
-// TestRewriteResponse verifies that responses are rewritten if rewrite rules are specified.
-func TestRewriteResponse(t *testing.T) {
-	// TODO(r0mant): Implement this.
-	t.Skip("Not Implemented")
-}
-
-// TestSessionClose makes sure sessions are closed after the given session time period.
-func TestSessionClose(t *testing.T) {
-	// TODO(r0mant): Implement this.
-	t.Skip("Not Implemented")
 }
 
 // TestAWSConsoleRedirect verifies AWS management console access.

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -1072,14 +1072,20 @@ func TestAuthorizeWithLocks(t *testing.T) {
 	// Wait for the lock watcher to process the event before making the
 	// request. This follows the same subscribe-then-wait pattern used in
 	// lib/authz/permissions_test.go (upsertLockWithPutEvent).
-	require.Eventually(t, func() bool {
+	timeout := time.After(2 * time.Second)
+	for {
 		select {
 		case event := <-lockWatch.Events():
-			return event.Type == types.OpPut && event.Resource.GetName() == lock.GetName()
+			if event.Type == types.OpPut && event.Resource.GetName() == lock.GetName() {
+				goto ready
+			}
 		case <-lockWatch.Done():
-			return false
+			t.Fatal("lock watcher closed while waiting for lock event")
+		case <-timeout:
+			t.Fatal("timed out waiting for lock event")
 		}
-	}, 2*time.Second, 100*time.Millisecond)
+	}
+ready:
 
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -1072,20 +1072,17 @@ func TestAuthorizeWithLocks(t *testing.T) {
 	// Wait for the lock watcher to process the event before making the
 	// request. This follows the same subscribe-then-wait pattern used in
 	// lib/authz/permissions_test.go (upsertLockWithPutEvent).
-	timeout := time.After(2 * time.Second)
+loop:
 	for {
 		select {
 		case event := <-lockWatch.Events():
 			if event.Type == types.OpPut && event.Resource.GetName() == lock.GetName() {
-				goto ready
+				break loop
 			}
 		case <-lockWatch.Done():
 			t.Fatal("lock watcher closed while waiting for lock event")
-		case <-timeout:
-			t.Fatal("timed out waiting for lock event")
 		}
 	}
-ready:
 
 	s.checkHTTPResponse(t, s.clientCertificate, func(resp *http.Response) {
 		require.Equal(t, http.StatusForbidden, resp.StatusCode)


### PR DESCRIPTION
`TestAuthorizeWithLocks` is flaky because it calls `UpsertLock` and
immediately makes an HTTP request expecting 403. If the lock watcher hasn't
processed the event yet, the request gets 200 instead.

Fix by subscribing to the lock watcher before upserting and waiting for the
matching `OpPut` event before making the request. This follows the proven
subscribe-then-wait pattern from `lib/authz/permissions_test.go`
(`upsertLockWithPutEvent`). Also add error checking on `UpsertLock` and
`DeleteLock` calls that were previously silent.

The `require.Eventually` approach (wrapping the HTTP assertion in a retry
loop) would also fix the flake, but `checkHTTPResponse` takes `*testing.T`
(not the `require.TestingT` interface) and creates a new pipe and goroutine
per attempt - wasteful for what is really a synchronisation gap, not an
assertion timing issue.

Issue: https://github.com/gravitational/teleport/issues/64008

---

**Reproduction**

To widen the race window and reproduce the flake deterministically, add a
sleep at the top of [`lockCollector.processEventsAndUpdateCurrent`](https://github.com/gravitational/teleport/blob/8667c796695bb99afea797cad0564e808b9445ae/lib/services/watcher.go#L1174-L1175)
in `lib/services/watcher.go`:

```go
func (p *lockCollector) processEventsAndUpdateCurrent(ctx context.Context, events []types.Event) {
	time.Sleep(200 * time.Millisecond) // TEMPORARY: widen race window
	p.currentRW.Lock()
```

Then run on master (unfixed):

```
go test -run TestAuthorizeWithLocks -count=10 -timeout=5m ./lib/srv/app/...
```

Result: 10/10 failures (`expected: 403, actual: 200`, same as CI flakiness).

Same sleep with this fix applied: 10/10 pass.
