### PR TITLE
Add disableDependencyDashboard to Renovate config so PRs are created automatically

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
     "branch/v17"
   ],
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":disableDependencyDashboard"
   ],
   "enabledManagers": [
     "custom.regex"


### PR DESCRIPTION
I forgot to disable the [Dependency Dashboard](https://docs.renovatebot.com/key-concepts/dashboard/) feature in https://github.com/gravitational/teleport/pull/64024. I had issues disabled in my forked test repo so I didn't see this issue until we merged the change to this repo we we have it enabled.

This change will make Renovate go straight to opening a PR versus opening an issue, [like this](https://github.com/gravitational/teleport/issues/64031), for approval before it creates a PR.

Docs for this config preset is [here](https://docs.renovatebot.com/presets-default/#disabledependencydashboard).

## Manual tests

- [x] Enable issues in [test repo](https://github.com/cthach/teleport). Run Renovate and confirm it opens PRs instead of an issue. 

<img width="1296" height="493" alt="Screenshot 2026-02-20 at 4 36 33 PM" src="https://github.com/user-attachments/assets/af0f467f-cca1-47c4-9646-5d9a33708326" />

Workflow test run: https://github.com/cthach/teleport/actions/runs/22242060846

