### PR TITLE
test: stabilize TestIntegrations/SessionRecordingModes by isolating per-subtest user/role state

### DIFF
--- a/integration/helpers/fixture.go
+++ b/integration/helpers/fixture.go
@@ -54,7 +54,6 @@ func NewFixture(t *testing.T) *Fixture {
 	fixture.Priv, fixture.Pub, err = testauthority.GenerateKeyPair()
 	require.NoError(t, err)
 
-	// Find AllocatePortsNum free listening ports to use.
 	fixture.Me, err = user.Current()
 	require.NoError(t, err)
 

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1525,6 +1525,7 @@ func (i *TeleInstance) NewUnauthenticatedClient(cfg ClientConfig) (tc *client.Te
 		Stdout:                        cfg.Stdout,
 		NonInteractive:                true,
 		DisableSSHResumption:          cfg.DisableSSHResumption,
+		AddKeysToAgent:                client.AddKeysToAgentNo,
 	}
 
 	// JumpHost turns on jump host mode


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/48043

`TestIntegrations/SessionRecordingModes` was flaky because the subtests reused the same Teleport user and role while switching recording mode between `strict` and `best_effort`. Under cache propagation delay/staleness, one subtest could observe the previous subtest’s role state, causing incorrect behavior (for example, `BestEffortMode` failing with `ssh: could not start shell` as if strict mode was still active).

To reproduce, I introduced a temporary cache fault to drop role update events after initial cache population. With `StrictMode` run before `BestEffortMode`, that reliably reproduced the failure by forcing stale role reads in later subtests.

The fix removes shared mutable identity state from the test:
- create a unique Teleport user per mode subtest
- create a unique role per mode subtest

This makes each subtest use a unique role that can't be stale in the cache, if the SSH authorizer gets a NotFound when trying to read from the cache it will fall back to an uncached read. Using a unique username might help in case the user's roleset is cached too.

Validation:
- with the temporary cache fault enabled, the old test shape reproduced the failure while the isolated user/role version passed
- after removing the temporary fault, `go test ./integration -run 'TestIntegrations/SessionRecordingModes' -count=50` passes with the final code

After running this a bunch of times I also noticed it was adding the identity to my local SSH agent for every test run (it broke my github SSH access). So I added `AddKeysToAgent: client.AddKeysToAgentNo` in the integration test helper.