### PR TITLE
[v18] chore: add in-process bufconn transport for authtest.TLSServer

### DIFF
--- a/lib/auth/auth_test.go
+++ b/lib/auth/auth_test.go
@@ -93,6 +93,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/log/logtest"
 	"github.com/gravitational/teleport/lib/utils/slices"
+	"github.com/gravitational/teleport/lib/utils/testutils/synctest"
 )
 
 type testPack struct {
@@ -4667,13 +4668,18 @@ func TestCleanupNotifications(t *testing.T) {
 }
 
 func TestCreateAccessListReminderNotifications(t *testing.T) {
+	synctest.Test(t, testCreateAccessListReminderNotifications)
+}
+
+func testCreateAccessListReminderNotifications(t *testing.T) {
 	ctx := context.Background()
 
 	modulestest.SetTestModules(t, *modulestest.EnterpriseModules())
 
 	// Setup test auth server
-	testServer := newTestTLSServer(t)
+	testServer := newTestTLSServer(t, withBufconnListener())
 	authServer := testServer.Auth()
+	defer testServer.Close()
 
 	testRole, err := types.NewRole("test", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -4694,6 +4700,7 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 
 	client, err := testServer.NewClient(authtest.TestUser(testUsername))
 	require.NoError(t, err)
+	defer client.Close()
 
 	// Create access lists with different expiry times
 	accessLists := []struct {
@@ -4748,26 +4755,20 @@ func TestCreateAccessListReminderNotifications(t *testing.T) {
 	}
 
 	// Check notifications
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind))
-	}, 5*time.Minute, 500*time.Millisecond)
+	synctest.Wait()
+	resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind))
 
 	// Run CreateAccessListReminderNotifications() again to verify no duplicates are created
 	authServer.CreateAccessListReminderNotifications(ctx, auth.WithCreateNotificationInterval(time.Nanosecond))
 
 	// Check notifications again, counts should remain the same.
-	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		resp, err := client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind),
-			"notifications should not have changed after second reconciliation")
-	}, 5*time.Minute, 500*time.Millisecond)
+	synctest.Wait()
+	resp, err = client.ListNotifications(ctx, &notificationsv1.ListNotificationsRequest{})
+	require.NoError(t, err)
+	assert.ElementsMatch(t, expectedSubKinds, slices.Map(resp.Notifications, reminderNotificationSubKind),
+		"notifications should not have changed after second reconciliation")
 }
 
 type createAccessListOptions struct {

--- a/lib/auth/authtest/authtest.go
+++ b/lib/auth/authtest/authtest.go
@@ -34,6 +34,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
+	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
@@ -888,6 +889,20 @@ func WithAccessGraphConfig(config auth.AccessGraphConfig) TestTLSServerOption {
 	}
 }
 
+// WithBufconnListener configures the auth test server to use a gRPC bufconn
+// listener and dialer instead of loopback TCP. This is useful with synctest
+// where real TCP listeners are not durably blocking.
+func WithBufconnListener() TestTLSServerOption {
+	const testBufconnSize = 1024
+	return func(cfg *TLSServerConfig) {
+		listener := bufconn.Listen(testBufconnSize)
+		cfg.Listener = listener
+		cfg.AuthDialer = client.ContextDialerFunc(func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		})
+	}
+}
+
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *AuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*authclient.Client, error) {
@@ -920,6 +935,8 @@ type TLSServerConfig struct {
 	Limiter *limiter.Config
 	// Listener is a listener to serve requests on
 	Listener net.Listener
+	// AuthDialer is a dialer to use when making auth clients.
+	AuthDialer client.ContextDialer
 	// AcceptedUsage is a list of accepted usage restrictions
 	AcceptedUsage []string
 }
@@ -989,9 +1006,11 @@ func NewTestTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 	tlsCert := tlsConfig.Certificates[0]
 
-	srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, trace.Wrap(err)
+	if srv.Listener == nil {
+		srv.Listener, err = net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	srv.TLSServer, err = auth.NewTLSServer(context.Background(), auth.TLSServerConfig{
@@ -1154,7 +1173,8 @@ func (t *TLSServer) NewClientFromWebSession(sess types.WebSession) (*authclient.
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 
 	return authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1209,7 +1229,8 @@ func (t *TLSServer) CloneClient(tt *testing.T, clt *authclient.Client) *authclie
 	}
 
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1232,7 +1253,8 @@ func (t *TLSServer) NewClientWithCert(clientCert tls.Certificate) (*authclient.C
 	tlsConfig.Time = t.AuthServer.AuthServer.GetClock().Now
 	tlsConfig.Certificates = []tls.Certificate{clientCert}
 	newClient, err := authclient.NewClient(client.Config{
-		Addrs: []string{t.Addr().String()},
+		Addrs:  []string{t.Addr().String()},
+		Dialer: t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
@@ -1263,6 +1285,7 @@ func (t *TLSServer) NewClient(identity TestIdentity) (*authclient.Client, error)
 	newClient, err := authclient.NewClient(client.Config{
 		DialInBackground: true,
 		Addrs:            []string{t.Addr().String()},
+		Dialer:           t.AuthDialer,
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -5690,9 +5690,10 @@ func verifyJWTAWSOIDC(clock clockwork.Clock, clusterName string, pairs []*types.
 }
 
 type testTLSServerOptions struct {
-	cacheEnabled bool
-	accessGraph  *auth.AccessGraphConfig
-	clock        clockwork.Clock
+	cacheEnabled    bool
+	accessGraph     *auth.AccessGraphConfig
+	clock           clockwork.Clock
+	bufconnListener bool
 }
 
 type testTLSServerOption func(*testTLSServerOptions)
@@ -5712,6 +5713,11 @@ func withAccessGraphConfig(cfg auth.AccessGraphConfig) testTLSServerOption {
 func withClock(clock clockwork.Clock) testTLSServerOption {
 	return func(options *testTLSServerOptions) {
 		options.clock = clock
+	}
+}
+func withBufconnListener() testTLSServerOption {
+	return func(options *testTLSServerOptions) {
+		options.bufconnListener = true
 	}
 }
 
@@ -5739,6 +5745,9 @@ func newTestTLSServer(t testing.TB, opts ...testTLSServerOption) *authtest.TLSSe
 	var tlsServerOpts []authtest.TestTLSServerOption
 	if options.accessGraph != nil {
 		tlsServerOpts = append(tlsServerOpts, authtest.WithAccessGraphConfig(*options.accessGraph))
+	}
+	if options.bufconnListener {
+		tlsServerOpts = append(tlsServerOpts, authtest.WithBufconnListener())
 	}
 	srv, err := as.NewTestTLSServer(tlsServerOpts...)
 	require.NoError(t, err)

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -137,10 +137,11 @@ func (l *Limiter) UnaryServerInterceptorWithCustomRate(customRate CustomRateFunc
 		if !ok {
 			return nil, trace.AccessDenied("missing peer info")
 		}
+
 		// Limit requests per second and simultaneous connection by client IP.
-		clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+		clientIP, err := clientIPFromPeer(peerInfo)
 		if err != nil {
-			return nil, trace.BadParameter("missing client IP")
+			return nil, trace.Wrap(err)
 		}
 		if err := l.RegisterRequestWithCustomRate(clientIP, customRate(info.FullMethod)); err != nil {
 			return nil, trace.LimitExceeded("rate limit exceeded")
@@ -161,9 +162,9 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 		return trace.AccessDenied("missing peer info")
 	}
 	// Limit requests per second and simultaneous connection by client IP.
-	clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	clientIP, err := clientIPFromPeer(peerInfo)
 	if err != nil {
-		return trace.BadParameter("missing client IP")
+		return trace.Wrap(err)
 	}
 	if err := l.RegisterRequest(clientIP); err != nil {
 		return trace.LimitExceeded("rate limit exceeded")
@@ -173,6 +174,21 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 	}
 	defer l.connectionLimiter.ReleaseConnection(clientIP)
 	return handler(srv, serverStream)
+}
+
+func clientIPFromPeer(peerInfo *peer.Peer) (string, error) {
+	clientIP, _, err := net.SplitHostPort(peerInfo.Addr.String())
+	if err == nil {
+		return clientIP, nil
+	}
+
+	// bufconn peers don't include host:port, so use a stable synthetic key
+	// for request/connection limiting in tests.
+	if peerInfo.Addr.Network() == "bufconn" && peerInfo.Addr.String() == "bufconn" {
+		return "bufconn", nil
+	}
+
+	return "", trace.BadParameter("missing client IP")
 }
 
 // WrapListener returns a [Listener] that wraps the provided listener


### PR DESCRIPTION
Backport #63942 to branch/v18