### PR TITLE
Fix logs from reexecuted processes not being logged in tests

### DIFF
--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -612,28 +612,36 @@ func NewServerContext(ctx context.Context, parent *sshutils.ConnectionContext, s
 	if fileWriter, ok := logCfg.Writer.(*os.File); ok {
 		child.logw = fileWriter
 	} else {
-		// Create a pipe so we can pass the writing side as an *os.File to the child process.
-		// Then we can copy from the reading side to the log writer (e.g. syslog, log file w/ concurrency protection).
-		r, w, err := os.Pipe()
-		if err != nil {
-			childErr := child.Close()
-			return nil, trace.NewAggregate(err, childErr)
+		if err := child.streamChildLogs(logCfg.Writer); err != nil {
+			return nil, trace.Wrap(err)
 		}
-
-		child.logw = w
-		child.AddCloser(r)
-		child.AddCloser(w)
-
-		// Copy logs from the child process to the parent process over
-		// the pipe until it is closed by the child context.
-		go func() {
-			if _, err := io.Copy(logCfg.Writer, r); err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
-				slog.ErrorContext(child.CancelContext(), "Failed to copy logs over pipe", "error", err)
-			}
-		}()
 	}
 
 	return child, nil
+}
+
+func (c *ServerContext) streamChildLogs(logCfgWriter io.Writer) error {
+	// Create a pipe so we can pass the writing side as an *os.File to the child process.
+	// Then we can copy from the reading side to the log writer (e.g. syslog, log file w/ concurrency protection).
+	r, w, err := os.Pipe()
+	if err != nil {
+		childErr := c.Close()
+		return trace.NewAggregate(err, childErr)
+	}
+
+	c.logw = w
+	c.AddCloser(r)
+	c.AddCloser(w)
+
+	// Copy logs from the child process to the parent process over
+	// the pipe until it is closed by the child context.
+	go func() {
+		if _, err := io.Copy(logCfgWriter, r); err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, os.ErrClosed) {
+			slog.ErrorContext(c.CancelContext(), "Failed to copy logs over pipe", "error", err)
+		}
+	}()
+
+	return nil
 }
 
 // Parent grants access to the connection-level context of which this

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -566,10 +566,8 @@ func (s *Server) GetLockWatcher() *services.LockWatcher {
 // does not spawn child processes.
 func (s *Server) ChildLogConfig() srv.ChildLogConfig {
 	return srv.ChildLogConfig{
-		ExecLogConfig: srv.ExecLogConfig{
-			Level: &slog.LevelVar{},
-		},
-		Writer: io.Discard,
+		ExecLogConfig: srv.ExecLogConfig{},
+		Writer:        io.Discard,
 	}
 }
 

--- a/lib/srv/git/forward.go
+++ b/lib/srv/git/forward.go
@@ -670,6 +670,7 @@ func makeRemoteSigner(ctx context.Context, cfg *ForwardServerConfig, identityCtx
 func (s *ForwardServer) Context() context.Context {
 	return s.cfg.ParentContext
 }
+
 func (s *ForwardServer) EventMetadata() apievents.ServerMetadata {
 	return apievents.ServerMetadata{
 		ServerVersion:   teleport.Version,
@@ -680,60 +681,79 @@ func (s *ForwardServer) EventMetadata() apievents.ServerMetadata {
 		ServerSubKind:   s.cfg.TargetServer.GetSubKind(),
 	}
 }
+
 func (s *ForwardServer) GetInfo() types.Server {
 	return s.cfg.TargetServer
 }
+
 func (s *ForwardServer) ID() string {
 	return s.id
 }
+
 func (s *ForwardServer) HostUUID() string {
 	return s.cfg.HostUUID
 }
+
 func (s *ForwardServer) GetNamespace() string {
 	return s.cfg.TargetServer.GetNamespace()
 }
+
 func (s *ForwardServer) AdvertiseAddr() string {
 	return s.clientConn.RemoteAddr().String()
 }
+
 func (s *ForwardServer) Component() string {
 	return teleport.ComponentForwardingGit
 }
+
 func (s *ForwardServer) PermitUserEnvironment() bool {
 	return false
 }
+
 func (s *ForwardServer) GetAccessPoint() srv.AccessPoint {
 	return s.cfg.AccessPoint
 }
+
 func (s *ForwardServer) GetDataDir() string {
 	return ""
 }
+
 func (s *ForwardServer) GetPAM() *servicecfg.PAMConfig {
 	return &servicecfg.PAMConfig{Enabled: false}
 }
+
 func (s *ForwardServer) GetClock() clockwork.Clock {
 	return s.cfg.Clock
 }
+
 func (s *ForwardServer) UseTunnel() bool {
 	return false
 }
+
 func (s *ForwardServer) GetBPF() bpf.BPF {
 	return nil
 }
+
 func (s *ForwardServer) GetUserAccountingPaths() (utmp, wtmp, btmp, wtmpdb string) {
 	return
 }
+
 func (s *ForwardServer) GetLockWatcher() *services.LockWatcher {
 	return s.cfg.LockWatcher
 }
+
 func (s *ForwardServer) GetCreateHostUser() bool {
 	return false
 }
+
 func (s *ForwardServer) GetHostUsers() srv.HostUsers {
 	return nil
 }
+
 func (s *ForwardServer) GetHostSudoers() srv.HostSudoers {
 	return nil
 }
+
 func (s *ForwardServer) GetSELinuxEnabled() bool {
 	return false
 }
@@ -742,10 +762,8 @@ func (s *ForwardServer) GetSELinuxEnabled() bool {
 // does not spawn child processes.
 func (s *ForwardServer) ChildLogConfig() srv.ChildLogConfig {
 	return srv.ChildLogConfig{
-		ExecLogConfig: srv.ExecLogConfig{
-			Level: &slog.LevelVar{},
-		},
-		Writer: io.Discard,
+		ExecLogConfig: srv.ExecLogConfig{},
+		Writer:        io.Discard,
 	}
 }
 

--- a/lib/srv/mock_test.go
+++ b/lib/srv/mock_test.go
@@ -108,8 +108,12 @@ func newTestServerContext(t *testing.T, srv Server, sessionJoiningRoleSet servic
 	scx.cmdr, scx.cmdw, err = os.Pipe()
 	require.NoError(t, err)
 
-	_, scx.logw, err = os.Pipe()
-	require.NoError(t, err)
+	logCfgWriter := srv.ChildLogConfig().Writer
+	if fileWriter, ok := logCfgWriter.(*os.File); ok {
+		scx.logw = fileWriter
+	} else {
+		require.NoError(t, scx.streamChildLogs(logCfgWriter))
+	}
 
 	scx.contr, scx.contw, err = os.Pipe()
 	require.NoError(t, err)
@@ -345,9 +349,10 @@ func (m *mockServer) GetSELinuxEnabled() bool {
 func (m *mockServer) ChildLogConfig() ChildLogConfig {
 	return ChildLogConfig{
 		ExecLogConfig: ExecLogConfig{
-			Level: &slog.LevelVar{},
+			Level:  slog.LevelDebug,
+			Format: "json",
 		},
-		Writer: io.Discard,
+		Writer: os.Stdout,
 	}
 }
 

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -191,7 +191,7 @@ type ExecCommand struct {
 // needs to be passed to the child.
 type ExecLogConfig struct {
 	// Level is the log level to use.
-	Level *slog.LevelVar
+	Level slog.Level
 	// Format defines the output format. Possible values are 'text' and 'json'.
 	Format string
 	// ExtraFields lists the output fields from KnownFormatFields. Example format: [timestamp, component, caller].
@@ -320,7 +320,6 @@ func RunCommand() (code int, err error) {
 	}
 
 	if err := auditd.SendEvent(auditd.AuditUserLogin, auditd.Success, auditdMsg); err != nil {
-		// Currently, this logs nothing. Related issue https://github.com/gravitational/teleport/issues/17318
 		slog.DebugContext(ctx, "failed to send user start event to auditd", "error", err)
 	}
 
@@ -355,6 +354,8 @@ func RunCommand() (code int, err error) {
 	// launch the shell under.
 	var pamEnvironment []string
 	if c.PAMConfig != nil {
+		slog.DebugContext(ctx, "Opening PAM context")
+
 		// Connect std{in,out,err} to the TTY if a terminal has been allocated,
 		// otherwise discard std{out,err}. If this was not done, things like MOTD
 		// would be printed for non-interactive "exec" requests.
@@ -485,7 +486,7 @@ func RunCommand() (code int, err error) {
 		// the thread as we're exiting after the child exits, and
 		// we want to avoid another goroutine getting denied due to
 		// running on this thread with a different (likely much more
-		// restrictive)SELinux context.
+		// restrictive) SELinux context.
 		runtime.LockOSThread()
 		if err := ocselinux.SetExecLabel(seContext); err != nil {
 			return teleport.RemoteCommandFailure, trace.Wrap(err, "failed to set SELinux context")

--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -544,7 +544,7 @@ func setAuditSessionID(ctx context.Context, c ExecCommand, preLoginUID []byte, l
 			return trace.Wrap(err)
 		}
 
-		slog.DebugContext(ctx, "Audit login session IDs", "old", oldID, "new", newID)
+		slog.DebugContext(ctx, "Audit login session IDs", "old", string(oldID), "new", string(newID))
 		// If the audit login session IDs are the same, the session ID
 		// was not changed and ESR logging will not work correctly.
 		if bytes.Equal(oldID, newID) {

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -369,10 +369,8 @@ func (s *Server) ChildLogConfig() srv.ChildLogConfig {
 
 	// return a noop log configuration
 	return srv.ChildLogConfig{
-		ExecLogConfig: srv.ExecLogConfig{
-			Level: &slog.LevelVar{},
-		},
-		Writer: io.Discard,
+		ExecLogConfig: srv.ExecLogConfig{},
+		Writer:        io.Discard,
 	}
 }
 
@@ -826,7 +824,7 @@ func SetChildLogConfig(cfg *servicecfg.Config) ServerOption {
 	return func(s *Server) error {
 		s.childLogConfig = &srv.ChildLogConfig{
 			ExecLogConfig: srv.ExecLogConfig{
-				Level:        cfg.LoggerLevel,
+				Level:        cfg.LoggerLevel.Level(),
 				Format:       strings.ToLower(cfg.LogConfig.Format),
 				ExtraFields:  cfg.LogConfig.ExtraFields,
 				EnableColors: cfg.LogConfig.EnableColors,

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -187,11 +187,9 @@ func (f *sshTestFixture) newSSHClient(ctx context.Context, t testing.TB, user *u
 
 func setChildLogConfigForTest() ServerOption {
 	return func(s *Server) error {
-		level := new(slog.LevelVar)
-		level.Set(slog.LevelDebug)
 		s.childLogConfig = &srv.ChildLogConfig{
 			ExecLogConfig: srv.ExecLogConfig{
-				Level: level,
+				Level: slog.LevelDebug,
 			},
 			Writer: os.Stderr,
 		}

--- a/lib/srv/regular/sshserver_unix_test.go
+++ b/lib/srv/regular/sshserver_unix_test.go
@@ -71,7 +71,7 @@ func BenchmarkRootExecCommand(b *testing.B) {
 				func(s *Server) error {
 					s.childLogConfig = &srv.ChildLogConfig{
 						ExecLogConfig: srv.ExecLogConfig{
-							Level: &slog.LevelVar{},
+							Level: slog.LevelError,
 						},
 						Writer: io.Discard,
 					}


### PR DESCRIPTION
Before change:

```
go test -run TestContinue -v ./lib/srv
=== RUN   TestContinue
{"timestamp":"2026-03-24T20:00:42-04:00","level":"warning","caller":"auth/auth.go:930","message":"Auth server starting without cache (may have negative performance implications)","component":"auth"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"debug","caller":"backend/buffer.go:278","message":"Adding watcher","component":"buffer","watcher":"Watcher(name=scoped-access-cache, prefixes=[/scoped_role/assignment/ /scoped_role/role/], capacity=1024, size=0)"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"info","caller":"access/access.go:298","message":"scoped access cache fetched initial state","elapsed":93001}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"info","caller":"access/access.go:305","message":"scoped access cache successfully initialized"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"debug","caller":"srv/term.go:502","message":"Set permissions on tty","component":"term:local","tty_name":"/dev/pts/5","uid":1000,"gid":5,"mode":"-rw-------"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"debug","caller":"srv/term.go:366","message":"Closing TTY","component":"term:local"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"debug","caller":"srv/term.go:375","message":"Closed TTY","component":"term:local"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"debug","caller":"srv/term.go:395","message":"Closed PTY","component":"term:local"}
{"timestamp":"2026-03-24T20:00:42-04:00","level":"info","caller":"access/access.go:229","message":"scoped access cache closing"}
--- PASS: TestContinue (0.03s)
PASS
ok      github.com/gravitational/teleport/lib/srv       0.059s
```

After change:

```
go test -run TestContinue -v ./lib/srv 
=== RUN   TestContinue
{"timestamp":"2026-03-24T19:59:44-04:00","level":"warning","caller":"auth/auth.go:930","message":"Auth server starting without cache (may have negative performance implications)","component":"auth"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"backend/buffer.go:278","message":"Adding watcher","component":"buffer","watcher":"Watcher(name=scoped-access-cache, prefixes=[/scoped_role/assignment/ /scoped_role/role/], capacity=1024, size=0)"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"info","caller":"access/access.go:298","message":"scoped access cache fetched initial state","elapsed":40777}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"info","caller":"access/access.go:305","message":"scoped access cache successfully initialized"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"srv/term.go:502","message":"Set permissions on tty","component":"term:local","tty_name":"/dev/pts/5","uid":1000,"gid":5,"mode":"-rw-------"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"uacc/uacc.go:78","message":"utmp user accounting is active","component":"reexec"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"host/hostusers.go:404","message":"Creating process with ambient credentials","component":"reexec","uid":1000,"gid":1000,"groups":[1000,4,27,121,134,3000]}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"srv/reexec.go:500","message":"Started command","component":"reexec"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"srv/term.go:366","message":"Closing TTY","component":"term:local"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"srv/term.go:375","message":"Closed TTY","component":"term:local"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"debug","caller":"srv/term.go:395","message":"Closed PTY","component":"term:local"}
{"timestamp":"2026-03-24T19:59:44-04:00","level":"info","caller":"access/access.go:229","message":"scoped access cache closing"}
--- PASS: TestContinue (0.03s)
PASS
ok      github.com/gravitational/teleport/lib/srv       0.050s
```