### PR TITLE
[v18] scoped token tctl updates

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -5996,6 +5996,11 @@ func (c *Client) ListScopedTokens(ctx context.Context, req *joiningv1.ListScoped
 	return res, trace.Wrap(err)
 }
 
+func (c *Client) GetScopedToken(ctx context.Context, req *joiningv1.GetScopedTokenRequest) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.GetScopedToken(ctx, req)
+	return res.GetToken(), trace.Wrap(err)
+}
+
 // DeleteScopedToken deletes an existing scoped token.
 func (c *Client) DeleteScopedToken(ctx context.Context, name string) error {
 	_, err := c.grpc.DeleteScopedToken(ctx, &joiningv1.DeleteScopedTokenRequest{
@@ -6007,6 +6012,13 @@ func (c *Client) DeleteScopedToken(ctx context.Context, name string) error {
 // CreateScopedToken creates a new scoped token.
 func (c *Client) CreateScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
 	res, err := c.grpc.CreateScopedToken(ctx, &joiningv1.CreateScopedTokenRequest{
+		Token: token,
+	})
+	return res.GetToken(), trace.Wrap(err)
+}
+
+func (c *Client) UpsertScopedToken(ctx context.Context, token *joiningv1.ScopedToken) (*joiningv1.ScopedToken, error) {
+	res, err := c.grpc.UpsertScopedToken(ctx, &joiningv1.UpsertScopedTokenRequest{
 		Token: token,
 	})
 	return res.GetToken(), trace.Wrap(err)

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -303,6 +303,8 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindRelayServer, nil
 	case types.KindWorkloadCluster, types.KindWorkloadCluster + "s":
 		return types.KindWorkloadCluster, nil
+	case scopedaccess.KindScopedToken, scopedaccess.KindScopedToken + "s", "scopedtoken", "scopedtokens":
+		return scopedaccess.KindScopedToken, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -19,6 +19,7 @@
 package common
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -43,6 +44,7 @@ import (
 	loginrulepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/loginrule/v1"
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -2223,12 +2225,54 @@ func (c *scopedRoleAssignmentCollection) writeText(w io.Writer, verbose bool) er
 	return trace.Wrap(err)
 }
 
+type scopedTokenCollection struct {
+	tokens []*joiningv1.ScopedToken
+}
+
+func (c *scopedTokenCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.tokens))
+	for i, resource := range c.tokens {
+		r[i] = types.ProtoResource153ToLegacy(resource)
+	}
+	return r
+}
+
+func (c *scopedTokenCollection) writeText(w io.Writer, verbose bool) error {
+	// when calling the getScopedToken, the secrets would already have been properly hidden or exposed.
+	_, err := scopedTokenTextHelper(c.tokens, false).WriteTo(w)
+	return trace.Wrap(err)
+}
+
 type autoUpdateBotInstanceReportCollection struct {
 	report *autoupdatev1pb.AutoUpdateBotInstanceReport
 }
 
 func (c *autoUpdateBotInstanceReportCollection) resources() []types.Resource {
 	return []types.Resource{types.ProtoResource153ToLegacy(c.report)}
+}
+
+func scopedTokenTextHelper(tokens []*joiningv1.ScopedToken, withSecrets bool) *bytes.Buffer {
+	table := asciitable.MakeTable([]string{"Token", "Secret", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
+
+	secretFunc := func(t *joiningv1.ScopedToken) string {
+		if withSecrets {
+			return t.GetStatus().GetSecret()
+		}
+		return "******"
+	}
+
+	now := time.Now()
+	for _, t := range tokens {
+		expiry := "never"
+		expiresAt := t.GetMetadata().GetExpires().AsTime()
+		if !expiresAt.IsZero() && expiresAt.Unix() != 0 {
+			exptime := expiresAt.Format(time.RFC822)
+			expdur := expiresAt.Sub(now).Round(time.Second)
+			expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
+		}
+		table.AddRow([]string{t.GetMetadata().GetName(), secretFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), printMetadataLabels(t.GetMetadata().Labels), expiry})
+	}
+	return table.AsBuffer()
 }
 
 func (c *autoUpdateBotInstanceReportCollection) writeText(w io.Writer, _ bool) error {

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -55,6 +55,7 @@ import (
 	machineidv1pb "github.com/gravitational/teleport/api/gen/proto/go/teleport/machineid/v1"
 	pluginsv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	usertasksv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/usertasks/v1"
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/vnet/v1"
@@ -199,6 +200,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindInferencePolicy:                    rc.createInferencePolicy,
 		scopedaccess.KindScopedRole:                  rc.createScopedRole,
 		scopedaccess.KindScopedRoleAssignment:        rc.createScopedRoleAssignment,
+		scopedaccess.KindScopedToken:                 rc.createScopedToken,
 	}
 	rc.UpdateHandlers = map[ResourceKind]ResourceCreateHandler{
 		types.KindUser:                               rc.updateUser,
@@ -229,6 +231,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, _ *tctlcfg.Globa
 		types.KindInferencePolicy:                    rc.updateInferencePolicy,
 		scopedaccess.KindScopedRole:                  rc.updateScopedRole,
 		scopedaccess.KindScopedRoleAssignment:        rc.updateScopedRoleAssignment,
+		scopedaccess.KindScopedToken:                 rc.updateScopedToken,
 	}
 	rc.config = config
 
@@ -1283,6 +1286,34 @@ func (rc *ResourceCommand) updateScopedRole(ctx context.Context, client *authcli
 	return nil
 }
 
+func (rc *ResourceCommand) createScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	verb := "created"
+	r, err := services.UnmarshalProtoResource[*joiningv1.ScopedToken](raw.Raw, services.DisallowUnknown())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	var token *joiningv1.ScopedToken
+	if rc.IsForced() {
+		token, err = client.UpsertScopedToken(ctx, r)
+		verb = "updated"
+	} else {
+		token, err = client.CreateScopedToken(ctx, r)
+	}
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf(
+		"%v %q has been %s\n",
+		types.KindScopedToken,
+		token.GetMetadata().GetName(),
+		verb,
+	)
+
+	return nil
+}
+
 func (rc *ResourceCommand) createScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	if rc.IsForced() {
 		return trace.BadParameter("scoped role assignment creation does not support --force")
@@ -1311,6 +1342,10 @@ func (rc *ResourceCommand) createScopedRoleAssignment(ctx context.Context, clien
 
 func (rc *ResourceCommand) updateScopedRoleAssignment(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
 	return trace.NotImplemented("scoped_role_assignment resources do not support updates")
+}
+
+func (rc *ResourceCommand) updateScopedToken(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
+	return trace.NotImplemented("scoped_token resources do not support updates")
 }
 
 func (rc *ResourceCommand) createSigstorePolicy(ctx context.Context, client *authclient.Client, raw services.UnknownResource) error {
@@ -2336,6 +2371,16 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client *authclient.Client
 			scopedaccess.KindScopedRoleAssignment+" %q has been deleted\n",
 			rc.ref.Name,
 		)
+	case scopedaccess.KindScopedToken:
+		if err := client.DeleteScopedToken(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf(
+			"%v %q has been deleted\n",
+			types.KindScopedToken,
+			rc.ref.Name,
+		)
+		return nil
 	case types.KindSigstorePolicy:
 		c := client.SigstorePolicyResourceServiceClient()
 		if _, err := c.DeleteSigstorePolicy(
@@ -3792,6 +3837,44 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client *authclient
 			return nil, trace.Wrap(err)
 		}
 		return &scopedRoleAssignmentCollection{items: items}, nil
+	case scopedaccess.KindScopedToken:
+		// If a specific token name is requested, filter the results
+		if rc.ref.Name != "" {
+			token, err := client.GetScopedToken(ctx, &joiningv1.GetScopedTokenRequest{
+				Name:       rc.ref.Name,
+				WithSecret: rc.withSecrets,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if !rc.withSecrets {
+				token.GetStatus().Secret = "******"
+			}
+			return &scopedTokenCollection{[]*joiningv1.ScopedToken{token}}, nil
+		}
+
+		tokens, err := stream.Collect(clientutils.Resources(ctx, func(ctx context.Context, pageSize int, pageKey string) ([]*joiningv1.ScopedToken, string, error) {
+			res, err := client.ListScopedTokens(ctx, &joiningv1.ListScopedTokensRequest{
+				Limit:       uint32(pageSize),
+				Cursor:      pageKey,
+				WithSecrets: rc.withSecrets,
+			})
+			if err != nil {
+				return nil, "", trace.Wrap(err)
+			}
+			if !rc.withSecrets {
+				for _, token := range res.GetTokens() {
+					token.GetStatus().Secret = "******"
+				}
+			}
+
+			return res.GetTokens(), res.GetCursor(), nil
+		}))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return &scopedTokenCollection{tokens: tokens}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/gravitational/teleport/api/gen/proto/go/teleport/autoupdate/v1"
 	headerv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/header/v1"
 	scopedaccessv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/access/v1"
+	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	userprovisioningpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/userprovisioning/v2"
 	"github.com/gravitational/teleport/api/types"
 	apicommon "github.com/gravitational/teleport/api/types/common"
@@ -524,6 +525,135 @@ version: v1
 		case <-time.After(time.Millisecond * 100):
 		}
 	}
+}
+
+func TestScopedToken(t *testing.T) {
+	const scopedTokenYAML = `kind: scoped_token
+version: v1
+metadata:
+  name: test-token
+scope: "/"
+spec:
+  roles:
+    - Node
+  assigned_scope: "/foo"
+  join_method: "token"
+  usage_mode: "unlimited"
+`
+
+	t.Setenv("TELEPORT_UNSTABLE_SCOPES", "yes")
+
+	dynAddr := helpers.NewDynamicServiceAddr(t)
+
+	fileConfig := &config.FileConfig{
+		Global: config.Global{
+			DataDir: t.TempDir(),
+		},
+		Proxy: config.Proxy{
+			Service: config.Service{
+				EnabledFlag: "true",
+			},
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
+		},
+		Auth: config.Auth{
+			Service: config.Service{
+				EnabledFlag:   "true",
+				ListenAddress: dynAddr.AuthAddr,
+			},
+		},
+	}
+
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
+	clt, err := testenv.NewDefaultAuthClient(auth)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = clt.Close() })
+
+	scopedTokenYAMLPath := filepath.Join(t.TempDir(), "test-token.yaml")
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, []byte(scopedTokenYAML), 0644))
+
+	// Create the scoped token
+	_, err = runResourceCommand(t, clt, []string{"create", scopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// wait for cache propagation
+	var raw []byte
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		// Get the scoped token by name
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		require.NoError(t, err)
+		raw = buff.Bytes()
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
+
+	tokens, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](raw, services.DisallowUnknown())
+	require.NoError(t, err)
+	require.Len(t, tokens, 1)
+
+	// Compare with expected value
+	token := tokens[0]
+	require.Equal(t, types.KindScopedToken, token.GetKind())
+	require.Equal(t, "test-token", token.GetMetadata().GetName())
+	require.Equal(t, "/", token.GetScope())
+	require.Equal(t, []string{"Node"}, token.GetSpec().GetRoles())
+	require.Equal(t, "/foo", token.GetSpec().GetAssignedScope())
+	require.Equal(t, "token", token.GetSpec().GetJoinMethod())
+	require.Equal(t, "unlimited", token.GetSpec().GetUsageMode())
+	// Secret should be populated
+	require.Equal(t, "******", token.GetStatus().GetSecret())
+
+	// Get all scoped tokens
+	buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token", "--format=json", "--with-secrets"})
+	require.NoError(t, err)
+	var allTokens []*joiningv1.ScopedToken
+	err = json.Unmarshal(buff.Bytes(), &allTokens)
+	require.NoError(t, err)
+	require.Len(t, allTokens, 1)
+	require.Equal(t, "test-token", allTokens[0].GetMetadata().GetName())
+	// Secret should be populated
+	require.NotEmpty(t, allTokens[0].GetStatus().GetSecret())
+	require.NotContains(t, allTokens[0].GetStatus().GetSecret(), "******")
+
+	// Overwrite scopedTokenYAMLPath with the retrieved token
+	retrievedBytes, err := services.MarshalProtoResource(allTokens[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, retrievedBytes, 0644))
+
+	// Create with --force for upsert
+	// Duplicate create without --force should fail
+	_, err = runResourceCommand(t, clt, []string{"create", scopedTokenYAMLPath})
+	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
+
+	// Using --force should succeed and act as an upsert
+	allTokens[0].Metadata.Labels = map[string]string{"env": "staging"}
+	allTokens[0].Spec.AssignedScope = "/bar"
+	updatedBytes, err := services.MarshalProtoResource(allTokens[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(scopedTokenYAMLPath, updatedBytes, 0644))
+
+	_, err = runResourceCommand(t, clt, []string{"create", "--force", scopedTokenYAMLPath})
+	require.NoError(t, err)
+
+	// Wait for cache propagation and verify the update took effect
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		buff, err := runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		require.NoError(t, err)
+		updated, err := services.UnmarshalProtoResourceArray[*joiningv1.ScopedToken](buff.Bytes(), services.DisallowUnknown())
+		require.NoError(t, err)
+		require.Len(t, updated, 1)
+		require.Equal(t, "test-token", updated[0].GetMetadata().GetName())
+		require.Equal(ct, "/bar", updated[0].GetSpec().GetAssignedScope())
+		require.Equal(ct, "staging", updated[0].GetMetadata().GetLabels()["env"])
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for upserted scoped token cache propagation")
+
+	// verify delete of token
+	_, err = runResourceCommand(t, clt, []string{"rm", "scoped_token/test-token"})
+	require.NoError(t, err)
+
+	// wait for delete cache propagation
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err = runResourceCommand(t, clt, []string{"get", "scoped_token/test-token", "--format=json"})
+		require.True(ct, trace.IsNotFound(err))
+	}, time.Second*30, time.Millisecond*100, "Timed out waiting for scoped token cache propagation")
 }
 
 // TestIntegrationResource tests tctl integration commands.

--- a/tool/tctl/common/scoped_token_command.go
+++ b/tool/tctl/common/scoped_token_command.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"os"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -39,7 +38,6 @@ import (
 	joiningv1 "github.com/gravitational/teleport/api/gen/proto/go/teleport/scopes/joining/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/clientutils"
-	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	libclient "github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -304,12 +302,6 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 		return left.GetMetadata().GetExpires().AsTime().Compare(right.GetMetadata().GetExpires().AsTime())
 	})
 
-	secretFunc := func(tok *joiningv1.ScopedToken) string {
-		if c.withSecrets {
-			return tok.GetStatus().GetSecret()
-		}
-		return "******"
-	}
 	switch c.format {
 	case teleport.JSON:
 		err := utils.WriteJSONArray(c.Stdout, tokens)
@@ -326,22 +318,7 @@ func (c *ScopedTokensCommand) List(ctx context.Context, client *authclient.Clien
 			fmt.Fprintln(c.Stdout, token.GetMetadata().GetName())
 		}
 	default:
-		tokensView := func() string {
-			table := asciitable.MakeTable([]string{"Token", "Secret", "Type", "Scope", "Assigns Scope", "Labels", "Expiry Time (UTC)"})
-			now := time.Now()
-			for _, t := range tokens {
-				expiry := "never"
-				expiresAt := t.GetMetadata().GetExpires().AsTime()
-				if !expiresAt.IsZero() && expiresAt.Unix() != 0 {
-					exptime := expiresAt.Format(time.RFC822)
-					expdur := expiresAt.Sub(now).Round(time.Second)
-					expiry = fmt.Sprintf("%s (%s)", exptime, expdur.String())
-				}
-				table.AddRow([]string{t.GetMetadata().GetName(), secretFunc(t), strings.Join(t.GetSpec().GetRoles(), ","), t.GetScope(), t.GetSpec().GetAssignedScope(), printMetadataLabels(t.GetMetadata().Labels), expiry})
-			}
-			return table.AsBuffer().String()
-		}
-		fmt.Fprint(c.Stdout, tokensView())
+		fmt.Fprint(c.Stdout, scopedTokenTextHelper(tokens, c.withSecrets).String())
 	}
 	return nil
 }


### PR DESCRIPTION
"backport" of https://github.com/gravitational/teleport/pull/63455.

## Implementation:

Since v18 does not have the new tctl resource handler format, copy pasted to the old style instead for v18.

## Testing

- [x] run tctl create 
- [x] run tctl get scoped_tokens
- [x] run tctl get scoped_tokens/sometoken
- [x] run tctl create scoped_tokens -f (ran this for creating and updating a resource)
- [x] Upsert the same token with a modified `status.usage` and verify that it fails (e.g. set a `single_use` status)
- [x] Upsert changing the scope and verify that it fails

changelog: Add scoped tokens to tctl resource commands
