### PR TITLE
Updated scoped command description

### DIFF
--- a/tool/tctl/common/scoped_command.go
+++ b/tool/tctl/common/scoped_command.go
@@ -64,7 +64,7 @@ func (c *ScopedCommand) Initialize(app *kingpin.Application, _ *tctlcfg.GlobalCL
 
 	c.tokens.Initialize(scoped, config)
 
-	c.status = scoped.Command("status", "Show the status of scoped resources")
+	c.status = scoped.Command("status", "Show the status of scoped resources.")
 }
 
 // TryRun takes the CLI command as an argument (like "scoped tokens") and executes it.


### PR DESCRIPTION
Include . at end of description sentence to match other `tctl` commands.